### PR TITLE
chore: strip stale gmeow-ontology issue refs and lint against regression

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,9 @@ jobs:
       - name: Check generated artifacts
         run: bash scripts/check-generated.sh
 
+      - name: Check for stale issue references in comments/docs
+        run: python3 scripts/check-issue-refs.py
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 CARGO_TARGET_DIR ?= target
 CAPI_HEADER := crates/rdf-capi/include/purrdf.h
 
-.PHONY: help metadata fmt check test bench bench-python pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-test wasm-pkg-bench \
+.PHONY: help metadata fmt check check-issue-refs test bench bench-python pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-test wasm-pkg-bench \
 	capi-build capi-header capi-check capi-install
 
 help: ## Show this help.
@@ -24,9 +24,13 @@ check: ## The full local gate: fmt, clippy, build, tests, hygiene.
 	python3 scripts/check-no-features.py
 	python3 scripts/check-licenses.py
 	bash scripts/check-generated.sh
+	python3 scripts/check-issue-refs.py
 	cargo test --workspace --locked
 	$(MAKE) rdf-core-hygiene
 	$(MAKE) wasm
+
+check-issue-refs: ## Reject #NNN issue-reference tokens in comments and docs.
+	python3 scripts/check-issue-refs.py
 
 test: ## Run the workspace test suite.
 	cargo test --workspace --locked

--- a/bindings/python/src/py_gts.rs
+++ b/bindings/python/src/py_gts.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! The native `RDF → GTS` producer surface for the `purrdf` Python extension
-//! (#819 Task 8 / C7).
+//! (Task 8 / C7).
 //!
 //! This module moves the byte-emitting core of `src/purrdf_tools/gts_producer.py`
 //! into Rust. The Python `_Builder` interns terms, content-sorts them, and emits
@@ -14,7 +14,7 @@
 //!
 //! To preserve **byte-identity** with the existing producer — and, crucially, the
 //! `snapshot_content_id()` self-attestation that `feedback_bundle.py` relies on
-//! (#654) — this module replicates `_Builder` exactly:
+//! — this module replicates `_Builder` exactly:
 //!
 //! * the same interning order (append-order, scope-aware blank nodes);
 //! * the same content sort (`(kind, value, datatype-IRI, lang)`, IRIs first);
@@ -33,14 +33,14 @@ use pyo3::types::{PyBytes, PyDict, PyList};
 
 use crate::bundle::{RdfBundle, UnitMetadata};
 // The byte-emitting compose core now lives in the pyo3-free `gts_compose` module
-// (#861 P6); this surface is the thin pyo3 wrapper that delegates to it.
+// (P6); this surface is the thin pyo3 wrapper that delegates to it.
 use crate::gts_compose::{emit_gts, BlobRow, SnapshotBuilder, DEFAULT_RSYNCABLE_THRESHOLD};
 use crate::ir::RdfDataset;
 use crate::provenance::{DatasetProvenance, OriginKind};
 use crate::py_store::{parse_quads, PyRdfFormat};
 use crate::{flat_dataset_from_quads, NativeRdfFormat, RdfQuad};
 
-/// The `rep`-label prefix every S3 slice-artifact blob carries (#820 S3). A blob
+/// The `rep`-label prefix every S3 slice-artifact blob carries (S3). A blob
 /// authored from the slice catalog rides ahead of the snapshot with
 /// `rep == "slice-artifact:{role}:{logical_path}"`, so a repo-free consumer can
 /// recover each ontology artifact by role + logical path + content digest. This
@@ -53,7 +53,7 @@ const SLICE_ARTIFACT_REP_PREFIX: &str = "slice-artifact:";
 /// bundle's normalized artifact path. Only the small ontology text artifacts
 /// (module / shapes / docs / manifest) are passed here; the large external DATA
 /// blobs (`graph.blobs`) STAY by-reference and never travel this channel
-/// (blob-by-reference doctrine, purrdf-gts#248).
+/// (blob-by-reference doctrine).
 struct SliceArtifactRow {
     slice_iri: String,
     slice_name: String,
@@ -71,7 +71,7 @@ fn dataset_from_quads(quads: &[RdfQuad]) -> Result<std::sync::Arc<RdfDataset>, S
 
 /// Assemble the self-describing S3 [`RdfBundle`] from the slice-artifact rows and
 /// the parsed base graph, hard-fail `validate()` it, and return the artifact bytes
-/// as content-addressed [`BlobRow`]s to embed (#820 S3, gap G4).
+/// as content-addressed [`BlobRow`]s to embed (S3, gap G4).
 ///
 /// One [`UnitId`] per slice (metadata = slice IRI + name), one content-addressed
 /// `ArtifactRecord` per ontology artifact, every blob inserted into the bundle's
@@ -225,7 +225,7 @@ fn parse_rdf(data: &[u8], format: PyRdfFormat) -> PyResult<Vec<RdfQuad>> {
 }
 
 /// Parse RDF bytes into a frozen native [`RdfDataset`] for `SnapshotBuilder`
-/// ingestion (the native carrier path, #909). The native parse folds the RDF 1.2
+/// ingestion (the native carrier path). The native parse folds the RDF 1.2
 /// statement layer into the dataset's reifier/annotation side-tables and preserves
 /// named graphs, so `add_dataset_scoped` reproduces the legacy oxigraph ingestion
 /// byte-for-byte. The blank-node `scope` is applied at INGESTION (by
@@ -388,7 +388,7 @@ fn from_json_ld(
     Ok(PyBytes::new(py, &nquads).unbind())
 }
 
-/// Serialize RDF bytes to **RDF/XML** via the FIRST-PARTY native codec (EPIC #906):
+/// Serialize RDF bytes to **RDF/XML** via the FIRST-PARTY native codec:
 /// parse the input RDF bytes into the frozen IR, then emit RDF/XML through the in-repo
 /// `native_codecs::rdfxml` serializer — no longer the external purrdf-gts RDF/XML codec.
 #[pyfunction]
@@ -410,7 +410,7 @@ fn to_rdf_xml(py: Python<'_>, data: &Bound<'_, PyBytes>, format: PyRdfFormat) ->
 }
 
 /// Parse **RDF/XML** text into N-Quads bytes, via the FIRST-PARTY native codec
