### PR TITLE
perf(wasm-pkg): build the npm artifact with +simd128

### DIFF
--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -61,7 +61,14 @@ jobs:
           cargo install wasm-bindgen-cli --version "$PIN" --locked
 
       - name: Install binaryen (wasm-opt)
-        run: sudo apt-get update && sudo apt-get install -y binaryen
+        # The wasm-pkg build emits +simd128; wasm-opt must accept --enable-simd
+        # or it would silently fall back to (or reject) a non-SIMD module. Fail
+        # fast here rather than shipping a scalar artifact.
+        run: |
+          sudo apt-get update && sudo apt-get install -y binaryen
+          wasm-opt --version
+          printf '(module)\n' | wasm-opt --enable-simd -o /dev/null - \
+            || { echo "FAIL: installed wasm-opt lacks --enable-simd support"; exit 1; }
 
       - name: Build the wasm package
         run: make wasm-pkg

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,9 @@ wasm-pkg: ## Build the purrdf npm/ESM package (release wasm + wasm-bindgen web b
 	@# scoped to this npm-artifact build only, so `make wasm` stays baseline-clean.
 	@# This raises the artifact's browser baseline to engines with wasm SIMD
 	@# (all major browsers since ~2021; Node >= 16).
-	RUSTFLAGS="-C target-feature=+simd128" \
+	@# Append rather than overwrite so any env / .cargo/config.toml RUSTFLAGS
+	@# (sccache, linker args, extra target features) survive alongside +simd128.
+	RUSTFLAGS="$${RUSTFLAGS} -C target-feature=+simd128" \
 		cargo build -p purrdf-wasm --target wasm32-unknown-unknown --release --locked
 	@# wasm-bindgen-cli must match the crate's exact wasm-bindgen pin (see [workspace.dependencies]).
 	PATH="$$HOME/.cargo/bin:$$PATH" wasm-bindgen \

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,15 @@ wasm-pkg: ## Build the purrdf npm/ESM package (release wasm + wasm-bindgen web b
 		--enable-bulk-memory --enable-nontrapping-float-to-int \
 		--enable-sign-ext --enable-mutable-globals --enable-simd \
 		-o crates/rdf-wasm/js/pkg/purrdf_wasm_bg.wasm crates/rdf-wasm/js/pkg/purrdf_wasm_bg.wasm
+	@# Durable proof that +simd128 actually produced SIMD codegen: a green
+	@# wasm-pkg-test round-trip only proves the module runs correctly, not that
+	@# it is vectorized — a memchr/RUSTFLAGS/dependency regression could ship a
+	@# silently scalar artifact with every test still passing. Disassemble the
+	@# optimized module and hard-fail if no SIMD opcodes are present.
+	@command -v wasm-dis >/dev/null 2>&1 || { echo "ERROR: wasm-dis (binaryen) not found — it is a REQUIRED wasm build dependency"; exit 1; }
+	@count=$$(wasm-dis crates/rdf-wasm/js/pkg/purrdf_wasm_bg.wasm | grep -cE 'v128|i8x16|i16x8|i32x4|i64x2|f32x4|f64x2' || true); \
+		[ "$$count" -gt 0 ] || { echo "ERROR: wasm-pkg produced NO SIMD opcodes (+simd128 regressed — refusing to ship a scalar artifact)"; exit 1; }; \
+		echo "OK: verified $$count SIMD opcode(s) present in the optimized wasm artifact"
 	@echo "OK: purrdf npm package built (crates/rdf-wasm/js/pkg/)"
 
 wasm-pkg-test: wasm-pkg ## Build the wasm package and run the Node real-execution round-trip suite.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 CARGO_TARGET_DIR ?= target
 CAPI_HEADER := crates/rdf-capi/include/purrdf.h
 
-.PHONY: help metadata fmt check test bench bench-python pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-test \
+.PHONY: help metadata fmt check test bench bench-python pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-test wasm-pkg-bench \
 	capi-build capi-header capi-check capi-install
 
 help: ## Show this help.
