### PR TITLE
perf(sparql-eval): single-threaded optimization backlog (items 3–7 + ORDER BY triple residual)

### DIFF
--- a/bindings/python/tests/rdflib_suite/xfail_ledger.toml
+++ b/bindings/python/tests/rdflib_suite/xfail_ledger.toml
@@ -57,7 +57,6 @@
 # --- Theme: SPARQL aggregate / filter evaluation semantics ---
 "test_agg_distinct.py::test_count_distinct" = "COUNT(DISTINCT ?x) grouped aggregation yields an empty Result under the native engine instead of the two expected grouped counts"
 "test_nested_filters.py::test_nested_filter_outer_binding_propagation" = "FILTER bindings from an outer group are not propagated into a nested group as rdflib does, so the computed solution set diverges from the expected set"
-"test_nested_filters.py::test_nested_filter_outermost_binding_propagation" = "outermost-group FILTER bindings are not propagated into nested groups as rdflib does, so the computed solution set diverges from the expected set"
 "test_conjunctive_graph.py::test_graph_ids[check-kws1]" = "ConjunctiveGraph.parse forwards a StringInputSource down a filesystem path in this keyword combination, raising FileNotFoundError instead of parsing the in-memory source"
 
 # --- Theme: ConjunctiveGraph legacy semantics ---

--- a/crates/rdf-core/src/ir/dataset.rs
+++ b/crates/rdf-core/src/ir/dataset.rs
@@ -266,7 +266,7 @@ fn compare_prefix(
 
 /// One of the six quad orderings. SPOG is the identity (the freeze-sorted table); the
 /// other five are materialized lazily as ordinal arrays.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum QuadPermutation {
     Spog,
     Pos,
@@ -301,6 +301,22 @@ impl QuadPermutation {
             Self::Gosp => AxisOrder::new([G, O, S, P]),
         }
     }
+}
+
+/// A loop-invariant probe plan: the permutation and prefix length chosen purely from
+/// *which* axes a pattern binds (not their bound values) plus the graph constraint.
+///
+/// The permutation choice in [`RdfDataset::pattern_candidate_run`] depends only on the
+/// bound-axis shape, which is constant across the rows of one index-nested-loop join
+/// slot (a variable bound by an earlier BGP pattern is bound for every row; an unbound
+/// one for none). So the join computes this **once** per slot via
+/// [`RdfDataset::probe_plan`] and reuses it for every probe row through
+/// [`RdfDataset::quads_for_pattern_with_plan`], instead of re-scanning all six
+/// permutations on each row. Opaque by design — callers only pass it back.
+#[derive(Clone, Copy, Debug)]
+pub struct QuadProbePlan {
+    perm: QuadPermutation,
+    prefix: usize,
 }
 
 /// The candidate-quad source for an indexed pattern query. Unifies the two access
@@ -670,49 +686,80 @@ impl RdfDataset {
         o: Option<TermId>,
         g: GraphMatch,
     ) -> (QuadPermutation, usize, usize) {
-        // The bound key for an axis, or `None` if the pattern leaves it free.
-        let bound = |axis: Axis| -> Option<u32> {
-            match axis {
-                Axis::S => s.map(|id| id.index() as u32),
-                Axis::P => p.map(|id| id.index() as u32),
-                Axis::O => o.map(|id| id.index() as u32),
-                Axis::G => match g {
-                    GraphMatch::Any => None,
-                    GraphMatch::Default => Some(0),
-                    GraphMatch::Named(id) => Some(id.index() as u32 + 1),
-                },
-            }
-        };
+        let plan = Self::probe_plan(s.is_some(), p.is_some(), o.is_some(), g);
+        self.candidate_run(&plan, s, p, o, g)
+    }
 
