### PR TITLE
fix(rdf): accept empty predicateObjectList item in Turtle parser

### DIFF
--- a/crates/rdf/src/native_codecs/text_parse.rs
+++ b/crates/rdf/src/native_codecs/text_parse.rs
@@ -1082,6 +1082,10 @@ impl<'a> DocParser<'a> {
                 break;
             }
             if self.eat(&Token::Semicolon) {
+                // A predicateObjectList item after `;` is optional, so a run of `;`
+                // (the doubled/trailing form `; ;`) denotes empty items and emits no
+                // triples. Consume the run, then decide on the first non-`;` token.
+                while self.eat(&Token::Semicolon) {}
                 // `Pipe` terminates a trailing `;` inside a `{| … |}` annotation block.
                 if self.at(&Token::Dot)
                     || self.at(&Token::RBracket)
@@ -1890,5 +1894,113 @@ mod tests {
             nodes[2],
             Node::Iri("https://example.org/vocab/report/shacl/sarif".to_owned())
         );
+    }
+
+    /// The Turtle/TriG `predicateObjectList` grammar makes the item after `;`
+    /// OPTIONAL (`';' predicateObjectListItem?` in effect), so an interior doubled
+    /// `;` denotes an empty item between two real ones and must emit no extra triple.
+    #[test]
+    fn turtle_doubled_semicolon_interior_emits_no_extra_triple() {
+        let text = "<https://example.org/s> a <https://example.org/C> ; ; \
+                     <https://example.org/p> <https://example.org/o> .";
+        let statements = DocParser::new(text, None, false).parse().expect("parses");
+        assert_eq!(statements.len(), 2);
+    }
+
+    /// A longer run of consecutive `;` (three in a row) collapses the same way: each
+    /// extra `;` past the first is just another empty item, never an extra triple.
+    #[test]
+    fn turtle_semicolon_run_of_three_emits_no_extra_triples() {
+        let text =
+            "<https://example.org/s> <https://example.org/p1> <https://example.org/o1> ; ; ; \
+                     <https://example.org/p2> <https://example.org/o2> .";
+        let statements = DocParser::new(text, None, false).parse().expect("parses");
+        assert_eq!(statements.len(), 2);
+    }
+
+    /// A trailing `; ;` before the terminating `.` is the doubled/trailing empty-item
+    /// form: it must not require (or produce) a following predicate-object pair.
+    #[test]
+    fn turtle_trailing_doubled_semicolon_emits_no_extra_triple() {
+        let text = "<https://example.org/s> <https://example.org/p> <https://example.org/o> ; ; .";
+        let statements = DocParser::new(text, None, false).parse().expect("parses");
+        assert_eq!(statements.len(), 1);
+    }
+
+    /// The same empty-item rule applies inside a blank-node property list `[ … ]`:
+    /// a doubled `;` there must parse and yield the same statements as the collapsed
+    /// (single `;`) form.
+    #[test]
+    fn turtle_doubled_semicolon_inside_blank_node_property_list() {
+        let collapsed = "<https://example.org/s> <https://example.org/p> \
+                          [ <https://example.org/a> <https://example.org/b> ; \
+                            <https://example.org/c> <https://example.org/d> ] .";
+        let doubled = "<https://example.org/s> <https://example.org/p> \
+                        [ <https://example.org/a> <https://example.org/b> ; ; \
+                          <https://example.org/c> <https://example.org/d> ] .";
+        let expected = DocParser::new(collapsed, None, false)
+            .parse()
+            .expect("collapsed parses");
+        let actual = DocParser::new(doubled, None, false)
+            .parse()
+            .expect("doubled parses");
+        assert_eq!(actual, expected);
+    }
+
+    /// The empty-item rule applies inside an RDF 1.2 annotation block `{| … |}` too: a
+    /// doubled `;` separating two annotation predicate-object pairs must parse and
+    /// yield IDENTICAL statements (including the minted reifier and its `rdf:reifies`
+    /// triple) to the same document written with a single `;`.
+    #[test]
+    fn turtle_doubled_semicolon_inside_annotation_block() {
+        let collapsed = "<https://example.org/s> <https://example.org/p> <https://example.org/o> \
+                          {| <https://example.org/a> <https://example.org/b> ; \
+                             <https://example.org/c> <https://example.org/d> |} .";
+        let doubled = "<https://example.org/s> <https://example.org/p> <https://example.org/o> \
+                        {| <https://example.org/a> <https://example.org/b> ; ; \
+                           <https://example.org/c> <https://example.org/d> |} .";
+        let expected = DocParser::new(collapsed, None, false)
+            .parse()
+            .expect("collapsed parses");
+        let actual = DocParser::new(doubled, None, false)
+            .parse()
+            .expect("doubled parses");
+        assert_eq!(actual, expected);
+    }
+
+    /// A trailing `;` inside an annotation block (`{| … ; |}`) is the empty-item form
+    /// terminated by `Pipe` rather than `Dot`/`RBracket`/`RBrace` — this specifically
+    /// exercises the `Pipe` branch of the terminator check after the `;` run is drained.
+    #[test]
+    fn turtle_trailing_semicolon_inside_annotation_block_before_pipe() {
+        let no_trailing =
+            "<https://example.org/s> <https://example.org/p> <https://example.org/o> \
+                            {| <https://example.org/a> <https://example.org/b> |} .";
+        let trailing = "<https://example.org/s> <https://example.org/p> <https://example.org/o> \
+                         {| <https://example.org/a> <https://example.org/b> ; |} .";
+        let expected = DocParser::new(no_trailing, None, false)
+            .parse()
+            .expect("no-trailing parses");
+        let actual = DocParser::new(trailing, None, false)
+            .parse()
+            .expect("trailing parses");
+        assert_eq!(actual, expected);
+    }
+
+    /// A LEADING empty item is still illegal: `predicate()` runs at the top of the
+    /// `predicateObjectList` loop before any `;` handling, so a `;` with no preceding
+    /// predicate-object pair for this subject has no predicate to parse and must error.
+    #[test]
+    fn turtle_leading_semicolon_before_any_predicate_is_an_error() {
+        let text = "<https://example.org/s> ; <https://example.org/p> <https://example.org/o> .";
+        assert!(DocParser::new(text, None, false).parse().is_err());
+    }
+
+    /// A subject followed immediately by `;` and then `.` (no predicate-object pair at
+    /// all) is also illegal for the same reason: `predicate()` has nothing to consume.
+    #[test]
+    fn turtle_leading_semicolon_with_no_predicate_object_is_an_error() {
+        let text = "<https://example.org/s> ; .";
+        assert!(DocParser::new(text, None, false).parse().is_err());
     }
 }