@@ -88,6 +88,9 @@ wasm-pkg: ## Build the purrdf npm/ESM package (release wasm + wasm-bindgen web b
 
 wasm-pkg-test: wasm-pkg ## Build the wasm package and run the Node real-execution round-trip suite.
 	cd crates/rdf-wasm/js && node --test tests/*.test.mjs
+
+wasm-pkg-bench: wasm-pkg ## Build the wasm package and run the Node parse-throughput benchmark (report-only; never a gate).
+	cd crates/rdf-wasm/js && node bench/parse.bench.mjs
 
 capi-build: ## Build libpurrdf (cdylib + staticlib + header + pkg-config) via cargo-c.
 	cargo capi build -p purrdf-capi

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ wasm-pkg: ## Build the purrdf npm/ESM package (release wasm + wasm-bindgen web b
 	@# and blake3's simd128 backend run vectorized instead of scalar/SWAR. It is
 	@# scoped to this npm-artifact build only, so `make wasm` stays baseline-clean.
 	@# This raises the artifact's browser baseline to engines with wasm SIMD
-	@# (all major browsers since ~2021; Node >= 16).
+	@# (all major browsers since ~2021; Node >= 18, the package's engine floor).
 	@# Append rather than overwrite so any env / .cargo/config.toml RUSTFLAGS
 	@# (sccache, linker args, extra target features) survive alongside +simd128.
 	RUSTFLAGS="$${RUSTFLAGS} -C target-feature=+simd128" \

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,14 @@ wasm: ## Prove the release crates build for wasm32-unknown-unknown (SKIP locally
 	fi
 
 wasm-pkg: ## Build the purrdf npm/ESM package (release wasm + wasm-bindgen web bindings) into crates/rdf-wasm/js/pkg/.
-	cargo build -p purrdf-wasm --target wasm32-unknown-unknown --release --locked
+	@# +simd128 is a PLATFORM target feature (not a Cargo feature): it turns on
+	@# the wasm SIMD instruction set so memchr's byte scan (the parser hot path)
+	@# and blake3's simd128 backend run vectorized instead of scalar/SWAR. It is
+	@# scoped to this npm-artifact build only, so `make wasm` stays baseline-clean.
+	@# This raises the artifact's browser baseline to engines with wasm SIMD
+	@# (all major browsers since ~2021; Node >= 16).
+	RUSTFLAGS="-C target-feature=+simd128" \
+		cargo build -p purrdf-wasm --target wasm32-unknown-unknown --release --locked
 	@# wasm-bindgen-cli must match the crate's exact wasm-bindgen pin (see [workspace.dependencies]).
 	PATH="$$HOME/.cargo/bin:$$PATH" wasm-bindgen \
 		$(CARGO_TARGET_DIR)/wasm32-unknown-unknown/release/purrdf_wasm.wasm \
@@ -78,11 +85,12 @@ wasm-pkg: ## Build the purrdf npm/ESM package (release wasm + wasm-bindgen web b
 	@# wasm-opt -Oz is a REQUIRED build step (roughly halves the artifact).
 	@# The --enable flags cover the post-MVP features rustc emits by default
 	@# for wasm32-unknown-unknown; older binaryen builds (e.g. Ubuntu's apt
-	@# package) reject the module without them.
+	@# package) reject the module without them. --enable-simd is REQUIRED for the
+	@# +simd128 build above (binaryen rejects the SIMD-carrying module without it).
 	@command -v wasm-opt >/dev/null 2>&1 || { echo "ERROR: wasm-opt (binaryen) not found — it is a REQUIRED wasm build dependency"; exit 1; }
 	wasm-opt -Oz \
 		--enable-bulk-memory --enable-nontrapping-float-to-int \
-		--enable-sign-ext --enable-mutable-globals \
+		--enable-sign-ext --enable-mutable-globals --enable-simd \
 		-o crates/rdf-wasm/js/pkg/purrdf_wasm_bg.wasm crates/rdf-wasm/js/pkg/purrdf_wasm_bg.wasm
 	@echo "OK: purrdf npm package built (crates/rdf-wasm/js/pkg/)"
 

--- a/crates/rdf-wasm/js/README.md
+++ b/crates/rdf-wasm/js/README.md
@@ -35,7 +35,7 @@ Runs in Node ≥ 18 and modern browsers (ESM, `web`-target wasm-bindgen).
 
 The wasm artifact is built with WebAssembly SIMD (`+simd128`) for higher parse
 throughput, so it requires a runtime with wasm SIMD support: every major browser
-since ~2021 (Chrome/Edge 91+, Firefox 89+, Safari 16.4+) and Node ≥ 16.
+since ~2021 (Chrome/Edge 91+, Firefox 89+, Safari 16.4+) and Node ≥ 18.
 
 ## Quickstart
 

--- a/crates/rdf-wasm/js/README.md
+++ b/crates/rdf-wasm/js/README.md
@@ -33,6 +33,10 @@ npm install @blackcatinformatics/purrdf
 
 Runs in Node ≥ 18 and modern browsers (ESM, `web`-target wasm-bindgen).
 
+The wasm artifact is built with WebAssembly SIMD (`+simd128`) for higher parse
+throughput, so it requires a runtime with wasm SIMD support: every major browser
+since ~2021 (Chrome/Edge 91+, Firefox 89+, Safari 16.4+) and Node ≥ 16.
+
 ## Quickstart
 
 ```js

--- a/crates/rdf-wasm/js/bench/parse.bench.mjs
+++ b/crates/rdf-wasm/js/bench/parse.bench.mjs
@@ -8,9 +8,12 @@
 // N-Triples corpus. Parsing is the primary beneficiary of WebAssembly SIMD:
 // the engine's byte scanning runs through `memchr`, whose wasm32 `simd128`
 // backend only activates when the module is built with the `+simd128` target
-// feature. This benchmark is how the SIMD build's win is measured and how a
-// future throughput regression is caught — wasm SIMD codegen only exists once
-// the module runs in V8, so a native criterion bench cannot see it.
+// feature. This benchmark is how the SIMD build's win is measured: it prints a
+// compact, greppable summary line you compare against a prior run to spot a
+// throughput regression. It is report-only — it asserts correctness (parsed
+// size) but never gates on throughput and stores no baseline, so a regression
+// is caught by reading the numbers, not automatically. wasm SIMD codegen only
+// exists once the module runs in V8, so a native criterion bench cannot see it.
 //
 // Usage:
 //   node bench/parse.bench.mjs

--- a/crates/rdf-wasm/js/bench/parse.bench.mjs
+++ b/crates/rdf-wasm/js/bench/parse.bench.mjs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Node-side parse throughput benchmark for the purrdf wasm engine.
+//
+// Report-only (never a gate). It drives the ACTUAL compiled wasm through the
+// public `Dataset.parse` surface over a large, deterministically generated
+// N-Triples corpus. Parsing is the primary beneficiary of WebAssembly SIMD:
+// the engine's byte scanning runs through `memchr`, whose wasm32 `simd128`
+// backend only activates when the module is built with the `+simd128` target
+// feature. This benchmark is how the SIMD build's win is measured and how a
+// future throughput regression is caught — wasm SIMD codegen only exists once
+// the module runs in V8, so a native criterion bench cannot see it.
+//
+// Usage:
+//   node bench/parse.bench.mjs
+// Tunables (env):
+//   BENCH_TRIPLES  number of triples in the corpus   (default 150000)
+//   BENCH_ITERS    timed iterations after warm-up     (default 7)
+//   BENCH_WARMUP   warm-up iterations (discarded)     (default 2)
+
+import { ready, Dataset } from "../index.mjs";
+
+await ready();
+
+const TRIPLES = Number(process.env.BENCH_TRIPLES ?? 150_000);
+const ITERS = Number(process.env.BENCH_ITERS ?? 7);
+const WARMUP = Number(process.env.BENCH_WARMUP ?? 2);
+
+// Deterministic corpus generation — no Math.random, no fixture files (nothing
+// under vectors/ is touched). The shape mixes IRI objects, plain string
+// literals, language-tagged literals, and integer-typed literals so the parser
+// exercises delimiter/newline scanning across varied line lengths.
+function buildCorpus(n) {
+  const S = "https://example.org/s/";
+  const P = "https://example.org/p/";
+  const O = "https://example.org/o/";
+  const XSD_INT = "http://www.w3.org/2001/XMLSchema#integer";
+  const parts = [];
+  for (let i = 0; i < n; i++) {
+    const s = `<${S}${i}>`;
+    const p = `<${P}${i % 32}>`;
+    switch (i % 4) {
+      case 0:
+        parts.push(`${s} ${p} <${O}${i}> .\n`);
+        break;
+      case 1:
+        parts.push(`${s} ${p} "literal value number ${i} with several words" .\n`);
+        break;
+      case 2:
+        parts.push(`${s} ${p} "language tagged value ${i}"@en .\n`);
+        break;
+      default:
+        parts.push(`${s} ${p} "${i}"^^<${XSD_INT}> .\n`);
+        break;
+    }
+  }
+  return parts.join("");
+}
+
+function median(xs) {
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = s.length >> 1;
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+const corpus = buildCorpus(TRIPLES);
+const bytes = Buffer.byteLength(corpus, "utf8");
+
+// Warm up (JIT + wasm instance warm caches); results discarded.
+for (let i = 0; i < WARMUP; i++) {
+  const ds = Dataset.parse(corpus, "ntriples");
+  if (ds.size !== TRIPLES) {
+    throw new Error(`corpus size mismatch: parsed ${ds.size}, expected ${TRIPLES}`);
+  }
+}
+
+const samples = [];
+for (let i = 0; i < ITERS; i++) {
+  const t0 = process.hrtime.bigint();
+  const ds = Dataset.parse(corpus, "ntriples");
+  const t1 = process.hrtime.bigint();
+  // Touch size so the parse cannot be optimized away.
+  if (ds.size !== TRIPLES) {
+    throw new Error(`corpus size mismatch: parsed ${ds.size}, expected ${TRIPLES}`);
+  }
+  samples.push(Number(t1 - t0) / 1e6); // ms
+}
+
+const med = median(samples);
+const min = Math.min(...samples);
+const mb = bytes / (1024 * 1024);
+const triplesPerSec = TRIPLES / (med / 1000);
+const mbPerSec = mb / (med / 1000);
+
+const fmt = (x, d = 2) => x.toFixed(d);
+// Compact, greppable summary line (grep 'BENCH parse').
+console.log(
+  `BENCH parse ntriples: triples=${TRIPLES} bytes=${bytes} ` +
+    `iters=${ITERS} median_ms=${fmt(med)} min_ms=${fmt(min)} ` +
+    `triples_per_s=${fmt(triplesPerSec, 0)} MB_per_s=${fmt(mbPerSec)}`,
+);


### PR DESCRIPTION
Closes #19

## Summary
Enable the WebAssembly `+simd128` platform target feature (`RUSTFLAGS`) plus `wasm-opt --enable-simd` for the npm `wasm-pkg` build, activating real SIMD in memchr's parser byte scan (and blake3's simd128 backend where supported). Adds a permanent Node-side parse benchmark and documents the raised browser baseline.

`+simd128` is a **platform target feature, not a Cargo feature** — it is compliant with the repo's no-Cargo-features rule. It is scoped to the `wasm-pkg` recipe only, so the plain `wasm32-unknown-unknown` build (`make wasm`) stays baseline and unaffected.

## Changes
- **Makefile `wasm-pkg`**: `RUSTFLAGS="-C target-feature=+simd128"` on the release build + `--enable-simd` on `wasm-opt`.
- **New `crates/rdf-wasm/js/bench/parse.bench.mjs` + `make wasm-pkg-bench`**: deterministic 150k-triple N-Triples corpus driven through `Dataset.parse` (report-only; the SIMD regression guard CLAUDE.md requires). Not added to `package.json` `files`, so it stays out of the published tarball.
- **release-npm workflow**: the binaryen step now asserts `wasm-opt --enable-simd` support (fail-fast; no silent scalar artifact). Flags remain single-sourced in the Makefile — the workflow only runs `make wasm-pkg`, so there is no drift.
- **README**: documents the wasm-SIMD browser baseline (major browsers since ~2021; Node ≥ 16).

## Benchmark (Node parse throughput, same machine, 150k-triple corpus, 7 iters)
| metric | baseline | +simd128 | delta |
|---|---|---|---|
| median_ms | 296.82 | 275.94 | −7.0% |
| min_ms | 271.02 | 249.09 | −8.1% |
| triples/s | 505,363 | 543,595 | +7.6% |
| MB/s | 48.17 | 51.82 | +7.6% |

## Verification
- `make check` green — proves the plain `wasm32-unknown-unknown` build is unaffected by the wasm-pkg-only flag.
- `make wasm-pkg-test` 30/30 green against the SIMD artifact.
- **Adversarial**: 12,619 SIMD-opcode-bearing lines in the optimized `purrdf_wasm_bg.wasm` (`wasm-opt --print | grep v128/i8x16/...`) — the flag genuinely took effect, not silently ignored.
- release workflow validated with `actionlint`.