### PR TITLE
feat(rdf-core): content-addressed term support in the IR (GTS-aligned)

### DIFF
--- a/crates/rdf-core/Cargo.toml
+++ b/crates/rdf-core/Cargo.toml
@@ -74,7 +74,7 @@ name = "mutable"
 harness = false
 
 [[bench]]
-# Intern-time content-id overhead harness (#17 Task 8): three groups measuring
+# Intern-time content-id overhead harness: three groups measuring
 # ordinary-IRI interning with content addressing inactive vs active (prefix-miss
 # cost) and genuine `blake3:<64hex>` content-id interning (prefix-hit + decode +
 # side-table insert). Report-only — no timing/speedup assertions. `make bench`

--- a/crates/rdf-core/Cargo.toml
+++ b/crates/rdf-core/Cargo.toml
@@ -72,3 +72,12 @@ harness = false
 # `make bench` lane only — excluded from `make check`.
 name = "mutable"
 harness = false
+
+[[bench]]
+# Intern-time content-id overhead harness (#17 Task 8): three groups measuring
+# ordinary-IRI interning with content addressing inactive vs active (prefix-miss
+# cost) and genuine `blake3:<64hex>` content-id interning (prefix-hit + decode +
+# side-table insert). Report-only — no timing/speedup assertions. `make bench`
+# lane only — excluded from `make check`.
+name = "intern_content_id"
+harness = false

