### PR TITLE
feat(xsd): shared XSD-1.0 float/double lexical restriction

### DIFF
--- a/crates/shapes/src/constraints.rs
+++ b/crates/shapes/src/constraints.rs
@@ -1412,31 +1412,6 @@ fn is_xsd_decimal_lexical(s: &str) -> bool {
     seen_digit
 }
 
-/// `xsd:double`/`xsd:float` lexical space: the three special values exactly
-/// (INF, -INF, NaN — case-sensitive per XSD), or a mantissa (decimal lexical)
-/// with an optional [eE][+-]?digits exponent.
-fn is_xsd_double_lexical(s: &str) -> bool {
-    let s = s.trim();
-    if matches!(s, "INF" | "-INF" | "NaN") {
-        return true;
-    }
-    // Split optional exponent.
-    let (mantissa, exponent) = match s.split_once(['e', 'E']) {
-        Some((m, e)) => (m, Some(e)),
-        None => (s, None),
-    };
-    if !is_xsd_decimal_lexical(mantissa) {
-        return false;
-    }
-    match exponent {
-        None => true,
-        Some(exp) => {
-            let digits = exp.strip_prefix(['+', '-']).unwrap_or(exp);
-            !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
-        }
-    }
-}
-
 /// Check that a `Term` satisfies `sh:datatype` requirements.
 ///
 /// - Must be a `Literal` whose datatype IRI matches `dt_iri` EXACTLY (spec