-        // Choose the permutation with the longest leading run of bound axes. SPOG is
-        // first in `ALL`, so it wins ties (it needs no array). The chosen `target`
-        // holds the bound key for each of the `prefix` leading axes.
+    /// Select the [`QuadProbePlan`] — permutation + prefix length — for a pattern's
+    /// bound-axis shape (which of s/p/o are bound, plus the graph constraint). This is
+    /// the **value-independent** half of [`Self::pattern_candidate_run`]: it reads only
+    /// the boundness of each axis, so an index-nested-loop join whose probe slot has a
+    /// fixed shape across rows computes it once and reuses it (see [`QuadProbePlan`]).
+    ///
+    /// Choose the permutation whose sort prefix covers the most leading bound axes;
+    /// SPOG is first in `ALL` so it wins ties (it needs no ordinal array).
+    #[must_use]
+    pub fn probe_plan(s_bound: bool, p_bound: bool, o_bound: bool, g: GraphMatch) -> QuadProbePlan {
+        let g_bound = !matches!(g, GraphMatch::Any);
+        let axis_bound = |axis: Axis| match axis {
+            Axis::S => s_bound,
+            Axis::P => p_bound,
+            Axis::O => o_bound,
+            Axis::G => g_bound,
+        };
         let mut best = QuadPermutation::Spog;
         let mut prefix = 0usize;
-        let mut target: QuadAxisKeys = [0; QUAD_ARITY];
         for perm in QuadPermutation::ALL {
             let axes = perm.axes();
             let mut k = 0;
-            let mut t: QuadAxisKeys = [0; QUAD_ARITY];
-            while k < QUAD_ARITY {
-                match bound(axes.axes[k]) {
-                    Some(v) => {
-                        t[k] = v;
-                        k += 1;
-                    }
-                    None => break,
-                }
+            while k < QUAD_ARITY && axis_bound(axes.axes[k]) {
+                k += 1;
             }
             if k > prefix {
                 prefix = k;
                 best = perm;
-                target = t;
             }
         }
+        QuadProbePlan { perm: best, prefix }
+    }
 
-        let axes = best.axes();
+    /// The contiguous `[lo, hi)` candidate run for this row's `(s, p, o, g)` values under
+    /// a precomputed [`QuadProbePlan`] — the **value-dependent** half of
+    /// [`Self::pattern_candidate_run`]. Builds the `target` key for the plan's `prefix`
+    /// leading (therefore bound) axes from the row's values, then binary-searches the
+    /// run. For SPOG the bounds index the freeze-sorted `quads` table directly;
+    /// otherwise the permutation's ordinal array.
+    fn candidate_run(
+        &self,
+        plan: &QuadProbePlan,
+        s: Option<TermId>,
+        p: Option<TermId>,
+        o: Option<TermId>,
+        g: GraphMatch,
+    ) -> (QuadPermutation, usize, usize) {
+        let axes = plan.perm.axes();
+        // The bound key for one of the `prefix` leading axes — each is bound by
+        // construction of the plan, so the `expect`/`unreachable` cannot fire.
+        let key_of = |axis: Axis| -> u32 {
+            match axis {
+                Axis::S => s.expect("plan prefix axis S is bound").index() as u32,
+                Axis::P => p.expect("plan prefix axis P is bound").index() as u32,
+                Axis::O => o.expect("plan prefix axis O is bound").index() as u32,
+                Axis::G => match g {
+                    GraphMatch::Default => 0,
+                    GraphMatch::Named(id) => id.index() as u32 + 1,
+                    GraphMatch::Any => unreachable!("plan prefix axis G is bound"),
+                },
+            }
+        };
+        let prefix = plan.prefix;
+        let mut target: QuadAxisKeys = [0; QUAD_ARITY];
+        for (slot, &axis) in target.iter_mut().zip(axes.axes.iter()).take(prefix) {
+            *slot = key_of(axis);
+        }
+
         // Binary-search the contiguous run whose `prefix` leading keys equal `target`.
-        match best {
+        match plan.perm {
             QuadPermutation::Spog => {
                 let lo = self
                     .quads
@@ -720,17 +767,17 @@ impl RdfDataset {
                 let hi = self
                     .quads
                     .partition_point(|q| compare_prefix(axes, q, &target, prefix).is_le());
-                (best, lo, hi)
+                (plan.perm, lo, hi)
             }
             _ => {
-                let arr = self.permutation(best);
+                let arr = self.permutation(plan.perm);
                 let lo = arr.partition_point(|&ord| {
                     compare_prefix(axes, &self.quads[ord as usize], &target, prefix).is_lt()
                 });
                 let hi = arr.partition_point(|&ord| {
                     compare_prefix(axes, &self.quads[ord as usize], &target, prefix).is_le()
                 });
-                (best, lo, hi)
+                (plan.perm, lo, hi)
             }
         }
     }
@@ -774,7 +821,25 @@ impl RdfDataset {
         o: Option<TermId>,
         g: GraphMatch,
     ) -> impl Iterator<Item = QuadIds> + '_ {
-        let (best, lo, hi) = self.pattern_candidate_run(s, p, o, g);
+        let plan = Self::probe_plan(s.is_some(), p.is_some(), o.is_some(), g);
+        self.quads_for_pattern_with_plan(&plan, s, p, o, g)
+    }
+
+    /// Like [`Self::quads_for_pattern_indexed`], but with a caller-precomputed
+    /// [`QuadProbePlan`] (see [`Self::probe_plan`]) so the per-call permutation
+    /// selection — loop-invariant across an index-nested-loop join slot — is skipped.
+    /// Behaviour is otherwise identical: the same selectivity guard and the same
+    /// residual `(s, p, o, g)` id-equality + [`GraphMatch`] filter, so the yielded
+    /// quads and their order are unchanged.
+    pub fn quads_for_pattern_with_plan(
+        &self,
+        plan: &QuadProbePlan,
+        s: Option<TermId>,
+        p: Option<TermId>,
+        o: Option<TermId>,
+        g: GraphMatch,
+    ) -> impl Iterator<Item = QuadIds> + '_ {
+        let (best, lo, hi) = self.candidate_run(plan, s, p, o, g);
         let candidates = match best {
             // For SPOG the run is a sub-slice of the freeze-sorted table (sequential).
             QuadPermutation::Spog => QuadCandidates::Slice(self.quads[lo..hi].iter()),

--- a/crates/rdf-core/src/ir/mod.rs
+++ b/crates/rdf-core/src/ir/mod.rs
@@ -40,7 +40,9 @@ pub use builder::{RdfDatasetBuilder, ValidatedRdfDatasetBuilder};
 pub use bundle::{GtsBundle, RdfEnvelope};
 pub use canon::{canonicalize, canonicalize_with, CanonHash, Canonicalized};
 pub use compare::{dataset_diff, datasets_isomorphic, DatasetDiff};
-pub use dataset::{QuadHandle, QuadIds, QuadRef, RdfDataset, RdfDatasetIter, TermRef};
+pub use dataset::{
+    QuadHandle, QuadIds, QuadProbePlan, QuadRef, RdfDataset, RdfDatasetIter, TermRef,
+};
 pub use event_sink::RdfDatasetVisitor;
 pub use ingest::{DatasetSink, FrozenDatasetSource};
 pub use mutable::{MutableDataset, QuadValues};

--- a/crates/rdf-core/src/lib.rs
+++ b/crates/rdf-core/src/lib.rs
@@ -79,9 +79,9 @@ pub use fno::{
 pub use ir::{
     canonicalize, canonicalize_with, dataset_diff, datasets_isomorphic, BlankScope, CanonHash,
     Canonicalized, DatasetDiff, DatasetSink, FrozenDatasetSource, GtsBundle, HandleEntry,
-    HandleKey, MutableDataset, PipelineBundle, PipelineBundleError, QuadHandle, QuadIds, QuadRef,
-    QuadValues, RdfDataset, RdfDatasetBuilder, RdfDatasetVisitor, RdfEnvelope, TermId, TermRef,
-    TermValue, ValidatedRdfDatasetBuilder,
+    HandleKey, MutableDataset, PipelineBundle, PipelineBundleError, QuadHandle, QuadIds,
+    QuadProbePlan, QuadRef, QuadValues, RdfDataset, RdfDatasetBuilder, RdfDatasetVisitor,
+    RdfEnvelope, TermId, TermRef, TermValue, ValidatedRdfDatasetBuilder,
 };
 pub use lookaside::{
     RdfBlobOrigin, RdfBlobRecord, RdfLookaside, RdfLookasideKind, RdfLookasideResource,

--- a/crates/sparql-eval/src/bgp.rs
+++ b/crates/sparql-eval/src/bgp.rs
@@ -31,7 +31,7 @@
 //! **projected away**, so two independent BGPs that happen to reuse the label `_:b`
 //! never accidentally share a join variable.
 
-use purrdf_core::{DatasetView, GraphMatch, QuadIds, RdfDataset, TermId, TermRef};
+use purrdf_core::{DatasetView, GraphMatch, QuadIds, QuadProbePlan, RdfDataset, TermId, TermRef};
 use purrdf_sparql_algebra::{NamedNodePattern, TermPattern, TriplePattern, Variable};
 
 use crate::convert::{ground_term_pattern_to_value, named_node_to_value};
@@ -137,6 +137,11 @@ pub(crate) fn eval_bgp(
     for &i in order.iter() {
         let cp = &compiled[i];
         let mut next = Vec::new();
+        // The probe's bound-axis shape is fixed across this slot's rows (a variable is
+        // bound by an earlier pattern for every row or for none), so the permutation
+        // choice is loop-invariant: compute the `QuadProbePlan` once (on the first
+        // single-graph probe) and reuse it, instead of re-selecting per row.
+        let mut probe_plan: Option<QuadProbePlan> = None;
         for row in &rows {
             let s = query_id(&cp.s, row);
             let p = query_id(&cp.p, row);
@@ -145,7 +150,10 @@ pub(crate) fn eval_bgp(
                 // Single-graph scope (store default / a named graph): the indexed
                 // partition_point read, unchanged — no de-dup overhead.
                 GraphScope::One(gm) => {
-                    for quad in ctx.dataset.quads_for_pattern(s, p, o, *gm) {
+                    let plan = *probe_plan.get_or_insert_with(|| {
+                        RdfDataset::probe_plan(s.is_some(), p.is_some(), o.is_some(), *gm)
+                    });
+                    for quad in ctx.dataset.quads_for_pattern_with_plan(&plan, s, p, o, *gm) {
                         if let Some(extended) = bind_row(row, cp, &quad, ctx.dataset) {
                             next.push(extended);
                         }

--- a/crates/sparql-eval/src/binop.rs
+++ b/crates/sparql-eval/src/binop.rs
@@ -24,7 +24,23 @@ use crate::error::EvalError;
 use crate::eval::{eval, EvalCtx};
 use crate::scratch::SolutionTerm;
 use crate::solution::{compatible, Solution, SolutionSeq, VarSchema};
-use crate::DetHashMap;
+use crate::{DetHashMap, DetHasher};
+
+/// A hash-join key over the shared columns of two solutions.
+///
+/// The overwhelmingly common case is a **single** shared variable (a star join on
+/// `?p`), so that case is specialized to a `Copy` `u64` ([`SolutionTerm::join_key_u64`])
+/// — no per-row heap allocation on either the build or probe side. Joins on zero or
+/// ≥2 shared columns keep the general owned-vector key. Within one join the shared
+/// column count is fixed, so every key is the same variant and the two never compare
+/// across variants.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(crate) enum JoinKey {
+    /// Exactly one shared column: the term encoded as a collision-free `u64`.
+    Single(u64),
+    /// Zero or ≥2 shared columns: the bound terms in shared-column order.
+    Multi(Vec<SolutionTerm>),
+}
 
 /// Evaluate `left . right` (algebra `Join`) as a hash join on shared variables.
 pub(crate) fn eval_join(
@@ -94,8 +110,11 @@ fn right_to_out_map(right: &VarSchema, out: &VarSchema) -> Vec<usize> {
 pub(crate) fn build_index(
     r: &SolutionSeq,
     shared: &[(usize, usize)],
-) -> (DetHashMap<Vec<SolutionTerm>, Vec<usize>>, Vec<usize>) {
-    let mut keyed: DetHashMap<Vec<SolutionTerm>, Vec<usize>> = DetHashMap::default();
+) -> (DetHashMap<JoinKey, Vec<usize>>, Vec<usize>) {
+    // Pre-size to the build-row count: the exact upper bound on distinct keys, so a
+    // large build side is filled without incremental rehash-and-reallocate churn.
+    let mut keyed: DetHashMap<JoinKey, Vec<usize>> =
+        DetHashMap::with_capacity_and_hasher(r.rows.len(), DetHasher::default());
     let mut wild: Vec<usize> = Vec::new();
     for (idx, rrow) in r.rows.iter().enumerate() {
         match bound_key(rrow, shared, KeySide::Right) {
@@ -121,7 +140,7 @@ pub(crate) fn build_index(
 pub(crate) fn probe_has_match(
     probe: &[Option<SolutionTerm>],
     shared: &[(usize, usize)],
-    keyed: &DetHashMap<Vec<SolutionTerm>, Vec<usize>>,
+    keyed: &DetHashMap<JoinKey, Vec<usize>>,
     wild: &[usize],
     r_rows: &[Solution],
 ) -> bool {
@@ -197,21 +216,27 @@ enum KeySide {
 /// The shared-column key of `row`, or `None` if any shared column is unbound.
 ///
 /// Both sides build the key in the same `shared` order, so a left key equals a
-/// right key iff the two rows agree on every (bound) shared column.
+/// right key iff the two rows agree on every (bound) shared column. A single shared
+/// column — the common star-join shape — produces an allocation-free
+/// [`JoinKey::Single`]; zero or ≥2 columns fall back to an owned [`JoinKey::Multi`].
 fn bound_key(
     row: &[Option<SolutionTerm>],
     shared: &[(usize, usize)],
     side: KeySide,
-) -> Option<Vec<SolutionTerm>> {
+) -> Option<JoinKey> {
+    let col_of = |ia: usize, ib: usize| match side {
+        KeySide::Left => ia,
+        KeySide::Right => ib,
+    };
+    if let [(ia, ib)] = *shared {
+        // Single shared column: no heap allocation for the key.
+        return Some(JoinKey::Single(row[col_of(ia, ib)]?.join_key_u64()));
+    }
     let mut key = Vec::with_capacity(shared.len());
     for &(ia, ib) in shared {
-        let col = match side {
-            KeySide::Left => ia,
-            KeySide::Right => ib,
-        };
-        key.push(row[col]?);
+        key.push(row[col_of(ia, ib)]?);
     }
-    Some(key)
+    Some(JoinKey::Multi(key))
 }
 
 /// Merge a compatible `(left_row, right_row)` pair into one solution over the output

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -100,7 +100,7 @@ pub(crate) struct ExistsInner {
     /// `(outer_ordinal, inner_ordinal)` pairs (the probe's join key).
     pub shared: Vec<(usize, usize)>,
     /// Inner rows fully bound on the shared columns, grouped by their key.
-    pub keyed: DetHashMap<Vec<SolutionTerm>, Vec<usize>>,
+    pub keyed: DetHashMap<crate::binop::JoinKey, Vec<usize>>,
     /// Inner rows with an unbound shared column (compatible with any probe value).
     pub wild: Vec<usize>,
 }

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -204,6 +204,16 @@ pub struct EvalCtx<'d> {
     /// fresh intern would produce. Naturally per-query: the algebra the addresses
     /// point into outlives this context's `query()` call.
     pub(crate) const_atom_cache: DetHashMap<usize, SolutionTerm>,
+    /// Per-query memo of the parsed XSD value of a dataset literal, keyed by its
+    /// `TermId`. `FILTER`/comparison hot paths (`compare`/`equal`/`ebv_term`) parse
+    /// the same `Existing(TermId)` literal's lexical form via `parse_by_iri` on
+    /// every row; a 30k-row `?age > 40` re-parses ~60 distinct ages 30k times. The
+    /// lexical form and datatype are immutable for a fixed id, so the parse is a
+    /// pure function of the id — memoizing it (including the `None` "not an XSD
+    /// value" outcome) collapses per-row re-parsing to one parse per distinct id.
+    /// Naturally per-query. Only dataset (`Existing`) ids are cached; computed
+    /// scratch values are ephemeral and stay on the borrowed-view path.
+    pub(crate) xsd_parse_cache: DetHashMap<purrdf_core::TermId, Option<purrdf_xsd::XsdValue>>,
     /// The `SERVICE` federation source, if one is injected. `None` in
     /// the default engine path: a non-silent `SERVICE` then hard-fails. Tests and
     /// the conformance harness inject an in-memory source via [`EvalCtx::with_remote`].
@@ -264,6 +274,7 @@ impl<'d> EvalCtx<'d> {
             regex_cache: DetHashMap::default(),
             cached_bool_terms: [None, None],
             const_atom_cache: DetHashMap::default(),
+            xsd_parse_cache: DetHashMap::default(),
             remote: None,
             bgp_order_cache: None,
             constructed: Vec::new(),

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -194,6 +194,16 @@ pub struct EvalCtx<'d> {
     /// the scratch interner dedups by value — so the cached term is bit-identical
     /// to what a fresh intern would return.
     pub(crate) cached_bool_terms: [Option<SolutionTerm>; 2],
+    /// Per-query memo of interned constant expression atoms (`NamedNode` /
+    /// `Literal`), keyed by the atom node's immutable AST address. A constant atom
+    /// inside a `FILTER`/`BIND` is otherwise re-`to_owned()`'d into an owned
+    /// `TermValue` and re-interned (a dataset reverse-index probe) once per row;
+    /// this collapses that to a single intern per distinct atom node. Like
+    /// [`Self::cached_bool_terms`], interning is deterministic for the pinned
+    /// `(dataset, scratch)` pair, so a cached hit is the same `SolutionTerm` a
+    /// fresh intern would produce. Naturally per-query: the algebra the addresses
+    /// point into outlives this context's `query()` call.
+    pub(crate) const_atom_cache: DetHashMap<usize, SolutionTerm>,
     /// The `SERVICE` federation source, if one is injected. `None` in
     /// the default engine path: a non-silent `SERVICE` then hard-fails. Tests and
     /// the conformance harness inject an in-memory source via [`EvalCtx::with_remote`].
@@ -253,6 +263,7 @@ impl<'d> EvalCtx<'d> {
             exists_expr_vars_cache: DetHashMap::default(),
             regex_cache: DetHashMap::default(),
             cached_bool_terms: [None, None],
+            const_atom_cache: DetHashMap::default(),
             remote: None,
             bgp_order_cache: None,
             constructed: Vec::new(),

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -201,8 +201,16 @@ pub struct EvalCtx<'d> {
     /// this collapses that to a single intern per distinct atom node. Like
     /// [`Self::cached_bool_terms`], interning is deterministic for the pinned
     /// `(dataset, scratch)` pair, so a cached hit is the same `SolutionTerm` a
-    /// fresh intern would produce. Naturally per-query: the algebra the addresses
-    /// point into outlives this context's `query()` call.
+    /// fresh intern would produce. Naturally per-query — **but only for the
+    /// static query algebra**: the address is a sound cache key precisely because
+    /// those nodes are allocated once and outlive the whole `query()` call.
+    /// Per-outer-row correlated-`EXISTS` substitution (`expr::exists`) is the
+    /// exception: it heap-allocates a fresh substituted pattern tree per row and
+    /// drops it at the end of that row, so a later row's differently-substituted
+    /// node can be allocated at the SAME address (an ABA hazard) and would
+    /// otherwise return a stale, wrong-row value from this cache.
+    /// [`Self::in_substituted_exists`] flags exactly that window so `const_atom`
+    /// bypasses this cache while it is set.
     pub(crate) const_atom_cache: DetHashMap<usize, SolutionTerm>,
     /// Per-query memo of the parsed XSD value of a dataset literal, keyed by its
     /// `TermId`. `FILTER`/comparison hot paths (`compare`/`equal`/`ebv_term`) parse
@@ -235,6 +243,16 @@ pub struct EvalCtx<'d> {
     /// output, and the native `query` egress into `SparqlResult::Solutions::aux`. Empty
     /// whenever no constructing builtin ran.
     pub(crate) constructed: Vec<(TermValue, TermValue, TermValue)>,
+    /// `true` while evaluating a per-outer-row correlated-`EXISTS` substituted
+    /// temporary pattern (see `expr::exists`'s correlated branch). That
+    /// temporary's `Expression`/`GraphPattern` nodes are heap-allocated fresh for
+    /// the current outer row and dropped at the end of it — they do NOT outlive
+    /// this context's `query()` call — so address-keyed memoization
+    /// ([`Self::const_atom_cache`], [`Self::exists_expr_vars_cache`],
+    /// [`Self::exists_inner_cache`]) is unsound over them (a later row's
+    /// allocation can reuse a dropped node's address) and must be bypassed
+    /// entirely while this flag is set.
+    pub(crate) in_substituted_exists: bool,
 }
 
 impl core::fmt::Debug for EvalCtx<'_> {
@@ -278,6 +296,7 @@ impl<'d> EvalCtx<'d> {
             remote: None,
             bgp_order_cache: None,
             constructed: Vec::new(),
+            in_substituted_exists: false,
         }
     }
 

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -313,7 +313,7 @@ fn ebv_of(
 }
 
 /// The effective boolean value of a concrete term (`None` = type error).
-fn ebv_term(ctx: &EvalCtx<'_>, term: SolutionTerm) -> Option<bool> {
+fn ebv_term(ctx: &mut EvalCtx<'_>, term: SolutionTerm) -> Option<bool> {
     match xsd_of_term(ctx, term) {
         Some(xv) => effective_boolean_value(&xv),
         None => None,
@@ -324,18 +324,31 @@ fn ebv_term(ctx: &EvalCtx<'_>, term: SolutionTerm) -> Option<bool> {
 /// [`TermRef`] for dataset terms, the scratch table for computed ones — so the
 /// per-row comparison hot path parses without materializing an owned
 /// [`TermValue`]. Semantically identical to `xsd_of(&value_of(ctx, term))`.
-fn xsd_of_term(ctx: &EvalCtx<'_>, term: SolutionTerm) -> Option<XsdValue> {
+///
+/// Dataset (`Existing`) parses are memoized per query by `TermId` (see
+/// [`EvalCtx::xsd_parse_cache`]): the lexical form and datatype are immutable for a
+/// fixed id, so a comparison/`FILTER` over N rows parses each distinct literal once
+/// instead of once per row. Computed scratch values are ephemeral and stay on the
+/// direct borrowed-view path.
+fn xsd_of_term(ctx: &mut EvalCtx<'_>, term: SolutionTerm) -> Option<XsdValue> {
     match term {
-        SolutionTerm::Existing(id) => match ctx.dataset.resolve(id) {
-            TermRef::Literal {
-                lexical, datatype, ..
-            } => match ctx.dataset.resolve(datatype) {
-                TermRef::Iri(iri) => parse_by_iri(lexical, iri).ok().flatten(),
-                // A literal's datatype is always an interned IRI (C0.1).
-                other => unreachable!("literal datatype must be an IRI, got {other:?}"),
-            },
-            _ => None,
-        },
+        SolutionTerm::Existing(id) => {
+            if let Some(cached) = ctx.xsd_parse_cache.get(&id) {
+                return cached.clone();
+            }
+            let parsed = match ctx.dataset.resolve(id) {
+                TermRef::Literal {
+                    lexical, datatype, ..
+                } => match ctx.dataset.resolve(datatype) {
+                    TermRef::Iri(iri) => parse_by_iri(lexical, iri).ok().flatten(),
+                    // A literal's datatype is always an interned IRI (C0.1).
+                    other => unreachable!("literal datatype must be an IRI, got {other:?}"),
+                },
+                _ => None,
+            };
+            ctx.xsd_parse_cache.insert(id, parsed.clone());
+            parsed
+        }
         SolutionTerm::Computed(sid) => xsd_of(ctx.scratch.computed_value(sid)),
     }
 }
@@ -375,8 +388,12 @@ fn compare(
     }
     // Value-space comparison over borrowed term views (no owned TermValue
     // clones). Distinct non-value terms (IRIs/blanks) or incomparable value
-    // spaces are a type error (`None`), exactly as before.
-    let ord = match (xsd_of_term(ctx, ta), xsd_of_term(ctx, tb)) {
+    // spaces are a type error (`None`), exactly as before. Each side is parsed
+    // through the per-query id→XSD memo; the two calls are sequenced (not a tuple
+    // literal) because each takes `&mut ctx`.
+    let ax = xsd_of_term(ctx, ta);
+    let bx = xsd_of_term(ctx, tb);
+    let ord = match (ax, bx) {
         (Some(ax), Some(bx)) => value_cmp(&ax, &bx),
         _ => None,
     };
@@ -414,7 +431,9 @@ fn equal(
     // value-space comparison and the literal/non-literal split remain — evaluated
     // here on borrowed views (no owned TermValue clones), semantically identical
     // to `rdf_equal(&value_of(ctx, ta), &value_of(ctx, tb))`.
-    let eq = match (xsd_of_term(ctx, ta), xsd_of_term(ctx, tb)) {
+    let ax = xsd_of_term(ctx, ta);
+    let bx = xsd_of_term(ctx, tb);
+    let eq = match (ax, bx) {
         (Some(ax), Some(bx)) => value_cmp(&ax, &bx).map(|o| o == Ordering::Equal),
         _ => {
             if term_is_literal(ctx, ta) && term_is_literal(ctx, tb) {

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -233,6 +233,14 @@ fn const_atom(
     expr: &Expression,
     build: impl FnOnce() -> TermValue,
 ) -> SolutionTerm {
+    // Address-keyed memoization is unsound over a per-row substituted-EXISTS
+    // temporary (see `EvalCtx::in_substituted_exists`): the node's address can
+    // be a dropped-and-reused allocation from an earlier outer row, so a hit
+    // here would silently return a stale, wrong-row constant. Bypass the cache
+    // entirely for the duration of that window.
+    if ctx.in_substituted_exists {
+        return intern(ctx, build());
+    }
     let key = std::ptr::from_ref::<Expression>(expr) as usize;
     if let Some(term) = ctx.const_atom_cache.get(&key) {
         return *term;
@@ -693,16 +701,26 @@ fn exists(
         })
         .collect();
 
-    let pattern_key = std::ptr::from_ref::<GraphPattern>(pattern) as usize;
-    let inner_expr_vars = ctx
-        .exists_expr_vars_cache
-        .entry(pattern_key)
-        .or_insert_with(|| {
-            let mut vars = DetHashSet::default();
-            pattern_expr_vars(pattern, &mut vars);
-            Rc::new(vars)
-        })
-        .clone();
+    // `pattern`'s address is a sound cache key only for the static query algebra.
+    // While evaluating a per-row substituted-EXISTS temporary
+    // (`ctx.in_substituted_exists`), `pattern` is itself such a temporary — its
+    // address can be a dropped-and-reused allocation from an earlier outer row —
+    // so skip both the cache read and the write and compute the var set fresh.
+    let inner_expr_vars = if ctx.in_substituted_exists {
+        let mut vars = DetHashSet::default();
+        pattern_expr_vars(pattern, &mut vars);
+        Rc::new(vars)
+    } else {
+        let pattern_key = std::ptr::from_ref::<GraphPattern>(pattern) as usize;
+        ctx.exists_expr_vars_cache
+            .entry(pattern_key)
+            .or_insert_with(|| {
+                let mut vars = DetHashSet::default();
+                pattern_expr_vars(pattern, &mut vars);
+                Rc::new(vars)
+            })
+            .clone()
+    };
 
     let is_expression_correlated = inner_expr_vars.iter().any(|v| outer_bound.contains(v));
 
@@ -720,7 +738,18 @@ fn exists(
         // pattern whose result is specific to this outer row; it is NOT memoized.
         let bindings = outer_bindings_for_substitution(row, schema, ctx);
         let substituted = substitute_pattern(pattern, &bindings);
-        let inner = eval(&substituted, ctx)?;
+        // `substituted` is a fresh heap allocation, specific to this outer row,
+        // that is dropped at the end of this call — its node addresses do NOT
+        // outlive the query. Flag the window so address-keyed memoization
+        // (`const_atom`, `exists_expr_vars_cache`, `exists_inner_cache`) is
+        // bypassed while it is evaluated, and restore the prior value afterward
+        // (even on error) so a doubly-nested correlated EXISTS is handled
+        // correctly.
+        let prev_in_substituted_exists = ctx.in_substituted_exists;
+        ctx.in_substituted_exists = true;
+        let inner = eval(&substituted, ctx);
+        ctx.in_substituted_exists = prev_in_substituted_exists;
+        let inner = inner?;
         Ok(!inner.is_empty())
     } else {
         // Fast memoized path: the inner pattern result is independent of the outer
@@ -729,12 +758,17 @@ fn exists(
         // schema), then existence-probe each outer row against the reused index. This
         // replaces the former per-row seed-join, whose `join_seqs` rebuilt the inner
         // hash index on every outer row (O(rows × |inner|)).
+        // As above: `pattern`'s address is a sound cache key only for the static
+        // query algebra. A doubly-nested EXISTS reached while
+        // `ctx.in_substituted_exists` is already set means `pattern` is itself
+        // part of an outer per-row substituted temporary, so skip both the cache
+        // get and the insert and build the entry fresh, unshared.
         let key = (
             std::ptr::from_ref::<GraphPattern>(pattern) as usize,
             ctx.graph_key(),
             crate::eval::schema_fingerprint(schema),
         );
-        let cached = if ctx.options.exists_memo {
+        let cached = if ctx.options.exists_memo && !ctx.in_substituted_exists {
             ctx.exists_inner_cache.get(&key).cloned()
         } else {
             None
@@ -755,7 +789,7 @@ fn exists(
                     keyed,
                     wild,
                 });
-                if ctx.options.exists_memo {
+                if ctx.options.exists_memo && !ctx.in_substituted_exists {
                     ctx.exists_inner_cache.insert(key, entry.clone());
                 }
                 entry
@@ -3228,6 +3262,75 @@ mod tests {
             ctx.exists_inner_cache.len(),
             1,
             "uncorrelated EXISTS must still populate the memo cache"
+        );
+    }
+
+    // ── Correlated EXISTS over many outer rows: address-reuse cache hazard ─────
+    //
+    // Regression guard for the `ctx.in_substituted_exists` cache bypass: the
+    // per-row `substitute_pattern` temporary built inside the expression-
+    // correlated branch of `exists()` is a fresh heap allocation that is
+    // dropped at the end of each outer row's evaluation. Across many rows the
+    // allocator can (and in practice does) hand back the *same address* for
+    // the next row's temporary. Before the fix, `const_atom_cache`,
+    // `exists_expr_vars_cache`, and `exists_inner_cache` were keyed on that
+    // address, so a later row could get a stale cache hit computed against an
+    // earlier row's substituted constant — corrupting the solution set. This
+    // test drives five outer rows (more than enough for address reuse to
+    // occur) with an alternating true/false correlated-FILTER-EXISTS result,
+    // so any stale hit flips at least one row to the wrong answer.
+
+    /// Five outer subjects `?s`, each with a single `:knows` edge (so each
+    /// contributes exactly one outer row). Only the odd-numbered subjects
+    /// (`s1`, `s3`, `s5`) additionally have a `:p` triple.
+    fn correlated_multi_row_ds() -> Arc<RdfDataset> {
+        let mut b = RdfDatasetBuilder::new();
+        let knows = b.intern_iri("http://example.org/knows");
+        let p = b.intern_iri("http://example.org/p");
+        let x = b.intern_iri("http://example.org/x");
+        for i in 1..=5 {
+            let s = b.intern_iri(&format!("http://example.org/s{i}"));
+            let o = b.intern_iri(&format!("http://example.org/o{i}"));
+            b.push_quad(s, knows, o, None);
+            if i % 2 == 1 {
+                // Odd subjects (s1, s3, s5) have :p; even ones (s2, s4) do not.
+                b.push_quad(s, p, x, None);
+            }
+        }
+        b.freeze().expect("freeze")
+    }
+
+    #[test]
+    fn correlated_exists_substitution_ignores_address_keyed_caches() {
+        // Each outer row substitutes a DIFFERENT constant for ?s into the inner
+        // FILTER(?s = ?x); the expected result alternates true/false/true/false/true
+        // across s1..s5. A stale address-keyed cache hit (the bug this guards)
+        // would carry an earlier row's substituted result into a later row and
+        // flip at least one entry — so the exact set below only holds because
+        // `ctx.in_substituted_exists` forces every row's substitution to be
+        // evaluated fresh.
+        let ds = correlated_multi_row_ds();
+        let q = "SELECT ?s WHERE { \
+                   ?s <http://example.org/knows> ?o \
+                   FILTER EXISTS { ?x <http://example.org/p> ?y FILTER(?s = ?x) } \
+                 }";
+        let rows = run_rows(&ds, q, true);
+        assert_eq!(
+            rows,
+            vec![
+                vec!["<http://example.org/s1>".to_owned()],
+                vec!["<http://example.org/s3>".to_owned()],
+                vec!["<http://example.org/s5>".to_owned()],
+            ],
+            "correlated EXISTS across many outer rows must return exactly the \
+             odd-numbered subjects (s1, s3, s5), each judged against its OWN \
+             substituted constant"
+        );
+        // Cross-check against the memo-off (naive per-row) reference path too.
+        assert_eq!(
+            rows,
+            run_rows(&ds, q, false),
+            "memo on/off must agree for the multi-row correlated EXISTS"
         );
     }
 

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -55,8 +55,12 @@ pub(crate) fn eval_expr(
 ) -> Result<Option<SolutionTerm>, EvalError> {
     match expr {
         // ---- atoms ---------------------------------------------------------
-        Expression::NamedNode(n) => Ok(Some(intern(ctx, TermValue::Iri(n.as_str().to_owned())))),
-        Expression::Literal(l) => Ok(Some(intern(ctx, crate::convert::literal_to_value(l)))),
+        Expression::NamedNode(n) => Ok(Some(const_atom(ctx, expr, || {
+            TermValue::Iri(n.as_str().to_owned())
+        }))),
+        Expression::Literal(l) => Ok(Some(const_atom(ctx, expr, || {
+            crate::convert::literal_to_value(l)
+        }))),
         Expression::Variable(v) => Ok(lookup(v, row, schema)),
         Expression::Bound(v) => Ok(Some(bool_term(ctx, lookup(v, row, schema).is_some()))),
 
@@ -218,6 +222,24 @@ fn lookup(
 /// Intern a value to a solution term (promoting to an existing dataset id).
 fn intern(ctx: &mut EvalCtx<'_>, value: TermValue) -> SolutionTerm {
     ctx.scratch.intern(ctx.dataset, value)
+}
+
+/// Intern a constant atom (`NamedNode`/`Literal`), memoized per query by the
+/// node's AST address (see [`EvalCtx::const_atom_cache`]). `build` — which owns
+/// the `TermValue` allocation — runs only on a cache miss, so a FILTER/BIND over
+/// N rows pays the `to_owned()` + intern probe once, not N times.
+fn const_atom(
+    ctx: &mut EvalCtx<'_>,
+    expr: &Expression,
+    build: impl FnOnce() -> TermValue,
+) -> SolutionTerm {
+    let key = std::ptr::from_ref::<Expression>(expr) as usize;
+    if let Some(term) = ctx.const_atom_cache.get(&key) {
+        return *term;
+    }
+    let term = intern(ctx, build());
+    ctx.const_atom_cache.insert(key, term);
+    term
 }
 
 /// Materialize a solution term to an owned value.

--- a/crates/sparql-eval/src/modifier.rs
+++ b/crates/sparql-eval/src/modifier.rs
@@ -279,8 +279,11 @@ enum SortKey {
         language: Option<String>,
         lexical: String,
     },
-    /// Triple term — kind rank 3 (rare; compared via [`term_value_order`]).
-    Triple(TermValue),
+    /// Triple term — kind rank 3 (rare). Its `(s, p, o)` components are themselves
+    /// precomputed sort keys, so the literal XSD parse of a nested component is paid
+    /// once at build time (not re-run per comparison, as `term_value_order` would);
+    /// [`compare_sort_keys`] recurses over them componentwise.
+    Triple(Box<[Self; 3]>),
 }
 
 /// The kind rank of a bound sort key: blank < IRI < literal < triple
@@ -311,7 +314,11 @@ fn sort_key(value: Option<TermValue>) -> SortKey {
             language,
             lexical: lexical_form,
         },
-        Some(triple @ TermValue::Triple { .. }) => SortKey::Triple(triple),
+        Some(TermValue::Triple { s, p, o }) => SortKey::Triple(Box::new([
+            sort_key(Some(*s)),
+            sort_key(Some(*p)),
+            sort_key(Some(*o)),
+        ])),
     }
 }
 
@@ -349,9 +356,18 @@ fn compare_sort_keys(a: &SortKey, b: &SortKey) -> Ordering {
             }
             (dx, gx, lx).cmp(&(dy, gy, ly))
         }
-        (SortKey::Triple(x), SortKey::Triple(y)) => term_value_order(x, y),
+        (SortKey::Triple(x), SortKey::Triple(y)) => compare_triple_keys(x, y),
         _ => sort_key_rank(a).cmp(&sort_key_rank(b)),
     }
+}
+
+/// Compare two triple-term sort keys componentwise (`s`, then `p`, then `o`) — the
+/// precomputed-key analogue of [`term_value_order`]'s triple arm, with each
+/// component already parsed at build time.
+fn compare_triple_keys(a: &[SortKey; 3], b: &[SortKey; 3]) -> Ordering {
+    compare_sort_keys(&a[0], &b[0])
+        .then_with(|| compare_sort_keys(&a[1], &b[1]))
+        .then_with(|| compare_sort_keys(&a[2], &b[2]))
 }
 
 fn kind_rank(v: &TermValue) -> u8 {
@@ -1190,5 +1206,49 @@ mod tests {
         let x = seq.schema.index_of(&Variable::new("x")).unwrap();
         assert!(seq.rows[0][x].is_some());
         assert!(seq.rows[1][x].is_none()); // UNDEF.
+    }
+
+    /// The precomputed triple sort key (`sort_key` + `compare_sort_keys`) must order
+    /// quoted-triple terms **identically** to the reference `term_value_order` over
+    /// the raw values — the only difference is that the nested literals' XSD parse is
+    /// paid once at key-build time instead of on every comparison. Includes cases
+    /// where value-space and lexical order disagree (integer `9` < `30` by value but
+    /// `"30"` < `"9"` lexically), cross-kind components, and a nested triple.
+    #[test]
+    fn triple_sort_keys_match_term_value_order() {
+        let lit = |n: &str| TermValue::Literal {
+            lexical_form: n.to_owned(),
+            datatype: XINT.to_owned(),
+            language: None,
+            direction: None,
+        };
+        let iri = |s: &str| TermValue::Iri(s.to_owned());
+        let triple = |s: TermValue, p: TermValue, o: TermValue| TermValue::Triple {
+            s: Box::new(s),
+            p: Box::new(p),
+            o: Box::new(o),
+        };
+        let samples = [
+            triple(iri("http://ex/a"), iri("http://ex/p"), lit("30")),
+            triple(iri("http://ex/a"), iri("http://ex/p"), lit("9")),
+            triple(iri("http://ex/a"), iri("http://ex/p"), iri("http://ex/z")),
+            triple(iri("http://ex/b"), iri("http://ex/p"), lit("9")),
+            triple(
+                triple(iri("http://ex/a"), iri("http://ex/p"), lit("9")),
+                iri("http://ex/q"),
+                lit("30"),
+            ),
+        ];
+        for a in &samples {
+            for b in &samples {
+                let via_keys =
+                    compare_sort_keys(&sort_key(Some(a.clone())), &sort_key(Some(b.clone())));
+                let via_ref = term_value_order(a, b);
+                assert_eq!(
+                    via_keys, via_ref,
+                    "ordering mismatch:\n  a={a:?}\n  b={b:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/sparql-eval/src/path.rs
+++ b/crates/sparql-eval/src/path.rs
@@ -51,7 +51,7 @@ use crate::error::EvalError;
 use crate::eval::EvalCtx;
 use crate::scratch::SolutionTerm;
 use crate::solution::{Solution, SolutionSeq, VarSchema};
-use crate::DetHashMap;
+use crate::{DetHashMap, DetHashSet};
 
 /// Excluded-predicate sets for every `NegatedPropertySet` in the path, resolved to
 /// dataset ids ONCE per `eval_path` call and keyed by the excluded slice's data
@@ -476,8 +476,12 @@ fn closure(
     forward: bool,
     ctx: &PathCtx<'_>,
 ) -> BTreeSet<TermId> {
+    // `result` stays an ordered `BTreeSet` — it is the returned/egress set, and its
+    // iteration order determines solution-row order (byte-identity). `visited` is a
+    // membership-only guard, never iterated into output, so it uses an O(1)
+    // `DetHashSet` instead of the O(log n) `BTreeSet` on the closure's hot loop.
     let mut result = BTreeSet::new();
-    let mut visited = BTreeSet::new();
+    let mut visited: DetHashSet<TermId> = DetHashSet::default();
     let mut frontier: Vec<TermId> = reach_cached(inner, node, forward, ctx)
         .iter()
         .copied()
@@ -506,8 +510,10 @@ fn closure_multi(
     forward: bool,
     ctx: &PathCtx<'_>,
 ) -> BTreeSet<TermId> {
+    // As in `closure`: ordered `result` for egress, O(1) `DetHashSet` for the
+    // membership-only `visited` guard.
     let mut result = BTreeSet::new();
-    let mut visited = BTreeSet::new();
+    let mut visited: DetHashSet<TermId> = DetHashSet::default();
     let mut frontier: Vec<TermId> = Vec::new();
     for &s in seeds {
         frontier.extend(reach_cached(inner, s, forward, ctx).iter().copied());

--- a/crates/sparql-eval/src/scratch.rs
+++ b/crates/sparql-eval/src/scratch.rs
@@ -64,6 +64,35 @@ pub enum SolutionTerm {
     Computed(ScratchId),
 }
 
+impl SolutionTerm {
+    /// A total, collision-free `u64` encoding used as a single-column hash-join key,
+    /// so a one-variable join key is a `Copy` `u64` with **no per-row `Vec`
+    /// allocation**.
+    ///
+    /// `Existing` ids map into `[0, 2^32)` and `Computed` ids into `[2^32, 2^33)`, so
+    /// two terms encode to the same `u64` **iff** they are equal — the same invariant
+    /// the `Existing`/`Computed` unification rule already guarantees for join
+    /// correctness (a value present in the dataset is never also a `Computed` id).
+    /// A collision here would be a *wrong join result*, not a slowdown, so the width
+    /// assumption (both ids fit `u32` — `TermId` is a `NonZeroU32`, `ScratchId` a
+    /// `u32`) is asserted in debug builds.
+    #[inline]
+    pub(crate) fn join_key_u64(self) -> u64 {
+        match self {
+            Self::Existing(id) => {
+                let ix = id.index() as u64;
+                debug_assert!(ix < (1 << 32), "TermId index must fit u32");
+                ix
+            }
+            Self::Computed(sid) => {
+                let s = sid.index() as u64;
+                debug_assert!(s < (1 << 32), "ScratchId must fit u32");
+                (1 << 32) | s
+            }
+        }
+    }
+}
+
 /// A per-query interner for terms computed during evaluation.
 ///
 /// Interns by [`TermValue`] (dataset-independent), de-duplicating equal computed


### PR DESCRIPTION
Closes #20

## Summary

Residual sweep of the profiled single-threaded optimization backlog for `purrdf-sparql-eval`.
Each item was implemented behind the issue's hard gates — **W3C conformance untouched,
byte-identical results, `DetHasher` for new maps, wasm-clean, no new deps, no Cargo features** —
and measured with **deterministic, contention-independent metrics** (see below).

Two backlog items were assessed and found **already implemented on `main`** (verified, not
skipped): **Item 1** (regex compile cache — two-level `DetHashMap`, borrowed-key probe, shared
`Rc<Regex>`) and **Item 2** common ORDER BY path (XSD parse already hoisted into `sort_key`).

## Measurement methodology

Wall-clock timing is meaningless on the shared build host (100+ tenants): back-to-back runs of
*identical* code swing ±17% at criterion `sample_size=10`. This PR uses metrics that count **work
done, not time**, and are exactly reproducible:
- **Heap-allocation counts/bytes** over the fixed `query_eval` dataset (allocation-reduction items).
- **Instructions retired** (`perf stat -e instructions:u`, run-to-run variance ~0.002%) for CPU items.

## Changes (one commit each, per-item evidence in each message)

| Item | Change | Deterministic result |
|---|---|---|
| 3 | Memoize constant `NamedNode`/`Literal` atoms per query | `b_scan_filter` −59,997 allocs (−25%) |
| 4 | Memoize dataset literal XSD parses (`TermId`→`XsdValue`) | `b_scan_filter` −5.5% instructions |
| 5 | Allocation-free single-column `u64` join keys + pre-sized build map | `c_optional_heavy` −213,038 allocs (−17.4%) |
| 7 | O(1) `DetHashSet` visited-set for path transitive closure | `f_path_transitive` −3.8% instructions |
| 6a | Hoist loop-invariant BGP probe permutation selection | `a` −1.4%, `e` −2.8% instructions |
| 2* | Pre-parse quoted-triple ORDER BY sort keys (residual) | correctness cleanup; equivalence unit test |

**Item 6 tier (ii)** (adaptive sort-merge) was profiled and **not shipped**: on every benched shape
the join is either selective (probe count ≪ run length → binary-search probing is already optimal)
or output-dominated (row materialization dominates; probe ≤6%), so an adaptive planner would never
select it — shipping it would be unreachable-on-this-workload code. The measurement decides the SOTA
shape (details on #20). Tier (i) is Item 6's deliverable.

## Cumulative allocations (origin/main → this branch, exact/reproducible)

- `b_scan_filter`: 240,453 → 180,462 (−24.9%)
- `c_optional_heavy`: 1,227,187 → 1,014,149 (−17.4%)
- `f_path_transitive`: 205,014 → 200,039 (−2.4%)

## Gates
- `make check` green (fmt + clippy pedantic/nursery + `cargo test --workspace` incl. W3C SPARQL
  conformance + hygiene + `make wasm`).
- **Byte-identical** results across all 7 `query_eval` shapes, diffed against origin/main row
  fixtures (BGP bag order + ORDER BY tie-breaks) after every commit.
- All new maps/sets use the crate's fixed-key `DetHasher`; no new dependencies; no Cargo features.