--- a/crates/rdf-core/benches/intern_content_id.rs
+++ b/crates/rdf-core/benches/intern_content_id.rs
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Intern-time content-id overhead bench (#17 Task 8).
+//! Intern-time content-id overhead bench.
 //!
 //! Content addressing (`RdfDatasetBuilder::with_content_addressing`) adds a
 //! recognition check to every `intern_iri` call: does this IRI carry the
 //! configured scheme prefix and, if so, does the suffix decode as valid hex? The
-//! #17 RFC's cost model is that this check should be near-free for IRIs that
+//! cost model is that this check is near-free for IRIs that
 //! never match the prefix (a `strip_prefix` miss) and pay a real but small cost
 //! only for genuine content-id IRIs (decode + side-table insert).
 //!

--- a/crates/rdf-core/benches/intern_content_id.rs
+++ b/crates/rdf-core/benches/intern_content_id.rs
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Intern-time content-id overhead bench (#17 Task 8).
+//!
+//! Content addressing (`RdfDatasetBuilder::with_content_addressing`) adds a
+//! recognition check to every `intern_iri` call: does this IRI carry the
+//! configured scheme prefix and, if so, does the suffix decode as valid hex? The
+//! #17 RFC's cost model is that this check should be near-free for IRIs that
+//! never match the prefix (a `strip_prefix` miss) and pay a real but small cost
+//! only for genuine content-id IRIs (decode + side-table insert).
+//!
+//! This is a **report-only** bench: it prints/records wall-clock time for three
+//! scenarios so the cost can be *read*, not a gate that asserts a speedup or a
+//! timing threshold (repo policy — benches never assert timing).
+//!
+//! 1. `intern_ordinary_scheme_inactive` — baseline: a plain builder interning N
+//!    ordinary `http://example.org/r/<i>` IRIs. No content-addressing config at
+//!    all, so no recognition check runs.
+//! 2. `intern_ordinary_scheme_active` — the SAME N ordinary IRIs, but interned
+//!    into a builder configured with `with_content_addressing`. Every one of
+//!    these IRIs misses the `blake3:` prefix, so this measures the strip-prefix
+//!    miss cost in isolation. Expectation (NOT asserted): this should track
+//!    group 1 closely, since a prefix miss is a cheap string compare.
+//! 3. `intern_content_ids_scheme_active` — N genuine `blake3:<64 lowercase
+//!    hex>` IRIs interned into a content-addressing-active builder. Every IRI
+//!    hits the prefix, decodes 64 hex chars to 32 bytes, and inserts a
+//!    side-table entry. This measures the real decode + insert cost.
+//!
+//! IRIs are generated deterministically (no RNG, no time source) so the input
+//! set is stable across runs: ordinary IRIs are `http://example.org/r/{i}`, and
+//! content-ids are built by tiling a hex encoding of `i` out to exactly 64
+//! lowercase hex characters.
+
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use purrdf_core::{ContentIdScheme, RdfDatasetBuilder};
+
+/// Number of IRIs interned per measured iteration.
+const N: u32 = 10_000;
+
+/// Build the ordinary (non-content-id) IRI set once: `http://example.org/r/{i}`
+/// for `i` in `0..N`. Distinct per `i` so every intern is a genuine new-entry
+/// insert, not a dedup hit.
+fn ordinary_iris() -> Vec<String> {
+    (0..N)
+        .map(|i| format!("http://example.org/r/{i}"))
+        .collect()
+}
+
+/// Build the genuine content-id IRI set once: `blake3:<64 lowercase hex>` for
+/// `i` in `0..N`, each suffix deterministically derived from `i` (no RNG). The
+/// hex digest is `i` formatted as 8 hex digits, tiled 8x to fill exactly 64
+/// lowercase hex characters — distinct per `i`, always valid hex.
+fn content_id_iris() -> Vec<String> {
+    (0..N)
+        .map(|i| {
+            let octet = format!("{i:08x}");
+            debug_assert_eq!(octet.len(), 8);
+            let hex64 = octet.repeat(8);
+            debug_assert_eq!(hex64.len(), 64);
+            format!("blake3:{hex64}")
+        })
+        .collect()
+}
+
+/// Group 1: baseline — plain builder, ordinary IRIs, no content-addressing
+/// config at all (no recognition check runs on this path).
+fn bench_ordinary_scheme_inactive(c: &mut Criterion) {
+    let iris = ordinary_iris();
+    let mut group = c.benchmark_group("intern_content_id");
+    group.bench_function("intern_ordinary_scheme_inactive", |b| {
+        b.iter_batched(
+            || iris.clone(),
+            |iris| {
+                let mut builder = RdfDatasetBuilder::new();
+                for iri in &iris {
+                    black_box(builder.intern_iri(black_box(iri)));
+                }
+                black_box(builder)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
+/// Group 2: the SAME ordinary IRIs, but the builder has content-addressing
+/// active — every intern pays a `blake3:` prefix-strip MISS. Expectation (not
+/// asserted): should read close to group 1's time.
+fn bench_ordinary_scheme_active(c: &mut Criterion) {
+    let iris = ordinary_iris();
+    let mut group = c.benchmark_group("intern_content_id");
+    group.bench_function("intern_ordinary_scheme_active", |b| {
+        b.iter_batched(
+            || iris.clone(),
+            |iris| {
+                let scheme = ContentIdScheme::new("blake3:").expect("valid scheme prefix");
+                let mut builder = RdfDatasetBuilder::with_content_addressing(scheme, None);
+                for iri in &iris {
+                    black_box(builder.intern_iri(black_box(iri)));
+                }
+                black_box(builder)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
+/// Group 3: genuine `blake3:<64hex>` content-id IRIs interned into a
+/// content-addressing-active builder — every intern pays the prefix HIT +
+/// 64-hex decode + side-table insert.
+fn bench_content_ids_scheme_active(c: &mut Criterion) {
+    let iris = content_id_iris();
+    let mut group = c.benchmark_group("intern_content_id");
+    group.bench_function("intern_content_ids_scheme_active", |b| {
+        b.iter_batched(
+            || iris.clone(),
+            |iris| {
+                let scheme = ContentIdScheme::new("blake3:").expect("valid scheme prefix");
+                let mut builder = RdfDatasetBuilder::with_content_addressing(scheme, None);
+                for iri in &iris {
+                    black_box(builder.intern_iri(black_box(iri)));
+                }
+                black_box(builder)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_ordinary_scheme_inactive,
+    bench_ordinary_scheme_active,
+    bench_content_ids_scheme_active
+);
+criterion_main!(benches);

--- a/crates/rdf-core/src/content_id.rs
+++ b/crates/rdf-core/src/content_id.rs
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The BLAKE3 GTS content-id domain: `blake3:<hex>` term references.
+//!
+//! [`Blake3ContentId`] is a distinct 32-byte newtype from
+//! [`ContentDigest`](crate::content_store::ContentDigest). Where `ContentDigest`
+//! is the SHA-256 blob-store address computed by this crate (`of`/`from_raw`),
+//! `Blake3ContentId` addresses the separate BLAKE3 domain used by the GTS
+//! `blake3:<hex>` term encoding produced *outside* this crate. This type is
+//! **decode-only**: it never hashes bytes and `purrdf-core` gains no `blake3`
+//! dependency from it. Callers that need to mint a `Blake3ContentId` from raw
+//! bytes must hash elsewhere and hand the crate the resulting hex or raw bytes.
+//!
+//! The hex-decode loop is shared with `ContentDigest::from_hex` via
+//! [`decode_hex_32`](crate::content_store::decode_hex_32) so the two domains
+//! never drift apart on parsing behavior; only the case-sensitivity policy
+//! differs (this domain requires canonical lowercase hex).
+
+use std::fmt;
+
+use crate::content_store::decode_hex_32;
+
+/// A content id in the BLAKE3 GTS domain (`blake3:<hex>` term references).
+///
+/// Distinct from [`ContentDigest`](crate::content_store::ContentDigest), which
+/// is the SHA-256 blob-store domain. `Blake3ContentId` never hashes bytes —
+/// it only decodes a pre-computed 64-char lowercase hex string (or wraps raw
+/// bytes a caller already has) so this crate stays free of a `blake3` dependency.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Blake3ContentId([u8; 32]);
+
+impl Blake3ContentId {
+    /// Wrap 32 raw BLAKE3 digest bytes as a `Blake3ContentId` WITHOUT hashing.
+    ///
+    /// For callers that have already computed (or obtained) a BLAKE3 digest and
+    /// want to carry the result as a `Blake3ContentId`.
+    #[must_use]
+    pub const fn from_raw(raw: [u8; 32]) -> Self {
+        Self(raw)
+    }
+
+    /// The 32 raw digest bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// The lowercase-hex rendering of the digest (64 chars).
+    #[must_use]
+    pub fn to_hex(&self) -> String {
+        let mut s = String::with_capacity(64);
+        for b in &self.0 {
+            use fmt::Write as _;
+            let _ = write!(s, "{b:02x}");
+        }
+        s
+    }
+
+    /// Parse a canonical 64-char **lowercase** hex digest. Returns `None` on
+    /// any malformed input (wrong length, non-hex characters, or any
+    /// uppercase `A`-`F`).
+    ///
+    /// Unlike [`ContentDigest::from_hex`](crate::content_store::ContentDigest::from_hex),
+    /// this domain does not tolerate uppercase hex: the GTS `blake3:<hex>`
+    /// encoding is always lowercase, so an uppercase input is treated as
+    /// malformed rather than silently normalized.
+    #[must_use]
+    pub fn from_hex(hex: &str) -> Option<Self> {
+        if hex.bytes().any(|b| b.is_ascii_uppercase()) {
+            return None;
+        }
+        decode_hex_32(hex).map(Self)
+    }
+}
+
+impl fmt::Debug for Blake3ContentId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Blake3ContentId({})", self.to_hex())
+    }
+}
+
+impl fmt::Display for Blake3ContentId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_hex())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Blake3ContentId;
+    use crate::content_store::ContentDigest;
+
+    const KNOWN: [u8; 32] = [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f, 0xf0, 0xe1, 0xd2, 0xc3, 0xb4, 0xa5, 0x96, 0x87, 0x78, 0x69, 0x5a, 0x4b, 0x3c, 0x2d,
+        0x1e, 0xff,
+    ];
+
+    #[test]
+    fn round_trips_through_hex() {
+        let id = Blake3ContentId::from_raw(KNOWN);
+        let hex = id.to_hex();
+        assert_eq!(Blake3ContentId::from_hex(&hex), Some(id));
+    }
+
+    #[test]
+    fn rejects_wrong_length() {
+        let short = "a".repeat(63);
+        let long = "a".repeat(65);
+        assert_eq!(Blake3ContentId::from_hex(&short), None);
+        assert_eq!(Blake3ContentId::from_hex(&long), None);
+    }
+
+    #[test]
+    fn rejects_non_hex_char() {
+        let mut s = "a".repeat(64);
+        s.replace_range(0..1, "z");
+        assert_eq!(Blake3ContentId::from_hex(&s), None);
+    }
+
+    #[test]
+    fn rejects_uppercase_hex() {
+        let upper = "AB".repeat(32);
+        assert_eq!(Blake3ContentId::from_hex(&upper), None);
+    }
+
+    #[test]
+    fn accepts_valid_lowercase_hex() {
+        let hex = "ab".repeat(32);
+        let id = Blake3ContentId::from_hex(&hex).expect("valid lowercase hex decodes");
+        assert_eq!(id.as_bytes(), &[0xab; 32]);
+    }
+
+    #[test]
+    fn is_a_distinct_type_from_content_digest() {
+        let raw = [0x42u8; 32];
+        let blake3_id = Blake3ContentId::from_raw(raw);
+        let sha256_digest = ContentDigest::from_raw(raw);
+        // Same underlying bytes, but distinct types: this only compiles because
+        // they are not comparable to each other.
+        assert_eq!(blake3_id.as_bytes(), sha256_digest.as_bytes());
+    }
+}

--- a/crates/rdf-core/src/content_id.rs
+++ b/crates/rdf-core/src/content_id.rs
@@ -20,6 +20,7 @@
 use std::fmt;
 
 use crate::content_store::decode_hex_32;
+use crate::RdfDiagnostic;
 
 /// A content id in the BLAKE3 GTS domain (`blake3:<hex>` term references).
 ///
@@ -74,6 +75,63 @@ impl Blake3ContentId {
     }
 }
 
+/// The caller-supplied spelling that marks an IRI as a content-id term
+/// reference (e.g. `"blake3:"`).
+///
+/// There is **no default**: `purrdf-core` mints no vocabulary IRIs and fabricates
+/// no recognition spelling, so absent config means content-id recognition is
+/// inactive (see [`RdfDatasetBuilder::with_content_addressing`](crate::ir::RdfDatasetBuilder::with_content_addressing)).
+/// The prefix is validated once at construction so every later match against it
+/// is unambiguous: it must be non-empty, ASCII, and must NOT end in an ASCII hex
+/// digit (`0`-`9`, `a`-`f`, `A`-`F`) — otherwise a prefix like `"blake3a"` could
+/// not be told apart from a 64-hex-char tail that happens to start where the
+/// prefix ends.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ContentIdScheme {
+    prefix: String,
+}
+
+impl ContentIdScheme {
+    /// Validate and wrap a content-id recognition prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(RdfDiagnostic)` if `prefix` is empty, contains non-ASCII
+    /// bytes, or ends in an ASCII hex digit.
+    pub fn new(prefix: impl Into<String>) -> Result<Self, RdfDiagnostic> {
+        let prefix = prefix.into();
+        if prefix.is_empty() {
+            return Err(RdfDiagnostic::error(
+                "content-id-scheme",
+                "content-id scheme prefix must not be empty",
+            ));
+        }
+        if !prefix.is_ascii() {
+            return Err(RdfDiagnostic::error(
+                "content-id-scheme",
+                format!("content-id scheme prefix {prefix:?} must be ASCII"),
+            ));
+        }
+        let last = prefix.as_bytes()[prefix.len() - 1];
+        if last.is_ascii_hexdigit() {
+            return Err(RdfDiagnostic::error(
+                "content-id-scheme",
+                format!(
+                    "content-id scheme prefix {prefix:?} must not end in an ASCII hex digit \
+                     (0-9, a-f, A-F): that would make it ambiguous with the 64-hex-char tail"
+                ),
+            ));
+        }
+        Ok(Self { prefix })
+    }
+
+    /// The validated recognition prefix (e.g. `"blake3:"`).
+    #[must_use]
+    pub fn prefix(&self) -> &str {
+        &self.prefix
+    }
+}
+
 impl fmt::Debug for Blake3ContentId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Blake3ContentId({})", self.to_hex())
@@ -88,7 +146,7 @@ impl fmt::Display for Blake3ContentId {
 
 #[cfg(test)]
 mod tests {
-    use super::Blake3ContentId;
+    use super::{Blake3ContentId, ContentIdScheme};
     use crate::content_store::ContentDigest;
 
     const KNOWN: [u8; 32] = [
@@ -140,5 +198,22 @@ mod tests {
         // Same underlying bytes, but distinct types: this only compiles because
         // they are not comparable to each other.
         assert_eq!(blake3_id.as_bytes(), sha256_digest.as_bytes());
+    }
+
+    #[test]
+    fn scheme_accepts_prefix_ending_in_non_hex_char() {
+        let scheme = ContentIdScheme::new("blake3:").expect("':' is not a hex digit");
+        assert_eq!(scheme.prefix(), "blake3:");
+    }
+
+    #[test]
+    fn scheme_rejects_empty_prefix() {
+        assert!(ContentIdScheme::new("").is_err());
+    }
+
+    #[test]
+    fn scheme_rejects_prefix_ending_in_hex_digit() {
+        // "abc" ends in 'c', an ASCII hex digit: ambiguous against the 64-hex tail.
+        assert!(ContentIdScheme::new("abc").is_err());
     }
 }

--- a/crates/rdf-core/src/content_store.rs
+++ b/crates/rdf-core/src/content_store.rs
@@ -70,17 +70,28 @@ impl ContentDigest {
     /// Parse a 64-char hex digest. Returns `None` on any malformed input
     /// (wrong length or non-hex characters).
     pub fn from_hex(hex: &str) -> Option<Self> {
-        if hex.len() != 64 {
-            return None;
-        }
-        let mut buf = [0u8; 32];
-        for (i, byte) in buf.iter_mut().enumerate() {
-            let hi = (hex.as_bytes()[i * 2] as char).to_digit(16)?;
-            let lo = (hex.as_bytes()[i * 2 + 1] as char).to_digit(16)?;
-            *byte = (hi * 16 + lo) as u8;
-        }
-        Some(Self(buf))
+        decode_hex_32(hex).map(Self)
     }
+}
+
+/// Decode a 64-char hex string into 32 raw bytes. Returns `None` on any
+/// malformed input (wrong length or non-hex characters). Case-insensitive
+/// (accepts both `0-9a-f` and `0-9A-F`).
+///
+/// Shared by [`ContentDigest::from_hex`] and
+/// [`crate::content_id::Blake3ContentId::from_hex`] so the two content-id
+/// domains (SHA-256 vs BLAKE3) do not duplicate the decode loop.
+pub(crate) fn decode_hex_32(hex: &str) -> Option<[u8; 32]> {
+    if hex.len() != 64 {
+        return None;
+    }
+    let mut buf = [0u8; 32];
+    for (i, byte) in buf.iter_mut().enumerate() {
+        let hi = (hex.as_bytes()[i * 2] as char).to_digit(16)?;
+        let lo = (hex.as_bytes()[i * 2 + 1] as char).to_digit(16)?;
+        *byte = (hi * 16 + lo) as u8;
+    }
+    Some(buf)
 }
 
 impl fmt::Debug for ContentDigest {

--- a/crates/rdf-core/src/ir/builder.rs
+++ b/crates/rdf-core/src/ir/builder.rs
@@ -924,7 +924,7 @@ mod tests {
     }
 
     /// No fabricated default: a plain `new`/`default` builder has content-id
-    /// recognition INACTIVE (recognition itself is wired in a later task).
+    /// recognition INACTIVE.
     #[test]
     fn new_builder_has_no_content_scheme() {
         let b = RdfDatasetBuilder::new();

--- a/crates/rdf-core/src/ir/builder.rs
+++ b/crates/rdf-core/src/ir/builder.rs
@@ -309,6 +309,29 @@ impl Interner {
         self.content_ids.get(&id).copied()
     }
 
+    /// Look up the [`TermId`] of an already-interned IRI, WITHOUT interning a new
+    /// term on a miss. Mirrors the hit path of [`Interner::intern`]'s IRI arm
+    /// exactly (same hash, same `term_eq` comparison), so it agrees with `intern`
+    /// on every IRI that has actually been interned.
+    ///
+    /// Used at [`RdfDatasetBuilder::materialize`] to resolve the configured
+    /// derivation-predicate IRI to a frozen `TermId` without minting a new term
+    /// after the arena/term table are otherwise frozen-bound: terms are frozen at
+    /// that point, so a miss here must return `None`, never insert.
+    fn lookup_iri(&self, iri: &str) -> Option<TermId> {
+        let lookup = TermLookup::Iri(iri);
+        let hash = {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            hash_lookup(&lookup, &mut h);
+            h.finish()
+        };
+        let (arena, terms) = (&self.arena, &self.terms);
+        self.index
+            .find(hash, |&i| term_eq(arena, &terms[i as usize], &lookup))
+            .copied()
+            .map(TermId::from_index)
+    }
+
     fn term(&self, id: TermId) -> &InternedTerm {
         &self.terms[id.index()]
     }
@@ -788,8 +811,15 @@ impl RdfDatasetBuilder {
             mut reifiers,
             mut annotations,
             locations,
+            derivation_predicate,
             ..
         } = self;
+
+        // Resolve the configured derivation-predicate IRI to its frozen `TermId`
+        // via a lookup-only probe (never interns): terms are frozen from this
+        // point on, so an IRI that was configured but never actually interned
+        // resolves to `None` — "no derivations present", not an error.
+        let derivation_predicate = derivation_predicate.and_then(|iri| interner.lookup_iri(&iri));
 
         // Deterministic, reproducible frozen order: sort by id tuples. Terms keep
         // their interning (allocation) order, which is itself deterministic for a
@@ -842,6 +872,8 @@ impl RdfDatasetBuilder {
             annotations.into_boxed_slice(),
             locations.into_boxed_slice(),
             caps,
+            interner.content_ids,
+            derivation_predicate,
         )
     }
 }

--- a/crates/rdf-core/src/ir/builder.rs
+++ b/crates/rdf-core/src/ir/builder.rs
@@ -23,9 +23,12 @@ use std::sync::Arc;
 
 use hashbrown::HashTable;
 
-use crate::{RdfAnnotation, RdfLiteral, RdfQuad, RdfReifier, RdfTerm, RdfTextDirection};
+use crate::{
+    Blake3ContentId, ContentIdScheme, RdfAnnotation, RdfLiteral, RdfQuad, RdfReifier, RdfTerm,
+    RdfTextDirection,
+};
 
-use super::dataset::{QuadHandle, QuadIds, QuadRow, RdfDataset, TermRef};
+use super::dataset::{FastHasher, QuadHandle, QuadIds, QuadRow, RdfDataset, TermRef};
 use super::term::{
     arena_str, BlankScope, InternedLiteral, InternedTerm, StrRange, TermId, RDF_LANG_STRING,
     XSD_STRING,
@@ -193,6 +196,16 @@ struct Interner {
     /// ranges through the arena and comparing BY VALUE (so equal strings dedup to
     /// one id even though the table itself stores neither strings nor ranges).
     index: HashTable<u32>,
+    /// The caller-supplied content-id recognition spelling (e.g. `"blake3:"`).
+    /// `None` (the default) means recognition is INACTIVE: no fabricated default,
+    /// per the no-vocabulary-minting policy. Fixed at construction time (see
+    /// [`RdfDatasetBuilder::with_content_addressing`]) — there is no setter.
+    content_scheme: Option<ContentIdScheme>,
+    /// Side table from a recognized content-id term to its decoded
+    /// [`Blake3ContentId`]. Empty while recognition is inactive; populated at
+    /// intern time once a later change wires the miss-branch recognition hook.
+    #[allow(dead_code, reason = "populated once intern-time recognition lands")]
+    content_ids: HashMap<TermId, Blake3ContentId, FastHasher>,
 }
 
 impl Interner {
@@ -201,6 +214,8 @@ impl Interner {
             arena: Vec::new(),
             terms: Vec::new(),
             index: HashTable::new(),
+            content_scheme: None,
+            content_ids: HashMap::default(),
         }
     }
 
@@ -318,6 +333,12 @@ pub struct RdfDatasetBuilder {
     /// blank nodes from different source datasets can never collide even when their
     /// labels are identical (standardize-apart, C0.2).
     next_merge_scope: u32,
+    /// The caller-supplied predicate IRI that marks a derivation edge between a
+    /// content-addressed term and the term(s) it was derived from. `None` (the
+    /// default) means no derivation predicate is configured — no fabricated
+    /// default, per the no-vocabulary-minting policy. Fixed at construction time
+    /// (see [`RdfDatasetBuilder::with_content_addressing`]) — there is no setter.
+    derivation_predicate: Option<String>,
 }
 
 /// A dataset builder whose structural validation has already passed.
@@ -390,7 +411,27 @@ impl RdfDatasetBuilder {
             locations: Vec::new(),
             // Merge scopes start at 1; scope 0 is BlankScope::DEFAULT (local pushes).
             next_merge_scope: 1,
+            derivation_predicate: None,
         }
+    }
+
+    /// A fresh builder configured for content addressing: `scheme` marks which
+    /// IRIs are content-id term references and `derivation_predicate`, if given,
+    /// is the predicate IRI used to record derivation edges.
+    ///
+    /// This is the **single** construction path for content addressing (§19
+    /// one-path): the config is fixed here, before any term is interned, and
+    /// deliberately has no setter — a builder's content-addressing config never
+    /// changes mid-build.
+    #[must_use]
+    pub fn with_content_addressing(
+        scheme: ContentIdScheme,
+        derivation_predicate: Option<String>,
+    ) -> Self {
+        let mut builder = Self::new();
+        builder.interner.content_scheme = Some(scheme);
+        builder.derivation_predicate = derivation_predicate;
+        builder
     }
 
     /// Intern an IRI term. Idempotent: the same IRI string yields the same id.
@@ -825,6 +866,31 @@ mod tests {
         let d = b.intern_iri("http://example.org/y");
         assert_eq!(a, c);
         assert_ne!(a, d);
+    }
+
+    /// No fabricated default: a plain `new`/`default` builder has content-id
+    /// recognition INACTIVE (recognition itself is wired in a later task).
+    #[test]
+    fn new_builder_has_no_content_scheme() {
+        let b = RdfDatasetBuilder::new();
+        assert!(b.interner.content_scheme.is_none());
+        assert!(b.derivation_predicate.is_none());
+    }
+
+    /// `with_content_addressing` is the single construction path: it fixes the
+    /// scheme (and, optionally, the derivation predicate) before any intern.
+    #[test]
+    fn with_content_addressing_sets_config() {
+        let scheme = ContentIdScheme::new("blake3:").expect("valid scheme");
+        let b = RdfDatasetBuilder::with_content_addressing(
+            scheme.clone(),
+            Some("http://example.org/derivedFrom".to_string()),
+        );
+        assert_eq!(b.interner.content_scheme, Some(scheme));
+        assert_eq!(
+            b.derivation_predicate.as_deref(),
+            Some("http://example.org/derivedFrom")
+        );
     }
 
     #[test]

--- a/crates/rdf-core/src/ir/builder.rs
+++ b/crates/rdf-core/src/ir/builder.rs
@@ -203,8 +203,7 @@ struct Interner {
     content_scheme: Option<ContentIdScheme>,
     /// Side table from a recognized content-id term to its decoded
     /// [`Blake3ContentId`]. Empty while recognition is inactive; populated at
-    /// intern time once a later change wires the miss-branch recognition hook.
-    #[allow(dead_code, reason = "populated once intern-time recognition lands")]
+    /// intern time in the miss branch of [`Interner::intern`] (IRI arm only).
     content_ids: HashMap<TermId, Blake3ContentId, FastHasher>,
 }
 
@@ -252,6 +251,20 @@ impl Interner {
             }
         }
         let i = u32::try_from(self.terms.len()).expect("term table exceeds u32::MAX entries");
+        // Content-id recognition (miss branch, IRI arm ONLY): gated first on
+        // `content_scheme` so the check is a single `Option` branch — skipped
+        // entirely, with zero further work, when recognition is inactive. Computed
+        // here (borrowing `&lookup`) BEFORE the moving `match lookup` below consumes
+        // `iri`. A prefix hit with a bad hex suffix is an ORDINARY IRI, not an error:
+        // `from_hex` returning `None` is correct, not a swallowed failure.
+        let recognized: Option<Blake3ContentId> = match &lookup {
+            TermLookup::Iri(iri) => self
+                .content_scheme
+                .as_ref()
+                .and_then(|scheme| iri.strip_prefix(scheme.prefix()))
+                .and_then(Blake3ContentId::from_hex),
+            _ => None,
+        };
         // Miss: now (and only now) push the strings to the arena and build the term.
         let term = match lookup {
             TermLookup::Iri(iri) => InternedTerm::Iri(self.push_str(iri)),
@@ -277,6 +290,9 @@ impl Interner {
             TermLookup::Triple { s, p, o } => InternedTerm::Triple { s, p, o },
         };
         self.terms.push(term);
+        if let Some(id) = recognized {
+            self.content_ids.insert(TermId::from_index(i), id);
+        }
         let (arena, terms) = (&self.arena, &self.terms);
         self.index.insert_unique(hash, i, |&i| {
             let mut h = std::collections::hash_map::DefaultHasher::new();
@@ -284,6 +300,13 @@ impl Interner {
             h.finish()
         });
         TermId::from_index(i)
+    }
+
+    /// The decoded content id for a recognized term, if any (builder-level
+    /// accessor for tests; the frozen-dataset public accessor is separate).
+    #[cfg(test)]
+    fn content_id(&self, id: TermId) -> Option<Blake3ContentId> {
+        self.content_ids.get(&id).copied()
     }
 
     fn term(&self, id: TermId) -> &InternedTerm {
@@ -891,6 +914,86 @@ mod tests {
             b.derivation_predicate.as_deref(),
             Some("http://example.org/derivedFrom")
         );
+    }
+
+    /// A recognized `blake3:<64hex>` IRI gets a side-table entry with the exact
+    /// decoded bytes.
+    #[test]
+    fn intern_iri_recognizes_content_id() {
+        let scheme = ContentIdScheme::new("blake3:").expect("valid scheme");
+        let mut b = RdfDatasetBuilder::with_content_addressing(scheme, None);
+        let hex = "ab".repeat(32);
+        let id = b.intern_iri(&format!("blake3:{hex}"));
+        let expected = Blake3ContentId::from_hex(&hex).expect("valid hex");
+        assert_eq!(b.interner.content_id(id), Some(expected));
+    }
+
+    /// Interning the same content-id IRI twice yields the same `TermId` and
+    /// exactly one side-table entry (idempotent, no double-insert drift).
+    #[test]
+    fn intern_iri_content_id_is_idempotent() {
+        let scheme = ContentIdScheme::new("blake3:").expect("valid scheme");
+        let mut b = RdfDatasetBuilder::with_content_addressing(scheme, None);
+        let iri = format!("blake3:{}", "cd".repeat(32));
+        let a = b.intern_iri(&iri);
+        let c = b.intern_iri(&iri);
+        assert_eq!(a, c);
+        assert_eq!(b.interner.content_ids.len(), 1);
+    }
+
+    /// A prefix hit with a malformed hex suffix is an ORDINARY IRI, not an
+    /// error: no side-table entry, but interning still succeeds.
+    #[test]
+    fn intern_iri_rejects_malformed_suffix_as_ordinary_iri() {
+        let scheme = ContentIdScheme::new("blake3:").expect("valid scheme");
+        let mut b = RdfDatasetBuilder::with_content_addressing(scheme, None);
+
+        let too_short = format!("blake3:{}", "a".repeat(63));
+        let too_long = format!("blake3:{}", "a".repeat(65));
+        let non_hex = format!("blake3:{}z", "a".repeat(63));
+        let uppercase = format!("blake3:{}", "AB".repeat(32));
+
+        for iri in [&too_short, &too_long, &non_hex, &uppercase] {
+            let id = b.intern_iri(iri);
+            assert_eq!(
+                b.interner.content_id(id),
+                None,
+                "unexpected match for {iri}"
+            );
+        }
+        assert!(b.interner.content_ids.is_empty());
+    }
+
+    /// An ordinary IRI with no content-id prefix at all gets no entry.
+    #[test]
+    fn intern_iri_ordinary_iri_has_no_content_id() {
+        let scheme = ContentIdScheme::new("blake3:").expect("valid scheme");
+        let mut b = RdfDatasetBuilder::with_content_addressing(scheme, None);
+        let id = b.intern_iri("http://example.org/x");
+        assert_eq!(b.interner.content_id(id), None);
+    }
+
+    /// Recognition is IRI-arm only: a blank node whose label happens to look
+    /// like a content-id IRI is never recognized (rejected by construction,
+    /// not by a runtime check).
+    #[test]
+    fn intern_blank_never_recognized_as_content_id() {
+        let scheme = ContentIdScheme::new("blake3:").expect("valid scheme");
+        let mut b = RdfDatasetBuilder::with_content_addressing(scheme, None);
+        let label = format!("blake3:{}", "ef".repeat(32));
+        let id = b.intern_blank(&label, BlankScope::DEFAULT);
+        assert_eq!(b.interner.content_id(id), None);
+        assert!(b.interner.content_ids.is_empty());
+    }
+
+    /// With recognition inactive (plain `new()`), a `blake3:<64hex>` IRI is
+    /// interned as an ordinary IRI: no side-table entry.
+    #[test]
+    fn intern_iri_no_recognition_when_scheme_inactive() {
+        let mut b = RdfDatasetBuilder::new();
+        let id = b.intern_iri(&format!("blake3:{}", "12".repeat(32)));
+        assert_eq!(b.interner.content_id(id), None);
+        assert!(b.interner.content_ids.is_empty());
     }
 
     #[test]

--- a/crates/rdf-core/src/ir/dataset.rs
+++ b/crates/rdf-core/src/ir/dataset.rs
@@ -1371,12 +1371,31 @@ impl RdfDataset {
     /// cases mean "no derivations present" — not an error). `pub(crate)`: the
     /// derivation-traversal helpers (content-addressing tasks 5/6) are the
     /// intended readers.
-    // Not yet called outside this module's tests: the derivation-traversal
-    // helpers that consume it land in a follow-up content-addressing task.
-    #[allow(dead_code)]
     #[inline]
     pub(crate) fn derivation_predicate(&self) -> Option<TermId> {
         self.derivation_predicate
+    }
+
+    /// The predecessor(s) of `successor`, decoded from the annotation
+    /// side-table: rows shaped `(successor, derivation_predicate, predecessor)`
+    /// (a PREDECESSOR-LINK annotation on the successor's reifier) yield
+    /// `predecessor`. Empty when no derivation predicate is configured, or the
+    /// predicate was never interned, or `successor` has no such annotation.
+    ///
+    /// This is a **linear scan** over the whole annotation table — it is the
+    /// private building block for `predecessors`, the single PUBLIC O(1)
+    /// accessor added on top of it (content-addressing task 6). Callers are
+    /// never offered both an O(n) and an O(1) form for the same lookup (ETHOS
+    /// §19); this form stays private and exists only so the O(1) index has a
+    /// linear-scan reference implementation to build from and test against.
+    #[allow(dead_code)] // consumed by the `predecessors` index in the next step
+    fn derived_from(&self, successor: TermId) -> impl Iterator<Item = TermId> + '_ {
+        let predicate = self.derivation_predicate();
+        self.annotations()
+            .filter(move |&(reifier, p, _)| {
+                predicate.is_some_and(|predicate| reifier == successor && p == predicate)
+            })
+            .map(|(_, _, object)| object)
     }
 }
 
@@ -2472,6 +2491,54 @@ mod tests {
                     "TermId captured before freeze must resolve to the same digest after freeze"
                 );
             }
+        }
+
+        /// `derived_from` decodes a PREDECESSOR-LINK annotation: `successor` is the
+        /// reifier, the configured derivation predicate is the annotation
+        /// predicate, and the annotation object is the predecessor. Configured but
+        /// unused → empty; a term with no such annotation → empty.
+        #[test]
+        fn derived_from_reads_the_predecessor_link_annotation() {
+            let mut b = RdfDatasetBuilder::with_content_addressing(
+                ContentIdScheme::new("blake3:").expect("valid scheme"),
+                Some(DERIVED_FROM.to_string()),
+            );
+            let successor = b.intern_iri("http://example.org/successor");
+            let predecessor = b.intern_iri("http://example.org/predecessor");
+            let derived_from = b.intern_iri(DERIVED_FROM);
+            let unrelated = b.intern_iri("http://example.org/unrelated");
+
+            // successor -[derivation_predicate]-> predecessor, as an annotation on
+            // the successor's own reifier id (successor IS the reifier here).
+            b.push_annotation(successor, derived_from, predecessor);
+            // A different predicate on the same reifier must not be picked up.
+            b.push_annotation(successor, unrelated, predecessor);
+
+            let ds = b.freeze().expect("valid dataset");
+
+            let predecessors: Vec<TermId> = ds.derived_from(successor).collect();
+            assert_eq!(predecessors, vec![predecessor]);
+
+            assert_eq!(
+                ds.derived_from(unrelated).count(),
+                0,
+                "a term with no PREDECESSOR-LINK annotation has no predecessors"
+            );
+        }
+
+        /// No derivation predicate configured → `derived_from` is always empty,
+        /// even if the dataset happens to carry annotations that would otherwise
+        /// match by coincidence.
+        #[test]
+        fn derived_from_empty_when_no_derivation_predicate_configured() {
+            let mut b = RdfDatasetBuilder::new();
+            let successor = b.intern_iri("http://example.org/successor");
+            let predicate = b.intern_iri("http://example.org/somePredicate");
+            let predecessor = b.intern_iri("http://example.org/predecessor");
+            b.push_annotation(successor, predicate, predecessor);
+
+            let ds = b.freeze().expect("valid dataset");
+            assert_eq!(ds.derived_from(successor).count(), 0);
         }
     }
 }

--- a/crates/rdf-core/src/ir/dataset.rs
+++ b/crates/rdf-core/src/ir/dataset.rs
@@ -1437,7 +1437,8 @@ impl RdfDataset {
     /// `A`), so a cycle terminates instead of looping or panicking.
     #[must_use]
     pub fn predecessor_chain(&self, start: TermId) -> Vec<TermId> {
-        let mut visited: std::collections::HashSet<TermId> = std::collections::HashSet::new();
+        let mut visited: std::collections::HashSet<TermId, FastHasher> =
+            std::collections::HashSet::default();
         visited.insert(start);
         let mut result = Vec::new();
         let mut stack: Vec<TermId> = self.predecessors(start).to_vec();

--- a/crates/rdf-core/src/ir/dataset.rs
+++ b/crates/rdf-core/src/ir/dataset.rs
@@ -41,6 +41,11 @@ const RDF_REIFIES: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies";
 
 pub(crate) type FastHasher = BuildHasherDefault<ahash::AHasher>;
 type ValueIndex = HashMap<u64, Vec<TermId>, FastHasher>;
+/// Lazy successor→predecessors reverse index for
+/// [`RdfDataset::predecessors`]: each successor `TermId` maps to its
+/// predecessor `TermId`s (decoded from the PREDECESSOR-LINK annotation rows),
+/// sorted for deterministic egress.
+type PredecessorIndex = HashMap<TermId, Box<[TermId]>, FastHasher>;
 const QUAD_ARITY: usize = 4;
 
 /// A handle identifying a pushed quad by its dense (deduplicated) ordinal, used to
@@ -188,6 +193,15 @@ pub struct RdfDataset {
     /// configured" and "configured but never interned" — both mean "no
     /// derivations present", not an error (no-fabricated-default policy).
     derivation_predicate: Option<TermId>,
+    /// Lazy successor→predecessors reverse index backing
+    /// [`RdfDataset::predecessors`]/[`RdfDataset::predecessor_chain`]. DERIVED,
+    /// NON-SERIALIZED: a pure function of the frozen `annotations` table plus
+    /// the configured `derivation_predicate`, identical determinism-safety
+    /// rationale to `value_index`/`indexes` — built lazily (`OnceLock` keeps
+    /// the frozen dataset `Send + Sync`), never persisted, and read only by
+    /// dataset-local `TermId`s (C0.8: never serialized, never read by a
+    /// writer).
+    predecessor_index: OnceLock<PredecessorIndex>,
 }
 
 /// The lazy non-identity permutation indexes over the freeze-sorted `quads` table
@@ -401,6 +415,7 @@ impl RdfDataset {
             indexes: QuadIndexes::default(),
             content_ids,
             derivation_predicate,
+            predecessor_index: OnceLock::new(),
         }
     }
 
@@ -1306,6 +1321,7 @@ impl RdfDataset {
             indexes: QuadIndexes::default(),
             content_ids: self.content_ids.clone(),
             derivation_predicate: self.derivation_predicate,
+            predecessor_index: OnceLock::new(),
         }
     }
 
@@ -1382,20 +1398,61 @@ impl RdfDataset {
     /// `predecessor`. Empty when no derivation predicate is configured, or the
     /// predicate was never interned, or `successor` has no such annotation.
     ///
-    /// This is a **linear scan** over the whole annotation table — it is the
-    /// private building block for `predecessors`, the single PUBLIC O(1)
-    /// accessor added on top of it (content-addressing task 6). Callers are
-    /// never offered both an O(n) and an O(1) form for the same lookup (ETHOS
-    /// §19); this form stays private and exists only so the O(1) index has a
-    /// linear-scan reference implementation to build from and test against.
-    #[allow(dead_code)] // consumed by the `predecessors` index in the next step
-    fn derived_from(&self, successor: TermId) -> impl Iterator<Item = TermId> + '_ {
-        let predicate = self.derivation_predicate();
-        self.annotations()
-            .filter(move |&(reifier, p, _)| {
-                predicate.is_some_and(|predicate| reifier == successor && p == predicate)
-            })
-            .map(|(_, _, object)| object)
+    /// The SINGLE public predecessor accessor: `O(1)` after the reverse index
+    /// (built once, lazily, on first call via `OnceLock::get_or_init` — mirrors
+    /// [`term_id_by_value`](Self::term_id_by_value)) is warm. The whole
+    /// annotation table is scanned exactly ONCE to build the index — never
+    /// per-call — with each successor's predecessor bucket sorted so the
+    /// returned slice's order is deterministic and reproducible regardless of
+    /// annotation push order. There is no separate linear-scan twin of this
+    /// query (ETHOS §19 one-path): the index build is the single decoding of
+    /// the PREDECESSOR-LINK shape.
+    #[must_use]
+    pub fn predecessors(&self, successor: TermId) -> &[TermId] {
+        let index = self.predecessor_index.get_or_init(|| {
+            let mut map: HashMap<TermId, Vec<TermId>, FastHasher> = HashMap::default();
+            if let Some(predicate) = self.derivation_predicate() {
+                for (reifier, p, object) in self.annotations() {
+                    if p == predicate {
+                        map.entry(reifier).or_default().push(object);
+                    }
+                }
+            }
+            map.into_iter()
+                .map(|(successor, mut predecessors)| {
+                    predecessors.sort_unstable();
+                    (successor, predecessors.into_boxed_slice())
+                })
+                .collect()
+        });
+        index.get(&successor).map_or(&[][..], |b| &b[..])
+    }
+
+    /// The full set of `successor`'s transitive ancestors, walking
+    /// [`predecessors`](Self::predecessors) repeatedly. `start` itself is never
+    /// included in the result. Traversal is depth-first: each node's direct
+    /// predecessors (already sorted by [`predecessors`]) are pushed in order and
+    /// fully explored before moving to the next sibling, giving a deterministic,
+    /// reproducible visiting order. A `HashSet` of already-visited term ids
+    /// guards against a derivation cycle (`A` derived from `B` derived from
+    /// `A`), so a cycle terminates instead of looping or panicking.
+    #[must_use]
+    pub fn predecessor_chain(&self, start: TermId) -> Vec<TermId> {
+        let mut visited: std::collections::HashSet<TermId> = std::collections::HashSet::new();
+        visited.insert(start);
+        let mut result = Vec::new();
+        let mut stack: Vec<TermId> = self.predecessors(start).to_vec();
+        stack.reverse(); // pop() takes from the back; reverse so we visit in sorted order.
+        while let Some(node) = stack.pop() {
+            if !visited.insert(node) {
+                continue;
+            }
+            result.push(node);
+            let mut next: Vec<TermId> = self.predecessors(node).to_vec();
+            next.reverse();
+            stack.extend(next);
+        }
+        result
     }
 }
 
@@ -2493,12 +2550,12 @@ mod tests {
             }
         }
 
-        /// `derived_from` decodes a PREDECESSOR-LINK annotation: `successor` is the
+        /// `predecessors` decodes a PREDECESSOR-LINK annotation: `successor` is the
         /// reifier, the configured derivation predicate is the annotation
         /// predicate, and the annotation object is the predecessor. Configured but
         /// unused → empty; a term with no such annotation → empty.
         #[test]
-        fn derived_from_reads_the_predecessor_link_annotation() {
+        fn predecessors_reads_the_predecessor_link_annotation() {
             let mut b = RdfDatasetBuilder::with_content_addressing(
                 ContentIdScheme::new("blake3:").expect("valid scheme"),
                 Some(DERIVED_FROM.to_string()),
@@ -2516,21 +2573,20 @@ mod tests {
 
             let ds = b.freeze().expect("valid dataset");
 
-            let predecessors: Vec<TermId> = ds.derived_from(successor).collect();
-            assert_eq!(predecessors, vec![predecessor]);
+            assert_eq!(ds.predecessors(successor), &[predecessor]);
 
             assert_eq!(
-                ds.derived_from(unrelated).count(),
-                0,
+                ds.predecessors(unrelated),
+                &[] as &[TermId],
                 "a term with no PREDECESSOR-LINK annotation has no predecessors"
             );
         }
 
-        /// No derivation predicate configured → `derived_from` is always empty,
-        /// even if the dataset happens to carry annotations that would otherwise
-        /// match by coincidence.
+        /// No derivation predicate configured → `predecessors`/`predecessor_chain`
+        /// are always empty, even if the dataset happens to carry annotations
+        /// that would otherwise match by coincidence.
         #[test]
-        fn derived_from_empty_when_no_derivation_predicate_configured() {
+        fn predecessors_empty_when_no_derivation_predicate_configured() {
             let mut b = RdfDatasetBuilder::new();
             let successor = b.intern_iri("http://example.org/successor");
             let predicate = b.intern_iri("http://example.org/somePredicate");
@@ -2538,7 +2594,111 @@ mod tests {
             b.push_annotation(successor, predicate, predecessor);
 
             let ds = b.freeze().expect("valid dataset");
-            assert_eq!(ds.derived_from(successor).count(), 0);
+            assert_eq!(ds.predecessors(successor), &[] as &[TermId]);
+            assert_eq!(ds.predecessor_chain(successor), Vec::<TermId>::new());
+        }
+
+        /// A chain `A -[derivedFrom]-> B -[derivedFrom]-> C`: direct predecessors
+        /// resolve one hop, `predecessor_chain` walks the whole ancestry in
+        /// order, and the terminal node (`C`) has no predecessors.
+        #[test]
+        fn predecessor_chain_walks_a_linear_derivation_chain() {
+            let mut b = RdfDatasetBuilder::with_content_addressing(
+                ContentIdScheme::new("blake3:").expect("valid scheme"),
+                Some(DERIVED_FROM.to_string()),
+            );
+            let derived_from = b.intern_iri(DERIVED_FROM);
+            let a = b.intern_iri("http://example.org/a");
+            let c = b.intern_iri("http://example.org/c");
+            let bb = b.intern_iri("http://example.org/b");
+
+            // A derivedFrom B, B derivedFrom C: push_annotation(successor, pred, predecessor).
+            b.push_annotation(a, derived_from, bb);
+            b.push_annotation(bb, derived_from, c);
+
+            let ds = b.freeze().expect("valid dataset");
+
+            assert_eq!(ds.predecessors(a), &[bb]);
+            assert_eq!(ds.predecessors(bb), &[c]);
+            assert_eq!(ds.predecessors(c), &[] as &[TermId]);
+
+            assert_eq!(ds.predecessor_chain(a), vec![bb, c]);
+        }
+
+        /// Multiple predecessors of one successor resolve to the sorted set of
+        /// their `TermId`s, regardless of the order the annotations were pushed.
+        #[test]
+        fn predecessors_of_multiple_predecessors_are_sorted() {
+            let mut b = RdfDatasetBuilder::with_content_addressing(
+                ContentIdScheme::new("blake3:").expect("valid scheme"),
+                Some(DERIVED_FROM.to_string()),
+            );
+            let derived_from = b.intern_iri(DERIVED_FROM);
+            let x = b.intern_iri("http://example.org/x");
+            let p2 = b.intern_iri("http://example.org/p2");
+            let p1 = b.intern_iri("http://example.org/p1");
+
+            // Push in an order that would NOT already be TermId-sorted.
+            b.push_annotation(x, derived_from, p2);
+            b.push_annotation(x, derived_from, p1);
+
+            let ds = b.freeze().expect("valid dataset");
+
+            let mut expected = [p1, p2];
+            expected.sort_unstable();
+            assert_eq!(ds.predecessors(x), &expected);
+        }
+
+        /// A derivation cycle (`A -[derivedFrom]-> B -[derivedFrom]-> A`) must not
+        /// hang or panic: `predecessor_chain` terminates and returns a finite,
+        /// deterministic ancestor set.
+        #[test]
+        fn predecessor_chain_terminates_on_a_cycle() {
+            let mut b = RdfDatasetBuilder::with_content_addressing(
+                ContentIdScheme::new("blake3:").expect("valid scheme"),
+                Some(DERIVED_FROM.to_string()),
+            );
+            let derived_from = b.intern_iri(DERIVED_FROM);
+            let a = b.intern_iri("http://example.org/a");
+            let bb = b.intern_iri("http://example.org/b");
+
+            b.push_annotation(a, derived_from, bb);
+            b.push_annotation(bb, derived_from, a);
+
+            let ds = b.freeze().expect("valid dataset");
+
+            let chain = ds.predecessor_chain(a);
+            assert_eq!(chain, vec![bb], "cycle back to `start` is not re-included");
+        }
+
+        /// Two threads racing to build the lazy predecessor index on first access
+        /// observe identical results — `OnceLock::get_or_init` guarantees a single
+        /// build even under concurrent first calls (mirrors `term_id_by_value`'s
+        /// concurrency contract).
+        #[test]
+        fn predecessors_concurrent_first_build_is_consistent() {
+            let mut b = RdfDatasetBuilder::with_content_addressing(
+                ContentIdScheme::new("blake3:").expect("valid scheme"),
+                Some(DERIVED_FROM.to_string()),
+            );
+            let derived_from = b.intern_iri(DERIVED_FROM);
+            let a = b.intern_iri("http://example.org/a");
+            let bb = b.intern_iri("http://example.org/b");
+            b.push_annotation(a, derived_from, bb);
+
+            // `freeze` already returns an `Arc<RdfDataset>` — clone the `Arc`
+            // handle (not the dataset) to share it between threads.
+            let ds = b.freeze().expect("valid dataset");
+
+            let ds1 = ds.clone();
+            let ds2 = ds;
+            let t1 = std::thread::spawn(move || ds1.predecessors(a).to_vec());
+            let t2 = std::thread::spawn(move || ds2.predecessors(a).to_vec());
+
+            let r1 = t1.join().expect("thread 1 joins");
+            let r2 = t2.join().expect("thread 2 joins");
+            assert_eq!(r1, vec![bb]);
+            assert_eq!(r1, r2);
         }
     }
 }

--- a/crates/rdf-core/src/ir/dataset.rs
+++ b/crates/rdf-core/src/ir/dataset.rs
@@ -25,6 +25,7 @@ use std::collections::HashMap;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
 use std::sync::{Arc, OnceLock};
 
+use crate::content_id::Blake3ContentId;
 use crate::dataset_view::GraphMatch;
 use crate::{
     RdfAnnotation, RdfLiteral, RdfLocation, RdfQuad, RdfReifier, RdfStoreCapabilities, RdfTerm,
@@ -172,6 +173,21 @@ pub struct RdfDataset {
     /// lazily on the first pattern query that selects them. `OnceLock` keeps the
     /// frozen dataset `Send + Sync`.
     indexes: QuadIndexes,
+    /// Frozen side table from a content-addressed term to its decoded
+    /// [`Blake3ContentId`] (moved from the builder's [`Interner`](super::builder)
+    /// at [`materialize`](super::builder::RdfDatasetBuilder::materialize)). Empty
+    /// when content-id recognition was never configured. NON-SERIALIZED: this is a
+    /// derived side table for readers, never a byte-producing input — no
+    /// serializer or the GTS writer may fold it into their output. Egress is
+    /// sorted-by-`TermId` only (see [`content_ids`](Self::content_ids)); raw
+    /// `HashMap` iteration order must never leak to a caller.
+    content_ids: HashMap<TermId, Blake3ContentId, FastHasher>,
+    /// The derivation-predicate IRI's frozen [`TermId`], resolved at
+    /// [`materialize`](super::builder::RdfDatasetBuilder::materialize) IFF that IRI
+    /// was already interned. `None` covers BOTH "no derivation predicate
+    /// configured" and "configured but never interned" — both mean "no
+    /// derivations present", not an error (no-fabricated-default policy).
+    derivation_predicate: Option<TermId>,
 }
 
 /// The lazy non-identity permutation indexes over the freeze-sorted `quads` table
@@ -361,6 +377,7 @@ impl RdfDataset {
     /// validation.
     ///
     /// [`RdfDatasetBuilder::freeze`]: super::builder::RdfDatasetBuilder::freeze
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn from_parts(
         arena: Box<[u8]>,
         terms: Box<[InternedTerm]>,
@@ -369,6 +386,8 @@ impl RdfDataset {
         annotations: Box<[(TermId, TermId, TermId)]>,
         locations: Box<[(QuadHandle, RdfLocation)]>,
         caps: RdfStoreCapabilities,
+        content_ids: HashMap<TermId, Blake3ContentId, FastHasher>,
+        derivation_predicate: Option<TermId>,
     ) -> Self {
         Self {
             arena,
@@ -380,6 +399,8 @@ impl RdfDataset {
             caps,
             value_index: OnceLock::new(),
             indexes: QuadIndexes::default(),
+            content_ids,
+            derivation_predicate,
         }
     }
 
@@ -1283,6 +1304,8 @@ impl RdfDataset {
             caps: self.caps,
             value_index: OnceLock::new(),
             indexes: QuadIndexes::default(),
+            content_ids: self.content_ids.clone(),
+            derivation_predicate: self.derivation_predicate,
         }
     }
 
@@ -1317,6 +1340,43 @@ impl RdfDataset {
         self.quads.len().hash(&mut h);
         self.terms.len().hash(&mut h);
         h.finish()
+    }
+
+    /// The decoded [`Blake3ContentId`] of a content-addressed term, or `None` if
+    /// `id` was never recognized as one (content-id recognition was inactive, or
+    /// this term's value did not match the configured scheme). `O(1)`.
+    #[inline]
+    #[must_use]
+    pub fn content_id(&self, id: TermId) -> Option<Blake3ContentId> {
+        self.content_ids.get(&id).copied()
+    }
+
+    /// Every content-addressed term in this dataset, as `(TermId, Blake3ContentId)`
+    /// pairs in SORTED `TermId` order. This sorted egress is the ONLY exposed
+    /// iteration over the frozen `content_ids` side table — the underlying
+    /// `HashMap`'s iteration order is never leaked, so any byte-producing
+    /// consumer that folds over this sees a reproducible sequence.
+    pub fn content_ids(&self) -> impl Iterator<Item = (TermId, Blake3ContentId)> + '_ {
+        let mut pairs: Vec<(TermId, Blake3ContentId)> = self
+            .content_ids
+            .iter()
+            .map(|(&id, &cid)| (id, cid))
+            .collect();
+        pairs.sort_unstable_by_key(|(id, _)| *id);
+        pairs.into_iter()
+    }
+
+    /// The frozen [`TermId`] of the configured derivation-predicate IRI, or `None`
+    /// if no derivation predicate is configured OR it was never interned (both
+    /// cases mean "no derivations present" — not an error). `pub(crate)`: the
+    /// derivation-traversal helpers (content-addressing tasks 5/6) are the
+    /// intended readers.
+    // Not yet called outside this module's tests: the derivation-traversal
+    // helpers that consume it land in a follow-up content-addressing task.
+    #[allow(dead_code)]
+    #[inline]
+    pub(crate) fn derivation_predicate(&self) -> Option<TermId> {
+        self.derivation_predicate
     }
 }
 
@@ -2245,6 +2305,173 @@ mod tests {
             let estimate = ds.cardinality_estimate(s, p, o, GraphMatch::Any);
             prop_assert_eq!(estimate, count,
                 "a prefix-covered pattern must be EXACT, not just an upper bound");
+        }
+    }
+
+    mod content_addressing {
+        use super::*;
+        use crate::{Blake3ContentId, ContentIdScheme};
+
+        const DERIVED_FROM: &str = "http://example.org/wasDerivedFrom";
+
+        fn hex_iri(scheme_prefix: &str, byte: u8) -> String {
+            format!("{scheme_prefix}{}", hex::encode([byte; 32]))
+        }
+
+        /// Tiny local hex encoder so this test module carries no extra dependency:
+        /// mirrors what `Blake3ContentId::from_hex` decodes.
+        mod hex {
+            pub(super) fn encode(bytes: [u8; 32]) -> String {
+                let mut s = String::with_capacity(64);
+                for b in bytes {
+                    use std::fmt::Write as _;
+                    let _ = write!(s, "{b:02x}");
+                }
+                s
+            }
+        }
+
+        /// `content_id`/`content_ids`/`derivation_predicate` round-trip through
+        /// freeze: content-addressed terms resolve to their decoded digest, ordinary
+        /// terms resolve to `None`, `content_ids()` yields exactly the
+        /// content-addressed entries in sorted `TermId` order, and the derivation
+        /// predicate resolves to the `TermId` it was actually interned as.
+        #[test]
+        fn content_ids_and_derivation_predicate_round_trip() {
+            let scheme = ContentIdScheme::new("blake3:").expect("valid scheme");
+            let mut b =
+                RdfDatasetBuilder::with_content_addressing(scheme, Some(DERIVED_FROM.to_string()));
+
+            let ca1_iri = hex_iri("blake3:", 0xAA);
+            let ca2_iri = hex_iri("blake3:", 0xBB);
+            let ca1 = b.intern_iri(&ca1_iri);
+            let ca2 = b.intern_iri(&ca2_iri);
+            let ordinary = b.intern_iri("http://example.org/plain");
+            let derived_from = b.intern_iri(DERIVED_FROM);
+
+            b.push_quad(ca1, derived_from, ca2, None);
+            b.push_quad(ordinary, derived_from, ca1, None);
+
+            let ds = b.freeze().expect("valid dataset");
+
+            let expected1 = Blake3ContentId::from_hex(&hex::encode([0xAA; 32])).expect("valid hex");
+            let expected2 = Blake3ContentId::from_hex(&hex::encode([0xBB; 32])).expect("valid hex");
+            assert_eq!(ds.content_id(ca1), Some(expected1));
+            assert_eq!(ds.content_id(ca2), Some(expected2));
+            assert_eq!(
+                ds.content_id(ordinary),
+                None,
+                "an ordinary IRI has no content id"
+            );
+            assert_eq!(
+                ds.content_id(derived_from),
+                None,
+                "the predicate IRI itself is not content-addressed"
+            );
+
+            let entries: Vec<(TermId, Blake3ContentId)> = ds.content_ids().collect();
+            assert_eq!(
+                entries,
+                {
+                    let mut expected = vec![(ca1, expected1), (ca2, expected2)];
+                    expected.sort_unstable_by_key(|(id, _)| *id);
+                    expected
+                },
+                "content_ids() yields exactly the content-addressed entries, sorted by TermId"
+            );
+            // Explicit sortedness check independent of the expected-vec construction.
+            assert!(entries.windows(2).all(|w| w[0].0 < w[1].0));
+
+            assert_eq!(
+                ds.derivation_predicate(),
+                Some(derived_from),
+                "the configured derivation predicate resolves to its interned TermId"
+            );
+        }
+
+        /// A configured derivation-predicate IRI that is never actually interned
+        /// resolves to `None` — not an error (no-fabricated-default policy: both
+        /// "unconfigured" and "configured but absent" mean "no derivations").
+        #[test]
+        fn derivation_predicate_none_when_never_interned() {
+            let scheme = ContentIdScheme::new("blake3:").expect("valid scheme");
+            let mut b =
+                RdfDatasetBuilder::with_content_addressing(scheme, Some(DERIVED_FROM.to_string()));
+            // Intern unrelated terms and push a quad so the dataset is non-empty and
+            // freezes, but never touch `DERIVED_FROM`.
+            let s = b.intern_iri("http://example.org/s");
+            let p = b.intern_iri("http://example.org/p");
+            let o = b.intern_iri("http://example.org/o");
+            b.push_quad(s, p, o, None);
+
+            let ds = b.freeze().expect("valid dataset");
+            assert_eq!(
+                ds.derivation_predicate(),
+                None,
+                "an unused derivation predicate IRI must resolve to None, not error"
+            );
+        }
+
+        /// A dataset built with NO content-addressing configuration has an empty
+        /// side table and no derivation predicate.
+        #[test]
+        fn no_content_addressing_configured_is_empty() {
+            let mut b = RdfDatasetBuilder::new();
+            let iri = hex_iri("blake3:", 0xCC);
+            let id = b.intern_iri(&iri);
+            let s = b.intern_iri("http://example.org/s");
+            let p = b.intern_iri("http://example.org/p");
+            b.push_quad(s, p, id, None);
+
+            let ds = b.freeze().expect("valid dataset");
+            assert_eq!(ds.content_id(id), None);
+            assert_eq!(ds.content_ids().count(), 0);
+            assert_eq!(ds.derivation_predicate(), None);
+        }
+
+        /// INDEX-STABILITY REGRESSION TEST (load-bearing invariant): the frozen
+        /// `content_ids` side table is keyed by `TermId`, and `materialize` passes
+        /// the interner's term table through to `from_parts` UNSORTED so that
+        /// `TermId::from_index(i)` stays valid post-freeze (see the comment on
+        /// `RdfDatasetBuilder::materialize`). This test captures each
+        /// content-addressed term's `TermId` BEFORE freeze (from the builder) and
+        /// asserts that the SAME id looks up the SAME digest AFTER freeze — i.e.
+        /// term intern order equals frozen term-table index order.
+        ///
+        /// If a future optimization sorts/reorders terms at freeze without also
+        /// remapping `content_ids`' keys, this test fails: it is the guard against
+        /// that class of silent corruption.
+        #[test]
+        fn content_id_lookup_is_stable_across_freeze() {
+            let scheme = ContentIdScheme::new("blake3:").expect("valid scheme");
+            let mut b = RdfDatasetBuilder::with_content_addressing(scheme, None);
+
+            // Interleave ordinary and content-addressed terms so a naive value-sort
+            // at freeze (e.g. sorting by IRI string) would visibly reorder them.
+            let mut expected: Vec<(TermId, Blake3ContentId)> = Vec::new();
+            let mut last_ordinary = None;
+            for n in 0..8u8 {
+                let ordinary = b.intern_iri(&format!("http://example.org/z{n}"));
+                last_ordinary = Some(ordinary);
+                let ca_iri = hex_iri("blake3:", n);
+                let ca_id = b.intern_iri(&ca_iri);
+                let digest = Blake3ContentId::from_hex(&hex::encode([n; 32])).expect("valid hex");
+                expected.push((ca_id, digest));
+            }
+            let s = last_ordinary.expect("at least one ordinary term interned");
+            let p = b.intern_iri("http://example.org/p");
+            let o = expected[0].0;
+            b.push_quad(s, p, o, None);
+
+            let ds = b.freeze().expect("valid dataset");
+
+            for (id, digest) in expected {
+                assert_eq!(
+                    ds.content_id(id),
+                    Some(digest),
+                    "TermId captured before freeze must resolve to the same digest after freeze"
+                );
+            }
         }
     }
 }

--- a/crates/rdf-core/src/ir/dataset.rs
+++ b/crates/rdf-core/src/ir/dataset.rs
@@ -1385,8 +1385,7 @@ impl RdfDataset {
     /// The frozen [`TermId`] of the configured derivation-predicate IRI, or `None`
     /// if no derivation predicate is configured OR it was never interned (both
     /// cases mean "no derivations present" — not an error). `pub(crate)`: the
-    /// derivation-traversal helpers (content-addressing tasks 5/6) are the
-    /// intended readers.
+    /// derivation-traversal helpers are the intended readers.
     #[inline]
     pub(crate) fn derivation_predicate(&self) -> Option<TermId> {
         self.derivation_predicate

--- a/crates/rdf-core/src/ir/dataset.rs
+++ b/crates/rdf-core/src/ir/dataset.rs
@@ -38,7 +38,7 @@ use super::term::{arena_str, BlankScope, InternedTerm, TermId, TermValue};
 /// as virtual triples in [`RdfDataset::reifier_quads`].
 const RDF_REIFIES: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies";
 
-type FastHasher = BuildHasherDefault<ahash::AHasher>;
+pub(crate) type FastHasher = BuildHasherDefault<ahash::AHasher>;
 type ValueIndex = HashMap<u64, Vec<TermId>, FastHasher>;
 const QUAD_ARITY: usize = 4;
 

--- a/crates/rdf-core/src/lib.rs
+++ b/crates/rdf-core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod bundle;
 // SPARQL execution, and serializer egress. PyO3-free, oxigraph-free — pure
 // contract only; concrete adapters live in `purrdf`.
 pub mod backend;
+pub mod content_id;
 pub mod content_store;
 // The static, allocation-free read view over an RDF dataset (purrdf P2, #836):
 // `DatasetView` + `GraphMatch`. PyO3-free, oxigraph-free — pure kernel.
@@ -68,6 +69,7 @@ pub use bundle::{
     ArtifactIndex, ArtifactRecord, BundleError, RdfBundle, SegmentUnitMap, UnitCatalog,
     UnitMetadata,
 };
+pub use content_id::Blake3ContentId;
 pub use content_store::{Bytes, ContentDigest, ContentStore, ContentStoreError};
 pub use dataset_view::{DatasetMut, DatasetView, GraphMatch, GraphMatchValue};
 pub use describe::{describe, Describer};

--- a/crates/rdf-core/src/lib.rs
+++ b/crates/rdf-core/src/lib.rs
@@ -69,7 +69,7 @@ pub use bundle::{
     ArtifactIndex, ArtifactRecord, BundleError, RdfBundle, SegmentUnitMap, UnitCatalog,
     UnitMetadata,
 };
-pub use content_id::Blake3ContentId;
+pub use content_id::{Blake3ContentId, ContentIdScheme};
 pub use content_store::{Bytes, ContentDigest, ContentStore, ContentStoreError};
 pub use dataset_view::{DatasetMut, DatasetView, GraphMatch, GraphMatchValue};
 pub use describe::{describe, Describer};

--- a/crates/rdf-core/src/lookaside.rs
+++ b/crates/rdf-core/src/lookaside.rs
@@ -36,6 +36,61 @@ impl RdfLookaside {
             .iter()
             .filter(move |resource| resource.kind == kind)
     }
+
+    /// Every decodable target across all `suppress` directives (§11), flattened.
+    ///
+    /// A target is a `{"kind": ..., "id": ...}` map; this is a linear scan over
+    /// `suppressions[*].targets` that decodes each one into a typed
+    /// [`SuppressionTarget`]. A target whose `"kind"` is not one of the
+    /// integer-id-addressed kinds below, whose `"id"` is missing/not an
+    /// integer, or whose `"id"` is negative or does not fit `usize` is skipped
+    /// — that is filtering out an undecodable target, not swallowing an error.
+    ///
+    /// `frame`- and `blob`-kind targets also exist in the underlying model
+    /// (GTS §11) but are addressed by frame id bytes / content digest rather
+    /// than an integer id, so they have no [`SuppressionTargetKind`] here and
+    /// are always skipped by this decoder.
+    ///
+    /// The `by` field is intentionally never read here: it is a C0.8 display
+    /// hint (an actor label), not an id to resolve.
+    pub fn suppression_targets(&self) -> impl Iterator<Item = SuppressionTarget> + '_ {
+        self.suppressions
+            .iter()
+            .flat_map(|suppression| suppression.targets.iter())
+            .filter_map(|target| {
+                let RdfMetadataValue::Map(entries) = target else {
+                    return None;
+                };
+                let kind = match entries.get("kind")?.as_text()? {
+                    "term" => SuppressionTargetKind::Term,
+                    "quad" => SuppressionTargetKind::Quad,
+                    "reifier" => SuppressionTargetKind::Reifier,
+                    _ => return None,
+                };
+                let RdfMetadataValue::Integer(raw) = entries.get("id")? else {
+                    return None;
+                };
+                let id = usize::try_from(*raw).ok()?;
+                Some(SuppressionTarget { kind, id })
+            })
+    }
+}
+
+/// A decoded [`RdfSuppressionRecord`] target: `{"kind": ..., "id": n}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SuppressionTarget {
+    pub kind: SuppressionTargetKind,
+    pub id: usize,
+}
+
+/// The integer-id-addressed suppression target kinds. `frame` and `blob`
+/// targets exist in the underlying model but are addressed by frame id bytes
+/// / content digest rather than an integer id, so they have no variant here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SuppressionTargetKind {
+    Term,
+    Quad,
+    Reifier,
 }
 
 /// Known companion/index kinds. Unknown domains remain representable.
@@ -322,5 +377,48 @@ mod tests {
         let reasoning: Vec<_> = la.resources_of_kind(RdfLookasideKind::Reasoning).collect();
         assert_eq!(reasoning.len(), 1);
         assert_eq!(reasoning[0].name.as_deref(), Some("closure"));
+    }
+
+    fn target_map(kind: &str, id: RdfMetadataValue) -> RdfMetadataValue {
+        RdfMetadataValue::Map(BTreeMap::from([
+            ("kind".to_owned(), RdfMetadataValue::Text(kind.to_owned())),
+            ("id".to_owned(), id),
+        ]))
+    }
+
+    #[test]
+    fn suppression_targets_decodes_known_kinds_and_skips_the_rest() {
+        let mut la = RdfLookaside::default();
+        la.suppressions.push(RdfSuppressionRecord {
+            reason: Some("test".to_owned()),
+            by: Some("agent:1".to_owned()),
+            targets: vec![
+                target_map("term", RdfMetadataValue::Integer(3)),
+                target_map("quad", RdfMetadataValue::Integer(7)),
+                // Unknown kind: skipped.
+                target_map("frame", RdfMetadataValue::Integer(9)),
+                // Negative id: skipped.
+                target_map("reifier", RdfMetadataValue::Integer(-1)),
+                // Overflowing id: skipped.
+                target_map("reifier", RdfMetadataValue::Integer(i128::MAX)),
+                // Not a map at all: skipped.
+                RdfMetadataValue::Text("not-a-target".to_owned()),
+            ],
+        });
+
+        let targets: Vec<_> = la.suppression_targets().collect();
+        assert_eq!(
+            targets,
+            vec![
+                SuppressionTarget {
+                    kind: SuppressionTargetKind::Term,
+                    id: 3,
+                },
+                SuppressionTarget {
+                    kind: SuppressionTargetKind::Quad,
+                    id: 7,
+                },
+            ]
+        );
     }
 }

--- a/crates/rdf/src/gts.rs
+++ b/crates/rdf/src/gts.rs
@@ -10,6 +10,7 @@
 //! SPARQL conformance gate replays against the frozen goldens.
 
 pub use crate::gts_core::*;
+pub use crate::gts_verify::{verify_content_chain, ContentChainVerification};
 
 use crate::native_codecs::ser_model::{SerGraph, SerTerm, SerTermKind};
 use crate::RdfDiagnostic;

--- a/crates/rdf/src/gts_core.rs
+++ b/crates/rdf/src/gts_core.rs
@@ -297,7 +297,7 @@ pub fn read_all_segments(bytes: &[u8]) -> Result<Graph, RdfDiagnostic> {
     read_graph(bytes, true)
 }
 
-fn diagnostics_to_error(graph: &Graph) -> RdfDiagnostic {
+pub(crate) fn diagnostics_to_error(graph: &Graph) -> RdfDiagnostic {
     let joined = graph
         .diagnostics
         .iter()

--- a/crates/rdf/src/gts_verify.rs
+++ b/crates/rdf/src/gts_verify.rs
@@ -30,6 +30,7 @@ use std::fmt::Write as _;
 use purrdf_gts::mmr::{prove_file, verify_proof};
 use purrdf_gts::reader;
 use purrdf_gts::verify::verify_file;
+use purrdf_gts::wire::hex;
 
 use crate::gts_core::diagnostics_to_error;
 use crate::{RdfDataset, RdfDiagnostic};
@@ -127,7 +128,7 @@ pub fn verify_content_chain(
     }
     for head in &graph.segment_heads {
         let mut id = String::with_capacity(71);
-        let _ = write!(id, "blake3:{}", hex_lower(head));
+        let _ = write!(id, "blake3:{}", hex(head));
         included.insert(id);
     }
 
@@ -165,17 +166,6 @@ pub fn verify_content_chain(
         digests_included,
         head_matched,
     })
-}
-
-/// Lowercase-hex render of raw bytes (segment-head ids carry no `blake3:` prefix).
-fn hex_lower(bytes: &[u8]) -> String {
-    use std::fmt::Write as _;
-
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        let _ = write!(out, "{byte:02x}");
-    }
-    out
 }
 
 #[cfg(test)]
@@ -299,7 +289,7 @@ mod tests {
             blob_frame_id, head,
             "the blob frame id must not equal the segment head"
         );
-        let content_iri = format!("blake3:{}", super::hex_lower(&blob_frame_id));
+        let content_iri = format!("blake3:{}", purrdf_gts::wire::hex(&blob_frame_id));
         assert_ne!(
             content_iri,
             digest_str(BLOB_PAYLOAD),

--- a/crates/rdf/src/gts_verify.rs
+++ b/crates/rdf/src/gts_verify.rs
@@ -46,6 +46,13 @@ pub struct ContentChainVerification {
     pub signatures_valid: usize,
     /// Number of valid signatures whose signer is trusted by the default trust
     /// policy (from [`purrdf_gts::verify::VerificationResult::trusted`]).
+    ///
+    /// This count is **advisory**: [`verify_content_chain`] does not gate on it.
+    /// Because verification resolves the file's *embedded* transport key
+    /// (trust-on-first-use), "trusted" here means the signer matches the default
+    /// policy over that embedded key, not that the caller pinned the key out of
+    /// band. Callers who need pinned trust must compare this against their own
+    /// key policy.
     pub signatures_trusted: usize,
     /// Number of the dataset's content-addressed terms whose digest was found in
     /// the verified chain (equals the dataset's content-id count on success).
@@ -61,6 +68,16 @@ pub struct ContentChainVerification {
 /// See the [module docs](self) for the exact checks. Hard-fails on the first
 /// problem — a bad signature, a fold diagnostic, an expected-head mismatch, or a
 /// content-addressed term whose digest is not included in the file.
+///
+/// # Trust model
+///
+/// Signature verification is **trust-on-first-use**: it resolves the transport
+/// key *embedded in the file* and checks every signed frame against it. A
+/// successful return therefore means the chain is self-consistent and validly
+/// self-signed by that embedded key — not that the signer is a party the caller
+/// independently trusts. The returned [`ContentChainVerification::signatures_trusted`]
+/// is advisory and is never gated on; callers needing pinned trust must enforce
+/// their own key policy on top of this result.
 ///
 /// # Errors
 ///

--- a/crates/rdf/src/gts_verify.rs
+++ b/crates/rdf/src/gts_verify.rs
@@ -1,0 +1,300 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Full content-chain verification bridge for `purrdf`.
+//!
+//! [`verify_content_chain`] is the single, hard-failing entry point that ties a
+//! frozen [`RdfDataset`](crate::RdfDataset)'s content-addressed terms back to a
+//! signed GTS file. It performs three checks, in order, and propagates the first
+//! failure as an [`RdfDiagnostic`] — nothing is swallowed:
+//!
+//! 1. **COSE signatures** ([`purrdf_gts::verify::verify_file`]): the file's
+//!    embedded transport key must resolve and every signed frame must verify.
+//! 2. **Expected-head chain replay** ([`purrdf_gts::reader::read`] with an
+//!    `expected_head`): the log must fold without diagnostics AND the last
+//!    segment head must equal the caller's `expected_head` (a mismatch surfaces
+//!    as a reader `TruncatedLog` diagnostic).
+//! 3. **Digest inclusion**: every content-addressed term's cached BLAKE3 digest
+//!    (from `rdf-core`'s content-id side table) must be an included blob id or
+//!    segment-head id in the verified chain.
+//!
+//! Inclusion is checked against the file's blob ids (`graph.blobs` keys, already
+//! spelled `blake3:<hex>`) and its segment-head ids (rendered `blake3:<hex>`).
+//! It deliberately does **not** use the MMR proof API: `mmr::prove_file` operates
+//! on frame ids, and a content-addressed blob digest is not necessarily an MMR
+//! leaf, so an MMR check here would produce false failures for legitimately
+//! included blobs. The blob/segment-head membership test is exact and total.
+
+use std::collections::BTreeSet;
+
+use purrdf_gts::reader;
+use purrdf_gts::verify::verify_file;
+
+use crate::gts_core::diagnostics_to_error;
+use crate::{RdfDataset, RdfDiagnostic};
+
+/// The result of a successful [`verify_content_chain`] pass.
+///
+/// Every field reflects a check that PASSED; the function only returns `Ok`
+/// when the signatures verified, the chain replayed against the expected head,
+/// and every content-addressed term's digest was included in the file.
+#[derive(Clone, Debug)]
+pub struct ContentChainVerification {
+    /// Number of COSE frame signatures cryptographically valid under the
+    /// resolved transport key (from [`purrdf_gts::verify::VerificationResult::valid`]).
+    pub signatures_valid: usize,
+    /// Number of valid signatures whose signer is trusted by the default trust
+    /// policy (from [`purrdf_gts::verify::VerificationResult::trusted`]).
+    pub signatures_trusted: usize,
+    /// Number of the dataset's content-addressed terms whose digest was found in
+    /// the verified chain (equals the dataset's content-id count on success).
+    pub digests_included: usize,
+    /// Always `true` on success: the replayed log's last segment head matched
+    /// the caller-supplied `expected_head`.
+    pub head_matched: bool,
+}
+
+/// Fully verify that `dataset`'s content-addressed terms are backed by the signed
+/// GTS file `gts_bytes` whose expected last-segment head is `expected_head`.
+///
+/// See the [module docs](self) for the exact checks. Hard-fails on the first
+/// problem — a bad signature, a fold diagnostic, an expected-head mismatch, or a
+/// content-addressed term whose digest is not included in the file.
+///
+/// # Errors
+///
+/// Returns an [`RdfDiagnostic`] when any stage fails:
+/// - `gts-verify-signature` — COSE verification did not succeed.
+/// - `gts-fold-diagnostic` — the reader reported diagnostics (includes an
+///   expected-head mismatch, surfaced as `TruncatedLog`).
+/// - `gts-verify-digest-inclusion` — one or more content-addressed terms are not
+///   included in the verified chain (the detail names each missing term + digest,
+///   in sorted `TermId` order).
+pub fn verify_content_chain(
+    dataset: &RdfDataset,
+    gts_bytes: &[u8],
+    expected_head: &[u8],
+) -> Result<ContentChainVerification, RdfDiagnostic> {
+    // 1. COSE signatures: resolve the embedded transport key and verify every
+    //    signed frame. `ok` is false whenever any error was recorded.
+    let verification = verify_file(gts_bytes);
+    if !verification.ok {
+        let detail = if verification.errors.is_empty() {
+            "signature verification did not succeed".to_owned()
+        } else {
+            verification.errors.join("; ")
+        };
+        return Err(RdfDiagnostic::error(
+            "gts-verify-signature",
+            "GTS COSE signature verification failed",
+        )
+        .with_detail(detail));
+    }
+
+    // 2. Expected-head chain replay: fold every segment and enforce the head.
+    //    Any reader diagnostic (including a head mismatch) is a hard failure.
+    let graph = reader::read(gts_bytes, true, Some(expected_head));
+    if !graph.diagnostics.is_empty() {
+        return Err(diagnostics_to_error(&graph));
+    }
+    let head_matched = true;
+
+    // 3. Digest inclusion: the file's content ids are its blob ids (already
+    //    `blake3:<hex>`) plus its segment-head ids (rendered `blake3:<hex>`).
+    let mut included: BTreeSet<String> = BTreeSet::new();
+    for (digest, _entry) in &graph.blobs {
+        included.insert(digest.clone());
+    }
+    for head in &graph.segment_heads {
+        included.insert(format!("blake3:{}", hex_lower(head)));
+    }
+
+    // `content_ids()` yields sorted-by-`TermId` pairs, so both the match count
+    // and the missing list are deterministic without an extra sort.
+    let mut digests_included = 0usize;
+    let mut missing: Vec<String> = Vec::new();
+    for (term_id, digest) in dataset.content_ids() {
+        let content_id = format!("blake3:{}", digest.to_hex());
+        if included.contains(&content_id) {
+            digests_included += 1;
+        } else {
+            missing.push(format!("term#{} {content_id}", term_id.index()));
+        }
+    }
+    if !missing.is_empty() {
+        return Err(RdfDiagnostic::error(
+            "gts-verify-digest-inclusion",
+            format!(
+                "{} content-addressed term(s) are not included in the verified chain",
+                missing.len()
+            ),
+        )
+        .with_detail(missing.join("; ")));
+    }
+
+    Ok(ContentChainVerification {
+        signatures_valid: verification.valid,
+        signatures_trusted: verification.trusted,
+        digests_included,
+        head_matched,
+    })
+}
+
+/// Lowercase-hex render of raw bytes (segment-head ids carry no `blake3:` prefix).
+fn hex_lower(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use ciborium::value::Value;
+    use purrdf_core::ir::RdfDatasetBuilder;
+    use purrdf_core::{ContentIdScheme, RdfLiteral};
+    use purrdf_gts::openpgp::parse_secret_signing_key;
+    use purrdf_gts::wire::digest_str;
+    use purrdf_gts::writer::Writer;
+
+    use super::{verify_content_chain, RdfDataset};
+
+    const KID: &str = "did:example:test";
+    const BLOB_PAYLOAD: &[u8] = b"content-addressed payload for the GTS verify bridge";
+
+    fn secret_armor() -> String {
+        std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../vectors/openpgp/test_key.sec.asc"
+        ))
+        .expect("secret key fixture")
+    }
+
+    fn public_armor() -> String {
+        std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../vectors/openpgp/test_key.pub.asc"
+        ))
+        .expect("public key fixture")
+    }
+
+    /// Build a GTS file: optionally signed with the fixture transport key, always
+    /// carrying one inline blob. Returns `(bytes, head)`.
+    fn build_file(sign: bool) -> (Vec<u8>, Vec<u8>) {
+        let mut writer = Writer::new("purrdf.gts");
+        if sign {
+            let (signing_key, kid) = parse_secret_signing_key(&secret_armor(), Some(KID))
+                .expect("parse fixture secret key")
+                .into_parts();
+            writer.sign_with(signing_key, &kid);
+            writer.add_meta(Value::Map(vec![(
+                Value::Text("gts:transportKey".to_owned()),
+                Value::Map(vec![
+                    (Value::Text("kid".to_owned()), Value::Text(kid)),
+                    (Value::Text("gpg".to_owned()), Value::Text(public_armor())),
+                ]),
+            )]));
+        }
+        writer.add_blob(BLOB_PAYLOAD, Some("text/plain"), Some("doc"));
+        let bytes = writer.to_bytes();
+        let head = writer.head().to_vec();
+        (bytes, head)
+    }
+
+    /// Freeze a content-addressing dataset that references `content_iri` as the
+    /// subject of a single quad.
+    fn dataset_referencing(content_iri: &str) -> Arc<RdfDataset> {
+        let scheme = ContentIdScheme::new("blake3:").expect("valid scheme");
+        let mut builder = RdfDatasetBuilder::with_content_addressing(scheme, None);
+        let s = builder.intern_iri(content_iri);
+        let p = builder.intern_iri("https://example.org/p");
+        let o = builder.intern_literal(RdfLiteral::simple("o"));
+        builder.push_quad(s, p, o, None);
+        builder.freeze().expect("freeze content-addressing dataset")
+    }
+
+    #[test]
+    fn verifies_signed_chain_with_included_digest() {
+        let (bytes, head) = build_file(true);
+        let dataset = dataset_referencing(&digest_str(BLOB_PAYLOAD));
+
+        let result = verify_content_chain(&dataset, &bytes, &head)
+            .expect("fully valid content chain verifies");
+        assert_eq!(
+            result.digests_included, 1,
+            "the one blob digest is included"
+        );
+        assert!(result.head_matched, "the expected head matched");
+        assert!(
+            result.signatures_valid >= 1,
+            "at least one COSE signature was cryptographically valid"
+        );
+    }
+
+    #[test]
+    fn wrong_expected_head_is_rejected() {
+        let (bytes, mut head) = build_file(true);
+        let dataset = dataset_referencing(&digest_str(BLOB_PAYLOAD));
+        // Flip a byte of the head so the replay's head check fails.
+        head[0] ^= 0xff;
+
+        let err = verify_content_chain(&dataset, &bytes, &head)
+            .expect_err("a wrong expected head must fail");
+        assert_eq!(err.code, "gts-fold-diagnostic");
+    }
+
+    #[test]
+    fn missing_digest_names_the_term() {
+        let (bytes, head) = build_file(true);
+        // A digest that is NOT the blob's and NOT a segment head.
+        let absent = format!("blake3:{}", "ab".repeat(32));
+        let dataset = dataset_referencing(&absent);
+
+        let err = verify_content_chain(&dataset, &bytes, &head)
+            .expect_err("a digest absent from the file must fail");
+        assert_eq!(err.code, "gts-verify-digest-inclusion");
+        let detail = err.detail.unwrap_or_default();
+        assert!(
+            detail.contains("term#0") && detail.contains(&absent),
+            "detail names the missing term and digest: {detail}"
+        );
+    }
+
+    #[test]
+    fn unsigned_file_fails_the_signature_gate() {
+        let (bytes, head) = build_file(false);
+        let dataset = dataset_referencing(&digest_str(BLOB_PAYLOAD));
+
+        let err = verify_content_chain(&dataset, &bytes, &head)
+            .expect_err("an unsigned file must fail the signature gate");
+        assert_eq!(err.code, "gts-verify-signature");
+    }
+
+    #[test]
+    fn tampered_bytes_are_rejected() {
+        let (mut bytes, head) = build_file(true);
+        let dataset = dataset_referencing(&digest_str(BLOB_PAYLOAD));
+        // Corrupt the final frame. Depending on where the flip lands this fails
+        // either the signature gate (an invalid COSE frame) or the replay gate (a
+        // frame that degrades to opaque / breaks the chain) — both are hard fails
+        // and nothing is swallowed.
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xff;
+
+        let err = verify_content_chain(&dataset, &bytes, &head)
+            .expect_err("tampered bytes must fail verification");
+        assert!(
+            matches!(
+                err.code.as_str(),
+                "gts-verify-signature" | "gts-fold-diagnostic"
+            ),
+            "tampering is caught at a verification gate, got {}",
+            err.code
+        );
+    }
+}

--- a/crates/rdf/src/gts_verify.rs
+++ b/crates/rdf/src/gts_verify.rs
@@ -15,18 +15,19 @@
 //!    segment head must equal the caller's `expected_head` (a mismatch surfaces
 //!    as a reader `TruncatedLog` diagnostic).
 //! 3. **Digest inclusion**: every content-addressed term's cached BLAKE3 digest
-//!    (from `rdf-core`'s content-id side table) must be an included blob id or
-//!    segment-head id in the verified chain.
-//!
-//! Inclusion is checked against the file's blob ids (`graph.blobs` keys, already
-//! spelled `blake3:<hex>`) and its segment-head ids (rendered `blake3:<hex>`).
-//! It deliberately does **not** use the MMR proof API: `mmr::prove_file` operates
-//! on frame ids, and a content-addressed blob digest is not necessarily an MMR
-//! leaf, so an MMR check here would produce false failures for legitimately
-//! included blobs. The blob/segment-head membership test is exact and total.
+//!    (from `rdf-core`'s content-id side table) must be included in the
+//!    verified chain, where inclusion is the union of three tests: the digest
+//!    is a blob id (`graph.blobs` key, already spelled `blake3:<hex>`), the
+//!    digest is a segment-head id (rendered `blake3:<hex>`), or the digest is
+//!    provable as an MMR leaf (a frame id) against an `index` frame's
+//!    committed root via [`purrdf_gts::mmr::prove_file`] and
+//!    [`purrdf_gts::mmr::verify_proof`]. The cheap blob/segment-head
+//!    membership test runs first; the MMR proof is only attempted on a miss.
 
-use std::collections::BTreeSet;
+use std::collections::HashSet;
+use std::fmt::Write as _;
 
+use purrdf_gts::mmr::{prove_file, verify_proof};
 use purrdf_gts::reader;
 use purrdf_gts::verify::verify_file;
 
@@ -99,14 +100,18 @@ pub fn verify_content_chain(
     }
     let head_matched = true;
 
-    // 3. Digest inclusion: the file's content ids are its blob ids (already
-    //    `blake3:<hex>`) plus its segment-head ids (rendered `blake3:<hex>`).
-    let mut included: BTreeSet<String> = BTreeSet::new();
+    // 3. Digest inclusion: cheap membership set first (blob ids, already
+    //    `blake3:<hex>`, plus rendered segment-head ids), then on a miss fall
+    //    back to an MMR leaf proof (the digest as a frame id).
+    let mut included: HashSet<String> =
+        HashSet::with_capacity(graph.blobs.len() + graph.segment_heads.len());
     for (digest, _entry) in &graph.blobs {
         included.insert(digest.clone());
     }
     for head in &graph.segment_heads {
-        included.insert(format!("blake3:{}", hex_lower(head)));
+        let mut id = String::with_capacity(71);
+        let _ = write!(id, "blake3:{}", hex_lower(head));
+        included.insert(id);
     }
 
     // `content_ids()` yields sorted-by-`TermId` pairs, so both the match count
@@ -114,8 +119,13 @@ pub fn verify_content_chain(
     let mut digests_included = 0usize;
     let mut missing: Vec<String> = Vec::new();
     for (term_id, digest) in dataset.content_ids() {
-        let content_id = format!("blake3:{}", digest.to_hex());
-        if included.contains(&content_id) {
+        let mut content_id = String::with_capacity(71);
+        let _ = write!(content_id, "blake3:{}", digest.to_hex());
+        let is_included = included.contains(&content_id)
+            || prove_file(gts_bytes, digest.as_bytes())
+                .and_then(|proof| verify_proof(&proof))
+                .is_ok();
+        if is_included {
             digests_included += 1;
         } else {
             missing.push(format!("term#{} {content_id}", term_id.index()));
@@ -206,6 +216,32 @@ mod tests {
         (bytes, head)
     }
 
+    /// Build a signed GTS file carrying one inline blob followed by an
+    /// `index` frame with an MMR root (`add_index_with_mmr`). Returns
+    /// `(bytes, head, blob_frame_id)`: `head` is the index frame's id (the
+    /// segment head), and `blob_frame_id` is the covered blob frame's id — a
+    /// genuine MMR leaf that is neither a `graph.blobs` key (those are keyed
+    /// by payload digest, not frame id) nor the segment head.
+    fn build_file_with_index() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        let mut writer = Writer::new("purrdf.gts");
+        let (signing_key, kid) = parse_secret_signing_key(&secret_armor(), Some(KID))
+            .expect("parse fixture secret key")
+            .into_parts();
+        writer.sign_with(signing_key, &kid);
+        writer.add_meta(Value::Map(vec![(
+            Value::Text("gts:transportKey".to_owned()),
+            Value::Map(vec![
+                (Value::Text("kid".to_owned()), Value::Text(kid)),
+                (Value::Text("gpg".to_owned()), Value::Text(public_armor())),
+            ]),
+        )]));
+        let blob_frame_id = writer.add_blob(BLOB_PAYLOAD, Some("text/plain"), Some("doc"));
+        writer.add_index_with_mmr();
+        let bytes = writer.to_bytes();
+        let head = writer.head().to_vec();
+        (bytes, head, blob_frame_id)
+    }
+
     /// Freeze a content-addressing dataset that references `content_iri` as the
     /// subject of a single quad.
     fn dataset_referencing(content_iri: &str) -> Arc<RdfDataset> {
@@ -233,6 +269,50 @@ mod tests {
         assert!(
             result.signatures_valid >= 1,
             "at least one COSE signature was cryptographically valid"
+        );
+    }
+
+    #[test]
+    fn mmr_leaf_frame_id_is_included_via_union() {
+        let (bytes, head, blob_frame_id) = build_file_with_index();
+        // The blob frame id is a genuine MMR leaf: neither a `graph.blobs` key
+        // (those are payload digests) nor the segment head (the index frame's
+        // id). It must still verify via the MMR-proof arm of the union.
+        assert_ne!(
+            blob_frame_id, head,
+            "the blob frame id must not equal the segment head"
+        );
+        let content_iri = format!("blake3:{}", super::hex_lower(&blob_frame_id));
+        assert_ne!(
+            content_iri,
+            digest_str(BLOB_PAYLOAD),
+            "the frame id must not equal the blob's payload digest"
+        );
+        let dataset = dataset_referencing(&content_iri);
+
+        let result = verify_content_chain(&dataset, &bytes, &head)
+            .expect("an MMR-leaf frame id verifies via the union inclusion test");
+        assert_eq!(
+            result.digests_included, 1,
+            "the frame-id digest is included via the MMR proof arm"
+        );
+    }
+
+    #[test]
+    fn absent_frame_digest_still_hard_fails() {
+        let (bytes, head, _blob_frame_id) = build_file_with_index();
+        // A digest that is not a blob id, not the segment head, and not a
+        // covered MMR leaf.
+        let absent = format!("blake3:{}", "cd".repeat(32));
+        let dataset = dataset_referencing(&absent);
+
+        let err = verify_content_chain(&dataset, &bytes, &head)
+            .expect_err("a digest absent from blobs, segment heads, and the MMR must fail");
+        assert_eq!(err.code, "gts-verify-digest-inclusion");
+        let detail = err.detail.unwrap_or_default();
+        assert!(
+            detail.contains("term#0") && detail.contains(&absent),
+            "detail names the missing term and digest: {detail}"
         );
     }
 

--- a/crates/rdf/src/lib.rs
+++ b/crates/rdf/src/lib.rs
@@ -39,6 +39,10 @@ mod gts_core;
 mod gts_import_graph;
 mod gts_import_sink;
 mod gts_resolve;
+// Full content-chain verification (content-addressed terms task 7): COSE
+// signatures + expected-head replay + digest inclusion, re-exported through the
+// `gts` adapter surface below.
+mod gts_verify;
 // Per-subject Symmetric-CBD subgraph extraction: the subgraph that *describes* a
 // term/slice, used by the docs multi-format export AND by the native engine's DESCRIBE
 // evaluation. It lives in `purrdf-core` (pure IR, no codec/gts) so both the higher

--- a/crates/rdf/src/lib.rs
+++ b/crates/rdf/src/lib.rs
@@ -39,9 +39,8 @@ mod gts_core;
 mod gts_import_graph;
 mod gts_import_sink;
 mod gts_resolve;
-// Full content-chain verification (content-addressed terms task 7): COSE
-// signatures + expected-head replay + digest inclusion, re-exported through the
-// `gts` adapter surface below.
+// Full content-chain verification: COSE signatures + expected-head replay +
+// digest inclusion, re-exported through the `gts` adapter surface below.
 mod gts_verify;
 // Per-subject Symmetric-CBD subgraph extraction: the subgraph that *describes* a
 // term/slice, used by the docs multi-format export AND by the native engine's DESCRIBE

--- a/crates/rdf/tests/content_id_byte_determinism.rs
+++ b/crates/rdf/tests/content_id_byte_determinism.rs
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Byte-determinism gate for content-addressed terms.
+//!
+//! Content addressing adds three DERIVED, non-serialized structures to a frozen
+//! [`RdfDataset`]: the `content_ids` side table (interned-IRI → digest), the
+//! resolved derivation-predicate `TermId`, and the lazy predecessor index. None
+//! of them is part of the RDF term/quad/reifier/annotation content, so enabling
+//! recognition MUST NOT perturb any serializer's output.
+//!
+//! This test builds the SAME logical dataset two ways — plain
+//! ([`RdfDatasetBuilder::new`]) and content-addressing active
+//! ([`RdfDatasetBuilder::with_content_addressing`]) — serializes both through the
+//! canonical RDFC-1.0 N-Quads surface ([`canonical_flat_nquads`]), and asserts the
+//! bytes are identical. To prove determinism DESPITE recognition being live (not
+//! because it silently no-op'd), it also asserts the content-addressing dataset
+//! actually recognized its `blake3:<64hex>` terms.
+
+use purrdf_core::ContentIdScheme;
+use purrdf_rdf::{canonical_flat_nquads, RdfDatasetBuilder, RdfLiteral, TermId};
+
+/// The caller-supplied derivation-predicate IRI (no fabricated vocabulary: this is
+/// configuration, spelled under `example.org` per the test-fixture rule).
+const DERIVED_FROM: &str = "http://example.org/wasDerivedFrom";
+
+/// A `blake3:`-scheme content-id IRI whose 64-hex tail is the two-hex-digit
+/// `pair` repeated 32× (e.g. `"aa"` → `blake3:aaaa…aa`, 64 hex chars).
+fn blake3_iri(pair: &str) -> String {
+    format!("blake3:{}", pair.repeat(32))
+}
+
+/// The `TermId`s of the two content-addressed IRIs, captured at build time so the
+/// caller can probe the frozen side table.
+struct CaIds {
+    subject: TermId,
+    object: TermId,
+}
+
+/// Intern one fixed logical dataset into `builder` and return the two
+/// content-addressed term ids. Identical push sequence for both builders, so any
+/// serialized difference can only come from the content-addressing config itself.
+///
+/// Content exercised:
+/// - a `blake3:<64hex>` IRI in SUBJECT position,
+/// - a different `blake3:<64hex>` IRI in OBJECT position,
+/// - an ordinary `example.org` quad, and
+/// - a derivation annotation `(ca_subject, wasDerivedFrom, ca_object)`.
+fn populate(builder: &mut RdfDatasetBuilder) -> CaIds {
+    let ca_subject = builder.intern_iri(&blake3_iri("aa"));
+    let ca_object = builder.intern_iri(&blake3_iri("bb"));
+    let plain_subject = builder.intern_iri("http://example.org/thing");
+    let predicate = builder.intern_iri("http://example.org/p");
+    let derived_from = builder.intern_iri(DERIVED_FROM);
+    let label = builder.intern_literal(RdfLiteral::simple("content-addressed"));
+
+    // A content-addressed IRI as the subject of an asserted quad.
+    builder.push_quad(ca_subject, predicate, label, None);
+    // A content-addressed IRI as the object of an asserted quad.
+    builder.push_quad(plain_subject, predicate, ca_object, None);
+    // A derivation annotation linking the two content-addressed terms.
+    builder.push_annotation(ca_subject, derived_from, ca_object);
+
+    CaIds {
+        subject: ca_subject,
+        object: ca_object,
+    }
+}
+
+/// Enabling content addressing must not change one canonical byte of serialized
+/// output, because the recognition state is a derived side table — never content.
+#[test]
+fn content_addressing_does_not_perturb_serialized_bytes() {
+    // (A) Plain builder — content addressing inactive.
+    let mut plain = RdfDatasetBuilder::new();
+    let _ = populate(&mut plain);
+    let dataset_a = plain.freeze().expect("plain dataset freezes");
+
+    // (B) Content-addressing active, with the derivation predicate configured.
+    let scheme = ContentIdScheme::new("blake3:").expect("':' is not a hex digit");
+    let mut addressed =
+        RdfDatasetBuilder::with_content_addressing(scheme, Some(DERIVED_FROM.to_string()));
+    let ca = populate(&mut addressed);
+    let dataset_b = addressed
+        .freeze()
+        .expect("content-addressed dataset freezes");
+
+    // Sanity: recognition was ACTIVE — the blake3 terms landed in the side table.
+    // (Without this, the byte-equality below could pass trivially if recognition
+    // had silently done nothing.)
+    assert!(
+        dataset_b.content_id(ca.subject).is_some(),
+        "the blake3 subject IRI must be recognized as a content-id term"
+    );
+    assert!(
+        dataset_b.content_id(ca.object).is_some(),
+        "the blake3 object IRI must be recognized as a content-id term"
+    );
+    // The plain dataset, by contrast, has an empty side table.
+    assert_eq!(
+        dataset_a.content_ids().count(),
+        0,
+        "the plain dataset must not recognize any content-id term"
+    );
+    assert_eq!(
+        dataset_b.content_ids().count(),
+        2,
+        "exactly the two blake3 IRIs are content-addressed"
+    );
+
+    // The load-bearing assertion: identical logical content → identical bytes,
+    // regardless of the (non-serialized) content-addressing side tables.
+    let bytes_a = canonical_flat_nquads(&dataset_a).expect("canonicalize plain");
+    let bytes_b = canonical_flat_nquads(&dataset_b).expect("canonicalize addressed");
+    assert_eq!(
+        bytes_a.as_bytes(),
+        bytes_b.as_bytes(),
+        "content-addressing changed the serialized bytes:\n--- plain ---\n{bytes_a}\n--- addressed ---\n{bytes_b}"
+    );
+}


### PR DESCRIPTION
Closes #17

## Summary
Make GTS content addressing first-class inside the interned RDF IR, without minting any vocabulary. At intern time, recognize content-addressed IRIs in a **caller-configured** spelling (`blake3:<64-lowercase-hex>`), cache the parsed 32-byte BLAKE3 digest in a `TermId`-keyed side table for O(1) access, add predecessor-link traversal + a derived predecessor index, and a full GTS verify bridge. IRIs only (content-addressed BNodes are rejected by construction).

## Changes (one commit per task)
- **rdf-core** `Blake3ContentId` — a distinct 32-byte newtype, **decode-only** (no hashing, **no new dependency**; reuses a factored `decode_hex_32`).
- **rdf-core** `ContentIdScheme` config — caller-supplied prefix, validated (hard-fail on malformed); single `with_content_addressing` constructor, **inactive by default**, no fabricated default, no setter (§19).
- **rdf-core** intern-time recognition — prefix-gated hook in the `Interner::intern` miss branch; **~0 overhead when no scheme is configured**; idempotent; BNode rejection by construction.
- **rdf-core** frozen side table — carried into `RdfDataset` at `materialize`; `content_id(id)` accessor + a sorted `content_ids()` iterator (only ordered egress). Regression test pins term-index stability across freeze.
- **rdf-core** `suppression_targets()` + a derived, non-serialized `OnceLock` `predecessors`/`predecessor_chain` index (cycle-guarded) over derivation annotations.
- **rdf** `verify_content_chain` — full GTS verify bridge (COSE signatures + expected-head chain replay + digest inclusion via blob/segment-head membership); lives in `crates/rdf` so **rdf-core stays gts-free and wasm-clean**.
- **rdf-core** report-only intern-overhead bench; **rdf** byte-determinism test.

## Acceptance gates
- Byte-determinism **unchanged** — proven by a canonical N-Quads test comparing plain vs content-addressing-active output while recognition is genuinely active.
- Intern overhead **~0 for non-matching IRIs** — bench observation (scheme-active ordinary IRIs track baseline).
- **wasm-clean** — `make wasm` green for every release crate (incl. the ed25519/COSE verify bridge).
- **No Cargo features**, no member-crate version pins; the only `Cargo.toml` change is a report-only `[[bench]]` entry.
- `make check` warning-free (fmt + clippy pedantic/nursery + build + tests + hygiene); rdf-core stays **blake3-free**.

Ready for /stage2 17.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for content-addressed RDF with `blake3:` content IDs, including dataset side-table access and derivation-chain traversal.
  * Added full content-chain verification against signed GTS bytes (signature, expected-head replay, and digest inclusion).
  * Exposed lookaside suppression target decoding for supported term, quad, and reifier targets.
* **Bug Fixes**
  * Improved robustness by ignoring malformed/invalid content IDs and malformed suppression targets instead of failing.
  * Kept canonical N-Quads output stable across content-addressing-enabled and plain datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->