@@ -1448,7 +1423,7 @@ fn is_xsd_double_lexical(s: &str) -> bool {
 ///   xsd:double/float, xsd:boolean), and for a DERIVED integer type validates
 ///   the VALUE space: the native codec keeps `"-2"^^xsd:nonNegativeInteger`
 ///   faithfully typed, but the value is outside the derived range and must
-///   violate (see #598 / corpus case 32).
+///   violate.
 fn check_datatype(value: &Term, dt_iri: &NamedNode) -> bool {
     let Term::Literal(lit) = value else {
         return false;
@@ -1496,8 +1471,12 @@ fn xsd_lexical_valid(dt: &str, lex: &str) -> bool {
     match dt {
         "http://www.w3.org/2001/XMLSchema#integer" => is_xsd_integer_lexical(lex),
         "http://www.w3.org/2001/XMLSchema#decimal" => is_xsd_decimal_lexical(lex),
-        "http://www.w3.org/2001/XMLSchema#double" => is_xsd_double_lexical(lex),
-        "http://www.w3.org/2001/XMLSchema#float" => is_xsd_double_lexical(lex),
+        "http://www.w3.org/2001/XMLSchema#double" => {
+            purrdf_xsd::parse_double_xsd10(lex.trim()).is_ok()
+        }
+        "http://www.w3.org/2001/XMLSchema#float" => {
+            purrdf_xsd::parse_float_xsd10(lex.trim()).is_ok()
+        }
         "http://www.w3.org/2001/XMLSchema#boolean" => {
             matches!(lex.trim(), "true" | "false" | "1" | "0")
         }
@@ -1509,7 +1488,6 @@ fn xsd_lexical_valid(dt: &str, lex: &str) -> bool {
 /// shape's required XSD *derived* integer type, by validating the lexical value
 /// against the derived type's value space. Every XSD integer-derived type
 /// canonicalizes to `xsd:integer` in oxigraph; only that base is considered here.
-/// See #598.
 fn derived_integer_matches(stored_dt: &str, required_dt: &str, lex: &str) -> bool {
     const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
     if stored_dt != XSD_INTEGER || !is_xsd_integer_lexical(lex) {
@@ -3005,6 +2983,22 @@ mod tests {
             !check_datatype(&value, &dt_iri),
             "+INF must not conform for xsd:double"
         );
+    }
+
+    #[test]
+    fn xsd_1_0_double_lexical_space_is_pinned() {
+        // The XSD-1.0 double/float lexical space, exactly: the three specials
+        // INF/-INF/NaN (not the XSD 1.1 "+INF"), a decimal mantissa with an
+        // optional [eE][+-]?digits exponent, and the SHACL-legacy whitespace
+        // leniency (the arm trims before validating). Guards the accept-set now
+        // owned by `purrdf_xsd::parse_double_xsd10`.
+        let ok = |x: &str| purrdf_xsd::parse_double_xsd10(x.trim()).is_ok();
+        for good in ["INF", "-INF", "NaN", "1", "1.", ".5", "+1.5", "1e10", "1E+5", "1e400", " 1.5 "] {
+            assert!(ok(good), "{good:?} is in the XSD-1.0 double lexical space");
+        }
+        for bad in ["+INF", "inf", "Infinity", "1e", "1.5.5", "", "abc"] {
+            assert!(!ok(bad), "{bad:?} is NOT in the XSD-1.0 double lexical space");
+        }
     }
 
     #[test]

--- a/crates/shapes/src/constraints.rs
+++ b/crates/shapes/src/constraints.rs
@@ -2986,12 +2986,37 @@ mod tests {
     }
 
     #[test]
+    fn xsd_float_accepts_inf() {
+        // "INF"^^xsd:float is a valid XSD special value.
+        let dt_iri = NamedNode::new_unchecked(format!("{XSD}float"));
+        let value = Term::Literal(Literal::new_typed_literal("INF", dt_iri.clone()));
+        assert!(
+            check_datatype(&value, &dt_iri),
+            "INF should conform for xsd:float"
+        );
+    }
+
+    #[test]
+    fn xsd_float_rejects_plus_inf() {
+        // "+INF" is NOT in the xsd:double/float lexical space (only INF, -INF, NaN).
+        let dt_iri = NamedNode::new_unchecked(format!("{XSD}float"));
+        let value = Term::Literal(Literal::new_typed_literal("+INF", dt_iri.clone()));
+        assert!(
+            !check_datatype(&value, &dt_iri),
+            "+INF must not conform for xsd:float"
+        );
+    }
+
+    #[test]
     fn xsd_1_0_double_lexical_space_is_pinned() {
-        // The XSD-1.0 double/float lexical space, exactly: the three specials
-        // INF/-INF/NaN (not the XSD 1.1 "+INF"), a decimal mantissa with an
-        // optional [eE][+-]?digits exponent, and the SHACL-legacy whitespace
-        // leniency (the arm trims before validating). Guards the accept-set now
-        // owned by `purrdf_xsd::parse_double_xsd10`.
+        // Characterizes the XSD-1.0 double/float accept-set, exactly: the
+        // three specials INF/-INF/NaN (not the XSD 1.1 "+INF"), a decimal
+        // mantissa with an optional [eE][+-]?digits exponent, and the
+        // SHACL-legacy whitespace leniency (the arm trims before
+        // validating). This is not a differential test against an external
+        // oracle — it directly pins the accept-set now owned by
+        // `purrdf_xsd::parse_double_xsd10`, which SHACL's `xsd_lexical_valid`
+        // relies on as defense-in-depth for float/double literals.
         let ok = |x: &str| purrdf_xsd::parse_double_xsd10(x.trim()).is_ok();
         for good in [
             "INF", "-INF", "NaN", "1", "1.", ".5", "+1.5", "1e10", "1E+5", "1e400", " 1.5 ",

--- a/crates/shapes/src/constraints.rs
+++ b/crates/shapes/src/constraints.rs
@@ -2993,11 +2993,16 @@ mod tests {
         // leniency (the arm trims before validating). Guards the accept-set now
         // owned by `purrdf_xsd::parse_double_xsd10`.
         let ok = |x: &str| purrdf_xsd::parse_double_xsd10(x.trim()).is_ok();
-        for good in ["INF", "-INF", "NaN", "1", "1.", ".5", "+1.5", "1e10", "1E+5", "1e400", " 1.5 "] {
+        for good in [
+            "INF", "-INF", "NaN", "1", "1.", ".5", "+1.5", "1e10", "1E+5", "1e400", " 1.5 ",
+        ] {
             assert!(ok(good), "{good:?} is in the XSD-1.0 double lexical space");
         }
         for bad in ["+INF", "inf", "Infinity", "1e", "1.5.5", "", "abc"] {
-            assert!(!ok(bad), "{bad:?} is NOT in the XSD-1.0 double lexical space");
+            assert!(
+                !ok(bad),
+                "{bad:?} is NOT in the XSD-1.0 double lexical space"
+            );
         }
     }
 

--- a/crates/shapes/src/constraints.rs
+++ b/crates/shapes/src/constraints.rs
@@ -87,7 +87,8 @@ pub fn validate_shape_with<G: ShaclDataGraph>(
     // --- sh:closed (node-shape-level; needs the sibling property shapes) ---
     // `eval_closed` stamps each result's box roles itself — the source roles plus
     // the OFFENDING PREDICATE's path roles — so closed-world violations carry the
-    // same predicate attribution that property-shape results do (#700 Gap B).
+    // same predicate attribution that property-shape results do — violations
+    // must not drop their predicate role.
     for constraint in &shape.constraints {
         if let Constraint::Closed { ignored } = constraint {
             results.extend(eval_closed(store, focus, shape, ignored, box_role_vocab));
@@ -1588,7 +1589,7 @@ fn numeric_value(term: &Term) -> Option<f64> {
     // violated every `sh:minInclusive`/`sh:maxInclusive` facet. (The omission was
     // masked while data round-tripped through oxigraph's NT serializer, which
     // value-space-normalized such literals to `xsd:integer`; the oxigraph-free
-    // path, #906, is the faithful one and exposes the gap.)
+    // path is the faithful one and exposes the gap.)
     let local = lit.datatype_str().strip_prefix(XSD_NS)?;
     if matches!(
         local,
@@ -1839,7 +1840,7 @@ mod tests {
 
     #[test]
     fn numeric_value_covers_all_derived_integer_datatypes() {
-        // Regression (#906): `numeric_value` must read EVERY xsd numeric-derived
+        // `numeric_value` must read EVERY xsd numeric-derived
         // datatype, not just the primitives. The omission of the derived/unsigned
         // integers (e.g. xsd:nonNegativeInteger) made a faithful
         // `"1"^^xsd:nonNegativeInteger` value read as non-numeric and spuriously
@@ -2201,7 +2202,7 @@ mod tests {
     fn class_pass_asserted_subclass() {
         // ex:b is typed ex:SubFoo and the data ASSERTS ex:SubFoo rdfs:subClassOf
         // ex:Foo, so b is a SHACL instance of ex:Foo (SHACL §4.2.5) and the
-        // sh:class ex:Foo constraint conforms — matching pySHACL. See #599.
+        // sh:class ex:Foo constraint conforms — matching pySHACL.
         let store = load_store(
             "@prefix ex: <http://example.org/ns#> . @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> . @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> . ex:a ex:p ex:b . ex:b rdf:type ex:SubFoo . ex:SubFoo rdfs:subClassOf ex:Foo .",
         );
@@ -2288,7 +2289,7 @@ mod tests {
         assert!(component_iri(&results)[0].contains("Datatype"));
     }
 
-    // ── datatype derived-integer (oxigraph canonicalization, #598) ──────────────
+    // ── datatype derived-integer (oxigraph canonicalization) ────────────────────
 
     #[test]
     fn datatype_derived_nonneg_integer_pass() {
@@ -3063,7 +3064,7 @@ mod tests {
         assert!(validate_shape(&store, &literal_focus, &shape).is_empty());
     }
 
-    // ── #700: maxLength ────────────────────────────────────────────────────────
+    // ── maxLength ─────────────────────────────────────────────────────────────
 
     #[test]
     fn max_length_pass() {
@@ -3082,7 +3083,7 @@ mod tests {
         assert!(component_iri(&results)[0].contains("MaxLength"));
     }
 
-    // ── #700: languageIn ───────────────────────────────────────────────────────
+    // ── languageIn ────────────────────────────────────────────────────────────
 
     #[test]
     fn language_in_pass_prefix_match() {
@@ -3117,7 +3118,7 @@ mod tests {
         assert!(component_iri(&results)[0].contains("LanguageIn"));
     }
 
-    // ── #700: not ──────────────────────────────────────────────────────────────
+    // ── not ───────────────────────────────────────────────────────────────────
 
     #[test]
     fn not_pass_when_inner_violated() {
@@ -3153,7 +3154,7 @@ mod tests {
         assert!(component_iri(&results)[0].contains("NotConstraintComponent"));
     }
 
-    // ── #700: closed ───────────────────────────────────────────────────────────
+    // ── closed ────────────────────────────────────────────────────────────────
 
     fn closed_shape(ignored: Vec<NamedNode>, path_iris: &[&str]) -> Shape {
         use crate::shapes::Path;
@@ -3238,7 +3239,7 @@ mod tests {
     fn closed_violation_carries_predicate_box_roles() {
         // The offending (undeclared) predicate ex:age declares a graph-box role;
         // the closed-world result must carry it as PATH attribution — closed
-        // violations previously dropped predicate roles (#700 Gap B).
+        // violations must not drop predicate roles.
         let vocab = meta_vocab();
         let store = load_store(&format!(
             "@prefix ex: <{EX}> .\n\

--- a/crates/shex/src/validate/node.rs
+++ b/crates/shex/src/validate/node.rs
@@ -142,16 +142,11 @@ fn check_datatype(datatype: &str, facts: &NodeFacts<'_>) -> Result<(), String> {
     }
     if let Some(xsd) = XsdDatatype::from_iri(datatype) {
         if is_checked_datatype(xsd) {
-            purrdf_xsd::parse(facts.lexical, xsd)
+            // shexTest v2.1.0 pins the XSD 1.0 float/double lexical space
+            // (INF/-INF, not the XSD 1.1 "+INF" spelling), so validate with the
+            // XSD-1.0-restricted parser rather than the 1.1 kernel default.
+            purrdf_xsd::parse_xsd10(facts.lexical, xsd)
                 .map_err(|e| format!("ill-formed <{datatype}> literal {:?}: {e}", facts.lexical))?;
-            // shexTest v2.1.0 pins the XSD **1.0** float/double lexical
-            // space, which has INF/-INF but not "+INF" (an XSD 1.1
-            // addition that purrdf-xsd accepts).
-            if matches!(xsd, XsdDatatype::Float | XsdDatatype::Double) && facts.lexical == "+INF" {
-                return Err(format!(
-                    "ill-formed <{datatype}> literal \"+INF\": XSD 1.0 spells positive infinity INF"
-                ));
-            }
         }
     }
     Ok(())
@@ -501,5 +496,23 @@ mod tests {
         assert!(check_datatype("http://www.w3.org/2001/XMLSchema#integer", &facts).is_err());
         let ok = literal_facts("42", "http://www.w3.org/2001/XMLSchema#integer", None);
         assert!(check_datatype("http://www.w3.org/2001/XMLSchema#integer", &ok).is_ok());
+    }
+
+    #[test]
+    fn float_double_pin_xsd_1_0_positive_infinity() {
+        // shexTest v2.1.0 pins XSD 1.0: `INF` is a valid positive infinity but
+        // the XSD 1.1 `+INF` spelling is not.
+        for dt in [
+            "http://www.w3.org/2001/XMLSchema#double",
+            "http://www.w3.org/2001/XMLSchema#float",
+        ] {
+            let inf = literal_facts("INF", dt, None);
+            assert!(check_datatype(dt, &inf).is_ok(), "INF valid for <{dt}>");
+            let plus_inf = literal_facts("+INF", dt, None);
+            assert!(
+                check_datatype(dt, &plus_inf).is_err(),
+                "+INF must be rejected for <{dt}>"
+            );
+        }
     }
 }

--- a/crates/shex/src/validate/node.rs
+++ b/crates/shex/src/validate/node.rs
@@ -245,7 +245,7 @@ fn numeric_value(facts: &NodeFacts<'_>) -> Result<XsdValue, String> {
             "numeric facet requires a numeric datatype, got <{datatype}>"
         ));
     }
-    purrdf_xsd::parse(facts.lexical, xsd)
+    purrdf_xsd::parse_xsd10(facts.lexical, xsd)
         .map_err(|e| format!("ill-formed numeric literal {:?}: {e}", facts.lexical))
 }
 
@@ -514,5 +514,32 @@ mod tests {
                 "+INF must be rejected for <{dt}>"
             );
         }
+    }
+
+    #[test]
+    fn numeric_facet_pins_xsd_1_0_positive_infinity() {
+        // A numeric facet with no accompanying datatype constraint routes
+        // through `numeric_value` rather than `check_datatype`; it must pin
+        // XSD 1.0 too, so `+INF` is rejected while `INF` is accepted.
+        let nc = NodeConstraint {
+            mininclusive: Some(NumericLiteral::Integer(0)),
+            ..NodeConstraint::default()
+        };
+        let dt = "http://www.w3.org/2001/XMLSchema#double";
+        let plus_inf = literal_facts("+INF", dt, None);
+        assert!(
+            check_numeric_facets(&nc, &plus_inf).is_err(),
+            "+INF must be rejected via the numeric-facet path"
+        );
+        let inf = literal_facts("INF", dt, None);
+        assert!(
+            check_numeric_facets(&nc, &inf).is_ok(),
+            "INF >= 0 must pass the numeric-facet path"
+        );
+        let one_point_five = literal_facts("1.5", dt, None);
+        assert!(
+            check_numeric_facets(&nc, &one_point_five).is_ok(),
+            "1.5 >= 0 must pass the numeric-facet path"
+        );
     }
 }

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -29,8 +29,8 @@ use purrdf_core::{BlankScope, DatasetView, GraphMatch, TermRef, TermValue};
 use purrdf_sparql_algebra::{Expression, Function, GraphPattern, PurrdfFn, Variable};
 use purrdf_xsd::{
     effective_boolean_value, numeric_abs, numeric_add, numeric_ceil, numeric_div, numeric_floor,
-    numeric_mul, numeric_round, numeric_sub, numeric_unary_minus, numeric_unary_plus,
-    parse_by_iri, parse_xsd10, value_cmp, XsdDatatype, XsdValue,
+    numeric_mul, numeric_round, numeric_sub, numeric_unary_minus, numeric_unary_plus, parse_by_iri,
+    parse_xsd10, value_cmp, XsdDatatype, XsdValue,
 };
 use sha2::Digest; // brings the Digest trait in scope for all RustCrypto hash calls
 
@@ -3016,8 +3016,16 @@ mod tests {
                     vec![lit(lex)],
                 )
             };
-            assert_eq!(lex(&ds, &cast("INF")).as_deref(), Some("INF"), "INF casts for <{dt}>");
-            assert_eq!(lex(&ds, &cast("+INF")), None, "+INF is a cast error for <{dt}>");
+            assert_eq!(
+                lex(&ds, &cast("INF")).as_deref(),
+                Some("INF"),
+                "INF casts for <{dt}>"
+            );
+            assert_eq!(
+                lex(&ds, &cast("+INF")),
+                None,
+                "+INF is a cast error for <{dt}>"
+            );
         }
     }
 

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -19,8 +19,8 @@
 //! **`ABS`/`CEIL`/`FLOOR`/`ROUND`**, and (Gap 4) **`ENCODE_FOR_URI`**,
 //! **`NOW`**, **`YEAR`/`MONTH`/`DAY`/`HOURS`/`MINUTES`/`SECONDS`**,
 //! **`TIMEZONE`/`TZ`**, **`MD5`/`SHA1`/`SHA256`/`SHA384`/`SHA512`**,
-//! **`RAND`**, and **`UUID`/`STRUUID`**. Still deferred (`Unsupported`):
-//! `SERVICE` (S6b #928), property paths (S8 #914), and `Function::Custom`.
+//! **`RAND`**, and **`UUID`/`STRUUID`**. Unsupported (`Unsupported`):
+//! `SERVICE`, property paths, and `Function::Custom`.
 
 use std::cmp::Ordering;
 use std::sync::Arc;

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -29,8 +29,8 @@ use purrdf_core::{BlankScope, DatasetView, GraphMatch, TermRef, TermValue};
 use purrdf_sparql_algebra::{Expression, Function, GraphPattern, PurrdfFn, Variable};
 use purrdf_xsd::{
     effective_boolean_value, numeric_abs, numeric_add, numeric_ceil, numeric_div, numeric_floor,
-    numeric_mul, numeric_round, numeric_sub, numeric_unary_minus, numeric_unary_plus, parse,
-    parse_by_iri, value_cmp, XsdDatatype, XsdValue,
+    numeric_mul, numeric_round, numeric_sub, numeric_unary_minus, numeric_unary_plus,
+    parse_by_iri, parse_xsd10, value_cmp, XsdDatatype, XsdValue,
 };
 use sha2::Digest; // brings the Digest trait in scope for all RustCrypto hash calls
 
@@ -1502,7 +1502,10 @@ fn eval_xsd_cast(
         TermValue::Iri(iri) if target == XsdDatatype::String => iri.clone(),
         _ => return None,
     };
-    if let Ok(value) = parse(&lexical, target) {
+    // The operand-mapping rules pin XSD 1.0, so a `xsd:float`/`xsd:double` constructor
+    // rejects the XSD 1.1-only `+INF` spelling (only `INF`); other targets are
+    // unaffected (`parse_xsd10` delegates to `parse`).
+    if let Ok(value) = parse_xsd10(&lexical, target) {
         return Some(xsd_to_term(ctx, &value));
     }
     // The lexical is not directly valid for `target`. If both source and target are
@@ -2996,6 +2999,41 @@ mod tests {
             }
             other => panic!("expected literal, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn xsd_float_double_cast_pins_xsd_1_0_positive_infinity() {
+        // The operand-mapping rules pin XSD 1.0: `INF` casts, but the XSD 1.1
+        // `+INF` spelling is a lexical error (the cast yields unbound).
+        let ds = empty_ds();
+        for dt in [
+            "http://www.w3.org/2001/XMLSchema#double",
+            "http://www.w3.org/2001/XMLSchema#float",
+        ] {
+            let cast = |lex: &str| {
+                Expression::FunctionCall(
+                    Function::Custom(NamedNode::new_unchecked(dt)),
+                    vec![lit(lex)],
+                )
+            };
+            assert_eq!(lex(&ds, &cast("INF")).as_deref(), Some("INF"), "INF casts for <{dt}>");
+            assert_eq!(lex(&ds, &cast("+INF")), None, "+INF is a cast error for <{dt}>");
+        }
+    }
+
+    #[test]
+    fn double_cast_of_a_double_typed_plus_inf_source_is_by_value() {
+        // The lexical constructor from a string applies the XSD-1.0 rules (above),
+        // but a numeric→numeric cast goes by VALUE (SPARQL 17.1): a source already
+        // typed `xsd:double` carries the value +INF, and casting that value to
+        // double is identity. So the two entry points differ by design.
+        let ds = empty_ds();
+        let dbl = "http://www.w3.org/2001/XMLSchema#double";
+        let expr = Expression::FunctionCall(
+            Function::Custom(NamedNode::new_unchecked(dbl)),
+            vec![typed_lit("+INF", dbl)],
+        );
+        assert_eq!(lex(&ds, &expr).as_deref(), Some("INF"));
     }
 
     // ---- Gap 4: RAND() deterministic with fixed seed ----------------------

--- a/crates/xsd/src/lib.rs
+++ b/crates/xsd/src/lib.rs
@@ -4,10 +4,10 @@
 //! `purrdf-xsd` — the native XSD **value space** for the RDF 1.2 query stack.
 //!
 //! This is a pure-Rust, **zero-runtime-dependency**, wasm-clean leaf crate. It is
-//! the drop-in replacement for the oxigraph-family `oxsdatatypes`, and the first
-//! foundation slice of the native SPARQL engine (purrdf S1, EPIC #906): the SPARQL
-//! evaluator evaluates `FILTER`/`ORDER BY` over *typed values*, which this crate
-//! supplies. It is deliberately decoupled from `purrdf-core` (no dependency in
+//! the drop-in replacement for the oxigraph-family `oxsdatatypes`, and the
+//! foundation layer of the native SPARQL engine: the SPARQL evaluator evaluates
+//! `FILTER`/`ORDER BY` over *typed values*, which this crate supplies. It is
+//! deliberately decoupled from `purrdf-core` (no dependency in
 //! either direction yet); the IR keeps literals **lexical-verbatim** (Constitution
 //! C0.1) and this crate is the value layer that complements it.
 //!
@@ -35,13 +35,24 @@
 //! # XSD version: 1.1
 //!
 //! purrdf-xsd targets the **XSD 1.1** value spaces (W3C REC 2012-04-05).
-//! Two load-bearing consequences for the year lexical affect slices #911/#912:
+//! Two load-bearing consequences for the year lexical:
 //!
 //! * Year `0000` is **permitted** (XSD 1.1; it denotes 1 BCE). XSD 1.0 forbade it.
 //! * The year field must have **at least 4 digits**. A year field wider than 4 digits
 //!   must **not** have a leading zero — e.g. `00044-03-15` and `012345-01-01` are
 //!   invalid; `12345-06-15` and `-12345-06-15` are valid. Exactly 4 digits with a
 //!   leading zero (`0044`, `0000`) are valid.
+//!
+//! # XSD 1.0 compatibility
+//!
+//! The crate stays honestly XSD 1.1 by default: [`parse`]/[`numeric::parse_float`]/
+//! [`numeric::parse_double`] accept the XSD 1.1-only `+INF` spelling of positive
+//! infinity for `xsd:float`/`xsd:double`. Spec-pinned consumers that reference XSD
+//! 1.0 (e.g. ShEx/SHACL/SPARQL conformance suites written against the 1.0 lexical
+//! space) call [`parse_xsd10`]/[`parse_float_xsd10`]/[`parse_double_xsd10`] instead,
+//! which reject `+INF` (XSD 1.0 spells positive infinity only `INF`). This is an
+//! opt-in function, not a Cargo feature — the kernel's default behavior never
+//! changes underneath a caller that did not ask for it.
 //!
 //! # Datatype coverage
 //!
@@ -81,9 +92,10 @@ pub use binary::{canonical_base64, canonical_hex, parse_base64, parse_binary, pa
 pub use datatype::{XsdDatatype, XSD_NS};
 pub use numeric::{
     numeric_abs, numeric_add, numeric_ceil, numeric_div, numeric_floor, numeric_mul, numeric_round,
-    numeric_sub, numeric_unary_minus, numeric_unary_plus, Decimal,
+    numeric_sub, numeric_unary_minus, numeric_unary_plus, parse_double_xsd10, parse_float_xsd10,
+    Decimal,
 };
 pub use ops::{effective_boolean_value, value_cmp, value_eq};
 pub use simple::{normalize_whitespace_collapse, normalize_whitespace_replace};
 pub use temporal::{datetime_epoch, datetime_from_unix_seconds};
-pub use value::{parse, parse_by_iri, XsdError, XsdValue};
+pub use value::{parse, parse_by_iri, parse_xsd10, XsdError, XsdValue};

--- a/crates/xsd/src/lib.rs
+++ b/crates/xsd/src/lib.rs
@@ -69,8 +69,9 @@
 //! * binary: `hexBinary`/`base64Binary` (hand-rolled codecs — still zero-dep).
 //!
 //! The derived-integer facets and the binary types are **not** modelled by
-//! `oxsdatatypes`; the gregorian family matches it. Bignum (arbitrary-precision
-//! integer/decimal) is a deferred enhancement (i128 + scale ≤ 18 hard-fail on range).
+//! `oxsdatatypes`; the gregorian family matches it. Integer and decimal are
+//! `i128`-bounded (decimal scale ≤ 18); lexicals beyond that domain hard-fail on
+//! range rather than promoting to arbitrary precision.
 //!
 //! # Hard-fail
 //!

--- a/crates/xsd/src/numeric.rs
+++ b/crates/xsd/src/numeric.rs
@@ -300,6 +300,38 @@ pub fn parse_float(s: &str) -> Result<f32, XsdError> {
         .map_err(|_| invalid(dt, s, "not a valid float lexical"))
 }
 
+/// XSD **1.0**-pinned `xsd:double` parse: identical to [`parse_double`] but rejects
+/// the XSD 1.1-only `+INF` spelling of positive infinity. XSD 1.0 (referenced by
+/// the ShEx/SHACL/SPARQL conformance suites) spells positive infinity only `INF`;
+/// spec-pinned consumers call this to opt out of the 1.1-only lexical without
+/// turning the whole crate back to 1.0.
+pub fn parse_double_xsd10(s: &str) -> Result<f64, XsdError> {
+    if s == "+INF" {
+        return Err(invalid(
+            XsdDatatype::Double,
+            s,
+            "XSD 1.0 spells positive infinity INF",
+        ));
+    }
+    parse_double(s)
+}
+
+/// XSD **1.0**-pinned `xsd:float` parse: identical to [`parse_float`] but rejects
+/// the XSD 1.1-only `+INF` spelling of positive infinity. XSD 1.0 (referenced by
+/// the ShEx/SHACL/SPARQL conformance suites) spells positive infinity only `INF`;
+/// spec-pinned consumers call this to opt out of the 1.1-only lexical without
+/// turning the whole crate back to 1.0.
+pub fn parse_float_xsd10(s: &str) -> Result<f32, XsdError> {
+    if s == "+INF" {
+        return Err(invalid(
+            XsdDatatype::Float,
+            s,
+            "XSD 1.0 spells positive infinity INF",
+        ));
+    }
+    parse_float(s)
+}
+
 /// Shared finite-numeric parse for double; returns `f64`.
 fn parse_ieee(s: &str, dt: XsdDatatype) -> Result<f64, XsdError> {
     match s {
@@ -1232,6 +1264,60 @@ mod tests {
         assert_eq!(canonical_double(f64::INFINITY), "INF");
         assert_eq!(canonical_double(f64::NEG_INFINITY), "-INF");
         assert_eq!(canonical_double(f64::NAN), "NaN");
+    }
+
+    #[test]
+    fn parse_float_still_accepts_plus_inf() {
+        // Regression guard: the XSD 1.1 default parse must keep accepting `+INF`.
+        assert_eq!(parse_float("+INF").unwrap(), f32::INFINITY);
+    }
+
+    #[test]
+    fn parse_double_still_accepts_plus_inf() {
+        // Regression guard: the XSD 1.1 default parse must keep accepting `+INF`.
+        assert_eq!(parse_double("+INF").unwrap(), f64::INFINITY);
+    }
+
+    #[test]
+    fn parse_float_xsd10_rejects_plus_inf() {
+        assert!(parse_float_xsd10("+INF").is_err());
+    }
+
+    #[test]
+    fn parse_double_xsd10_rejects_plus_inf() {
+        assert!(parse_double_xsd10("+INF").is_err());
+    }
+
+    #[test]
+    fn parse_float_xsd10_accepts_xsd10_lexicals() {
+        assert_eq!(parse_float_xsd10("INF").unwrap(), f32::INFINITY);
+        assert_eq!(parse_float_xsd10("-INF").unwrap(), f32::NEG_INFINITY);
+        assert!(parse_float_xsd10("NaN").unwrap().is_nan());
+        assert_eq!(parse_float_xsd10("1.5").unwrap(), 1.5f32);
+        assert_eq!(parse_float_xsd10("1e10").unwrap(), 1e10f32);
+    }
+
+    #[test]
+    fn parse_double_xsd10_accepts_xsd10_lexicals() {
+        assert_eq!(parse_double_xsd10("INF").unwrap(), f64::INFINITY);
+        assert_eq!(parse_double_xsd10("-INF").unwrap(), f64::NEG_INFINITY);
+        assert!(parse_double_xsd10("NaN").unwrap().is_nan());
+        assert_eq!(parse_double_xsd10("1.5").unwrap(), 1.5f64);
+        assert_eq!(parse_double_xsd10("1e10").unwrap(), 1e10f64);
+    }
+
+    #[test]
+    fn value_parse_xsd10_rejects_plus_inf_for_float_and_double() {
+        assert!(crate::value::parse_xsd10("+INF", D::Double).is_err());
+        assert!(crate::value::parse_xsd10("+INF", D::Float).is_err());
+    }
+
+    #[test]
+    fn value_parse_xsd10_unaffected_for_non_float_double_datatypes() {
+        // Non-float/double datatypes must behave exactly as `parse`.
+        let xsd10 = crate::value::parse_xsd10("1", D::Integer).unwrap();
+        let xsd11 = crate::value::parse("1", D::Integer).unwrap();
+        assert_eq!(xsd10.canonical_lexical(), xsd11.canonical_lexical());
     }
 
     #[test]

--- a/crates/xsd/src/value.rs
+++ b/crates/xsd/src/value.rs
@@ -162,6 +162,16 @@ pub fn parse(lexical: &str, datatype: XsdDatatype) -> Result<XsdValue, XsdError>
     }
 }
 
+/// As [`parse`], but applies the XSD-1.0 lexical restriction for `Float`/`Double`
+/// (rejects `+INF`). All other datatypes behave exactly as [`parse`].
+pub fn parse_xsd10(s: &str, dt: XsdDatatype) -> Result<XsdValue, XsdError> {
+    match dt {
+        XsdDatatype::Float => crate::numeric::parse_float_xsd10(s).map(XsdValue::Float),
+        XsdDatatype::Double => crate::numeric::parse_double_xsd10(s).map(XsdValue::Double),
+        _ => parse(s, dt),
+    }
+}
+
 /// Parse a lexical form by datatype IRI.
 ///
 /// Returns `Ok(None)` when `datatype_iri` is **not** an XSD value-space datatype —

--- a/crates/xsd/src/value.rs
+++ b/crates/xsd/src/value.rs
@@ -201,7 +201,8 @@ pub enum XsdError {
     /// The lexical form is well-formed but exceeds this crate's representable range
     /// (e.g. an integer beyond `i128`, a derived integer out of its subtype bounds,
     /// or a decimal beyond `i128` mantissa). This is a deliberate hard-fail rather
-    /// than saturation; bignum support is a deferred enhancement.
+    /// than saturation: values outside the `i128` / scale-≤18 domain are rejected,
+    /// never silently truncated.
     OutOfRange {
         /// The datatype the lexical was being parsed as.
         datatype: XsdDatatype,


### PR DESCRIPTION
Closes #16

## Summary
purrdf-xsd stays honestly XSD 1.1 by default (it accepts `+INF`). A shared,
opt-in `parse_float_xsd10` / `parse_double_xsd10` / `parse_xsd10` function now
owns the XSD-1.0 restriction (reject the 1.1-only `+INF` spelling of positive
infinity). Every spec-pinned consumer routes through it, and SHACL's divergent
`is_xsd_double_lexical` reimplementation is deleted — purrdf-xsd becomes the
single source of truth for the float/double lexical space.

This resolves the policy question in the issue: **Option 2** (a shared function,
never a Cargo feature). Option 3 (switch the crate wholesale to XSD 1.0) is
rejected — 1.1 is the modern spec that RDF 1.2 references.

## Changes
- **purrdf-xsd**: add `parse_float_xsd10`, `parse_double_xsd10` (numeric.rs) and
  `value::parse_xsd10`; re-export from lib.rs; new `# XSD 1.0 compatibility`
  module-doc subsection. The 1.1 kernel parsers are unchanged.
- **ShEx**: `check_datatype` validates float/double via `parse_xsd10`; the
  hand-written `+INF` special case and bespoke error string are removed.
- **SHACL**: `xsd_lexical_valid` float/double arms call the kernel; the bespoke
  `is_xsd_double_lexical` is deleted. Equivalence was proven by a differential
  test over an accept-set battery (overflow, whitespace, garbage) before deleting
  the oracle; a pinned-lexical test retains the guard.
- **SPARQL**: the `xsd:float`/`xsd:double` constructor cast routes through
  `parse_xsd10`, so `xsd:double("+INF")` from a string is a cast error while
  `xsd:double("INF")` casts. Numeric→numeric value casts (SPARQL §17.1) are
  intentionally unaffected — a test pins that asymmetry.

## Verification
- `make check` (fmt + pedantic/nursery clippy + build + tests + hygiene) green.
- `make wasm` — wasm32 clean.
- ShEx, SHACL, and SPARQL conformance suites unchanged (the equivalence gate for
  the SHACL subsume).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added XSD 1.0-compatible parsing for floating-point values, including new handling for `float` and `double`.
  * Improved support for casting and validation of XSD literals across parsing, SHACL, SHEx, and SPARQL evaluation.

* **Bug Fixes**
  * Corrected handling of `+INF` so it is rejected in XSD 1.0-compatible paths while `INF`, `-INF`, and `NaN` remain supported.
  * Added regression coverage for float and double lexical forms to keep behavior consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->