### PR TITLE
perf(sparql-eval): deterministic parallel evaluation (UNION, joins, BGP, FILTER, aggregates)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,6 +1246,7 @@ dependencies = [
  "purrdf-sparql-algebra",
  "purrdf-sparql-results",
  "purrdf-xsd",
+ "rayon",
  "regex",
  "sha1",
  "sha2",

--- a/crates/sparql-conformance/src/lib.rs
+++ b/crates/sparql-conformance/src/lib.rs
@@ -129,7 +129,7 @@ fn verdict_of(case: &SparqlTestCase) -> Verdict {
     };
     let remote = remote
         .as_ref()
-        .map(|s| s as &dyn purrdf_sparql_eval::RemoteQuerySource);
+        .map(|s| s as &(dyn purrdf_sparql_eval::RemoteQuerySource + Sync));
     match run::run(case, remote) {
         Ok(outcome) => match compare::compare(case, &outcome) {
             Ok(()) => Verdict::Pass,

--- a/crates/sparql-conformance/src/run.rs
+++ b/crates/sparql-conformance/src/run.rs
@@ -104,7 +104,7 @@ pub fn load_dataset(case: &SparqlTestCase) -> Result<Arc<RdfDataset>, String> {
 /// whether that is an expected failure).
 pub fn run(
     case: &SparqlTestCase,
-    remote: Option<&dyn RemoteQuerySource>,
+    remote: Option<&(dyn RemoteQuerySource + Sync)>,
 ) -> Result<RunOutcome, String> {
     let query_text = std::fs::read_to_string(&case.query)
         .map_err(|e| format!("read query {}: {e}", case.query.display()))?;

--- a/crates/sparql-eval/Cargo.toml
+++ b/crates/sparql-eval/Cargo.toml
@@ -51,6 +51,11 @@ sha2 = { workspace = true }
 # SPARQL Results reader for decoding remote SERVICE responses. Wasm-clean
 # (hand-rolled, no serde). No oxigraph-family edge.
 purrdf-sparql-results = { workspace = true }
+# Deterministic two-phase parallel evaluation primitives (`parallel` module):
+# fork-join per BGP/group row batch, reduced back in source order. Unconditional —
+# rayon compiles cleanly on wasm32-unknown-unknown and degrades to inline-sequential
+# execution there (same pattern as purrdf-rdf's chunk-parallel text parse).
+rayon = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # OS entropy for the RAND()/UUID()/STRUUID() seed on native targets. Target-gated

--- a/crates/sparql-eval/src/bgp.rs
+++ b/crates/sparql-eval/src/bgp.rs
@@ -150,11 +150,10 @@ pub(crate) fn eval_bgp(
             )),
             GraphScope::Merge(_) => None,
         };
-        let next = crate::parallel::par_flat_map(&rows, |_, row| {
+        let next = crate::parallel::par_chunk_map(&rows, |acc, row| {
             let s = query_id(&cp.s, row);
             let p = query_id(&cp.p, row);
             let o = query_id(&cp.o, row);
-            let mut out = Vec::new();
             match &scope {
                 // Single-graph scope (store default / a named graph): the indexed
                 // partition_point read, unchanged — no de-dup overhead.
@@ -162,7 +161,7 @@ pub(crate) fn eval_bgp(
                     let plan = plan.expect("plan computed above for GraphScope::One");
                     for quad in ctx.dataset.quads_for_pattern_with_plan(&plan, s, p, o, *gm) {
                         if let Some(extended) = bind_row(row, cp, &quad, ctx.dataset) {
-                            out.push(extended);
+                            acc.push(extended);
                         }
                     }
                     // The RDF 1.2 reification layer is a dataset-level (default-graph)
@@ -173,7 +172,7 @@ pub(crate) fn eval_bgp(
                     if gm.matches(None) {
                         emit_virtual_candidates(ctx.dataset, cp, s, p, o, reifies_id, |quad| {
                             if let Some(extended) = bind_row(row, cp, &quad, ctx.dataset) {
-                                out.push(extended);
+                                acc.push(extended);
                             }
                         });
                     }
@@ -193,13 +192,12 @@ pub(crate) fn eval_bgp(
                                 continue;
                             }
                             if let Some(extended) = bind_row(row, cp, &quad, ctx.dataset) {
-                                out.push(extended);
+                                acc.push(extended);
                             }
                         }
                     }
                 }
             }
-            out
         });
         rows = next;
         if rows.is_empty() {

--- a/crates/sparql-eval/src/bgp.rs
+++ b/crates/sparql-eval/src/bgp.rs
@@ -221,7 +221,7 @@ fn plan_or_cached_order(
         return Arc::from(cost_based_order(compiled, dataset, scope));
     };
     let key = (dataset.stats_fingerprint(), bgp_shape_key(compiled, scope));
-    if let Some(order) = cache.borrow().get(&key) {
+    if let Some(order) = cache.read().expect("order cache lock poisoned").get(&key) {
         // A shape-key collision is NOT licensed by the stats-fingerprint safety
         // argument: a wrong-length order would index out of bounds in the join loop.
         // Guard it — on a length mismatch fall through and re-plan.
@@ -230,7 +230,10 @@ fn plan_or_cached_order(
         }
     }
     let order: Arc<[usize]> = Arc::from(cost_based_order(compiled, dataset, scope));
-    cache.borrow_mut().insert(key, Arc::clone(&order));
+    cache
+        .write()
+        .expect("order cache lock poisoned")
+        .insert(key, Arc::clone(&order));
     order
 }
 

--- a/crates/sparql-eval/src/bgp.rs
+++ b/crates/sparql-eval/src/bgp.rs
@@ -41,7 +41,6 @@ use crate::eval::{BgpOrderCache, EvalCtx};
 use crate::scratch::SolutionTerm;
 use crate::solution::{Solution, SolutionSeq, VarSchema};
 use crate::DetHashSet;
-use std::rc::Rc;
 use std::sync::Arc;
 
 /// The `rdf:reifies` predicate IRI — the indirection edge of the RDF 1.2 reification
@@ -951,7 +950,7 @@ fn object_can_be_triple_term(pos: &Pos, dataset: &RdfDataset) -> bool {
 /// An empty solution sequence over only the real (non-blank) variables of `working`.
 fn empty_over_real_vars(working: &VarSchema) -> SolutionSeq {
     let real = real_var_schema(working);
-    SolutionSeq::empty(Rc::new(real))
+    SolutionSeq::empty(Arc::new(real))
 }
 
 /// The schema of `working` restricted to its real variables, in order.
@@ -974,12 +973,12 @@ fn project_out_blanks(working: &VarSchema, rows: Vec<Solution>) -> SolutionSeq {
     // Fast path: no blank columns — reuse rows as-is.
     if keep.len() == working.len() {
         return SolutionSeq {
-            schema: Rc::new(real_var_schema(working)),
+            schema: Arc::new(real_var_schema(working)),
             rows,
         };
     }
 
-    let schema = Rc::new(real_var_schema(working));
+    let schema = Arc::new(real_var_schema(working));
     let projected = rows
         .into_iter()
         .map(|row| keep.iter().map(|&i| row[i]).collect())
@@ -997,7 +996,6 @@ mod tests {
     use pretty_assertions::assert_eq;
     use purrdf_core::{RdfDatasetBuilder, RdfLiteral, TermValue};
     use purrdf_sparql_algebra::{Literal, NamedNode};
-    use std::sync::Arc;
 
     /// A small graph:
     ///   :alice :knows :bob ; :name "Alice" .

--- a/crates/sparql-eval/src/bgp.rs
+++ b/crates/sparql-eval/src/bgp.rs
@@ -135,26 +135,34 @@ pub(crate) fn eval_bgp(
     let mut rows: Vec<Solution> = vec![vec![None; working.len()]];
     for &i in order.iter() {
         let cp = &compiled[i];
-        let mut next = Vec::new();
         // The probe's bound-axis shape is fixed across this slot's rows (a variable is
         // bound by an earlier pattern for every row or for none), so the permutation
-        // choice is loop-invariant: compute the `QuadProbePlan` once (on the first
-        // single-graph probe) and reuse it, instead of re-selecting per row.
-        let mut probe_plan: Option<QuadProbePlan> = None;
-        for row in &rows {
+        // choice is loop-invariant: for a single-graph scope, compute the
+        // `QuadProbePlan` once from the first row (non-empty — the loop `break`s above
+        // the moment `rows` empties) and capture the `Copy` plan in every worker,
+        // instead of re-selecting it per row.
+        let plan: Option<QuadProbePlan> = match &scope {
+            GraphScope::One(gm) => Some(RdfDataset::probe_plan(
+                query_id(&cp.s, &rows[0]).is_some(),
+                query_id(&cp.p, &rows[0]).is_some(),
+                query_id(&cp.o, &rows[0]).is_some(),
+                *gm,
+            )),
+            GraphScope::Merge(_) => None,
+        };
+        let next = crate::parallel::par_flat_map(&rows, |_, row| {
             let s = query_id(&cp.s, row);
             let p = query_id(&cp.p, row);
             let o = query_id(&cp.o, row);
+            let mut out = Vec::new();
             match &scope {
                 // Single-graph scope (store default / a named graph): the indexed
                 // partition_point read, unchanged — no de-dup overhead.
                 GraphScope::One(gm) => {
-                    let plan = *probe_plan.get_or_insert_with(|| {
-                        RdfDataset::probe_plan(s.is_some(), p.is_some(), o.is_some(), *gm)
-                    });
+                    let plan = plan.expect("plan computed above for GraphScope::One");
                     for quad in ctx.dataset.quads_for_pattern_with_plan(&plan, s, p, o, *gm) {
                         if let Some(extended) = bind_row(row, cp, &quad, ctx.dataset) {
-                            next.push(extended);
+                            out.push(extended);
                         }
                     }
                     // The RDF 1.2 reification layer is a dataset-level (default-graph)
@@ -165,7 +173,7 @@ pub(crate) fn eval_bgp(
                     if gm.matches(None) {
                         emit_virtual_candidates(ctx.dataset, cp, s, p, o, reifies_id, |quad| {
                             if let Some(extended) = bind_row(row, cp, &quad, ctx.dataset) {
-                                next.push(extended);
+                                out.push(extended);
                             }
                         });
                     }
@@ -174,7 +182,9 @@ pub(crate) fn eval_bgp(
                 // RDF-merge unions *triples*, so a triple present in two merged graphs
                 // must bind once — de-dupe by (s, p, o) for this pattern+row. The
                 // reification layer is store-default content (not part of an explicitly
-                // FROM-named merge), so it is not folded into a merged scope.
+                // FROM-named merge), so it is not folded into a merged scope. `seen` is
+                // local to this row's worker (each row gets its own), identical to the
+                // sequential path.
                 GraphScope::Merge(gs) => {
                     let mut seen: DetHashSet<(TermId, TermId, TermId)> = DetHashSet::default();
                     for &g in gs {
@@ -183,13 +193,14 @@ pub(crate) fn eval_bgp(
                                 continue;
                             }
                             if let Some(extended) = bind_row(row, cp, &quad, ctx.dataset) {
-                                next.push(extended);
+                                out.push(extended);
                             }
                         }
                     }
                 }
             }
-        }
+            out
+        });
         rows = next;
         if rows.is_empty() {
             break;

--- a/crates/sparql-eval/src/binop.rs
+++ b/crates/sparql-eval/src/binop.rs
@@ -168,10 +168,15 @@ fn hash_join(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
     // Build side = right (split into key-indexed + wild rows).
     let (keyed, wild) = build_index(r, &shared);
 
-    // Probe-side cardinality is a cheap, usually-tight lower-bound estimate for
-    // the output (the common star join is ~1:1), avoiding most growth reallocs.
-    let mut rows = Vec::with_capacity(l.rows.len());
-    for lrow in &l.rows {
+    // Each left row's worker returns its merged matches in the same order as the
+    // sequential path (keyed-bucket matches in `idxs` order, then wild matches; or,
+    // for the unbound-shared-column case, the compatibility scan over `r.rows` in
+    // order); flattening across rows in index order reproduces the exact sequential
+    // row sequence. Captures only read-only borrows: `keyed`/`wild`/`r.rows` (the
+    // prebuilt index), `right_to_out`/`shared` (pure layout), `left_len`/`out_len`
+    // (`Copy`), and `merge`/`compatible` (pure fns).
+    let rows = crate::parallel::par_flat_map(&l.rows, |_, lrow| {
+        let mut out_rows = Vec::new();
         match bound_key(lrow, &shared, KeySide::Left) {
             // Probe is fully bound on shared columns: hit the matching bucket
             // (exact key ⇒ compatible) plus any wild build rows it is compatible
@@ -179,12 +184,12 @@ fn hash_join(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
             Some(key) => {
                 if let Some(idxs) = keyed.get(&key) {
                     for &idx in idxs {
-                        rows.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
+                        out_rows.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
                     }
                 }
                 for &idx in &wild {
                     if compatible(lrow, &r.rows[idx], &shared) {
-                        rows.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
+                        out_rows.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
                     }
                 }
             }
@@ -193,12 +198,13 @@ fn hash_join(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
             None => {
                 for rrow in &r.rows {
                     if compatible(lrow, rrow, &shared) {
-                        rows.push(merge(lrow, rrow, left_len, &right_to_out, out_len));
+                        out_rows.push(merge(lrow, rrow, left_len, &right_to_out, out_len));
                     }
                 }
             }
         }
-    }
+        out_rows
+    });
 
     SolutionSeq {
         schema: Arc::new(out),
@@ -331,39 +337,43 @@ fn left_outer_join(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
 
     let (keyed, wild) = build_index(r, &shared);
 
-    // A left outer join emits at least one row per left row.
-    let mut rows = Vec::with_capacity(l.rows.len());
-    for lrow in &l.rows {
-        let before = rows.len();
+    // A left outer join emits at least one row per left row. Each worker returns the
+    // matched merges (keyed then wild, same order as the sequential path) or, when
+    // none match, the single padded left-alone row — reproducing the existing "emit
+    // alone iff no match" per-row semantics inside the worker so flattening in index
+    // order is byte-identical to the sequential path.
+    let rows = crate::parallel::par_flat_map(&l.rows, |_, lrow| {
+        let mut out_rows = Vec::new();
         match bound_key(lrow, &shared, KeySide::Left) {
             Some(key) => {
                 if let Some(idxs) = keyed.get(&key) {
                     for &idx in idxs {
-                        rows.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
+                        out_rows.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
                     }
                 }
                 for &idx in &wild {
                     if compatible(lrow, &r.rows[idx], &shared) {
-                        rows.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
+                        out_rows.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
                     }
                 }
             }
             None => {
                 for rrow in &r.rows {
                     if compatible(lrow, rrow, &shared) {
-                        rows.push(merge(lrow, rrow, left_len, &right_to_out, out_len));
+                        out_rows.push(merge(lrow, rrow, left_len, &right_to_out, out_len));
                     }
                 }
             }
         }
         // No compatible right solution → keep the left solution alone (the OPTIONAL
         // contributed nothing, its variables stay unbound).
-        if rows.len() == before {
+        if out_rows.is_empty() {
             let mut row = vec![None; out_len];
             row[..left_len].copy_from_slice(lrow);
-            rows.push(row);
+            out_rows.push(row);
         }
-    }
+        out_rows
+    });
 
     SolutionSeq {
         schema: Arc::new(out),
@@ -387,20 +397,15 @@ pub(crate) fn eval_minus(
     let r = eval(right, ctx)?;
     let shared = l.schema.shared_columns(&r.schema);
 
-    let rows = l
-        .rows
-        .iter()
-        .filter(|lrow| {
-            // Keep the left row unless some right row removes it.
-            !r.rows.iter().any(|rrow| {
-                compatible(lrow, rrow, &shared)
-                    && shared
-                        .iter()
-                        .any(|&(la, ra)| lrow[la].is_some() && rrow[ra].is_some())
-            })
+    let rows = crate::parallel::par_retain(&l.rows, |lrow| {
+        // Keep the left row unless some right row removes it.
+        !r.rows.iter().any(|rrow| {
+            compatible(lrow, rrow, &shared)
+                && shared
+                    .iter()
+                    .any(|&(la, ra)| lrow[la].is_some() && rrow[ra].is_some())
         })
-        .cloned()
-        .collect();
+    });
 
     Ok(SolutionSeq {
         schema: l.schema,

--- a/crates/sparql-eval/src/binop.rs
+++ b/crates/sparql-eval/src/binop.rs
@@ -16,7 +16,7 @@
 //! a compatibility scan over all build rows. The common case — two fully-bound BGPs
 //! — stays an O(n+m) hash join.
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use purrdf_sparql_algebra::{Expression, GraphPattern};
 
@@ -83,7 +83,7 @@ pub(crate) fn eval_union(
     }
 
     Ok(SolutionSeq {
-        schema: Rc::new(out),
+        schema: Arc::new(out),
         rows,
     })
 }
@@ -201,7 +201,7 @@ fn hash_join(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
     }
 
     SolutionSeq {
-        schema: Rc::new(out),
+        schema: Arc::new(out),
         rows,
     }
 }
@@ -291,7 +291,7 @@ fn left_outer_join_filtered(
     expr: &Expression,
     ctx: &mut EvalCtx<'_>,
 ) -> Result<SolutionSeq, EvalError> {
-    let out = Rc::new(l.schema.union(&r.schema));
+    let out = Arc::new(l.schema.union(&r.schema));
     let out_len = out.len();
     let left_len = l.schema.len();
     let right_to_out = right_to_out_map(&r.schema, &out);
@@ -366,7 +366,7 @@ fn left_outer_join(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
     }
 
     SolutionSeq {
-        schema: Rc::new(out),
+        schema: Arc::new(out),
         rows,
     }
 }
@@ -417,7 +417,6 @@ mod tests {
     use purrdf_sparql_algebra::{
         NamedNode, NamedNodePattern, TermPattern, TriplePattern, Variable,
     };
-    use std::sync::Arc;
 
     fn graph() -> Arc<RdfDataset> {
         // :a :knows :b ; :likes :cake .
@@ -628,7 +627,7 @@ mod tests {
 
         // Inner over schema [x]: x=1, x=2, and one wild row (x unbound).
         let inner = SolutionSeq {
-            schema: Rc::new(VarSchema::from_vars([Variable::new("x")])),
+            schema: Arc::new(VarSchema::from_vars([Variable::new("x")])),
             rows: vec![vec![t(1)], vec![t(2)], vec![None]],
         };
         // Probe layout is the FULL outer schema [x, y]; shared = {x} → [(0, 0)].
@@ -665,7 +664,7 @@ mod tests {
 
         // Same shape but NO wild inner row, so a keyed miss is a true non-match.
         let inner2 = SolutionSeq {
-            schema: Rc::new(VarSchema::from_vars([Variable::new("x")])),
+            schema: Arc::new(VarSchema::from_vars([Variable::new("x")])),
             rows: vec![vec![t(1)], vec![t(2)]],
         };
         let (keyed2, wild2) = build_index(&inner2, &shared);
@@ -683,7 +682,7 @@ mod tests {
             &inner2.rows
         ));
         let empty = SolutionSeq {
-            schema: Rc::new(VarSchema::from_vars([Variable::new("x")])),
+            schema: Arc::new(VarSchema::from_vars([Variable::new("x")])),
             rows: vec![],
         };
         let (ek, ew) = build_index(&empty, &shared);

--- a/crates/sparql-eval/src/binop.rs
+++ b/crates/sparql-eval/src/binop.rs
@@ -87,39 +87,42 @@ pub(crate) fn eval_union(
     let ctx_ref: &EvalCtx<'_> = ctx;
 
     // Each closure forks its own child, evaluates its branch on it, and
-    // materializes every result row to a portable form while the child (and its
-    // scratch) is still alive — the child does not survive past this closure.
+    // classifies every result row (see [`crate::parallel::minted_row`]): a row
+    // the child minted nothing new into (the common case for a UNION-over-BGP
+    // branch) is kept as-is with zero extra allocation, and only a row
+    // carrying a genuinely fresh cell pays for the portable-materialize round
+    // trip. The child (and its scratch) does not survive past this closure.
     let eval_branch = |pattern: &GraphPattern| -> Result<PortableBranch, EvalError> {
         let mut child = ctx_ref.fork_for_worker();
         let seq = eval(pattern, &mut child)?;
-        let prows: Vec<_> = seq
+        let minted: Vec<_> = seq
             .rows
-            .iter()
-            .map(|row| crate::parallel::portable_row(&child.scratch, base, row))
+            .into_iter()
+            .map(|row| crate::parallel::minted_row(&child.scratch, base, row))
             .collect();
-        Ok((seq.schema, prows))
+        Ok((seq.schema, minted))
     };
 
     let (left_result, right_result) = rayon::join(|| eval_branch(left), || eval_branch(right));
-    let (l_schema, l_prows) = left_result?;
-    let (r_schema, r_prows) = right_result?;
+    let (l_schema, l_minted) = left_result?;
+    let (r_schema, r_minted) = right_result?;
 
     let out = l_schema.union(&r_schema);
     let out_len = out.len();
     let left_len = l_schema.len();
     let right_to_out = right_to_out_map(&r_schema, &out);
 
-    let mut rows = Vec::with_capacity(l_prows.len() + r_prows.len());
-    for prow in &l_prows {
+    let mut rows = Vec::with_capacity(l_minted.len() + r_minted.len());
+    for minted in l_minted {
         let mut row = vec![None; out_len];
         let reinterned =
-            crate::parallel::reintern_portable_row(&mut ctx.scratch, ctx.dataset, prow);
+            crate::parallel::reintern_minted_row(&mut ctx.scratch, ctx.dataset, minted);
         row[..left_len].copy_from_slice(&reinterned);
         rows.push(row);
     }
-    for prow in &r_prows {
+    for minted in r_minted {
         let reinterned =
-            crate::parallel::reintern_portable_row(&mut ctx.scratch, ctx.dataset, prow);
+            crate::parallel::reintern_minted_row(&mut ctx.scratch, ctx.dataset, minted);
         let mut row = vec![None; out_len];
         for (j, &cell) in reinterned.iter().enumerate() {
             row[right_to_out[j]] = cell;
@@ -164,14 +167,11 @@ fn concat_union(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
     }
 }
 
-/// One `UNION` branch's forked-child result, materialized to a portable form:
-/// its output schema plus every result row re-expressed as portable cells (see
-/// [`crate::parallel::portable_row`]) so it survives the branch's forked child
-/// being dropped.
-type PortableBranch = (
-    Arc<VarSchema>,
-    Vec<Vec<Option<crate::parallel::PortableTerm>>>,
-);
+/// One `UNION` branch's forked-child result: its output schema plus every
+/// result row classified via [`crate::parallel::minted_row`] — `Direct` (no
+/// remap needed) or `Portable` (materialized while the branch's forked child
+/// is still alive) — so it survives that child being dropped.
+type PortableBranch = (Arc<VarSchema>, Vec<crate::parallel::MintedRow>);
 
 /// The mapping from a right operand's column ordinal to its ordinal in `out`.
 fn right_to_out_map(right: &VarSchema, out: &VarSchema) -> Vec<usize> {
@@ -260,8 +260,7 @@ fn hash_join(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
     // row sequence. Captures only read-only borrows: `keyed`/`wild`/`r.rows` (the
     // prebuilt index), `right_to_out`/`shared` (pure layout), `left_len`/`out_len`
     // (`Copy`), and `merge`/`compatible` (pure fns).
-    let rows = crate::parallel::par_flat_map(&l.rows, |_, lrow| {
-        let mut out_rows = Vec::new();
+    let rows = crate::parallel::par_chunk_map(&l.rows, |acc, lrow| {
         match bound_key(lrow, &shared, KeySide::Left) {
             // Probe is fully bound on shared columns: hit the matching bucket
             // (exact key ⇒ compatible) plus any wild build rows it is compatible
@@ -269,12 +268,12 @@ fn hash_join(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
             Some(key) => {
                 if let Some(idxs) = keyed.get(&key) {
                     for &idx in idxs {
-                        out_rows.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
+                        acc.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
                     }
                 }
                 for &idx in &wild {
                     if compatible(lrow, &r.rows[idx], &shared) {
-                        out_rows.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
+                        acc.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
                     }
                 }
             }
@@ -283,12 +282,11 @@ fn hash_join(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
             None => {
                 for rrow in &r.rows {
                     if compatible(lrow, rrow, &shared) {
-                        out_rows.push(merge(lrow, rrow, left_len, &right_to_out, out_len));
+                        acc.push(merge(lrow, rrow, left_len, &right_to_out, out_len));
                     }
                 }
             }
         }
-        out_rows
     });
 
     SolutionSeq {
@@ -399,26 +397,26 @@ fn left_outer_join_filtered(
 
     // A left outer join emits at least one row per left row.
     let rows = if crate::parallel::is_parallel_safe(expr) {
-        crate::parallel::par_try_flat_map_init(
+        crate::parallel::par_chunk_try_map_init(
             &l.rows,
             || ctx.fork_for_worker(),
-            |child, _, lrow| {
-                let mut out_rows = Vec::new();
+            |child, acc, lrow| {
+                let before = acc.len();
                 for rrow in &r.rows {
                     if !compatible(lrow, rrow, &shared) {
                         continue;
                     }
                     let merged = merge(lrow, rrow, left_len, &right_to_out, out_len);
                     if crate::expr::eval_ebv(expr, &merged, &out, child)? == Some(true) {
-                        out_rows.push(merged);
+                        acc.push(merged);
                     }
                 }
-                if out_rows.is_empty() {
+                if acc.len() == before {
                     let mut row = vec![None; out_len];
                     row[..left_len].copy_from_slice(lrow);
-                    out_rows.push(row);
+                    acc.push(row);
                 }
-                Ok(out_rows)
+                Ok(())
             },
         )?
     } else {
@@ -462,37 +460,36 @@ fn left_outer_join(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
     // none match, the single padded left-alone row — reproducing the existing "emit
     // alone iff no match" per-row semantics inside the worker so flattening in index
     // order is byte-identical to the sequential path.
-    let rows = crate::parallel::par_flat_map(&l.rows, |_, lrow| {
-        let mut out_rows = Vec::new();
+    let rows = crate::parallel::par_chunk_map(&l.rows, |acc, lrow| {
+        let before = acc.len();
         match bound_key(lrow, &shared, KeySide::Left) {
             Some(key) => {
                 if let Some(idxs) = keyed.get(&key) {
                     for &idx in idxs {
-                        out_rows.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
+                        acc.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
                     }
                 }
                 for &idx in &wild {
                     if compatible(lrow, &r.rows[idx], &shared) {
-                        out_rows.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
+                        acc.push(merge(lrow, &r.rows[idx], left_len, &right_to_out, out_len));
                     }
                 }
             }
             None => {
                 for rrow in &r.rows {
                     if compatible(lrow, rrow, &shared) {
-                        out_rows.push(merge(lrow, rrow, left_len, &right_to_out, out_len));
+                        acc.push(merge(lrow, rrow, left_len, &right_to_out, out_len));
                     }
                 }
             }
         }
         // No compatible right solution → keep the left solution alone (the OPTIONAL
         // contributed nothing, its variables stay unbound).
-        if out_rows.is_empty() {
+        if acc.len() == before {
             let mut row = vec![None; out_len];
             row[..left_len].copy_from_slice(lrow);
-            out_rows.push(row);
+            acc.push(row);
         }
-        out_rows
     });
 
     SolutionSeq {

--- a/crates/sparql-eval/src/binop.rs
+++ b/crates/sparql-eval/src/binop.rs
@@ -54,14 +54,90 @@ pub(crate) fn eval_join(
 }
 
 /// Evaluate `left UNION right` as a multiset concatenation over the union schema.
+///
+/// Gated on [`crate::parallel::is_parallel_safe_pattern`] over **both** branches:
+/// if either reaches an unsafe (counter/RNG-mutating) builtin, the sequential
+/// body below runs, evaluating both branches directly against the real `ctx`
+/// exactly as before this task. Otherwise both branches mint new `Computed`
+/// terms that must escape into the union's output rows, so they are evaluated
+/// concurrently (`rayon::join`) against their own forked child context, and each
+/// branch's escaping rows are captured via [`crate::parallel::portable_row`]
+/// **while its child is still alive** (the child is dropped the instant its
+/// closure returns). Only once both branches are done does the MAIN thread
+/// re-intern them back into `ctx.scratch`, left branch first then right, via
+/// [`crate::parallel::reintern_portable_row`] — reproducing the sequential
+/// concat's exact row order (left rows, then right rows) and column layout.
 pub(crate) fn eval_union(
     left: &GraphPattern,
     right: &GraphPattern,
     ctx: &mut EvalCtx<'_>,
 ) -> Result<SolutionSeq, EvalError> {
-    let l = eval(left, ctx)?;
-    let r = eval(right, ctx)?;
+    if !crate::parallel::is_parallel_safe_pattern(left)
+        || !crate::parallel::is_parallel_safe_pattern(right)
+    {
+        let l = eval(left, ctx)?;
+        let r = eval(right, ctx)?;
+        return Ok(concat_union(&l, &r));
+    }
 
+    let base = ctx.scratch.computed_count();
+    // A shared (immutable) borrow of `ctx`: both closures below only need
+    // `fork_for_worker`'s `&self` access, so they run concurrently over the same
+    // `&EvalCtx` — `EvalCtx: Sync` (see its definition) makes this sound.
+    let ctx_ref: &EvalCtx<'_> = ctx;
+
+    // Each closure forks its own child, evaluates its branch on it, and
+    // materializes every result row to a portable form while the child (and its
+    // scratch) is still alive — the child does not survive past this closure.
+    let eval_branch = |pattern: &GraphPattern| -> Result<PortableBranch, EvalError> {
+        let mut child = ctx_ref.fork_for_worker();
+        let seq = eval(pattern, &mut child)?;
+        let prows: Vec<_> = seq
+            .rows
+            .iter()
+            .map(|row| crate::parallel::portable_row(&child.scratch, base, row))
+            .collect();
+        Ok((seq.schema, prows))
+    };
+
+    let (left_result, right_result) = rayon::join(|| eval_branch(left), || eval_branch(right));
+    let (l_schema, l_prows) = left_result?;
+    let (r_schema, r_prows) = right_result?;
+
+    let out = l_schema.union(&r_schema);
+    let out_len = out.len();
+    let left_len = l_schema.len();
+    let right_to_out = right_to_out_map(&r_schema, &out);
+
+    let mut rows = Vec::with_capacity(l_prows.len() + r_prows.len());
+    for prow in &l_prows {
+        let mut row = vec![None; out_len];
+        let reinterned =
+            crate::parallel::reintern_portable_row(&mut ctx.scratch, ctx.dataset, prow);
+        row[..left_len].copy_from_slice(&reinterned);
+        rows.push(row);
+    }
+    for prow in &r_prows {
+        let reinterned =
+            crate::parallel::reintern_portable_row(&mut ctx.scratch, ctx.dataset, prow);
+        let mut row = vec![None; out_len];
+        for (j, &cell) in reinterned.iter().enumerate() {
+            row[right_to_out[j]] = cell;
+        }
+        rows.push(row);
+    }
+
+    Ok(SolutionSeq {
+        schema: Arc::new(out),
+        rows,
+    })
+}
+
+/// The sequential `UNION` body: concatenate `l` then `r` over the ordered
+/// union schema (left columns first). Shared by both the sequential fallback
+/// and (conceptually) documents the exact row shape the parallel path in
+/// [`eval_union`] must reproduce.
+fn concat_union(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
     let out = l.schema.union(&r.schema);
     let out_len = out.len();
     let left_len = l.schema.len();
@@ -82,11 +158,20 @@ pub(crate) fn eval_union(
         rows.push(row);
     }
 
-    Ok(SolutionSeq {
+    SolutionSeq {
         schema: Arc::new(out),
         rows,
-    })
+    }
 }
+
+/// One `UNION` branch's forked-child result, materialized to a portable form:
+/// its output schema plus every result row re-expressed as portable cells (see
+/// [`crate::parallel::portable_row`]) so it survives the branch's forked child
+/// being dropped.
+type PortableBranch = (
+    Arc<VarSchema>,
+    Vec<Vec<Option<crate::parallel::PortableTerm>>>,
+);
 
 /// The mapping from a right operand's column ordinal to its ordinal in `out`.
 fn right_to_out_map(right: &VarSchema, out: &VarSchema) -> Vec<usize> {
@@ -453,7 +538,7 @@ mod tests {
     use super::*;
     use crate::eval::EvalCtx;
     use pretty_assertions::assert_eq;
-    use purrdf_core::{RdfDataset, RdfDatasetBuilder};
+    use purrdf_core::{RdfDataset, RdfDatasetBuilder, TermValue};
     use purrdf_sparql_algebra::{
         NamedNode, NamedNodePattern, TermPattern, TriplePattern, Variable,
     };
@@ -503,7 +588,7 @@ mod tests {
                 cols.iter()
                     .map(|&c| {
                         row[c].map(|t| match scratch.value_of(ds, t) {
-                            purrdf_core::TermValue::Iri(s) => s,
+                            TermValue::Iri(s) => s,
                             other => format!("{other:?}"),
                         })
                     })
@@ -745,5 +830,143 @@ mod tests {
         let right = bgp(vp("x"), pred("http://ex/knows"), vp("y")); // 1 row
         let seq = eval_minus(&left, &right, &mut ctx).expect("minus");
         assert_eq!(seq.len(), 2);
+    }
+
+    /// Determinism smoke test (Task 6): a 3-branch `UNION` (the `d_union_4` bench
+    /// shape) where each branch `BIND`s a freshly-computed value — two branches
+    /// minting the SAME value (`11`), one minting a DISJOINT value (`12`) — so the
+    /// escaping-computed-term merge in [`eval_union`] is exercised both ways.
+    /// Evaluated once with the parallel `UNION` path FORCED and once with the
+    /// sequential path FORCED, the two must produce byte-identical rows (schema
+    /// and row order, left-branch rows then right-branch rows, nested left-to-right).
+    #[test]
+    fn union_three_branches_with_overlapping_and_disjoint_binds_agree() {
+        use purrdf_sparql_algebra::Variable;
+
+        let mut b = RdfDatasetBuilder::new();
+        let p1 = b.intern_iri("http://ex/p1");
+        let p2 = b.intern_iri("http://ex/p2");
+        let p3 = b.intern_iri("http://ex/p3");
+        let a = b.intern_iri("http://ex/a");
+        let bb = b.intern_iri("http://ex/b");
+        let c = b.intern_iri("http://ex/c");
+        const XINT: &str = "http://www.w3.org/2001/XMLSchema#integer";
+        let ten = b.intern_literal(purrdf_core::RdfLiteral {
+            lexical_form: "10".to_owned(),
+            datatype: Some(XINT.to_owned()),
+            language: None,
+            direction: None,
+        });
+        let twenty = b.intern_literal(purrdf_core::RdfLiteral {
+            lexical_form: "20".to_owned(),
+            datatype: Some(XINT.to_owned()),
+            language: None,
+            direction: None,
+        });
+        b.push_quad(a, p1, ten, None);
+        b.push_quad(bb, p2, twenty, None);
+        b.push_quad(c, p3, ten, None);
+        let ds = b.freeze().expect("freeze");
+
+        let one = || {
+            Expression::Literal(purrdf_sparql_algebra::Literal::new_typed(
+                "1",
+                NamedNode::new_unchecked(XINT),
+            ))
+        };
+        let nine = || {
+            Expression::Literal(purrdf_sparql_algebra::Literal::new_typed(
+                "9",
+                NamedNode::new_unchecked(XINT),
+            ))
+        };
+        let two = || {
+            Expression::Literal(purrdf_sparql_algebra::Literal::new_typed(
+                "2",
+                NamedNode::new_unchecked(XINT),
+            ))
+        };
+
+        // branch1: {?s :p1 ?o} BIND(?o + 1 AS ?sum)  -> s=a, o=10, sum=11
+        let branch1 = GraphPattern::Extend {
+            inner: Box::new(bgp(vp("s"), pred("http://ex/p1"), vp("o"))),
+            variable: Variable::new("sum"),
+            expression: Expression::Add(
+                Box::new(Expression::Variable(Variable::new("o"))),
+                Box::new(one()),
+            ),
+        };
+        // branch2: {?s :p2 ?o} BIND(?o - 9 AS ?sum)  -> s=b, o=20, sum=11 (SAME as branch1)
+        let branch2 = GraphPattern::Extend {
+            inner: Box::new(bgp(vp("s"), pred("http://ex/p2"), vp("o"))),
+            variable: Variable::new("sum"),
+            expression: Expression::Subtract(
+                Box::new(Expression::Variable(Variable::new("o"))),
+                Box::new(nine()),
+            ),
+        };
+        // branch3: {?s :p3 ?o} BIND(?o + 2 AS ?sum)  -> s=c, o=10, sum=12 (DISJOINT)
+        let branch3 = GraphPattern::Extend {
+            inner: Box::new(bgp(vp("s"), pred("http://ex/p3"), vp("o"))),
+            variable: Variable::new("sum"),
+            expression: Expression::Add(
+                Box::new(Expression::Variable(Variable::new("o"))),
+                Box::new(two()),
+            ),
+        };
+
+        let pattern = GraphPattern::Union {
+            left: Box::new(GraphPattern::Union {
+                left: Box::new(branch1),
+                right: Box::new(branch2),
+            }),
+            right: Box::new(branch3),
+        };
+
+        let run = |forced: bool| {
+            let _guard = crate::parallel::force_parallel_for_test(forced);
+            let mut ctx = EvalCtx::new(&ds);
+            let seq = eval(&pattern, &mut ctx).expect("eval");
+            let schema = seq.schema.vars().to_vec();
+            let s_col = seq.schema.index_of(&Variable::new("s")).unwrap();
+            let sum_col = seq.schema.index_of(&Variable::new("sum")).unwrap();
+            let resolved: Vec<(TermValue, TermValue)> = seq
+                .rows
+                .iter()
+                .map(|row| {
+                    (
+                        ctx.scratch.value_of(&ds, row[s_col].unwrap()),
+                        ctx.scratch.value_of(&ds, row[sum_col].unwrap()),
+                    )
+                })
+                .collect();
+            (schema, seq.rows, resolved)
+        };
+
+        let (schema_par, rows_par, resolved_par) = run(true);
+        let (schema_seq, rows_seq, resolved_seq) = run(false);
+
+        assert_eq!(
+            schema_par, schema_seq,
+            "schema must match regardless of path"
+        );
+        assert_eq!(
+            rows_par, rows_seq,
+            "parallel and sequential UNION paths must produce byte-identical row order"
+        );
+        assert_eq!(
+            resolved_par, resolved_seq,
+            "resolved (s, sum) values must match regardless of path"
+        );
+        // Row order: branch1 then branch2 then branch3 (left-to-right nesting).
+        let expected_sums = vec!["11".to_owned(), "11".to_owned(), "12".to_owned()];
+        let got_sums: Vec<String> = resolved_seq
+            .iter()
+            .map(|(_, v)| match v {
+                TermValue::Literal { lexical_form, .. } => lexical_form.clone(),
+                other => format!("{other:?}"),
+            })
+            .collect();
+        assert_eq!(got_sums, expected_sums);
     }
 }

--- a/crates/sparql-eval/src/binop.rs
+++ b/crates/sparql-eval/src/binop.rs
@@ -291,6 +291,15 @@ pub(crate) fn eval_left_join(
 /// A left outer join whose right-side pairings must additionally satisfy `expr`
 /// (the inline `OPTIONAL { ... FILTER expr }` condition, §18.6). A left solution
 /// with no pairing that is both compatible and passes the filter is emitted alone.
+///
+/// Gated on [`crate::parallel::is_parallel_safe`] exactly like `eval_filter`: an
+/// unsafe `expr` (reaches `RAND`/`UUID`/`STRUUID`/`BNODE`/the PurRDF list
+/// constructors) MUST run on the real `ctx` sequentially, since a forked child
+/// would advance a throwaway copy of the per-query counter/RNG state instead of
+/// the real one. A safe `expr` only decides which merged rows pass; every
+/// surviving cell is copied from `lrow`/`rrow` by [`merge`] (which interns
+/// nothing — see its doc comment), so nothing new escapes a forked child's
+/// scratch and it is discarded after use — no `absorb` needed.
 fn left_outer_join_filtered(
     l: &SolutionSeq,
     r: &SolutionSeq,
@@ -304,25 +313,51 @@ fn left_outer_join_filtered(
     let shared = l.schema.shared_columns(&r.schema);
 
     // A left outer join emits at least one row per left row.
-    let mut rows = Vec::with_capacity(l.rows.len());
-    for lrow in &l.rows {
-        let mut matched = false;
-        for rrow in &r.rows {
-            if !compatible(lrow, rrow, &shared) {
-                continue;
+    let rows = if crate::parallel::is_parallel_safe(expr) {
+        crate::parallel::par_try_flat_map_init(
+            &l.rows,
+            || ctx.fork_for_worker(),
+            |child, _, lrow| {
+                let mut out_rows = Vec::new();
+                for rrow in &r.rows {
+                    if !compatible(lrow, rrow, &shared) {
+                        continue;
+                    }
+                    let merged = merge(lrow, rrow, left_len, &right_to_out, out_len);
+                    if crate::expr::eval_ebv(expr, &merged, &out, child)? == Some(true) {
+                        out_rows.push(merged);
+                    }
+                }
+                if out_rows.is_empty() {
+                    let mut row = vec![None; out_len];
+                    row[..left_len].copy_from_slice(lrow);
+                    out_rows.push(row);
+                }
+                Ok(out_rows)
+            },
+        )?
+    } else {
+        let mut rows = Vec::with_capacity(l.rows.len());
+        for lrow in &l.rows {
+            let mut matched = false;
+            for rrow in &r.rows {
+                if !compatible(lrow, rrow, &shared) {
+                    continue;
+                }
+                let merged = merge(lrow, rrow, left_len, &right_to_out, out_len);
+                if crate::expr::eval_ebv(expr, &merged, &out, ctx)? == Some(true) {
+                    rows.push(merged);
+                    matched = true;
+                }
             }
-            let merged = merge(lrow, rrow, left_len, &right_to_out, out_len);
-            if crate::expr::eval_ebv(expr, &merged, &out, ctx)? == Some(true) {
-                rows.push(merged);
-                matched = true;
+            if !matched {
+                let mut row = vec![None; out_len];
+                row[..left_len].copy_from_slice(lrow);
+                rows.push(row);
             }
         }
-        if !matched {
-            let mut row = vec![None; out_len];
-            row[..left_len].copy_from_slice(lrow);
-            rows.push(row);
-        }
-    }
+        rows
+    };
     Ok(SolutionSeq { schema: out, rows })
 }
 

--- a/crates/sparql-eval/src/binop.rs
+++ b/crates/sparql-eval/src/binop.rs
@@ -382,7 +382,8 @@ pub(crate) fn eval_left_join(
 /// the real one. A safe `expr` only decides which merged rows pass; every
 /// surviving cell is copied from `lrow`/`rrow` by [`merge`] (which interns
 /// nothing — see its doc comment), so nothing new escapes a forked child's
-/// scratch and it is discarded after use — no `absorb` needed.
+/// scratch and it is discarded after use — no re-interning via
+/// [`crate::parallel::reintern_minted_row`] is needed.
 fn left_outer_join_filtered(
     l: &SolutionSeq,
     r: &SolutionSeq,

--- a/crates/sparql-eval/src/engine.rs
+++ b/crates/sparql-eval/src/engine.rs
@@ -199,7 +199,7 @@ impl NativeSparqlEngine {
         &self,
         dataset: &Arc<RdfDataset>,
         request: SparqlRequest<'_>,
-        source: &dyn crate::remote::RemoteQuerySource,
+        source: &(dyn crate::remote::RemoteQuerySource + Sync),
     ) -> Result<SparqlResult, RdfDiagnostic> {
         let prepared = self.cache.borrow_mut().prepare_with(
             request.query,
@@ -1446,20 +1446,38 @@ mod tests {
         };
 
         engine.query(&ds, req()).expect("first query");
-        assert_eq!(engine.order_cache.borrow().len(), 1, "one BGP cached");
+        assert_eq!(
+            engine
+                .order_cache
+                .read()
+                .expect("order cache lock poisoned")
+                .len(),
+            1,
+            "one BGP cached"
+        );
         let first = engine
             .order_cache
-            .borrow()
+            .read()
+            .expect("order cache lock poisoned")
             .values()
             .next()
             .expect("cached order")
             .clone();
 
         engine.query(&ds, req()).expect("second query");
-        assert_eq!(engine.order_cache.borrow().len(), 1, "no duplicate entry");
+        assert_eq!(
+            engine
+                .order_cache
+                .read()
+                .expect("order cache lock poisoned")
+                .len(),
+            1,
+            "no duplicate entry"
+        );
         let second = engine
             .order_cache
-            .borrow()
+            .read()
+            .expect("order cache lock poisoned")
             .values()
             .next()
             .expect("cached order")
@@ -1498,7 +1516,11 @@ mod tests {
         assert_eq!(rows.len(), 2);
 
         assert_eq!(
-            engine.order_cache.borrow().len(),
+            engine
+                .order_cache
+                .read()
+                .expect("order cache lock poisoned")
+                .len(),
             2,
             "distinct datasets ⇒ distinct fingerprints ⇒ two cache entries"
         );

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -789,7 +789,7 @@ mod tests {
         // The `ctx.exists_inner_cache.len()` check this test used to make against
         // `ctx` directly no longer applies: this EXISTS reaches no unsafe builtin,
         // so (Task 5) `expr::eval_filter` routes it through
-        // `crate::parallel::par_try_flat_map_init`, which runs the per-row loop on
+        // `crate::parallel::par_chunk_try_map_init`, which runs the per-row loop on
         // a FORKED child context (`EvalCtx::fork_for_worker`), not `ctx` itself —
         // even below the parallel threshold, exactly one child is forked and reused
         // across every outer row. So the cache still builds exactly once per query,

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -409,6 +409,65 @@ impl<'d> EvalCtx<'d> {
         self
     }
 
+    /// Fork a `Send` child context for a parallel worker (Task 4-6's fork-join
+    /// evaluation), sharing this context's immutable/read-only state and starting
+    /// its mutable evaluation state fresh.
+    ///
+    /// The split is what makes fork-join deterministic under [`crate::parallel`]:
+    ///
+    /// - **Shared** (`dataset`/`remote`/`bgp_order_cache`/`options`, and the cheap
+    ///   `Clone`s `active_graph`/`active_dataset`/`now`/`standpoint_predicates`):
+    ///   read-only for the duration of evaluation, so sharing them across workers
+    ///   cannot introduce a data race or a cross-worker ordering dependency.
+    /// - **Cloned** (`exists_inner_cache`/`exists_expr_vars_cache`): cheap
+    ///   `Arc`-valued maps, so a memo the parent already warmed (e.g. from
+    ///   evaluating an earlier sibling sequentially) is inherited by the child
+    ///   instead of rebuilt — a performance inheritance, not a correctness
+    ///   requirement, since a cache miss just re-derives the same value.
+    /// - **Fresh** (`scratch`, `regex_cache`, `cached_bool_terms`,
+    ///   `const_atom_cache`, `xsd_parse_cache`, `constructed`,
+    ///   `in_substituted_exists`): per-worker mutable state that must NOT be
+    ///   shared, so each worker mints its own [`crate::scratch::ScratchId`] space
+    ///   and constructed-quad buffer without contending on a lock. The caller
+    ///   folds a child's fresh state back into the parent deterministically via
+    ///   [`crate::parallel::absorb_row`] / [`crate::parallel::absorb_constructed`]
+    ///   in source order, so the result is bit-identical to sequential evaluation.
+    /// - **Copied scalars** (`bnode_counter`, `rng_state`): their only stateful
+    ///   builtins (`BNODE`, `RAND`/`UUID`/`STRUUID`, and the PurRDF list
+    ///   constructors) are excluded from parallel evaluation by
+    ///   [`crate::parallel::is_parallel_safe`], so the copied value is never
+    ///   actually observed divergently across workers — copying it here is
+    ///   harmless rather than load-bearing.
+    ///
+    /// Exercised by `parallel`'s unit tests; has no production caller until
+    /// Tasks 4-6 wire fork-join into the evaluator, hence the crate-build-only
+    /// `allow(dead_code)` (lifted the moment a caller lands).
+    #[must_use]
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn fork_for_worker(&self) -> Self {
+        Self {
+            dataset: self.dataset,
+            scratch: ScratchInterner::new(),
+            active_graph: self.active_graph,
+            active_dataset: self.active_dataset.clone(),
+            bnode_counter: self.bnode_counter,
+            now: self.now.clone(),
+            rng_state: self.rng_state,
+            options: self.options,
+            standpoint_predicates: self.standpoint_predicates.clone(),
+            exists_inner_cache: self.exists_inner_cache.clone(),
+            exists_expr_vars_cache: self.exists_expr_vars_cache.clone(),
+            regex_cache: DetHashMap::default(),
+            cached_bool_terms: [None, None],
+            const_atom_cache: DetHashMap::default(),
+            xsd_parse_cache: DetHashMap::default(),
+            remote: self.remote,
+            bgp_order_cache: self.bgp_order_cache,
+            constructed: Vec::new(),
+            in_substituted_exists: false,
+        }
+    }
+
     /// A compact hashable encoding of the active graph, for [`ExistsCacheKey`].
     pub(crate) fn graph_key(&self) -> (u8, u32) {
         match self.active_graph {

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -849,7 +849,9 @@ mod tests {
     /// something the conformance suite's multiset comparisons would not.
     #[test]
     fn parallel_and_sequential_paths_agree_bit_for_bit() {
-        use purrdf_sparql_algebra::{NamedNode, NamedNodePattern, TermPattern, TriplePattern, Variable};
+        use purrdf_sparql_algebra::{
+            NamedNode, NamedNodePattern, TermPattern, TriplePattern, Variable,
+        };
 
         // :a :knows :b . :b :knows :c .
         // :a :likes :cake . :b :likes :tea . :c :likes :juice .
@@ -916,7 +918,10 @@ mod tests {
         let (schema_par, rows_par) = run(true);
         let (schema_seq, rows_seq) = run(false);
 
-        assert_eq!(schema_par, schema_seq, "schema must match regardless of path");
+        assert_eq!(
+            schema_par, schema_seq,
+            "schema must match regardless of path"
+        );
         assert_eq!(
             rows_par, rows_seq,
             "parallel and sequential paths must produce byte-identical row order"
@@ -1012,7 +1017,10 @@ mod tests {
         let (schema_par, rows_par) = run(true);
         let (schema_seq, rows_seq) = run(false);
 
-        assert_eq!(schema_par, schema_seq, "schema must match regardless of path");
+        assert_eq!(
+            schema_par, schema_seq,
+            "schema must match regardless of path"
+        );
         assert_eq!(
             rows_par, rows_seq,
             "parallel and sequential FILTER paths must produce byte-identical row order"
@@ -1078,7 +1086,10 @@ mod tests {
         let (schema_par, rows_par) = run(true);
         let (schema_seq, rows_seq) = run(false);
 
-        assert_eq!(schema_par, schema_seq, "schema must match regardless of path");
+        assert_eq!(
+            schema_par, schema_seq,
+            "schema must match regardless of path"
+        );
         assert_eq!(
             rows_par, rows_seq,
             "parallel and sequential FILTER EXISTS paths must produce byte-identical row order"
@@ -1143,10 +1154,9 @@ mod tests {
         let right = bgp(vp("y"), pred("http://ex/age"), vp("a"));
         let cond = Expression::Greater(
             Box::new(Expression::Variable(Variable::new("a"))),
-            Box::new(Expression::Literal(purrdf_sparql_algebra::Literal::new_typed(
-                "40",
-                NamedNode::new_unchecked(XINT),
-            ))),
+            Box::new(Expression::Literal(
+                purrdf_sparql_algebra::Literal::new_typed("40", NamedNode::new_unchecked(XINT)),
+            )),
         );
         let pattern = GraphPattern::LeftJoin {
             left: Box::new(left),
@@ -1164,7 +1174,10 @@ mod tests {
         let (schema_par, rows_par) = run(true);
         let (schema_seq, rows_seq) = run(false);
 
-        assert_eq!(schema_par, schema_seq, "schema must match regardless of path");
+        assert_eq!(
+            schema_par, schema_seq,
+            "schema must match regardless of path"
+        );
         assert_eq!(
             rows_par, rows_seq,
             "parallel and sequential OPTIONAL-FILTER paths must produce byte-identical row order"

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -424,12 +424,27 @@ impl<'d> EvalCtx<'d> {
     ///   evaluating an earlier sibling sequentially) is inherited by the child
     ///   instead of rebuilt — a performance inheritance, not a correctness
     ///   requirement, since a cache miss just re-derives the same value.
-    /// - **Fresh** (`scratch`, `regex_cache`, `cached_bool_terms`,
-    ///   `const_atom_cache`, `xsd_parse_cache`, `constructed`,
-    ///   `in_substituted_exists`): per-worker mutable state that must NOT be
-    ///   shared, so each worker mints its own [`crate::scratch::ScratchId`] space
-    ///   and constructed-quad buffer without contending on a lock. The caller
-    ///   folds a child's fresh state back into the parent deterministically via
+    /// - **Cloned base, fresh appends** (`scratch`): input rows carry
+    ///   [`crate::scratch::SolutionTerm::Computed`] ids that index into THIS
+    ///   context's scratch value table, so a child given a fresh, empty scratch
+    ///   could not resolve them (wrong value, or an out-of-bounds panic). The
+    ///   whole [`crate::scratch::ScratchInterner`] (value table AND its
+    ///   value→id dedup index) is cloned instead: the child resolves every
+    ///   existing `Computed` id identically to the parent, and any NEW value it
+    ///   mints is deduped against its own clone of the index exactly as the
+    ///   parent would dedup it. A child's fresh mints are ephemeral — discarded
+    ///   for a read-only FILTER predicate (the surviving rows are the original
+    ///   rows, nothing new escapes) or folded back by VALUE via
+    ///   [`crate::parallel::absorb_row`] when a worker's output can carry a
+    ///   freshly-minted cell, which re-interns it against the parent so its id
+    ///   is valid in the parent's space (a raw child `ScratchId` is never
+    ///   reused in the parent — only the id space, not individual ids, is
+    ///   shared by the clone).
+    /// - **Fresh** (`regex_cache`, `cached_bool_terms`, `const_atom_cache`,
+    ///   `xsd_parse_cache`, `constructed`, `in_substituted_exists`): per-worker
+    ///   mutable state that must NOT be shared, so each worker mints its own
+    ///   constructed-quad buffer without contending on a lock. The caller folds
+    ///   a child's fresh state back into the parent deterministically via
     ///   [`crate::parallel::absorb_row`] / [`crate::parallel::absorb_constructed`]
     ///   in source order, so the result is bit-identical to sequential evaluation.
     /// - **Copied scalars** (`bnode_counter`, `rng_state`): their only stateful
@@ -439,15 +454,13 @@ impl<'d> EvalCtx<'d> {
     ///   actually observed divergently across workers — copying it here is
     ///   harmless rather than load-bearing.
     ///
-    /// Exercised by `parallel`'s unit tests; has no production caller until
-    /// Tasks 4-6 wire fork-join into the evaluator, hence the crate-build-only
-    /// `allow(dead_code)` (lifted the moment a caller lands).
+    /// Called by `expr::eval_filter` and `binop::left_outer_join_filtered` (Task 5)
+    /// to give each FILTER-predicate worker its own child context.
     #[must_use]
-    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn fork_for_worker(&self) -> Self {
         Self {
             dataset: self.dataset,
-            scratch: ScratchInterner::new(),
+            scratch: self.scratch.clone(),
             active_graph: self.active_graph,
             active_dataset: self.active_dataset.clone(),
             bnode_counter: self.bnode_counter,
@@ -761,6 +774,8 @@ mod tests {
             vp("ctype"),
         );
         let inner = bgp(vp("class"), pred("http://ex/stereo"), vp("st"));
+        let outer_for_low_level_check = outer.clone();
+        let inner_for_low_level_check = inner.clone();
         let filter = GraphPattern::Filter {
             expr: Expression::Exists(Box::new(inner)),
             inner: Box::new(outer),
@@ -770,9 +785,37 @@ mod tests {
         let seq = eval(&filter, &mut ctx).expect("filter exists");
         // EXISTS keeps the two subjects with a :stereo (a, b); drops c.
         assert_eq!(seq.len(), 2);
-        // The inner pattern AND its probe index were built exactly once despite three
-        // outer rows — the per-row index rebuild is gone.
-        assert_eq!(ctx.exists_inner_cache.len(), 1);
+
+        // The `ctx.exists_inner_cache.len()` check this test used to make against
+        // `ctx` directly no longer applies: this EXISTS reaches no unsafe builtin,
+        // so (Task 5) `expr::eval_filter` routes it through
+        // `crate::parallel::par_try_flat_map_init`, which runs the per-row loop on
+        // a FORKED child context (`EvalCtx::fork_for_worker`), not `ctx` itself —
+        // even below the parallel threshold, exactly one child is forked and reused
+        // across every outer row. So the cache still builds exactly once per query,
+        // just on that (discarded-after-use) child rather than on `ctx`. Reproduce
+        // the same shape here directly (drive `eval_ebv` for each outer row over one
+        // shared ctx, exactly as the child's per-row loop does) to keep exercising
+        // the "no per-row index rebuild" invariant.
+        let mut child_ctx = EvalCtx::new(&ds);
+        let outer_seq = eval(&outer_for_low_level_check, &mut child_ctx).expect("outer bgp");
+        let exists_expr = Expression::Exists(Box::new(inner_for_low_level_check));
+        let mut kept = 0;
+        for row in &outer_seq.rows {
+            if crate::expr::eval_ebv(&exists_expr, row, &outer_seq.schema, &mut child_ctx)
+                .expect("ebv")
+                == Some(true)
+            {
+                kept += 1;
+            }
+        }
+        assert_eq!(kept, 2);
+        assert_eq!(
+            child_ctx.exists_inner_cache.len(),
+            1,
+            "the inner pattern AND its probe index were built exactly once despite \
+             three outer rows — the per-row index rebuild is gone"
+        );
     }
 
     #[test]
@@ -881,5 +924,253 @@ mod tests {
         // Sanity: the MINUS removes the x=a row (it has a :bad edge); only the
         // x=b/y=c/z=juice row (with ?w unbound, no :extra match) survives.
         assert_eq!(rows_seq.len(), 1);
+    }
+
+    /// Determinism smoke test (Task 5): `FILTER(REGEX(...) && ?a > k)` — the
+    /// `b_scan_filter` bench shape — evaluated once with the parallel path FORCED
+    /// and once with the sequential path FORCED must produce byte-identical rows.
+    #[test]
+    fn filter_regex_and_numeric_forced_parallel_and_sequential_agree() {
+        use purrdf_core::RdfLiteral;
+        use purrdf_sparql_algebra::{
+            Expression, Function, Literal, NamedNode, NamedNodePattern, TermPattern, TriplePattern,
+            Variable,
+        };
+
+        const XINT: &str = "http://www.w3.org/2001/XMLSchema#integer";
+
+        let mut b = RdfDatasetBuilder::new();
+        let name = b.intern_iri("http://ex/name");
+        let age = b.intern_iri("http://ex/age");
+        let p1 = b.intern_iri("http://ex/p1");
+        let p2 = b.intern_iri("http://ex/p2");
+        let p3 = b.intern_iri("http://ex/p3");
+        let name1 = b.intern_literal(RdfLiteral::simple("Name1002"));
+        let name2 = b.intern_literal(RdfLiteral::simple("Name1003"));
+        let name3 = b.intern_literal(RdfLiteral::simple("Name2002"));
+        let typed_int = |v: &str| RdfLiteral {
+            lexical_form: v.to_owned(),
+            datatype: Some(XINT.to_owned()),
+            language: None,
+            direction: None,
+        };
+        let age1 = b.intern_literal(typed_int("45"));
+        let age2 = b.intern_literal(typed_int("30"));
+        let age3 = b.intern_literal(typed_int("50"));
+        b.push_quad(p1, name, name1, None);
+        b.push_quad(p1, age, age1, None);
+        b.push_quad(p2, name, name2, None);
+        b.push_quad(p2, age, age2, None);
+        b.push_quad(p3, name, name3, None);
+        b.push_quad(p3, age, age3, None);
+        let ds = b.freeze().expect("freeze");
+
+        let vp = |n: &str| TermPattern::Variable(Variable::new(n));
+        let pred = |iri: &str| NamedNodePattern::NamedNode(NamedNode::new_unchecked(iri));
+        let bgp = |s, p, o| GraphPattern::Bgp {
+            patterns: vec![TriplePattern {
+                subject: s,
+                predicate: p,
+                object: o,
+            }],
+        };
+
+        let name_bgp = bgp(vp("x"), pred("http://ex/name"), vp("n"));
+        let age_bgp = bgp(vp("x"), pred("http://ex/age"), vp("a"));
+        let join = GraphPattern::Join {
+            left: Box::new(name_bgp),
+            right: Box::new(age_bgp),
+        };
+
+        let regex = Expression::FunctionCall(
+            Function::Regex,
+            vec![
+                Expression::Variable(Variable::new("n")),
+                Expression::Literal(Literal::new_simple("^Name1[0-9][0-9]2$")),
+            ],
+        );
+        let numeric = Expression::Greater(
+            Box::new(Expression::Variable(Variable::new("a"))),
+            Box::new(Expression::Literal(Literal::new_typed(
+                "40",
+                NamedNode::new_unchecked(XINT),
+            ))),
+        );
+        let cond = Expression::And(Box::new(regex), Box::new(numeric));
+        let pattern = GraphPattern::Filter {
+            expr: cond,
+            inner: Box::new(join),
+        };
+
+        let run = |forced: bool| {
+            let _guard = crate::parallel::force_parallel_for_test(forced);
+            let mut ctx = EvalCtx::new(&ds);
+            let seq = eval(&pattern, &mut ctx).expect("eval");
+            (seq.schema.vars().to_vec(), seq.rows)
+        };
+
+        let (schema_par, rows_par) = run(true);
+        let (schema_seq, rows_seq) = run(false);
+
+        assert_eq!(schema_par, schema_seq, "schema must match regardless of path");
+        assert_eq!(
+            rows_par, rows_seq,
+            "parallel and sequential FILTER paths must produce byte-identical row order"
+        );
+        // Only p1 (Name1002, age 45) satisfies both the regex and the numeric bound.
+        assert_eq!(rows_seq.len(), 1);
+    }
+
+    /// Determinism smoke test (Task 5): `FILTER EXISTS { ... }` evaluated once with
+    /// the parallel FILTER path FORCED and once with the sequential path FORCED
+    /// must produce byte-identical rows. `EXISTS` reaches no stateful builtin, so
+    /// [`crate::parallel::is_parallel_safe`] must accept it.
+    #[test]
+    fn filter_exists_forced_parallel_and_sequential_agree() {
+        use purrdf_sparql_algebra::{
+            Expression, NamedNode, NamedNodePattern, TermPattern, TriplePattern, Variable,
+        };
+
+        // :a, :b carry a :stereo; :c does not.
+        let mut b = RdfDatasetBuilder::new();
+        let ty = b.intern_iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
+        let cls = b.intern_iri("http://ex/Class");
+        let stereo = b.intern_iri("http://ex/stereo");
+        let a = b.intern_iri("http://ex/a");
+        let bb = b.intern_iri("http://ex/b");
+        let c = b.intern_iri("http://ex/c");
+        let s = b.intern_iri("http://ex/S");
+        b.push_quad(a, ty, cls, None);
+        b.push_quad(bb, ty, cls, None);
+        b.push_quad(c, ty, cls, None);
+        b.push_quad(a, stereo, s, None);
+        b.push_quad(bb, stereo, s, None);
+        let ds = b.freeze().expect("freeze");
+
+        let vp = |n: &str| TermPattern::Variable(Variable::new(n));
+        let pred = |iri: &str| NamedNodePattern::NamedNode(NamedNode::new_unchecked(iri));
+        let bgp = |s, p, o| GraphPattern::Bgp {
+            patterns: vec![TriplePattern {
+                subject: s,
+                predicate: p,
+                object: o,
+            }],
+        };
+
+        let outer = bgp(
+            vp("class"),
+            pred("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+            vp("ctype"),
+        );
+        let inner = bgp(vp("class"), pred("http://ex/stereo"), vp("st"));
+        let pattern = GraphPattern::Filter {
+            expr: Expression::Exists(Box::new(inner)),
+            inner: Box::new(outer),
+        };
+
+        let run = |forced: bool| {
+            let _guard = crate::parallel::force_parallel_for_test(forced);
+            let mut ctx = EvalCtx::new(&ds);
+            let seq = eval(&pattern, &mut ctx).expect("eval");
+            (seq.schema.vars().to_vec(), seq.rows)
+        };
+
+        let (schema_par, rows_par) = run(true);
+        let (schema_seq, rows_seq) = run(false);
+
+        assert_eq!(schema_par, schema_seq, "schema must match regardless of path");
+        assert_eq!(
+            rows_par, rows_seq,
+            "parallel and sequential FILTER EXISTS paths must produce byte-identical row order"
+        );
+        // EXISTS keeps the two subjects with a :stereo (a, b); drops c.
+        assert_eq!(rows_seq.len(), 2);
+    }
+
+    /// Determinism smoke test (Task 5): `OPTIONAL { ... FILTER ... }` (the inline
+    /// `LeftJoin` filter, [`crate::binop`]'s `left_outer_join_filtered`) evaluated
+    /// once with the parallel path FORCED and once with the sequential path FORCED
+    /// must produce byte-identical rows, including left-alone padded rows for a
+    /// left solution whose only compatible right row fails the filter.
+    #[test]
+    fn optional_filter_forced_parallel_and_sequential_agree() {
+        use purrdf_sparql_algebra::{
+            Expression, NamedNode, NamedNodePattern, TermPattern, TriplePattern, Variable,
+        };
+
+        const XINT: &str = "http://www.w3.org/2001/XMLSchema#integer";
+
+        // :a :knows :b (age 50) — passes the OPTIONAL filter (age > 40).
+        // :a :knows :c (age 10) — right row exists but fails the filter ⇒ left-alone.
+        let mut b = RdfDatasetBuilder::new();
+        let knows = b.intern_iri("http://ex/knows");
+        let age = b.intern_iri("http://ex/age");
+        let a = b.intern_iri("http://ex/a");
+        let bb = b.intern_iri("http://ex/b");
+        let c = b.intern_iri("http://ex/c");
+        let age50 = b.intern_literal(purrdf_core::RdfLiteral {
+            lexical_form: "50".to_owned(),
+            datatype: Some(XINT.to_owned()),
+            language: None,
+            direction: None,
+        });
+        let age10 = b.intern_literal(purrdf_core::RdfLiteral {
+            lexical_form: "10".to_owned(),
+            datatype: Some(XINT.to_owned()),
+            language: None,
+            direction: None,
+        });
+        b.push_quad(a, knows, bb, None);
+        b.push_quad(a, knows, c, None);
+        b.push_quad(bb, age, age50, None);
+        b.push_quad(c, age, age10, None);
+        let ds = b.freeze().expect("freeze");
+
+        let vp = |n: &str| TermPattern::Variable(Variable::new(n));
+        let pred = |iri: &str| NamedNodePattern::NamedNode(NamedNode::new_unchecked(iri));
+        let bgp = |s, p, o| GraphPattern::Bgp {
+            patterns: vec![TriplePattern {
+                subject: s,
+                predicate: p,
+                object: o,
+            }],
+        };
+
+        // left = { ?x :knows ?y }: the two rows (x=a,y=b) and (x=a,y=c) exercise
+        // both "filter passes" (b, age 50) and "compatible right row exists but
+        // fails the filter ⇒ left-alone" (c, age 10) in one shape.
+        let left = bgp(vp("x"), pred("http://ex/knows"), vp("y"));
+        let right = bgp(vp("y"), pred("http://ex/age"), vp("a"));
+        let cond = Expression::Greater(
+            Box::new(Expression::Variable(Variable::new("a"))),
+            Box::new(Expression::Literal(purrdf_sparql_algebra::Literal::new_typed(
+                "40",
+                NamedNode::new_unchecked(XINT),
+            ))),
+        );
+        let pattern = GraphPattern::LeftJoin {
+            left: Box::new(left),
+            right: Box::new(right),
+            expression: Some(cond),
+        };
+
+        let run = |forced: bool| {
+            let _guard = crate::parallel::force_parallel_for_test(forced);
+            let mut ctx = EvalCtx::new(&ds);
+            let seq = eval(&pattern, &mut ctx).expect("eval");
+            (seq.schema.vars().to_vec(), seq.rows)
+        };
+
+        let (schema_par, rows_par) = run(true);
+        let (schema_seq, rows_seq) = run(false);
+
+        assert_eq!(schema_par, schema_seq, "schema must match regardless of path");
+        assert_eq!(
+            rows_par, rows_seq,
+            "parallel and sequential OPTIONAL-FILTER paths must produce byte-identical row order"
+        );
+        // x=a/y=b/age=50 passes the filter; x=a/y=c fails it and falls back to a
+        // left-alone row (y/a unbound) — two rows total.
+        assert_eq!(rows_seq.len(), 2);
     }
 }

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -15,7 +15,6 @@
 //! indexed read surface through `DatasetView` (the inherent `quads_for_pattern`
 //! override, P4b #891).
 
-use std::rc::Rc;
 use std::sync::Arc;
 
 use purrdf_core::{GraphMatch, RdfDataset, TermFactory, TermValue};
@@ -129,7 +128,7 @@ pub(crate) fn schema_fingerprint(schema: &crate::solution::VarSchema) -> u64 {
 /// materialised as triples (Principle 12). A stale or colliding key is at worst a
 /// suboptimal order (the reorder is a permutation of a commutative join), never an
 /// incorrect result, so the fingerprint can be cheap.
-pub type BgpOrderCache = std::cell::RefCell<DetHashMap<(u64, u64), Arc<[usize]>>>;
+pub type BgpOrderCache = std::sync::RwLock<DetHashMap<(u64, u64), Arc<[usize]>>>;
 
 /// The mutable evaluation context threaded through [`eval`].
 pub struct EvalCtx<'d> {
@@ -178,15 +177,15 @@ pub struct EvalCtx<'d> {
     /// Correlation detection runs for every outer row; caching this pure walk keeps
     /// the row loop focused on the cheap membership test against currently-bound
     /// outer variables.
-    pub(crate) exists_expr_vars_cache: DetHashMap<usize, Rc<crate::DetHashSet<Variable>>>,
+    pub(crate) exists_expr_vars_cache: DetHashMap<usize, Arc<crate::DetHashSet<Variable>>>,
     /// Per-query cache for SPARQL `REGEX`/`REPLACE` pattern+flag compilations,
     /// keyed pattern-then-flags so a hit probes with **borrowed** strings (no
-    /// per-row key allocation). The compiled regex is behind an `Rc`, so a hit
+    /// per-row key allocation). The compiled regex is behind an `Arc`, so a hit
     /// hands out a cheap pointer clone that **shares** the regex's lazy-DFA cache
     /// pool instead of minting a fresh one per row. Dynamic pattern expressions
     /// still compile per distinct value, but a filter over many rows no longer
     /// rebuilds the same automata (or their DFA caches) for every row.
-    pub(crate) regex_cache: DetHashMap<String, DetHashMap<String, Option<Rc<regex::Regex>>>>,
+    pub(crate) regex_cache: DetHashMap<String, DetHashMap<String, Option<Arc<regex::Regex>>>>,
     /// Lazily-resolved solution terms for the `xsd:boolean` literals `"false"` /
     /// `"true"` (indexed by `usize::from(bool)`), so per-row boolean expression
     /// results skip the value-hash intern probe. Interning is deterministic per
@@ -225,7 +224,7 @@ pub struct EvalCtx<'d> {
     /// The `SERVICE` federation source, if one is injected. `None` in
     /// the default engine path: a non-silent `SERVICE` then hard-fails. Tests and
     /// the conformance harness inject an in-memory source via [`EvalCtx::with_remote`].
-    pub(crate) remote: Option<&'d dyn crate::remote::RemoteQuerySource>,
+    pub(crate) remote: Option<&'d (dyn crate::remote::RemoteQuerySource + Sync)>,
     /// The shared, dataset-aware BGP join-order cache, if one is injected. `None` for
     /// a directly-built context (e.g. a unit test): planning then runs every BGP, which
     /// is semantically identical — just not memoised. The engine injects its own cache
@@ -254,6 +253,17 @@ pub struct EvalCtx<'d> {
     /// entirely while this flag is set.
     pub(crate) in_substituted_exists: bool,
 }
+
+/// Compile-time proof that [`EvalCtx`] is `Send + Sync`, so a future parallel
+/// worker can hold `&EvalCtx`/build its own from a shared `&'d RdfDataset`
+/// across threads. Every field must stay `Send + Sync` for this to hold — the
+/// `Rc`/`RefCell` fields that used to block it were switched to `Arc`/`RwLock`
+/// and `remote`'s trait object was given an explicit `+ Sync` bound precisely
+/// so this assertion compiles.
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<EvalCtx<'static>>();
+};
 
 impl core::fmt::Debug for EvalCtx<'_> {
     /// Summarized: the injected `SERVICE` source (`remote`) is a plain `dyn`
@@ -382,7 +392,10 @@ impl<'d> EvalCtx<'d> {
     /// Attach a `SERVICE` federation source for this evaluation. The borrow shares
     /// the dataset lifetime `'d`; the engine's default path leaves it `None`.
     #[must_use]
-    pub fn with_remote(mut self, source: &'d dyn crate::remote::RemoteQuerySource) -> Self {
+    pub fn with_remote(
+        mut self,
+        source: &'d (dyn crate::remote::RemoteQuerySource + Sync),
+    ) -> Self {
         self.remote = Some(source);
         self
     }

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -434,19 +434,26 @@ impl<'d> EvalCtx<'d> {
     ///   mints is deduped against its own clone of the index exactly as the
     ///   parent would dedup it. A child's fresh mints are ephemeral — discarded
     ///   for a read-only FILTER predicate (the surviving rows are the original
-    ///   rows, nothing new escapes) or folded back by VALUE via
-    ///   [`crate::parallel::absorb_row`] when a worker's output can carry a
-    ///   freshly-minted cell, which re-interns it against the parent so its id
-    ///   is valid in the parent's space (a raw child `ScratchId` is never
+    ///   rows, nothing new escapes) or, for a minting worker, captured by
+    ///   [`crate::parallel::portable_row`] as a `Vec` of
+    ///   [`crate::parallel::PortableTerm`] while the child's scratch is still
+    ///   alive and re-interned against the parent by
+    ///   [`crate::parallel::reintern_minted_row`] so each freshly-minted cell's
+    ///   id is valid in the parent's space (a raw child `ScratchId` is never
     ///   reused in the parent — only the id space, not individual ids, is
     ///   shared by the clone).
     /// - **Fresh** (`regex_cache`, `cached_bool_terms`, `const_atom_cache`,
     ///   `xsd_parse_cache`, `constructed`, `in_substituted_exists`): per-worker
     ///   mutable state that must NOT be shared, so each worker mints its own
-    ///   constructed-quad buffer without contending on a lock. The caller folds
-    ///   a child's fresh state back into the parent deterministically via
-    ///   [`crate::parallel::absorb_row`] / [`crate::parallel::absorb_constructed`]
-    ///   in source order, so the result is bit-identical to sequential evaluation.
+    ///   constructed-quad buffer without contending on a lock. The caller
+    ///   classifies each worker row with [`crate::parallel::minted_row`] into a
+    ///   [`crate::parallel::MintedRow`] (`Direct` — no post-fork mint, passed
+    ///   through untouched — or `Portable`) and folds it back into the parent
+    ///   via [`crate::parallel::reintern_minted_row`], invoked once per row in
+    ///   source-index order across all workers, so the result is bit-identical
+    ///   to sequential evaluation. A read-only FILTER-predicate worker never
+    ///   reaches this path: only the boolean result and the original `Copy` row
+    ///   escape, so its child scratch is discarded whole.
     /// - **Copied scalars** (`bnode_counter`, `rng_state`): their only stateful
     ///   builtins (`BNODE`, `RAND`/`UUID`/`STRUUID`, and the PurRDF list
     ///   constructors) are excluded from parallel evaluation by

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -95,7 +95,7 @@ pub(crate) type ExistsCacheKey = (usize, (u8, u32), u64);
 /// EXISTS` anti-join from N per-row index rebuilds into N O(1)/scan probes.
 pub(crate) struct ExistsInner {
     /// The inner pattern's unconstrained result (outer-row-independent).
-    pub inner: Rc<SolutionSeq>,
+    pub inner: Arc<SolutionSeq>,
     /// Shared columns between the outer schema and `inner.schema`, as
     /// `(outer_ordinal, inner_ordinal)` pairs (the probe's join key).
     pub shared: Vec<(usize, usize)>,
@@ -172,7 +172,7 @@ pub struct EvalCtx<'d> {
     /// over it are outer-row-independent, so this turns `expr::exists`'s per-row
     /// re-evaluation *and* per-row index rebuild into a single build per site.
     /// Naturally per-query: a fresh [`EvalCtx`] is built for each `query()` call.
-    pub(crate) exists_inner_cache: DetHashMap<ExistsCacheKey, Rc<ExistsInner>>,
+    pub(crate) exists_inner_cache: DetHashMap<ExistsCacheKey, Arc<ExistsInner>>,
     /// Per-query syntactic variable cache for expression positions inside an
     /// `EXISTS` inner pattern, keyed by the immutable inner-pattern AST address.
     /// Correlation detection runs for every outer row; caching this pure walk keeps

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -795,4 +795,91 @@ mod tests {
             schema_fingerprint(&s(&["x", "y"]))
         );
     }
+
+    /// Determinism smoke test (Task 4): a query exercising BGP, JOIN, a
+    /// non-filtered OPTIONAL, and MINUS evaluated once with the parallel path
+    /// FORCED (via [`crate::parallel::force_parallel_for_test`]) and once with
+    /// the sequential path FORCED must produce byte-identical `Vec<Solution>`
+    /// rows (schema and row order both). This is a narrower, faster-running
+    /// tripwire than the full Task 7 gate — it catches an ordering regression
+    /// in any of the four read-only nodes wired in this task immediately,
+    /// something the conformance suite's multiset comparisons would not.
+    #[test]
+    fn parallel_and_sequential_paths_agree_bit_for_bit() {
+        use purrdf_sparql_algebra::{NamedNode, NamedNodePattern, TermPattern, TriplePattern, Variable};
+
+        // :a :knows :b . :b :knows :c .
+        // :a :likes :cake . :b :likes :tea . :c :likes :juice .
+        // :tea :extra :hot .
+        // :a :bad :x .
+        let mut b = RdfDatasetBuilder::new();
+        let knows = b.intern_iri("http://ex/knows");
+        let likes = b.intern_iri("http://ex/likes");
+        let extra = b.intern_iri("http://ex/extra");
+        let bad = b.intern_iri("http://ex/bad");
+        let a = b.intern_iri("http://ex/a");
+        let bb = b.intern_iri("http://ex/b");
+        let c = b.intern_iri("http://ex/c");
+        let cake = b.intern_iri("http://ex/cake");
+        let tea = b.intern_iri("http://ex/tea");
+        let juice = b.intern_iri("http://ex/juice");
+        let hot = b.intern_iri("http://ex/hot");
+        let x = b.intern_iri("http://ex/x");
+        b.push_quad(a, knows, bb, None);
+        b.push_quad(bb, knows, c, None);
+        b.push_quad(a, likes, cake, None);
+        b.push_quad(bb, likes, tea, None);
+        b.push_quad(c, likes, juice, None);
+        b.push_quad(tea, extra, hot, None);
+        b.push_quad(a, bad, x, None);
+        let ds = b.freeze().expect("freeze");
+
+        let vp = |n: &str| TermPattern::Variable(Variable::new(n));
+        let pred = |iri: &str| NamedNodePattern::NamedNode(NamedNode::new_unchecked(iri));
+        let bgp = |s, p, o| GraphPattern::Bgp {
+            patterns: vec![TriplePattern {
+                subject: s,
+                predicate: p,
+                object: o,
+            }],
+        };
+
+        // { ?x :knows ?y } JOIN { ?y :likes ?z } OPTIONAL { ?z :extra ?w } MINUS { ?x :bad ?v }
+        let knows_bgp = bgp(vp("x"), pred("http://ex/knows"), vp("y"));
+        let likes_bgp = bgp(vp("y"), pred("http://ex/likes"), vp("z"));
+        let join = GraphPattern::Join {
+            left: Box::new(knows_bgp),
+            right: Box::new(likes_bgp),
+        };
+        let extra_bgp = bgp(vp("z"), pred("http://ex/extra"), vp("w"));
+        let optional = GraphPattern::LeftJoin {
+            left: Box::new(join),
+            right: Box::new(extra_bgp),
+            expression: None,
+        };
+        let bad_bgp = bgp(vp("x"), pred("http://ex/bad"), vp("v"));
+        let pattern = GraphPattern::Minus {
+            left: Box::new(optional),
+            right: Box::new(bad_bgp),
+        };
+
+        let run = |forced: bool| {
+            let _guard = crate::parallel::force_parallel_for_test(forced);
+            let mut ctx = EvalCtx::new(&ds);
+            let seq = eval(&pattern, &mut ctx).expect("eval");
+            (seq.schema.vars().to_vec(), seq.rows)
+        };
+
+        let (schema_par, rows_par) = run(true);
+        let (schema_seq, rows_seq) = run(false);
+
+        assert_eq!(schema_par, schema_seq, "schema must match regardless of path");
+        assert_eq!(
+            rows_par, rows_seq,
+            "parallel and sequential paths must produce byte-identical row order"
+        );
+        // Sanity: the MINUS removes the x=a row (it has a :bad edge); only the
+        // x=b/y=c/z=juice row (with ?w unbound, no :extra match) survives.
+        assert_eq!(rows_seq.len(), 1);
+    }
 }

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -166,6 +166,16 @@ pub(crate) fn eval_ebv(
 
 /// `Filter(expr, inner)`: keep solutions whose `expr` has effective boolean value
 /// `true`; an error/unbound (or `false`) drops the row.
+///
+/// [`crate::parallel::is_parallel_safe`] gates the strategy: an expression that
+/// can reach a stateful builtin (`RAND`/`UUID`/`STRUUID`/`BNODE`, the PurRDF list
+/// constructors) MUST run on the real `ctx` sequentially, so its per-query
+/// counter/RNG state advances exactly as it would without this parallel path — a
+/// forked child would advance a throwaway copy instead, silently diverging from
+/// the sequential result. A safe expression only decides keep/drop; the
+/// surviving rows are the ORIGINAL rows (never a value derived from the child's
+/// scratch), so each forked child's scratch is discarded after use — nothing to
+/// `absorb`.
 pub(crate) fn eval_filter(
     expr: &Expression,
     inner: &GraphPattern,
@@ -173,12 +183,27 @@ pub(crate) fn eval_filter(
 ) -> Result<SolutionSeq, EvalError> {
     let seq = eval(inner, ctx)?;
     let schema = seq.schema.clone();
-    let mut rows = Vec::new();
-    for row in seq.rows {
-        if eval_ebv(expr, &row, &schema, ctx)? == Some(true) {
-            rows.push(row);
+    let rows = if crate::parallel::is_parallel_safe(expr) {
+        crate::parallel::par_try_flat_map_init(
+            &seq.rows,
+            || ctx.fork_for_worker(),
+            |child, _, row| {
+                Ok(if eval_ebv(expr, row, &schema, child)? == Some(true) {
+                    vec![row.clone()]
+                } else {
+                    Vec::new()
+                })
+            },
+        )?
+    } else {
+        let mut rows = Vec::new();
+        for row in seq.rows {
+            if eval_ebv(expr, &row, &schema, ctx)? == Some(true) {
+                rows.push(row);
+            }
         }
-    }
+        rows
+    };
     Ok(SolutionSeq { schema, rows })
 }
 
@@ -3147,15 +3172,42 @@ mod tests {
     fn exists_memo_populates_cache_once() {
         // Two outer rows share the same EXISTS site; with the memo on the inner
         // pattern is evaluated and cached exactly once.
+        //
+        // Driven directly via `eval`/`eval_ebv` on ONE shared `ctx`, rather than
+        // through `evaluate_query`'s FILTER node: this EXISTS reaches no unsafe
+        // builtin, so (Task 5) `eval_filter` routes it through
+        // `crate::parallel::par_try_flat_map_init`, which runs the per-row loop on a
+        // FORKED child context — the memo would land on that (discarded-after-use)
+        // child, not on a `ctx` inspected from outside `evaluate_query`. This
+        // reproduces the identical per-row loop shape the forked child runs,
+        // directly on `ctx`, to keep exercising the underlying "cache built once,
+        // not once per outer row" invariant.
+        use purrdf_sparql_algebra::{NamedNode, NamedNodePattern, TermPattern, TriplePattern, Variable};
+
         let ds = knows_ds();
-        let parsed = purrdf_sparql_algebra::SparqlParser::new()
-            .parse_query(
-                "SELECT ?s ?o WHERE { ?s <http://ex/knows> ?o \
-                 FILTER EXISTS { ?z <http://ex/member> ?m } }",
-            )
-            .expect("parse");
+        let vp = |n: &str| TermPattern::Variable(Variable::new(n));
+        let pred = |iri: &str| NamedNodePattern::NamedNode(NamedNode::new_unchecked(iri));
+        let outer = GraphPattern::Bgp {
+            patterns: vec![TriplePattern {
+                subject: vp("s"),
+                predicate: pred("http://ex/knows"),
+                object: vp("o"),
+            }],
+        };
+        let inner = GraphPattern::Bgp {
+            patterns: vec![TriplePattern {
+                subject: vp("z"),
+                predicate: pred("http://ex/member"),
+                object: vp("m"),
+            }],
+        };
+
         let mut ctx = EvalCtx::new(&ds);
-        crate::eval::evaluate_query(&parsed, &mut ctx).expect("eval");
+        let seq = eval(&outer, &mut ctx).expect("outer bgp");
+        let exists_expr = Expression::Exists(Box::new(inner));
+        for row in &seq.rows {
+            eval_ebv(&exists_expr, row, &seq.schema, &mut ctx).expect("ebv");
+        }
         assert_eq!(
             ctx.exists_inner_cache.len(),
             1,
@@ -3247,16 +3299,38 @@ mod tests {
     fn uncorrelated_exists_fast_path_still_uses_cache() {
         // Verify the fast/memoized path is still taken when there is no expression
         // correlation: the cache must be populated after the query.
+        //
+        // Driven directly via `eval`/`eval_ebv` on ONE shared `ctx` rather than
+        // through `evaluate_query`'s FILTER node — see
+        // `exists_memo_populates_cache_once`'s comment: Task 5 routes this
+        // parallel-safe FILTER through a forked child context, so the memo would
+        // land there, not on a `ctx` inspected from outside `evaluate_query`.
+        use purrdf_sparql_algebra::{NamedNode, NamedNodePattern, TermPattern, TriplePattern, Variable};
+
         let ds = knows_ds();
-        let q = "SELECT ?s ?o WHERE { \
-                   ?s <http://ex/knows> ?o \
-                   FILTER EXISTS { ?z <http://ex/member> ?m } \
-                 }";
-        let parsed = purrdf_sparql_algebra::SparqlParser::new()
-            .parse_query(q)
-            .expect("parse");
+        let vp = |n: &str| TermPattern::Variable(Variable::new(n));
+        let pred = |iri: &str| NamedNodePattern::NamedNode(NamedNode::new_unchecked(iri));
+        let outer = GraphPattern::Bgp {
+            patterns: vec![TriplePattern {
+                subject: vp("s"),
+                predicate: pred("http://ex/knows"),
+                object: vp("o"),
+            }],
+        };
+        let inner = GraphPattern::Bgp {
+            patterns: vec![TriplePattern {
+                subject: vp("z"),
+                predicate: pred("http://ex/member"),
+                object: vp("m"),
+            }],
+        };
+
         let mut ctx = EvalCtx::new(&ds);
-        crate::eval::evaluate_query(&parsed, &mut ctx).expect("eval");
+        let seq = eval(&outer, &mut ctx).expect("outer bgp");
+        let exists_expr = Expression::Exists(Box::new(inner));
+        for row in &seq.rows {
+            eval_ebv(&exists_expr, row, &seq.schema, &mut ctx).expect("ebv");
+        }
         assert_eq!(
             ctx.exists_inner_cache.len(),
             1,

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -175,7 +175,7 @@ pub(crate) fn eval_ebv(
 /// the sequential result. A safe expression only decides keep/drop; the
 /// surviving rows are the ORIGINAL rows (never a value derived from the child's
 /// scratch), so each forked child's scratch is discarded after use — nothing to
-/// `absorb`.
+/// re-intern via [`crate::parallel::reintern_minted_row`].
 pub(crate) fn eval_filter(
     expr: &Expression,
     inner: &GraphPattern,

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -23,7 +23,6 @@
 //! `SERVICE` (S6b #928), property paths (S8 #914), and `Function::Custom`.
 
 use std::cmp::Ordering;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use purrdf_core::{BlankScope, DatasetView, GraphMatch, TermRef, TermValue};
@@ -710,7 +709,7 @@ fn exists(
     let inner_expr_vars = if ctx.in_substituted_exists {
         let mut vars = DetHashSet::default();
         pattern_expr_vars(pattern, &mut vars);
-        Rc::new(vars)
+        Arc::new(vars)
     } else {
         let pattern_key = std::ptr::from_ref::<GraphPattern>(pattern) as usize;
         ctx.exists_expr_vars_cache
@@ -718,7 +717,7 @@ fn exists(
             .or_insert_with(|| {
                 let mut vars = DetHashSet::default();
                 pattern_expr_vars(pattern, &mut vars);
-                Rc::new(vars)
+                Arc::new(vars)
             })
             .clone()
     };
@@ -1974,11 +1973,11 @@ fn eval_regex(
 /// The compiled regex for `(pattern, flags)`, from the per-query cache.
 ///
 /// The hit path probes with the **borrowed** strings (the two-level map avoids
-/// allocating a `(String, String)` key per row) and returns an `Rc` clone — the
+/// allocating a `(String, String)` key per row) and returns an `Arc` clone — the
 /// rows of one filter share a single compiled regex and therefore its lazy-DFA
 /// cache pool, instead of each row cloning a fresh one. Compile failures are
 /// cached as `None` (same errors, compiled once).
-fn cached_regex(ctx: &mut EvalCtx<'_>, pattern: &str, flags: &str) -> Option<Rc<regex::Regex>> {
+fn cached_regex(ctx: &mut EvalCtx<'_>, pattern: &str, flags: &str) -> Option<Arc<regex::Regex>> {
     if let Some(cached) = ctx
         .regex_cache
         .get(pattern)
@@ -1986,7 +1985,7 @@ fn cached_regex(ctx: &mut EvalCtx<'_>, pattern: &str, flags: &str) -> Option<Rc<
     {
         return cached.clone();
     }
-    let compiled = build_regex(pattern, flags).map(Rc::new);
+    let compiled = build_regex(pattern, flags).map(Arc::new);
     ctx.regex_cache
         .entry(pattern.to_owned())
         .or_default()

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -24,6 +24,7 @@
 
 use std::cmp::Ordering;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use purrdf_core::{BlankScope, DatasetView, GraphMatch, TermRef, TermValue};
 use purrdf_sparql_algebra::{Expression, Function, GraphPattern, PurrdfFn, Variable};
@@ -194,7 +195,7 @@ pub(crate) fn eval_extend(
     let mut schema = (*seq.schema).clone();
     let col = schema.push(var.clone());
     let width = schema.len();
-    let schema = Rc::new(schema);
+    let schema = Arc::new(schema);
 
     let mut rows = Vec::with_capacity(seq.rows.len());
     for mut row in seq.rows {
@@ -776,14 +777,14 @@ fn exists(
         let entry = match cached {
             Some(entry) => entry,
             None => {
-                let inner = Rc::new(eval(pattern, ctx)?);
+                let inner = Arc::new(eval(pattern, ctx)?);
                 // `shared` is computed against the FULL outer schema (not just the
                 // row's bound vars), so one index serves every row: an outer var
                 // unbound in a given row is `None` in the probe and matches anything
                 // via `compatible`, exactly as the prior bound-only seed-join did.
                 let shared = schema.shared_columns(&inner.schema);
                 let (keyed, wild) = crate::binop::build_index(&inner, &shared);
-                let entry = Rc::new(crate::eval::ExistsInner {
+                let entry = Arc::new(crate::eval::ExistsInner {
                     inner,
                     shared,
                     keyed,
@@ -2283,7 +2284,6 @@ mod tests {
     use super::*;
     use purrdf_core::{RdfDataset, RdfDatasetBuilder};
     use purrdf_sparql_algebra::{Literal, NamedNode};
-    use std::sync::Arc;
 
     fn empty_ds() -> Arc<RdfDataset> {
         RdfDatasetBuilder::new().freeze().expect("freeze")

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -209,6 +209,14 @@ pub(crate) fn eval_filter(
 
 /// `Extend(inner, var, expr)` (BIND): add `var` bound to `expr`'s value for each
 /// solution. An error/unbound value leaves `var` unbound (the row is NOT dropped).
+///
+/// Gated on [`crate::parallel::is_parallel_safe`] like `eval_filter`: an unsafe
+/// `expr` MUST run on the real `ctx` sequentially. A safe `expr` mints a NEW
+/// `Computed` term that escapes into the output row (unlike FILTER's read-only
+/// predicate), so each worker's forked child materializes its bound row via
+/// [`crate::parallel::portable_row`] while its scratch is still alive, and this
+/// function re-interns each portable row against `ctx.scratch` afterwards, in
+/// source-index order, via [`crate::parallel::reintern_portable_row`].
 pub(crate) fn eval_extend(
     inner: &GraphPattern,
     var: &Variable,
@@ -221,13 +229,37 @@ pub(crate) fn eval_extend(
     let width = schema.len();
     let schema = Arc::new(schema);
 
-    let mut rows = Vec::with_capacity(seq.rows.len());
-    for mut row in seq.rows {
-        row.resize(width, None);
-        let value = eval_expr(expr, &row, &schema, ctx)?;
-        row[col] = value;
-        rows.push(row);
-    }
+    let rows = if crate::parallel::is_parallel_safe(expr) {
+        let base = ctx.scratch.computed_count();
+        let prows = crate::parallel::par_try_flat_map_init(
+            &seq.rows,
+            || ctx.fork_for_worker(),
+            |child, _, in_row| {
+                let mut row = in_row.clone();
+                row.resize(width, None);
+                let value = eval_expr(expr, &row, &schema, child)?;
+                row[col] = value;
+                Ok(vec![crate::parallel::portable_row(
+                    &child.scratch,
+                    base,
+                    &row,
+                )])
+            },
+        )?;
+        prows
+            .iter()
+            .map(|prow| crate::parallel::reintern_portable_row(&mut ctx.scratch, ctx.dataset, prow))
+            .collect()
+    } else {
+        let mut rows = Vec::with_capacity(seq.rows.len());
+        for mut row in seq.rows {
+            row.resize(width, None);
+            let value = eval_expr(expr, &row, &schema, ctx)?;
+            row[col] = value;
+            rows.push(row);
+        }
+        rows
+    };
     Ok(SolutionSeq { schema, rows })
 }
 
@@ -3182,7 +3214,9 @@ mod tests {
         // reproduces the identical per-row loop shape the forked child runs,
         // directly on `ctx`, to keep exercising the underlying "cache built once,
         // not once per outer row" invariant.
-        use purrdf_sparql_algebra::{NamedNode, NamedNodePattern, TermPattern, TriplePattern, Variable};
+        use purrdf_sparql_algebra::{
+            NamedNode, NamedNodePattern, TermPattern, TriplePattern, Variable,
+        };
 
         let ds = knows_ds();
         let vp = |n: &str| TermPattern::Variable(Variable::new(n));
@@ -3305,7 +3339,9 @@ mod tests {
         // `exists_memo_populates_cache_once`'s comment: Task 5 routes this
         // parallel-safe FILTER through a forked child context, so the memo would
         // land there, not on a `ctx` inspected from outside `evaluate_query`.
-        use purrdf_sparql_algebra::{NamedNode, NamedNodePattern, TermPattern, TriplePattern, Variable};
+        use purrdf_sparql_algebra::{
+            NamedNode, NamedNodePattern, TermPattern, TriplePattern, Variable,
+        };
 
         let ds = knows_ds();
         let vp = |n: &str| TermPattern::Variable(Variable::new(n));
@@ -3532,5 +3568,99 @@ mod tests {
             None,
             "unbound argument ⇒ SPARQL error (None)"
         );
+    }
+
+    /// Determinism smoke test (Task 6): a chained `BIND` — `BIND(?o + 5 AS ?sum)`
+    /// then `BIND(CONCAT("v-", STR(?sum)) AS ?label)` over three rows — mints both
+    /// a NUMERIC (`?sum`) and a STRING (`?label`) `Computed` term per row, each of
+    /// which must escape a forked child via [`crate::parallel::portable_row`]/
+    /// [`crate::parallel::reintern_portable_row`]. Evaluated once with the
+    /// parallel `Extend` path FORCED and once with the sequential path FORCED,
+    /// the two must produce byte-identical rows (row order + resolved values).
+    #[test]
+    fn bind_chain_numeric_and_string_forced_parallel_and_sequential_agree() {
+        use purrdf_core::RdfLiteral;
+        use purrdf_sparql_algebra::{NamedNodePattern, TermPattern, TriplePattern};
+
+        const XINT: &str = "http://www.w3.org/2001/XMLSchema#integer";
+
+        let mut b = RdfDatasetBuilder::new();
+        let val = b.intern_iri("http://ex/val");
+        for (s, n) in [("a", "10"), ("b", "20"), ("c", "30")] {
+            let subj = b.intern_iri(&format!("http://ex/{s}"));
+            let v = b.intern_literal(RdfLiteral {
+                lexical_form: n.to_owned(),
+                datatype: Some(XINT.to_owned()),
+                language: None,
+                direction: None,
+            });
+            b.push_quad(subj, val, v, None);
+        }
+        let ds = b.freeze().expect("freeze");
+
+        let vp = |n: &str| TermPattern::Variable(Variable::new(n));
+        let pred = |iri: &str| NamedNodePattern::NamedNode(NamedNode::new_unchecked(iri));
+        let scan = GraphPattern::Bgp {
+            patterns: vec![TriplePattern {
+                subject: vp("s"),
+                predicate: pred("http://ex/val"),
+                object: vp("o"),
+            }],
+        };
+        let bind_sum = GraphPattern::Extend {
+            inner: Box::new(scan),
+            variable: Variable::new("sum"),
+            expression: Expression::Add(
+                Box::new(Expression::Variable(Variable::new("o"))),
+                Box::new(typed_lit("5", XINT)),
+            ),
+        };
+        let bind_label = GraphPattern::Extend {
+            inner: Box::new(bind_sum),
+            variable: Variable::new("label"),
+            expression: Expression::FunctionCall(
+                Function::Concat,
+                vec![
+                    lit("v-"),
+                    Expression::FunctionCall(
+                        Function::Str,
+                        vec![Expression::Variable(Variable::new("sum"))],
+                    ),
+                ],
+            ),
+        };
+
+        let run = |forced: bool| {
+            let _guard = crate::parallel::force_parallel_for_test(forced);
+            let mut ctx = EvalCtx::new(&ds);
+            let seq = eval(&bind_label, &mut ctx).expect("eval");
+            let schema = seq.schema.vars().to_vec();
+            let label_col = seq.schema.index_of(&Variable::new("label")).unwrap();
+            let labels: Vec<String> = seq
+                .rows
+                .iter()
+                .map(
+                    |row| match ctx.scratch.value_of(&ds, row[label_col].unwrap()) {
+                        TermValue::Literal { lexical_form, .. } => lexical_form,
+                        other => format!("{other:?}"),
+                    },
+                )
+                .collect();
+            (schema, seq.rows, labels)
+        };
+
+        let (schema_par, rows_par, labels_par) = run(true);
+        let (schema_seq, rows_seq, labels_seq) = run(false);
+
+        assert_eq!(
+            schema_par, schema_seq,
+            "schema must match regardless of path"
+        );
+        assert_eq!(
+            rows_par, rows_seq,
+            "parallel and sequential BIND paths must produce byte-identical row order"
+        );
+        assert_eq!(labels_par, labels_seq);
+        assert_eq!(labels_seq, vec!["v-15", "v-25", "v-35"]);
     }
 }

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -184,15 +184,14 @@ pub(crate) fn eval_filter(
     let seq = eval(inner, ctx)?;
     let schema = seq.schema.clone();
     let rows = if crate::parallel::is_parallel_safe(expr) {
-        crate::parallel::par_try_flat_map_init(
+        crate::parallel::par_chunk_try_map_init(
             &seq.rows,
             || ctx.fork_for_worker(),
-            |child, _, row| {
-                Ok(if eval_ebv(expr, row, &schema, child)? == Some(true) {
-                    vec![row.clone()]
-                } else {
-                    Vec::new()
-                })
+            |child, acc, row| {
+                if eval_ebv(expr, row, &schema, child)? == Some(true) {
+                    acc.push(row.clone());
+                }
+                Ok(())
             },
         )?
     } else {
@@ -231,24 +230,21 @@ pub(crate) fn eval_extend(
 
     let rows = if crate::parallel::is_parallel_safe(expr) {
         let base = ctx.scratch.computed_count();
-        let prows = crate::parallel::par_try_flat_map_init(
+        let minted = crate::parallel::par_chunk_try_map_init(
             &seq.rows,
             || ctx.fork_for_worker(),
-            |child, _, in_row| {
+            |child, acc, in_row| {
                 let mut row = in_row.clone();
                 row.resize(width, None);
                 let value = eval_expr(expr, &row, &schema, child)?;
                 row[col] = value;
-                Ok(vec![crate::parallel::portable_row(
-                    &child.scratch,
-                    base,
-                    &row,
-                )])
+                acc.push(crate::parallel::minted_row(&child.scratch, base, row));
+                Ok(())
             },
         )?;
-        prows
-            .iter()
-            .map(|prow| crate::parallel::reintern_portable_row(&mut ctx.scratch, ctx.dataset, prow))
+        minted
+            .into_iter()
+            .map(|row| crate::parallel::reintern_minted_row(&mut ctx.scratch, ctx.dataset, row))
             .collect()
     } else {
         let mut rows = Vec::with_capacity(seq.rows.len());
@@ -3208,7 +3204,7 @@ mod tests {
         // Driven directly via `eval`/`eval_ebv` on ONE shared `ctx`, rather than
         // through `evaluate_query`'s FILTER node: this EXISTS reaches no unsafe
         // builtin, so (Task 5) `eval_filter` routes it through
-        // `crate::parallel::par_try_flat_map_init`, which runs the per-row loop on a
+        // `crate::parallel::par_chunk_try_map_init`, which runs the per-row loop on a
         // FORKED child context — the memo would land on that (discarded-after-use)
         // child, not on a `ctx` inspected from outside `evaluate_query`. This
         // reproduces the identical per-row loop shape the forked child runs,

--- a/crates/sparql-eval/src/lib.rs
+++ b/crates/sparql-eval/src/lib.rs
@@ -54,6 +54,7 @@ pub mod eval;
 mod expr;
 mod list_fn;
 mod modifier;
+pub(crate) mod parallel;
 mod path;
 pub mod remote;
 // HTTP-shaped SERVICE source. The actual POST transport is host-injected so this

--- a/crates/sparql-eval/src/lib.rs
+++ b/crates/sparql-eval/src/lib.rs
@@ -55,6 +55,8 @@ mod expr;
 mod list_fn;
 mod modifier;
 pub(crate) mod parallel;
+#[cfg(test)]
+mod parallel_determinism_gate;
 mod path;
 pub mod remote;
 // HTTP-shaped SERVICE source. The actual POST transport is host-injected so this

--- a/crates/sparql-eval/src/modifier.rs
+++ b/crates/sparql-eval/src/modifier.rs
@@ -486,7 +486,7 @@ pub(crate) fn eval_group(
 
     // Every aggregate expression must be parallel-safe (no RAND/UUID/STRUUID/
     // BNODE/list-mint reachable) for the per-group compute below to run under
-    // the fork-join model; `should_parallelize` (inside `par_try_flat_map_init`)
+    // the fork-join model; `should_parallelize` (inside `par_chunk_try_map_init`)
     // still gates on group count.
     let safe = aggregates.iter().all(|(_, agg)| match agg {
         AggregateExpression::CountStar { .. } => true,
@@ -497,10 +497,10 @@ pub(crate) fn eval_group(
 
     let rows = if safe {
         let base = ctx.scratch.computed_count();
-        let prows = crate::parallel::par_try_flat_map_init(
+        let minted = crate::parallel::par_chunk_try_map_init(
             &order,
             || ctx.fork_for_worker(),
-            |child, _, key| {
+            |child, acc, key| {
                 let idxs = &groups[key];
                 let mut row = vec![None; out_width];
                 for (i, _) in variables.iter().enumerate() {
@@ -509,16 +509,13 @@ pub(crate) fn eval_group(
                 for (j, (_, agg)) in aggregates.iter().enumerate() {
                     row[var_count + j] = eval_aggregate(agg, idxs, &seq.rows, &in_schema, child)?;
                 }
-                Ok(vec![crate::parallel::portable_row(
-                    &child.scratch,
-                    base,
-                    &row,
-                )])
+                acc.push(crate::parallel::minted_row(&child.scratch, base, row));
+                Ok(())
             },
         )?;
-        prows
-            .iter()
-            .map(|prow| crate::parallel::reintern_portable_row(&mut ctx.scratch, ctx.dataset, prow))
+        minted
+            .into_iter()
+            .map(|row| crate::parallel::reintern_minted_row(&mut ctx.scratch, ctx.dataset, row))
             .collect()
     } else {
         let mut rows = Vec::with_capacity(order.len());

--- a/crates/sparql-eval/src/modifier.rs
+++ b/crates/sparql-eval/src/modifier.rs
@@ -6,7 +6,7 @@
 //! and named-graph scoping.
 
 use std::cmp::Ordering;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use purrdf_core::{GraphMatch, TermId, TermValue};
 use purrdf_sparql_algebra::{
@@ -33,7 +33,7 @@ pub(crate) fn eval_values(
     bindings: &[Vec<Option<purrdf_sparql_algebra::GroundTerm>>],
     ctx: &mut EvalCtx<'_>,
 ) -> Result<SolutionSeq, EvalError> {
-    let schema = Rc::new(VarSchema::from_vars(variables.iter().cloned()));
+    let schema = Arc::new(VarSchema::from_vars(variables.iter().cloned()));
     let width = schema.len();
     let mut rows = Vec::with_capacity(bindings.len());
     for binding in bindings {
@@ -59,7 +59,7 @@ pub(crate) fn eval_project(
     ctx: &mut EvalCtx<'_>,
 ) -> Result<SolutionSeq, EvalError> {
     let seq = eval(inner, ctx)?;
-    let out = Rc::new(VarSchema::from_vars(variables.iter().cloned()));
+    let out = Arc::new(VarSchema::from_vars(variables.iter().cloned()));
     // For each projected column, the source column in the inner schema (if any).
     let src: Vec<Option<usize>> = out.vars().iter().map(|v| seq.schema.index_of(v)).collect();
     let rows = seq
@@ -200,7 +200,7 @@ fn eval_graph_var(
     graphs.dedup();
 
     let saved = ctx.active_graph;
-    let mut out_schema: Option<Rc<VarSchema>> = None;
+    let mut out_schema: Option<Arc<VarSchema>> = None;
     let mut rows = Vec::new();
     for g in graphs {
         ctx.active_graph = GraphMatch::Named(g);
@@ -213,7 +213,7 @@ fn eval_graph_var(
             row[gcol] = Some(SolutionTerm::Existing(g));
             rows.push(row);
         }
-        out_schema = Some(Rc::new(sch));
+        out_schema = Some(Arc::new(sch));
     }
     ctx.active_graph = saved;
 
@@ -224,7 +224,7 @@ fn eval_graph_var(
             let seq = eval(inner, ctx)?;
             let mut sch = (*seq.schema).clone();
             sch.push(var.clone());
-            Rc::new(sch)
+            Arc::new(sch)
         }
     };
     Ok(SolutionSeq { schema, rows })
@@ -480,7 +480,7 @@ pub(crate) fn eval_group(
     for (out_var, _) in aggregates {
         out_schema.push(out_var.clone());
     }
-    let out_schema = Rc::new(out_schema);
+    let out_schema = Arc::new(out_schema);
 
     let mut rows = Vec::with_capacity(order.len());
     for key in &order {
@@ -687,7 +687,6 @@ mod tests {
     use super::*;
     use purrdf_core::{RdfDataset, RdfDatasetBuilder, RdfLiteral};
     use purrdf_sparql_algebra::{NamedNode, NamedNodePattern, TermPattern, TriplePattern};
-    use std::sync::Arc;
 
     const XINT: &str = "http://www.w3.org/2001/XMLSchema#integer";
 

--- a/crates/sparql-eval/src/modifier.rs
+++ b/crates/sparql-eval/src/modifier.rs
@@ -481,19 +481,60 @@ pub(crate) fn eval_group(
         out_schema.push(out_var.clone());
     }
     let out_schema = Arc::new(out_schema);
+    let out_width = out_schema.len();
+    let var_count = variables.len();
 
-    let mut rows = Vec::with_capacity(order.len());
-    for key in &order {
-        let idxs = &groups[key];
-        let mut row = vec![None; out_schema.len()];
-        for (i, _) in variables.iter().enumerate() {
-            row[i] = key[i];
+    // Every aggregate expression must be parallel-safe (no RAND/UUID/STRUUID/
+    // BNODE/list-mint reachable) for the per-group compute below to run under
+    // the fork-join model; `should_parallelize` (inside `par_try_flat_map_init`)
+    // still gates on group count.
+    let safe = aggregates.iter().all(|(_, agg)| match agg {
+        AggregateExpression::CountStar { .. } => true,
+        AggregateExpression::FunctionCall { expression, .. } => {
+            crate::parallel::is_parallel_safe(expression)
         }
-        for (j, (_, agg)) in aggregates.iter().enumerate() {
-            row[variables.len() + j] = eval_aggregate(agg, idxs, &seq.rows, &in_schema, ctx)?;
+    });
+
+    let rows = if safe {
+        let base = ctx.scratch.computed_count();
+        let prows = crate::parallel::par_try_flat_map_init(
+            &order,
+            || ctx.fork_for_worker(),
+            |child, _, key| {
+                let idxs = &groups[key];
+                let mut row = vec![None; out_width];
+                for (i, _) in variables.iter().enumerate() {
+                    row[i] = key[i];
+                }
+                for (j, (_, agg)) in aggregates.iter().enumerate() {
+                    row[var_count + j] = eval_aggregate(agg, idxs, &seq.rows, &in_schema, child)?;
+                }
+                Ok(vec![crate::parallel::portable_row(
+                    &child.scratch,
+                    base,
+                    &row,
+                )])
+            },
+        )?;
+        prows
+            .iter()
+            .map(|prow| crate::parallel::reintern_portable_row(&mut ctx.scratch, ctx.dataset, prow))
+            .collect()
+    } else {
+        let mut rows = Vec::with_capacity(order.len());
+        for key in &order {
+            let idxs = &groups[key];
+            let mut row = vec![None; out_width];
+            for (i, _) in variables.iter().enumerate() {
+                row[i] = key[i];
+            }
+            for (j, (_, agg)) in aggregates.iter().enumerate() {
+                row[var_count + j] = eval_aggregate(agg, idxs, &seq.rows, &in_schema, ctx)?;
+            }
+            rows.push(row);
         }
-        rows.push(row);
-    }
+        rows
+    };
 
     Ok(SolutionSeq {
         schema: out_schema,
@@ -1249,5 +1290,111 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Determinism smoke test (Task 6): `GROUP BY ?cat` with `COUNT(*)`/`AVG(?val)`/
+    /// `MAX(?val)` over 220 groups (the `e_group_aggregate` bench shape) evaluated
+    /// once with the parallel per-group path FORCED and once with the sequential
+    /// path FORCED must produce byte-identical rows — group ORDER (first-seen) is
+    /// always computed sequentially, but the per-group `AVG`/`MAX` compute (which
+    /// mints fresh `Computed` terms that must escape a forked child via
+    /// [`crate::parallel::portable_row`]/[`crate::parallel::reintern_portable_row`])
+    /// runs under fork-join when FORCED.
+    #[test]
+    fn group_aggregate_forced_parallel_and_sequential_agree() {
+        use purrdf_core::RdfLiteral;
+
+        const XINT: &str = "http://www.w3.org/2001/XMLSchema#integer";
+        const GROUPS: i64 = 220;
+        const ROWS: i64 = 260;
+
+        let mut b = RdfDatasetBuilder::new();
+        let cat_pred = b.intern_iri("http://ex/cat");
+        let val_pred = b.intern_iri("http://ex/val");
+        for i in 0..ROWS {
+            let subj = b.intern_iri(&format!("http://ex/s{i}"));
+            let cat = b.intern_literal(RdfLiteral {
+                lexical_form: format!("cat{}", i % GROUPS),
+                datatype: Some(XINT.to_owned()),
+                language: None,
+                direction: None,
+            });
+            let val = b.intern_literal(RdfLiteral {
+                lexical_form: i.to_string(),
+                datatype: Some(XINT.to_owned()),
+                language: None,
+                direction: None,
+            });
+            b.push_quad(subj, cat_pred, cat, None);
+            b.push_quad(subj, val_pred, val, None);
+        }
+        let ds = b.freeze().expect("freeze");
+
+        let inner = GraphPattern::Join {
+            left: Box::new(GraphPattern::Bgp {
+                patterns: vec![TriplePattern {
+                    subject: TermPattern::Variable(Variable::new("s")),
+                    predicate: NamedNodePattern::NamedNode(NamedNode::new_unchecked(
+                        "http://ex/cat",
+                    )),
+                    object: TermPattern::Variable(Variable::new("cat")),
+                }],
+            }),
+            right: Box::new(GraphPattern::Bgp {
+                patterns: vec![TriplePattern {
+                    subject: TermPattern::Variable(Variable::new("s")),
+                    predicate: NamedNodePattern::NamedNode(NamedNode::new_unchecked(
+                        "http://ex/val",
+                    )),
+                    object: TermPattern::Variable(Variable::new("val")),
+                }],
+            }),
+        };
+        let group = GraphPattern::Group {
+            inner: Box::new(inner),
+            variables: vec![Variable::new("cat")],
+            aggregates: vec![
+                (
+                    Variable::new("cnt"),
+                    AggregateExpression::CountStar { distinct: false },
+                ),
+                (
+                    Variable::new("avg"),
+                    AggregateExpression::FunctionCall {
+                        function: AggregateFunction::Avg,
+                        expression: Box::new(Expression::Variable(Variable::new("val"))),
+                        distinct: false,
+                    },
+                ),
+                (
+                    Variable::new("mx"),
+                    AggregateExpression::FunctionCall {
+                        function: AggregateFunction::Max,
+                        expression: Box::new(Expression::Variable(Variable::new("val"))),
+                        distinct: false,
+                    },
+                ),
+            ],
+        };
+
+        let run = |forced: bool| {
+            let _guard = crate::parallel::force_parallel_for_test(forced);
+            let mut ctx = EvalCtx::new(&ds);
+            let seq = eval(&group, &mut ctx).expect("eval");
+            (seq.schema.vars().to_vec(), seq.rows)
+        };
+
+        let (schema_par, rows_par) = run(true);
+        let (schema_seq, rows_seq) = run(false);
+
+        assert_eq!(
+            schema_par, schema_seq,
+            "schema must match regardless of path"
+        );
+        assert_eq!(
+            rows_par, rows_seq,
+            "parallel and sequential per-group aggregate paths must produce byte-identical rows"
+        );
+        assert_eq!(rows_seq.len() as i64, GROUPS);
     }
 }

--- a/crates/sparql-eval/src/parallel.rs
+++ b/crates/sparql-eval/src/parallel.rs
@@ -3,27 +3,39 @@
 
 //! Deterministic two-phase parallel evaluation primitives.
 //!
-//! [`crate::bgp`]'s per-batch evaluation, `binop`'s `Join`/`LeftJoin`/`MINUS`, and
-//! (Task 5) `expr::eval_filter` / `binop::left_outer_join_filtered`'s FILTER
-//! predicates are all wired to the fork-join model below. `absorb_row` /
-//! `absorb_constructed` are still unused outside this module's own tests — no
-//! wired caller yet mints a NEW value that must escape a forked child (Task 6:
-//! parallel `GROUP BY`/aggregate and `CONSTRUCT` list-mint sites) — hence the
-//! crate-build-only `allow(dead_code)` below (lifted the moment a caller lands
-//! for those two). The two phases, always in this order:
+//! [`crate::bgp`]'s per-batch evaluation, `binop`'s `Join`/`LeftJoin`/`MINUS`/
+//! `Union`, `expr::eval_filter`/`eval_extend`, `binop::left_outer_join_filtered`,
+//! and `modifier::eval_group`'s per-group aggregates are all wired to the
+//! fork-join model below. The two phases, always in this order:
 //!
 //! 1. **Fork.** [`crate::eval::EvalCtx::fork_for_worker`] gives each worker a
 //!    `Send` child context with its own scratch/constructed state, so workers
 //!    never contend on a lock or share mutable evaluation state.
-//! 2. **Join.** [`par_try_flat_map`] / [`par_try_flat_map_init`] run the workers
-//!    via rayon's *indexed* `collect` (never `par_sort`/`par_bridge`, which are
-//!    not order-stable) and then reduce strictly in source-index order:
-//!    successes flatten in index order and the first `Err` **by index** wins,
-//!    regardless of which worker finished first. [`absorb_row`] /
-//!    [`absorb_constructed`] fold a worker's fresh scratch/constructed state back
-//!    into the parent, also index-ordered by the caller. The result is
-//!    bit-identical to the sequential evaluation of the same pattern —
-//!    parallelism is purely a scheduling change.
+//! 2. **Join.** [`par_try_flat_map_init`]/[`par_flat_map`]/[`par_retain`] run the
+//!    workers via rayon's *indexed* `collect` (never `par_sort`/`par_bridge`,
+//!    which are not order-stable) and then reduce strictly in source-index
+//!    order: successes flatten in index order and the first `Err` **by index**
+//!    wins, regardless of which worker finished first.
+//!
+//! A read-only FILTER predicate discards its child's scratch mints entirely (the
+//! surviving rows are the original rows, nothing new escapes). A **minting** node
+//! — `UNION`, per-group aggregates, `BIND`/`Extend` — is different: its output
+//! rows can carry a cell the child *just interned*, and the child (and its
+//! scratch) is dropped the moment the fork-join call returns, so that cell's
+//! `ScratchId` cannot be resolved against the child after the fact. Those callers
+//! instead materialize each escaping row to a dataset-independent
+//! ([`PortableTerm`]) form **while the child is still alive** ([`portable_row`])
+//! and the node re-interns it against the **parent** scratch afterwards, strictly
+//! in source-index order ([`reintern_portable_row`]) — see those two functions'
+//! doc comments for the base-aware id rule that makes this exact, not just
+//! value-equal, to the sequential path.
+//!
+//! Note there is no `constructed`-merging counterpart here: the parallel minting
+//! path only ever runs when [`is_parallel_safe`]/[`is_parallel_safe_pattern`]
+//! passes, which excludes every builtin that pushes to
+//! [`crate::eval::EvalCtx::constructed`] (the blank-minting list constructors) —
+//! so a forked child on this path never populates `constructed`, and there is
+//! nothing to fold back.
 //!
 //! [`is_parallel_safe`] is the gate deciding whether an expression may run under
 //! this model at all: any builtin whose result depends on the per-query mutable
@@ -33,15 +45,13 @@
 //! fork-join would make its result depend on worker scheduling, not just row
 //! content.
 
-#![cfg_attr(not(test), allow(dead_code))]
-
 use purrdf_core::{RdfDataset, TermValue};
 use purrdf_sparql_algebra::{
     AggregateExpression, Expression, Function, GraphPattern, OrderExpression,
 };
 
 use crate::error::EvalError;
-use crate::scratch::ScratchInterner;
+use crate::scratch::{ScratchInterner, SolutionTerm};
 use crate::solution::Solution;
 
 /// Rows/groups at or below this stay sequential (thread spin-up would dominate
@@ -114,10 +124,12 @@ pub(crate) fn should_parallelize(work_items: usize) -> bool {
 ///   fresh blank nodes from the shared `bnode_counter` (so a list cell's label
 ///   never collides with a `BNODE()` or CONSTRUCT-template blank) AND pushes
 ///   the new cell quads onto `EvalCtx::constructed`. `constructed` is
-///   dataset-independent so the cells themselves fold back deterministically
-///   (see [`absorb_constructed`]), but the *label* is only collision-free
+///   dataset-independent so the cells themselves would fold back
+///   deterministically if ever needed, but the *label* is only collision-free
 ///   against the single shared counter; two forked workers each minting from
-///   their own fresh `bnode_counter` could produce colliding cell labels.
+///   their own fresh `bnode_counter` could produce colliding cell labels. (In
+///   practice this whole builtin is excluded from the parallel path anyway —
+///   see the module docs' note on why no `constructed`-merge exists here.)
 ///
 /// Every other reader-only PurRDF list function (`listLength`/`listGet`/
 /// `listIndexOf`/`listContains`) and `heldIn` touch neither counter, so they are
@@ -127,13 +139,23 @@ pub(crate) fn is_parallel_safe(expr: &Expression) -> bool {
     !expr_reaches_unsafe_builtin(expr)
 }
 
+/// Whether `pattern` (recursively) is safe to evaluate under the fork-join
+/// parallel model — the pattern-level twin of [`is_parallel_safe`], for callers
+/// (e.g. `UNION`) that must gate a whole sub-pattern rather than a single
+/// expression. Exposes the same walk [`is_parallel_safe`] already runs
+/// internally for `EXISTS`.
+pub(crate) fn is_parallel_safe_pattern(pattern: &GraphPattern) -> bool {
+    !pattern_reaches_unsafe_builtin(pattern)
+}
+
 /// `true` iff `expr` (recursively) reaches an unsafe builtin — see
 /// [`is_parallel_safe`].
 fn expr_reaches_unsafe_builtin(expr: &Expression) -> bool {
     match expr {
-        Expression::NamedNode(_) | Expression::Literal(_) | Expression::Variable(_) | Expression::Bound(_) => {
-            false
-        }
+        Expression::NamedNode(_)
+        | Expression::Literal(_)
+        | Expression::Variable(_)
+        | Expression::Bound(_) => false,
         Expression::Or(a, b)
         | Expression::And(a, b)
         | Expression::Equal(a, b)
@@ -145,7 +167,9 @@ fn expr_reaches_unsafe_builtin(expr: &Expression) -> bool {
         | Expression::Add(a, b)
         | Expression::Subtract(a, b)
         | Expression::Multiply(a, b)
-        | Expression::Divide(a, b) => expr_reaches_unsafe_builtin(a) || expr_reaches_unsafe_builtin(b),
+        | Expression::Divide(a, b) => {
+            expr_reaches_unsafe_builtin(a) || expr_reaches_unsafe_builtin(b)
+        }
         Expression::UnaryPlus(a) | Expression::UnaryMinus(a) | Expression::Not(a) => {
             expr_reaches_unsafe_builtin(a)
         }
@@ -172,7 +196,8 @@ fn function_is_unsafe(f: &Function) -> bool {
         Function::Rand | Function::Uuid | Function::StrUuid | Function::BNode => true,
         Function::Purrdf(call) => matches!(
             call.fn_kind,
-            purrdf_sparql_algebra::PurrdfFn::ListSlice | purrdf_sparql_algebra::PurrdfFn::ListConcat
+            purrdf_sparql_algebra::PurrdfFn::ListSlice
+                | purrdf_sparql_algebra::PurrdfFn::ListConcat
         ),
         _ => false,
     }
@@ -208,9 +233,7 @@ fn pattern_reaches_unsafe_builtin(pattern: &GraphPattern) -> bool {
         } => {
             pattern_reaches_unsafe_builtin(left)
                 || pattern_reaches_unsafe_builtin(right)
-                || expression
-                    .as_ref()
-                    .is_some_and(expr_reaches_unsafe_builtin)
+                || expression.as_ref().is_some_and(expr_reaches_unsafe_builtin)
         }
         GraphPattern::OrderBy { inner, expression } => {
             pattern_reaches_unsafe_builtin(inner)
@@ -234,76 +257,40 @@ fn pattern_reaches_unsafe_builtin(pattern: &GraphPattern) -> bool {
     }
 }
 
-/// Run `worker` over every item of `items` and reduce the results
-/// **deterministically**: order-stable success flattening (rayon's indexed
-/// `collect` preserves source order — never `par_sort`/`par_bridge`, which are
-/// not order-stable) and, on failure, the first `Err` **by source index** wins
-/// regardless of which worker finished first.
-///
-/// Internally gated on [`should_parallelize`]: at or below [`PARALLEL_MIN_ROWS`]
-/// this runs a plain sequential `iter().enumerate()` fold (bit-identical output,
-/// no rayon hand-off cost); above it, rayon's indexed `par_iter`. Callers get a
-/// single call site — the `#[cfg(test)]` force seam in [`should_parallelize`]
-/// routes through here.
-///
-/// Mirrors `purrdf_rdf::native_codecs::text_parse::parse_lines_parallel_with_chunk_size`:
-/// every worker result is collected into a plain `Vec` FIRST, then walked in
-/// order and `?`-propagated, so a fast late item can never race ahead of an
-/// earlier item's diagnostic.
-pub(crate) fn par_try_flat_map<T, F>(items: &[T], worker: F) -> Result<Vec<Solution>, EvalError>
-where
-    T: Sync,
-    F: Fn(usize, &T) -> Result<Vec<Solution>, EvalError> + Sync + Send,
-{
-    if !should_parallelize(items.len()) {
-        let mut out = Vec::new();
-        for (i, item) in items.iter().enumerate() {
-            out.extend(worker(i, item)?);
-        }
-        return Ok(out);
-    }
-
-    use rayon::prelude::*;
-
-    let per_item: Vec<Result<Vec<Solution>, EvalError>> = items
-        .par_iter()
-        .enumerate()
-        .map(|(i, item)| worker(i, item))
-        .collect();
-
-    let mut out = Vec::with_capacity(per_item.iter().map(|r| r.as_ref().map_or(0, Vec::len)).sum());
-    for result in per_item {
-        out.extend(result?);
-    }
-    Ok(out)
-}
-
-/// The fork-per-worker sibling of [`par_try_flat_map`]: instead of one immutable
-/// `worker` closure applied per item, each rayon *worker thread* first runs
-/// `init` **once** to build its own `S` (e.g. an `EvalCtx::fork_for_worker`
+/// The fork-per-worker sibling of [`par_flat_map`]/[`par_retain`]: instead of one
+/// immutable `worker` closure applied per item, each rayon *worker thread* first
+/// runs `init` **once** to build its own `S` (e.g. an `EvalCtx::fork_for_worker`
 /// child) and then reuses that state across every item it is scheduled, via
 /// rayon's `map_init`. This avoids forking a fresh child per row — the fork
 /// (cloning the scratch interner, the `exists_inner_cache`, etc.) is real, if
 /// cheap, work that should happen once per worker thread, not once per row.
 ///
-/// Internally gated on [`should_parallelize`] exactly like [`par_try_flat_map`]:
-/// at or below [`PARALLEL_MIN_ROWS`], `init` runs exactly once and every item is
-/// folded sequentially over that single state (bit-identical to a hand-written
-/// sequential loop — no rayon hand-off, no extra `init` calls); above it,
-/// `par_iter().map_init` gives each worker thread its own `S` and the results
-/// are collected into an indexed `Vec` first, then reduced in source order —
-/// the same "collect first, then walk in order" shape as [`par_try_flat_map`],
-/// so a fast late item can never race ahead of an earlier item's diagnostic.
-pub(crate) fn par_try_flat_map_init<T, S, Init, F>(
+/// Internally gated on [`should_parallelize`]: at or below [`PARALLEL_MIN_ROWS`],
+/// `init` runs exactly once and every item is folded sequentially over that
+/// single state (bit-identical to a hand-written sequential loop — no rayon
+/// hand-off, no extra `init` calls); above it, `par_iter().map_init` gives each
+/// worker thread its own `S` and the results are collected into an indexed
+/// `Vec` first, then reduced strictly in source order: successes flatten in
+/// index order and the first `Err` **by index** wins regardless of which
+/// worker finished first — so a fast late item can never race ahead of an
+/// earlier item's diagnostic (mirrors
+/// `purrdf_rdf::native_codecs::text_parse::parse_lines_parallel_with_chunk_size`).
+///
+/// Generic over the returned element type `R` (not just [`Solution`]): a
+/// minting caller (e.g. `eval_extend`, `eval_group`'s per-group compute) returns
+/// [`PortableTerm`] rows instead, since the worker's forked child (and its
+/// scratch) is gone by the time the caller can re-intern against the parent.
+pub(crate) fn par_try_flat_map_init<T, S, R, Init, F>(
     items: &[T],
     init: Init,
     worker: F,
-) -> Result<Vec<Solution>, EvalError>
+) -> Result<Vec<R>, EvalError>
 where
     T: Sync,
     S: Send,
+    R: Send,
     Init: Fn() -> S + Sync + Send,
-    F: Fn(&mut S, usize, &T) -> Result<Vec<Solution>, EvalError> + Sync + Send,
+    F: Fn(&mut S, usize, &T) -> Result<Vec<R>, EvalError> + Sync + Send,
 {
     if !should_parallelize(items.len()) {
         let mut state = init();
@@ -316,21 +303,26 @@ where
 
     use rayon::prelude::*;
 
-    let per_item: Vec<Result<Vec<Solution>, EvalError>> = items
+    let per_item: Vec<Result<Vec<R>, EvalError>> = items
         .par_iter()
         .enumerate()
         .map_init(&init, |state, (i, item)| worker(state, i, item))
         .collect();
 
-    let mut out = Vec::with_capacity(per_item.iter().map(|r| r.as_ref().map_or(0, Vec::len)).sum());
+    let mut out = Vec::with_capacity(
+        per_item
+            .iter()
+            .map(|r| r.as_ref().map_or(0, Vec::len))
+            .sum(),
+    );
     for result in per_item {
         out.extend(result?);
     }
     Ok(out)
 }
 
-/// The infallible sibling of [`par_try_flat_map`]: run `worker` over every item
-/// of `items` and flatten the per-item `Vec<R>` results in source-index order.
+/// The infallible sibling of [`par_try_flat_map_init`]: run `worker` over every
+/// item of `items` and flatten the per-item `Vec<R>` results in source-index order.
 /// Same internal [`should_parallelize`] gate — sequential at/below the
 /// threshold, rayon's indexed `par_iter` above it — so there is exactly one
 /// call site per caller and the `#[cfg(test)]` force seam applies uniformly.
@@ -350,7 +342,11 @@ where
 
     use rayon::prelude::*;
 
-    let per_item: Vec<Vec<R>> = items.par_iter().enumerate().map(|(i, item)| worker(i, item)).collect();
+    let per_item: Vec<Vec<R>> = items
+        .par_iter()
+        .enumerate()
+        .map(|(i, item)| worker(i, item))
+        .collect();
 
     let mut out = Vec::with_capacity(per_item.iter().map(Vec::len).sum());
     for result in per_item {
@@ -377,40 +373,82 @@ where
 
     use rayon::prelude::*;
 
-    items.par_iter().filter(|item| keep(item)).cloned().collect()
+    items
+        .par_iter()
+        .filter(|item| keep(item))
+        .cloned()
+        .collect()
 }
 
-/// Fold one row produced by a forked worker's `local` scratch back into the
-/// `main` (parent) scratch, re-interning any [`crate::scratch::SolutionTerm::Computed`]
-/// cell against `main`/`dataset` so its [`crate::scratch::ScratchId`] is valid in the
-/// parent's id space. `Existing`/`None` cells pass through unchanged (they are
-/// already dataset-space ids, valid in any scratch).
-pub(crate) fn absorb_row(
-    main: &mut ScratchInterner,
-    dataset: &RdfDataset,
+/// One cell of a minting node's output row, materialized to a form that
+/// survives the forked child (and its scratch) being dropped.
+///
+/// A forked child's scratch is a **clone** of the parent's at fork time (see
+/// [`crate::eval::EvalCtx::fork_for_worker`]), so a [`crate::scratch::SolutionTerm::Computed`]
+/// id already carries meaning independent of *which* scratch resolves it, as
+/// long as that id was minted before the fork: `base` (the parent's
+/// [`ScratchInterner::computed_count`] at fork time) is the dividing line.
+///
+/// - `sid < base` — already a valid PARENT id (the child inherited it via the
+///   clone); pass it through unchanged as [`PortableTerm::Parent`].
+/// - `sid >= base` — a term the CHILD freshly minted after the fork; the
+///   parent has never seen it, so it is captured as its dataset-independent
+///   [`TermValue`] ([`PortableTerm::Fresh`]) while the child (and its scratch)
+///   is still alive, for the caller to re-intern against the parent later.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum PortableTerm {
+    /// A term already valid in the parent's id space: an `Existing` dataset
+    /// term, or a `Computed` id minted before the fork.
+    Parent(SolutionTerm),
+    /// A value the child minted after the fork; not yet interned anywhere but
+    /// the child's own (about-to-be-dropped) scratch.
+    Fresh(TermValue),
+}
+
+/// Materialize one output `row` produced against a forked child's `local`
+/// scratch into a portable form, while `local` is still alive. `base` is the
+/// parent's [`ScratchInterner::computed_count`] captured **at fork time** —
+/// see [`PortableTerm`] for the id rule this relies on.
+pub(crate) fn portable_row(
     local: &ScratchInterner,
+    base: usize,
     row: &Solution,
-) -> Solution {
+) -> Vec<Option<PortableTerm>> {
     row.iter()
         .map(|cell| match cell {
-            Some(crate::scratch::SolutionTerm::Computed(sid)) => {
-                Some(main.intern(dataset, local.computed_value(*sid).clone()))
+            None => None,
+            Some(SolutionTerm::Computed(sid)) if sid.index() >= base => {
+                Some(PortableTerm::Fresh(local.computed_value(*sid).clone()))
             }
-            other => *other,
+            Some(term) => Some(PortableTerm::Parent(*term)),
         })
         .collect()
 }
 
-/// Append a forked worker's constructed cells onto `main`, in the order given.
-/// The cells are dataset-independent [`TermValue`] triples (no id space to
-/// re-map, unlike [`absorb_row`]) — the caller is responsible for invoking this
-/// once per child **in source-index order**, which is what makes the merged
-/// buffer deterministic.
-pub(crate) fn absorb_constructed(
-    main: &mut Vec<(TermValue, TermValue, TermValue)>,
-    child: Vec<(TermValue, TermValue, TermValue)>,
-) {
-    main.extend(child);
+/// Re-intern a [`portable_row`] output back into the `main` (parent) scratch:
+/// a [`PortableTerm::Parent`] cell passes through unchanged (already valid in
+/// `main`'s id space); a [`PortableTerm::Fresh`] cell is interned against
+/// `main`/`dataset`, deduplicating against anything `main` (or an
+/// earlier-reinterned sibling row, when the caller processes rows in source
+/// order as required) already holds.
+///
+/// Callers MUST invoke this once per row **in source-index order** across all
+/// workers — that ordering, not anything in this function, is what makes two
+/// workers minting the same fresh value converge on the same parent id
+/// deterministically (whichever reinterns first wins the id; the same value
+/// reinterned again is deduplicated against it, not re-minted).
+pub(crate) fn reintern_portable_row(
+    main: &mut ScratchInterner,
+    dataset: &RdfDataset,
+    prow: &[Option<PortableTerm>],
+) -> Solution {
+    prow.iter()
+        .map(|cell| match cell {
+            None => None,
+            Some(PortableTerm::Parent(term)) => Some(*term),
+            Some(PortableTerm::Fresh(value)) => Some(main.intern(dataset, value.clone())),
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -511,7 +549,11 @@ mod tests {
         let rand = call(Function::Rand, vec![]);
         let safe = Expression::Literal(Literal::new_simple("ok"));
 
-        let in_if = Expression::If(Box::new(cond), Box::new(safe.clone()), Box::new(rand.clone()));
+        let in_if = Expression::If(
+            Box::new(cond),
+            Box::new(safe.clone()),
+            Box::new(rand.clone()),
+        );
         assert!(!is_parallel_safe(&in_if));
 
         let in_coalesce = Expression::Coalesce(vec![safe.clone(), rand.clone()]);
@@ -523,9 +565,9 @@ mod tests {
 
     #[test]
     fn unsafe_inside_nested_exists_filter_is_detected() {
-        let vp = |n: &str| purrdf_sparql_algebra::TermPattern::Variable(
-            purrdf_sparql_algebra::Variable::new(n),
-        );
+        let vp = |n: &str| {
+            purrdf_sparql_algebra::TermPattern::Variable(purrdf_sparql_algebra::Variable::new(n))
+        };
         let pred = |iri: &str| {
             purrdf_sparql_algebra::NamedNodePattern::NamedNode(NamedNode::new_unchecked(iri))
         };
@@ -555,55 +597,6 @@ mod tests {
         assert!(is_parallel_safe(&safe_exists));
     }
 
-    // ---- par_try_flat_map ----------------------------------------------------
-
-    #[test]
-    fn par_try_flat_map_flattens_in_index_order() {
-        let items: Vec<usize> = (0..64).collect();
-        let result = par_try_flat_map(&items, |i, &item| {
-            // Deliberately makes later-indexed items "finish faster" by doing less
-            // work, to prove the reduce is still index-ordered rather than
-            // completion-ordered.
-            if item % 7 != 0 {
-                std::thread::yield_now();
-            }
-            Ok(vec![vec![
-                Some(crate::scratch::SolutionTerm::Existing(
-                    purrdf_core::TermId::from_index(i as u32),
-                )),
-            ]])
-        })
-        .expect("no errors");
-        let indices: Vec<u32> = result
-            .iter()
-            .map(|row| match row[0] {
-                Some(crate::scratch::SolutionTerm::Existing(id)) => id.index() as u32,
-                _ => unreachable!(),
-            })
-            .collect();
-        let expected: Vec<u32> = (0..64).collect();
-        assert_eq!(indices, expected);
-    }
-
-    #[test]
-    fn par_try_flat_map_surfaces_the_lower_indexed_error() {
-        let items: Vec<usize> = (0..32).collect();
-        let result: Result<Vec<Solution>, EvalError> = par_try_flat_map(&items, |i, _| {
-            if i == 20 {
-                // The "slow" earlier error: give the scheduler a chance to let a
-                // later index finish first.
-                std::thread::yield_now();
-                return Err(EvalError::internal("error at 20"));
-            }
-            if i == 5 {
-                return Err(EvalError::internal("error at 5"));
-            }
-            Ok(vec![])
-        });
-        let err = result.unwrap_err();
-        assert_eq!(err, EvalError::internal("error at 5"));
-    }
-
     // ---- par_try_flat_map_init -------------------------------------------------
 
     #[test]
@@ -621,7 +614,7 @@ mod tests {
                 if item % 7 != 0 {
                     std::thread::yield_now();
                 }
-                Ok(vec![vec![Some(crate::scratch::SolutionTerm::Existing(
+                Ok(vec![vec![Some(SolutionTerm::Existing(
                     purrdf_core::TermId::from_index(i as u32),
                 ))]])
             },
@@ -630,7 +623,7 @@ mod tests {
         let indices: Vec<u32> = result
             .iter()
             .map(|row| match row[0] {
-                Some(crate::scratch::SolutionTerm::Existing(id)) => id.index() as u32,
+                Some(SolutionTerm::Existing(id)) => id.index() as u32,
                 _ => unreachable!(),
             })
             .collect();
@@ -653,15 +646,17 @@ mod tests {
                 init_calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 0_u64
             },
-            |_state, i, _item| Ok(vec![vec![Some(crate::scratch::SolutionTerm::Existing(
-                purrdf_core::TermId::from_index(i as u32),
-            ))]]),
+            |_state, i, _item| {
+                Ok(vec![vec![Some(SolutionTerm::Existing(
+                    purrdf_core::TermId::from_index(i as u32),
+                ))]])
+            },
         )
         .expect("no errors");
         let indices: Vec<u32> = result
             .iter()
             .map(|row| match row[0] {
-                Some(crate::scratch::SolutionTerm::Existing(id)) => id.index() as u32,
+                Some(SolutionTerm::Existing(id)) => id.index() as u32,
                 _ => unreachable!(),
             })
             .collect();
@@ -674,8 +669,10 @@ mod tests {
     #[test]
     fn par_try_flat_map_init_surfaces_the_lower_indexed_error() {
         let items: Vec<usize> = (0..32).collect();
-        let result: Result<Vec<Solution>, EvalError> =
-            par_try_flat_map_init(&items, || (), |(), i, _| {
+        let result: Result<Vec<Solution>, EvalError> = par_try_flat_map_init(
+            &items,
+            || (),
+            |(), i, _| {
                 if i == 20 {
                     std::thread::yield_now();
                     return Err(EvalError::internal("error at 20"));
@@ -684,7 +681,8 @@ mod tests {
                     return Err(EvalError::internal("error at 5"));
                 }
                 Ok(vec![])
-            });
+            },
+        );
         let err = result.unwrap_err();
         assert_eq!(err, EvalError::internal("error at 5"));
     }
@@ -734,10 +732,19 @@ mod tests {
         assert_eq!(kept, expected);
     }
 
-    // ---- fork_for_worker + absorb_row -----------------------------------------
+    // ---- fork_for_worker + portable_row/reintern_portable_row -----------------
+
+    fn lit(s: &str) -> TermValue {
+        TermValue::Literal {
+            lexical_form: s.to_owned(),
+            datatype: "http://www.w3.org/2001/XMLSchema#string".to_owned(),
+            language: None,
+            direction: None,
+        }
+    }
 
     #[test]
-    fn fork_and_absorb_row_round_trips_computed_values() {
+    fn portable_row_round_trips_fresh_and_pre_fork_and_existing_and_none() {
         let ds = RdfDatasetBuilder::new()
             .freeze()
             .expect("freeze empty dataset");
@@ -745,70 +752,70 @@ mod tests {
 
         // Seed the PARENT scratch with an already-minted value BEFORE forking, so
         // an input row carrying that `Computed` id (as a real parallel worker's
-        // input rows would) is something the fork must be able to resolve.
-        let existing_value = TermValue::Literal {
-            lexical_form: "already minted".to_owned(),
-            datatype: "http://www.w3.org/2001/XMLSchema#string".to_owned(),
-            language: None,
-            direction: None,
-        };
-        let existing_term = parent.scratch.intern(&ds, existing_value.clone());
+        // input rows would) is something the fork must be able to resolve, and
+        // `portable_row` must classify it as `Parent` (sid < base), not `Fresh`.
+        let pre_fork_value = lit("already minted");
+        let pre_fork_term = parent.scratch.intern(&ds, pre_fork_value.clone());
+        let base = parent.scratch.computed_count();
 
         let mut child = parent.fork_for_worker();
-
-        // The fork must resolve the PARENT's pre-existing `Computed` term
-        // identically — this is the fix under test: a fresh (empty) child scratch
-        // would panic (`values[sid.index()]` out of bounds) or, if it happened not
-        // to, resolve nonsense. `fork_for_worker` now clones the parent scratch, so
-        // this must round-trip.
         assert_eq!(
-            child.scratch.value_of(&ds, existing_term),
-            existing_value,
+            child.scratch.value_of(&ds, pre_fork_term),
+            pre_fork_value,
             "child must resolve a Computed id it inherited from the parent scratch"
         );
 
-        // The child mints a NEW value (not known to the parent at fork time).
-        let value = TermValue::Literal {
-            lexical_form: "hello parallel".to_owned(),
-            datatype: "http://www.w3.org/2001/XMLSchema#string".to_owned(),
-            language: None,
-            direction: None,
-        };
-        let child_term = child.scratch.intern(&ds, value.clone());
-        let row: Solution = vec![Some(existing_term), Some(child_term)];
+        // The child mints a NEW value (not known to the parent at fork time) —
+        // `portable_row` must classify this as `Fresh` (sid >= base).
+        let fresh_value = lit("hello parallel");
+        let fresh_term = child.scratch.intern(&ds, fresh_value.clone());
+        let row: Solution = vec![None, Some(pre_fork_term), Some(fresh_term)];
 
-        let absorbed = absorb_row(&mut parent.scratch, &ds, &child.scratch, &row);
-        // The pre-existing term passes through absorb unchanged (still resolves in
-        // the parent, which already owned it).
-        let absorbed_existing = absorbed[0].expect("cell present");
-        assert_eq!(parent.scratch.value_of(&ds, absorbed_existing), existing_value);
-        // The child's fresh mint is folded back into the parent's id space and
+        let prow = portable_row(&child.scratch, base, &row);
+        assert_eq!(prow[0], None);
+        assert_eq!(prow[1], Some(PortableTerm::Parent(pre_fork_term)));
+        assert_eq!(prow[2], Some(PortableTerm::Fresh(fresh_value.clone())));
+
+        let reinterned = reintern_portable_row(&mut parent.scratch, &ds, &prow);
+        assert_eq!(reinterned[0], None);
+        // The pre-fork term passes through unchanged and still resolves in the
+        // parent (which already owned it).
+        assert_eq!(reinterned[1], Some(pre_fork_term));
+        assert_eq!(
+            parent.scratch.value_of(&ds, reinterned[1].unwrap()),
+            pre_fork_value
+        );
+        // The child's fresh mint is folded into the parent's id space and
         // resolves to the same value there.
-        let main_term = absorbed[1].expect("cell present");
-        assert_eq!(parent.scratch.value_of(&ds, main_term), value);
+        let reinterned_fresh = reinterned[2].expect("cell present");
+        assert_eq!(parent.scratch.value_of(&ds, reinterned_fresh), fresh_value);
     }
 
     #[test]
-    fn absorb_constructed_appends_in_call_order() {
-        let cell = |n: &str| TermValue::Iri(format!("http://ex/{n}"));
-        let mut main: Vec<(TermValue, TermValue, TermValue)> = vec![(
-            cell("s0"),
-            cell("p0"),
-            cell("o0"),
-        )];
-        let child_a = vec![(cell("s1"), cell("p1"), cell("o1"))];
-        let child_b = vec![(cell("s2"), cell("p2"), cell("o2"))];
+    fn reintern_portable_row_dedups_two_children_minting_the_same_value() {
+        let ds = RdfDatasetBuilder::new()
+            .freeze()
+            .expect("freeze empty dataset");
+        let mut parent = crate::eval::EvalCtx::new(&ds);
+        let base = parent.scratch.computed_count();
 
-        absorb_constructed(&mut main, child_a);
-        absorb_constructed(&mut main, child_b);
+        let mut child_a = parent.fork_for_worker();
+        let mut child_b = parent.fork_for_worker();
+        let shared_value = lit("same value from two workers");
+        let term_a = child_a.scratch.intern(&ds, shared_value.clone());
+        let term_b = child_b.scratch.intern(&ds, shared_value);
+
+        let row_a: Solution = vec![Some(term_a)];
+        let row_b: Solution = vec![Some(term_b)];
+        let prow_a = portable_row(&child_a.scratch, base, &row_a);
+        let prow_b = portable_row(&child_b.scratch, base, &row_b);
+
+        let reinterned_a = reintern_portable_row(&mut parent.scratch, &ds, &prow_a);
+        let reinterned_b = reintern_portable_row(&mut parent.scratch, &ds, &prow_b);
 
         assert_eq!(
-            main,
-            vec![
-                (cell("s0"), cell("p0"), cell("o0")),
-                (cell("s1"), cell("p1"), cell("o1")),
-                (cell("s2"), cell("p2"), cell("o2")),
-            ]
+            reinterned_a[0], reinterned_b[0],
+            "two workers minting the same fresh value must reintern to the same parent id"
         );
     }
 }

--- a/crates/sparql-eval/src/parallel.rs
+++ b/crates/sparql-eval/src/parallel.rs
@@ -11,11 +11,12 @@
 //! 1. **Fork.** [`crate::eval::EvalCtx::fork_for_worker`] gives each worker a
 //!    `Send` child context with its own scratch/constructed state, so workers
 //!    never contend on a lock or share mutable evaluation state.
-//! 2. **Join.** [`par_try_flat_map_init`]/[`par_flat_map`]/[`par_retain`] run the
-//!    workers via rayon's *indexed* `collect` (never `par_sort`/`par_bridge`,
-//!    which are not order-stable) and then reduce strictly in source-index
-//!    order: successes flatten in index order and the first `Err` **by index**
-//!    wins, regardless of which worker finished first.
+//! 2. **Join.** [`par_chunk_try_map_init`]/[`par_chunk_map`]/[`par_retain`] run
+//!    the workers via rayon's *indexed* `par_chunks`/`par_iter` (never
+//!    `par_sort`/`par_bridge`, which are not order-stable) and then reduce
+//!    strictly in source-index order: successes concatenate in chunk (hence
+//!    source) order and the first `Err` **by chunk index** wins, regardless of
+//!    which worker finished first.
 //!
 //! A read-only FILTER predicate discards its child's scratch mints entirely (the
 //! surviving rows are the original rows, nothing new escapes). A **minting** node
@@ -58,6 +59,31 @@ use crate::solution::Solution;
 /// the work for small inputs). Initial value; Task 7's bench tunes it.
 pub(crate) const PARALLEL_MIN_ROWS: usize = 1024;
 
+/// Floor on a chunk's item count: below this, splitting further would hand
+/// rayon workers slivers dominated by per-chunk overhead (the fork, the `Vec`
+/// staging) rather than real work. Mirrors the byte-based floor
+/// `purrdf_rdf::native_codecs::text_parse::PARALLEL_MIN_CHUNK_BYTES` applies to
+/// the parser's chunk geometry, just in item-count terms.
+const PARALLEL_MIN_CHUNK_ITEMS: usize = 16;
+
+/// The chunk size for a [`par_chunk_map`]/[`par_chunk_try_map_init`] run over
+/// `len` items: aim for roughly four chunks per rayon worker thread, so
+/// work-stealing has enough slices to balance ragged per-item costs (a BGP
+/// pattern whose candidate count varies row to row, a GROUP BY group whose
+/// size varies group to group) without handing every thread only one
+/// coarse-grained slice. Clamped below by [`PARALLEL_MIN_CHUNK_ITEMS`] so a
+/// small-but-still-parallel input (just over [`PARALLEL_MIN_ROWS`]) on a
+/// many-thread machine never degenerates into chunks of a handful of items
+/// each — mirrors the parser's `len / (threads * 4)` geometry.
+fn chunk_size_for(len: usize) -> usize {
+    #[cfg(test)]
+    if let Some(forced) = FORCE_CHUNK_SIZE.with(std::cell::Cell::get) {
+        return forced.max(1);
+    }
+    let threads = rayon::current_num_threads().max(1);
+    (len / (threads * 4).max(1)).max(PARALLEL_MIN_CHUNK_ITEMS)
+}
+
 #[cfg(test)]
 std::thread_local! {
     /// Test-only override for [`should_parallelize`], so a bench/test can force
@@ -86,6 +112,38 @@ pub(crate) struct ForceParallelGuard {
 impl Drop for ForceParallelGuard {
     fn drop(&mut self) {
         FORCE_PARALLEL.with(|cell| cell.set(self.previous));
+    }
+}
+
+#[cfg(test)]
+std::thread_local! {
+    /// Test-only override for [`chunk_size_for`]'s result, so a test can pin an
+    /// exact chunk size (hence an exact chunk count) regardless of
+    /// `rayon::current_num_threads()`, which varies by machine/CI runner.
+    /// Never consulted outside `cfg(test)`.
+    static FORCE_CHUNK_SIZE: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+}
+
+/// Force [`chunk_size_for`] to always return `size` for the current thread
+/// until the returned guard is dropped (restores the prior override).
+/// Test-only — lets a test span an exact number of chunks deterministically.
+#[cfg(test)]
+#[must_use]
+pub(crate) fn force_chunk_size_for_test(size: usize) -> ForceChunkSizeGuard {
+    let previous = FORCE_CHUNK_SIZE.with(|cell| cell.replace(Some(size)));
+    ForceChunkSizeGuard { previous }
+}
+
+/// RAII guard restoring the prior [`FORCE_CHUNK_SIZE`] override on drop.
+#[cfg(test)]
+pub(crate) struct ForceChunkSizeGuard {
+    previous: Option<usize>,
+}
+
+#[cfg(test)]
+impl Drop for ForceChunkSizeGuard {
+    fn drop(&mut self) {
+        FORCE_CHUNK_SIZE.with(|cell| cell.set(self.previous));
     }
 }
 
@@ -257,102 +315,127 @@ fn pattern_reaches_unsafe_builtin(pattern: &GraphPattern) -> bool {
     }
 }
 
-/// The fork-per-worker sibling of [`par_flat_map`]/[`par_retain`]: instead of one
-/// immutable `worker` closure applied per item, each rayon *worker thread* first
-/// runs `init` **once** to build its own `S` (e.g. an `EvalCtx::fork_for_worker`
-/// child) and then reuses that state across every item it is scheduled, via
-/// rayon's `map_init`. This avoids forking a fresh child per row — the fork
-/// (cloning the scratch interner, the `exists_inner_cache`, etc.) is real, if
-/// cheap, work that should happen once per worker thread, not once per row.
+/// Chunk-based, infallible parallel collect: split `items` into index-ordered
+/// chunks (never `par_sort`/`par_bridge`), give each chunk worker ONE `Vec<R>`
+/// accumulator (`push` is called once per item, appending into it), and
+/// concatenate the per-chunk accumulators in chunk order. This is the
+/// allocation shape [`purrdf_rdf::native_codecs::text_parse::parse_lines_parallel_with_chunk_size`]
+/// uses for its phase 1: one allocation per CHUNK, not one per item — the
+/// per-item shape (a fresh `Vec` returned by every worker call, flattened
+/// afterwards) this replaces cost an extra small allocation for every row of
+/// an N-row BGP/join/filter loop, pure overhead the chunk shape avoids.
 ///
-/// Internally gated on [`should_parallelize`]: at or below [`PARALLEL_MIN_ROWS`],
-/// `init` runs exactly once and every item is folded sequentially over that
-/// single state (bit-identical to a hand-written sequential loop — no rayon
-/// hand-off, no extra `init` calls); above it, `par_iter().map_init` gives each
-/// worker thread its own `S` and the results are collected into an indexed
-/// `Vec` first, then reduced strictly in source order: successes flatten in
-/// index order and the first `Err` **by index** wins regardless of which
-/// worker finished first — so a fast late item can never race ahead of an
-/// earlier item's diagnostic (mirrors
-/// `purrdf_rdf::native_codecs::text_parse::parse_lines_parallel_with_chunk_size`).
-///
-/// Generic over the returned element type `R` (not just [`Solution`]): a
-/// minting caller (e.g. `eval_extend`, `eval_group`'s per-group compute) returns
-/// [`PortableTerm`] rows instead, since the worker's forked child (and its
-/// scratch) is gone by the time the caller can re-intern against the parent.
-pub(crate) fn par_try_flat_map_init<T, S, R, Init, F>(
-    items: &[T],
-    init: Init,
-    worker: F,
-) -> Result<Vec<R>, EvalError>
-where
-    T: Sync,
-    S: Send,
-    R: Send,
-    Init: Fn() -> S + Sync + Send,
-    F: Fn(&mut S, usize, &T) -> Result<Vec<R>, EvalError> + Sync + Send,
-{
-    if !should_parallelize(items.len()) {
-        let mut state = init();
-        let mut out = Vec::new();
-        for (i, item) in items.iter().enumerate() {
-            out.extend(worker(&mut state, i, item)?);
-        }
-        return Ok(out);
-    }
-
-    use rayon::prelude::*;
-
-    let per_item: Vec<Result<Vec<R>, EvalError>> = items
-        .par_iter()
-        .enumerate()
-        .map_init(&init, |state, (i, item)| worker(state, i, item))
-        .collect();
-
-    let mut out = Vec::with_capacity(
-        per_item
-            .iter()
-            .map(|r| r.as_ref().map_or(0, Vec::len))
-            .sum(),
-    );
-    for result in per_item {
-        out.extend(result?);
-    }
-    Ok(out)
-}
-
-/// The infallible sibling of [`par_try_flat_map_init`]: run `worker` over every
-/// item of `items` and flatten the per-item `Vec<R>` results in source-index order.
-/// Same internal [`should_parallelize`] gate — sequential at/below the
-/// threshold, rayon's indexed `par_iter` above it — so there is exactly one
-/// call site per caller and the `#[cfg(test)]` force seam applies uniformly.
-pub(crate) fn par_flat_map<T, R, F>(items: &[T], worker: F) -> Vec<R>
+/// Internally gated on [`should_parallelize`]: at or below [`PARALLEL_MIN_ROWS`]
+/// this is a single sequential pass pushing into one `Vec` (bit-identical to a
+/// hand-written loop, no rayon hand-off); above it, `items.par_chunks(..)` (an
+/// *indexed*, order-preserving split) runs `push` over each chunk into its own
+/// accumulator, and the chunk accumulators are concatenated strictly in chunk
+/// (hence source) order — so the result is byte-identical to the sequential
+/// pass regardless of chunk geometry or worker scheduling.
+pub(crate) fn par_chunk_map<T, R>(items: &[T], push: impl Fn(&mut Vec<R>, &T) + Sync) -> Vec<R>
 where
     T: Sync,
     R: Send,
-    F: Fn(usize, &T) -> Vec<R> + Sync + Send,
 {
     if !should_parallelize(items.len()) {
         let mut out = Vec::new();
-        for (i, item) in items.iter().enumerate() {
-            out.extend(worker(i, item));
+        for item in items {
+            push(&mut out, item);
         }
         return out;
     }
 
     use rayon::prelude::*;
 
-    let per_item: Vec<Vec<R>> = items
-        .par_iter()
-        .enumerate()
-        .map(|(i, item)| worker(i, item))
+    let size = chunk_size_for(items.len());
+    let chunk_outs: Vec<Vec<R>> = items
+        .par_chunks(size)
+        .map(|chunk| {
+            let mut acc = Vec::new();
+            for item in chunk {
+                push(&mut acc, item);
+            }
+            acc
+        })
         .collect();
 
-    let mut out = Vec::with_capacity(per_item.iter().map(Vec::len).sum());
-    for result in per_item {
-        out.extend(result);
+    let mut out = Vec::with_capacity(chunk_outs.iter().map(Vec::len).sum());
+    for chunk_out in chunk_outs {
+        out.extend(chunk_out);
     }
     out
+}
+
+/// The fallible, fork-per-worker sibling of [`par_chunk_map`]: each rayon
+/// *chunk* worker first runs `init` **once** to build its own `S` (e.g. an
+/// `EvalCtx::fork_for_worker` child), then folds `push` over every item of its
+/// chunk into one `Vec<R>` accumulator, short-circuiting the chunk on the
+/// first `Err`. This forks one child per CHUNK, not per item — the fork
+/// (cloning the scratch interner, the `exists_inner_cache`, etc.) is real, if
+/// cheap, work that should happen a handful of times, not once per row — and
+/// gives the chunk exactly one output allocation instead of one per item.
+///
+/// Internally gated on [`should_parallelize`]: at or below [`PARALLEL_MIN_ROWS`],
+/// `init` runs exactly once and every item folds sequentially over that single
+/// state into one `Vec` (bit-identical to a hand-written sequential loop, no
+/// rayon hand-off, no extra `init` calls); above it, `items.par_chunks(..)`
+/// (an *indexed*, order-preserving split) runs each chunk to completion,
+/// collecting `Vec<Result<Vec<R>, EvalError>>` in chunk order, then reduces
+/// strictly in that order: successes concatenate in chunk (hence source)
+/// order and the first `Err` **by chunk index** wins regardless of which
+/// worker finished first — so a fast late chunk can never race ahead of an
+/// earlier chunk's diagnostic (mirrors
+/// `purrdf_rdf::native_codecs::text_parse::parse_lines_parallel_with_chunk_size`'s
+/// phase 2 reduce). Within a chunk, items are folded in source order, so the
+/// overall output is exactly source order.
+///
+/// Generic over the returned element type `R` (not just [`Solution`]): a
+/// minting caller (e.g. `eval_extend`, `eval_group`'s per-group compute) can
+/// push [`MintedRow`]s instead, since the worker's forked child (and its
+/// scratch) is gone by the time the caller can re-intern against the parent.
+pub(crate) fn par_chunk_try_map_init<T, S, R>(
+    items: &[T],
+    init: impl Fn() -> S + Sync,
+    push: impl Fn(&mut S, &mut Vec<R>, &T) -> Result<(), EvalError> + Sync,
+) -> Result<Vec<R>, EvalError>
+where
+    T: Sync,
+    R: Send,
+{
+    if !should_parallelize(items.len()) {
+        let mut state = init();
+        let mut out = Vec::new();
+        for item in items {
+            push(&mut state, &mut out, item)?;
+        }
+        return Ok(out);
+    }
+
+    use rayon::prelude::*;
+
+    let size = chunk_size_for(items.len());
+    let per_chunk: Vec<Result<Vec<R>, EvalError>> = items
+        .par_chunks(size)
+        .map(|chunk| {
+            let mut state = init();
+            let mut acc = Vec::new();
+            for item in chunk {
+                push(&mut state, &mut acc, item)?;
+            }
+            Ok(acc)
+        })
+        .collect();
+
+    let mut out = Vec::with_capacity(
+        per_chunk
+            .iter()
+            .map(|r| r.as_ref().map_or(0, Vec::len))
+            .sum(),
+    );
+    for chunk_result in per_chunk {
+        out.extend(chunk_result?);
+    }
+    Ok(out)
 }
 
 /// An order-stable, internally-gated parallel filter-clone: keep every item of
@@ -449,6 +532,61 @@ pub(crate) fn reintern_portable_row(
             Some(PortableTerm::Fresh(value)) => Some(main.intern(dataset, value.clone())),
         })
         .collect()
+}
+
+/// One row escaping a minting fork-join worker (a `UNION` branch, a GROUP BY
+/// group, a `BIND`): either already valid in the PARENT id space, or one that
+/// must be re-interned via a [`portable_row`] captured while the minting
+/// child's scratch is still alive.
+///
+/// This is the "no-mint fast path": a `Computed(sid)` cell with `sid < base`
+/// is already a valid parent id (the child inherited it via the fork-time
+/// scratch clone — see [`PortableTerm`]'s doc comment for the exact rule), so
+/// a row none of whose cells is a POST-fork mint needs no remap at all — the
+/// [`portable_row`]/[`reintern_portable_row`] round trip would be a correct
+/// no-op that still pays a per-cell match and a `Vec<Option<PortableTerm>>`
+/// allocation. This matters most for a UNION branch that is pure BGP (mints
+/// nothing) or a `MIN`/`MAX`/`SAMPLE` group (whose result is an existing bound
+/// value passed through) — `BIND`/most aggregates mint a genuinely new value
+/// and always take the `Portable` arm, exactly as before this fast path.
+pub(crate) enum MintedRow {
+    /// No cell of this row is a post-fork mint — pass it through untouched.
+    Direct(Solution),
+    /// At least one cell was freshly minted by the child after the fork;
+    /// captured in portable form for [`reintern_minted_row`] to re-intern.
+    Portable(Vec<Option<PortableTerm>>),
+}
+
+/// Classify one worker-produced `row` into a [`MintedRow`]: `Direct` iff no
+/// cell is a `Computed(sid)` with `sid >= base` (a post-fork mint), else
+/// `Portable` (materialized against `local` — the minting child's scratch —
+/// while it is still alive). See [`MintedRow`] for the reasoning.
+pub(crate) fn minted_row(local: &ScratchInterner, base: usize, row: Solution) -> MintedRow {
+    let has_fresh_mint = row
+        .iter()
+        .any(|cell| matches!(cell, Some(SolutionTerm::Computed(sid)) if sid.index() >= base));
+    if has_fresh_mint {
+        MintedRow::Portable(portable_row(local, base, &row))
+    } else {
+        MintedRow::Direct(row)
+    }
+}
+
+/// Re-intern one [`MintedRow`] back into the parent (`main`) scratch: a
+/// `Direct` row passes through unchanged; a `Portable` row goes through
+/// [`reintern_portable_row`]. Callers MUST invoke this once per row in
+/// source-index order across all workers — see [`reintern_portable_row`]'s doc
+/// comment for why that ordering (not anything in this function) is what makes
+/// the result deterministic.
+pub(crate) fn reintern_minted_row(
+    main: &mut ScratchInterner,
+    dataset: &RdfDataset,
+    row: MintedRow,
+) -> Solution {
+    match row {
+        MintedRow::Direct(solution) => solution,
+        MintedRow::Portable(prow) => reintern_portable_row(main, dataset, &prow),
+    }
 }
 
 #[cfg(test)]
@@ -597,26 +735,81 @@ mod tests {
         assert!(is_parallel_safe(&safe_exists));
     }
 
-    // ---- par_try_flat_map_init -------------------------------------------------
+    // ---- par_chunk_map ----------------------------------------------------
 
     #[test]
-    fn par_try_flat_map_init_flattens_in_index_order_forced_parallel() {
-        let _guard = force_parallel_for_test(true);
+    fn par_chunk_map_matches_sequential_one_chunk() {
+        // A chunk size far bigger than the input: everything lands in a
+        // single chunk, exercising the "one chunk" boundary.
+        let _parallel_guard = force_parallel_for_test(true);
+        let _chunk_guard = force_chunk_size_for_test(1000);
+        let items: Vec<usize> = (0..64).collect();
+        let result = par_chunk_map(&items, |acc, &item| {
+            if item % 7 != 0 {
+                std::thread::yield_now();
+            }
+            acc.push(item * 2);
+        });
+        let expected: Vec<usize> = (0..64).map(|i| i * 2).collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn par_chunk_map_matches_sequential_many_chunks() {
+        // A tiny chunk size over a larger input spans many chunk boundaries
+        // (100 items / chunk size 7 ⇒ 15 chunks, several ragged).
+        let _parallel_guard = force_parallel_for_test(true);
+        let _chunk_guard = force_chunk_size_for_test(7);
+        let items: Vec<usize> = (0..100).collect();
+        let result = par_chunk_map(&items, |acc, &item| {
+            if item % 3 == 0 {
+                std::thread::yield_now();
+            }
+            acc.push(item * 2);
+        });
+        let expected: Vec<usize> = (0..100).map(|i| i * 2).collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn par_chunk_map_forced_sequential_matches_forced_parallel() {
+        let items: Vec<usize> = (0..100).collect();
+        let push = |acc: &mut Vec<usize>, &item: &usize| acc.push(item * 2);
+
+        let sequential = {
+            let _guard = force_parallel_for_test(false);
+            par_chunk_map(&items, push)
+        };
+        let parallel = {
+            let _parallel_guard = force_parallel_for_test(true);
+            let _chunk_guard = force_chunk_size_for_test(9);
+            par_chunk_map(&items, push)
+        };
+        assert_eq!(sequential, parallel);
+    }
+
+    // ---- par_chunk_try_map_init ---------------------------------------------
+
+    #[test]
+    fn par_chunk_try_map_init_flattens_in_index_order_one_chunk() {
+        let _parallel_guard = force_parallel_for_test(true);
+        let _chunk_guard = force_chunk_size_for_test(1000);
         let init_calls = std::sync::atomic::AtomicUsize::new(0);
         let items: Vec<usize> = (0..64).collect();
-        let result = par_try_flat_map_init(
+        let result = par_chunk_try_map_init(
             &items,
             || {
                 init_calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                0_u64 // per-worker state: unused counter, just proves init ran.
+                0_u64 // per-chunk state: unused counter, just proves init ran.
             },
-            |_state, i, &item| {
+            |_state, acc, &item| {
                 if item % 7 != 0 {
                     std::thread::yield_now();
                 }
-                Ok(vec![vec![Some(SolutionTerm::Existing(
-                    purrdf_core::TermId::from_index(i as u32),
-                ))]])
+                acc.push(vec![Some(SolutionTerm::Existing(
+                    purrdf_core::TermId::from_index(item as u32),
+                ))]);
+                Ok(())
             },
         )
         .expect("no errors");
@@ -629,27 +822,64 @@ mod tests {
             .collect();
         let expected: Vec<u32> = (0..64).collect();
         assert_eq!(indices, expected);
-        // At least one worker thread ran `init` (forced parallel with 64 items and
-        // rayon's default pool); it never runs per-row (64 items, far fewer inits).
-        assert!(init_calls.load(std::sync::atomic::Ordering::Relaxed) >= 1);
-        assert!(init_calls.load(std::sync::atomic::Ordering::Relaxed) <= 64);
+        // A single chunk ⇒ `init` runs exactly once.
+        assert_eq!(init_calls.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
 
     #[test]
-    fn par_try_flat_map_init_flattens_in_index_order_forced_sequential() {
-        let _guard = force_parallel_for_test(false);
+    fn par_chunk_try_map_init_flattens_in_index_order_many_chunks() {
+        let _parallel_guard = force_parallel_for_test(true);
+        let _chunk_guard = force_chunk_size_for_test(7);
         let init_calls = std::sync::atomic::AtomicUsize::new(0);
-        let items: Vec<usize> = (0..64).collect();
-        let result = par_try_flat_map_init(
+        let items: Vec<usize> = (0..100).collect();
+        let result = par_chunk_try_map_init(
             &items,
             || {
                 init_calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 0_u64
             },
-            |_state, i, _item| {
-                Ok(vec![vec![Some(SolutionTerm::Existing(
-                    purrdf_core::TermId::from_index(i as u32),
-                ))]])
+            |_state, acc, &item| {
+                if item % 3 == 0 {
+                    std::thread::yield_now();
+                }
+                acc.push(vec![Some(SolutionTerm::Existing(
+                    purrdf_core::TermId::from_index(item as u32),
+                ))]);
+                Ok(())
+            },
+        )
+        .expect("no errors");
+        let indices: Vec<u32> = result
+            .iter()
+            .map(|row| match row[0] {
+                Some(SolutionTerm::Existing(id)) => id.index() as u32,
+                _ => unreachable!(),
+            })
+            .collect();
+        let expected: Vec<u32> = (0..100).collect();
+        assert_eq!(indices, expected);
+        // 100 items / chunk size 7 ⇒ 15 chunks, so `init` ran more than once but
+        // never once per item.
+        let inits = init_calls.load(std::sync::atomic::Ordering::Relaxed);
+        assert!((1..=15).contains(&inits), "inits={inits}");
+    }
+
+    #[test]
+    fn par_chunk_try_map_init_forced_sequential_runs_init_exactly_once() {
+        let _guard = force_parallel_for_test(false);
+        let init_calls = std::sync::atomic::AtomicUsize::new(0);
+        let items: Vec<usize> = (0..64).collect();
+        let result = par_chunk_try_map_init(
+            &items,
+            || {
+                init_calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                0_u64
+            },
+            |_state, acc, &item| {
+                acc.push(vec![Some(SolutionTerm::Existing(
+                    purrdf_core::TermId::from_index(item as u32),
+                ))]);
+                Ok(())
             },
         )
         .expect("no errors");
@@ -662,54 +892,34 @@ mod tests {
             .collect();
         let expected: Vec<u32> = (0..64).collect();
         assert_eq!(indices, expected);
-        // Sequential path: `init` runs exactly once, never per row.
         assert_eq!(init_calls.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
 
     #[test]
-    fn par_try_flat_map_init_surfaces_the_lower_indexed_error() {
-        let items: Vec<usize> = (0..32).collect();
-        let result: Result<Vec<Solution>, EvalError> = par_try_flat_map_init(
+    fn par_chunk_try_map_init_surfaces_the_lower_chunk_indexed_error() {
+        // Chunk size 5 over 40 items ⇒ 8 chunks; index 22 (chunk 4) and index 6
+        // (chunk 1) both error, index 22's chunk is nudged to finish first via
+        // `yield_now`, but the chunk-index-ordered reduce must still surface
+        // chunk 1's (index 6's) error, never chunk 4's.
+        let _parallel_guard = force_parallel_for_test(true);
+        let _chunk_guard = force_chunk_size_for_test(5);
+        let items: Vec<usize> = (0..40).collect();
+        let result: Result<Vec<Solution>, EvalError> = par_chunk_try_map_init(
             &items,
             || (),
-            |(), i, _| {
-                if i == 20 {
+            |(), _acc, &i| {
+                if i == 22 {
                     std::thread::yield_now();
-                    return Err(EvalError::internal("error at 20"));
+                    return Err(EvalError::internal("error at 22"));
                 }
-                if i == 5 {
-                    return Err(EvalError::internal("error at 5"));
+                if i == 6 {
+                    return Err(EvalError::internal("error at 6"));
                 }
-                Ok(vec![])
+                Ok(())
             },
         );
         let err = result.unwrap_err();
-        assert_eq!(err, EvalError::internal("error at 5"));
-    }
-
-    // ---- par_flat_map ---------------------------------------------------------
-
-    #[test]
-    fn par_flat_map_flattens_in_index_order_forced_parallel() {
-        let _guard = force_parallel_for_test(true);
-        let items: Vec<usize> = (0..64).collect();
-        let result = par_flat_map(&items, |i, &item| {
-            if item % 7 != 0 {
-                std::thread::yield_now();
-            }
-            vec![i]
-        });
-        let expected: Vec<usize> = (0..64).collect();
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn par_flat_map_flattens_in_index_order_forced_sequential() {
-        let _guard = force_parallel_for_test(false);
-        let items: Vec<usize> = (0..64).collect();
-        let result = par_flat_map(&items, |i, _| vec![i]);
-        let expected: Vec<usize> = (0..64).collect();
-        assert_eq!(result, expected);
+        assert_eq!(err, EvalError::internal("error at 6"));
     }
 
     // ---- par_retain -------------------------------------------------------

--- a/crates/sparql-eval/src/parallel.rs
+++ b/crates/sparql-eval/src/parallel.rs
@@ -3,22 +3,27 @@
 
 //! Deterministic two-phase parallel evaluation primitives.
 //!
-//! Nothing in this module is wired into the evaluation recursion yet — it is the
-//! shared foundation the per-operator fork-join tasks (parallel BGP batches,
-//! parallel `GROUP BY` group evaluation, parallel `UNION` branches) build on. The
-//! two phases, always in this order:
+//! [`crate::bgp`]'s per-batch evaluation, `binop`'s `Join`/`LeftJoin`/`MINUS`, and
+//! (Task 5) `expr::eval_filter` / `binop::left_outer_join_filtered`'s FILTER
+//! predicates are all wired to the fork-join model below. `absorb_row` /
+//! `absorb_constructed` are still unused outside this module's own tests — no
+//! wired caller yet mints a NEW value that must escape a forked child (Task 6:
+//! parallel `GROUP BY`/aggregate and `CONSTRUCT` list-mint sites) — hence the
+//! crate-build-only `allow(dead_code)` below (lifted the moment a caller lands
+//! for those two). The two phases, always in this order:
 //!
 //! 1. **Fork.** [`crate::eval::EvalCtx::fork_for_worker`] gives each worker a
 //!    `Send` child context with its own scratch/constructed state, so workers
 //!    never contend on a lock or share mutable evaluation state.
-//! 2. **Join.** [`par_try_flat_map`] runs the workers via rayon's *indexed*
-//!    `collect` (never `par_sort`/`par_bridge`, which are not order-stable) and
-//!    then reduces strictly in source-index order: successes flatten in index
-//!    order and the first `Err` **by index** wins, regardless of which worker
-//!    finished first. [`absorb_row`] / [`absorb_constructed`] fold a worker's
-//!    fresh scratch/constructed state back into the parent, also index-ordered
-//!    by the caller. The result is bit-identical to the sequential evaluation of
-//!    the same pattern — parallelism is purely a scheduling change.
+//! 2. **Join.** [`par_try_flat_map`] / [`par_try_flat_map_init`] run the workers
+//!    via rayon's *indexed* `collect` (never `par_sort`/`par_bridge`, which are
+//!    not order-stable) and then reduce strictly in source-index order:
+//!    successes flatten in index order and the first `Err` **by index** wins,
+//!    regardless of which worker finished first. [`absorb_row`] /
+//!    [`absorb_constructed`] fold a worker's fresh scratch/constructed state back
+//!    into the parent, also index-ordered by the caller. The result is
+//!    bit-identical to the sequential evaluation of the same pattern —
+//!    parallelism is purely a scheduling change.
 //!
 //! [`is_parallel_safe`] is the gate deciding whether an expression may run under
 //! this model at all: any builtin whose result depends on the per-query mutable
@@ -27,11 +32,6 @@
 //! that state rather than a shared, ordered one — running such a builtin under
 //! fork-join would make its result depend on worker scheduling, not just row
 //! content.
-//!
-//! Every item here is exercised by this module's unit tests but, until Tasks
-//! 4-6 wire it into `bgp`/`modifier`/`binop`, has no production caller — hence
-//! the crate-build-only `allow(dead_code)` below (lifted the moment a caller
-//! lands).
 
 #![cfg_attr(not(test), allow(dead_code))]
 
@@ -269,6 +269,57 @@ where
         .par_iter()
         .enumerate()
         .map(|(i, item)| worker(i, item))
+        .collect();
+
+    let mut out = Vec::with_capacity(per_item.iter().map(|r| r.as_ref().map_or(0, Vec::len)).sum());
+    for result in per_item {
+        out.extend(result?);
+    }
+    Ok(out)
+}
+
+/// The fork-per-worker sibling of [`par_try_flat_map`]: instead of one immutable
+/// `worker` closure applied per item, each rayon *worker thread* first runs
+/// `init` **once** to build its own `S` (e.g. an `EvalCtx::fork_for_worker`
+/// child) and then reuses that state across every item it is scheduled, via
+/// rayon's `map_init`. This avoids forking a fresh child per row — the fork
+/// (cloning the scratch interner, the `exists_inner_cache`, etc.) is real, if
+/// cheap, work that should happen once per worker thread, not once per row.
+///
+/// Internally gated on [`should_parallelize`] exactly like [`par_try_flat_map`]:
+/// at or below [`PARALLEL_MIN_ROWS`], `init` runs exactly once and every item is
+/// folded sequentially over that single state (bit-identical to a hand-written
+/// sequential loop — no rayon hand-off, no extra `init` calls); above it,
+/// `par_iter().map_init` gives each worker thread its own `S` and the results
+/// are collected into an indexed `Vec` first, then reduced in source order —
+/// the same "collect first, then walk in order" shape as [`par_try_flat_map`],
+/// so a fast late item can never race ahead of an earlier item's diagnostic.
+pub(crate) fn par_try_flat_map_init<T, S, Init, F>(
+    items: &[T],
+    init: Init,
+    worker: F,
+) -> Result<Vec<Solution>, EvalError>
+where
+    T: Sync,
+    S: Send,
+    Init: Fn() -> S + Sync + Send,
+    F: Fn(&mut S, usize, &T) -> Result<Vec<Solution>, EvalError> + Sync + Send,
+{
+    if !should_parallelize(items.len()) {
+        let mut state = init();
+        let mut out = Vec::new();
+        for (i, item) in items.iter().enumerate() {
+            out.extend(worker(&mut state, i, item)?);
+        }
+        return Ok(out);
+    }
+
+    use rayon::prelude::*;
+
+    let per_item: Vec<Result<Vec<Solution>, EvalError>> = items
+        .par_iter()
+        .enumerate()
+        .map_init(&init, |state, (i, item)| worker(state, i, item))
         .collect();
 
     let mut out = Vec::with_capacity(per_item.iter().map(|r| r.as_ref().map_or(0, Vec::len)).sum());
@@ -553,6 +604,91 @@ mod tests {
         assert_eq!(err, EvalError::internal("error at 5"));
     }
 
+    // ---- par_try_flat_map_init -------------------------------------------------
+
+    #[test]
+    fn par_try_flat_map_init_flattens_in_index_order_forced_parallel() {
+        let _guard = force_parallel_for_test(true);
+        let init_calls = std::sync::atomic::AtomicUsize::new(0);
+        let items: Vec<usize> = (0..64).collect();
+        let result = par_try_flat_map_init(
+            &items,
+            || {
+                init_calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                0_u64 // per-worker state: unused counter, just proves init ran.
+            },
+            |_state, i, &item| {
+                if item % 7 != 0 {
+                    std::thread::yield_now();
+                }
+                Ok(vec![vec![Some(crate::scratch::SolutionTerm::Existing(
+                    purrdf_core::TermId::from_index(i as u32),
+                ))]])
+            },
+        )
+        .expect("no errors");
+        let indices: Vec<u32> = result
+            .iter()
+            .map(|row| match row[0] {
+                Some(crate::scratch::SolutionTerm::Existing(id)) => id.index() as u32,
+                _ => unreachable!(),
+            })
+            .collect();
+        let expected: Vec<u32> = (0..64).collect();
+        assert_eq!(indices, expected);
+        // At least one worker thread ran `init` (forced parallel with 64 items and
+        // rayon's default pool); it never runs per-row (64 items, far fewer inits).
+        assert!(init_calls.load(std::sync::atomic::Ordering::Relaxed) >= 1);
+        assert!(init_calls.load(std::sync::atomic::Ordering::Relaxed) <= 64);
+    }
+
+    #[test]
+    fn par_try_flat_map_init_flattens_in_index_order_forced_sequential() {
+        let _guard = force_parallel_for_test(false);
+        let init_calls = std::sync::atomic::AtomicUsize::new(0);
+        let items: Vec<usize> = (0..64).collect();
+        let result = par_try_flat_map_init(
+            &items,
+            || {
+                init_calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                0_u64
+            },
+            |_state, i, _item| Ok(vec![vec![Some(crate::scratch::SolutionTerm::Existing(
+                purrdf_core::TermId::from_index(i as u32),
+            ))]]),
+        )
+        .expect("no errors");
+        let indices: Vec<u32> = result
+            .iter()
+            .map(|row| match row[0] {
+                Some(crate::scratch::SolutionTerm::Existing(id)) => id.index() as u32,
+                _ => unreachable!(),
+            })
+            .collect();
+        let expected: Vec<u32> = (0..64).collect();
+        assert_eq!(indices, expected);
+        // Sequential path: `init` runs exactly once, never per row.
+        assert_eq!(init_calls.load(std::sync::atomic::Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn par_try_flat_map_init_surfaces_the_lower_indexed_error() {
+        let items: Vec<usize> = (0..32).collect();
+        let result: Result<Vec<Solution>, EvalError> =
+            par_try_flat_map_init(&items, || (), |(), i, _| {
+                if i == 20 {
+                    std::thread::yield_now();
+                    return Err(EvalError::internal("error at 20"));
+                }
+                if i == 5 {
+                    return Err(EvalError::internal("error at 5"));
+                }
+                Ok(vec![])
+            });
+        let err = result.unwrap_err();
+        assert_eq!(err, EvalError::internal("error at 5"));
+    }
+
     // ---- par_flat_map ---------------------------------------------------------
 
     #[test]
@@ -606,8 +742,32 @@ mod tests {
             .freeze()
             .expect("freeze empty dataset");
         let mut parent = crate::eval::EvalCtx::new(&ds);
+
+        // Seed the PARENT scratch with an already-minted value BEFORE forking, so
+        // an input row carrying that `Computed` id (as a real parallel worker's
+        // input rows would) is something the fork must be able to resolve.
+        let existing_value = TermValue::Literal {
+            lexical_form: "already minted".to_owned(),
+            datatype: "http://www.w3.org/2001/XMLSchema#string".to_owned(),
+            language: None,
+            direction: None,
+        };
+        let existing_term = parent.scratch.intern(&ds, existing_value.clone());
+
         let mut child = parent.fork_for_worker();
 
+        // The fork must resolve the PARENT's pre-existing `Computed` term
+        // identically — this is the fix under test: a fresh (empty) child scratch
+        // would panic (`values[sid.index()]` out of bounds) or, if it happened not
+        // to, resolve nonsense. `fork_for_worker` now clones the parent scratch, so
+        // this must round-trip.
+        assert_eq!(
+            child.scratch.value_of(&ds, existing_term),
+            existing_value,
+            "child must resolve a Computed id it inherited from the parent scratch"
+        );
+
+        // The child mints a NEW value (not known to the parent at fork time).
         let value = TermValue::Literal {
             lexical_form: "hello parallel".to_owned(),
             datatype: "http://www.w3.org/2001/XMLSchema#string".to_owned(),
@@ -615,10 +775,16 @@ mod tests {
             direction: None,
         };
         let child_term = child.scratch.intern(&ds, value.clone());
-        let row: Solution = vec![Some(child_term)];
+        let row: Solution = vec![Some(existing_term), Some(child_term)];
 
         let absorbed = absorb_row(&mut parent.scratch, &ds, &child.scratch, &row);
-        let main_term = absorbed[0].expect("cell present");
+        // The pre-existing term passes through absorb unchanged (still resolves in
+        // the parent, which already owned it).
+        let absorbed_existing = absorbed[0].expect("cell present");
+        assert_eq!(parent.scratch.value_of(&ds, absorbed_existing), existing_value);
+        // The child's fresh mint is folded back into the parent's id space and
+        // resolves to the same value there.
+        let main_term = absorbed[1].expect("cell present");
         assert_eq!(parent.scratch.value_of(&ds, main_term), value);
     }
 

--- a/crates/sparql-eval/src/parallel.rs
+++ b/crates/sparql-eval/src/parallel.rs
@@ -523,13 +523,13 @@ pub(crate) fn portable_row(
 pub(crate) fn reintern_portable_row(
     main: &mut ScratchInterner,
     dataset: &RdfDataset,
-    prow: &[Option<PortableTerm>],
+    prow: Vec<Option<PortableTerm>>,
 ) -> Solution {
-    prow.iter()
+    prow.into_iter()
         .map(|cell| match cell {
             None => None,
-            Some(PortableTerm::Parent(term)) => Some(*term),
-            Some(PortableTerm::Fresh(value)) => Some(main.intern(dataset, value.clone())),
+            Some(PortableTerm::Parent(term)) => Some(term),
+            Some(PortableTerm::Fresh(value)) => Some(main.intern(dataset, value)),
         })
         .collect()
 }
@@ -585,7 +585,7 @@ pub(crate) fn reintern_minted_row(
 ) -> Solution {
     match row {
         MintedRow::Direct(solution) => solution,
-        MintedRow::Portable(prow) => reintern_portable_row(main, dataset, &prow),
+        MintedRow::Portable(prow) => reintern_portable_row(main, dataset, prow),
     }
 }
 
@@ -986,7 +986,7 @@ mod tests {
         assert_eq!(prow[1], Some(PortableTerm::Parent(pre_fork_term)));
         assert_eq!(prow[2], Some(PortableTerm::Fresh(fresh_value.clone())));
 
-        let reinterned = reintern_portable_row(&mut parent.scratch, &ds, &prow);
+        let reinterned = reintern_portable_row(&mut parent.scratch, &ds, prow);
         assert_eq!(reinterned[0], None);
         // The pre-fork term passes through unchanged and still resolves in the
         // parent (which already owned it).
@@ -1020,8 +1020,8 @@ mod tests {
         let prow_a = portable_row(&child_a.scratch, base, &row_a);
         let prow_b = portable_row(&child_b.scratch, base, &row_b);
 
-        let reinterned_a = reintern_portable_row(&mut parent.scratch, &ds, &prow_a);
-        let reinterned_b = reintern_portable_row(&mut parent.scratch, &ds, &prow_b);
+        let reinterned_a = reintern_portable_row(&mut parent.scratch, &ds, prow_a);
+        let reinterned_b = reintern_portable_row(&mut parent.scratch, &ds, prow_b);
 
         assert_eq!(
             reinterned_a[0], reinterned_b[0],

--- a/crates/sparql-eval/src/parallel.rs
+++ b/crates/sparql-eval/src/parallel.rs
@@ -240,6 +240,12 @@ fn pattern_reaches_unsafe_builtin(pattern: &GraphPattern) -> bool {
 /// not order-stable) and, on failure, the first `Err` **by source index** wins
 /// regardless of which worker finished first.
 ///
+/// Internally gated on [`should_parallelize`]: at or below [`PARALLEL_MIN_ROWS`]
+/// this runs a plain sequential `iter().enumerate()` fold (bit-identical output,
+/// no rayon hand-off cost); above it, rayon's indexed `par_iter`. Callers get a
+/// single call site — the `#[cfg(test)]` force seam in [`should_parallelize`]
+/// routes through here.
+///
 /// Mirrors `purrdf_rdf::native_codecs::text_parse::parse_lines_parallel_with_chunk_size`:
 /// every worker result is collected into a plain `Vec` FIRST, then walked in
 /// order and `?`-propagated, so a fast late item can never race ahead of an
@@ -249,6 +255,14 @@ where
     T: Sync,
     F: Fn(usize, &T) -> Result<Vec<Solution>, EvalError> + Sync + Send,
 {
+    if !should_parallelize(items.len()) {
+        let mut out = Vec::new();
+        for (i, item) in items.iter().enumerate() {
+            out.extend(worker(i, item)?);
+        }
+        return Ok(out);
+    }
+
     use rayon::prelude::*;
 
     let per_item: Vec<Result<Vec<Solution>, EvalError>> = items
@@ -262,6 +276,57 @@ where
         out.extend(result?);
     }
     Ok(out)
+}
+
+/// The infallible sibling of [`par_try_flat_map`]: run `worker` over every item
+/// of `items` and flatten the per-item `Vec<R>` results in source-index order.
+/// Same internal [`should_parallelize`] gate — sequential at/below the
+/// threshold, rayon's indexed `par_iter` above it — so there is exactly one
+/// call site per caller and the `#[cfg(test)]` force seam applies uniformly.
+pub(crate) fn par_flat_map<T, R, F>(items: &[T], worker: F) -> Vec<R>
+where
+    T: Sync,
+    R: Send,
+    F: Fn(usize, &T) -> Vec<R> + Sync + Send,
+{
+    if !should_parallelize(items.len()) {
+        let mut out = Vec::new();
+        for (i, item) in items.iter().enumerate() {
+            out.extend(worker(i, item));
+        }
+        return out;
+    }
+
+    use rayon::prelude::*;
+
+    let per_item: Vec<Vec<R>> = items.par_iter().enumerate().map(|(i, item)| worker(i, item)).collect();
+
+    let mut out = Vec::with_capacity(per_item.iter().map(Vec::len).sum());
+    for result in per_item {
+        out.extend(result);
+    }
+    out
+}
+
+/// An order-stable, internally-gated parallel filter-clone: keep every item of
+/// `items` for which `keep` returns `true`, cloning it into the output in
+/// source order. Sequential at/below [`PARALLEL_MIN_ROWS`] (a plain retain);
+/// above it, rayon's indexed `par_iter().filter().cloned()`, which preserves
+/// source order exactly like the sequential path (never `par_sort`/
+/// `par_bridge`). Used by `MINUS`, whose predicate is a pure read-only
+/// compatibility check.
+pub(crate) fn par_retain<T, F>(items: &[T], keep: F) -> Vec<T>
+where
+    T: Clone + Sync + Send,
+    F: Fn(&T) -> bool + Sync + Send,
+{
+    if !should_parallelize(items.len()) {
+        return items.iter().filter(|item| keep(item)).cloned().collect();
+    }
+
+    use rayon::prelude::*;
+
+    items.par_iter().filter(|item| keep(item)).cloned().collect()
 }
 
 /// Fold one row produced by a forked worker's `local` scratch back into the
@@ -486,6 +551,51 @@ mod tests {
         });
         let err = result.unwrap_err();
         assert_eq!(err, EvalError::internal("error at 5"));
+    }
+
+    // ---- par_flat_map ---------------------------------------------------------
+
+    #[test]
+    fn par_flat_map_flattens_in_index_order_forced_parallel() {
+        let _guard = force_parallel_for_test(true);
+        let items: Vec<usize> = (0..64).collect();
+        let result = par_flat_map(&items, |i, &item| {
+            if item % 7 != 0 {
+                std::thread::yield_now();
+            }
+            vec![i]
+        });
+        let expected: Vec<usize> = (0..64).collect();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn par_flat_map_flattens_in_index_order_forced_sequential() {
+        let _guard = force_parallel_for_test(false);
+        let items: Vec<usize> = (0..64).collect();
+        let result = par_flat_map(&items, |i, _| vec![i]);
+        let expected: Vec<usize> = (0..64).collect();
+        assert_eq!(result, expected);
+    }
+
+    // ---- par_retain -------------------------------------------------------
+
+    #[test]
+    fn par_retain_preserves_order_forced_parallel() {
+        let _guard = force_parallel_for_test(true);
+        let items: Vec<usize> = (0..64).collect();
+        let kept = par_retain(&items, |&i| i % 3 == 0);
+        let expected: Vec<usize> = (0..64).filter(|i| i % 3 == 0).collect();
+        assert_eq!(kept, expected);
+    }
+
+    #[test]
+    fn par_retain_preserves_order_forced_sequential() {
+        let _guard = force_parallel_for_test(false);
+        let items: Vec<usize> = (0..64).collect();
+        let kept = par_retain(&items, |&i| i % 3 == 0);
+        let expected: Vec<usize> = (0..64).filter(|i| i % 3 == 0).collect();
+        assert_eq!(kept, expected);
     }
 
     // ---- fork_for_worker + absorb_row -----------------------------------------

--- a/crates/sparql-eval/src/parallel.rs
+++ b/crates/sparql-eval/src/parallel.rs
@@ -1,0 +1,538 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Deterministic two-phase parallel evaluation primitives.
+//!
+//! Nothing in this module is wired into the evaluation recursion yet — it is the
+//! shared foundation the per-operator fork-join tasks (parallel BGP batches,
+//! parallel `GROUP BY` group evaluation, parallel `UNION` branches) build on. The
+//! two phases, always in this order:
+//!
+//! 1. **Fork.** [`crate::eval::EvalCtx::fork_for_worker`] gives each worker a
+//!    `Send` child context with its own scratch/constructed state, so workers
+//!    never contend on a lock or share mutable evaluation state.
+//! 2. **Join.** [`par_try_flat_map`] runs the workers via rayon's *indexed*
+//!    `collect` (never `par_sort`/`par_bridge`, which are not order-stable) and
+//!    then reduces strictly in source-index order: successes flatten in index
+//!    order and the first `Err` **by index** wins, regardless of which worker
+//!    finished first. [`absorb_row`] / [`absorb_constructed`] fold a worker's
+//!    fresh scratch/constructed state back into the parent, also index-ordered
+//!    by the caller. The result is bit-identical to the sequential evaluation of
+//!    the same pattern — parallelism is purely a scheduling change.
+//!
+//! [`is_parallel_safe`] is the gate deciding whether an expression may run under
+//! this model at all: any builtin whose result depends on the per-query mutable
+//! `bnode_counter`/`rng_state` (or that mints into [`crate::eval::EvalCtx::constructed`])
+//! is excluded, because the fork model gives every worker an *independent* copy of
+//! that state rather than a shared, ordered one — running such a builtin under
+//! fork-join would make its result depend on worker scheduling, not just row
+//! content.
+//!
+//! Every item here is exercised by this module's unit tests but, until Tasks
+//! 4-6 wire it into `bgp`/`modifier`/`binop`, has no production caller — hence
+//! the crate-build-only `allow(dead_code)` below (lifted the moment a caller
+//! lands).
+
+#![cfg_attr(not(test), allow(dead_code))]
+
+use purrdf_core::{RdfDataset, TermValue};
+use purrdf_sparql_algebra::{
+    AggregateExpression, Expression, Function, GraphPattern, OrderExpression,
+};
+
+use crate::error::EvalError;
+use crate::scratch::ScratchInterner;
+use crate::solution::Solution;
+
+/// Rows/groups at or below this stay sequential (thread spin-up would dominate
+/// the work for small inputs). Initial value; Task 7's bench tunes it.
+pub(crate) const PARALLEL_MIN_ROWS: usize = 1024;
+
+#[cfg(test)]
+std::thread_local! {
+    /// Test-only override for [`should_parallelize`], so a bench/test can force
+    /// the parallel or sequential branch regardless of `work_items`. Never
+    /// consulted outside `cfg(test)` — the shipping decision is purely
+    /// `work_items > PARALLEL_MIN_ROWS`.
+    static FORCE_PARALLEL: std::cell::Cell<Option<bool>> = const { std::cell::Cell::new(None) };
+}
+
+/// Force [`should_parallelize`] to always return `force` for the current thread
+/// until the returned guard is dropped (restores the prior override). Test-only.
+#[cfg(test)]
+#[must_use]
+pub(crate) fn force_parallel_for_test(force: bool) -> ForceParallelGuard {
+    let previous = FORCE_PARALLEL.with(|cell| cell.replace(Some(force)));
+    ForceParallelGuard { previous }
+}
+
+/// RAII guard restoring the prior [`FORCE_PARALLEL`] override on drop.
+#[cfg(test)]
+pub(crate) struct ForceParallelGuard {
+    previous: Option<bool>,
+}
+
+#[cfg(test)]
+impl Drop for ForceParallelGuard {
+    fn drop(&mut self) {
+        FORCE_PARALLEL.with(|cell| cell.set(self.previous));
+    }
+}
+
+/// Whether a batch of `work_items` (rows, groups, branches) should run in
+/// parallel rather than sequentially. Small inputs stay sequential because
+/// rayon thread hand-off cost would dominate the actual work.
+pub(crate) fn should_parallelize(work_items: usize) -> bool {
+    #[cfg(test)]
+    if let Some(forced) = FORCE_PARALLEL.with(std::cell::Cell::get) {
+        return forced;
+    }
+    work_items > PARALLEL_MIN_ROWS
+}
+
+/// Whether `expr` (and everything it recursively contains, including nested
+/// `EXISTS` patterns) is safe to evaluate under the fork-join parallel model.
+///
+/// Unsafe means the expression can reach a builtin whose result depends on
+/// per-query mutable counter/RNG/mint state that [`crate::eval::EvalCtx::fork_for_worker`]
+/// deliberately does NOT share across workers:
+///
+/// - [`Function::Rand`], [`Function::Uuid`], [`Function::StrUuid`] — draw from
+///   `EvalCtx::rng_state`, which advances per call; forked workers would each
+///   restart from the same seed and diverge from (or duplicate) the sequential
+///   stream.
+/// - [`Function::BNode`] (**every** arity, including `BNODE(?x)`) — mints from
+///   `EvalCtx::bnode_counter`. Even the one-argument form is unsafe here: SPARQL
+///   only requires "same argument value within one query ⇒ same blank node", but
+///   under the fork model each worker has its own independent counter, so two
+///   workers minting for the *same* argument value would produce two different
+///   labels. A worker-local counter cannot honor that invariant across workers.
+/// - The PurRDF list constructors `listSlice`/`listConcat`
+///   ([`purrdf_sparql_algebra::PurrdfFn::ListSlice`] /
+///   [`purrdf_sparql_algebra::PurrdfFn::ListConcat`], reached through
+///   [`Function::Purrdf`]) — `crate::list_fn::materialize_list` both mints
+///   fresh blank nodes from the shared `bnode_counter` (so a list cell's label
+///   never collides with a `BNODE()` or CONSTRUCT-template blank) AND pushes
+///   the new cell quads onto `EvalCtx::constructed`. `constructed` is
+///   dataset-independent so the cells themselves fold back deterministically
+///   (see [`absorb_constructed`]), but the *label* is only collision-free
+///   against the single shared counter; two forked workers each minting from
+///   their own fresh `bnode_counter` could produce colliding cell labels.
+///
+/// Every other reader-only PurRDF list function (`listLength`/`listGet`/
+/// `listIndexOf`/`listContains`) and `heldIn` touch neither counter, so they are
+/// left safe. When in doubt this walk flags UNSAFE — a sequential fallback is
+/// always a correct (if slower) answer.
+pub(crate) fn is_parallel_safe(expr: &Expression) -> bool {
+    !expr_reaches_unsafe_builtin(expr)
+}
+
+/// `true` iff `expr` (recursively) reaches an unsafe builtin — see
+/// [`is_parallel_safe`].
+fn expr_reaches_unsafe_builtin(expr: &Expression) -> bool {
+    match expr {
+        Expression::NamedNode(_) | Expression::Literal(_) | Expression::Variable(_) | Expression::Bound(_) => {
+            false
+        }
+        Expression::Or(a, b)
+        | Expression::And(a, b)
+        | Expression::Equal(a, b)
+        | Expression::SameTerm(a, b)
+        | Expression::Greater(a, b)
+        | Expression::GreaterOrEqual(a, b)
+        | Expression::Less(a, b)
+        | Expression::LessOrEqual(a, b)
+        | Expression::Add(a, b)
+        | Expression::Subtract(a, b)
+        | Expression::Multiply(a, b)
+        | Expression::Divide(a, b) => expr_reaches_unsafe_builtin(a) || expr_reaches_unsafe_builtin(b),
+        Expression::UnaryPlus(a) | Expression::UnaryMinus(a) | Expression::Not(a) => {
+            expr_reaches_unsafe_builtin(a)
+        }
+        Expression::In(head, list) => {
+            expr_reaches_unsafe_builtin(head) || list.iter().any(expr_reaches_unsafe_builtin)
+        }
+        Expression::If(a, b, c) => {
+            expr_reaches_unsafe_builtin(a)
+                || expr_reaches_unsafe_builtin(b)
+                || expr_reaches_unsafe_builtin(c)
+        }
+        Expression::Coalesce(list) => list.iter().any(expr_reaches_unsafe_builtin),
+        Expression::FunctionCall(f, args) => {
+            function_is_unsafe(f) || args.iter().any(expr_reaches_unsafe_builtin)
+        }
+        Expression::Exists(pattern) => pattern_reaches_unsafe_builtin(pattern),
+    }
+}
+
+/// Whether `f` is itself one of the stateful-mint builtins (see
+/// [`is_parallel_safe`]'s doc comment for the full rationale).
+fn function_is_unsafe(f: &Function) -> bool {
+    match f {
+        Function::Rand | Function::Uuid | Function::StrUuid | Function::BNode => true,
+        Function::Purrdf(call) => matches!(
+            call.fn_kind,
+            purrdf_sparql_algebra::PurrdfFn::ListSlice | purrdf_sparql_algebra::PurrdfFn::ListConcat
+        ),
+        _ => false,
+    }
+}
+
+/// `true` iff `pattern` (recursively) reaches an unsafe builtin through any
+/// expression-bearing variant — see [`is_parallel_safe`].
+fn pattern_reaches_unsafe_builtin(pattern: &GraphPattern) -> bool {
+    match pattern {
+        GraphPattern::Bgp { .. } | GraphPattern::Path { .. } | GraphPattern::Values { .. } => false,
+        GraphPattern::Join { left, right }
+        | GraphPattern::Lateral { left, right }
+        | GraphPattern::Union { left, right }
+        | GraphPattern::Minus { left, right } => {
+            pattern_reaches_unsafe_builtin(left) || pattern_reaches_unsafe_builtin(right)
+        }
+        GraphPattern::Graph { inner, .. }
+        | GraphPattern::Service { inner, .. }
+        | GraphPattern::Distinct { inner }
+        | GraphPattern::Reduced { inner }
+        | GraphPattern::Slice { inner, .. }
+        | GraphPattern::Project { inner, .. } => pattern_reaches_unsafe_builtin(inner),
+        GraphPattern::Filter { expr, inner } => {
+            expr_reaches_unsafe_builtin(expr) || pattern_reaches_unsafe_builtin(inner)
+        }
+        GraphPattern::Extend {
+            inner, expression, ..
+        } => expr_reaches_unsafe_builtin(expression) || pattern_reaches_unsafe_builtin(inner),
+        GraphPattern::LeftJoin {
+            left,
+            right,
+            expression,
+        } => {
+            pattern_reaches_unsafe_builtin(left)
+                || pattern_reaches_unsafe_builtin(right)
+                || expression
+                    .as_ref()
+                    .is_some_and(expr_reaches_unsafe_builtin)
+        }
+        GraphPattern::OrderBy { inner, expression } => {
+            pattern_reaches_unsafe_builtin(inner)
+                || expression.iter().any(|oe| match oe {
+                    OrderExpression::Asc(e) | OrderExpression::Desc(e) => {
+                        expr_reaches_unsafe_builtin(e)
+                    }
+                })
+        }
+        GraphPattern::Group {
+            inner, aggregates, ..
+        } => {
+            pattern_reaches_unsafe_builtin(inner)
+                || aggregates.iter().any(|(_, agg)| match agg {
+                    AggregateExpression::CountStar { .. } => false,
+                    AggregateExpression::FunctionCall { expression, .. } => {
+                        expr_reaches_unsafe_builtin(expression)
+                    }
+                })
+        }
+    }
+}
+
+/// Run `worker` over every item of `items` and reduce the results
+/// **deterministically**: order-stable success flattening (rayon's indexed
+/// `collect` preserves source order — never `par_sort`/`par_bridge`, which are
+/// not order-stable) and, on failure, the first `Err` **by source index** wins
+/// regardless of which worker finished first.
+///
+/// Mirrors `purrdf_rdf::native_codecs::text_parse::parse_lines_parallel_with_chunk_size`:
+/// every worker result is collected into a plain `Vec` FIRST, then walked in
+/// order and `?`-propagated, so a fast late item can never race ahead of an
+/// earlier item's diagnostic.
+pub(crate) fn par_try_flat_map<T, F>(items: &[T], worker: F) -> Result<Vec<Solution>, EvalError>
+where
+    T: Sync,
+    F: Fn(usize, &T) -> Result<Vec<Solution>, EvalError> + Sync + Send,
+{
+    use rayon::prelude::*;
+
+    let per_item: Vec<Result<Vec<Solution>, EvalError>> = items
+        .par_iter()
+        .enumerate()
+        .map(|(i, item)| worker(i, item))
+        .collect();
+
+    let mut out = Vec::with_capacity(per_item.iter().map(|r| r.as_ref().map_or(0, Vec::len)).sum());
+    for result in per_item {
+        out.extend(result?);
+    }
+    Ok(out)
+}
+
+/// Fold one row produced by a forked worker's `local` scratch back into the
+/// `main` (parent) scratch, re-interning any [`crate::scratch::SolutionTerm::Computed`]
+/// cell against `main`/`dataset` so its [`crate::scratch::ScratchId`] is valid in the
+/// parent's id space. `Existing`/`None` cells pass through unchanged (they are
+/// already dataset-space ids, valid in any scratch).
+pub(crate) fn absorb_row(
+    main: &mut ScratchInterner,
+    dataset: &RdfDataset,
+    local: &ScratchInterner,
+    row: &Solution,
+) -> Solution {
+    row.iter()
+        .map(|cell| match cell {
+            Some(crate::scratch::SolutionTerm::Computed(sid)) => {
+                Some(main.intern(dataset, local.computed_value(*sid).clone()))
+            }
+            other => *other,
+        })
+        .collect()
+}
+
+/// Append a forked worker's constructed cells onto `main`, in the order given.
+/// The cells are dataset-independent [`TermValue`] triples (no id space to
+/// re-map, unlike [`absorb_row`]) — the caller is responsible for invoking this
+/// once per child **in source-index order**, which is what makes the merged
+/// buffer deterministic.
+pub(crate) fn absorb_constructed(
+    main: &mut Vec<(TermValue, TermValue, TermValue)>,
+    child: Vec<(TermValue, TermValue, TermValue)>,
+) {
+    main.extend(child);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use purrdf_core::RdfDatasetBuilder;
+    use purrdf_sparql_algebra::{Literal, NamedNode, PurrdfCall, PurrdfFn, TriplePattern};
+
+    // ---- should_parallelize -------------------------------------------------
+
+    #[test]
+    fn should_parallelize_boundary() {
+        assert!(!should_parallelize(PARALLEL_MIN_ROWS));
+        assert!(should_parallelize(PARALLEL_MIN_ROWS + 1));
+    }
+
+    #[test]
+    fn should_parallelize_force_seam() {
+        {
+            let _guard = force_parallel_for_test(true);
+            assert!(should_parallelize(0));
+        }
+        {
+            let _guard = force_parallel_for_test(false);
+            assert!(!should_parallelize(usize::MAX));
+        }
+        // Guard dropped: back to the real threshold.
+        assert!(!should_parallelize(1));
+    }
+
+    // ---- is_parallel_safe ----------------------------------------------------
+
+    fn call(f: Function, args: Vec<Expression>) -> Expression {
+        Expression::FunctionCall(f, args)
+    }
+
+    #[test]
+    fn plain_arithmetic_and_regex_are_safe() {
+        let arith = Expression::Add(
+            Box::new(Expression::Literal(Literal::new_simple("1"))),
+            Box::new(Expression::Literal(Literal::new_simple("2"))),
+        );
+        assert!(is_parallel_safe(&arith));
+
+        let regex = call(
+            Function::Regex,
+            vec![
+                Expression::Variable(purrdf_sparql_algebra::Variable::new("x")),
+                Expression::Literal(Literal::new_simple("^a")),
+            ],
+        );
+        assert!(is_parallel_safe(&regex));
+    }
+
+    #[test]
+    fn rand_uuid_struuid_bnode_are_unsafe() {
+        assert!(!is_parallel_safe(&call(Function::Rand, vec![])));
+        assert!(!is_parallel_safe(&call(Function::Uuid, vec![])));
+        assert!(!is_parallel_safe(&call(Function::StrUuid, vec![])));
+        assert!(!is_parallel_safe(&call(Function::BNode, vec![])));
+        assert!(!is_parallel_safe(&call(
+            Function::BNode,
+            vec![Expression::Variable(purrdf_sparql_algebra::Variable::new(
+                "x"
+            ))]
+        )));
+    }
+
+    #[test]
+    fn list_constructors_are_unsafe_readers_are_safe() {
+        let mk = |kind: PurrdfFn, iri: &str| {
+            call(
+                Function::Purrdf(PurrdfCall {
+                    fn_kind: kind,
+                    iri: iri.to_owned(),
+                }),
+                vec![],
+            )
+        };
+        assert!(!is_parallel_safe(&mk(
+            PurrdfFn::ListSlice,
+            "http://ex/listSlice"
+        )));
+        assert!(!is_parallel_safe(&mk(
+            PurrdfFn::ListConcat,
+            "http://ex/listConcat"
+        )));
+        assert!(is_parallel_safe(&mk(
+            PurrdfFn::ListLength,
+            "http://ex/listLength"
+        )));
+        assert!(is_parallel_safe(&mk(PurrdfFn::HeldIn, "http://ex/heldIn")));
+    }
+
+    #[test]
+    fn unsafe_nested_in_if_coalesce_and_function_args_is_detected() {
+        let cond = Expression::Bound(purrdf_sparql_algebra::Variable::new("x"));
+        let rand = call(Function::Rand, vec![]);
+        let safe = Expression::Literal(Literal::new_simple("ok"));
+
+        let in_if = Expression::If(Box::new(cond), Box::new(safe.clone()), Box::new(rand.clone()));
+        assert!(!is_parallel_safe(&in_if));
+
+        let in_coalesce = Expression::Coalesce(vec![safe.clone(), rand.clone()]);
+        assert!(!is_parallel_safe(&in_coalesce));
+
+        let in_fn_args = call(Function::Concat, vec![safe, rand]);
+        assert!(!is_parallel_safe(&in_fn_args));
+    }
+
+    #[test]
+    fn unsafe_inside_nested_exists_filter_is_detected() {
+        let vp = |n: &str| purrdf_sparql_algebra::TermPattern::Variable(
+            purrdf_sparql_algebra::Variable::new(n),
+        );
+        let pred = |iri: &str| {
+            purrdf_sparql_algebra::NamedNodePattern::NamedNode(NamedNode::new_unchecked(iri))
+        };
+        let inner_bgp = GraphPattern::Bgp {
+            patterns: vec![TriplePattern {
+                subject: vp("s"),
+                predicate: pred("http://ex/p"),
+                object: vp("o"),
+            }],
+        };
+        let filtered_inner = GraphPattern::Filter {
+            expr: call(Function::Rand, vec![]),
+            inner: Box::new(inner_bgp),
+        };
+        let exists = Expression::Exists(Box::new(filtered_inner));
+        assert!(!is_parallel_safe(&exists));
+
+        // Sanity: the same shape without RAND() is safe.
+        let inner_bgp2 = GraphPattern::Bgp {
+            patterns: vec![TriplePattern {
+                subject: vp("s"),
+                predicate: pred("http://ex/p"),
+                object: vp("o"),
+            }],
+        };
+        let safe_exists = Expression::Exists(Box::new(inner_bgp2));
+        assert!(is_parallel_safe(&safe_exists));
+    }
+
+    // ---- par_try_flat_map ----------------------------------------------------
+
+    #[test]
+    fn par_try_flat_map_flattens_in_index_order() {
+        let items: Vec<usize> = (0..64).collect();
+        let result = par_try_flat_map(&items, |i, &item| {
+            // Deliberately makes later-indexed items "finish faster" by doing less
+            // work, to prove the reduce is still index-ordered rather than
+            // completion-ordered.
+            if item % 7 != 0 {
+                std::thread::yield_now();
+            }
+            Ok(vec![vec![
+                Some(crate::scratch::SolutionTerm::Existing(
+                    purrdf_core::TermId::from_index(i as u32),
+                )),
+            ]])
+        })
+        .expect("no errors");
+        let indices: Vec<u32> = result
+            .iter()
+            .map(|row| match row[0] {
+                Some(crate::scratch::SolutionTerm::Existing(id)) => id.index() as u32,
+                _ => unreachable!(),
+            })
+            .collect();
+        let expected: Vec<u32> = (0..64).collect();
+        assert_eq!(indices, expected);
+    }
+
+    #[test]
+    fn par_try_flat_map_surfaces_the_lower_indexed_error() {
+        let items: Vec<usize> = (0..32).collect();
+        let result: Result<Vec<Solution>, EvalError> = par_try_flat_map(&items, |i, _| {
+            if i == 20 {
+                // The "slow" earlier error: give the scheduler a chance to let a
+                // later index finish first.
+                std::thread::yield_now();
+                return Err(EvalError::internal("error at 20"));
+            }
+            if i == 5 {
+                return Err(EvalError::internal("error at 5"));
+            }
+            Ok(vec![])
+        });
+        let err = result.unwrap_err();
+        assert_eq!(err, EvalError::internal("error at 5"));
+    }
+
+    // ---- fork_for_worker + absorb_row -----------------------------------------
+
+    #[test]
+    fn fork_and_absorb_row_round_trips_computed_values() {
+        let ds = RdfDatasetBuilder::new()
+            .freeze()
+            .expect("freeze empty dataset");
+        let mut parent = crate::eval::EvalCtx::new(&ds);
+        let mut child = parent.fork_for_worker();
+
+        let value = TermValue::Literal {
+            lexical_form: "hello parallel".to_owned(),
+            datatype: "http://www.w3.org/2001/XMLSchema#string".to_owned(),
+            language: None,
+            direction: None,
+        };
+        let child_term = child.scratch.intern(&ds, value.clone());
+        let row: Solution = vec![Some(child_term)];
+
+        let absorbed = absorb_row(&mut parent.scratch, &ds, &child.scratch, &row);
+        let main_term = absorbed[0].expect("cell present");
+        assert_eq!(parent.scratch.value_of(&ds, main_term), value);
+    }
+
+    #[test]
+    fn absorb_constructed_appends_in_call_order() {
+        let cell = |n: &str| TermValue::Iri(format!("http://ex/{n}"));
+        let mut main: Vec<(TermValue, TermValue, TermValue)> = vec![(
+            cell("s0"),
+            cell("p0"),
+            cell("o0"),
+        )];
+        let child_a = vec![(cell("s1"), cell("p1"), cell("o1"))];
+        let child_b = vec![(cell("s2"), cell("p2"), cell("o2"))];
+
+        absorb_constructed(&mut main, child_a);
+        absorb_constructed(&mut main, child_b);
+
+        assert_eq!(
+            main,
+            vec![
+                (cell("s0"), cell("p0"), cell("o0")),
+                (cell("s1"), cell("p1"), cell("o1")),
+                (cell("s2"), cell("p2"), cell("o2")),
+            ]
+        );
+    }
+}

--- a/crates/sparql-eval/src/parallel_determinism_gate.rs
+++ b/crates/sparql-eval/src/parallel_determinism_gate.rs
@@ -1,0 +1,527 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Task 7 comprehensive determinism gate: forcing the parallel fork-join path
+//! (`parallel::force_parallel_for_test(true)`) vs forcing the sequential path
+//! (`force_parallel_for_test(false)`) must yield **byte-identical** results for
+//! every parallelized node (BGP/joins, MINUS, FILTER, UNION, GROUP BY, BIND) —
+//! not just value-equal, but identical row order, since [`crate::parallel`]'s
+//! whole contract is order-stability under fork-join.
+//!
+//! This module lives inside the crate (`#[cfg(test)]`, gated in `lib.rs`) rather
+//! than under `tests/` because [`crate::parallel::force_parallel_for_test`] is
+//! `pub(crate)` — an external integration-test binary cannot see it.
+//!
+//! Two things are proven here:
+//!
+//! 1. [`parallel_paths_are_byte_identical_across_the_corpus`] — a broad query
+//!    corpus, each query run twice against the *same* [`NativeSparqlEngine`] +
+//!    dataset (so the plan cache and BGP order cache are identical across the
+//!    two runs; the *only* difference is the forced threshold), asserting the
+//!    two [`SparqlResult`]s match exactly.
+//! 2. [`default_pool_runs_a_genuinely_parallel_query`] — one query, run under
+//!    the real (unforced) rayon global pool, whose hot BGP scan exceeds
+//!    [`crate::parallel::PARALLEL_MIN_ROWS`] — proving the parallel path
+//!    actually compiles and schedules under a live multi-thread pool, not just
+//!    under the test-only force seam.
+
+use std::sync::Arc;
+
+use purrdf_core::{
+    canonicalize, RdfDataset, RdfDatasetBuilder, RdfLiteral, SparqlEngine, SparqlRequest,
+    SparqlResult,
+};
+
+use crate::engine::NativeSparqlEngine;
+use crate::parallel::{force_parallel_for_test, PARALLEL_MIN_ROWS};
+
+const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const EX: &str = "https://example.org/";
+
+/// Entity count for this gate's dataset. Small enough to build/evaluate the
+/// whole corpus twice (forced-parallel + forced-sequential) quickly in `cargo
+/// test`, but large enough that the hot predicates (`knows` at 3x, `name`,
+/// `age`, `dept`, `city`, ...) comfortably exceed [`PARALLEL_MIN_ROWS`] (1024),
+/// so the forced-parallel run genuinely exercises rayon's `par_iter` branch
+/// (see [`gate_dataset_crosses_the_parallel_threshold`]) rather than the
+/// trivial one-chunk case.
+const PEOPLE: usize = 5_000;
+
+/// Build the same star-shaped "people" dataset shape as
+/// `benches/query_eval.rs`'s `people_dataset` (predicate list, skew, and the
+/// binary `reportsTo` tree), scaled down to [`PEOPLE`] for test speed. Kept as
+/// a separate copy (not shared with the bench) because the bench lives in a
+/// different crate target (`benches/`) with no access to this crate's
+/// `pub(crate)` force seam.
+fn people_dataset() -> Arc<RdfDataset> {
+    let mut b = RdfDatasetBuilder::new();
+    let rdf_type = b.intern_iri(RDF_TYPE);
+    let person_class = b.intern_iri(&format!("{EX}Person"));
+    let p_name = b.intern_iri(&format!("{EX}name"));
+    let p_age = b.intern_iri(&format!("{EX}age"));
+    let p_label = b.intern_iri(&format!("{EX}label"));
+    let p_dept = b.intern_iri(&format!("{EX}dept"));
+    let p_city = b.intern_iri(&format!("{EX}city"));
+    let p_knows = b.intern_iri(&format!("{EX}knows"));
+    let p_email = b.intern_iri(&format!("{EX}email"));
+    let p_reports = b.intern_iri(&format!("{EX}reportsTo"));
+
+    let people: Vec<_> = (0..PEOPLE)
+        .map(|i| b.intern_iri(&format!("{EX}person{i}")))
+        .collect();
+    let depts: Vec<_> = (0..200)
+        .map(|d| b.intern_iri(&format!("{EX}dept{d}")))
+        .collect();
+    let cities: Vec<_> = (0..50)
+        .map(|c| b.intern_iri(&format!("{EX}city{c}")))
+        .collect();
+
+    for i in 0..PEOPLE {
+        let s = people[i];
+        b.push_quad(s, rdf_type, person_class, None);
+
+        let name = b.intern_literal(RdfLiteral::simple(format!("Name{i}")));
+        b.push_quad(s, p_name, name, None);
+
+        let age = b.intern_literal(RdfLiteral::typed((18 + i % 60).to_string(), XSD_INTEGER));
+        b.push_quad(s, p_age, age, None);
+
+        let lang = if i % 2 == 0 { "en" } else { "de" };
+        let label = b.intern_literal(RdfLiteral::language_tagged(format!("Person {i}"), lang));
+        b.push_quad(s, p_label, label, None);
+
+        b.push_quad(s, p_dept, depts[i % 200], None);
+        b.push_quad(s, p_city, cities[i % 50], None);
+
+        for step in [1usize, 17, 97] {
+            b.push_quad(s, p_knows, people[(i + step) % PEOPLE], None);
+        }
+
+        if i % 10 == 0 {
+            let email = b.intern_literal(RdfLiteral::simple(format!("p{i}@example.org")));
+            b.push_quad(s, p_email, email, None);
+        }
+
+        if i > 0 {
+            b.push_quad(s, p_reports, people[(i - 1) / 2], None);
+        }
+    }
+
+    b.freeze()
+        .expect("freeze parallel-determinism-gate people dataset")
+}
+
+/// Sanity check that this gate's dataset is not a toy: the `knows` predicate
+/// (the hot join/BGP-scan predicate exercised by most of the corpus) has
+/// `3 * PEOPLE` rows, which must clear [`PARALLEL_MIN_ROWS`] — otherwise the
+/// forced-parallel runs below would still take the `rayon::par_iter` branch
+/// (the force seam makes that unconditional), but this test documents *why*
+/// the dataset size was chosen: even an unforced run over this predicate
+/// would genuinely parallelize.
+#[test]
+fn gate_dataset_crosses_the_parallel_threshold() {
+    let hot_predicate_rows = 3 * PEOPLE;
+    assert!(
+        hot_predicate_rows > PARALLEL_MIN_ROWS,
+        "the gate dataset's hot `knows` predicate ({hot_predicate_rows} rows) must exceed \
+         PARALLEL_MIN_ROWS ({PARALLEL_MIN_ROWS}) for the corpus below to exercise a genuine \
+         parallel workload"
+    );
+    let scan_rows = PEOPLE;
+    assert!(
+        scan_rows > PARALLEL_MIN_ROWS,
+        "the gate dataset's per-person scan predicates ({scan_rows} rows) must exceed \
+         PARALLEL_MIN_ROWS ({PARALLEL_MIN_ROWS})"
+    );
+}
+
+/// (name, query text) corpus covering every node [`crate::parallel`] wires
+/// up (BGP/joins, MINUS, FILTER, UNION, GROUP BY, BIND) plus the 7
+/// `benches/query_eval.rs` shapes verbatim (kept in lock-step with that
+/// bench's cases, since Task 7's bench evidence and this determinism gate
+/// should watch the exact same query mix).
+const CORPUS: &[(&str, &str)] = &[
+    // -- BGP joins ---------------------------------------------------------
+    (
+        "join_single_var_selective",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?n ?a WHERE {
+  ?p ex:email ?e .
+  ?p ex:name ?n .
+  ?p ex:age ?a .
+  ?p ex:city ex:city20 .
+}",
+    ),
+    (
+        "join_multi_var_star",
+        // Two SHARED variables (?d, ?c) join independently-bound ?p/?q pairs
+        // (not linked via `knows`): every 25-person dept group guarantees a
+        // non-empty match, exercising the multi-variable join path.
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?q ?qn WHERE {
+  ?p ex:dept ?d .
+  ?q ex:dept ?d .
+  ?p ex:city ?c .
+  ?q ex:city ?c .
+  ?q ex:name ?qn .
+  FILTER(?p != ?q)
+}",
+    ),
+    (
+        "join_unselective_scan_filter",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?n WHERE {
+  ?p ex:name ?n .
+  ?p ex:age ?a .
+  FILTER(REGEX(?n, \"^Name1[0-9][0-9]2$\") && ?a > 40)
+}",
+    ),
+    // -- OPTIONAL ------------------------------------------------------------
+    (
+        "optional_heavy_no_filter",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?e ?l ?f WHERE {
+  ?p a ex:Person .
+  OPTIONAL { ?p ex:email ?e }
+  OPTIONAL { ?p ex:label ?l }
+  OPTIONAL { ?p ex:knows ?f }
+}",
+    ),
+    (
+        "optional_with_inline_filter",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?a ?e WHERE {
+  ?p ex:age ?a .
+  OPTIONAL { ?p ex:email ?e . FILTER(?a > 30) }
+}",
+    ),
+    // -- UNION ---------------------------------------------------------------
+    (
+        "union_4_overlap_and_disjoint",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?v WHERE {
+  { ?p ex:name ?v }
+  UNION { ?p ex:label ?v }
+  UNION { ?p ex:email ?v }
+  UNION { ?p ex:dept ?v }
+}",
+    ),
+    (
+        "union_with_bind_branches",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?tag WHERE {
+  { ?p ex:email ?e . BIND(\"has-email\" AS ?tag) }
+  UNION { ?p ex:age ?a . FILTER(?a > 50) BIND(\"senior\" AS ?tag) }
+  UNION { ?p ex:city ex:city20 . BIND(\"city20\" AS ?tag) }
+}",
+    ),
+    // -- FILTER (REGEX/numeric/EXISTS/NOT EXISTS) -----------------------------
+    (
+        "filter_regex_numeric",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?n ?a WHERE {
+  ?p ex:name ?n .
+  ?p ex:age ?a .
+  FILTER(REGEX(?n, \"^Name[0-9]*0$\") && ?a >= 20)
+}",
+    ),
+    (
+        "filter_exists",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p WHERE {
+  ?p a ex:Person .
+  FILTER EXISTS { ?p ex:email ?e }
+}",
+    ),
+    (
+        "filter_not_exists",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p WHERE {
+  ?p a ex:Person .
+  FILTER NOT EXISTS { ?p ex:email ?e }
+}",
+    ),
+    // -- MINUS -----------------------------------------------------------------
+    (
+        "minus_email_holders",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p WHERE {
+  ?p a ex:Person .
+  MINUS { ?p ex:email ?e }
+}",
+    ),
+    // -- BIND chains ------------------------------------------------------------
+    (
+        "bind_chain_numeric",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?a ?doubled ?bucket WHERE {
+  ?p ex:age ?a .
+  BIND(?a * 2 AS ?doubled)
+  BIND(?doubled + 1 AS ?bucket)
+}",
+    ),
+    (
+        "bind_chain_string",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?n ?upper ?greeting WHERE {
+  ?p ex:name ?n .
+  BIND(UCASE(?n) AS ?upper)
+  BIND(CONCAT(\"Hello, \", ?upper) AS ?greeting)
+}",
+    ),
+    // -- GROUP BY / aggregates ----------------------------------------------------
+    (
+        "group_by_all_aggregates",
+        "PREFIX ex: <https://example.org/>
+SELECT ?d
+  (COUNT(?p) AS ?n)
+  (COUNT(DISTINCT ?a) AS ?distinctAges)
+  (SUM(?a) AS ?sum)
+  (AVG(?a) AS ?avg)
+  (MIN(?a) AS ?min)
+  (MAX(?a) AS ?max)
+  (SAMPLE(?n2) AS ?sample)
+  (GROUP_CONCAT(?n2; separator=\",\") AS ?names)
+WHERE {
+  ?p ex:dept ?d .
+  ?p ex:age ?a .
+  ?p ex:name ?n2 .
+} GROUP BY ?d",
+    ),
+    // -- ORDER BY + LIMIT ---------------------------------------------------------
+    (
+        "order_by_desc_limit",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?a WHERE {
+  ?p ex:age ?a .
+} ORDER BY DESC(?a) ?p LIMIT 10",
+    ),
+    // -- subquery / nested pattern -------------------------------------------------
+    (
+        "nested_subquery",
+        "PREFIX ex: <https://example.org/>
+SELECT ?d ?maxAge WHERE {
+  ?p ex:dept ?d .
+  {
+    SELECT ?d2 (MAX(?a) AS ?maxAge) WHERE {
+      ?q ex:dept ?d2 .
+      ?q ex:age ?a .
+    } GROUP BY ?d2
+  }
+  FILTER(?d = ?d2)
+}",
+    ),
+    // -- ASK -------------------------------------------------------------------
+    (
+        "ask_email_exists",
+        "PREFIX ex: <https://example.org/>
+ASK { ?p ex:email ?e }",
+    ),
+    // -- CONSTRUCT ---------------------------------------------------------------
+    (
+        "construct_dept_edges",
+        "PREFIX ex: <https://example.org/>
+CONSTRUCT { ?p ex:inDept ?d } WHERE {
+  ?p ex:dept ?d .
+  ?p ex:age ?a .
+  FILTER(?a > 55)
+}",
+    ),
+    // -- the 7 benches/query_eval.rs shapes, verbatim -----------------------------
+    (
+        "bench_a_selective_join",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?n ?a WHERE {
+  ?p ex:email ?e .
+  ?p ex:name ?n .
+  ?p ex:age ?a .
+  ?p ex:city ex:city20 .
+}",
+    ),
+    (
+        "bench_b_scan_filter",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?n WHERE {
+  ?p ex:name ?n .
+  ?p ex:age ?a .
+  FILTER(REGEX(?n, \"^Name1[0-9][0-9]2$\") && ?a > 40)
+}",
+    ),
+    (
+        "bench_c_optional_heavy",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?e ?l ?f WHERE {
+  ?p a ex:Person .
+  OPTIONAL { ?p ex:email ?e }
+  OPTIONAL { ?p ex:label ?l }
+  OPTIONAL { ?p ex:knows ?f }
+}",
+    ),
+    (
+        "bench_d_union_4",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?v WHERE {
+  { ?p ex:name ?v } UNION { ?p ex:label ?v }
+  UNION { ?p ex:email ?v } UNION { ?p ex:dept ?v }
+}",
+    ),
+    (
+        "bench_e_group_aggregate",
+        "PREFIX ex: <https://example.org/>
+SELECT ?d (COUNT(?p) AS ?n) (AVG(?a) AS ?avg) (MAX(?a) AS ?max) WHERE {
+  ?p ex:dept ?d .
+  ?p ex:age ?a .
+} GROUP BY ?d",
+    ),
+    (
+        "bench_f_path_transitive",
+        "PREFIX ex: <https://example.org/>
+SELECT ?e WHERE { ?e ex:reportsTo+ ex:person0 }",
+    ),
+    (
+        "bench_g_order_by_limit",
+        "PREFIX ex: <https://example.org/>
+SELECT ?p ?a WHERE {
+  ?p ex:age ?a .
+} ORDER BY DESC(?a) ?p LIMIT 10",
+    ),
+];
+
+/// Evaluate `query` against `engine`/`ds` under the forced threshold `force`
+/// (see [`force_parallel_for_test`]), returning the raw [`SparqlResult`]. The
+/// guard is scoped to this call so the override never leaks into the next
+/// query in the corpus loop.
+fn eval_forced(
+    engine: &NativeSparqlEngine,
+    ds: &Arc<RdfDataset>,
+    query: &str,
+    force: bool,
+) -> SparqlResult {
+    let _guard = force_parallel_for_test(force);
+    engine
+        .query(
+            ds,
+            SparqlRequest {
+                query,
+                base_iri: None,
+                substitutions: &[],
+            },
+        )
+        .unwrap_or_else(|e| panic!("query evaluation failed: {e:?}\nquery:\n{query}"))
+}
+
+/// Materialize a [`SparqlResult`] into a form comparable with plain
+/// `assert_eq!`/`PartialEq`, canonicalizing whichever payload the result
+/// variant carries: SELECT compares `(variables, rows)` (rows in the exact
+/// row order the engine returned — this is the whole point, since fork-join
+/// order-stability is the property under test), ASK compares the bare bool,
+/// and CONSTRUCT/DESCRIBE compare canonical N-Quads (RDFC-1.0 blank-node
+/// canonicalization; `TermId`s from the two independently-evaluated queries
+/// are never expected to match, only the abstract graph they denote).
+#[derive(Debug, PartialEq)]
+enum Comparable {
+    Solutions {
+        variables: Vec<String>,
+        rows: Vec<Vec<Option<purrdf_core::TermValue>>>,
+    },
+    Boolean(bool),
+    Graph {
+        nquads: String,
+    },
+}
+
+fn comparable(result: &SparqlResult) -> Comparable {
+    match result {
+        SparqlResult::Solutions {
+            variables, rows, ..
+        } => Comparable::Solutions {
+            variables: variables.clone(),
+            rows: rows.clone(),
+        },
+        SparqlResult::Boolean(b) => Comparable::Boolean(*b),
+        SparqlResult::Graph(ds) => Comparable::Graph {
+            nquads: canonicalize(ds).nquads,
+        },
+    }
+}
+
+/// **The comprehensive determinism gate.** For every `(name, query)` in
+/// [`CORPUS`], evaluate it twice against the *same* engine + dataset — once
+/// forced parallel, once forced sequential — and assert the results are
+/// byte-identical (same variables, same rows, same order; ASK bool equal;
+/// CONSTRUCT canonical N-Quads equal). Same engine on both sides so the plan
+/// cache and BGP order cache are identical across the two runs — the forced
+/// threshold is the *only* variable.
+#[test]
+fn parallel_paths_are_byte_identical_across_the_corpus() {
+    let ds = people_dataset();
+    let engine = NativeSparqlEngine::new();
+
+    for &(name, query) in CORPUS {
+        let parallel = eval_forced(&engine, &ds, query, true);
+        let sequential = eval_forced(&engine, &ds, query, false);
+
+        let parallel_cmp = comparable(&parallel);
+        let sequential_cmp = comparable(&sequential);
+
+        assert_eq!(
+            parallel_cmp, sequential_cmp,
+            "query `{name}` diverged between forced-parallel and forced-sequential evaluation:\n{query}"
+        );
+
+        // Every case must do real work: an accidentally-empty result on both
+        // sides would make the byte-identity assertion above vacuous.
+        let is_nonempty = match &parallel {
+            SparqlResult::Solutions { rows, .. } => !rows.is_empty(),
+            SparqlResult::Boolean(_) => true,
+            SparqlResult::Graph(ds) => ds.quad_count() > 0,
+        };
+        assert!(
+            is_nonempty,
+            "query `{name}` returned an empty/no-op result on both paths — \
+             the determinism assertion above would be vacuous"
+        );
+    }
+}
+
+/// **Default-pool instantiation test** (deliberately NOT using the force
+/// seam): evaluate a query whose hot BGP scan (`ex:knows`, `3 * PEOPLE` rows,
+/// see [`gate_dataset_crosses_the_parallel_threshold`]) genuinely exceeds
+/// [`PARALLEL_MIN_ROWS`] under the real, default rayon global pool. The
+/// byte-identity test above proves order-stability between the two forced
+/// paths; this test proves the parallel path actually *compiles and runs*
+/// under live rayon scheduling (real `Send`/`Sync` bounds honored, no forced
+/// override), by checking the returned rows are exactly what the dataset
+/// construction guarantees.
+#[test]
+fn default_pool_runs_a_genuinely_parallel_query() {
+    let ds = people_dataset();
+    let engine = NativeSparqlEngine::new();
+
+    let query = "PREFIX ex: <https://example.org/>
+SELECT ?p ?f WHERE {
+  ?p ex:knows ?f .
+}";
+    let result = engine
+        .query(
+            &ds,
+            SparqlRequest {
+                query,
+                base_iri: None,
+                substitutions: &[],
+            },
+        )
+        .expect("default-pool query evaluates");
+
+    match result {
+        SparqlResult::Solutions { rows, .. } => {
+            assert_eq!(
+                rows.len(),
+                3 * PEOPLE,
+                "expected exactly 3 * PEOPLE `knows` edges under the default rayon pool"
+            );
+        }
+        other => panic!("expected Solutions, got {other:?}"),
+    }
+}

--- a/crates/sparql-eval/src/path.rs
+++ b/crates/sparql-eval/src/path.rs
@@ -41,6 +41,7 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use purrdf_core::{RdfDataset, TermId, TermRef};
 use purrdf_sparql_algebra::{NamedNode, PropertyPathExpression, TermPattern, Variable};
@@ -134,7 +135,7 @@ pub(crate) fn eval_path(
 
     // An absent ground endpoint cannot match anything.
     let (Some(s_end), Some(o_end)) = (s_end, o_end) else {
-        return Ok(SolutionSeq::empty(Rc::new(schema)));
+        return Ok(SolutionSeq::empty(Arc::new(schema)));
     };
 
     // Pre-resolve all NegatedPropertySet excluded predicates once for this eval call.
@@ -206,7 +207,7 @@ pub(crate) fn eval_path(
     }
 
     Ok(SolutionSeq {
-        schema: Rc::new(schema),
+        schema: Arc::new(schema),
         rows,
     })
 }
@@ -580,7 +581,6 @@ mod tests {
     use pretty_assertions::assert_eq;
     use purrdf_core::RdfDatasetBuilder;
     use purrdf_sparql_algebra::NamedNode;
-    use std::sync::Arc;
 
     const EX: &str = "http://ex/";
 

--- a/crates/sparql-eval/src/remote.rs
+++ b/crates/sparql-eval/src/remote.rs
@@ -252,7 +252,7 @@ mod tests {
 
     fn run_with_source(
         ds: &Arc<RdfDataset>,
-        source: &dyn RemoteQuerySource,
+        source: &(dyn RemoteQuerySource + Sync),
         query: &str,
     ) -> Result<SparqlResult, EvalError> {
         use crate::eval::evaluate_query;

--- a/crates/sparql-eval/src/remote.rs
+++ b/crates/sparql-eval/src/remote.rs
@@ -29,7 +29,6 @@
 //! identity (one empty row) so the surrounding query proceeds unchanged.
 
 use std::collections::HashMap;
-use std::rc::Rc;
 use std::sync::Arc;
 
 use purrdf_core::{RdfDataset, TermValue};
@@ -146,7 +145,7 @@ fn silent_or_err(silent: bool, msg: impl FnOnce() -> String) -> Result<SolutionS
 /// so a swallowed `SERVICE SILENT` leaves the surrounding query unchanged.
 fn identity_seq() -> SolutionSeq {
     SolutionSeq {
-        schema: Rc::new(VarSchema::new()),
+        schema: Arc::new(VarSchema::new()),
         rows: vec![vec![]],
     }
 }
@@ -156,7 +155,7 @@ fn identity_seq() -> SolutionSeq {
 /// but carries `TermValue` directly, so remote blank nodes survive — `GroundTerm`
 /// has no blank-node variant.)
 fn ingest(resolved: ResolvedBindings, ctx: &mut EvalCtx<'_>) -> SolutionSeq {
-    let schema = Rc::new(VarSchema::from_vars(resolved.variables));
+    let schema = Arc::new(VarSchema::from_vars(resolved.variables));
     let width = schema.len();
     let mut rows = Vec::with_capacity(resolved.rows.len());
     for binding in resolved.rows {

--- a/crates/sparql-eval/src/scratch.rs
+++ b/crates/sparql-eval/src/scratch.rs
@@ -99,7 +99,7 @@ impl SolutionTerm {
 /// values to one [`ScratchId`]. Stateless with respect to the dataset: the dataset
 /// is passed to each operation so the interner does not hold a borrow that would
 /// conflict with the evaluator's other dataset access.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ScratchInterner {
     /// `ScratchId` index → the computed value.
     values: Vec<TermValue>,

--- a/crates/sparql-eval/src/scratch.rs
+++ b/crates/sparql-eval/src/scratch.rs
@@ -46,8 +46,13 @@ impl ScratchId {
         Self(u32::try_from(index).expect("scratch table cannot exceed u32::MAX entries"))
     }
 
+    /// The raw table index behind this id. `pub(crate)` for
+    /// [`crate::parallel::portable_row`], which must compare a `Computed` id
+    /// against the parent's fork-time `computed_count()` to decide whether it
+    /// was already valid in the parent's id space or freshly minted by the
+    /// child after the fork.
     #[inline]
-    fn index(self) -> usize {
+    pub(crate) fn index(self) -> usize {
         self.0 as usize
     }
 }

--- a/crates/sparql-eval/src/solution.rs
+++ b/crates/sparql-eval/src/solution.rs
@@ -14,7 +14,7 @@
 //! tuple hash, and join keys are precomputed column ordinals rather than per-probe
 //! variable-name lookups.
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use purrdf_sparql_algebra::Variable;
 
@@ -128,14 +128,14 @@ pub type Solution = Vec<Option<SolutionTerm>>;
 #[derive(Clone, Debug)]
 pub struct SolutionSeq {
     /// The shared variable schema (so a row is just a `Vec<Option<SolutionTerm>>`).
-    pub schema: Rc<VarSchema>,
+    pub schema: Arc<VarSchema>,
     /// The solution rows (a bag — duplicates significant).
     pub rows: Vec<Solution>,
 }
 
 impl SolutionSeq {
     /// An empty sequence over `schema` (zero solutions).
-    pub fn empty(schema: Rc<VarSchema>) -> Self {
+    pub fn empty(schema: Arc<VarSchema>) -> Self {
         Self {
             schema,
             rows: Vec::new(),
@@ -147,7 +147,7 @@ impl SolutionSeq {
     /// identity, so this is the correct seed for an empty group pattern.
     pub fn unit() -> Self {
         Self {
-            schema: Rc::new(VarSchema::new()),
+            schema: Arc::new(VarSchema::new()),
             rows: vec![Vec::new()],
         }
     }


### PR DESCRIPTION
Closes #18

## Summary
Parallelizes the data-parallel SPARQL plan nodes in `purrdf-sparql-eval` using the deterministic two-phase pattern already proven in the parser and GTS verifier: an order-stable, chunk-based positional collect followed by a sequential in-order reduce (first-by-index error). Correctness is proven byte-identical to the sequential path and is timing-independent; wasm32 keeps the sequential path automatically (rayon degrades to inline-sequential on threadless targets).

The mechanism is **fork-based** rather than a new context type threaded through every evaluator: the `EvalCtx` type was made `Send + Sync`, and each worker gets a freshly-forked child context (immutable dataset/order-cache/remote shared; scratch cloned so the child resolves input rows' existing computed terms) that runs the **existing, unchanged** evaluators — one code path.

## Changes (commit-by-commit)
- `Rc→Arc` on `SolutionSeq.schema` / `ExistsInner.inner` (load-bearing: `!Sync` otherwise).
- `EvalCtx: Send + Sync` — remaining caches `Rc→Arc`, `BgpOrderCache` `RefCell→RwLock`, `remote` tightened to `+ Sync`; compile-time `Send+Sync` assertion.
- rayon dep + two-phase scaffold: adaptive threshold, `is_parallel_safe` (routes BNODE/RAND/UUID/STRUUID and blank-minting list constructors to the sequential real ctx), `fork_for_worker`, chunk-based collect helpers.
- Read-only tier: BGP inner loop, inner hash-join probe, non-filtered left-join probe, MINUS.
- FILTER / filtered-left-join via forked per-worker children (child scratch discarded — nothing escapes).
- Minting tier — UNION (`rayon::join`), BIND, per-group aggregates — via a deterministic portable-materialization merge: escaping `Computed` terms are captured as dataset-independent `TermValue` in the worker and re-interned into the parent scratch in index order; a no-mint fast path skips materialization entirely.
- Chunk-based collects: allocation is O(chunks≈threads), not O(rows).

## Correctness & determinism (the gate)
- Forced-parallel-vs-sequential canonical output is **byte-identical** across a 22-query corpus (all node types + the 7 `query_eval` bench shapes) on a threshold-crossing dataset. Timing-independent; always runs in CI.
- Nondeterministic builtins are statically routed to the sequential path, so results never depend on scheduling or thread count.
- Default-pool test exercises the real Send/Sync bounds under multi-thread rayon.
- W3C SPARQL conformance unchanged (xfail ledger unchanged). `make check` green (fmt + workspace clippy pedantic/nursery + all tests + hygiene + `make wasm`).

## Performance
Efficiency is reasoned from the code, not benchmarked: the collect helpers are chunk-based (one accumulator per worker, ~thread-count allocations, matching the parser) rather than per-row, and a no-mint pass-through avoids per-row materialization on UNION-over-BGP and MIN/MAX/SAMPLE groups. **No speedup is asserted.** The criterion `query_eval` bench is report-only (per the Makefile / CLAUDE.md) and should be run in a genuinely quiet environment — wall-clock figures from a shared machine are not meaningful and are deliberately omitted.