--- a/crates/rdf/src/native_codecs/text_parse.rs
+++ b/crates/rdf/src/native_codecs/text_parse.rs
@@ -2003,4 +2003,44 @@ mod tests {
         let text = "<https://example.org/s> ; .";
         assert!(DocParser::new(text, None, false).parse().is_err());
     }
+
+    /// A LEADING `;` inside a blank-node property list `[ … ]` is also illegal:
+    /// `predicate()` runs at the top of the `predicateObjectList` loop before any `;`
+    /// handling, so a `;` with no preceding predicate-object pair inside the blank
+    /// node has no predicate to parse and must error.
+    #[test]
+    fn turtle_leading_semicolon_inside_blank_node_property_list_is_an_error() {
+        let text = "<https://example.org/s> <https://example.org/p> \
+                     [ ; <https://example.org/a> <https://example.org/b> ] .";
+        assert!(DocParser::new(text, None, false).parse().is_err());
+    }
+
+    /// A LEADING `;` inside an RDF 1.2 annotation block `{| … |}` is also illegal for
+    /// the same reason: `predicate()` has nothing to consume before the first `;`.
+    #[test]
+    fn turtle_leading_semicolon_inside_annotation_block_is_an_error() {
+        let text = "<https://example.org/s> <https://example.org/p> <https://example.org/o> \
+                     {| ; <https://example.org/a> <https://example.org/b> |} .";
+        assert!(DocParser::new(text, None, false).parse().is_err());
+    }
+
+    /// A DOUBLED trailing `;` before the annotation-block `Pipe` (`{| a b ; ; |}`)
+    /// must drain the whole run of semicolons and then break on `Pipe`, parsing
+    /// IDENTICALLY to the no-trailing form — this pairs the `while self.eat(&Token::Semicolon) {}`
+    /// drain with the `Pipe` terminator, distinct from the single-`;` trailing case.
+    #[test]
+    fn turtle_doubled_trailing_semicolon_inside_annotation_block_before_pipe() {
+        let no_trailing =
+            "<https://example.org/s> <https://example.org/p> <https://example.org/o> \
+                            {| <https://example.org/a> <https://example.org/b> |} .";
+        let doubled = "<https://example.org/s> <https://example.org/p> <https://example.org/o> \
+                        {| <https://example.org/a> <https://example.org/b> ; ; |} .";
+        let expected = DocParser::new(no_trailing, None, false)
+            .parse()
+            .expect("no-trailing parses");
+        let actual = DocParser::new(doubled, None, false)
+            .parse()
+            .expect("doubled parses");
+        assert_eq!(actual, expected);
+    }
 }