-/// (EPIC #906): parse RDF/XML into the frozen IR, then serialize to N-Quads — no longer
+/// parse RDF/XML into the frozen IR, then serialize to N-Quads — no longer
 /// the external purrdf-gts RDF/XML codec.
 #[pyfunction]
 fn from_rdf_xml(py: Python<'_>, text: &str) -> PyResult<Py<PyBytes>> {
@@ -545,7 +545,7 @@ fn compile_gts_native(
                 .map_err(PyValueError::new_err)?;
         }
 
-        // S3 (#820, gap G4): assemble the self-describing RdfBundle from the slice
+        // S3 (gap G4): assemble the self-describing RdfBundle from the slice
         // catalog rows, hard-fail `validate()`, and fold each ontology artifact in as
         // a content-addressed blob through the SAME channel doc_blobs ride. The base
         // graph is the bundle's hot dataset. Large external DATA blobs (graph.blobs)
@@ -577,7 +577,7 @@ fn compile_gts_native(
 }
 
 /// The `blake3:<hex>` snapshot content id of a base graph (RDF bytes), mirroring
-/// `_Builder.snapshot_content_id` for the feedback-bundle self-attestation (#654).
+/// `_Builder.snapshot_content_id` for the feedback-bundle self-attestation.
 #[pyfunction]
 #[pyo3(signature = (data, *, format))]
 fn snapshot_content_id_native(

--- a/bindings/python/src/py_gts_dataset.rs
+++ b/bindings/python/src/py_gts_dataset.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! `PyRdfDataset` — a Python handle to a frozen, immutable [`crate::RdfDataset`]
-//! (#819 C7 foundation).
+//! (C7 foundation).
 //!
 //! This pyclass wraps an `Arc<RdfDataset>` so a parsed RDF artifact can cross the
 //! FFI boundary ONCE (as bytes), be frozen into the validated IR, and then be
 //! consumed natively (count, GTS emission) WITHOUT re-serializing back to text.
-//! A later commit (#819 C7) migrates the text-exchange call sites onto this
+//! A later commit (C7) migrates the text-exchange call sites onto this
 //! handle so the producer/consumer seam stops round-tripping through N-Quads.
 //!
 //! Construction parses Turtle/N-Quads/TriG through the PyO3-free
@@ -60,7 +60,7 @@ impl PyRdfDataset {
     /// Emit a GTS byte stream for this dataset under `profile`. Uses the
     /// [`gts_write`] encoder (separate `terms`/`quads`/`reifies`/`annot` frames via
     /// `Writer::deterministic`); the folded graph is semantically identical to the
-    /// snapshot-frame producer (the SEMANTIC-FOLD gate, #819 STEP 1).
+    /// snapshot-frame producer (the SEMANTIC-FOLD gate, STEP 1).
     #[pyo3(signature = (profile="dist"))]
     fn to_gts(&self, py: Python<'_>, profile: &str) -> PyResult<Py<PyBytes>> {
         // A bare dataset carries no out-of-band envelope, so the lookaside is empty

--- a/bindings/python/src/py_slice.rs
+++ b/bindings/python/src/py_slice.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! PyO3 Python bindings for `purrdf-slice` (#820 S8).
+//! PyO3 Python bindings for `purrdf-slice` (S8).
 //!
 //! # Engine core separation
 //!
@@ -13,7 +13,7 @@
 //! # What is exposed
 //!
 //! This binding makes the native slice machinery the authoritative slice
-//! catalog/analyzer for the Python tooling (#820 S8), retiring the redundant
+//! catalog/analyzer for the Python tooling (S8), retiring the redundant
 //! Python `slice_ownership_lint` / `module_specs` plumbing:
 //!
 //! * [`PySliceCatalog`] — manifest-based discovery (`SliceCatalog::discover`),
@@ -128,7 +128,7 @@ impl PyArtifactRecord {
 
     /// The raw artifact bytes (content cache). Exposed so the GTS producer can
     /// fold each ontology artifact into the self-describing S3 bundle as a
-    /// content-addressed blob without a second disk read (#820 S3).
+    /// content-addressed blob without a second disk read (S3).
     #[getter]
     fn content<'py>(&self, py: Python<'py>) -> Bound<'py, pyo3::types::PyBytes> {
         pyo3::types::PyBytes::new(py, &self.inner.content)
@@ -234,7 +234,7 @@ impl PySliceRecord {
     }
 
     /// The on-disk slice directory this record was discovered from. Authoritative
-    /// — no scan or substring match is needed to locate the slice's files (#820 G8).
+    /// — no scan or substring match is needed to locate the slice's files (G8).
     #[getter]
     fn slice_dir(&self) -> String {
         self.slice_dir.clone()
@@ -250,7 +250,7 @@ impl PySliceRecord {
 // ── SliceCatalog ───────────────────────────────────────────────────────────────
 
 /// The native slice catalog: manifest-based discovery of every slice under a
-/// root directory, the authoritative slice machinery (#820 S8).
+/// root directory, the authoritative slice machinery (S8).
 #[pyclass(name = "SliceCatalog", module = "purrdf_slice")]
 #[derive(Debug)]
 pub struct PySliceCatalog {
@@ -305,7 +305,7 @@ impl PySliceCatalog {
 
     /// Compute the RDF-aware `purrdf:sliceDependsOn` reconciliation patches for
     /// every manifest with undeclared (add) or stale (remove) semantic edges
-    /// (#820 G8). Each result carries the manifest path, original text, and the
+    /// (G8). Each result carries the manifest path, original text, and the
     /// surgically-patched, re-parse-validated text. Hard-fails (`ValueError`) on
     /// any manifest read/parse error or post-patch validation failure — no silent
     /// skips, no wrong-manifest matching, no malformed Turtle.
@@ -410,7 +410,7 @@ impl PyDependencyEdge {
 // ── OwnershipReport ────────────────────────────────────────────────────────────
 
 /// Format one ownership diagnostic as a single error string, equivalent to the
-/// retired path-derived `slice_ownership_lint` finding (#329) but derived from
+/// retired path-derived `slice_ownership_lint` finding but derived from
 /// the term's *physical origin*, not its directory name.
 fn ownership_error_string(diag: &OwnershipDiagnostic) -> Option<String> {
     match diag {
@@ -563,7 +563,7 @@ impl PyOwnershipAnalyzer {
     }
 
     /// Emit the computed `purrdf:graph/slice-analysis` named graph as a Turtle
-    /// body string (#820 S7, gap G5).
+    /// body string (S7, gap G5).
     ///
     /// This is the production consumer of `purrdf_slice::analysis::emit_analysis_graph`:
     /// it builds the `tier_of` / `term_count_of` closures from the analyzer's own

--- a/bindings/python/src/py_sssom.rs
+++ b/bindings/python/src/py_sssom.rs
@@ -3,7 +3,7 @@
 
 //! PyO3 bindings for the native SSSOM codec — the `purrdf` SSSOM surface that
 //! replaces the `sssom` PyPI package's parse + validate behaviour on the
-//! `purrdf-dev regenerate` / mappings-generator path (#848).
+//! `purrdf-dev regenerate` / mappings-generator path.
 //!
 //! # Kernel-clean separation
 //!

--- a/bindings/python/src/py_store.rs
+++ b/bindings/python/src/py_store.rs
@@ -3,8 +3,8 @@
 
 //! Native Store / SPARQL / parse / canonicalize surface for the `purrdf` Python
 //! extension — the in-repo replacement for the external `pyoxigraph` package
-//! (#667). Backed entirely by the oxigraph-free `purrdf-core` IR + the native
-//! SPARQL engine (EPIC #906): no `oxigraph` types cross this surface.
+//!. Backed entirely by the oxigraph-free `purrdf-core` IR + the native
+//! SPARQL engine: no `oxigraph` types cross this surface.
 //!
 //! # Why this exists
 //!
@@ -21,10 +21,10 @@
 //! This module lives in the dedicated Python binding crate. The RDF kernel stays
 //! PyO3-free.
 //!
-//! # Single-responsibility layout (#835)
+//! # Single-responsibility layout
 //!
 //! This module is the thin facade over five focused submodules, split along the
-//! P2 backend-trait seams so the trait extraction (#836) is a clean lift:
+//! P2 backend-trait seams so the trait extraction is a clean lift:
 //!
 //! * [`term`] — the term object model (`NamedNode` … `Quad`, `Variable`) and the
 //!   Python ⇄ oxigraph term converters/extractors (`TermFactory` seam).

--- a/bindings/python/src/py_store/canon.rs
+++ b/bindings/python/src/py_store/canon.rs
@@ -5,8 +5,7 @@
 //! `CanonicalizationAlgorithm` pyclass and the `canonicalize_quads` wrapper.
 //!
 //! All canonicalization runs the **native full W3C RDFC-1.0** engine
-//! (`purrdf_core::ir::canon`); there is no oxigraph on this path (/ EPIC
-//! ). The `CanonicalizationAlgorithm` pyclass is retained for Python API
+//! (`purrdf_core::ir::canon`); there is no oxigraph on this path. The `CanonicalizationAlgorithm` pyclass is retained for Python API
 //! compatibility, but both variants resolve to the one native canonicalizer
 //! (greenfield: a single canonicalization algorithm).
 

--- a/bindings/python/src/py_store/canon.rs
+++ b/bindings/python/src/py_store/canon.rs
@@ -5,8 +5,8 @@
 //! `CanonicalizationAlgorithm` pyclass and the `canonicalize_quads` wrapper.
 //!
 //! All canonicalization runs the **native full W3C RDFC-1.0** engine
-//! (`purrdf_core::ir::canon`); there is no oxigraph on this path (#910 / EPIC
-//! #906). The `CanonicalizationAlgorithm` pyclass is retained for Python API
+//! (`purrdf_core::ir::canon`); there is no oxigraph on this path (/ EPIC
+//! ). The `CanonicalizationAlgorithm` pyclass is retained for Python API
 //! compatibility, but both variants resolve to the one native canonicalizer
 //! (greenfield: a single canonicalization algorithm).
 

--- a/bindings/python/src/py_store/io.rs
+++ b/bindings/python/src/py_store/io.rs
@@ -6,7 +6,7 @@
 //! pure-Rust `parse_quads` / `serialize_triples` cores plus the `read_input`
 //! helper the store seam shares.
 //!
-//! Native backing (EPIC #906): the parse/serialize cores produce and consume the
+//! Native backing: the parse/serialize cores produce and consume the
 //! oxigraph-free owned model (`RdfQuad` / `RdfTriple`) via the native codecs — no
 //! `oxigraph::model::*` and no `flat_oxigraph_quads_from_dataset` bridge.
 
@@ -46,7 +46,7 @@ pub(crate) enum PyRdfFormat {
 }
 
 impl PyRdfFormat {
-    /// The native codec format selector (#909): the always-on replacement for the
+    /// The native codec format selector: the always-on replacement for the
     /// oxigraph `RdfFormat` router on the parse/serialize path.
     pub(crate) fn to_native(self) -> NativeRdfFormat {
         match self {
@@ -114,7 +114,7 @@ pub(crate) fn serialize(
 
 // ── Pure-Rust cores (unit-tested without a Python interpreter) ───────────────────
 
-/// Parse RDF bytes into owned quads via the native codec (#909) with no blank-node
+/// Parse RDF bytes into owned quads via the native codec with no blank-node
 /// renaming. Routes through [`parse_dataset`](crate::parse_dataset) → IR → the flat
 /// quad un-fold ([`flat_rdf_quads_from_dataset`]) so the `rdf:reifies` / annotation
 /// rows of the RDF 1.2 statement layer reappear in the quad stream exactly as a flat
@@ -143,7 +143,7 @@ pub(crate) fn serialize_triples(
 
 /// Freeze a flat native quad list into the IR verbatim — RDF 1.2 triple-term objects
 /// preserved as triple-term objects (no statement-layer fold), named graphs kept —
-/// for native serialization (#909). Shared by the `Store`/`MutableDataset` dump
+/// for native serialization. Shared by the `Store`/`MutableDataset` dump
 /// paths.
 pub(super) fn dataset_from_quads_verbatim(quads: &[RdfQuad]) -> Result<Arc<RdfDataset>, String> {
     flat_dataset_from_quads(quads)
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn parse_quads_accepts_private_language_tag_in_turtle_and_ntriples() {
-        // #909: the project's `@x-purrdf-*` private-use tags exceed BCP-47's 8-char
+        // the project's `@x-purrdf-*` private-use tags exceed BCP-47's 8-char
         // subtag limit (`afrikaans` is 9 chars). purrdf-gts runs its Turtle / N-Triples
         // codecs in `lenient` mode — matching the prior oxigraph `RdfParser::lenient()`
         // path — so these tags parse in EVERY format, not just N-Quads.

--- a/bindings/python/src/py_store/mutable.rs
+++ b/bindings/python/src/py_store/mutable.rs
@@ -5,7 +5,7 @@
 //!
 //! The canonical mutation semantics live in `purrdf-core::MutableDataset`.
 //! This adapter keeps Python on that COW surface; query / update run on the native
-//! `NativeSparqlEngine` over a frozen snapshot (EPIC #906 — no oxigraph).
+//! `NativeSparqlEngine` over a frozen snapshot ( — no oxigraph).
 
 use purrdf_core::ir::{MutableDataset, QuadValues};
 use pyo3::exceptions::{PyTypeError, PyValueError};
@@ -139,7 +139,7 @@ impl PyMutableDataset {
         let explicit_from_graph = from_graph.is_some();
         let inner = &self.inner;
         // Materialize the effective set into the IR verbatim, then serialize through
-        // the native codec (#909) — literal lexical forms are preserved. Both steps
+        // the native codec — literal lexical forms are preserved. Both steps
         // run detached (GIL released).
         let buf: Vec<u8> = py.detach(|| {
             let quads: Vec<RdfQuad> = inner

--- a/bindings/python/src/py_store/query.rs
+++ b/bindings/python/src/py_store/query.rs
@@ -6,7 +6,7 @@
 //! `QueryBoolean` (ASK) pyclasses, plus the `materialize_results` adapter the
 //! store seam uses to turn a native [`SparqlResult`] into these objects.
 //!
-//! Native backing (EPIC #906): solution cells are `purrdf_core::TermValue`,
+//! Native backing: solution cells are `purrdf_core::TermValue`,
 //! CONSTRUCT triples are `RdfTriple`. The engine is `NativeSparqlEngine`; the
 //! oxigraph `QueryResults` type is gone from this surface.
 

--- a/bindings/python/src/py_store/store.rs
+++ b/bindings/python/src/py_store/store.rs
@@ -5,7 +5,7 @@
 //! SPARQL-capable `Store`, the canonicalization-capable `Dataset`, and the
 //! `QuadIter` snapshot iterator they share.
 //!
-//! # Native backing (EPIC #906)
+//! # Native backing
 //!
 //! `Store` wraps a copy-on-write [`MutableDataset`] over the oxigraph-free
 //! `purrdf-core` IR — never `oxigraph::store::Store`. Mutation (`add` / `remove`
@@ -64,7 +64,7 @@ impl PyStore {
     ) -> PyResult<()> {
         let format = format.ok_or_else(|| PyValueError::new_err("load: format is required"))?;
         let data = read_input(input, path)?;
-        // Parse natively (#909) into the flat quad stream, then insert into the COW set.
+        // Parse natively into the flat quad stream, then insert into the COW set.
         //
         // Blank-node labels in a serialized document are document-local: two distinct
         // documents may reuse the same label (`_:b0`) for *different* nodes, and the same
@@ -217,7 +217,7 @@ impl PyStore {
                 Some(extract_graph_name(from_graph)?)
             };
         let buf: Vec<u8> = py.detach(|| {
-            // Serialize natively (#909): materialize the store's quads into the IR
+            // Serialize natively: materialize the store's quads into the IR
             // verbatim (preserving literal lexical forms) and dispatch to the codec.
             let (quads, selection) = match &graph_projection {
                 None => (self.collect_all_quads(), SerializeGraph::Dataset),
@@ -610,7 +610,7 @@ mod tests {
 
     #[test]
     fn same_label_different_scopes_yields_distinct_nodes() {
-        // The regression guard (#909): the SAME document-local blank label loaded
+        // The regression guard: the SAME document-local blank label loaded
         // under two different scopes (two `Store::load` calls) MUST become two
         // distinct nodes once surfaced.
         let quad = RdfQuad::new(RdfTerm::blank_node("b0"), "https://e/p", iri("https://e/o"));
@@ -664,7 +664,7 @@ mod tests {
         assert_eq!(lit.datatype, None, "plain literal stays datatype-less");
     }
 
-    // ── capsule boundary (EPIC #906) ─────────────────────────────────────────────
+    // ── capsule boundary ─────────────────────────────────────────────
     //
     // These tests pin the `_store_capsule` contract WITHOUT a Python interpreter:
     // they exercise the same snapshot → `Box<Arc<RdfDataset>>` → raw-address →

--- a/bindings/python/src/py_store/term.rs
+++ b/bindings/python/src/py_store/term.rs
@@ -556,7 +556,7 @@ pub(super) fn quad_to_py(py: Python<'_>, quad: &RdfQuad) -> PyResult<Py<PyAny>> 
 
 /// Build the live `purrdf.Quad` list for every (flattened) quad of a native
 /// [`RdfDataset`](crate::RdfDataset) — the oxigraph-free cross-crate entry point for
-/// engine crates (`purrdf-logic`'s RL closure, / ) that produce a
+/// engine crates (e.g. `purrdf-logic`'s RL closure) that produce a
 /// frozen IR dataset and must hand Python live quad objects without naming any
 /// oxigraph type themselves.
 ///

--- a/bindings/python/src/py_store/term.rs
+++ b/bindings/python/src/py_store/term.rs
@@ -6,7 +6,7 @@
 //! `Variable` pyclasses, plus the Python ⇄ native-IR term converters and
 //! extractors the store, query, and io seams share.
 //!
-//! # Native backing (EPIC #906)
+//! # Native backing
 //!
 //! Every pyclass is backed by the oxigraph-free `purrdf_core` owned model
 //! (`RdfTerm` / `RdfLiteral` / `RdfTriple` / `RdfQuad`) plus `String` for IRI
@@ -538,7 +538,7 @@ fn quad_key(quad: &RdfQuad) -> String {
 /// Build a Python `Quad` object from a native [`RdfQuad`].
 ///
 /// Cross-crate constructor for the engine crates that produce quads natively (the
-/// RL closure in `purrdf-logic`, issue #630): they assemble a native `RdfQuad` and
+/// RL closure in `purrdf-logic`): they assemble a native `RdfQuad` and
 /// hand Python a live `purrdf.Quad` directly, so the closure result never makes
 /// a round-trip through an intermediate N-Triples string the Python side has to
 /// re-parse. The returned object is the same `PyQuad` the parser/SPARQL surface
@@ -556,7 +556,7 @@ pub(super) fn quad_to_py(py: Python<'_>, quad: &RdfQuad) -> PyResult<Py<PyAny>> 
 
 /// Build the live `purrdf.Quad` list for every (flattened) quad of a native
 /// [`RdfDataset`](crate::RdfDataset) — the oxigraph-free cross-crate entry point for
-/// engine crates (`purrdf-logic`'s RL closure, #630 / EPIC #906) that produce a
+/// engine crates (`purrdf-logic`'s RL closure, / ) that produce a
 /// frozen IR dataset and must hand Python live quad objects without naming any
 /// oxigraph type themselves.
 ///

--- a/bindings/python/src/rdf.rs
+++ b/bindings/python/src/rdf.rs
@@ -33,7 +33,7 @@ fn normalize_rdf12_to_owl(py: Python<'_>, rdf12_ttl: &str) -> PyResult<String> {
         .map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
-/// The machine-readable RDF↔GTS loss matrix as deterministic JSON (#819 C0).
+/// The machine-readable RDF↔GTS loss matrix as deterministic JSON (C0).
 ///
 /// Mirrors the committed `generated/rdf-loss-matrix.json` artifact so Python
 /// consumers read the same enumerated, intentional conversion losses the Rust
@@ -43,7 +43,7 @@ fn loss_matrix_json() -> String {
     loss::loss_matrix_json()
 }
 
-/// Canonical, review-friendly Turtle serialization over the purrdf IR (#819
+/// Canonical, review-friendly Turtle serialization over the purrdf IR (
 /// Task 9) — the native replacement for rdflib `longturtle` in `purrdf normalize`.
 ///
 /// `extra_prefixes` is the project's standard prefix set; only prefixes the
@@ -64,7 +64,7 @@ fn canonicalize_turtle(
 
 /// Register the `purrdf` surface on a Python module.
 ///
-/// Called by the unified `purrdf_native` cdylib (#630) to populate the
+/// Called by the unified `purrdf_native` cdylib to populate the
 /// `purrdf_native.rdf` submodule; the legacy `import purrdf` name resolves to
 /// that same submodule object via a Python shim.
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -73,15 +73,15 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(loss_matrix_json, m)?)?;
     m.add_function(wrap_pyfunction!(canonicalize_turtle, m)?)?;
     // The native oxigraph Store / SPARQL / parse / canonicalize surface that
-    // replaces the external `pyoxigraph` package (#667).
+    // replaces the external `pyoxigraph` package.
     crate::py_store::register(m)?;
     // The native RDF → GTS producer surface (snapshot author + compile_gts) and
-    // the `PyRdfDataset` Arc handle (#819 Task 8 / C7).
+    // the `PyRdfDataset` Arc handle (Task 8 / C7).
     crate::py_gts::register(m)?;
     // The native GTS fold-view and database export surface.
     crate::py_gts_view::register(m)?;
     // The native SSSOM codec surface (parse + validate + RDF serialize) that
-    // replaces the external `sssom` package on the mapping-compile path (#848).
+    // replaces the external `sssom` package on the mapping-compile path.
     crate::py_sssom::register(m)?;
     Ok(())
 }

--- a/bindings/python/src/shacl.rs
+++ b/bindings/python/src/shacl.rs
@@ -119,7 +119,7 @@ impl PyShapes {
 
     /// Validate an N-Triples data graph against these parsed shapes.
     fn validate_nt(&self, py: Python<'_>, data_nt: &str) -> PyResult<PyValidationReport> {
-        // Native codec ingest (#909): lenient on private-use language tags, every
+        // Native codec ingest: lenient on private-use language tags, every
         // malformed line reported in one pass. The engine runs over the frozen IR.
         // Both the ingest and the validation run detached (GIL released).
         let shapes = &self.inner;
@@ -137,7 +137,7 @@ impl PyShapes {
     /// `data` must be an object (typically `purrdf_validate.ValidationStore`) that
     /// exposes an internal `_store_capsule()` method returning a capsule borrowing a
     /// frozen `Arc<RdfDataset>` snapshot. This avoids serialising the store to
-    /// N-Triples for each validation phase (#634).
+    /// N-Triples for each validation phase.
     ///
     /// # Errors
     ///
@@ -239,7 +239,7 @@ impl PyValidationReport {
 ///
 /// Exposes the legacy `validate(shapes_ttl, data_nt)` function and the reusable
 /// `Shapes` / `ValidationReport` wrappers used by the Rust-native orchestration
-/// in `purrdf-validate`. Called by the unified `purrdf_native` cdylib (#630) to
+/// in `purrdf-validate`. Called by the unified `purrdf_native` cdylib to
 /// populate the `purrdf_native.shacl` submodule.
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(validate, m)?)?;

--- a/crates/gts/src/lib.rs
+++ b/crates/gts/src/lib.rs
@@ -17,7 +17,7 @@
 pub mod codec;
 pub mod compact;
 pub mod cose;
-// emojihash + randomart now live in the standalone `visual-hashing` crate (#16);
+// emojihash + randomart now live in the standalone `visual-hashing` crate;
 // re-exported here so `purrdf_gts::emojihash::…` paths keep resolving.
 pub use visual_hashing as emojihash;
 pub mod examples;

--- a/crates/iri/src/lib.rs
+++ b/crates/iri/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! A pure-Rust, **zero-runtime-dependency**, wasm-clean leaf crate: the drop-in
 //! replacement for the oxigraph-family `oxiri`, and the second foundation slice of
-//! the native SPARQL engine (purrdf S2, EPIC #906). It is deliberately decoupled
+//! the native SPARQL engine (purrdf S2). It is deliberately decoupled
 //! from `purrdf-core` (no dependency in either direction yet); the IR keeps
 //! IRIs **lexical-verbatim** (Constitution C0.1) and this crate is the
 //! validation/resolution layer beside it.

--- a/crates/rdf-capi/README.md
+++ b/crates/rdf-capi/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 
 # `purrdf-capi` — libpurrdf
 
-The **purrdf semantic C-ABI** (purrdf parcel P8, issue #842): a stable,
+The **purrdf semantic C-ABI** (purrdf parcel P8): a stable,
 SemVer-disciplined `extern "C"` surface over the native `purrdf` RDF-1.2
 stack. It is the rich companion to the permissive `libgts` C-ABI — where
 `libgts` is transport/format only, **libpurrdf** exposes parse, serialize,

--- a/crates/rdf-capi/src/gts.rs
+++ b/crates/rdf-capi/src/gts.rs
@@ -11,7 +11,7 @@
 //! GTS is a lossless container: both the plain-graph data AND the full RDF-1.2
 //! statement layer (quoted triples + reifier bindings) survive the round-trip.
 //! The earlier `gts-missing-reifier-binding` gap was closed by the native
-//! text-codec work (#909); see [`purrdf_from_gts`].
+//! text-codec work; see [`purrdf_from_gts`].
 
 use std::os::raw::c_char;
 
@@ -32,7 +32,7 @@ use crate::status::PurrdfStatus;
 /// **Lossless**, including the RDF-1.2 statement layer: a reifier-bound quoted
 /// triple written by `to_gts` is read back intact via the canonical fold-back
 /// (`read_graph` → `import_gts_graph`). The earlier `gts-missing-reifier-binding`
-/// gap was closed by the native text-codec work (#909).
+/// gap was closed by the native text-codec work.
 ///
 /// # Safety
 /// `bytes` must be valid for `len` bytes; the out-params must be writable.

--- a/crates/rdf-capi/src/lib.rs
+++ b/crates/rdf-capi/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! # libpurrdf — the PurRDF purrdf semantic RDF-1.2 C-ABI (purrdf P8, #842)
+//! # libpurrdf — the PurRDF purrdf semantic RDF-1.2 C-ABI (purrdf P8)
 //!
 //! A stable, SemVer-disciplined `extern "C"` surface over the native
 //! `purrdf` semantic stack. It is the rich companion to the permissive

--- a/crates/rdf-capi/src/query.rs
+++ b/crates/rdf-capi/src/query.rs
@@ -39,7 +39,7 @@ unsafe fn run_query(
         let base_iri = opt_cstr_to_str(base_iri)?;
         // Evaluate over the frozen `Arc<RdfDataset>` directly via the native engine —
         // no oxigraph `Store` round-trip. `NativeSparqlEngine::query` is the single
-        // `SparqlEngine` impl (#887/#912); its `Dataset` IS the `Arc<RdfDataset>` the
+        // `SparqlEngine` impl (/); its `Dataset` IS the `Arc<RdfDataset>` the
         // handle already owns.
         engine()
             .query(

--- a/crates/rdf-capi/src/query.rs
+++ b/crates/rdf-capi/src/query.rs
@@ -39,7 +39,7 @@ unsafe fn run_query(
         let base_iri = opt_cstr_to_str(base_iri)?;
         // Evaluate over the frozen `Arc<RdfDataset>` directly via the native engine —
         // no oxigraph `Store` round-trip. `NativeSparqlEngine::query` is the single
-        // `SparqlEngine` impl (/); its `Dataset` IS the `Arc<RdfDataset>` the
+        // `SparqlEngine` impl; its `Dataset` IS the `Arc<RdfDataset>` the
         // handle already owns.
         engine()
             .query(

--- a/crates/rdf-capi/tests/abi.rs
+++ b/crates/rdf-capi/tests/abi.rs
@@ -792,8 +792,8 @@ fn gts_round_trips_a_plain_graph() {
 /// The C-ABI's `purrdf_to_gts` → `purrdf_from_gts` round-trip preserves the
 /// RDF-1.2 star layer (quoted triples + reifier bindings) losslessly. The C-ABI
 /// calls the canonical kernel path (`to_gts` → `read_graph` → `import_gts_graph`);
-/// the earlier `gts-missing-reifier-binding` gap (formerly tracked in #1032) was
-/// closed by the native text-codec work (#909), so a reifier-bound quoted triple
+/// the earlier `gts-missing-reifier-binding` gap (formerly tracked in) was
+/// closed by the native text-codec work, so a reifier-bound quoted triple
 /// now survives intact rather than failing with a `GtsError`.
 #[test]
 fn gts_star_roundtrip_preserves_the_statement_layer() {

--- a/crates/rdf-core/README.md
+++ b/crates/rdf-core/README.md
@@ -8,7 +8,7 @@ workspace. It owns the shared RDF model, RDF diagnostics, the interned IR
 (`TermId`/`RdfDataset`), store traits, `DatasetView`, and the oxigraph-free GTS
 readers.
 
-This crate is the **strong ring-fence** of the purrdf plan (#885, P2b): it has
+This crate is the **strong ring-fence** of the purrdf plan (P2b): it has
 **no oxigraph dependency at all**, so an accidental `use oxigraph` here is a
 compile error rather than a lint miss. The oxigraph adapter lives in the sibling
 `purrdf` crate, which depends on and re-exports this kernel. The invariant is

--- a/crates/rdf-core/benches/ir_layout.rs
+++ b/crates/rdf-core/benches/ir_layout.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Layout / IR benchmark for the value-interned `RdfDataset` (#819 C1, Task 7).
+//! Layout / IR benchmark for the value-interned `RdfDataset` (C1, Task 7).
 //!
-//! The #819 RFC removes "columnar" and "zero-copy" as *asserted* commitments and
+//! The RFC removes "columnar" and "zero-copy" as *asserted* commitments and
 //! replaces them with a measurable gate: *"Layout is chosen by benchmark, not
 //! asserted"* and *"Benchmarks report total allocated bytes, allocation count, peak
 //! memory, index-build cost, and end-to-end latency — not only quads/sec."* This
@@ -454,7 +454,7 @@ fn bench_resolve(c: &mut Criterion) {
     group.finish();
 }
 
-/// P4b (#891) indexed `quads_for_pattern` vs the linear scan, on WARM permutation
+/// P4b indexed `quads_for_pattern` vs the linear scan, on WARM permutation
 /// indexes. Each `(s|p|o)`-bound shape exercises a different permutation (SPOG / POS /
 /// OSP); the scan baseline is the same id-equality filter the trait default runs.
 fn bench_pattern_warm(c: &mut Criterion) {

--- a/crates/rdf-core/benches/mutable.rs
+++ b/crates/rdf-core/benches/mutable.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The copy-on-write `MutableDataset` measured hypothesis (purrdf P5, #839).
+//! The copy-on-write `MutableDataset` measured hypothesis (purrdf P5).
 //!
 //! The PLAN frames COW as *"a measured hypothesis, not an assumed win — benchmark it
 //! against a simpler hash-indexed mutable store before committing"*. This harness is

--- a/crates/rdf-core/src/backend.rs
+++ b/crates/rdf-core/src/backend.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Narrow purrdf backend traits (P2d, #887).
+//! Narrow purrdf backend traits (P2d).
 //!
 //! These are the dependency-inversion seams that remain after `DatasetView`
-//! (#836), the oxigraph crate ring-fence (#885), and `DatasetMut` (#839): term
+//! the oxigraph crate ring-fence, and `DatasetMut`: term
 //! interning, parser ingress, SPARQL execution, and serializer egress. They live in
 //! `purrdf-core` so consumers can depend on the contract without depending on
 //! oxigraph. Concrete oxigraph adapters live in the sibling `purrdf` crate.
@@ -103,7 +103,7 @@ pub trait RdfParserBackend {
 
 /// SPARQL operation request.
 ///
-/// `substitutions` carries variable **pre-bindings** (purrdf S5, EPIC #906 GAP-A):
+/// `substitutions` carries variable **pre-bindings** (purrdf S5,  GAP-A):
 /// each `(name, value)` pre-binds the query variable `name` to `value` before
 /// evaluation, as if the `WHERE` had been joined with a single-row
 /// `VALUES { ?name value }`. This is the native replacement for oxigraph's

--- a/crates/rdf-core/src/bundle.rs
+++ b/crates/rdf-core/src/bundle.rs
@@ -1,15 +1,15 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The self-describing bundle resource layer (#820 S3).
+//! The self-describing bundle resource layer (S3).
 //!
 //! [`RdfBundle`] is the kernel-generic, repo-free package that carries
 //! *everything* needed to recover a compilation product without a filesystem:
 //!
 //! ```text
 //! RdfBundle
-//! ├── dataset:    RdfDataset          // #819 — the hot graph
-//! ├── provenance: DatasetProvenance   // #820 S2 — units / occurrences / origins
+//! ├── dataset:    RdfDataset          // — the hot graph
+//! ├── provenance: DatasetProvenance   // S2 — units / occurrences / origins
 //! ├── units:      UnitCatalog         // UnitId -> metadata
 //! ├── artifacts:  ArtifactIndex       // ArtifactId -> ArtifactRecord (no bytes)
 //! └── blobs:      ContentStore        // the actual bytes, content-addressed
@@ -374,7 +374,7 @@ impl From<ContentStoreError> for BundleError {
 #[derive(Debug)]
 pub struct RdfBundle {
     /// The immutable, value-interned RDF 1.2 dataset — the hot graph. Shared
-    /// via `Arc` because `RdfDataset` is a frozen, non-clonable value (#819 C1).
+    /// via `Arc` because `RdfDataset` is a frozen, non-clonable value (C1).
     pub dataset: Arc<RdfDataset>,
     /// Generic provenance sidecar (units / occurrences / origin sets).
     pub provenance: DatasetProvenance,

--- a/crates/rdf-core/src/content_store.rs
+++ b/crates/rdf-core/src/content_store.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Content-addressed blob store for the self-describing bundle (#820 S3).
+//! Content-addressed blob store for the self-describing bundle (S3).
 //!
 //! [`ContentStore`] is the **one** place bytes live. The RDF IR, the
 //! [`ArtifactRecord`](crate::bundle::ArtifactRecord), and every quad hold a

--- a/crates/rdf-core/src/dataset_view.rs
+++ b/crates/rdf-core/src/dataset_view.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! The static, allocation-free **read view** over an RDF dataset (purrdf P2,
-//! #836). See [`docs/design/purrdf-backend-contract.md`](../../../docs/design/purrdf-backend-contract.md).
+//! ). See [`docs/design/purrdf-backend-contract.md`](../../../docs/design/purrdf-backend-contract.md).
 //!
 //! [`DatasetView`] is the id-based, borrowed read interface: it yields `Copy`
 //! [`QuadIds`] and borrowed [`QuadRef`]s (no per-quad allocation, no term-string clones), and offers
 //! [`DatasetView::quads_for_pattern`] keyed on dataset-local [`TermId`]s plus a
 //! [`GraphMatch`]. The default `quads_for_pattern` is a linear scan; backends with
-//! access-pattern indexes (P4, #838) override it.
+//! access-pattern indexes (P4) override it.
 //!
 //! This is the **static** trait layer (generic `impl DatasetView`, RPITIT — not
 //! object-safe). Per the backend contract (C1), backend selection is compile-time
@@ -95,7 +95,7 @@ pub trait DatasetView: sealed::Sealed {
     /// Quads matching an optional `(s, p, o)` id pattern and a [`GraphMatch`].
     ///
     /// The default is an id-equality linear scan (no string resolution); backends
-    /// with access-pattern indexes (P4, #838) override this with an indexed lookup.
+    /// with access-pattern indexes (P4) override this with an indexed lookup.
     /// Callers resolve term *values* to ids first (`term_id_by_value`, P4).
     fn quads_for_pattern(
         &self,
@@ -124,7 +124,7 @@ pub trait DatasetView: sealed::Sealed {
 }
 
 /// The **write companion** to [`DatasetView`] — the mutation surface a copy-on-write
-/// or backed-by-store dataset exposes (purrdf P5, #839; backend contract C4).
+/// or backed-by-store dataset exposes (purrdf P5,; backend contract C4).
 ///
 /// Where [`DatasetView`] reads in dataset-local [`TermId`]s, `DatasetMut` mutates by
 /// **value**: its [`Quad`](DatasetMut::Quad) associated type is an owned, dataset-
@@ -170,7 +170,7 @@ pub trait DatasetMut: sealed::Sealed {
     ) -> Vec<Self::Quad>;
 }
 
-/// The production read view: the immutable value-interned [`RdfDataset`] (#819 C1).
+/// The production read view: the immutable value-interned [`RdfDataset`] (C1).
 impl DatasetView for RdfDataset {
     #[inline]
     fn quads(&self) -> impl Iterator<Item = QuadIds> + '_ {
@@ -197,7 +197,7 @@ impl DatasetView for RdfDataset {
         o: Option<TermId>,
         g: GraphMatch,
     ) -> impl Iterator<Item = QuadIds> + '_ {
-        // Indexed override (P4b, #891): lazy permutation indexes + a bound-set ->
+        // Indexed override (P4b): lazy permutation indexes + a bound-set ->
         // permutation -> partition_point dispatch, byte-identical to the trait's
         // default linear scan (differential proptest in `ir/dataset.rs`).
         Self::quads_for_pattern_indexed(self, s, p, o, g)

--- a/crates/rdf-core/src/dataset_view.rs
+++ b/crates/rdf-core/src/dataset_view.rs
@@ -124,7 +124,7 @@ pub trait DatasetView: sealed::Sealed {
 }
 
 /// The **write companion** to [`DatasetView`] — the mutation surface a copy-on-write
-/// or backed-by-store dataset exposes (purrdf P5,; backend contract C4).
+/// or backed-by-store dataset exposes (purrdf P5; backend contract C4).
 ///
 /// Where [`DatasetView`] reads in dataset-local [`TermId`]s, `DatasetMut` mutates by
 /// **value**: its [`Quad`](DatasetMut::Quad) associated type is an owned, dataset-

--- a/crates/rdf-core/src/diagnostic.rs
+++ b/crates/rdf-core/src/diagnostic.rs
@@ -59,7 +59,7 @@ impl RdfLocation {
     /// A source-file (physical) location, by repo-relative path. Pair with
     /// [`with_line`](Self::with_line)/[`with_column`](Self::with_column) for a
     /// sub-file position. This is the file-level anchor that threads into a SARIF
-    /// `physicalLocation` (#819 Task 12).
+    /// `physicalLocation` (Task 12).
     pub fn file(path: impl Into<String>) -> Self {
         Self {
             path: Some(path.into()),

--- a/crates/rdf-core/src/fno.rs
+++ b/crates/rdf-core/src/fno.rs
@@ -3,7 +3,7 @@
 
 //! Native FnO (W3C Function Ontology) typed model + serializer.
 //!
-//! This is the PyO3-free Rust FnO model and serializer (#848). It carries a single,
+//! This is the PyO3-free Rust FnO model and serializer. It carries a single,
 //! fully-resolved **catalog** of the PurRDF projection-function surface
 //! (`generated/projections/functions.fno.ttl`) into an owned RDF quad set and
 //! serializes it to N-Triples text.

--- a/crates/rdf-core/src/ir/builder.rs
+++ b/crates/rdf-core/src/ir/builder.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! The fallible `RdfDataset` builder: value-interning plus the quad / reifier /
-//! annotation / source-location tables, and the validate-then-freeze path (#819 C1).
+//! annotation / source-location tables, and the validate-then-freeze path (C1).
 //!
 //! This module owns term storage and value-interning. The C0 literal-identity
 //! policy (datatype expansion, language lowercasing, direction-in-key, verbatim
@@ -44,7 +44,7 @@ fn hash_of<T: Hash>(value: &T) -> u64 {
     hasher.finish()
 }
 
-/// **Store-once** insert-or-find (#880 P3c): `vec` is the sole owner of the values;
+/// **Store-once** insert-or-find (P3c): `vec` is the sole owner of the values;
 /// `table` holds only their `u32` indices, with hash/eq that look INTO `vec`. Returns
 /// the index of the (existing or newly pushed) value. No value is ever stored twice.
 ///
@@ -61,7 +61,7 @@ fn store_once<T: Hash + Eq>(vec: &mut Vec<T>, table: &mut HashTable<u32>, value:
     i
 }
 
-/// A borrowed term lookup key (#879 P3b): carries the string components by reference
+/// A borrowed term lookup key (P3b): carries the string components by reference
 /// so the interner can dedup BY VALUE *before* anything is pushed to the arena.
 /// Mirrors [`InternedTerm`] but with `&str` where the stored form holds a `StrRange`.
 #[derive(Clone, Copy)]
@@ -188,7 +188,7 @@ fn term_eq(arena: &[u8], term: &InternedTerm, lookup: &TermLookup<'_>) -> bool {
 /// unit (SRP). Private: the builder is the only public surface.
 #[derive(Debug)]
 struct Interner {
-    /// The byte arena owning every interned string ONCE (#879 P3b); terms hold ranges.
+    /// The byte arena owning every interned string ONCE (P3b); terms hold ranges.
     arena: Vec<u8>,
     /// Dense table of interned terms (range-backed); the sole structural owner.
     terms: Vec<InternedTerm>,
@@ -359,7 +359,7 @@ pub struct RdfDatasetBuilder {
     /// Owns terms + the value-intern index + the C0 identity policy.
     interner: Interner,
     /// Deduplicated quad rows in first-seen order; `g == None` is the default graph.
-    /// The **sole** owner of each row; `quad_index` holds only indices (#880 P3c).
+    /// The **sole** owner of each row; `quad_index` holds only indices (P3c).
     quads: Vec<QuadRow>,
     /// Store-once dedup index into `quads` (replaces the duplicate `HashSet<QuadRow>`).
     quad_index: HashTable<u32>,
@@ -716,7 +716,7 @@ impl RdfDatasetBuilder {
     }
 
     /// Resolve a term's [`StrRange`] to a `&str` borrowed from the builder's arena
-    /// (for build-time readers that have an interned term's range, #879).
+    /// (for build-time readers that have an interned term's range).
     pub(crate) fn interned_str(&self, range: StrRange) -> &str {
         arena_str(self.interner.arena(), range)
     }

--- a/crates/rdf-core/src/ir/bundle.rs
+++ b/crates/rdf-core/src/ir/bundle.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! The `GtsBundle` — the frozen hot graph paired with its out-of-band envelope
-//! (#819 C2).
+//! (C2).
 //!
 //! An [`RdfDataset`] is the immutable, value-interned RDF 1.2 graph: the *hot*
 //! triple/quad surface every consumer reasons over. Material that travels *with*
@@ -10,7 +10,7 @@
 //! suppression overlays, opaque nodes, signatures — lives in the [`RdfEnvelope`],
 //! keyed through the crate's existing [`RdfLookaside`] (`store.rs`).
 //!
-//! Both [`GtsBundle`] and [`RdfEnvelope`] are `#[non_exhaustive]`: #820 extends the
+//! Both [`GtsBundle`] and [`RdfEnvelope`] are `#[non_exhaustive]`: extends the
 //! envelope additively with provenance / units / artifacts / blob fields, and a
 //! `#[non_exhaustive]` struct lets those land without a breaking change. Consumers
 //! therefore construct these only through the provided constructors.
@@ -43,7 +43,7 @@ impl GtsBundle {
 /// Out-of-band material that travels with an [`RdfDataset`] but is not part of the
 /// hot graph (C0.6).
 ///
-/// `#[non_exhaustive]` because #820 grows this envelope additively (provenance,
+/// `#[non_exhaustive]` because grows this envelope additively (provenance,
 /// units, artifacts, decoded blobs); construct it via [`RdfEnvelope::new`] or
 /// [`RdfEnvelope::default`].
 #[non_exhaustive]

--- a/crates/rdf-core/src/ir/canon.rs
+++ b/crates/rdf-core/src/ir/canon.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Native **full W3C RDFC-1.0** RDF Dataset Canonicalization (#910), oxigraph-free.
+//! Native **full W3C RDFC-1.0** RDF Dataset Canonicalization, oxigraph-free.
 //!
 //! This module is the canonicalization authority for the purrdf family. It
-//! replaces `oxrdf`'s `Dataset::canonicalize` (EPIC #906 oxigraph eviction) and
+//! replaces `oxrdf`'s `Dataset::canonicalize` ( oxigraph eviction) and
 //! supersedes the simplified FNV signature comparator that `compare.rs` used to
 //! carry: it implements the real algorithm — *Hash First Degree Quads* (§4.6),
 //! initial canonical assignment (§4.4), and *Hash N-Degree Quads* (§4.8) with
@@ -34,7 +34,7 @@
 //!
 //! Because the sentinels are disjoint from genuine quads, the **reifier COUNT**
 //! and **annotation presence** stay observable in the canonical form — preserving
-//! the #819 lossless identity contract (two datasets differing only in reifier
+//! the lossless identity contract (two datasets differing only in reifier
 //! count or an annotation compare UNEQUAL). RDFC-1.0 canonicalizes blank labels
 //! **only**: literal lexical forms, datatypes, language tags and base directions
 //! are emitted verbatim (`0.70` ≠ `0.7`, `@en--ltr` ≠ `@en--rtl`).
@@ -1123,7 +1123,7 @@ mod tests {
         assert_ne!(canon(&build("o1")), canon(&build("o2")));
     }
 
-    /// Reifier COUNT is observable in the canonical form (the #819 headline gate).
+    /// Reifier COUNT is observable in the canonical form (the headline gate).
     #[test]
     fn reifier_count_shows_in_canon() {
         let build = |reifiers: &[&str]| -> Arc<RdfDataset> {

--- a/crates/rdf-core/src/ir/compare.rs
+++ b/crates/rdf-core/src/ir/compare.rs
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The `RdfDataset`-direct structural comparator (#819 C1/C2): the equality oracle
+//! The `RdfDataset`-direct structural comparator (C1/C2): the equality oracle
 //! for importer equivalence and downstream tests.
 //!
 //! [`datasets_isomorphic`] decides whether two frozen datasets are
 //! **RDF-structurally isomorphic**: the same quads (under a blank-node bijection),
 //! the same reifier bindings, and the same annotations. It operates **directly on
 //! [`RdfDataset`]** and **NEVER consults oxigraph**. That is deliberate and is the
-//! acceptance gate of #819 (design doc *Appendix C0*, point 4): oxigraph
+//! acceptance gate of (design doc *Appendix C0*, point 4): oxigraph
 //! canonicalizes typed-literal lexical forms (`0.70` → `0.7`, `+00:00` → `Z`) and
 //! drops the reifier/annotation overlay entirely — so two datasets that differ only
 //! in lexical spelling or in reifier COUNT would compare *equal* through oxigraph,
@@ -34,7 +34,7 @@
 //! ([`super::canon::canonicalize`]): two datasets are isomorphic **iff** their
 //! canonical N-Quads strings are byte-equal. RDFC-1.0 resolves blank-node
 //! automorphisms via hash-partition + permutation backtracking, so — unlike the
-//! simplified FNV signature refinement this comparator used to carry (#910) — the
+//! simplified FNV signature refinement this comparator used to carry — the
 //! oracle is **exact**: never a false positive *and* never a false negative, even on
 //! pathologically symmetric blank graphs. The canonicalizer folds the RDF-1.2
 //! reifier/annotation overlay and triple terms into the canonical form, so reifier
@@ -49,7 +49,7 @@ use super::dataset::RdfDataset;
 ///
 /// Backed by full RDFC-1.0 canonicalization, this is an **exact** oracle: it never
 /// reports a false positive *or* a false negative (the simplified comparator's
-/// pathological-symmetry false negative is gone, #910).
+/// pathological-symmetry false negative is gone).
 pub fn datasets_isomorphic(a: &RdfDataset, b: &RdfDataset) -> bool {
     // Cheap structural rejections that do not depend on blank labeling — they avoid
     // running the (poison-guarded) canonicalizer on obviously-different inputs.

--- a/crates/rdf-core/src/ir/dataset.rs
+++ b/crates/rdf-core/src/ir/dataset.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! The frozen, immutable `RdfDataset` and its infallible, zero-allocation
-//! iteration surface (#819 C1).
+//! iteration surface (C1).
 //!
 //! A `RdfDataset` is produced only by
 //! [`RdfDatasetBuilder::freeze`](super::builder::RdfDatasetBuilder::freeze)
@@ -89,7 +89,7 @@ pub(crate) struct QuadRow {
     pub g: Option<TermId>,
 }
 
-// #837 P3a: with the `NonZeroU32` `TermId` niche, the `g: Option<TermId>` slot
+//  P3a: with the `NonZeroU32` `TermId` niche, the `g: Option<TermId>` slot
 // costs no discriminant word, so a quad row is 16 bytes (3×4 ids + 4 for the
 // niche-packed optional graph) rather than 20. This is the ~20%-off-the-quad-table
 // win; the assertion fails the build if the niche or field layout regresses.
@@ -156,7 +156,7 @@ pub struct QuadRef<'a> {
 /// flags are computed once at freeze.
 #[derive(Debug)]
 pub struct RdfDataset {
-    /// The byte arena owning every interned string ONCE (#879 P3b); `terms` hold
+    /// The byte arena owning every interned string ONCE (P3b); `terms` hold
     /// `StrRange`s into it, and `resolve` borrows `&str` from here.
     arena: Box<[u8]>,
     /// The interned term table; addressed by [`TermId::index`].
@@ -177,7 +177,7 @@ pub struct RdfDataset {
     locations: Box<[(QuadHandle, RdfLocation)]>,
     /// Capability flags, computed ONCE at freeze.
     caps: RdfStoreCapabilities,
-    /// Lazy value→id reverse index for [`RdfDataset::term_id_by_value`] (#838).
+    /// Lazy value→id reverse index for [`RdfDataset::term_id_by_value`].
     /// Keyed by a canonical **hash** of each term's dataset-independent value (with
     /// `Vec<TermId>` buckets to resolve the rare collision), NOT by full
     /// [`TermValue`] copies — so building it duplicates **no** term strings (~10×
@@ -185,7 +185,7 @@ pub struct RdfDataset {
     /// dropped at freeze); `OnceLock` keeps the frozen dataset `Send + Sync`.
     value_index: OnceLock<ValueIndex>,
     /// Lazy permutation quad indexes for indexed
-    /// [`quads_for_pattern`](RdfDataset::quads_for_pattern_indexed) (#891 P4b). SPOG
+    /// [`quads_for_pattern`](RdfDataset::quads_for_pattern_indexed) (P4b). SPOG
     /// is free (the `quads` table is already freeze-sorted by `(s, p, o, g)`); the
     /// other five orderings are `u32` ordinal-indirection arrays (4 B/quad) built
     /// lazily on the first pattern query that selects them. `OnceLock` keeps the
@@ -234,7 +234,7 @@ pub struct RdfDataset {
 }
 
 /// The lazy non-identity permutation indexes over the freeze-sorted `quads` table
-/// (#891 P4b). Each is a `u32`-per-quad ordinal-indirection array: `arr[i]` is the
+/// (P4b). Each is a `u32`-per-quad ordinal-indirection array: `arr[i]` is the
 /// ordinal into the [`RdfDataset`] quads table of the `i`-th quad in that permutation's
 /// order. SPOG needs no array (the table is already SPOG-sorted); these five cover
 /// the remaining bound-set shapes. All five warm ≈ 20 B/quad on top of the table.
@@ -745,7 +745,7 @@ impl RdfDataset {
     }
 
     /// Borrow (building on first access) the ordinal-indirection array for a
-    /// non-identity permutation (#891 P4b): `arr[i]` is the ordinal into `self.quads`
+    /// non-identity permutation (P4b): `arr[i]` is the ordinal into `self.quads`
     /// of the `i`-th quad in `perm`'s order. Sorted by [`perm_key`]; `OnceLock` makes
     /// the first-access build race-safe and keeps the dataset `Send + Sync`. Never
     /// called for [`QuadPermutation::Spog`] (the table is already that order).
@@ -1074,7 +1074,7 @@ impl RdfDataset {
     }
 
     /// The id of an interned term given its **dataset-independent** value, or
-    /// `None` if the dataset contains no such term (purrdf P4, #838).
+    /// `None` if the dataset contains no such term (purrdf P4).
     ///
     /// The reverse hash→id index is built **lazily on first call** (the builder's
     /// interner index is dropped at freeze) and cached; `OnceLock::get_or_init`
@@ -1204,7 +1204,7 @@ impl RdfDataset {
     /// The borrowed twin of [`reifiers`](Self::reifiers): consumers that read the
     /// RDF 1.2 statement layer off the concrete IR (the GTS writer, the oxigraph
     /// materializer) use this to read reifiers WITHOUT the owned `RdfReifier` model —
-    /// the id-based read surface for the purrdf consumer migration (#886).
+    /// the id-based read surface for the purrdf consumer migration.
     #[inline]
     pub fn reifier_refs(&self) -> impl Iterator<Item = (TermRef<'_>, TermRef<'_>)> + '_ {
         self.reifiers()
@@ -1617,8 +1617,8 @@ impl<'a> IntoIterator for &'a RdfDataset {
 // serialization across threads. These guards fail the build if that ever regresses.
 const _: fn() = || {
     fn assert_send_sync<T: Send + Sync>() {}
-    // RdfDataset carries lazy `OnceLock` indexes — the value index (#838) and the
-    // permutation quad indexes (#891 P4b). `OnceLock` (not `RefCell`) is what keeps
+    // RdfDataset carries lazy `OnceLock` indexes — the value index and the
+    // permutation quad indexes (P4b). `OnceLock` (not `RefCell`) is what keeps
     // this guard holding once those interior-mutable caches are added.
     assert_send_sync::<RdfDataset>();
     assert_send_sync::<TermId>();
@@ -1751,7 +1751,7 @@ mod tests {
     fn term_id_by_value_is_dataset_independent_not_id_based() {
         // The SAME value maps to DIFFERENT ids across datasets; a value lookup must
         // return each dataset's OWN id (proves it is value-keyed, never smuggling a
-        // foreign dataset-local id — the #838 correctness rule).
+        // foreign dataset-local id — the correctness rule).
         let val = TermValue::Iri("http://example.org/x".to_string());
         let mut a = RdfDatasetBuilder::new();
         let _pad = iri(&mut a, "pad"); // shift x's id in dataset `a`
@@ -1795,7 +1795,7 @@ mod tests {
         let mut b = RdfDatasetBuilder::new();
         let (s, p) = (iri(&mut b, "s"), iri(&mut b, "p"));
         let (o1, o2) = (iri(&mut b, "o1"), iri(&mut b, "o2"));
-        // Extend<QuadIds>: bulk-push ids interned in THIS builder (#841).
+        // Extend<QuadIds>: bulk-push ids interned in THIS builder.
         b.extend([
             QuadIds {
                 s,
@@ -1814,7 +1814,7 @@ mod tests {
         assert_eq!(ds.quad_count(), 2);
         // IntoIterator for &RdfDataset yields one QuadRef per quad.
         assert_eq!((&*ds).into_iter().count(), 2);
-        // The named iterator is ExactSize, DoubleEnded, and Fused (#841).
+        // The named iterator is ExactSize, DoubleEnded, and Fused.
         let mut it = ds.quad_refs();
         assert_eq!(it.len(), 2);
         assert!(it.next_back().is_some());
@@ -1965,7 +1965,7 @@ mod tests {
 
     #[test]
     fn reifier_and_annotation_refs_resolve_to_borrowed_terms() {
-        // The borrowed read surface (#886) must resolve every reifier/annotation id to
+        // The borrowed read surface must resolve every reifier/annotation id to
         // its `TermRef` with full fidelity — including a triple-term reifier statement
         // and a directional literal annotation object (MAXIMAL INFORMATION FLOW).
         let mut b = RdfDatasetBuilder::new();
@@ -2337,7 +2337,7 @@ mod tests {
             }
         }
 
-        /// The #891 P4b correctness gate: the indexed `quads_for_pattern` must return
+        /// The P4b correctness gate: the indexed `quads_for_pattern` must return
         /// EXACTLY the same quad set as a linear scan, for every `(s?, p?, o?) ×
         /// GraphMatch` shape. The index only narrows candidates; the residual filter is
         /// the same predicate the scan applies, so any divergence is a range-math bug.

--- a/crates/rdf-core/src/ir/event_sink.rs
+++ b/crates/rdf-core/src/ir/event_sink.rs
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Evented, ID-addressed OUTPUT of a frozen [`RdfDataset`] (#819 C6).
+//! Evented, ID-addressed OUTPUT of a frozen [`RdfDataset`] (C6).
 //!
 //! [`RdfDatasetVisitor`] is the **frozen-dataset OUTPUT visitor**: it is the dual of
 //! the permissive ingestion protocol (the `purrdf-events` `RdfEventSink`, purrdf
-//! P6 #840) — where that ingestion sink folds an
+//! P6) — where that ingestion sink folds an
 //! *external* event stream *into* the
 //! IR, [`RdfDataset::emit`] walks an *already-frozen* dataset and streams it *out* as
 //! events, so downstream consumers — the chase materializer, SHACL result emission,

--- a/crates/rdf-core/src/ir/ingest.rs
+++ b/crates/rdf-core/src/ir/ingest.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The permissive-ingestion bridge (purrdf P6, #840): wire the immutable IR to the
+//! The permissive-ingestion bridge (purrdf P6): wire the immutable IR to the
 //! dependency-free `purrdf-events` protocol.
 //!
 //! Two pieces live here:
@@ -21,7 +21,7 @@
 //!   already-frozen `&RdfDataset` *into* any sink: it declares a `term` event for
 //!   every term in [`TermId`] order (so it declares-before-reference), then the quad
 //!   / reifier / annotation events. This is the in-repo source that lets P6 be tested
-//!   end-to-end without the cross-repo GTS source (deferred, purrdf-gts#249).
+//!   end-to-end without the cross-repo GTS source (deferred).
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;

--- a/crates/rdf-core/src/ir/mod.rs
+++ b/crates/rdf-core/src/ir/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The immutable, value-interned RDF 1.2 dataset IR (#819 C1).
+//! The immutable, value-interned RDF 1.2 dataset IR (C1).
 //!
 //! This module tree realizes the normative C0 semantic contract from
 //! `docs/design/819-rdf-ir-dataflow.md`. Task 2 (C1.a) landed the **interning
@@ -13,23 +13,23 @@
 
 pub mod builder;
 pub mod bundle;
-// The pipeline carrier (#1132 C1): the frozen hot graph + lookaside + blob store +
+// The pipeline carrier (C1): the frozen hot graph + lookaside + blob store +
 // provenance + a typed-handle lane, generic over the kernel-opaque handle payload.
 pub mod pipeline_bundle;
-// Native full W3C RDFC-1.0 dataset canonicalization (#910): stable canonical blank
+// Native full W3C RDFC-1.0 dataset canonicalization: stable canonical blank
 // labels + canonical N-Quads, extended for the RDF-1.2 reifier/annotation overlay.
 // The canonicalization authority for the purrdf family — explicitly NOT oxigraph.
 pub mod canon;
-// The `RdfDataset`-direct, blank-aware structural comparator (#819 C1/C2): the
+// The `RdfDataset`-direct, blank-aware structural comparator (C1/C2): the
 // equality oracle for importer equivalence — explicitly NOT oxigraph.
 pub mod compare;
 pub mod dataset;
-// The copy-on-write, suppression-delta mutable dataset + `DatasetMut` impl (#839 P5).
+// The copy-on-write, suppression-delta mutable dataset + `DatasetMut` impl (P5).
 pub mod mutable;
-// Evented, ID-addressed OUTPUT of a frozen dataset (#819 C6): the dual of the
+// Evented, ID-addressed OUTPUT of a frozen dataset (C6): the dual of the
 // permissive ingestion protocol, for chase / SHACL-result / projection consumers.
 pub mod event_sink;
-// The permissive-ingestion adapter (purrdf P6 #840): an `RdfEventSink` (the
+// The permissive-ingestion adapter (purrdf P6): an `RdfEventSink` (the
 // `purrdf-events` protocol) that buffers forward references and freezes a dataset
 // at `finish()`, plus the frozen-IR-replay `RdfEventSource` that drives it.
 pub mod ingest;

--- a/crates/rdf-core/src/ir/mutable.rs
+++ b/crates/rdf-core/src/ir/mutable.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The copy-on-write, suppression-delta **mutable dataset** (purrdf P5, #839).
+//! The copy-on-write, suppression-delta **mutable dataset** (purrdf P5).
 //!
 //! A [`MutableDataset`] branches cheaply off a shared, frozen
 //! [`Arc<RdfDataset>`](RdfDataset) base and records mutations as an *append delta*
@@ -149,7 +149,7 @@ impl DeltaBuilder {
     }
 }
 
-/// A copy-on-write mutable RDF dataset (purrdf P5, #839). Branches cheaply off a
+/// A copy-on-write mutable RDF dataset (purrdf P5). Branches cheaply off a
 /// shared frozen base; records mutations as an append delta + a suppression set; and
 /// compacts back to a frozen [`RdfDataset`] via [`freeze`](Self::freeze).
 ///

--- a/crates/rdf-core/src/ir/pipeline_bundle.rs
+++ b/crates/rdf-core/src/ir/pipeline_bundle.rs
@@ -5,7 +5,7 @@
 //! the frozen hot graph, its out-of-band lookaside, the content-addressed blob
 //! store, the provenance sidecar, and a typed-handle lane.
 //!
-//! ## Kernel boundary (#885)
+//! ## Kernel boundary
 //!
 //! The kernel owns the bundle SHAPE but NOT the concrete handle payloads. The
 //! payload type `H` is generic so that pipeline-side types (logic programs,

--- a/crates/rdf-core/src/ir/term.rs
+++ b/crates/rdf-core/src/ir/term.rs
@@ -201,8 +201,7 @@ pub(crate) enum InternedTerm {
 }
 
 /// A **dataset-independent** term value — the lookup key for
-/// [`RdfDataset::term_id_by_value`](super::RdfDataset::term_id_by_value) (purrdf P4,
-/// ).
+/// [`RdfDataset::term_id_by_value`](super::RdfDataset::term_id_by_value) (purrdf P4).
 ///
 /// Unlike [`crate::ir::TermRef`] (whose literal-datatype and triple-component slots carry
 /// dataset-local [`TermId`]s), `TermValue` expresses every component **by value** —

--- a/crates/rdf-core/src/ir/term.rs
+++ b/crates/rdf-core/src/ir/term.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Typed term identity and interned-term storage for the immutable IR (#819 C1).
+//! Typed term identity and interned-term storage for the immutable IR (C1).
 //!
 //! These types realize the normative C0 identity contract (see
 //! `docs/design/819-rdf-ir-dataflow.md`, *Appendix C0*):
@@ -31,7 +31,7 @@ pub(crate) const RDF_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-synta
 /// (C0.8). Any consumer needing a durable identifier MUST resolve the term to its
 /// RDF value rather than retaining a `TermId`.
 ///
-/// # Layout (#837 P3a)
+/// # Layout (P3a)
 ///
 /// The inner value is a [`NonZeroU32`] holding `dense_index + 1`, so the all-zero
 /// bit pattern is free for the [`Option`] niche: `Option<TermId>` is **4 bytes**
@@ -98,7 +98,7 @@ impl TermId {
     }
 }
 
-// The NonZeroU32 niche is the load-bearing P3a invariant (#837): it is *why*
+// The NonZeroU32 niche is the load-bearing P3a invariant: it is *why*
 // `Option<TermId>` — and the `g` graph slot of every quad row — costs no extra
 // word. These compile-time assertions fail the build if the niche ever regresses.
 const _: () = assert!(size_of::<TermId>() == 4);
@@ -146,7 +146,7 @@ impl Default for BlankScope {
 /// An interned literal. The identity key per C0.1: datatype is ALWAYS expanded to
 /// an interned IRI [`TermId`]; the language tag is lowercased; base direction is in
 /// the key; and the lexical spelling is preserved verbatim.
-/// A `(offset, len)` range into the interner's byte arena (#879 P3b). Each interned
+/// A `(offset, len)` range into the interner's byte arena (P3b). Each interned
 /// string is stored once in the arena rather than as its own `Box<str>`, so a term
 /// holds only this 8-byte range — `InternedTerm` becomes `Copy` and per-term heap
 /// allocations collapse to one growable arena.
@@ -186,7 +186,7 @@ pub(crate) struct InternedLiteral {
 
 /// An interned term — the storage form behind a [`TermId`]. Crate-private: the IR
 /// exposes terms through resolved views, never this internal representation. Strings
-/// are `StrRange`s into the interner's byte arena (#879).
+/// are `StrRange`s into the interner's byte arena.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub(crate) enum InternedTerm {
     /// An IRI, by its arena range.
@@ -202,7 +202,7 @@ pub(crate) enum InternedTerm {
 
 /// A **dataset-independent** term value — the lookup key for
 /// [`RdfDataset::term_id_by_value`](super::RdfDataset::term_id_by_value) (purrdf P4,
-/// #838).
+/// ).
 ///
 /// Unlike [`crate::ir::TermRef`] (whose literal-datatype and triple-component slots carry
 /// dataset-local [`TermId`]s), `TermValue` expresses every component **by value** —
@@ -323,7 +323,7 @@ impl TermValue {
 // `Hash` is hand-written (not derived) with **explicit** discriminant tags so it is
 // robust against compiler-dependent enum-discriminant hashing AND matches the
 // allocation-free `RdfDataset::hash_term` (which hashes the interned representation
-// directly) byte-for-byte (#838). The two MUST stay in sync — the
+// directly) byte-for-byte. The two MUST stay in sync — the
 // `term_id_by_value` round-trip tests fail if they diverge. `String`/`Box<str>`/
 // `&str` all hash via `str`, so the by-value datatype here matches the resolved IRI
 // string there.
@@ -385,7 +385,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "cannot exceed u32::MAX entries")]
     fn term_id_from_index_rejects_u32_max() {
-        // `index + 1` would overflow the id space; the mint hard-fails (#837).
+        // `index + 1` would overflow the id space; the mint hard-fails.
         let _ = TermId::from_index(u32::MAX);
     }
 
@@ -408,7 +408,7 @@ mod tests {
     fn interned_literal_equality_includes_direction() {
         let a = InternedLiteral {
             // The arena range is irrelevant here — this pins that base direction
-            // participates in literal identity (#879: lexical form is now a range).
+            // participates in literal identity (: lexical form is now a range).
             lexical_form: StrRange { offset: 0, len: 1 },
             datatype: TermId::from_index(0),
             language: None,

--- a/crates/rdf-core/src/ir/validate.rs
+++ b/crates/rdf-core/src/ir/validate.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Pre-freeze structural validation for the immutable `RdfDataset` (#819 C1).
+//! Pre-freeze structural validation for the immutable `RdfDataset` (C1).
 //!
 //! [`validate`] is invoked by [`RdfDatasetBuilder::freeze`] BEFORE any dataset is
 //! materialized; on any failure it returns a precise [`RdfDiagnostic`] and freeze

--- a/crates/rdf-core/src/lib.rs
+++ b/crates/rdf-core/src/lib.rs
@@ -3,14 +3,14 @@
 
 //! `purrdf-core` -- oxigraph-free, PyO3-free RDF 1.2 kernel for the PurRDF Rust workspace.
 //!
-//! This crate is the ring-fenced core (/ purrdf P2b) extracted out of
+//! This crate is the ring-fenced core (purrdf P2b) extracted out of
 //! `purrdf`: the immutable value-interned IR, the owned value model, structured
 //! diagnostics, dataset capability flags, the loss ledger, and provenance. It
 //! models RDF 1.2 terms directly, preserves
 //! source/location context where adapters can provide it, and keeps reporting
 //! structured but SARIF-free. The oxigraph adapters and the PyO3 extension surface
 //! live in the sibling `purrdf` crate; **nothing here may pull oxigraph** — that
-//! is the acceptance gate of.
+//! is the acceptance gate.
 //!
 //! # `no_std` readiness
 //!

--- a/crates/rdf-core/src/lib.rs
+++ b/crates/rdf-core/src/lib.rs
@@ -3,55 +3,55 @@
 
 //! `purrdf-core` -- oxigraph-free, PyO3-free RDF 1.2 kernel for the PurRDF Rust workspace.
 //!
-//! This crate is the ring-fenced core (#885 / purrdf P2b) extracted out of
+//! This crate is the ring-fenced core (/ purrdf P2b) extracted out of
 //! `purrdf`: the immutable value-interned IR, the owned value model, structured
 //! diagnostics, dataset capability flags, the loss ledger, and provenance. It
 //! models RDF 1.2 terms directly, preserves
 //! source/location context where adapters can provide it, and keeps reporting
 //! structured but SARIF-free. The oxigraph adapters and the PyO3 extension surface
 //! live in the sibling `purrdf` crate; **nothing here may pull oxigraph** — that
-//! is the acceptance gate of #885.
+//! is the acceptance gate of.
 //!
-//! # `no_std` readiness (#841)
+//! # `no_std` readiness
 //!
 //! The immutable IR ([`ir`]) is the kernel's purest layer and is **file-IO-free**
 //! (no `std::fs`/`std::io`), the first prerequisite for an eventual `alloc`-only
 //! `no_std` core for embedded / C-ABI consumers. The remaining blocker is the
 //! interner's `std::collections::{HashMap, HashSet}` (not in `alloc`); migrating it
-//! to `hashbrown` is tracked as **P3c (#880)**. New IR code therefore prefers
+//! to `hashbrown` is tracked as **P3c**. New IR code therefore prefers
 //! `core::`/`alloc::` over `std::` where the item exists in both (e.g. `core::fmt`,
 //! `alloc::sync::Arc`) so the eventual `#![no_std]` flip stays mechanical. Per the
 //! purrdf plan, `no_std` is for embedded/C-ABI targets and is **not** a WASM
 //! prerequisite. Common types are re-exported from [`prelude`].
 
 pub mod bundle;
-// Narrow purrdf backend traits (P2d, #887): term interning, parser ingress,
+// Narrow purrdf backend traits (P2d): term interning, parser ingress,
 // SPARQL execution, and serializer egress. PyO3-free, oxigraph-free — pure
 // contract only; concrete adapters live in `purrdf`.
 pub mod backend;
 pub mod content_id;
 pub mod content_store;
-// The static, allocation-free read view over an RDF dataset (purrdf P2, #836):
+// The static, allocation-free read view over an RDF dataset (purrdf P2):
 // `DatasetView` + `GraphMatch`. PyO3-free, oxigraph-free — pure kernel.
 pub mod dataset_view;
 pub mod describe;
 pub mod diagnostic;
-// Native FnO (W3C Function Ontology) typed catalog model + serializer (#848).
+// Native FnO (W3C Function Ontology) typed catalog model + serializer.
 // PyO3-free; the `purrdf-slice` FnO emitter builds a `FnoCatalog` from the slice
 // framework and serializes it here, replacing rdflib `emit_fno`/`_emit_fnom`.
 pub mod fno;
-// The immutable, value-interned RDF 1.2 dataset IR (#819 C1).
+// The immutable, value-interned RDF 1.2 dataset IR (C1).
 pub mod ir;
-// Generic provenance sidecar for the immutable RDF 1.2 dataset (#820 S2):
+// Generic provenance sidecar for the immutable RDF 1.2 dataset (S2):
 // UnitId/ArtifactId/OriginSetId newtypes, interners, AssertionOccurrence,
 // DatasetProvenance, and the provenance gate. No PurRDF-specific concepts here.
 pub mod lookaside;
 pub mod provenance;
-// The machine-readable RDF↔GTS loss ledger and its drift-gated matrix (#819 C0).
+// The machine-readable RDF↔GTS loss ledger and its drift-gated matrix (C0).
 pub mod loss;
 pub mod model;
 // Native SSSOM (Simple Standard for Sharing Ontology Mappings) TSV codec +
-// validator + RDF serializer (#848). PyO3-free; replaces the `sssom` PyPI
+// validator + RDF serializer. PyO3-free; replaces the `sssom` PyPI
 // package's parse+validate behaviour for the PurRDF mapping artifacts.
 pub mod sssom;
 pub mod store;

--- a/crates/rdf-core/src/lookaside.rs
+++ b/crates/rdf-core/src/lookaside.rs
@@ -296,7 +296,7 @@ pub struct RdfBlobOrigin {
 /// A content-addressed reference to a blob that travels with an RDF store.
 ///
 /// Carries the blob_id ([`digest`](Self::digest)) and declared metadata — but
-/// **never** the payload bytes (purrdf-gts#214 made the bytes reachable; the IR
+/// **never** the payload bytes ( made the bytes reachable; the IR
 /// deliberately does not materialize them). The bytes are recovered by streaming
 /// from [`origin`](Self::origin) when a destination is materialized.
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/rdf-core/src/loss.rs
+++ b/crates/rdf-core/src/loss.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The machine-readable RDF↔GTS loss ledger (#819 C0).
+//! The machine-readable RDF↔GTS loss ledger (C0).
 //!
 //! "RDF 1.2 fidelity" cannot be claimed for a conversion until either the GTS
 //! representation is extended to carry every RDF 1.2 feature, **or** every
@@ -479,8 +479,8 @@ mod tests {
     use std::path::PathBuf;
 
     /// The intentional loss codes this ledger is required to enumerate.
-    /// `direction-dropped` was retired by purrdf-gts#212 (`Term.direction`) and
-    /// `multi-reifier-collapsed` by purrdf-gts#213 (reifier-id-keyed
+    /// `direction-dropped` was retired by  (`Term.direction`) and
+    /// `multi-reifier-collapsed` by  (reifier-id-keyed
     /// `Graph.reifiers`); both now round-trip losslessly.
     const EXPECTED_CODES: [&str; 2] = ["blob-bytes-absent", "bnode-scope-flatten"];
 

--- a/crates/rdf-core/src/model.rs
+++ b/crates/rdf-core/src/model.rs
@@ -274,7 +274,7 @@ mod tests {
         );
         assert_eq!(RdfTerm::blank_node("b0").to_string(), "_:b0");
         // `Display` MUST delegate to the single-source-of-truth serializer for ALL
-        // four RDF term kinds (IRI, blank node, literal, triple term) (#841).
+        // four RDF term kinds (IRI, blank node, literal, triple term).
         for t in [
             RdfTerm::iri("https://example.org/x"),
             RdfTerm::blank_node("b1"),

--- a/crates/rdf-core/src/provenance.rs
+++ b/crates/rdf-core/src/provenance.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Generic provenance sidecar for the immutable RDF 1.2 dataset (#820 S2).
+//! Generic provenance sidecar for the immutable RDF 1.2 dataset (S2).
 //!
 //! This module realizes the normative S0 provenance contract from
 //! `docs/design/820-slices-first-class.md`. The types here are **kernel-generic**:

--- a/crates/rdf-core/src/sssom.rs
+++ b/crates/rdf-core/src/sssom.rs
@@ -881,7 +881,7 @@ ex:A\tskos:exactMatch\tex:B\tsemapv:ManualMappingCuration\t1:1
     fn serialize_preserves_unknown_columns_roundtrip() {
         // A non-PurRDF SSSOM file carrying an extra column must survive
         // parse → serialize_tsv (lossless round-trip), not be silently dropped
-        // because the column set is built only from SSSOM_ORDER (H-1 /).
+        // because the column set is built only from SSSOM_ORDER (H-1).
         let doc = "\
 # mapping_set_id: https://example.org/x
 # curie_map:

--- a/crates/rdf-core/src/sssom.rs
+++ b/crates/rdf-core/src/sssom.rs
@@ -911,7 +911,7 @@ ex:A\tskos:exactMatch\tex:B\tsemapv:ManualMappingCuration\t1:1
     #[test]
     fn diagnostic_line_survives_interleaved_comment() {
         // A `#` provenance comment between data rows must not shift the reported
-        // line of a later row's diagnostic. Before M-1 (gemini #1+#2 on) a
+        // line of a later row's diagnostic. Before M-1, a
         // flat offset ignored the filtered comment and reported the wrong line.
         let doc = "\
 # mapping_set_id: https://example.org/x

--- a/crates/rdf-core/src/sssom.rs
+++ b/crates/rdf-core/src/sssom.rs
@@ -4,7 +4,7 @@
 //! Native SSSOM (Simple Standard for Sharing Ontology Mappings) codec.
 //!
 //! This is the PyO3-free Rust replacement for the `sssom` PyPI package's
-//! parse + validate behaviour (#848). It carries the PurRDF mapping artifacts
+//! parse + validate behaviour. It carries the PurRDF mapping artifacts
 //! (`generated/mappings/*.sssom.tsv`) in and out of an owned IR and adds a
 //! native RDF serializer the Python toolkit never had (the SUBSUME/ENHANCE
 //! deliverable).
@@ -881,7 +881,7 @@ ex:A\tskos:exactMatch\tex:B\tsemapv:ManualMappingCuration\t1:1
     fn serialize_preserves_unknown_columns_roundtrip() {
         // A non-PurRDF SSSOM file carrying an extra column must survive
         // parse → serialize_tsv (lossless round-trip), not be silently dropped
-        // because the column set is built only from SSSOM_ORDER (H-1 / #855).
+        // because the column set is built only from SSSOM_ORDER (H-1 /).
         let doc = "\
 # mapping_set_id: https://example.org/x
 # curie_map:
@@ -911,7 +911,7 @@ ex:A\tskos:exactMatch\tex:B\tsemapv:ManualMappingCuration\t1:1
     #[test]
     fn diagnostic_line_survives_interleaved_comment() {
         // A `#` provenance comment between data rows must not shift the reported
-        // line of a later row's diagnostic. Before M-1 (gemini #1+#2 on #855) a
+        // line of a later row's diagnostic. Before M-1 (gemini #1+#2 on) a
         // flat offset ignored the filtered comment and reported the wrong line.
         let doc = "\
 # mapping_set_id: https://example.org/x

--- a/crates/rdf-core/src/turtle.rs
+++ b/crates/rdf-core/src/turtle.rs
@@ -352,7 +352,7 @@ mod tests {
         // With no folded annotations the reifier's annotations are emitted as
         // standalone triples that reference it by blank-node label, so the
         // reifier must keep that label (not collapse to an anonymous `[]`),
-        // else the rdf:reifies binding is severed from its annotations. (#666)
+        // else the rdf:reifies binding is severed from its annotations.
         let triple = RdfTriple::new(
             iri("http://example.org/s"),
             "http://example.org/p",

--- a/crates/rdf-core/src/turtle_render.rs
+++ b/crates/rdf-core/src/turtle_render.rs
@@ -82,7 +82,7 @@ impl<'a> Renderer<'a> {
         // TABLES, not `quads` — so the canonical renderer must fold in `reifier_quads`
         // (`<reifier> rdf:reifies << s p o >>`) and `annotation_quads`
         // (`<reifier> <pred> <value>`) alongside the base quads, or it silently drops the
-        // whole statement layer (#1155 bug 2). Folding them in here — rather than a
+        // whole statement layer (bug 2). Folding them in here — rather than a
         // separate emission pass — keeps a reifier subject's `rdf:reifies` edge and its
         // annotations on ONE flat top-level subject (`<reifier> rdf:reifies << s p o >> ;
         // <ann> <v> .`), which round-trips idempotently: the quoted triple term renders as
@@ -229,7 +229,7 @@ impl<'a> Renderer<'a> {
         };
         // `a` (rdf:type) first, then `rdf:reifies` — the reifier's defining edge must
         // precede its annotations so a parser that folds a reifier's sibling triples as
-        // annotations sees the `rdf:reifies` binding first (idempotent #1155 round trip
+        // annotations sees the `rdf:reifies` binding first (idempotent round trip
         // and the canonical committed form `<r> rdf:reifies << s p o >> ; <ann> .`).
         let mut preds: Vec<TermId> = props.keys().copied().collect();
         preds.sort_by_cached_key(|p| {
@@ -856,7 +856,7 @@ mod tests {
         let ds = b.freeze().unwrap();
         let out = render(&ds, &[("rdf".to_string(), RDF.to_string())]);
         // The reifier renders FLAT — the quoted triple inline, the annotation alongside
-        // — never nested into an intermediate `[ rdf:reifies … ]` blank (#1155).
+        // — never nested into an intermediate `[ rdf:reifies … ]` blank.
         assert!(
             out.contains("rdf:reifies <<( <https://ex/s> <https://ex/p> <https://ex/o> )>>"),
             "reifier must render the quoted triple flat, got:\n{out}"

--- a/crates/rdf-core/tests/ir_zero_alloc.rs
+++ b/crates/rdf-core/tests/ir_zero_alloc.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Gate 1 (#819 C1): `RdfDataset::quads()` performs **zero allocations** and never
+//! Gate 1 (C1): `RdfDataset::quads()` performs **zero allocations** and never
 //! clones or formats a term, and `quad_refs()` resolves terms without allocating.
 //!
 //! The proof is operational, not a slogan: this test installs a process-global
@@ -11,7 +11,7 @@
 //! `#[global_allocator]`, it observes every heap allocation any code in the loop body
 //! would make — there is nowhere for a hidden allocation to hide.
 
-// Rich colored line-diffs on assert_eq! failure (#871); shadows the std macro
+// Rich colored line-diffs on assert_eq! failure; shadows the std macro
 // for this file. Identical behaviour on pass; insta snapshots are unaffected.
 use pretty_assertions::assert_eq;
 use std::alloc::{GlobalAlloc, Layout, System};

--- a/crates/rdf-events/src/lib.rs
+++ b/crates/rdf-events/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The **permissive RDF 1.2 ingestion protocol** (purrdf P6, #840): the neutral
+//! The **permissive RDF 1.2 ingestion protocol** (purrdf P6): the neutral
 //! event seam that an RDF *source* (a parser, a GTS reader, a frozen-dataset
 //! replayer) uses to push a dataset *into* a *sink* (an IR builder, a serializer)
 //! WITHOUT either side knowing the other's concrete types.

--- a/crates/rdf-wasm/README.md
+++ b/crates/rdf-wasm/README.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 [`purrdf`](../purrdf) umbrella crate and surfaced to JavaScript/TypeScript through the
 [RDF/JS](https://rdf.js.org/) community spec (`DataFactory`, `DatasetCore`,
 `Stream`/`Sink`). It is parcel **P10** of the purrdf program
-(EPIC #832, [`docs/design/PurRDF-PLAN.md`](../../docs/design/PurRDF-PLAN.md)).
+([`docs/design/PurRDF-PLAN.md`](../../docs/design/PurRDF-PLAN.md)).
 
 This crate (`purrdf-wasm`) is the Rust cdylib; the published npm/ESM package lives
 in [`js/`](./js/) and is named **`@blackcatinformatics/purrdf`**.

--- a/crates/rdf-wasm/src/lib.rs
+++ b/crates/rdf-wasm/src/lib.rs
@@ -3,7 +3,7 @@
 
 //! # purrdf — a wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS API
 //!
-//! Parcel **P10** of the purrdf program (EPIC #832, `docs/design/PurRDF-PLAN.md`).
+//! Parcel **P10** of the purrdf program (`docs/design/PurRDF-PLAN.md`).
 //! This crate compiles the oxigraph-free, PyO3-free [`purrdf`](purrdf) kernel to
 //! `wasm32-unknown-unknown` and exposes it to JavaScript/TypeScript through the
 //! [RDF/JS](https://rdf.js.org/) community spec — `DataFactory`, `DatasetCore`, and
@@ -21,7 +21,7 @@
 //!   host can provide SERVICE federation; this default browser surface installs no
 //!   remote source, so `SERVICE` / `LOAD` hard-fails here rather than silently
 //!   returning a partial answer.
-//! - **Separate from the C-ABI (P8 #842).** WASM has its own ownership model,
+//! - **Separate from the C-ABI (P8).** WASM has its own ownership model,
 //!   packaging, and async I/O; it is not a C-ABI consumer and does not depend on the
 //!   `no_std` track.
 //!
@@ -44,7 +44,7 @@
 
 use wasm_bindgen::prelude::*;
 
-// The idiomatic RDF/JS surface, built up parcel by parcel (issue #846):
+// The idiomatic RDF/JS surface, built up parcel by parcel:
 //   * `term`    — RDF/JS Term types (NamedNode/BlankNode/Literal/Variable/DefaultGraph
 //                 + the RDF-1.2 Quad-as-term wedge)
 //   * `factory` — the RDF/JS DataFactory over the engine's owned term model

--- a/crates/rdf/README.md
+++ b/crates/rdf/README.md
@@ -10,7 +10,7 @@ GTS readers) and adds parsing/materialization, Turtle normalization, statement
 codecs, and GTS adapters. Python bindings live in `bindings/python` and are not
 compiled into this crate.
 
-The core/adapter split (#885, P2b) makes the oxigraph boundary a **crate
+The core/adapter split (P2b) makes the oxigraph boundary a **crate
 boundary**: `purrdf-core` never names oxigraph, so leaks are compile errors.
 Most consumers should depend on the umbrella `purrdf` crate, which re-exports
 this implementation crate and includes the first-class slice and shape APIs.

--- a/crates/rdf/src/bin/capture_sparql_goldens.rs
+++ b/crates/rdf/src/bin/capture_sparql_goldens.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Capture the native SPARQL engine as committed goldens (EPIC #906 Task 2/8).
+//! Capture the native SPARQL engine as committed goldens ( Task 2/8).
 //!
-//! EPIC #906 removed oxigraph; the native [`NativeSparqlEngine`] is now the SOLE
+//!  removed oxigraph; the native [`NativeSparqlEngine`] is now the SOLE
 //! SPARQL authority (the cutover proved native ≡ oxigraph). This maintainer-only
 //! binary captures the native engine's deterministic SPARQL outputs over OUR corpus
 //! (`queries/**` + `generated/queries/**`) and over the GAP-A `$this`-substitution

--- a/crates/rdf/src/capture_support.rs
+++ b/crates/rdf/src/capture_support.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Shared corpus-classification helpers for the native golden-capture binary
-//! (EPIC #906 Task 2/8).
+//! ( Task 2/8).
 //!
 //! These pure helpers — corpus enumeration, the nondeterministic / multi-query /
 //! deferred-construct classifiers, and the stable solution-row key — are used by the
@@ -27,7 +27,7 @@ pub fn is_nondeterministic(query_text: &str) -> bool {
 
 /// Returns true if the error message matches a known-deferred SPARQL construct
 /// (property paths, SERVICE federation, LATERAL, DESCRIBE, RDF-1.2 triple terms in
-/// patterns). These are in-scope for later S8 (#914) / S6b (#928) / SPARQL-1.2 work;
+/// patterns). These are in-scope for later S8 / S6b / SPARQL-1.2 work;
 /// an Err here is expected, not a gap.
 #[must_use]
 pub fn is_deferred_construct(err_msg: &str) -> bool {

--- a/crates/rdf/src/dataset_io.rs
+++ b/crates/rdf/src/dataset_io.rs
@@ -4,7 +4,7 @@
 //! RDF text/bytes ingress into the frozen [`RdfDataset`] IR.
 //!
 //! The text codec is the oxigraph-free native [`parse_dataset`](crate::parse_dataset)
-//! path (#909 / EPIC #906 S3); the read model handed to PurRDF consumers is the
+//! path (/  S3); the read model handed to PurRDF consumers is the
 //! concrete IR. This module is deliberately PyO3-free so logic, SHACL, and pipeline
 //! stages can route parsed inputs through the same `RdfDataset` path as the Python
 //! `RdfDataset` handle. The already-parsed-quads → IR fold lives in
@@ -19,7 +19,7 @@ use crate::{parse_dataset, NativeRdfFormat, RdfDataset};
 /// Parse RDF bytes and freeze them into a validated [`RdfDataset`] via the native
 /// codec path.
 ///
-/// `format` is a [`NativeRdfFormat`] codec selector — the workspace-wide #909 sweep
+/// `format` is a [`NativeRdfFormat`] codec selector — the workspace-wide sweep
 /// (Tasks 2–6) routed every call site onto the native enum. The RDF 1.2 statement
 /// layer is folded in: a `rdf:reifies` triple-term object becomes a reifier binding,
 /// and a reifier subject's other triples become annotations (matching the GTS
@@ -62,7 +62,7 @@ mod tests {
 
     #[test]
     fn dataset_from_bytes_routes_each_native_format() {
-        // The codec selector is the native enum across every format — the #909 sweep
+        // The codec selector is the native enum across every format — the sweep
         // removed the temporary oxigraph::io::RdfFormat From shim entirely.
         let nq = "<https://e/s> <https://e/p> <https://e/o> <https://e/g> .\n";
         let ds = dataset_from_bytes(nq.as_bytes(), NativeRdfFormat::NQuads).expect("build nquads");

--- a/crates/rdf/src/dataset_io.rs
+++ b/crates/rdf/src/dataset_io.rs
@@ -4,7 +4,7 @@
 //! RDF text/bytes ingress into the frozen [`RdfDataset`] IR.
 //!
 //! The text codec is the oxigraph-free native [`parse_dataset`](crate::parse_dataset)
-//! path (/  S3); the read model handed to PurRDF consumers is the
+//! path (S3); the read model handed to PurRDF consumers is the
 //! concrete IR. This module is deliberately PyO3-free so logic, SHACL, and pipeline
 //! stages can route parsed inputs through the same `RdfDataset` path as the Python
 //! `RdfDataset` handle. The already-parsed-quads → IR fold lives in

--- a/crates/rdf/src/gts.rs
+++ b/crates/rdf/src/gts.rs
@@ -6,7 +6,7 @@
 //! The oxigraph-free reader half (`read_graph`, `read_all_segments`,
 //! `lookaside_from_graph`, …) lives in this adapter crate so `purrdf-core`
 //! remains independent of transport. The oxigraph-FREE
-//! [`flattened_dataset_from_bytes`] (EPIC #906 Task 4) is the load path the native
+//! [`flattened_dataset_from_bytes`] ( Task 4) is the load path the native
 //! SPARQL conformance gate replays against the frozen goldens.
 
 pub use crate::gts_core::*;
@@ -140,7 +140,7 @@ mod tests {
 
     /// The oxigraph-free [`flattened_dataset_from_bytes`] folds the one named-graph
     /// quad into the DEFAULT graph (graph component `None`). This is the load contract
-    /// the EPIC #906 Task-4 native conformance gate relies on, and it accepts a
+    /// the  Task-4 native conformance gate relies on, and it accepts a
     /// private (`x-purrdf-…`) language tag.
     #[test]
     fn flattened_dataset_from_bytes_folds_named_graph_into_default() {

--- a/crates/rdf/src/gts_compose.rs
+++ b/crates/rdf/src/gts_compose.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The pyo3-free GTS snapshot compose core (#861 P6).
+//! The pyo3-free GTS snapshot compose core (P6).
 //!
 //! This is the byte-emitting heart of `src/purrdf_tools/gts_producer.py::_Builder`,
 //! lifted out of the Python binding surface so the non-python
@@ -28,7 +28,7 @@ use purrdf_gts::writer::{term_to_wire, Writer};
 /// The `rdf:reifies` predicate IRI (RDF 1.2 statement layer).
 pub const RDF_REIFIES: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies";
 const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
-/// Payloads larger than this select `zstd-rsyncable` over `zstd` (#513).
+/// Payloads larger than this select `zstd-rsyncable` over `zstd`.
 pub const DEFAULT_RSYNCABLE_THRESHOLD: usize = 65536;
 /// zstd compression level for the committed `dist` bundle's frames (purrdf-gts 0.9.11
 /// per-frame level). The writer's `Fastest` default left the rsyncable bundle at
@@ -751,7 +751,7 @@ mod tests {
 
     #[test]
     fn conflicting_reifier_rebind_is_rejected() {
-        // FINDING (#909): two DIFFERENT `rdf:reifies` triple terms for one reifier
+        // FINDING: two DIFFERENT `rdf:reifies` triple terms for one reifier
         // subject is HARD-rejected (CONSTITUTION P7, never silently last-write-win).
         // The native `parse_dataset` folds the statement layer during parse and detects
         // the conflicting rebind there ("conflicting rdf:reifies binding"), before the

--- a/crates/rdf/src/gts_import_graph.rs
+++ b/crates/rdf/src/gts_import_graph.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The **consuming** GTS `Graph` importer (#819 C2.b).
+//! The **consuming** GTS `Graph` importer (C2.b).
 //!
 //! Where [`super::import_sink`] is the authoritative, scope-preserving *streaming*
 //! path, this is the convenience path: it takes an already-folded

--- a/crates/rdf/src/gts_import_sink.rs
+++ b/crates/rdf/src/gts_import_sink.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! The **authoritative** GTS ingestion path: a [`StreamingSink`] that preserves
-//! per-segment blank-node scope while folding into the immutable IR (#819 C2.a).
+//! per-segment blank-node scope while folding into the immutable IR (C2.a).
 //!
 //! `purrdf_gts::reader::read()` folds every segment into one append-order term
 //! table, which destroys per-segment blank-node scope (the same `_:b1` label in

--- a/crates/rdf/src/gts_resolve.rs
+++ b/crates/rdf/src/gts_resolve.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The shared GTS term resolver (#819 C2).
+//! The shared GTS term resolver (C2).
 //!
 //! GTS graph readers and the consuming [`super::import_graph`] importer both fold a
 //! *folded* `purrdf_gts::model::Graph` into RDF terms, and both need the SAME
@@ -36,7 +36,7 @@ use crate::{RdfLiteral, RdfLocation, RdfTerm, RdfTriple};
 /// eager resolver here and the move-based importer in [`super::import_graph`].
 pub(crate) const MAX_GTS_TERM_NESTING_DEPTH: usize = 16;
 
-/// Parse a GTS literal base-direction string (`"ltr"`/`"rtl"`, purrdf-gts#212)
+/// Parse a GTS literal base-direction string (`"ltr"`/`"rtl"`)
 /// into the IR's [`RdfTextDirection`]. `None` is legitimate absence; an
 /// unrecognized non-empty value is a hard error rather than a silent drop —
 /// the GTS round-trip is ours, so a malformed direction is corrupt input, not

--- a/crates/rdf/src/gts_write.rs
+++ b/crates/rdf/src/gts_write.rs
@@ -7,7 +7,7 @@
 //! [`purrdf_gts::writer::Writer`] to canonicalise it. All interning, term remapping,
 //! and frame authoring is delegated to `purrdf-gts`.
 //!
-//! The writer consumes the IR directly (purrdf P2c part 1, #886): it reads the
+//! The writer consumes the IR directly (purrdf P2c part 1): it reads the
 //! frozen dataset's quad/reifier/annotation tables and resolves each row to the
 //! owned model at the boundary, then interns into the GTS term table. Out-of-band material
 //! (GTS metadata, suppressions) is passed in explicitly as an [`RdfLookaside`]
@@ -121,7 +121,7 @@ struct InternState {
     terms: Vec<Term>,
     index: HashMap<RdfTerm, usize>,
     /// Triple component ids → reifier term ids. RDF 1.2 permits several distinct
-    /// explicit reifiers for one (s,p,o) (purrdf-gts#213); they are all retained.
+    /// explicit reifiers for one (s,p,o); they are all retained.
     /// A nested triple term reuses the first-bound reifier for its single
     /// `Term.reifier` slot. Reifiers are IRI/blank-node terms already in `terms`.
     reifier_map: HashMap<Triple3, Vec<usize>>,
@@ -153,7 +153,7 @@ fn bind_explicit_reifier(
     let o = intern_term(state, &reifier.statement.object)?;
 
     // RDF 1.2 allows several distinct explicit reifiers for the same triple
-    // content (purrdf-gts#213); record each one, deduplicating only an identical
+    // content; record each one, deduplicating only an identical
     // (rid, (s,p,o)) pair. Every distinct reifier is emitted as its own
     // `graph.reifiers` row below, so no binding is collapsed.
     let bound = state.reifier_map.entry((s, p, o)).or_default();
@@ -251,7 +251,7 @@ fn intern_literal(
         None
     };
 
-    // RDF 1.2 literal base direction now round-trips through GTS (purrdf-gts#212):
+    // RDF 1.2 literal base direction now round-trips through GTS:
     // map the IR's RdfTextDirection onto the GTS Term.direction string. Lexical
     // form, datatype, language tag, and direction are all preserved.
     let lang = literal.language.clone();
@@ -517,7 +517,7 @@ mod tests {
 
     #[test]
     fn direction_roundtrips_through_gts() {
-        // RDF 1.2 directional language-tagged literal (purrdf-gts#212): the base
+        // RDF 1.2 directional language-tagged literal: the base
         // direction must survive RDF IR -> GTS -> read. This proves the retired
         // `direction-dropped` loss is genuinely gone, not merely undocumented.
         let mut lit = RdfLiteral::language_tagged("\u{645}\u{631}\u{62d}\u{628}\u{627}", "ar");
@@ -591,7 +591,7 @@ mod tests {
     #[test]
     fn two_reifiers_same_triple_both_survive() {
         // RDF 1.2 permits several distinct explicit reifiers for one (s,p,o).
-        // purrdf-gts#213 lets the writer keep both, so `multi-reifier-collapsed`
+        //  lets the writer keep both, so `multi-reifier-collapsed`
         // is no longer a loss: both bindings must survive the round-trip.
         let statement = RdfTriple::new(
             RdfTerm::iri("https://example.org/s"),

--- a/crates/rdf/src/lib.rs
+++ b/crates/rdf/src/lib.rs
@@ -8,7 +8,7 @@
 //! terms directly, preserves source/location context where adapters can provide it,
 //! and keeps reporting structured but SARIF-free.
 //!
-//! # Crate boundary (/ purrdf P2b)
+//! # Crate boundary (purrdf P2b)
 //!
 //! The oxigraph-free, PyO3-free kernel — the immutable IR, the owned value model,
 //! diagnostics, dataset capability flags, the loss ledger, provenance, the FnO and
@@ -49,7 +49,7 @@ mod gts_verify;
 // re-exported here for existing `purrdf::describe::*` callers.
 pub use purrdf_core::describe;
 pub mod gts_view;
-// The native RDF text codecs (/  S3): the codec-only `GtsCodecBackend`
+// The native RDF text codecs (S3): the codec-only `GtsCodecBackend`
 // over the `purrdf-gts` Turtle/TriG/NT/NQ/RDF-XML codecs, oxigraph-free.
 pub mod native_codecs;
 // Oxigraph-free `RdfQuad` ⇄ `RdfDataset` conversions: the native twins of

--- a/crates/rdf/src/lib.rs
+++ b/crates/rdf/src/lib.rs
@@ -8,7 +8,7 @@
 //! terms directly, preserves source/location context where adapters can provide it,
 //! and keeps reporting structured but SARIF-free.
 //!
-//! # Crate boundary (#885 / purrdf P2b)
+//! # Crate boundary (/ purrdf P2b)
 //!
 //! The oxigraph-free, PyO3-free kernel — the immutable IR, the owned value model,
 //! diagnostics, dataset capability flags, the loss ledger, provenance, the FnO and
@@ -19,7 +19,7 @@
 //! *here* is the native text/statement/normalize surface ([`native_codecs`],
 //! [`native_quads`], [`statements`], [`turtle_normalize`]), the [`gts_compose`]
 //! author, the `flattened_dataset_from_bytes` GTS helper in [`gts`], and the
-//! the Python bindings now live in `bindings/python`. EPIC #906 removed the last
+//! the Python bindings now live in `bindings/python`.  removed the last
 //! oxigraph adapters, so the entire crate is now oxigraph-free.
 
 // ---------------------------------------------------------------------------
@@ -49,27 +49,27 @@ mod gts_verify;
 // re-exported here for existing `purrdf::describe::*` callers.
 pub use purrdf_core::describe;
 pub mod gts_view;
-// The native RDF text codecs (#909 / EPIC #906 S3): the codec-only `GtsCodecBackend`
+// The native RDF text codecs (/  S3): the codec-only `GtsCodecBackend`
 // over the `purrdf-gts` Turtle/TriG/NT/NQ/RDF-XML codecs, oxigraph-free.
 pub mod native_codecs;
-// Oxigraph-free `RdfQuad` ⇄ `RdfDataset` conversions (EPIC #906): the native twins of
+// Oxigraph-free `RdfQuad` ⇄ `RdfDataset` conversions: the native twins of
 // the oxigraph-quad helpers, available to every Rust consumer without pulling the
 // oxigraph Store adapter.
 pub mod native_quads;
-// The PyO3-free GTS snapshot compose core (#861 P6): SnapshotBuilder + emit_gts +
+// The PyO3-free GTS snapshot compose core (P6): SnapshotBuilder + emit_gts +
 // BlobRow, lifted out of the Python binding surface so purrdf-pipeline can
 // author a full multi-named-graph snapshot without pulling pyo3. Oxigraph-free
-// (EPIC #906).
+//.
 pub mod dataset_io;
 pub mod gts_compose;
 // The native OWL ↔ RDF 1.2 statement codec is fully oxigraph-free (it folds over the
-// native flat-quad stream) (EPIC #906).
+// native flat-quad stream).
 pub mod statements;
-// Shared corpus-classification helpers (EPIC #906 Task 2): the pure corpus
+// Shared corpus-classification helpers ( Task 2): the pure corpus
 // enumeration / classification helpers the native golden-capture binary
 // (src/bin/capture_sparql_goldens.rs) uses. Oxigraph-free.
 pub mod capture_support;
-// Canonical, review-friendly Turtle serializer over the IR (#819 Task 9): the
+// Canonical, review-friendly Turtle serializer over the IR (Task 9): the
 // native replacement for rdflib `longturtle` in `purrdf normalize`. Oxigraph-free.
 pub mod turtle_normalize;
 

--- a/crates/rdf/src/native_codecs/media_type.rs
+++ b/crates/rdf/src/native_codecs/media_type.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Media-type → native RDF text format routing (/  S3).
+//! Media-type → native RDF text format routing (S3).
 //!
 //! [`NativeRdfFormat`] is the single chokepoint the eventual `oxigraph::io::RdfFormat`
 //! removal (S14) retargets: every codec consumer names a format by media type at the

--- a/crates/rdf/src/native_codecs/media_type.rs
+++ b/crates/rdf/src/native_codecs/media_type.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Media-type → native RDF text format routing (#909 / EPIC #906 S3).
+//! Media-type → native RDF text format routing (/  S3).
 //!
 //! [`NativeRdfFormat`] is the single chokepoint the eventual `oxigraph::io::RdfFormat`
 //! removal (S14) retargets: every codec consumer names a format by media type at the

--- a/crates/rdf/src/native_codecs/mod.rs
+++ b/crates/rdf/src/native_codecs/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Native RDF text codecs (/  S3).
+//! Native RDF text codecs (S3).
 //!
 //! The codec-only backend that parses and serializes Turtle / TriG / N-Triples /
 //! N-Quads / RDF/XML, emitting through the `purrdf-events` seam into the frozen

--- a/crates/rdf/src/native_codecs/mod.rs
+++ b/crates/rdf/src/native_codecs/mod.rs
@@ -1,20 +1,20 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Native RDF text codecs (#909 / EPIC #906 S3).
+//! Native RDF text codecs (/  S3).
 //!
 //! The codec-only backend that parses and serializes Turtle / TriG / N-Triples /
 //! N-Quads / RDF/XML, emitting through the `purrdf-events` seam into the frozen
 //! [`RdfDataset`] IR. The line/Turtle family and RDF/XML are now FIRST-PARTY (EPIC
-//! #906: `text_parse` for the line/Turtle family, `rdfxml` for RDF/XML); they no
+//! `text_parse` for the line/Turtle family, `rdfxml` for RDF/XML); they no
 //! longer route through the external `purrdf-gts` text/RDF-XML codecs. It implements
 //! the narrow
 //! [`RdfParserBackend`]/[`RdfSerializer`] traits and is **codec-only** — it never
 //! touches the oxigraph Store, so it compiles under `--no-default-features --features
-//! gts` (no oxigraph). That is the EPIC #906 end-state: the text path needs no Store.
+//! gts` (no oxigraph). That is the  end-state: the text path needs no Store.
 //!
 //! [`GtsCodecBackend`] is the always-on native replacement for `OxigraphBackend`'s
-//! codec role; the workspace-wide sweep (#909 Tasks 2–5) routes every
+//! codec role; the workspace-wide sweep (Tasks 2–5) routes every
 //! `oxigraph::io` text parse/serialize call site through it.
 
 mod media_type;
@@ -24,7 +24,7 @@ mod media_type;
 // `SerGraph` from a real purrdf-gts model graph read out of a bundle.
 pub(crate) mod ser_model;
 // `pub(crate)` so the legacy `dataset_io` oxigraph path can reuse the SHARED
-// `fold_statement_layer` (one fold, no drift) — #909 Task 1.
+// `fold_statement_layer` (one fold, no drift) — Task 1.
 pub(crate) mod parse;
 mod serialize;
 // First-party JSON-LD-star / YAML-LD-star codec: serializes the frozen IR to the PurRDF
@@ -33,11 +33,11 @@ mod serialize;
 // validate / pipeline consumers share, so all three call it here (the codec previously
 // lived in `purrdf-pipeline::stages::yaml_ld`, above `rdf` and `validate`).
 pub mod jsonld;
-// First-party N-Triples / N-Quads / Turtle / TriG text parser (EPIC #906): lowers
+// First-party N-Triples / N-Quads / Turtle / TriG text parser: lowers
 // directly to the in-memory GtsGraph the statement-layer fold consumes, replacing the
 // purrdf-gts text codecs for the line/Turtle family.
 mod text_parse;
-// First-party RDF/XML codec (EPIC #906): implements the W3C RDF/XML grammar in-repo on
+// First-party RDF/XML codec: implements the W3C RDF/XML grammar in-repo on
 // a pure-Rust XML DOM (`roxmltree`), parsing straight into the frozen IR through the
 // shared statement-layer fold and serializing from the first-party `SerGraph` —
 // replacing the external purrdf-gts `rdf_codecs::{from_rdf_xml, to_rdf_xml}` codec
@@ -190,7 +190,7 @@ mod tests {
         let asserts = b.intern_iri("https://e/asserts");
         b.push_quad(s, asserts, inner, None);
         let ds = b.freeze().expect("freeze");
-        // FINDING (#909): purrdf-gts 0.9.5's `to_turtle`/`to_ntriples`/`to_trig`/
+        // FINDING: purrdf-gts 0.9.5's `to_turtle`/`to_ntriples`/`to_trig`/
         // `to_rdf_xml` event-source serializers CANNOT emit a quoted-triple term that
         // appears as a quad object — they hit a self-reifier "cycle while declaring
         // term N" (reproducible directly against purrdf-gts's own `from_nquads` output).

--- a/crates/rdf/src/native_codecs/parse.rs
+++ b/crates/rdf/src/native_codecs/parse.rs
@@ -634,7 +634,7 @@ mod tests {
 
     #[test]
     fn malformed_text_is_rejected_without_unwinding() {
-        // The first-party line/Turtle-family parser (EPIC #906) returns a clean parse
+        // The first-party line/Turtle-family parser returns a clean parse
         // diagnostic for malformed input rather than unwinding — strictly better than
         // the prior purrdf-gts codec, which panicked on this fragment and relied on the
         // `catch_unwind` guard to convert the panic to `native-codec-panic`. The guard

--- a/crates/rdf/src/native_codecs/rdfxml.rs
+++ b/crates/rdf/src/native_codecs/rdfxml.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! First-party RDF/XML codec (W3C RDF 1.1 / RDF-XML grammar) — EPIC #906.
+//! First-party RDF/XML codec (W3C RDF 1.1 / RDF-XML grammar) — .
 //!
 //! This module REPLACES the external purrdf-gts `rdf_codecs::{from_rdf_xml,
 //! to_rdf_xml}` codecs (the first-party mandate: RDF/XML must NOT be parsed or

--- a/crates/rdf/src/native_codecs/serialize.rs
+++ b/crates/rdf/src/native_codecs/serialize.rs
@@ -100,8 +100,7 @@ pub(crate) fn serialize_into<W: Write>(
 }
 
 /// Outcome of serializing an [`RdfDataset`] to a concrete RDF format through the
-/// native codecs (universal transcoder helper, ported onto the native path in
-/// ).
+/// native codecs (universal transcoder helper, ported onto the native path).
 #[derive(Debug, Clone)]
 pub struct SerializeOutcome {
     /// The serialized document bytes.

--- a/crates/rdf/src/native_codecs/serialize.rs
+++ b/crates/rdf/src/native_codecs/serialize.rs
@@ -36,7 +36,7 @@ const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
 /// The full RDF 1.2 statement layer (reifier bindings + annotations) is emitted for
 /// every star-capable format. To serialize the base quads ONLY — for a star-incapable
 /// projection target where the statement layer is declared loss (RDF/XML, JSON-LD in
-/// the #671 transcode contract) — use [`serialize_dataset_base_only`].
+/// the transcode contract) — use [`serialize_dataset_base_only`].
 pub fn serialize_dataset(
     dataset: &RdfDataset,
     media_type: &str,
@@ -49,7 +49,7 @@ pub fn serialize_dataset(
 /// base quads and DROPPING the RDF 1.2 statement layer (reifier bindings +
 /// annotations).
 ///
-/// This is the projection egress for star-incapable targets in the #671 transcode
+/// This is the projection egress for star-incapable targets in the transcode
 /// loss contract: the dropped statement-row count is the caller's to record as
 /// declared loss (`rdf12-star-unrepresentable` / `rdf12-star-jsonld-rejected`) — the
 /// drop here is never silent (CONSTITUTION P7), it is the realized count the caller
@@ -100,24 +100,24 @@ pub(crate) fn serialize_into<W: Write>(
 }
 
 /// Outcome of serializing an [`RdfDataset`] to a concrete RDF format through the
-/// native codecs (#671 universal transcoder helper, ported onto the native path in
-/// #909).
+/// native codecs (universal transcoder helper, ported onto the native path in
+/// ).
 #[derive(Debug, Clone)]
 pub struct SerializeOutcome {
     /// The serialized document bytes.
     pub bytes: Vec<u8>,
     /// The number of RDF-1.2 statement-layer rows (reifier bindings + annotation
     /// triples) dropped because the target format does not carry the star layer in
-    /// the #671 transcode contract. Zero for star-capable formats.
+    /// the transcode contract. Zero for star-capable formats.
     pub statement_rows_dropped: usize,
 }
 
 /// Whether a [`NativeRdfFormat`] carries the RDF-1.2 statement layer (quoted-triple
-/// reifiers + annotations) under the #671 transcode loss contract.
+/// reifiers + annotations) under the transcode loss contract.
 ///
 /// Turtle, N-Triples, N-Quads and TriG are star-capable. RDF/XML is treated as
 /// star-INcapable here even though the native serializer *can* emit classic
-/// `rdf:Statement` reification: the #671 loss ledger
+/// `rdf:Statement` reification: the loss ledger
 /// (`crates/rdf-core/src/loss.rs`) declares `*→rdfxml` as `rdf12-star-unrepresentable`
 /// because classic reification is a lossy projection, not faithful RDF-1.2 star.
 /// Keeping the predicate aligned with the ledger keeps the realized-loss accounting
@@ -134,7 +134,7 @@ fn is_star_capable(format: NativeRdfFormat) -> bool {
 
 /// Serialize the frozen IR to a concrete [`NativeRdfFormat`], returning the bytes and
 /// the count of RDF-1.2 statement-layer rows dropped because the target format does
-/// not carry the star layer (the #671 projection doctrine).
+/// not carry the star layer (the projection doctrine).
 ///
 /// Star-capable formats (Turtle, N-Triples, N-Quads, TriG) emit the full RDF-1.2
 /// statement layer and report `statement_rows_dropped = 0`. Star-incapable formats
@@ -467,8 +467,8 @@ fn direction_str(direction: RdfTextDirection) -> String {
 
 #[cfg(test)]
 mod serialize_to_format_tests {
-    //! Coverage for the #671 universal-transcoder helper
-    //! [`serialize_dataset_to_format`], ported onto the native codecs in #909.
+    //! Coverage for the universal-transcoder helper
+    //! [`serialize_dataset_to_format`], ported onto the native codecs in.
     //! (JSON-LD is no longer routed through this helper — it has no [`NativeRdfFormat`]
     //! variant — so the JSON-LD drop accounting is exercised in
     //! `crates/pipeline/src/transcode.rs` via the native `yaml_ld` serializer.)
@@ -575,7 +575,7 @@ mod serialize_to_format_tests {
         let ds = reifier_dataset();
         let out = serialize_dataset_to_format(&ds, NativeRdfFormat::RdfXml, None)
             .expect("serialize to RDF/XML");
-        // 1 reifier + 1 annotation = 2 statement rows declared dropped (the #671
+        // 1 reifier + 1 annotation = 2 statement rows declared dropped (the
         // loss contract treats classic reification as non-faithful star).
         assert_eq!(out.statement_rows_dropped, 2);
         let text = text_of(&out);

--- a/crates/rdf/src/native_quads.rs
+++ b/crates/rdf/src/native_quads.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Native [`RdfQuad`] ⇄ [`RdfDataset`] conversions (EPIC #906).
+//! Native [`RdfQuad`] ⇄ [`RdfDataset`] conversions.
 //!
 //! A consumer that already holds (or wants) a flat owned-[`RdfQuad`] stream can fold it
 //! into the frozen IR (or un-fold the IR back into the source-faithful quad stream).
@@ -175,7 +175,7 @@ mod tests {
         assert_eq!(flat.len(), 2);
     }
 
-    /// Native flat-canonical determinism + shape gate (EPIC #906): over an input that
+    /// Native flat-canonical determinism + shape gate: over an input that
     /// exercises every literal/term shape (simple, typed, lang, blank-node, and an RDF
     /// 1.2 reifier with an annotation), `canonical_flat_nquads` must
     /// (a) re-materialize the RDF 1.2 statement layer as plain `rdf:reifies` /

--- a/crates/rdf/src/statements.rs
+++ b/crates/rdf/src/statements.rs
@@ -7,7 +7,7 @@
 //! and `rdf12-to-owl.rq`) as pure structural folds over the purrdf model, so
 //! the RDF 1.2 statement lead artifact (`generated/statements/purrdf.rdf12.ttl`)
 //! is produced with **no Apache Jena, no Docker, and no SPARQL engine**. The native
-//! [`parse_dataset`] codec (#909) only *parses* the input
+//! [`parse_dataset`] codec only *parses* the input
 //! Turtle into the IR; the projection itself is a fold over native RDF quads (the
 //! IR flattened back to a flat quad stream) into RDF 1.2 triple terms.
 //!
@@ -455,7 +455,7 @@ ex:ax a owl:Axiom ;
         // Two DIFFERENT rdf:reifies triple terms for one reifier subject: corrupt
         // input the codec must hard-fail on, never silently last-write-win.
         //
-        // FINDING (#909): the rejection now fires EARLIER — the native
+        // FINDING: the rejection now fires EARLIER — the native
         // `parse_dataset` folds the statement layer during parse and detects the
         // conflicting reifier rebind there, so `parse_quads` surfaces it as a
         // `statements-turtle-parse` error before `normalize_rdf12_to_owl` reaches its

--- a/crates/rdf/src/turtle_normalize.rs
+++ b/crates/rdf/src/turtle_normalize.rs
@@ -17,7 +17,7 @@
 //! wasm-clean kernel ([`purrdf_core::turtle_render`]); it is re-exported here so
 //! existing `purrdf::turtle_normalize::render` callers resolve unchanged. The text
 //! *parser* edge ([`canonical_turtle`] / `ingest`) is the native codec — fully
-//! oxigraph-free (EPIC #906).
+//! oxigraph-free.
 
 use std::sync::Arc;
 
@@ -129,9 +129,9 @@ mod tests {
 
     #[test]
     fn reifier_annotation_render_is_flat_and_idempotent() {
-        // #1155 bug 2 + Task 5 guard. The canonical renderer must emit the RDF 1.2
+        //  bug 2 + Task 5 guard. The canonical renderer must emit the RDF 1.2
         // statement layer (reifier bindings + annotations) from the SIDE-TABLES — which
-        // `canonical_turtle`/`ingest` flattens away, but the #1142 byte-exact fold renders
+        // `canonical_turtle`/`ingest` flattens away, but the byte-exact fold renders
         // directly — flat (never nested) and byte-idempotent under parse→render→parse.
         // Use `parse_dataset` + `render` directly (NOT `canonical_turtle`, which flattens
         // the side-tables before rendering and so never exercises this path).

--- a/crates/rdf/src/ustar.rs
+++ b/crates/rdf/src/ustar.rs
@@ -27,7 +27,7 @@ const LONGLINK_NAME: &str = "././@LongLink";
 /// `'L'` (LongLink) record carrying the full path (NUL-terminated, 512-padded);
 /// the real header then truncates the name to 100 bytes (GNU convention — readers
 /// take the path from the LongLink). Names ≤ 100 bytes emit no LongLink and are
-/// byte-identical to the pre-#897 writer, so existing archive blobs are
+/// byte-identical to the pre writer, so existing archive blobs are
 /// fold-stable.
 ///
 /// # Errors
@@ -114,7 +114,7 @@ pub fn read_archive(tar: &[u8]) -> Result<Vec<(String, Vec<u8>)>, String> {
 /// A single USTAR 512-byte header with the given `typeflag` (`b'0'` regular file,
 /// `b'L'` GNU LongLink). A name longer than 100 bytes is truncated into the field
 /// — the caller MUST have emitted a preceding LongLink record carrying the full
-/// path. For a name ≤ 100 bytes the bytes are identical to the pre-#897
+/// path. For a name ≤ 100 bytes the bytes are identical to the pre
 /// single-typeflag header.
 fn ustar_header(name: &str, size: usize, typeflag: u8) -> Result<[u8; 512], String> {
     let nb = name.as_bytes();

--- a/crates/rdf/tests/corpus/w3c/README.md
+++ b/crates/rdf/tests/corpus/w3c/README.md
@@ -8,8 +8,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 This directory is a **vendored subset** of the official W3C RDF 1.2 test suites,
 used by `crates/rdf/tests/native_codec_conformance.rs` to prove the native
 `purrdf` text codecs (Turtle / TriG / N-Triples / N-Quads / RDF-XML) parse the
-W3C syntax suites and **round-trip** them with no oxigraph dependency (#909 /
-EPIC #906).
+W3C syntax suites and **round-trip** them with no oxigraph dependency.
 
 ## Provenance
 
@@ -28,7 +27,7 @@ has no `syntax/` subdir upstream; its negative-syntax tests live in
 
 **Trimmed:** the `c14n/` (canonicalization) sub-suites for N-Triples and N-Quads
 were **not** vendored — they test RDF dataset canonicalization (RDFC-1.0), not
-text-codec round-trip, and are out of scope for #909. The top-level aggregator
+text-codec round-trip, and are out of scope here. The top-level aggregator
 `manifest.ttl` (which only `mf:include`s the sub-manifests and the RDF 1.1
 suites) was also not vendored; the harness reads the `syntax/`/`eval/`
 sub-manifests directly.

--- a/crates/rdf/tests/fixtures/rdfc/SOURCE.md
+++ b/crates/rdf/tests/fixtures/rdfc/SOURCE.md
@@ -2,7 +2,7 @@
 
 These fixtures are the **canonicalization (`rdfc10`) test vectors** from the W3C
 `rdf-canon` test suite, vendored verbatim for the native RDFC-1.0 conformance gate
-(`crates/rdf/tests/rdfc_w3c.rs`, issue #910).
+(`crates/rdf/tests/rdfc_w3c.rs`).
 
 - **Upstream:** <https://github.com/w3c/rdf-canon> — `tests/rdfc10/`
 - **Spec:** *RDF Dataset Canonicalization* (RDFC-1.0), W3C Recommendation —

--- a/crates/rdf/tests/native_codec_conformance.rs
+++ b/crates/rdf/tests/native_codec_conformance.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! W3C RDF 1.2 syntax-suite **round-trip** conformance gate for the native
-//! `purrdf` text codecs (#909 acceptance: "W3C syntax test suites round-trip").
+//! `purrdf` text codecs (acceptance: "W3C syntax test suites round-trip").
 //!
 //! This harness is deliberately **oxigraph-free**: a green run proves the native Turtle /
 //! TriG / N-Triples / N-Quads / RDF-XML codecs parse and round-trip the official W3C
-//! suites with no Store dependency (EPIC #906 end-state).
+//! suites with no Store dependency ( end-state).
 //!
 //! ## What it does (per the W3C RDF test semantics)
 //!
@@ -42,7 +42,7 @@ use purrdf_rdf::{
 /// strict W3C manifest expects, keyed by `mf:name` → reason. A failing allowlisted case
 /// is tolerated; a passing allowlisted case is flagged STALE (prune it).
 ///
-/// As of purrdf-gts 0.9.7 (#909) the native codecs pass the **entire** W3C RDF 1.2 syntax
+/// As of purrdf-gts 0.9.7 the native codecs pass the **entire** W3C RDF 1.2 syntax
 /// suite — Turtle, TriG, N-Triples, N-Quads, and RDF/XML — with NO gaps:
 ///
 /// - The former **G2** serializer gap (a triple term in quad-object position tripping a

--- a/crates/rdf/tests/never_panic.rs
+++ b/crates/rdf/tests/never_panic.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! "Reject malformed, never panic" property gate (T7, #788) for the purrdf
+//! "Reject malformed, never panic" property gate (T7) for the purrdf
 //! format frontends.
 //!
 //! Every parser given arbitrary input must return — `Ok` or `Err` — and NEVER
@@ -16,7 +16,7 @@
 //! timeout would be a false red.
 //!
 //! The parser under test is the native, oxigraph-free [`purrdf_rdf::parse_dataset`]
-//! codec (EPIC #906): it must return `Ok`/`Err` and NEVER panic on arbitrary input
+//! codec: it must return `Ok`/`Err` and NEVER panic on arbitrary input
 //! across every text format it accepts (N-Quads / Turtle / TriG / N-Triples).
 
 use proptest::prelude::*;

--- a/crates/rdf/tests/proptest_roundtrip.rs
+++ b/crates/rdf/tests/proptest_roundtrip.rs
@@ -1,24 +1,24 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Property-based round-trip tests (#787, T6 of #781): `parse ∘ serialize = id`,
+//! Property-based round-trip tests (T6 of): `parse ∘ serialize = id`,
 //! modulo canonical form, for the native RDF serialization codecs the kernel exposes.
 //!
 //! # Equivalence is canonical, never byte-exact
 //!
 //! A faithful round-trip is allowed to rename blank nodes and to collapse the
 //! `"x"` ≡ `"x"^^xsd:string` distinction. Byte equality would therefore produce
-//! spurious failures (cf. the GTS codec-skew doctrine, PR #595: the drift gate is
+//! spurious failures (cf. the GTS codec-skew doctrine, : the drift gate is
 //! semantic). Every property here compares **RDFC-1.0 canonical quad sets** via the
-//! native [`purrdf_rdf::canonical_flat_nquads`] (#910), the same comparator the
+//! native [`purrdf_rdf::canonical_flat_nquads`], the same comparator the
 //! production native canonicalizer wraps.
 //!
-//! # Single generator, three codecs (EPIC #906 — native only)
+//! # Single generator, three codecs ( — native only)
 //!
 //! One generator authors a frozen [`RdfDataset`] fixture; the native text codecs
 //! ([`purrdf_rdf::serialize_dataset`] / [`purrdf_rdf::parse_dataset`]) serialize and
 //! re-parse it for N-Quads and TriG, and the GTS fold/unfold path covers the third
-//! codec. EPIC #906 removed oxigraph, so this gate now exercises the native codecs
+//! codec.  removed oxigraph, so this gate now exercises the native codecs
 //! against the native RDFC-1.0 comparator directly (it is no longer a cross-check
 //! against an independent oxigraph implementation — the native engine is the sole
 //! authority). The native text codec's own isomorphism round-trips additionally live
@@ -34,9 +34,9 @@
 //!
 //! * **JSON-LD** is no longer exercised here: the native text codecs cover Turtle /
 //!   TriG / N-Triples / N-Quads / RDF-XML (no JSON-LD), and the prior JSON-LD
-//!   property tested oxigraph's JSON-LD serializer — removed with oxigraph (EPIC #906).
+//!   property tested oxigraph's JSON-LD serializer — removed with oxigraph.
 //! * **CLIF / CGIF / XCL** round-trips: depend on the open Common Logic epic
-//!   (#718/#719) and do not exist yet.
+//!   (/) and do not exist yet.
 
 use proptest::prelude::*;
 use purrdf_rdf::{
@@ -51,7 +51,7 @@ const XSD_BOOLEAN: &str = "http://www.w3.org/2001/XMLSchema#boolean";
 const XSD_DECIMAL: &str = "http://www.w3.org/2001/XMLSchema#decimal";
 const XSD_NON_NEGATIVE_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#nonNegativeInteger";
 
-// ── Canonical comparator (native RDFC-1.0, #910) ─────────────────────────────────
+// ── Canonical comparator (native RDFC-1.0) ─────────────────────────────────
 
 /// The native flat RDFC-1.0 canonical N-Quads of a dataset — the comparator for every
 /// round-trip property (blank-node labels canonicalized, lines sorted/deduped).

--- a/crates/rdf/tests/proptest_roundtrip.rs
+++ b/crates/rdf/tests/proptest_roundtrip.rs
@@ -36,7 +36,7 @@
 //!   TriG / N-Triples / N-Quads / RDF-XML (no JSON-LD), and the prior JSON-LD
 //!   property tested oxigraph's JSON-LD serializer — removed with oxigraph.
 //! * **CLIF / CGIF / XCL** round-trips: depend on the open Common Logic epic
-//!   (/) and do not exist yet.
+//!   and do not exist yet.
 
 use proptest::prelude::*;
 use purrdf_rdf::{

--- a/crates/rdf/tests/rdfc_w3c.rs
+++ b/crates/rdf/tests/rdfc_w3c.rs
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! W3C RDF Dataset Canonicalization (RDFC-1.0) conformance gate (#910).
+//! W3C RDF Dataset Canonicalization (RDFC-1.0) conformance gate.
 //!
 //! The vendored W3C `rdf-canon` test suite (`tests/fixtures/rdfc/`, see
 //! `SOURCE.md`) is the acceptance gate for the native canonicalizer. Each
 //! `testNNN-in.nq` input is parsed with the native [`purrdf_rdf::parse_dataset`] codec
-//! (oxigraph-free, EPIC #906), canonicalized graph-preservingly by
+//! (oxigraph-free), canonicalized graph-preservingly by
 //! [`purrdf_rdf::canonicalize_with`], and its canonical N-Quads compared to
 //! the expected `testNNN-rdfc10.nq`. Inputs WITHOUT an expected output are
 //! **negative** (poison / complexity-limit) tests that must abort rather than
@@ -16,7 +16,7 @@
 //! blank-node symmetries can only be resolved by RDFC-1.0's n-degree permutation
 //! backtracking — a weaker (hash-only) implementation fails them.
 //!
-//! ## Sharding + heavy carve-out for the 25 s per-test budget (#1045)
+//! ## Sharding + heavy carve-out for the 25 s per-test budget
 //!
 //! The full 65-fixture suite runs ~28–32 s on CI, over the always-on 25 s budget.
 //! Per-fixture timing (2026-06-26) showed the cost is NOT spread: exactly one
@@ -42,11 +42,11 @@ use purrdf_rdf::{canonicalize_with, parse_dataset, CanonHash, NativeRdfFormat};
 /// ("blank node - diamond (uses SHA-384)").
 const SHA384_TESTS: &[&str] = &["test075"];
 
-/// How many independent shard tests the GATED (non-heavy) subset is split across (#1045).
+/// How many independent shard tests the GATED (non-heavy) subset is split across.
 const NUM_SHARDS: usize = 4;
 
 /// OFF-GATE heavy fixtures: stems whose canonicalization is too slow to fit the 25 s
-/// always-on per-test budget (#1045). Carved out of the gated shards and exercised
+/// always-on per-test budget. Carved out of the gated shards and exercised
 /// only on the maint lane via [`w3c_rdfc10_heavy_offgate`].
 ///
 /// Current entry: `test074` — the suite's sole negative/poison vector. The native
@@ -87,7 +87,7 @@ fn fixtures_dir() -> PathBuf {
 /// gated shards so the suite stays green while the gap stays VISIBLE and tracked
 /// (not silently dropped).
 ///
-/// NOW EMPTY (EPIC #906): the first-party N-Triples/N-Quads/Turtle/TriG parser decodes
+/// NOW EMPTY: the first-party N-Triples/N-Quads/Turtle/TriG parser decodes
 /// `\u`/`\U` UCHAR escapes inside IRIREFs (reusing the sparql-algebra term lexer), so
 /// `test060` (`<urn:ex:s:000:s⁰1>` etc.) parses and canonicalizes correctly. The slot
 /// is retained (empty) so a future native-parse gap can be tracked here rather than
@@ -230,7 +230,7 @@ fn run_w3c_shard(shard: usize) {
 }
 
 // ---------------------------------------------------------------------------
-// Gated shard entry points (#1045)
+// Gated shard entry points
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -255,7 +255,7 @@ fn w3c_rdfc10_shard_3() {
 
 // ---------------------------------------------------------------------------
 // Off-gate heavy vectors (maint lane only; excluded from the per-commit gate via
-// `default-filter` in `.config/nextest.toml`) (#1045)
+// `default-filter` in `.config/nextest.toml`)
 // ---------------------------------------------------------------------------
 
 /// OFF-GATE: runs exactly the [`HEAVY_OFFGATE_STEMS`] (the sole negative/poison

--- a/crates/shapes/README.md
+++ b/crates/shapes/README.md
@@ -20,7 +20,7 @@
 ontology toolchain. It validates an RDF 1.2 data graph against a SHACL shapes
 graph with no inference (parity with pySHACL `inference="none"`), using the
 non-SPARQL constraint/target surface. SPARQL-based constraints and targets
-arrive in issue #577.
+are planned for a future release.
 
 In four-box terms, the data graph is usually the ABox, the shapes graph is a
 TBox/RBox validation surface, and RDF 1.2 reifier metadata is the CBox. The
@@ -38,7 +38,7 @@ The Python SHACL surface is exposed from `bindings/python` as part of the
 **PyO3-free** — it links as a plain `rlib` into the future Rust compiler without
 any Python dependency.
 
-This crate is gated by a SHACL conformance corpus and is part of **EPIC #575**.
+This crate is gated by a SHACL conformance corpus.
 
 ---
 
@@ -86,7 +86,7 @@ Each result dict keeps the stable keys `focus`, `path`, `value`, `severity`,
 
 `purrdf-shapes` is developed by [Blackcat Informatics® Inc.](https://blackcatinformatics.ca)
 as part of the [PurRDF ontology and tooling](https://github.com/Blackcat-Informatics/purrdf)
-suite. See EPIC #575 for the full roadmap.
+suite.
 
 Related packages:
 

--- a/crates/shapes/benches/validate.rs
+++ b/crates/shapes/benches/validate.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Baseline benchmark for the SHACL Core validator (#630 acceleration, Phase 0).
+//! Baseline benchmark for the SHACL Core validator (acceleration, Phase 0).
 //!
 //! Sweeps the whole committed conformance corpus through
 //! [`purrdf_shapes::engine::validate_graphs`] — parse data + shapes, resolve focus
@@ -56,11 +56,11 @@ fn bench_validate(c: &mut Criterion) {
 
 /// Build a 40-class rdfs:subClassOf chain + 3000 typed focus nodes as N-Triples.
 ///
-/// This is the measurement instrument for #828 item 2 (focus-node parallelism).
+/// This is the measurement instrument for item 2 (focus-node parallelism).
 /// The engine validates focus nodes SERIALLY: a rayon `par_iter` over this 3000-
 /// node workload was measured here and regressed ~9% (per-focus work is too cheap
 /// — ~5 µs — to amortize thread-pool dispatch and shared-`Store` read contention),
-/// confirming #827. The `ShaclDataGraph: Send + Sync` bound keeps the seam ready;
+/// confirming. The `ShaclDataGraph: Send + Sync` bound keeps the seam ready;
 /// the parallel path re-enters once per-focus cost exceeds ~50–100 µs.
 fn large_hierarchy_inputs() -> (String, String) {
     // Shape: one NodeShape targeting ex:C0 with sh:pattern + sh:minCount constraints.

--- a/crates/shapes/src/data.rs
+++ b/crates/shapes/src/data.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The SHACL engine's data-access abstraction (#819 C4, EPIC #906).
+//! The SHACL engine's data-access abstraction (C4).
 //!
 //! [`ShaclDataGraph`] is the single seam through which the SHACL Core engine reads
 //! the data graph. The engine, constraint evaluator, and path evaluator are all
@@ -154,7 +154,7 @@ impl ShaclDataGraph for IrDataGraph {
             GraphFilter::DefaultGraph => GraphMatch::Default,
         };
 
-        // Indexed pattern lookup (#891 P4b): only matched quads are materialized into
+        // Indexed pattern lookup (P4b): only matched quads are materialized into
         // native terms — no whole-table scan per call.
         let mut out = Vec::new();
         for q in dataset.quads_for_pattern(s_id, p_id, o_id, graph_match) {

--- a/crates/shapes/src/engine.rs
+++ b/crates/shapes/src/engine.rs
@@ -60,7 +60,7 @@ fn objects_of<G: ShaclDataGraph>(data: &G, pred: &NamedNode) -> Vec<Term> {
 /// subclass relationships present in the data. It is NOT OWL/RDFS inference: we
 /// read `rdfs:subClassOf` triples that exist and materialize nothing. (The
 /// "no-inference contract" means no reasoner is run, not that asserted subclass
-/// edges are ignored.) See #599.
+/// edges are ignored.) See the issue tracker.
 pub(crate) fn subclass_closure<G: ShaclDataGraph>(
     data: &G,
     class_iri: &NamedNode,
@@ -231,13 +231,13 @@ where
 
         // Per-focus constraint evaluation stays SERIAL. A rayon `par_iter` over the
         // focus loop was measured on `shacl_validate/large_hierarchy` (3000 focus
-        // nodes) and REGRESSED ~9% (15.71 ms → 16.43 ms), confirming #827: per-focus
+        // nodes) and REGRESSED ~9% (15.71 ms → 16.43 ms), confirming that per-focus
         // work (~5 µs: an rdfs:subClassOf BFS-backed lookup + a `sh:pattern` regex)
         // is dwarfed by thread-pool dispatch and shared-`Store` read contention. The
         // `ShaclDataGraph: Send + Sync` bound (data.rs) keeps the seam ready, but the
         // parallel path waits on the re-entry condition: per-focus cost >50–100 µs,
         // i.e. once SHACL-SPARQL constraints are common or the IR-native backend runs
-        // end-to-end (dropping the shared-`Store` contention). See #828 (item 2).
+        // end-to-end (dropping the shared-`Store` contention). See the issue tracker (item 2).
         for focus in &focus_nodes {
             if !include_focus(shape, focus) {
                 continue;
@@ -417,12 +417,12 @@ pub fn parse_shapes_with_config(
     shapes_ttl: &str,
     box_role_vocab: Option<crate::model::BoxRoleVocab>,
 ) -> Result<Shapes, String> {
-    // Parse the shapes graph via the native purrdf codecs (#909) — no
+    // Parse the shapes graph via the native purrdf codecs — no
     // the oxigraph `io` parser. The native codec drops document prefixes once it folds to
     // the IR, so we recover the `@prefix`/SPARQL `PREFIX` map by scanning the
     // source text: SHACL-AF sh:select queries (and pySHACL) rely on prefixed
-    // names. See #578. A syntax error is reported per-statement so
-    // a SHACL author sees the full list in one pass (#828 item 4), not the
+    // names. See the issue tracker. A syntax error is reported per-statement so
+    // a SHACL author sees the full list in one pass (item 4), not the
     // fix-one-rerun-find-the-next loop.
     let shapes_dataset = crate::text_ingest::parse_turtle_to_dataset(shapes_ttl)
         .map_err(|errors| errors.join("\n"))?;
@@ -442,7 +442,7 @@ pub fn parse_shapes_with_config(
 /// The purrdf ontology carries private-use `@x-purrdf-*` language tags whose
 /// subtag exceeds BCP-47's 8-char limit (e.g. `@x-purrdf-afrikaans`); the strict
 /// parser rejects the entire file on these, which would make the real ontology
-/// un-validatable. Lenient parsing skips that check so the data ingests. See #597.
+/// un-validatable. Lenient parsing skips that check so the data ingests. See the issue tracker.
 ///
 /// # Errors
 ///
@@ -463,9 +463,9 @@ pub fn validate_graphs_with_config(
     shapes_ttl: &str,
     box_role_vocab: Option<crate::model::BoxRoleVocab>,
 ) -> Result<ValidationReport, String> {
-    // Parse the data graph via the native codecs (#909). Every malformed
+    // Parse the data graph via the native codecs. Every malformed
     // N-Triples line is reported in one pass — same multi-error contract as
-    // `parse_shapes`. See #828 (item 4).
+    // `parse_shapes`. See the issue tracker (item 4).
     let data = crate::text_ingest::parse_ntriples_to_dataset(data_nt)
         .map_err(|errors| errors.join("\n"))?;
 
@@ -519,7 +519,7 @@ mod tests {
         validate_dataset(data.as_ref(), shapes).expect("validate_dataset must succeed")
     }
 
-    // ── Multi-error syntax reporting (#828 item 4) ─────────────────────────────
+    // ── Multi-error syntax reporting (item 4) ─────────────────────────────
 
     #[test]
     fn parse_shapes_reports_all_syntax_errors() {
@@ -749,7 +749,7 @@ mod tests {
     // Test 4: sh:targetClass honors ASSERTED rdfs:subClassOf (SHACL §4.2.5).
     // This is NOT OWL inference — the subclass edge is asserted in the data; we
     // read it, materialize nothing. (Inverted from the former no-subclass
-    // contract; see #599.)
+    // contract; see the issue tracker.)
     #[test]
     fn target_class_honors_asserted_subclass() {
         let shapes_ttl = format!(

--- a/crates/shapes/src/instance.rs
+++ b/crates/shapes/src/instance.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! JSON-LD `@graph` projector for PurRDF instance data (#700).
+//! JSON-LD `@graph` projector for PurRDF instance data.
 //!
 //! Walks an oxigraph data graph (the default graph) and emits a JSON-LD document
 //! `{ "@context": {<prefix map>}, "@graph": [ <node objects> ] }`. The projection

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! SHACL → JSON Schema (draft 2020-12) + OpenAPI 3.1 emitter (#700).
+//! SHACL → JSON Schema (draft 2020-12) + OpenAPI 3.1 emitter.
 //!
 //! Compiles a parsed [`Shapes`] graph into a closed-world JSON Schema describing
 //! the JSON-LD projection of PurRDF instance data (see [`crate::instance`]). The
@@ -21,7 +21,7 @@
 //! * **Language-tagged literal** — `{"@value": "<lexical>", "@language": "<tag>"}`.
 //! * **Plain string** — a bare JSON string.
 //! * **Statement metadata** — an optional `@annotation` key on any property value
-//!   object, referencing `#/$defs/Annotation` (RDF-1.2 reifier metadata, #699).
+//!   object, referencing `#/$defs/Annotation` (RDF-1.2 reifier metadata).
 //!
 //! # SPARQL losses
 //!
@@ -293,7 +293,7 @@ impl<'ns> Ctx<'ns> {
 /// namespace with no declared prefix, or when two distinct target classes
 /// would share a `$defs` key — see [`Namespaces::def_key`].
 pub fn compile(shapes: &Shapes, ns: &Namespaces) -> CompiledSchema {
-    // Keying invariant (#700 Gap D, fail-closed): every primary-namespace `$def`
+    // Keying invariant (Gap D, fail-closed): every primary-namespace `$def`
     // is keyed by the class LOCAL NAME and the `@type` discriminator is
     // `<primary_prefix>:<LocalName>`. That is sound ONLY while every target
     // class is in a declared namespace and no two distinct class IRIs share a
@@ -344,7 +344,7 @@ pub fn compile(shapes: &Shapes, ns: &Namespaces) -> CompiledSchema {
         }
     }
 
-    // The shared statement-metadata fragment (#699).
+    // The shared statement-metadata fragment.
     defs.insert("Annotation".to_owned(), annotation_def());
 
     let class_names: Vec<String> = defs
@@ -354,7 +354,7 @@ pub fn compile(shapes: &Shapes, ns: &Namespaces) -> CompiledSchema {
         .collect();
     // `class_names` is already sorted because `defs` is a BTree-ordered Map iter.
 
-    // The `@type`-discriminated `Node` schema (#700 closed-world enforcement):
+    // The `@type`-discriminated `Node` schema (closed-world enforcement):
     // a node typed `<primary>:Foo` MUST satisfy `#/$defs/Foo`. Inserted AFTER
     // `class_names` is snapshotted so `Node` itself is never treated as a class
     // branch.
@@ -370,7 +370,7 @@ pub fn compile(shapes: &Shapes, ns: &Namespaces) -> CompiledSchema {
     }
 }
 
-/// Enforce the keying precondition (#700 Gap D): every active `sh:targetClass`
+/// Enforce the keying precondition (Gap D): every active `sh:targetClass`
 /// is in a DECLARED namespace (so [`Namespaces::def_key`] yields a stable
 /// `$defs` key and [`node_def`] can rebuild its `@type` const) and those keys
 /// are collision-free. Panics with a descriptive message otherwise
@@ -412,7 +412,7 @@ fn assert_target_class_keys_are_unambiguous(shapes: &Shapes, ns: &Namespaces) {
 ///
 /// Every instance node — whether a `@graph` member or a bare single-node root —
 /// is validated by the single `#/$defs/Node` schema, which discriminates on
-/// `@type` (closed-world enforcement, #700).
+/// `@type` (closed-world enforcement).
 fn root_schema(defs: &Map<String, Value>, ns: &Namespaces) -> Value {
     let node_ref = json!({ "$ref": "#/$defs/Node" });
 
@@ -420,7 +420,7 @@ fn root_schema(defs: &Map<String, Value>, ns: &Namespaces) -> Value {
     // envelope branch REQUIRES `@graph`, so a bare single-node document cannot
     // slip through this permissive branch and escape `Node` discrimination — a
     // bare node must satisfy the `node_ref` branch of the root `anyOf` instead
-    // (closed-world: a bare incomplete node is rejected, #700).
+    // (closed-world: a bare incomplete node is rejected).
     let graph_envelope = json!({
         "type": "object",
         "required": ["@graph"],
@@ -450,7 +450,7 @@ fn root_schema(defs: &Map<String, Value>, ns: &Namespaces) -> Value {
     })
 }
 
-/// Build the `@type`-discriminated `Node` schema (#700).
+/// Build the `@type`-discriminated `Node` schema.
 ///
 /// A node carries `@id`/`@type`/`@annotation` permissively, then an `allOf` of
 /// per-class conditionals (sorted by class name for determinism). Each entry
@@ -557,11 +557,11 @@ fn openapi_doc(defs: &Map<String, Value>) -> Value {
     })
 }
 
-// ── The `@annotation` fragment (#699 statement metadata) ─────────────────────
+// ── The `@annotation` fragment (statement metadata) ─────────────────────
 
 /// The shared `$defs/Annotation` object schema: free-form statement metadata.
 ///
-/// Permissive on purpose — #699 tightens it. Values may be node refs
+/// Permissive on purpose — future work tightens it. Values may be node refs
 /// (`{"@id":..}`), scalars, or typed literals (`{"@value":..,"@type":..}`).
 fn annotation_def() -> Value {
     json!({
@@ -1162,7 +1162,7 @@ mod tests {
     fn unknown_namespace_target_class_hard_fails() {
         // A target class from an UNDECLARED namespace has no prefix CURIE to key
         // its `$defs`/discriminator by; the keying guard must reject it loudly
-        // (#700 Gap D). A DECLARED non-primary prefix (e.g. logic:) is accepted —
+        // (Gap D). A DECLARED non-primary prefix (e.g. logic:) is accepted —
         // see `logic_target_class_keyed_by_curie`.
         compile_ttl(
             r"
@@ -1178,7 +1178,7 @@ mod tests {
     fn logic_target_class_keyed_by_curie() {
         // A non-primary but KNOWN-prefix target class (logic:) keys its `$defs` body
         // by the full CURIE and discriminates `@type` on that same CURIE, so a
-        // closed-world logic node is enforced exactly like a primary-namespace node (#772).
+        // closed-world logic node is enforced exactly like a primary-namespace node.
         let schema = schema_of(&compile_ttl(
             r"
             @prefix logic: <https://blackcatinformatics.ca/logic/> .
@@ -1367,7 +1367,7 @@ mod tests {
         // nickname (no maxCount, minCount<=1) accepts BOTH the bare single form
         // AND the array form: the projector emits a bare scalar for a single
         // value and an array only for multiple values, so the schema must accept
-        // either or it would reject SHACL-conformant single-value data (#700).
+        // either or it would reject SHACL-conformant single-value data.
         let nickname = &person["properties"]["meta:nickname"];
         let alts = nickname["anyOf"]
             .as_array()
@@ -1608,7 +1608,7 @@ mod tests {
 
     /// Self-consistency invariant: EVERY `#/$defs/<name>` ref the emitter writes
     /// must resolve to an actually-emitted key in the top-level `$defs`. This is
-    /// the bug guard for #700 — an object property whose `sh:class` points at a
+    /// the bug guard — an object property whose `sh:class` points at a
     /// class with NO NodeShape must NOT emit a dangling `$ref`.
     #[test]
     fn every_ref_resolves() {

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -8,7 +8,7 @@
 //! PyO3-free so the rlib links into the future Rust compiler over its own Store.
 //! SHACL-AF SPARQL-based constraints (`sh:sparql`/`sh:SPARQLConstraint`) and
 //! targets (`sh:SPARQLTarget`) are implemented in the [`sparql`] module,
-//! delegated to oxigraph's SPARQL 1.1 engine (#577).
+//! delegated to oxigraph's SPARQL 1.1 engine.
 
 pub mod constraints;
 pub mod data;

--- a/crates/shapes/src/model.rs
+++ b/crates/shapes/src/model.rs
@@ -5,7 +5,7 @@
 //!
 //! All constants are plain `&'static str` IRIs. Native query patterns key on the
 //! IRI string directly; constructors like [`crate::term::NamedNode::from`] wrap one
-//! into a term when a value is needed (EPIC #906).
+//! into a term when a value is needed.
 
 /// SHACL namespace constants (`http://www.w3.org/ns/shacl#`).
 pub mod sh {

--- a/crates/shapes/src/report.rs
+++ b/crates/shapes/src/report.rs
@@ -114,7 +114,7 @@ impl ValidationResult {
     /// a triple term.
     ///
     /// This lets a consumer render the focus without naming the (oxigraph) [`Term`] type
-    /// in its own surface (EPIC #906) — it is the exact value-extraction the PurRDF
+    /// in its own surface — it is the exact value-extraction the PurRDF
     /// scoreboard's `shacl_term_to_str` performed.
     #[must_use]
     pub fn focus_value(&self) -> String {
@@ -167,7 +167,7 @@ pub type ResultTuple = (
 );
 
 impl ValidationReport {
-    /// Emit the report as N-Triples text using the native purrdf codec (#909).
+    /// Emit the report as N-Triples text using the native purrdf codec.
     ///
     /// The report is built into an in-memory [`Store`] as quads in the default
     /// graph, folded back to the IR ([`dataset_from_store`]), then serialised via
@@ -494,7 +494,7 @@ pub fn tuples_from_ntriples(nt: &str) -> Result<BTreeSet<ResultTuple>, String> {
 }
 
 /// Parse a SHACL report N-Triples string into a query-able [`IrDataGraph`] via the
-/// native purrdf codec (#909) — no oxigraph.
+/// native purrdf codec — no oxigraph.
 fn dataset_from_ntriples(nt: &str) -> Result<IrDataGraph, String> {
     let dataset = ::purrdf::parse_dataset(nt.as_bytes(), "application/n-triples", None)
         .map_err(|e| format!("N-Triples parse error: {e}"))?;

--- a/crates/shapes/src/shape_union.rs
+++ b/crates/shapes/src/shape_union.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The shared SHACL shape-file set (#700).
+//! The shared SHACL shape-file set.
 //!
 //! Replicates EXACTLY the shape union the Python validator builds in
 //! `src/purrdf_tools/validate.py::_shapes_turtle` so the JSON-Schema emitter sees
@@ -76,13 +76,13 @@ pub fn shape_files(repo_root: &Path) -> Result<Vec<PathBuf>, String> {
 /// [`shapes::from_dataset_with_prefixes`] (the frozen IR does not retain prefix
 /// maps): SHACL-AF `sh:select` queries — e.g. the music `MetricGroupShape`
 /// uniqueness constraint — use prefixed names like `meta:` and fail to parse
-/// without them. This mirrors the live validator (`engine::parse_shapes`, #578).
+/// without them. This mirrors the live validator (`engine::parse_shapes`).
 /// When the same prefix is declared in multiple files, the last declaration wins
 /// (deterministic via the merge order over the sorted file list).
 ///
 /// Blank labels are scoped per source file: a NodeShape's anonymous property shapes
 /// (`sh:property [ … ]`) restart the blank counter per file, so merging several
-/// shape files unscoped would fuse distinct property shapes (#909).
+/// shape files unscoped would fuse distinct property shapes.
 /// [`RdfDataset::union`] standardizes each input's blanks apart under a fresh scope,
 /// providing exactly that per-file isolation.
 ///
@@ -99,7 +99,7 @@ pub fn load_shapes(repo_root: &Path) -> Result<(Arc<RdfDataset>, Shapes), String
             .map_err(|e| format!("failed to read shape file {}: {e}", file.display()))?;
         let text = std::str::from_utf8(&bytes)
             .map_err(|e| format!("shape file {} is not UTF-8: {e}", file.display()))?;
-        // Parse via the native codecs (#909). The native codec drops document
+        // Parse via the native codecs. The native codec drops document
         // prefixes once it folds to the IR, so the per-file `@prefix` map is
         // recovered by scanning the source text — see the doc comment above.
         let dataset = parse_dataset(&bytes, "text/turtle", None)

--- a/crates/shapes/src/shapes.rs
+++ b/crates/shapes/src/shapes.rs
@@ -2403,7 +2403,7 @@ mod tests {
         );
     }
 
-    // ── #700: sh:maxLength parses to Constraint::MaxLength ────────────────────
+    // ──: sh:maxLength parses to Constraint::MaxLength ────────────────────
 
     #[test]
     fn test_max_length_parses() {
@@ -2427,7 +2427,7 @@ mod tests {
         assert!(has_max, "expected MaxLength(5), got {:?}", ps.constraints);
     }
 
-    // ── #700: sh:languageIn parses to Constraint::LanguageIn ──────────────────
+    // ──: sh:languageIn parses to Constraint::LanguageIn ──────────────────
 
     #[test]
     fn test_language_in_parses() {
@@ -2459,7 +2459,7 @@ mod tests {
         );
     }
 
-    // ── #700: sh:not parses to Constraint::Not(nested shape) ──────────────────
+    // ──: sh:not parses to Constraint::Not(nested shape) ──────────────────
 
     #[test]
     fn test_not_parses() {
@@ -2488,7 +2488,7 @@ mod tests {
         );
     }
 
-    // ── #700: sh:closed true (+ sh:ignoredProperties) parses to Closed ────────
+    // ──: sh:closed true (+ sh:ignoredProperties) parses to Closed ────────
 
     #[test]
     fn test_closed_parses() {
@@ -2526,7 +2526,7 @@ mod tests {
     fn test_ignored_properties_non_iri_member_errors() {
         // A non-IRI sh:ignoredProperties member (a literal) is malformed: the
         // shapes graph must HARD-fail to load rather than silently dropping it
-        // (#700 Gap H).
+        // (Gap H).
         let ttl = format!(
             r#"{PREFIXES}
             ex:ClosedShape a sh:NodeShape ;
@@ -2544,7 +2544,7 @@ mod tests {
         );
     }
 
-    // ── #700: sh:closed false emits NO Closed constraint ──────────────────────
+    // ──: sh:closed false emits NO Closed constraint ──────────────────────
 
     #[test]
     fn test_closed_false_emits_nothing() {

--- a/crates/shapes/src/sparql.rs
+++ b/crates/shapes/src/sparql.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Pure SPARQL evaluation helpers for SHACL-AF, over the native engine (EPIC #906).
+//! Pure SPARQL evaluation helpers for SHACL-AF, over the native engine.
 //!
 //! [`eval_target`] runs a `sh:SPARQLTarget` SELECT query and returns the bound
 //! `?this` focus nodes. [`eval_sparql_constraint`] runs a `sh:SPARQLConstraint`
@@ -11,7 +11,7 @@
 //! Both run the [`NativeSparqlEngine`] over the borrowed `Arc<RdfDataset>` — there is
 //! no oxigraph SPARQL engine and no materialized `Store`. Focus-node substitution
 //! uses [`SparqlRequest::substitutions`] (the native replacement for oxigraph's
-//! `PreparedSparqlQuery::substitute_variable`, EPIC #906 GAP-A).
+//! `PreparedSparqlQuery::substitute_variable`,  GAP-A).
 
 use std::sync::Arc;
 

--- a/crates/shapes/src/term.rs
+++ b/crates/shapes/src/term.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The SHACL engine's native RDF 1.2 term value model (EPIC #906).
+//! The SHACL engine's native RDF 1.2 term value model.
 //!
 //! The engine, constraint evaluator, path evaluator, shape parser, and report all
 //! work over ONE term value type. Historically that type was

--- a/crates/shapes/src/text_ingest.rs
+++ b/crates/shapes/src/text_ingest.rs
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Native RDF-text ingestion for the SHACL engine (#909).
+//! Native RDF-text ingestion for the SHACL engine.
 //!
 //! The SHACL engine ingests two kinds of RDF text: the shapes graph (Turtle) and
 //! the data graph (N-Triples). It used to drive the oxigraph `io` RDF parser
 //! directly so it could (a) recover the document `@prefix` map — oxigraph stores
 //! drop prefixes, but SHACL-AF `sh:select` queries reference prefixed names — and
-//! (b) accumulate EVERY syntax error in one pass (#828 item 4) instead of
+//! (b) accumulate EVERY syntax error in one pass (item 4) instead of
 //! short-circuiting on the first.
 //!
 //! This module reproduces both capabilities on top of the native purrdf
@@ -79,7 +79,7 @@ fn scan_prefixes(text: &str) -> impl Iterator<Item = (String, String)> + '_ {
 ///
 /// On a clean parse the dataset is returned. On a syntax error the document is
 /// re-parsed one top-level statement at a time so EVERY independently-malformed
-/// statement is reported (the multi-error contract, #828 item 4); the returned
+/// statement is reported (the multi-error contract, item 4); the returned
 /// `Err` is the list of per-statement error strings.
 pub fn parse_turtle_to_dataset(ttl: &str) -> Result<Arc<RdfDataset>, Vec<String>> {
     if ttl.is_empty() {

--- a/crates/shapes/tests/ir_oxigraph_equivalence.rs
+++ b/crates/shapes/tests/ir_oxigraph_equivalence.rs
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Differential equivalence across the two native engine entry-paths (#819 C4,
-//! EPIC #906).
+//! Differential equivalence across the two native engine entry-paths (C4,
+//! ).
 //!
 //! Historically this proved the IR-native SHACL backend agreed with an oxigraph
 //! `Store` oracle. The engine is now IR-native end-to-end (no oxigraph backend), so
@@ -33,7 +33,7 @@ const PREFIXES: &str = r"
 ";
 
 /// Parse a Turtle data document (so RDF 1.2 `<<( … )>>` reifier syntax can be
-/// expressed) into a frozen dataset via the native codec (#909).
+/// expressed) into a frozen dataset via the native codec.
 fn load_data_turtle(ttl: &str) -> Arc<RdfDataset> {
     parse_dataset(ttl.as_bytes(), "text/turtle", None).expect("valid Turtle")
 }

--- a/crates/shapes/tests/ir_oxigraph_equivalence.rs
+++ b/crates/shapes/tests/ir_oxigraph_equivalence.rs
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Differential equivalence across the two native engine entry-paths (C4,
-//! ).
+//! Differential equivalence across the two native engine entry-paths (C4).
 //!
 //! Historically this proved the IR-native SHACL backend agreed with an oxigraph
 //! `Store` oracle. The engine is now IR-native end-to-end (no oxigraph backend), so

--- a/crates/shapes/tests/never_panic.rs
+++ b/crates/shapes/tests/never_panic.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! "Reject malformed, never panic" property gate (T7, #788) for the purrdf-shapes
+//! "Reject malformed, never panic" property gate (T7) for the purrdf-shapes
 //! shapes frontend.
 //!
 //! `engine::parse_shapes` parses untrusted SHACL Turtle; given arbitrary input it

--- a/crates/shapes/tests/proptest_monotonicity.rs
+++ b/crates/shapes/tests/proptest_monotonicity.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Property-based SHACL conformance monotonicity (#787, T6 of #781).
+//! Property-based SHACL conformance monotonicity (T6 of).
 //!
 //! # The property
 //!

--- a/crates/slice/src/analysis.rs
+++ b/crates/slice/src/analysis.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Slice-analysis graph emitter ( §11 / S7).
+//! Slice-analysis graph emitter (§11 / S7).
 //!
 //! Serialises computed dependency edges into the `<vocab>graph/slice-analysis`
 //! named graph (the graph IRI and every emitted term derive from the caller's

--- a/crates/slice/src/analysis.rs
+++ b/crates/slice/src/analysis.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Slice-analysis graph emitter (RFC #820 §11 / S7).
+//! Slice-analysis graph emitter ( §11 / S7).
 //!
 //! Serialises computed dependency edges into the `<vocab>graph/slice-analysis`
 //! named graph (the graph IRI and every emitted term derive from the caller's

--- a/crates/slice/src/cache.rs
+++ b/crates/slice/src/cache.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Phase-specific, path-independent, semantic Merkle cache keys plus
-//! SCC / profile composition ( §12 / §8, child S6a).
+//! SCC / profile composition (§12 / §8, child S6a).
 //!
 //! # Principle 12 — semantic, phase-specific, path-independent cache keys
 //!

--- a/crates/slice/src/cache.rs
+++ b/crates/slice/src/cache.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Phase-specific, path-independent, semantic Merkle cache keys plus
-//! SCC / profile composition (RFC #820 §12 / §8, child S6a).
+//! SCC / profile composition ( §12 / §8, child S6a).
 //!
 //! # Principle 12 — semantic, phase-specific, path-independent cache keys
 //!

--- a/crates/slice/src/cache/tests.rs
+++ b/crates/slice/src/cache/tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Acceptance tests for the phase-specific Merkle cache + SCC/profile
-//! composition (RFC #820 §12 / §8, child S6a). All fixtures are hermetic
+//! composition ( §12 / §8, child S6a). All fixtures are hermetic
 //! (`tempfile`); no repository state is read.
 
 use std::fmt::Write as _;

--- a/crates/slice/src/catalog.rs
+++ b/crates/slice/src/catalog.rs
@@ -68,11 +68,11 @@ pub struct ManifestView {
     /// `<vocab>sliceProfile` values — the named profiles this slice declares
     /// membership in (e.g. `claims`, `memory`, `narrative`). Profile-document
     /// generation lives in the pipeline; this view exposes the raw declarations
-    /// so docs consumers can compute per-term profile membership (#1026).
+    /// so docs consumers can compute per-term profile membership.
     pub profiles: Vec<String>,
     /// `<vocab>sliceDependsOn` values — the slice IRIs this slice depends on.
     /// A named profile's membership is the closure of its declared members over
-    /// this relation (#330); docs reuse it for the same closure (#1026).
+    /// this relation; docs reuse it for the same closure.
     pub depends_on: Vec<String>,
 }
 
@@ -88,7 +88,7 @@ pub struct SliceRecord {
     pub artifacts: Vec<ArtifactRecord>,
     /// The on-disk slice directory the record was loaded from. Retained so the
     /// authoritative `manifest.ttl` path is known without any scan/substring
-    /// match (#820 G8: the discover walk already knows it).
+    /// match (G8: the discover walk already knows it).
     pub slice_dir: PathBuf,
 }
 
@@ -384,10 +384,10 @@ fn compute_semantic_digest(bytes: &[u8], path: &Path) -> Result<String, SliceErr
     // non-deterministically, so a plain sorted-N-Triples digest would differ
     // run-to-run for any artifact that uses blank nodes (e.g. SHACL property shapes,
     // OWL restrictions). Canonicalization makes the *semantic* digest a stable
-    // function of the graph's identity (RFC #820 §12 — semantic, path-independent,
+    // function of the graph's identity ( §12 — semantic, path-independent,
     // deterministic keys).
     //
-    // Native full RDFC-1.0 (#910): the `canonical_nquads_flat` projection flattens the
+    // Native full RDFC-1.0: the `canonical_nquads_flat` projection flattens the
     // RDF 1.2 statement overlay back to plain `rdf:reifies`/annotation triples and
     // canonicalizes that flat set, byte-identical to the prior oxigraph-quad path.
     let canonical = dataset.canonical_nquads_flat()?;

--- a/crates/slice/src/dsl_stats_emit.rs
+++ b/crates/slice/src/dsl_stats_emit.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Native DSL surface-count emission — PurRDF's committed, drift-gated
-//! `generated/mappings/dsl-stats.json` (#861).
+//! `generated/mappings/dsl-stats.json`.
 //!
 //! Emits the counts summary over the SAME merged mapping-DSL source set every
 //! other emitter loads (the shared

--- a/crates/slice/src/fix_deps.rs
+++ b/crates/slice/src/fix_deps.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Native `<vocab>sliceDependsOn` reconciliation patcher (#820 G8).
+//! Native `<vocab>sliceDependsOn` reconciliation patcher (G8).
 //!
 //! Replaces the former Python `slice_fix_deps` line-regex Turtle surgery with an
 //! **RDF-aware, surgical** manifest patcher driven by the native ownership

--- a/crates/slice/src/ownership.rs
+++ b/crates/slice/src/ownership.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Native ownership + dependency analyzer ( §10 / S4).
+//! Native ownership + dependency analyzer (§10 / S4).
 //!
 //! This module derives an **evidence-bearing dependency graph** from validated
 //! term ownership. It is the manifest-driven replacement for the path-derived

--- a/crates/slice/src/ownership.rs
+++ b/crates/slice/src/ownership.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Native ownership + dependency analyzer (RFC #820 §10 / S4).
+//! Native ownership + dependency analyzer ( §10 / S4).
 //!
 //! This module derives an **evidence-bearing dependency graph** from validated
 //! term ownership. It is the manifest-driven replacement for the path-derived
@@ -594,7 +594,7 @@ fn parse_rdf_artifact(artifact: &ArtifactRecord) -> Result<Dataset, SliceError> 
     // A malformed ownership-bearing artifact must FAIL LOUDLY, never be silently
     // dropped — a swallowed parse error would hide a term from the
     // one-validated-owner gate and miscompute the dependency graph
-    // (no-optionality / hard-fail doctrine, #820).
+    // (no-optionality / hard-fail doctrine).
     Dataset::parse_turtle(artifact.content.as_slice(), &artifact.logical_path)
 }
 
@@ -642,7 +642,7 @@ fn collect_declared_terms(store: &Dataset, vocab_ns: &str) -> BTreeSet<NamedNode
 /// scoped to the manifest's own slice subject ONLY. A `sliceDependsOn` triple
 /// whose subject is some *other* resource in the manifest (e.g. a blank-node
 /// description or an unrelated IRI) is never picked up — only edges authored on
-/// the slice itself reconcile against computed dependencies (#820 G8 MED).
+/// the slice itself reconcile against computed dependencies (G8 MED).
 fn collect_slice_depends_on(
     record: &SliceRecord,
     depends_on_iri: &str,

--- a/crates/slice/src/prefix_emit.rs
+++ b/crates/slice/src/prefix_emit.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Prefix-set projections (#1009 §2): the importable named prefix set
+//! Prefix-set projections (§2): the importable named prefix set
 //! (`<vocab>CorePrefixes`) and the JSON-LD `@context` document — both *projections*
 //! of the single prefix authority (the caller's [`SliceVocab`] entry plus
 //! [`crate::mapping_support::PREFIX_REGISTRY`]).
@@ -10,7 +10,7 @@
 //! shape / `.rq` author redeclaring the same prefixes, publish ONE named set,
 //! importable by IRI, that consumers reference with `... sh:prefixes
 //! <prefix>:CorePrefixes .`. The same registry also drives the JSON-LD `@context`,
-//! which replaces the now-retired Python `jsonld_context.py` builder (#933 Python
+//! which replaces the now-retired Python `jsonld_context.py` builder (Python
 //! cull — the `@context` builder moves to Rust).
 //!
 //! Both artifacts are emitted as the `mappings` stage's projection family (they
@@ -75,7 +75,7 @@ pub fn emit_core_prefixes(vocab: &SliceVocab) -> String {
 
 /// Emit the JSON-LD `@context` document from the prefix authority.
 ///
-/// Replaces `src/purrdf_tools/jsonld_context.py::build_context` (#933). Shape:
+/// Replaces `src/purrdf_tools/jsonld_context.py::build_context`. Shape:
 /// `{"@context": {"@vocab": <vocab ns>, <prefix>: <namespace>, ...}}` with a
 /// trailing newline, 2-space indent, registry insertion order preserved (the
 /// caller's vocab entry first) — the same logical document the retired Python

--- a/crates/slice/src/prefix_lint.rs
+++ b/crates/slice/src/prefix_lint.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Prefix-consistency lint (#1009 §2).
+//! Prefix-consistency lint (§2).
 //!
 //! The article's §2 win — "a prefix-consistency lint falls out for free" once the
 //! prefix authority ([`crate::mapping_support::PREFIX_REGISTRY`]) is the single named
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn config_prefixes_match_the_rust_registry() {
-        // Dual-authority parity (#933): the Python `config.PREFIXES` mirror must
+        // Dual-authority parity: the Python `config.PREFIXES` mirror must
         // agree with the Rust authority exactly — same prefix→namespace pairs, same
         // insertion order. Parsing failure or any divergence is a hard test failure
         // (the registry comment pins them as mirrors; this is the missing guard).

--- a/crates/slice/src/rdf_query.rs
+++ b/crates/slice/src/rdf_query.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Oxigraph-free RDF query surface for the slice emitters and linters (EPIC #906).
+//! Oxigraph-free RDF query surface for the slice emitters and linters.
 //!
 //! The slice crate used to parse Turtle/N-Triples into an `oxigraph::store::Store`
 //! and pattern-match it. Every store/term type is now native: parsing folds the

--- a/crates/slice/src/standpoint_emit.rs
+++ b/crates/slice/src/standpoint_emit.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Native standpoint-projection emission — PurRDF's hand-authored
-//! `generated/queries/standpoint-*.rq` SPARQL CONSTRUCT projections (#861).
+//! `generated/queries/standpoint-*.rq` SPARQL CONSTRUCT projections.
 //!
 //! Unlike the per-profile SPARQL projections (the correspondence lowerings), these
 //! queries are NOT compiled from the `mapping-dsl/` tree: they are fixed,

--- a/crates/slice/src/standpoint_modality.rs
+++ b/crates/slice/src/standpoint_modality.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Factored claim-modality projection (#769, ME3 of #766).
+//! Factored claim-modality projection (ME3 of).
 //!
 //! The closed 5-value `purrdf:StandpointModality` vocabulary fuses four separable
 //! epistemic notions onto one axis. The standpoint slice now decomposes it into
@@ -18,7 +18,7 @@
 //!   or a HARD [`ProjectionVerdict::Unsupported`]. A tuple with no legacy twin
 //!   (e.g. `supportBoth`, `modalForceCounterfactual`, `assertoricRetract`,
 //!   `truthStrategic`) is NEVER silently approximated to a nearby value — the
-//!   `logic-compile`'s `compat.rs` "never silently approximate" doctrine (#767), transplanted to
+//!   `logic-compile`'s `compat.rs` "never silently approximate" doctrine, transplanted to
 //!   the purrdf: domain (Principle 9).
 //!
 //! # Single source of truth
@@ -32,7 +32,7 @@
 /// separator that cannot occur in a local name (mirrors `logic-compile`'s `ir.rs` `SEP`).
 const SEP: &str = "\u{1f}";
 
-/// The canonical six-axis decomposition of a standpoint modality (#769).
+/// The canonical six-axis decomposition of a standpoint modality.
 ///
 /// Axis values are local names (e.g. `"polarityDeny"`), not enums, so a new value
 /// individual added to `module.ttl` joins the vocabulary without a Rust change —

--- a/crates/slice/tests/catalog_tests.rs
+++ b/crates/slice/tests/catalog_tests.rs
@@ -186,7 +186,7 @@ fn role_classification() {
 /// A module that uses blank nodes (e.g. an OWL restriction) must produce a STABLE
 /// `semantic_digest` across repeated loads. Oxigraph assigns blank-node labels
 /// non-deterministically at parse time, so the digest must canonicalize blank
-/// nodes (RFC #820 §12 — the semantic Merkle key must be deterministic). A
+/// nodes ( §12 — the semantic Merkle key must be deterministic). A
 /// comment-only edit must NOT change the semantic digest.
 #[test]
 fn semantic_digest_blank_nodes_are_deterministic() {

--- a/crates/slice/tests/ownership_tests.rs
+++ b/crates/slice/tests/ownership_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Hermetic acceptance tests for the native ownership + dependency analyzer
-//! (RFC #820 §10 / S4). Each test builds minimal slice directories on disk
+//! ( §10 / S4). Each test builds minimal slice directories on disk
 //! under a `tempfile::TempDir`, discovers them via [`SliceCatalog::discover`],
 //! and asserts on the [`OwnershipReport`].
 
@@ -728,7 +728,7 @@ fn values_quoted_triple_iri_reaches_dependency_walk() {
 fn malformed_artifact_hard_fails_analysis() {
     // A slice whose module.ttl is malformed RDF must make analyze() return Err,
     // never silently drop the artifact (which would hide its terms from the
-    // one-validated-owner gate). No-optionality / hard-fail doctrine (#820).
+    // one-validated-owner gate). No-optionality / hard-fail doctrine.
     let tmp = TempDir::new().unwrap();
     let root = tmp.path();
 

--- a/crates/sparql-algebra/src/algebra.rs
+++ b/crates/sparql-algebra/src/algebra.rs
@@ -10,7 +10,7 @@
 //! `pattern` and a consumer walks *into* the pattern to find `Project`/`Distinct`/
 //! `Slice`/`OrderBy`/`Group`.
 //!
-//! ## S6 extension seam (#912)
+//! ## S6 extension seam
 //!
 //! This algebra is intentionally a faithful, standard, *evaluable* IR — the form
 //! the downstream evaluator S6 (`sparql-eval`) consumes. The greenfield lever for

--- a/crates/sparql-algebra/src/ast.rs
+++ b/crates/sparql-algebra/src/ast.rs
@@ -264,7 +264,7 @@ pub enum GroundTerm {
     Literal(Literal),
     /// A ground RDF 1.2 quoted triple term.
     Triple(Box<GroundTriple>),
-    /// A blank node — **injection-only** (purrdf S5, EPIC #906 GAP-A). The SPARQL
+    /// A blank node — **injection-only** (purrdf S5,  GAP-A). The SPARQL
     /// grammar forbids a blank node in a `VALUES`/`DataBlock` cell, so the
     /// [parser](crate::parser) NEVER produces this variant. It exists solely so
     /// [`Query::substitute_variable`](crate::Query::substitute_variable) can pre-bind

--- a/crates/sparql-algebra/src/error.rs
+++ b/crates/sparql-algebra/src/error.rs
@@ -12,7 +12,7 @@
 //! * [`ParseError::Syntax`] — the token stream violates the SPARQL grammar.
 //! * [`ParseError::Unsupported`] — the query is well-formed SPARQL but uses a
 //!   construct outside this crate's in-scope subset (purrdf S5 scope). It is a
-//!   hard error, NOT a parse-it-anyway: the downstream evaluator (S6 #912) must
+//!   hard error, NOT a parse-it-anyway: the downstream evaluator (S6) must
 //!   never be handed a partially-understood algebra.
 //! * [`ParseError::Iri`] — an IRI/CURIE in term position failed RFC-3987
 //!   validation (delegated to `purrdf-iri`).

--- a/crates/sparql-algebra/src/lib.rs
+++ b/crates/sparql-algebra/src/lib.rs
@@ -7,9 +7,9 @@
 //! A pure-Rust, wasm-clean leaf crate that parses SPARQL query text into a
 //! purrdf-owned, **RDF 1.2-native** query algebra ([`Query`]/[`GraphPattern`]).
 //! It is the drop-in replacement for the oxigraph-family SPARQL parser (purrdf S5,
-//! EPIC #906) and the front-end the downstream evaluator S6 (`sparql-eval`,
-//! #912) consumes. It builds only on the two CLOSED foundation leaves
-//! [`purrdf_iri`] (#908) and [`purrdf_xsd`] (#907), and deliberately does **not**
+//! ) and the front-end the downstream evaluator S6 (`sparql-eval`,
+//! ) consumes. It builds only on the two CLOSED foundation leaves
+//! [`purrdf_iri`] and [`purrdf_xsd`], and deliberately does **not**
 //! depend on `purrdf-core`.
 //!
 //! # Scope (purrdf S5)

--- a/crates/sparql-algebra/src/parser.rs
+++ b/crates/sparql-algebra/src/parser.rs
@@ -3554,7 +3554,7 @@ mod tests {
         );
     }
 
-    // ── Bounded repetition {n,m} + predicate wildcard (#1010 PurRDF extensions) ──
+    // ── Bounded repetition {n,m} + predicate wildcard (PurRDF extensions) ──
 
     fn path_of(q: &str) -> PropertyPathExpression {
         match unproject(select_pattern(q)) {

--- a/crates/sparql-algebra/src/serialize.rs
+++ b/crates/sparql-algebra/src/serialize.rs
@@ -448,7 +448,7 @@ fn fmt_ground_term(s: &mut String, gt: &GroundTerm) {
         }
         GroundTerm::Literal(l) => fmt_literal(s, l),
         GroundTerm::Triple(t) => fmt_ground_triple(s, t),
-        // Injection-only (#906 GAP-A): emitted as a blank-node label. This appears
+        // Injection-only (GAP-A): emitted as a blank-node label. This appears
         // only if a substituted query is re-serialized (e.g. forwarded to SERVICE);
         // the parser never produces it, so a round-trip of an un-substituted query is
         // unaffected.

--- a/crates/sparql-algebra/src/substitute.rs
+++ b/crates/sparql-algebra/src/substitute.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Variable **pre-binding** by algebra rewrite (purrdf S5, EPIC #906 GAP-A).
+//! Variable **pre-binding** by algebra rewrite (purrdf S5,  GAP-A).
 //!
 //! This is the native replacement for the oxigraph-family
 //! `PreparedSparqlQuery::substitute_variable`, which SHACL-AF uses to inject the

--- a/crates/sparql-algebra/tests/algebra_snapshots.rs
+++ b/crates/sparql-algebra/tests/algebra_snapshots.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Structural AST goldens (purrdf S5 /).
+//! Structural AST goldens (purrdf S5).
 //!
 //! The corpus suite asserts only that queries parse (`Ok`); it does not pin the
 //! *shape* of the produced algebra, so a refactor could silently change what a

--- a/crates/sparql-algebra/tests/algebra_snapshots.rs
+++ b/crates/sparql-algebra/tests/algebra_snapshots.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Structural AST goldens (purrdf S5 / #911).
+//! Structural AST goldens (purrdf S5 /).
 //!
 //! The corpus suite asserts only that queries parse (`Ok`); it does not pin the
 //! *shape* of the produced algebra, so a refactor could silently change what a

--- a/crates/sparql-algebra/tests/corpus.rs
+++ b/crates/sparql-algebra/tests/corpus.rs
@@ -4,7 +4,7 @@
 //! Corpus conformance: every hand-authored `queries/**/*.rq` and every committed
 //! DSL-generated `generated/queries/*.rq` MUST parse into the algebra.
 //!
-//! This is the acceptance gate for purrdf S5 (#911): parse our 90 `.rq` files
+//! This is the acceptance gate for purrdf S5: parse our 90 `.rq` files
 //! plus the DSL-generated projections. Both trees are tracked in git, so reading
 //! them directly pins the test to committed artifacts (no regeneration needed).
 //!

--- a/crates/sparql-algebra/tests/fixtures.rs
+++ b/crates/sparql-algebra/tests/fixtures.rs
@@ -3,7 +3,7 @@
 
 //! Curated SPARQL syntax fixtures — the in-house stand-in for the W3C SPARQL
 //! syntax suite (the full official suite is deferred to a follow-up, the
-//! option-3 deferral noted on #911).
+//! option-3 deferral noted on).
 //!
 //! POSITIVE fixtures: one per in-scope feature; each MUST parse.
 //! NEGATIVE fixtures: out-of-scope or malformed; each MUST hard-fail with the

--- a/crates/sparql-eval/src/convert.rs
+++ b/crates/sparql-eval/src/convert.rs
@@ -95,7 +95,7 @@ pub(crate) fn ground_term_to_value(term: &GroundTerm) -> TermValue {
         GroundTerm::NamedNode(n) => named_node_to_value(n),
         GroundTerm::Literal(l) => literal_to_value(l),
         GroundTerm::Triple(t) => ground_triple_to_value(t),
-        // Injection-only (#906 GAP-A): a substituted blank-node focus node. The
+        // Injection-only (GAP-A): a substituted blank-node focus node. The
         // default blank scope matches the dataset's interned blank identity for
         // `term_id_by_value` resolution.
         GroundTerm::BlankNode(b) => TermValue::Blank {

--- a/crates/sparql-eval/src/engine.rs
+++ b/crates/sparql-eval/src/engine.rs
@@ -4,9 +4,9 @@
 //! The native [`SparqlEngine`] implementation and its parse-memoizing plan cache.
 //!
 //! [`NativeSparqlEngine`] is the single required impl of the `purrdf-core`
-//! `SparqlEngine` seam (#887) — the native replacement for the oxigraph-family
+//! `SparqlEngine` seam — the native replacement for the oxigraph-family
 //! `spareval` on the query path. Its `Dataset` is the concrete frozen
-//! [`RdfDataset`]: the evaluator needs `term_id_by_value` (P4 #838), which is an
+//! [`RdfDataset`]: the evaluator needs `term_id_by_value` (P4), which is an
 //! inherent method on the dataset rather than part of the `DatasetView` trait.
 //!
 //! The [`PlanCache`] memoizes parsing so the static generated query corpus compiles
@@ -88,7 +88,7 @@ impl PlanCache {
     }
 }
 
-/// The native, RDF-1.2-first multiset SPARQL engine (purrdf S6, #912).
+/// The native, RDF-1.2-first multiset SPARQL engine (purrdf S6).
 ///
 /// Domain-vocabulary seams are **caller configuration**, never engine constants:
 ///
@@ -212,7 +212,7 @@ impl NativeSparqlEngine {
     }
 }
 
-/// Evaluate `prepared`, applying any pre-binding `substitutions` first (#906 GAP-A).
+/// Evaluate `prepared`, applying any pre-binding `substitutions` first (GAP-A).
 ///
 /// When there are no substitutions the cached parse is evaluated directly (the hot
 /// path). Otherwise the cached parse is **cloned** and rewritten — the substitution
@@ -378,7 +378,7 @@ mod tests {
             .expect("query")
     }
 
-    // ── substitution / pre-binding (#906 GAP-A) ────────────────────────────────
+    // ── substitution / pre-binding (GAP-A) ────────────────────────────────
 
     /// A dataset for substitution tests:
     ///   :a   :p  :x    (IRI subject)

--- a/crates/sparql-eval/src/error.rs
+++ b/crates/sparql-eval/src/error.rs
@@ -23,7 +23,7 @@ pub enum EvalError {
     /// This is the hard-fail boundary: `SERVICE`, `LATERAL`, SPARQL `UPDATE`, and
     /// not-yet-implemented builtins all surface here rather than being partially
     /// evaluated. The string names the unsupported construct. (Property paths are now
-    /// evaluated in-engine — S8 #914 — and `DESCRIBE` now evaluates via the canonical
+    /// evaluated in-engine — S8 — and `DESCRIBE` now evaluates via the canonical
     /// Symmetric CBD, so neither is here.)
     Unsupported(String),
 

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -4,16 +4,16 @@
 //! The graph-pattern evaluation recursion and its [`EvalCtx`].
 //!
 //! [`eval`] maps a [`GraphPattern`] to a [`SolutionSeq`] over the dataset in
-//! [`EvalCtx`]. The recursion is filled in across the S6 build tasks (#912); each
+//! [`EvalCtx`]. The recursion is filled in across the S6 build tasks; each
 //! not-yet-implemented variant hard-errors ([`EvalError::Unsupported`]) rather than
 //! returning a partial bag (the `no-optionality` doctrine).
 //!
 //! Evaluation pins the **concrete** [`RdfDataset`] rather than a generic
-//! `DatasetView`: the value→id bridge [`RdfDataset::term_id_by_value`] (P4 #838),
+//! `DatasetView`: the value→id bridge [`RdfDataset::term_id_by_value`] (P4),
 //! which BGP constant-resolution needs, is an inherent method on the frozen dataset
 //! and is not part of the `DatasetView` trait. The dataset still exposes its
 //! indexed read surface through `DatasetView` (the inherent `quads_for_pattern`
-//! override, P4b #891).
+//! override, P4b).
 
 use std::sync::Arc;
 
@@ -539,8 +539,8 @@ impl<'d> EvalCtx<'d> {
 ///
 /// Implemented incrementally over the S6 build tasks; an unimplemented variant
 /// returns [`EvalError::Unsupported`] naming the construct. Property paths are
-/// evaluated in-engine (S8 #914, the `path` module); the remaining out-of-scope
-/// nodes (`Service`, `Lateral`) stay permanent hard errors (SERVICE is S6b #928).
+/// evaluated in-engine (S8, the `path` module); the remaining out-of-scope
+/// nodes (`Service`, `Lateral`) stay permanent hard errors (SERVICE is S6b).
 pub fn eval(pattern: &GraphPattern, ctx: &mut EvalCtx<'_>) -> Result<SolutionSeq, EvalError> {
     match pattern {
         GraphPattern::Bgp { patterns } => crate::bgp::eval_bgp(patterns, ctx),

--- a/crates/sparql-eval/src/lib.rs
+++ b/crates/sparql-eval/src/lib.rs
@@ -1,21 +1,21 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Native, RDF-1.2-first **multiset SPARQL evaluator** (purrdf S6, EPIC #906).
+//! Native, RDF-1.2-first **multiset SPARQL evaluator** (purrdf S6).
 //!
 //! This crate is the evaluation runtime that consumes the
-//! [`purrdf_sparql_algebra`] front-end (S5, #911) and evaluates it over the
+//! [`purrdf_sparql_algebra`] front-end (S5) and evaluates it over the
 //! [`purrdf_core`] IR's [`DatasetView`](purrdf_core::DatasetView) read trait
 //! **entirely in interned [`TermId`](purrdf_core::TermId) space**. It is the
 //! native replacement for the oxigraph-family `spareval` on the query path and
 //! the single required impl of the
-//! [`SparqlEngine`](purrdf_core::SparqlEngine) seam (#887).
+//! [`SparqlEngine`](purrdf_core::SparqlEngine) seam.
 //!
 //! ## Design pillars
 //!
 //! - **TermId hot path.** Basic-graph-pattern matching and joins never leave
 //!   interned-id space: constants resolve to a dataset
-//!   [`purrdf_core::TermId`] once (via `term_id_by_value`, P4 #838) and
+//!   [`purrdf_core::TermId`] once (via `term_id_by_value`, P4) and
 //!   solutions carry [`SolutionTerm`]s that are a single integer compare apart.
 //!   Computed terms (FILTER/BIND results not already in the dataset) are interned
 //!   in a per-query scratch table — but a computed value that *does* exist in the
@@ -25,7 +25,7 @@
 //!   [`scratch`].
 //! - **Multiset (bag) semantics.** Solutions are a bag, preserved until
 //!   `DISTINCT`/`REDUCED`. See [`solution`].
-//! - **Property paths in-engine (S8 #914).** The `Path` graph pattern is evaluated
+//! - **Property paths in-engine (S8).** The `Path` graph pattern is evaluated
 //!   over the same indexed surface, wasm-safe, covering the full algebra
 //!   (`* + ? / | ^ !()` and the PurRDF `{n,m}` / `<any>` extensions) — see the
 //!   `path` module.
@@ -35,7 +35,7 @@
 //!   `no-optionality` doctrine).
 //!
 //! The crate carries **zero oxigraph-family dependencies** and builds for
-//! `wasm32-unknown-unknown` (the wasm query path of EPIC #906); both invariants are
+//! `wasm32-unknown-unknown` (the wasm query path of ); both invariants are
 //! gated by `make rdf-core-hygiene`.
 
 #![forbid(unsafe_code)]

--- a/crates/sparql-eval/src/lib.rs
+++ b/crates/sparql-eval/src/lib.rs
@@ -35,7 +35,7 @@
 //!   `no-optionality` doctrine).
 //!
 //! The crate carries **zero oxigraph-family dependencies** and builds for
-//! `wasm32-unknown-unknown` (the wasm query path of ); both invariants are
+//! `wasm32-unknown-unknown` (the wasm query path); both invariants are
 //! gated by `make rdf-core-hygiene`.
 
 #![forbid(unsafe_code)]

--- a/crates/sparql-eval/src/path.rs
+++ b/crates/sparql-eval/src/path.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! SPARQL property-path evaluation (S8 #914) — the wasm-safe in-engine runtime.
+//! SPARQL property-path evaluation (S8) — the wasm-safe in-engine runtime.
 //!
 //! A property path constrains two endpoints by a *relation* between them rather
 //! than a single triple. This module evaluates the `Path` graph pattern entirely in

--- a/crates/sparql-eval/src/scratch.rs
+++ b/crates/sparql-eval/src/scratch.rs
@@ -13,7 +13,7 @@
 //! `VALUES`/template constant absent from the data.
 //!
 //! [`ScratchInterner::intern`] **first probes the dataset**
-//! (`term_id_by_value`, P4 #838): if the value already exists, the binding is
+//! (`term_id_by_value`, P4): if the value already exists, the binding is
 //! promoted to [`SolutionTerm::Existing`] and never becomes `Computed`. The
 //! consequence is load-bearing:
 //!

--- a/crates/sparql-eval/src/substitute.rs
+++ b/crates/sparql-eval/src/substitute.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Engine-side variable **pre-binding** (purrdf S6, EPIC #906 GAP-A).
+//! Engine-side variable **pre-binding** (purrdf S6,  GAP-A).
 //!
 //! Bridges the engine's egress term model ([`TermValue`]) to the algebra's
 //! [`Query::substitute_variable`] rewrite. Each `(name, value)` of a

--- a/crates/sparql-eval/tests/plan_cache_corpus.rs
+++ b/crates/sparql-eval/tests/plan_cache_corpus.rs
@@ -3,7 +3,7 @@
 
 //! Integration test: `compiles_generated_query_set_once`
 //!
-//! **Requirement #912 / S6 — Requirement 11 evidence.**
+//! **Requirement / S6 — Requirement 11 evidence.**
 //!
 //! The requirement states: "Plan cache / DSL→native-plan path so the static
 //! generated query corpus compiles once."

--- a/crates/sparql-eval/tests/property_path_corpus.rs
+++ b/crates/sparql-eval/tests/property_path_corpus.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Integration test: a real corpus-shaped property-path query evaluates end-to-end
-//! through the public API (S8 #914).
+//! through the public API (S8).
 //!
-//! This proves the #914 gap is closed on the public path — a `rdfs:subClassOf*`
+//! This proves the gap is closed on the public path — a `rdfs:subClassOf*`
 //! query (the most common corpus shape, e.g. `queries/competency/agents.rq`) is
 //! parsed by [`SparqlParser`] and evaluated by [`evaluate_query`], returning
 //! solutions rather than the old `EvalError::Unsupported("property path …")`.

--- a/crates/sparql-results/src/lib.rs
+++ b/crates/sparql-results/src/lib.rs
@@ -8,7 +8,7 @@
 //! [`SparqlResult`] (SELECT solutions, ASK boolean, or CONSTRUCT graph) into the
 //! four W3C SPARQL Results formats — JSON (SRJ), XML, CSV, and TSV — plus an
 //! additive, provenance-carrying `purrdf` extension. It replaces the
-//! oxigraph-family `sparesults` on the results path (purrdf S9, EPIC #906).
+//! oxigraph-family `sparesults` on the results path (purrdf S9).
 //!
 //! It depends **only** on `purrdf-core` (with `default-features = false`) so
 //! it stays oxigraph-free and wasm-clean. Term and N-Triples syntax are produced

--- a/crates/sparql-results/src/model.rs
+++ b/crates/sparql-results/src/model.rs
@@ -11,7 +11,7 @@
 //!
 //! Honesty note: population of this structure is **incremental**. The fields are
 //! typed and threaded through the serializer surface now, but the evaluator and
-//! the S11 (#917) derivation graph fill them in progressively — most results
+//! the S11 derivation graph fill them in progressively — most results
 //! today carry an empty value.
 
 /// Result-level provenance carried alongside a SPARQL result. Default is empty →
@@ -38,7 +38,7 @@ impl ResultProvenance {
 }
 
 /// Per-solution provenance hook. Typed-but-mostly-empty today; populated as the
-/// evaluator / S11 (#917) derivation graph begins producing it.
+/// evaluator / S11 derivation graph begins producing it.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SolutionProvenance {
     /// Source references (e.g. named-graph / quad IRIs) that produced this solution.

--- a/crates/sparql-results/tests/results_corpus.rs
+++ b/crates/sparql-results/tests/results_corpus.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! W3C-conformance golden corpus for the native SPARQL Results serializer
-//! (purrdf S9, EPIC #906 / #915).
+//! (purrdf S9,  /).
 //!
 //! A single, realistic "books" running-example dataset (the shape from the W3C
 //! SPARQL Results spec) is serialized to ALL FOUR formats (JSON/XML/CSV/TSV) and

--- a/crates/sparql-results/tests/results_corpus.rs
+++ b/crates/sparql-results/tests/results_corpus.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! W3C-conformance golden corpus for the native SPARQL Results serializer
-//! (purrdf S9,  /).
+//! (purrdf S9).
 //!
 //! A single, realistic "books" running-example dataset (the shape from the W3C
 //! SPARQL Results spec) is serialized to ALL FOUR formats (JSON/XML/CSV/TSV) and

--- a/crates/xsd/tests/operator_mapping.rs
+++ b/crates/xsd/tests/operator_mapping.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The SPARQL operator-mapping table (acceptance artifact #2 for #907).
+//! The SPARQL operator-mapping table (acceptance artifact #2 for).
 //!
 //! Each row asserts `value_cmp(lhs, rhs)`, which is the value-space primitive behind
 //! the SPARQL `=`, `<`, `>`, `<=`, `>=` operators (the evaluator derives those and

--- a/crates/xsd/tests/operator_mapping.rs
+++ b/crates/xsd/tests/operator_mapping.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The SPARQL operator-mapping table (acceptance artifact #2 for).
+//! The SPARQL operator-mapping table (acceptance artifact 2 for).
 //!
 //! Each row asserts `value_cmp(lhs, rhs)`, which is the value-space primitive behind
 //! the SPARQL `=`, `<`, `>`, `<=`, `>=` operators (the evaluator derives those and

--- a/crates/xsd/tests/value_space.rs
+++ b/crates/xsd/tests/value_space.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! XSD value-space conformance vectors (acceptance artifact #1 for #907):
+//! XSD value-space conformance vectors (acceptance artifact #1 for):
 //! per-datatype lexical → value → canonical round-trips, the parse-by-IRI contract,
 //! the zero-dep numeric bounds, and the partial-order edge cases.
 
@@ -126,7 +126,7 @@ fn numeric_bounds_are_hard_failed_not_saturated() {
         Err(XsdError::OutOfRange { .. })
     ));
     // NOTE: corpus-range exposure (that our actual literals stay within i128 /
-    // scale-18) is proven downstream at S5 #911 / S6 #912 integration; this test
+    // scale-18) is proven downstream at S5 / S6 integration; this test
     // proves only that the bound itself hard-fails.
 }
 

--- a/crates/xsd/tests/value_space.rs
+++ b/crates/xsd/tests/value_space.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! XSD value-space conformance vectors (acceptance artifact #1 for):
+//! XSD value-space conformance vectors (acceptance artifact 1 for):
 //! per-datatype lexical → value → canonical round-trips, the parse-by-IRI contract,
 //! the zero-dep numeric bounds, and the partial-order edge cases.
 

--- a/scripts/check-issue-refs.py
+++ b/scripts/check-issue-refs.py
@@ -24,7 +24,7 @@ and markdown anchors while still catching references like ``#16`` or ``#123``.
 from __future__ import annotations
 
 import re
-import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 ISSUE_RE = re.compile(r"#\d{1,5}(?![\dA-Fa-f-])(?!\.\d)")
@@ -36,13 +36,13 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
-def iter_scan_paths(root: Path):
+def iter_scan_paths(root: Path) -> Iterator[Path]:
     """Yield every ``.rs`` and ``.md`` file the lint enforces."""
     for name in SCAN_DIRS:
         base = root / name
         if not base.is_dir():
             continue
-        for path in base.rglob("*"):
+        for path in sorted(base.rglob("*")):
             if path.is_file() and path.suffix in (".rs", ".md"):
                 yield path
     for md in sorted(root.glob("*.md")):
@@ -226,14 +226,14 @@ def find_inline_code_spans(line: str) -> list[tuple[int, int]]:
             if line[k] != "`":
                 k += 1
                 continue
-            l = k
-            while l < n and line[l] == "`":
-                l += 1
-            if l - k == run_len:
-                spans.append((i, l))
-                i = l
+            m = k
+            while m < n and line[m] == "`":
+                m += 1
+            if m - k == run_len:
+                spans.append((i, m))
+                i = m
                 break
-            k = l
+            k = m
         else:
             i = j
 

--- a/scripts/check-issue-refs.py
+++ b/scripts/check-issue-refs.py
@@ -1,0 +1,297 @@
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""Reject new ``#NNN`` GitHub issue-reference tokens in Rust comments and docs.
+
+PurRDF issue references in comments and in-tree markdown documentation are a
+form of hidden TODO debt. Once an issue is closed the token becomes stale and
+misleading, so we do not allow new ones. This lint scans:
+
+* ``.rs`` files under ``crates/`` and ``bindings/`` — only Rust comments are
+  examined. A small Rust-aware lexer skips string, character, and raw-string
+  literals so ``//`` inside ``"http://example.org"`` is not treated as a
+  comment.
+* ``.md`` files under ``crates/``, ``bindings/``, ``docs/``, and root ``*.md``
+  files — markdown header anchors (``#101-...``), hex color codes, inline code,
+  and fenced code blocks are excluded.
+
+The issue token pattern is ``#`` followed by 3–5 decimal digits that is not
+followed by another digit, a hex letter, or a hyphen. This avoids 6-digit hex
+colors and markdown anchors while still catching references like ``#123``.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ISSUE_RE = re.compile(r"#\d{3,5}(?![\dA-Fa-f-])")
+
+SCAN_DIRS = ("crates", "bindings", "docs")
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def iter_scan_paths(root: Path):
+    """Yield every ``.rs`` and ``.md`` file the lint enforces."""
+    for name in SCAN_DIRS:
+        base = root / name
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*"):
+            if path.is_file() and path.suffix in (".rs", ".md"):
+                yield path
+    for md in sorted(root.glob("*.md")):
+        if md.is_file():
+            yield md
+
+
+def pos_to_line_col(src: str, pos: int) -> tuple[int, int]:
+    """Convert a 0-based source index to 1-based line/column."""
+    line = src.count("\n", 0, pos) + 1
+    last_nl = src.rfind("\n", 0, pos)
+    col = pos - last_nl
+    return line, col
+
+
+def snippet(text: str, start: int, end: int, window: int = 24) -> str:
+    """Return a short snippet of ``text`` surrounding ``text[start:end]``."""
+    prefix = text[max(0, start - window) : start].replace("\n", " ")
+    matched = text[start:end]
+    suffix = text[end : min(len(text), end + window)].replace("\n", " ")
+    return f"{prefix}{matched}{suffix}".strip()
+
+
+def rust_comments(src: str) -> list[tuple[int, int, str]]:
+    """Extract Rust comments as ``(start_line, start_col, comment_text)``.
+
+    The scanner is deliberately conservative: it only needs to avoid treating
+    ``//`` or ``/*`` inside string/char/raw-string literals as comment
+    starters. It understands line comments, block comments (including nested
+    ones), byte/regular strings, byte/regular character literals, lifetimes,
+    and raw strings with arbitrary hash counts.
+    """
+    comments: list[tuple[int, int, str]] = []
+    n = len(src)
+    i = 0
+
+    while i < n:
+        c = src[i]
+
+        # Line comment: //, ///, //!
+        if c == "/" and i + 1 < n and src[i + 1] == "/":
+            j = src.find("\n", i)
+            if j == -1:
+                j = n
+            line, col = pos_to_line_col(src, i)
+            comments.append((line, col, src[i:j]))
+            i = j
+            continue
+
+        # Block comment: /*, /**, /*!
+        if c == "/" and i + 1 < n and src[i + 1] == "*":
+            j = i + 2
+            depth = 1
+            while j < n and depth > 0:
+                if src[j] == "/" and j + 1 < n and src[j + 1] == "*":
+                    depth += 1
+                    j += 2
+                elif src[j] == "*" and j + 1 < n and src[j + 1] == "/":
+                    depth -= 1
+                    j += 2
+                else:
+                    j += 1
+            line, col = pos_to_line_col(src, i)
+            comments.append((line, col, src[i:j]))
+            i = j
+            continue
+
+        # String literal or byte string literal.
+        if c == '"' or (c == "b" and i + 1 < n and src[i + 1] == '"'):
+            if c == "b":
+                i += 1
+            i += 1  # skip opening quote
+            while i < n and src[i] != '"':
+                if src[i] == "\\":
+                    i += 2
+                else:
+                    i += 1
+            if i < n:
+                i += 1  # skip closing quote
+            continue
+
+        # Character literal, byte character literal, or lifetime.
+        if c == "'" or (c == "b" and i + 1 < n and src[i + 1] == "'"):
+            if c == "b":
+                i += 1
+            i += 1  # skip opening quote
+            if i < n:
+                if src[i].isalpha() or src[i] == "_":
+                    # Could be a lifetime or a single-character literal like 'a'.
+                    if i + 1 < n and src[i + 1] == "'":
+                        i += 2  # char literal
+                        continue
+                    # Lifetime: consume the identifier.
+                    while i < n and (src[i].isalnum() or src[i] == "_"):
+                        i += 1
+                    continue
+                # Char literal (possibly escaped).
+                while i < n and src[i] != "'":
+                    if src[i] == "\\":
+                        i += 2
+                    else:
+                        i += 1
+                if i < n:
+                    i += 1  # skip closing quote
+                continue
+            continue
+
+        # Raw string literal (possibly byte-prefixed).
+        if c == "r" or (c == "b" and i + 1 < n and src[i + 1] == "r"):
+            start = i
+            if c == "b":
+                i += 1
+            i += 1  # skip 'r'
+            hash_count = 0
+            while i < n and src[i] == "#":
+                hash_count += 1
+                i += 1
+            if i < n and src[i] == '"':
+                i += 1  # skip opening quote
+                while i < n:
+                    if src[i] == '"':
+                        k = i + 1
+                        matched_hashes = 0
+                        while (
+                            k < n
+                            and src[k] == "#"
+                            and matched_hashes < hash_count
+                        ):
+                            matched_hashes += 1
+                            k += 1
+                        if matched_hashes == hash_count:
+                            i = k
+                            break
+                    i += 1
+                continue
+            # Not a raw string; resume scanning from just after the 'r'/'b'.
+            i = start + 1
+            continue
+
+        i += 1
+
+    return comments
+
+
+def scan_rust(path: Path) -> list[tuple[int, int, str, str]]:
+    """Return violations found in a Rust source file."""
+    src = path.read_text(encoding="utf-8")
+    violations: list[tuple[int, int, str, str]] = []
+
+    for start_line, start_col, text in rust_comments(src):
+        for match in ISSUE_RE.finditer(text):
+            offset = match.start()
+            rel_line = text.count("\n", 0, offset) + 1
+            last_nl = text.rfind("\n", 0, offset)
+            rel_col = offset - last_nl
+            line = start_line + rel_line - 1
+            col = start_col + rel_col - 1 if rel_line == 1 else rel_col
+            violations.append(
+                (line, col, match.group(), snippet(text, offset, match.end()))
+            )
+
+    return violations
+
+
+def find_inline_code_spans(line: str) -> list[tuple[int, int]]:
+    """Return ``(start, end)`` column ranges of inline code spans in ``line``."""
+    spans: list[tuple[int, int]] = []
+    i = 0
+    n = len(line)
+
+    while i < n:
+        if line[i] != "`":
+            i += 1
+            continue
+        j = i
+        while j < n and line[j] == "`":
+            j += 1
+        run_len = j - i
+        k = j
+        while k < n:
+            if line[k] != "`":
+                k += 1
+                continue
+            l = k
+            while l < n and line[l] == "`":
+                l += 1
+            if l - k == run_len:
+                spans.append((i, l))
+                i = l
+                break
+            k = l
+        else:
+            i = j
+
+    return spans
+
+
+def scan_markdown(path: Path) -> list[tuple[int, int, str, str]]:
+    """Return violations found in a Markdown file."""
+    src = path.read_text(encoding="utf-8")
+    violations: list[tuple[int, int, str, str]] = []
+
+    in_fence = False
+    for line_no, line in enumerate(src.splitlines(), start=1):
+        stripped = line.lstrip()
+        if re.match(r"(?:```+|~~~+)", stripped):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+
+        code_spans = find_inline_code_spans(line)
+
+        for match in ISSUE_RE.finditer(line):
+            start = match.start()
+            if any(start >= s and start < e for s, e in code_spans):
+                continue
+            violations.append(
+                (
+                    line_no,
+                    start + 1,
+                    match.group(),
+                    snippet(line, start, match.end()),
+                )
+            )
+
+    return violations
+
+
+def main() -> int:
+    root = repo_root()
+    violations: list[tuple[Path, int, int, str, str]] = []
+
+    for path in iter_scan_paths(root):
+        if path.suffix == ".rs":
+            for line, col, token, text in scan_rust(path):
+                violations.append((path, line, col, token, text))
+        elif path.suffix == ".md":
+            for line, col, token, text in scan_markdown(path):
+                violations.append((path, line, col, token, text))
+
+    if violations:
+        for path, line, col, token, text in violations:
+            rel = path.relative_to(root)
+            print(f"{rel}:{line}:{col}: {token} {text}")
+        return 1
+
+    print("OK: no #NNN issue-reference tokens found in comments or docs.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-issue-refs.py
+++ b/scripts/check-issue-refs.py
@@ -15,9 +15,10 @@ misleading, so we do not allow new ones. This lint scans:
   files — markdown header anchors (``#101-...``), hex color codes, inline code,
   and fenced code blocks are excluded.
 
-The issue token pattern is ``#`` followed by 3–5 decimal digits that is not
-followed by another digit, a hex letter, or a hyphen. This avoids 6-digit hex
-colors and markdown anchors while still catching references like ``#123``.
+The issue token pattern is ``#`` followed by 1–5 decimal digits that is not
+followed by another digit, a hex letter, a hyphen, or a decimal fraction
+(so ``#3.1`` section numbers are not flagged). This avoids 6-digit hex colors
+and markdown anchors while still catching references like ``#16`` or ``#123``.
 """
 
 from __future__ import annotations
@@ -26,7 +27,7 @@ import re
 import sys
 from pathlib import Path
 
-ISSUE_RE = re.compile(r"#\d{3,5}(?![\dA-Fa-f-])")
+ISSUE_RE = re.compile(r"#\d{1,5}(?![\dA-Fa-f-])(?!\.\d)")
 
 SCAN_DIRS = ("crates", "bindings", "docs")
 


### PR DESCRIPTION
Closes #5

## Summary
Removes stale `#NNN` issue references left over from the gmeow-ontology extraction and adds a durable lint to prevent regression.

## Changes
- Strip `#NNN` tokens from `//` and `///` Rust comments across `crates/` and `bindings/python/src/`.
- Strip `#NNN` tokens from in-tree READMEs and design docs under `crates/` and `docs/`.
- Add `scripts/check-issue-refs.py` to detect `#NNN` in Rust comments and Markdown docs.
- Wire the new check into `make check` and `.github/workflows/ci.yaml`.
- Verify full local gate (`make check`) remains green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a repository check that scans comments and documentation for stale issue-reference tokens.
  * The main validation workflow now runs this check automatically, and a dedicated check command is available.

* **Bug Fixes**
  * Improved consistency across docs and comments by removing outdated reference markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->