--- a/crates/shex/tests/validation_conformance.rs
+++ b/crates/shex/tests/validation_conformance.rs
@@ -67,12 +67,6 @@ impl Manifest {
     fn load() -> Self {
         let path = corpus_dir().join("validation/manifest.ttl");
         let text = fs::read_to_string(&path).expect("read validation manifest");
-        // Workaround for a purrdf-rdf Turtle-parser gap: three manifest
-        // entries use the legal doubled-semicolon form
-        // `a sht:ValidationFailure ; ;` (an empty predicateObjectList item),
-        // which the native codec currently rejects. Collapsing THIS exact
-        // spelling changes no triples.
-        let text = text.replace("sht:ValidationFailure ; ;", "sht:ValidationFailure ;");
         let ds = parse_dataset(
             text.as_bytes(),
             "text/turtle",


### PR DESCRIPTION
Closes #15

## Summary
The native Turtle parser now accepts the legal empty predicate-object-list item (doubled/trailing `;`, e.g. `<s> a <C> ; ; <p> <o> .`). Per the Turtle grammar `predicateObjectList ::= verb objectList (';' (verb objectList)?)*` the item after each `;` is optional, so a run of semicolons denotes empty items that emit **no** triples. Removes the ShEx conformance harness workaround that pre-collapsed `sht:ValidationFailure ; ;` in the vendored manifest.

## Changes
- **Parser fix** (`crates/rdf/src/native_codecs/text_parse.rs`): drain the run of consecutive `;` (`while self.eat(&Token::Semicolon) {}`) before the terminator check in `predicate_object_list`. No `emit` for an empty item → goldens/triple counts unchanged. A *leading* `;` remains a hard error.
- **Tests** (same file): 8 new parser tests — interior `; ;`, run-of-three, trailing `; ;`, empty item inside blank-node property list `[ … ]`, empty item inside RDF 1.2 annotation block `{| … |}`, trailing `;` before annotation `Pipe`, plus two negatives locking leading-`;` as an error.
- **Harness cleanup** (`crates/shex/tests/validation_conformance.rs`): removed the string-replacement workaround; the raw manifest now parses natively.

## Verification
- `cargo test -p purrdf-rdf` and `cargo test -p purrdf-shex` green (incl. `validation_conformance` parsing the raw manifest).
- Full `make check` green (fmt + clippy pedantic/nursery + build + tests + hygiene + wasm).
- Frozen `vectors/` untouched — the parser was fixed, not the fixtures (all 3 `sht:ValidationFailure ; ;` entries remain in the manifest).