### PR TITLE
feat(python): finish rdflib plugin entry-point discovery (#7)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,8 +165,8 @@ jobs:
       - name: Python binding tests (maturin build + pytest)
         working-directory: bindings/python
         run: |
-          uv run --group acceptance maturin develop
-          uv run --group acceptance pytest tests -q
+          uv run maturin develop
+          uv run pytest tests -q
 
   # The single conformance matrix: runs the native Rust W3C
   # harnesses (RDFC-1.0, IRI, syntax codecs, SPARQL-eval subset, SHACL, shexTest)

--- a/bindings/python-rdflib-shadow/rdflib/__init__.py
+++ b/bindings/python-rdflib-shadow/rdflib/__init__.py
@@ -33,6 +33,9 @@ import purrdf.compat.rdflib as _compat
 for _name in _compat.__all__:
     globals()[_name] = getattr(_compat, _name)
 
+# Expose the API version the shim targets.
+__version__ = _compat.__version__
+
 # Submodules real rdflib code reaches for. Register each purrdf compat submodule
 # under the shadow's dotted name so both `import rdflib.<sub>` and
 # `from rdflib.<sub> import X` resolve to the single source of truth. Order
@@ -54,6 +57,8 @@ _SUBMODULES: tuple[str, ...] = (
     "resource",
     "plugins",
     "plugins.sparql",
+    "plugins.serializers",
+    "plugins.serializers.turtle",
 )
 
 for _sub in _SUBMODULES:

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -36,20 +36,18 @@ rdflib = ["purrdf-rdflib"]
 Homepage = "https://blackcatinformatics.ca/purrdf/"
 Repository = "https://github.com/Blackcat-Informatics/purrdf"
 
-# Dev + acceptance dependency groups (PEP 735; consumed by `uv`, ignored by the
-# maturin build backend). The `dev` group carries the REAL rdflib — the differential
-# oracle for the compat shim and the target of the rdflib-suite gate. The
-# top-level `rdflib` shadow package is deliberately kept OUT of this environment
-# so the oracle is never shadowed (see tests/README.md). The `acceptance` group
-# holds the dependencies for the downstream acceptance matrix drivers.
+# Dev dependency group (PEP 735; consumed by `uv`, ignored by the maturin build
+# backend). The `dev` group carries the REAL rdflib — the differential oracle for
+# the compat shim and the target of the rdflib-suite gate — plus the downstream
+# acceptance-matrix consumers and the build/test tooling. The top-level `rdflib`
+# shadow package is deliberately kept OUT of this environment so the oracle is
+# never shadowed (see tests/README.md).
 [dependency-groups]
 dev = [
   "pytest>=8,<10",
   "rdflib>=7.1,<8",
   "mypy>=1.10",
   "maturin>=1.7,<2",
-]
-acceptance = [
   "pyshacl",
   "SPARQLWrapper",
   "sssom",

--- a/bindings/python/python/src/purrdf/compat/rdflib/__init__.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/__init__.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from . import parser, paths, plugin, serializer, store, util
 
+#: Target rdflib API compatibility level. This must stay in sync with the locked
+#: rdflib version in ``bindings/python/uv.lock``; tests enforce the invariant.
 __version__ = "7.6.0"
 
 #: RDFLib's literal-normalization switch. pyshacl's monkey patch toggles this at

--- a/bindings/python/python/src/purrdf/compat/rdflib/__init__.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/__init__.py
@@ -64,7 +64,7 @@ from .namespace import (
 )
 from .query import Result, ResultRow
 from .resource import Resource
-from .term import BNode, Identifier, Literal, Node, URIRef, Variable
+from .term import BNode, IdentifiedNode, Identifier, Literal, Node, URIRef, Variable
 
 __all__ = [
     "BRICK",
@@ -105,6 +105,7 @@ __all__ = [
     "DefinedNamespace",
     "DefinedNamespaceMeta",
     "Graph",
+    "IdentifiedNode",
     "Identifier",
     "Literal",
     "Namespace",

--- a/bindings/python/python/src/purrdf/compat/rdflib/__init__.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/__init__.py
@@ -19,6 +19,11 @@ from __future__ import annotations
 from . import parser, paths, plugin, serializer, store, util
 
 __version__ = "7.6.0"
+
+#: RDFLib's literal-normalization switch. pyshacl's monkey patch toggles this at
+#: runtime; exposing it keeps the top-level module assignment from failing.
+NORMALIZE_LITERALS = True
+
 from .graph import (
     DATASET_DEFAULT_GRAPH_ID,
     BatchAddGraph,
@@ -69,6 +74,7 @@ from .resource import Resource
 from .term import BNode, IdentifiedNode, Identifier, Literal, Node, URIRef, Variable
 
 __all__ = [
+    "NORMALIZE_LITERALS",
     "BRICK",
     "CSVW",
     "DC",

--- a/bindings/python/python/src/purrdf/compat/rdflib/__init__.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/__init__.py
@@ -17,6 +17,8 @@ import OWL`` → ``from purrdf.compat.rdflib.namespace import OWL`` and so on.
 from __future__ import annotations
 
 from . import parser, paths, plugin, serializer, store, util
+
+__version__ = "7.6.0"
 from .graph import (
     DATASET_DEFAULT_GRAPH_ID,
     BatchAddGraph,

--- a/bindings/python/python/src/purrdf/compat/rdflib/graph.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/graph.py
@@ -21,7 +21,7 @@ import random
 import re
 from collections.abc import Iterable, Iterator
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, overload
+from typing import IO, TYPE_CHECKING, Any, Literal as TypingLiteral, overload
 from urllib.parse import urljoin, urlparse
 
 import purrdf
@@ -93,10 +93,9 @@ def _de_skolemize_uri(uri: URIRef) -> BNode:
         _EXTERNAL_SKOLEMS[key] = bnode
     return bnode
 
+
 #: A Turtle/TriG/N3/SPARQL prefix declaration: ``@prefix foo: <iri>`` / ``PREFIX foo: <iri>``.
-_PREFIX_DECL_RE = re.compile(
-    r"@?prefix\s+([^\s:]*)\s*:\s*<([^>\s]*)>", re.IGNORECASE
-)
+_PREFIX_DECL_RE = re.compile(r"@?prefix\s+([^\s:]*)\s*:\s*<([^>\s]*)>", re.IGNORECASE)
 
 
 def _scan_prefixes(text: str) -> list[tuple[str, str]]:
@@ -109,6 +108,7 @@ def _scan_prefixes(text: str) -> list[tuple[str, str]]:
     ledger for the residual prefix-wiring gap).
     """
     return [(m.group(1), m.group(2)) for m in _PREFIX_DECL_RE.finditer(text)]
+
 
 #: A graph triple of compat terms.
 _Triple = tuple[Identifier, Identifier, Identifier]
@@ -312,14 +312,16 @@ class Graph:
         *,
         namespace_manager: NamespaceManager | None = None,
         base: str | None = None,
-        bind_namespaces: str | None = None,
+        bind_namespaces: TypingLiteral["none", "core", "rdflib"] = "rdflib",
     ) -> None:
         """Create an empty graph (or import an existing native store/dataset).
 
-        ``bind_namespaces`` is accepted for RDFLib 7.x API parity but is currently a
-        no-op; namespace prefixes are managed through the graph's namespace manager.
+        ``bind_namespaces`` mirrors RDFLib 7.x: ``"none"`` leaves the namespace
+        manager empty, ``"core"`` pre-binds ``owl``/``rdf``/``rdfs``/``xsd``/``xml``,
+        and ``"rdflib"`` (the default) binds the full shipped vocabulary set.
+        When an explicit ``namespace_manager`` is supplied, ``bind_namespaces`` is
+        ignored, matching RDFLib's behavior.
         """
-        _ = bind_namespaces
         if isinstance(store, purrdf.MutableDataset):
             self._store = store
         else:
@@ -329,7 +331,9 @@ class Graph:
                 if nquads.strip():
                     self._store.load(nquads, format=_NQ)
         self._nsm = (
-            namespace_manager if namespace_manager is not None else (NamespaceManager())
+            namespace_manager
+            if namespace_manager is not None
+            else NamespaceManager(bind_namespaces=bind_namespaces)
         )
         # RDFLib assigns a fresh BNode name when no identifier is given, and wraps
         # a bare string as a URIRef — its __hash__/__eq__ contract keys on this.
@@ -743,9 +747,7 @@ class Graph:
 
     # ── skolemization ───────────────────────────────────────────────────────────────
 
-    def _process_skolem_tuples(
-        self, target: Graph, func: Any
-    ) -> None:
+    def _process_skolem_tuples(self, target: Graph, func: Any) -> None:
         """Copy every triple through ``func`` into ``target`` (RDFLib helper)."""
         for t in self.triples((None, None, None)):
             target.add(func(t))
@@ -859,9 +861,7 @@ class Graph:
         """Return the ``prefix:local`` form of ``uri`` (delegates to the nsm)."""
         return self._nsm.qname(uri)
 
-    def compute_qname(
-        self, uri: str, generate: bool = True
-    ) -> tuple[str, URIRef, str]:
+    def compute_qname(self, uri: str, generate: bool = True) -> tuple[str, URIRef, str]:
         """Return the ``(prefix, namespace, local)`` split of ``uri``."""
         return self._nsm.compute_qname(uri, generate)
 
@@ -1082,7 +1082,9 @@ class Graph:
             nt = res.serialize(_NT)
             if nt:
                 constructed._store.load(nt, format=_NT)
-            form = "DESCRIBE" if _query_form(query_object) == "DESCRIBE" else "CONSTRUCT"
+            form = (
+                "DESCRIBE" if _query_form(query_object) == "DESCRIBE" else "CONSTRUCT"
+            )
             return Result(form, graph=constructed)
         variables = list(res.variables)
         var_names = tuple(v.value for v in variables)
@@ -1224,9 +1226,7 @@ class Graph:
     ) -> None:
         """Add a quad and remember exact literal provenance at the RDFLib boundary."""
         native_graph = (
-            purrdf.DefaultGraph()
-            if graph_name is None
-            else _native_subject(graph_name)
+            purrdf.DefaultGraph() if graph_name is None else _native_subject(graph_name)
         )
         self._store.add(
             purrdf.Quad(
@@ -1407,9 +1407,7 @@ class Dataset(Graph):
                 names.add(name)
         return names
 
-    def contexts(
-        self, triple: _Pattern | None = None
-    ) -> Iterator[_DatasetGraph]:
+    def contexts(self, triple: _Pattern | None = None) -> Iterator[_DatasetGraph]:
         """Yield each graph (default + named) as a context :class:`Graph`.
 
         With ``triple`` given, only graphs containing a matching triple are

--- a/bindings/python/python/src/purrdf/compat/rdflib/graph.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/graph.py
@@ -312,8 +312,14 @@ class Graph:
         *,
         namespace_manager: NamespaceManager | None = None,
         base: str | None = None,
+        bind_namespaces: str | None = None,
     ) -> None:
-        """Create an empty graph (or import an existing native store/dataset)."""
+        """Create an empty graph (or import an existing native store/dataset).
+
+        ``bind_namespaces`` is accepted for RDFLib 7.x API parity but is currently a
+        no-op; namespace prefixes are managed through the graph's namespace manager.
+        """
+        _ = bind_namespaces
         if isinstance(store, purrdf.MutableDataset):
             self._store = store
         else:

--- a/bindings/python/python/src/purrdf/compat/rdflib/plugin.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/plugin.py
@@ -141,11 +141,7 @@ def _discover_entry_points() -> None:
     """Register third-party plugins published against RDFLib's entry-point groups."""
     all_entry_points = entry_points()
     for group, kind in rdflib_entry_points.items():
-        if hasattr(all_entry_points, "select"):
-            eps = all_entry_points.select(group=group)
-        else:  # pragma: no cover - Python < 3.10 fallback
-            eps = all_entry_points.get(group, [])  # type: ignore[attr-defined]
-        for ep in eps:
+        for ep in all_entry_points.select(group=group):
             _plugins[(ep.name, kind)] = PKGPlugin(ep.name, kind, ep)
 
 

--- a/bindings/python/python/src/purrdf/compat/rdflib/plugins/serializers/__init__.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/plugins/serializers/__init__.py
@@ -21,7 +21,22 @@ from typing import IO, Any
 
 import purrdf
 
-from ..serializer import Serializer
+from ...serializer import Serializer
+
+__all__ = [
+    "HextuplesSerializer",
+    "JsonLDSerializer",
+    "LongTurtleSerializer",
+    "N3Serializer",
+    "NQuadsSerializer",
+    "NT11Serializer",
+    "NTSerializer",
+    "PrettyXMLSerializer",
+    "TriGSerializer",
+    "TriXSerializer",
+    "TurtleSerializer",
+    "XMLSerializer",
+]
 
 _TURTLE = purrdf.RdfFormat.TURTLE
 _NT = purrdf.RdfFormat.N_TRIPLES

--- a/bindings/python/python/src/purrdf/compat/rdflib/plugins/serializers/turtle.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/plugins/serializers/turtle.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""RDFLib ``plugins.serializers.turtle`` shim (purrdf compat)."""
+
+from __future__ import annotations
+
+from ..serializers import TurtleSerializer
+
+__all__ = ["TurtleSerializer"]

--- a/bindings/python/python/src/purrdf/compat/rdflib/plugins/serializers/turtle.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/plugins/serializers/turtle.py
@@ -4,6 +4,6 @@
 
 from __future__ import annotations
 
-from ..serializers import TurtleSerializer
+from . import TurtleSerializer
 
 __all__ = ["TurtleSerializer"]

--- a/bindings/python/python/src/purrdf/compat/rdflib/term.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/term.py
@@ -35,8 +35,8 @@ if TYPE_CHECKING:
 
 __all__ = [
     "BNode",
-    "Identifier",
     "IdentifiedNode",
+    "Identifier",
     "Literal",
     "Node",
     "URIRef",

--- a/bindings/python/python/src/purrdf/compat/rdflib/term.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/term.py
@@ -17,6 +17,7 @@ is a P9 concern — here term equality follows RDFLib's *term* equality over
 
 from __future__ import annotations
 
+import abc
 import datetime
 import re
 import warnings
@@ -187,12 +188,29 @@ _DAYTIME_DURATION_RE = re.compile(
 )
 
 
-class Identifier(str):
+class Node(abc.ABC):
+    """RDFLib's abstract ``Node`` base (mirrors ``rdflib.term.Node``).
+
+    In RDFLib 7.6 ``Node`` is an abstract base with ``n3`` as its only abstract
+    method; every concrete term inherits from it. The shim preserves it as a
+    distinct base so ``isinstance(x, Node)`` and the ``IdentifiedNode`` MRO
+    match real rdflib.
+    """
+
+    __slots__ = ()
+
+    @abc.abstractmethod
+    def n3(self, namespace_manager: _SupportsNormalizeUri | None = None) -> str:
+        """Return the N3/Turtle form (subclasses implement)."""
+        ...
+
+
+class Identifier(Node, str):
     """A ``str``-subclass RDF term (mirrors ``rdflib.term.Identifier``).
 
-    The compat surface collapses RDFLib's abstract ``Node`` base into this class
-    (``Node`` below is an alias): every concrete term is a ``str`` subclass, so a
-    separate non-``str`` base buys nothing and only introduces type-boundary noise.
+    In RDFLib 7.6 :class:`Identifier` inherits from both :class:`Node` and
+    ``str``; the shim keeps the same MRO so type checks and plugin discovery
+    behave identically.
     """
 
     __slots__ = ()
@@ -206,11 +224,7 @@ class Identifier(str):
         return f"<{self}>"
 
 
-#: RDFLib's abstract ``Node`` base — collapsed to :class:`Identifier` here.
-Node = Identifier
-
-
-class IdentifiedNode(Identifier):
+class IdentifiedNode(Identifier, abc.ABC):
     """A ``str``-subclass base for URI and blank nodes (mirrors ``rdflib.term.IdentifiedNode``).
 
     In RDFLib 7.6 this is the shared abstract base class of :class:`URIRef` and

--- a/bindings/python/python/src/purrdf/compat/rdflib/term.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/term.py
@@ -360,10 +360,11 @@ def _coerce_value(lexical: str, datatype: URIRef | None, language: str | None) -
     dt = str(datatype)
     # Private-internals consumers (e.g. pyshacl's bool patch) may have mutated the
     # rdflib-style ``_toPythonMapping``; honor that override before falling back
-    # to the native-backed coercion table.
-    dt_ref = URIRef(dt)
-    if dt_ref in _toPythonMapping:
-        conv = _toPythonMapping[dt_ref]
+    # to the native-backed coercion table.  RDFLib stores URIRef keys, but URIRef
+    # is a str subclass with inherited hash/equality, so a bare string lookup is
+    # equivalent and avoids an allocation.
+    if dt in _toPythonMapping:
+        conv = _toPythonMapping[dt]
         if conv is not None:
             try:
                 return conv(lexical)
@@ -742,7 +743,7 @@ def _parseBoolean(value: str | bytes) -> bool:  # noqa: N802 - rdflib API name
 
 #: Runtime-mutable datatype → converter table mirroring rdflib's private
 #: ``_toPythonMapping``. Consumers such as pyshacl patch the boolean entry.
-_toPythonMapping: dict[URIRef, Callable[[str], Any] | None] = {}
+_toPythonMapping: dict[str, Callable[[str], Any] | None] = {}
 
 
 def to_native(

--- a/bindings/python/python/src/purrdf/compat/rdflib/term.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/term.py
@@ -19,9 +19,10 @@ from __future__ import annotations
 
 import datetime
 import re
+import warnings
 from decimal import Decimal
 from functools import total_ordering
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Callable, Protocol
 from uuid import uuid4
 
 import purrdf
@@ -343,6 +344,18 @@ def _coerce_value(lexical: str, datatype: URIRef | None, language: str | None) -
     if language is not None or datatype is None:
         return lexical
     dt = str(datatype)
+    # Private-internals consumers (e.g. pyshacl's bool patch) may have mutated the
+    # rdflib-style ``_toPythonMapping``; honor that override before falling back
+    # to the native-backed coercion table.
+    dt_ref = URIRef(dt)
+    if dt_ref in _toPythonMapping:
+        conv = _toPythonMapping[dt_ref]
+        if conv is not None:
+            try:
+                return conv(lexical)
+            except Exception:  # noqa: BLE001 - rdflib parity: bad lexical → lexical string
+                return lexical
+        return lexical
     if dt in _XSD_STRINGLIKE:
         return lexical
     if dt == _XSD_BOOLEAN:
@@ -682,6 +695,40 @@ class Variable(Identifier):
     def to_native(self) -> purrdf.Variable:
         """Return the native :class:`purrdf.Variable` counterpart."""
         return purrdf.Variable(str(self))
+
+
+# ── Private-internals compatibility shims ─────────────────────────────────────
+#
+# These are NOT public rdflib API. They exist only because downstream consumers
+# (notably pyshacl) reach into rdflib's private Python internals and mutate them
+# at runtime. The shim keeps the absolute minimum surface needed for those
+# consumers to function, while the real value-space work stays in Rust.
+
+#: The XSD namespace prefix used by rdflib's private ``_XSD_PFX`` symbol.
+_XSD_PFX: str = _XSD
+
+
+def _parseBoolean(value: str | bytes) -> bool:  # noqa: N802 - rdflib API name
+    """Parse an XSD boolean lexical form (rdflib 7.6 private API parity).
+
+    Lexical space is ``{"true", "false", "1", "0"}``; any other input emits a
+    warning and maps to ``False``, matching rdflib's lenient behavior.
+    """
+    new_value = value.lower()
+    if new_value in ("1", "true", b"1", b"true"):
+        return True
+    if new_value not in ("0", "false", b"0", b"false"):
+        warnings.warn(
+            f"Parsing weird boolean, {value!r} does not map to True or False",
+            category=UserWarning,
+            stacklevel=2,
+        )
+    return False
+
+
+#: Runtime-mutable datatype → converter table mirroring rdflib's private
+#: ``_toPythonMapping``. Consumers such as pyshacl patch the boolean entry.
+_toPythonMapping: dict[URIRef, Callable[[str], Any] | None] = {}
 
 
 def to_native(

--- a/bindings/python/python/src/purrdf/compat/rdflib/term.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/term.py
@@ -31,6 +31,19 @@ if TYPE_CHECKING:
     from purrdf import Literal as _NativeLiteral
 
 
+__all__ = [
+    "BNode",
+    "Identifier",
+    "IdentifiedNode",
+    "Literal",
+    "Node",
+    "URIRef",
+    "Variable",
+    "from_native",
+    "to_native",
+]
+
+
 class _SupportsNormalizeUri(Protocol):
     """Structural type for a namespace manager that can abbreviate an IRI.
 
@@ -196,7 +209,19 @@ class Identifier(str):
 Node = Identifier
 
 
-class URIRef(Identifier):
+class IdentifiedNode(Identifier):
+    """A ``str``-subclass base for URI and blank nodes (mirrors ``rdflib.term.IdentifiedNode``).
+
+    In RDFLib 7.6 this is the shared abstract base class of :class:`URIRef` and
+    :class:`BNode`; :class:`Literal` and :class:`Variable` intentionally do *not*
+    inherit from it. The shim keeps the same hierarchy so type checks and plugin
+    discovery that rely on ``isinstance(x, IdentifiedNode)`` behave identically.
+    """
+
+    __slots__ = ()
+
+
+class URIRef(IdentifiedNode):
     """An IRI term — RDFLib-shaped, backed by :class:`purrdf.NamedNode`."""
 
     __slots__ = ()
@@ -261,7 +286,7 @@ class URIRef(Identifier):
         return NegatedPath(self)
 
 
-class BNode(Identifier):
+class BNode(IdentifiedNode):
     """A blank-node term — RDFLib-shaped, backed by :class:`purrdf.BlankNode`."""
 
     __slots__ = ()

--- a/bindings/python/tests/_shadow_test_utils.py
+++ b/bindings/python/tests/_shadow_test_utils.py
@@ -20,25 +20,31 @@ from pathlib import Path
 _SHADOW_DIR = Path(__file__).resolve().parent.parent.parent / "python-rdflib-shadow"
 
 
-def _run_in_shadow(code: str) -> str:
-    """Run ``code`` in a child interpreter whose ``import rdflib`` is the shadow.
+def _run_with_shadow(argv: list[str | Path]) -> subprocess.CompletedProcess[str]:
+    """Run ``argv`` in a child process with the rdflib shadow prepended to ``PYTHONPATH``.
 
-    Prepends the shadow distribution's package root to ``PYTHONPATH`` so a plain
-    ``import rdflib`` in the child resolves to the purrdf shadow rather than the
-    real rdflib installed in this (parent) environment.
+    The shadow distribution's package root is inserted first so ``import rdflib``
+    in the child resolves to the purrdf shadow rather than the real rdflib
+    installed in this (parent) environment.  The caller decides how to interpret
+    the return code and output.
     """
     env = dict(os.environ)
     existing = env.get("PYTHONPATH", "")
     env["PYTHONPATH"] = (
         f"{_SHADOW_DIR}{os.pathsep}{existing}" if existing else str(_SHADOW_DIR)
     )
-    proc = subprocess.run(
-        [sys.executable, "-c", code],
+    return subprocess.run(
+        [str(arg) for arg in argv],
         env=env,
         capture_output=True,
         text=True,
         check=False,
     )
+
+
+def _run_in_shadow(code: str) -> str:
+    """Run ``code`` in a child interpreter whose ``import rdflib`` is the shadow."""
+    proc = _run_with_shadow([sys.executable, "-c", code])
     assert proc.returncode == 0, (
         f"shadow subprocess failed (rc={proc.returncode})\n"
         f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"

--- a/bindings/python/tests/_shadow_test_utils.py
+++ b/bindings/python/tests/_shadow_test_utils.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Shared helpers for tests that exercise the ``rdflib`` shadow distribution.
+
+The shadow distribution re-exports :mod:`purrdf.compat.rdflib` under the
+top-level ``rdflib`` package name.  Because the parent pytest process also
+has the *real* rdflib installed, any test that needs ``import rdflib`` to
+resolve to the shadow must run that code in a subprocess whose
+``PYTHONPATH`` is adjusted so the shadow package comes first.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# bindings/python/tests/ -> bindings/ -> python-rdflib-shadow/
+_SHADOW_DIR = Path(__file__).resolve().parent.parent.parent / "python-rdflib-shadow"
+
+
+def _run_in_shadow(code: str) -> str:
+    """Run ``code`` in a child interpreter whose ``import rdflib`` is the shadow.
+
+    Prepends the shadow distribution's package root to ``PYTHONPATH`` so a plain
+    ``import rdflib`` in the child resolves to the purrdf shadow rather than the
+    real rdflib installed in this (parent) environment.
+    """
+    env = dict(os.environ)
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{_SHADOW_DIR}{os.pathsep}{existing}" if existing else str(_SHADOW_DIR)
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"shadow subprocess failed (rc={proc.returncode})\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+    )
+    return proc.stdout

--- a/bindings/python/tests/acceptance/_harness.py
+++ b/bindings/python/tests/acceptance/_harness.py
@@ -4,20 +4,21 @@
 
 Each ``driver_<package>.py`` next to this file is a standalone script executed in
 a CHILD interpreter whose ``PYTHONPATH`` prepends ``bindings/python-rdflib-shadow``
-so a plain ``import rdflib`` resolves to the purrdf shadow, *shadowing*
-the genuine rdflib that the acceptance dependency group also installed. The
-driver then imports a real third-party rdflib consumer and drives its core path.
+so a plain ``import rdflib`` resolves to the purrdf shadow, *shadowing* the
+genuine rdflib that the ``dev`` dependency group also installed. The driver then
+imports a real third-party rdflib consumer and drives its core path.
 
 A driver never raises to the shell uncaught: it prints exactly one machine-
 readable ``ACCEPT_RESULT <json>`` line and exits with a coded status the parent
 test (:mod:`tests.test_acceptance_matrix`) maps to a pytest outcome:
 
-* ``0`` / ``outcome="pass"``  — the consumer imported and ran its core path,
+* ``0`` / ``outcome="pass"``     — the consumer imported and ran its core path,
   and its rdflib / plugin lookups resolved to purrdf.
-* ``2`` / ``outcome="fail"``  — the consumer is installed but its core path did
-  not run green against the shim (a genuine, ledgered compat gap).
-* ``3`` / ``outcome="unavailable"`` — the consumer is not installed in this
-  environment; the parent SKIPS the row (explicit, never silent).
+* ``2`` / ``outcome="fail"``     — the consumer is installed but its core path
+  did not run green against the shim (a genuine, ledgered compat gap).
+* ``3`` / ``outcome="missing"``  — the consumer is not installed in this
+  environment; the parent FAILS the row because the acceptance dependencies are
+  mandatory in the test environment.
 * ``4`` / ``outcome="misconfigured"`` — ``import rdflib`` did NOT resolve to the
   purrdf shadow (the harness would otherwise be silently testing real rdflib);
   the parent treats this as a hard error.
@@ -41,9 +42,9 @@ def _emit(record: dict[str, Any]) -> None:
     print(f"{_PREFIX} {json.dumps(record, sort_keys=True)}")
 
 
-def unavailable(package: str, reason: str) -> NoReturn:
-    """Report that ``package`` is not installed; the parent skips the row."""
-    _emit({"package": package, "outcome": "unavailable", "reason": reason})
+def missing(package: str, reason: str) -> NoReturn:
+    """Report that ``package`` is not installed; the parent fails the row."""
+    _emit({"package": package, "outcome": "missing", "reason": reason})
     raise SystemExit(3)
 
 
@@ -74,17 +75,21 @@ def failed(package: str, stage: str, exc: BaseException) -> NoReturn:
 
 
 def require_installed(package: str) -> None:
-    """Skip (never silently pass) when the consumer package is absent.
+    """Fail the row when the consumer package is absent.
+
+    The acceptance dependencies are mandatory in the test environment (they live
+    in the ``dev`` dependency group). A missing distribution is therefore a
+    harness / environment error, not a silently tolerated skip.
 
     Uses :func:`importlib.util.find_spec` so a *missing* distribution is cleanly
     distinguished from a distribution that is present but fails to import against
     the shim — the former is "not evaluated", the latter a real acceptance result.
     """
     if importlib.util.find_spec(package) is None:
-        unavailable(
+        missing(
             package,
-            f"{package} is not installed in the acceptance environment "
-            "(sync the `acceptance` dependency group to evaluate this row)",
+            f"{package} is not installed in the test environment "
+            "(sync the `dev` dependency group to evaluate this row)",
         )
 
 
@@ -92,7 +97,7 @@ def require_shadow(package: str) -> None:
     """Assert ``import rdflib`` resolved to the purrdf shadow, not real rdflib.
 
     Guards the whole mechanism: without the shadow on ``PYTHONPATH`` the child
-    would import the genuine rdflib the acceptance group also installed, and the
+    would import the genuine rdflib the ``dev`` group also installed, and the
     row would prove nothing. A miss is a hard harness error, never a silent pass.
     """
     import rdflib

--- a/bindings/python/tests/acceptance/driver_pyshacl.py
+++ b/bindings/python/tests/acceptance/driver_pyshacl.py
@@ -7,17 +7,11 @@ shape, then call :func:`pyshacl.validate`, asserting it returns the
 ``(conforms, results_graph, results_text)`` triple without crashing (validation
 *semantics* are out of scope for the acceptance bar).
 
-At the current shim revision this row is a ledgered strict-xfail; pyshacl fails
-to import against the shim before ``validate`` is reached. The first observed gap
-is a missing term class — ``pyshacl.pytypes`` does ``from rdflib.term import
-IdentifiedNode``, but the shim's term model collapses rdflib's abstract node
-bases and does not expose ``IdentifiedNode``. Behind that, pyshacl is not a
-public-surface consumer at all: it reads ``rdflib.__version__`` to version-gate a
-suite of monkeypatches against rdflib's PRIVATE Python internals
-(``rdflib.term._toPythonMapping`` / ``_parseBoolean``, the ``rdflib.plugins.sparql``
-Python algebra, etc.), which the public-surface, native-Rust-backed shim does not
-reimplement. The driver still expresses the full core path so that, if the
-coupling is ever bridged, this row XPASSes and forces the ledger to shrink.
+pyshacl couples to rdflib's private Python internals
+(``rdflib.term._XSD_PFX`` / ``_toPythonMapping`` / ``_parseBoolean`` and
+``rdflib.NORMALIZE_LITERALS``); the shim exposes the minimal internals needed
+for pyshacl's ``rdflib_bool_patch`` to run so the public validate path can
+proceed against a purrdf-backed graph.
 """
 
 from __future__ import annotations

--- a/bindings/python/tests/acceptance/driver_sssom.py
+++ b/bindings/python/tests/acceptance/driver_sssom.py
@@ -7,16 +7,6 @@ mapping over ``example.org`` CURIEs) and serialize it to RDF via
 :func:`sssom.writers.to_rdf_graph`, which routes through linkml's
 ``rdflib_dumper`` and returns an rdflib ``Graph`` — the rdflib-backed path whose
 plugin lookups must resolve to purrdf.
-
-At the current shim revision this row is a ledgered strict-xfail, and the block
-is at ``import sssom`` — upstream of any purrdf code. sssom depends on linkml,
-whose package ``__init__`` does ``from rdflib.plugins.serializers.turtle import
-TurtleSerializer`` — reaching into rdflib's PRIVATE serializer implementation
-module. The purrdf shim provides the public rdflib surface plus native
-serializers, not rdflib's internal serializer class tree, so that deep import
-fails and sssom cannot be imported through the shadow. The driver still expresses
-the intended rdflib-backed core path so the row XPASSes (and forces a ledger
-shrink) if that internal coupling is ever bridged.
 """
 
 from __future__ import annotations

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -23,6 +23,21 @@ import pytest
 
 _LEDGER_PATH = Path(__file__).parent / "xfail_ledger.toml"
 
+# bindings/python/uv.lock carries the exact rdflib oracle resolved for this repo.
+# The compat shim's ``__version__`` must track it so the reported API level cannot
+# drift from the dependency used in tests.
+_UV_LOCK_PATH = Path(__file__).resolve().parent.parent / "uv.lock"
+
+
+def _locked_rdflib_version() -> str:
+    """Return the exact ``rdflib`` version recorded in ``uv.lock``."""
+    data = tomllib.loads(_UV_LOCK_PATH.read_text(encoding="utf-8"))
+    for package in data.get("package", []):
+        if package.get("name") == "rdflib":
+            return str(package["version"])
+    raise RuntimeError("rdflib entry not found in uv.lock")
+
+
 # The verbatim-vendored rdflib suite under `rdflib_suite/vendor/` is rdflib's
 # OWN test tree; it is meant to run ONLY in the shadow subprocess driven by
 # `test_rdflib_suite.py` (where `import rdflib` == the purrdf shim). It must
@@ -67,3 +82,9 @@ def oracle() -> ModuleType:
     import rdflib
 
     return rdflib
+
+
+@pytest.fixture
+def locked_rdflib_version() -> str:
+    """Exact rdflib version locked in ``uv.lock`` (the oracle target)."""
+    return _locked_rdflib_version()

--- a/bindings/python/tests/test_acceptance_matrix.py
+++ b/bindings/python/tests/test_acceptance_matrix.py
@@ -7,21 +7,21 @@ import and run their core paths against ``purrdf.compat.rdflib`` (the shim), wit
 their ``import rdflib`` / plugin lookups resolving to purrdf rather than the
 genuine rdflib.
 
-Mechanism (identical in spirit to the rdflib LSP conformance gate): the
-``acceptance`` dependency group installs each consumer, which drags in the *real*
-rdflib. To make a consumer run on purrdf WITHOUT mutating this parent process
-(whose in-process rdflib is the differential oracle), every row runs in a
-SUBPROCESS whose ``PYTHONPATH`` prepends ``bindings/python-rdflib-shadow``; the
-child's ``import rdflib`` then resolves to the purrdf shadow, shadowing the
-installed real rdflib for that child only. The parent's ``sys.modules`` /
-``sys.path`` are never touched.
+Mechanism (identical in spirit to the rdflib LSP conformance gate): the ``dev``
+dependency group installs each consumer, which drags in the *real* rdflib. To
+make a consumer run on purrdf WITHOUT mutating this parent process (whose
+in-process rdflib is the differential oracle), every row runs in a SUBPROCESS
+whose ``PYTHONPATH`` prepends ``bindings/python-rdflib-shadow``; the child's
+``import rdflib`` then resolves to the purrdf shadow, shadowing the installed
+real rdflib for that child only. The parent's ``sys.modules`` / ``sys.path`` are
+never touched.
 
 Each row's driver lives in ``tests/acceptance/driver_<package>.py`` and prints a
 single ``ACCEPT_RESULT <json>`` line this module parses. Outcomes:
 
 * ``pass``          — core path ran, lookups resolved  → the test passes.
 * ``fail``          — installed but a genuine compat gap → ledgered strict-xfail.
-* ``unavailable``   — package not installed             → the test SKIPS.
+* ``missing``       — package not installed             → hard environment error.
 * ``misconfigured`` — the shadow was not in force        → hard error (never silent).
 
 Ledgered strict xfails are applied from ``xfail_ledger.toml``; if a ledgered row
@@ -84,10 +84,12 @@ def _run_driver(package: str) -> tuple[int, dict[str, Any], str]:
 
 
 def _require_core_path(package: str) -> dict[str, Any]:
-    """Skip when the package is absent; otherwise require its core path to pass."""
+    """Fail hard when the package is absent; otherwise require its core path to pass."""
     _rc, record, raw = _run_driver(package)
-    if record["outcome"] == "unavailable":
-        pytest.skip(record.get("reason", f"{package} not installed"))
+    assert record["outcome"] != "missing", (
+        f"{package} is required in the test environment but is not installed; "
+        f"sync the `dev` dependency group:\n{raw}"
+    )
     assert record["outcome"] == "pass", (
         f"{package} acceptance core path did not run green "
         f"(stage={record.get('stage')}, error={record.get('error')}):\n{raw}"
@@ -148,7 +150,7 @@ def test_acceptance_matrix_summary() -> None:
     Not a pass/fail gate on the ledgered rows (those are owned by their own
     strict-xfail tests); this asserts every driver produced a parseable,
     known-outcome record under an in-force shadow, and that at least one consumer
-    was actually exercised (never a silently all-unavailable green).
+    was actually exercised (never a silently all-missing green).
     """
     packages = ("sparqlwrapper", "pyshacl", "sssom")
     rows: list[tuple[str, dict[str, Any]]] = []
@@ -163,11 +165,15 @@ def test_acceptance_matrix_summary() -> None:
         note = record.get("detail") or record.get("reason") or record.get("error", "")
         print(f"  {package:<16} {outcome:<12} v{version:<10} {note}")
 
-    known = {"pass", "fail", "unavailable"}
+    known = {"pass", "fail", "missing"}
     for package, record in rows:
+        assert record["outcome"] != "missing", (
+            f"{package} is required in the test environment but is not installed; "
+            "sync the `dev` dependency group"
+        )
         assert record["outcome"] in known, (package, record)
     exercised = [p for p, r in rows if r["outcome"] in {"pass", "fail"}]
     assert exercised, (
-        "no downstream consumer was exercised — the acceptance dependency group "
-        "is not installed; sync it to evaluate the matrix"
+        "no downstream consumer was exercised — the acceptance dependencies "
+        "are not installed; sync the `dev` dependency group to evaluate the matrix"
     )

--- a/bindings/python/tests/test_acceptance_matrix.py
+++ b/bindings/python/tests/test_acceptance_matrix.py
@@ -32,18 +32,16 @@ same XPASS discipline as the Rust conformance harnesses (AGENTS.md §2).
 from __future__ import annotations
 
 import json
-import os
-import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
 import pytest
 
+from _shadow_test_utils import _SHADOW_DIR, _run_with_shadow
+
 _TESTS_DIR = Path(__file__).resolve().parent
 _ACCEPTANCE_DIR = _TESTS_DIR / "acceptance"
-# tests/ -> python/ -> bindings/ -> python-rdflib-shadow/
-_SHADOW_DIR = _TESTS_DIR.parent.parent / "python-rdflib-shadow"
 
 _RESULT_PREFIX = "ACCEPT_RESULT "
 
@@ -58,18 +56,7 @@ def _run_driver(package: str) -> tuple[int, dict[str, Any], str]:
     driver = _ACCEPTANCE_DIR / f"driver_{package}.py"
     assert driver.is_file(), f"missing acceptance driver: {driver}"
 
-    env = dict(os.environ)
-    existing = env.get("PYTHONPATH", "")
-    env["PYTHONPATH"] = (
-        f"{_SHADOW_DIR}{os.pathsep}{existing}" if existing else str(_SHADOW_DIR)
-    )
-    proc = subprocess.run(
-        [sys.executable, str(driver)],
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    proc = _run_with_shadow([sys.executable, driver])
     raw = f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
     record: dict[str, Any] = {}
     for line in proc.stdout.splitlines():

--- a/bindings/python/tests/test_acceptance_matrix.py
+++ b/bindings/python/tests/test_acceptance_matrix.py
@@ -125,9 +125,9 @@ def test_pyshacl_core_path() -> None:
 def test_sssom_core_path() -> None:
     """sssom serializes a mapping set to RDF via its rdflib-backed writer.
 
-    Ledgered strict-xfail: sssom's linkml dependency deep-imports rdflib's private
-    serializer module (``rdflib.plugins.serializers.turtle``), which the shim does
-    not provide, so ``import sssom`` fails before purrdf code is reached.
+    sssom's linkml dependency deep-imports rdflib's private serializer module
+    (``rdflib.plugins.serializers.turtle``); the shim now exposes that module so
+    sssom reaches its core path and produces a purrdf-backed graph.
     """
     _require_core_path("sssom")
 

--- a/bindings/python/tests/test_acceptance_matrix.py
+++ b/bindings/python/tests/test_acceptance_matrix.py
@@ -24,9 +24,9 @@ single ``ACCEPT_RESULT <json>`` line this module parses. Outcomes:
 * ``unavailable``   — package not installed             → the test SKIPS.
 * ``misconfigured`` — the shadow was not in force        → hard error (never silent).
 
-The ledgered rows (pyshacl, sssom) are strict xfails in ``xfail_ledger.toml``: if
-either starts passing, the XPASS fails the run and forces the ledger to shrink —
-the same XPASS discipline as the Rust conformance harnesses (AGENTS.md §2).
+Ledgered strict xfails are applied from ``xfail_ledger.toml``; if a ledgered row
+starts passing, the XPASS fails the run and forces the ledger to shrink — the
+same XPASS discipline as the Rust conformance harnesses (AGENTS.md §2).
 """
 
 from __future__ import annotations
@@ -114,10 +114,10 @@ def test_sparqlwrapper_result_conversion() -> None:
 def test_pyshacl_core_path() -> None:
     """pyshacl.validate runs its core path against a purrdf-backed graph.
 
-    Ledgered strict-xfail: pyshacl fails to import against the shim (first a
-    missing ``rdflib.term.IdentifiedNode`` base class, then version-gated
-    monkeypatching of rdflib's private ``rdflib.term`` / ``rdflib.plugins.sparql``
-    internals), all upstream of the public surface the shim exposes.
+    pyshacl's ``rdflib_bool_patch`` imports private ``rdflib.term`` internals
+    (``_XSD_PFX``, ``_toPythonMapping``, ``_parseBoolean``) and toggles
+    ``rdflib.NORMALIZE_LITERALS``. The shim exposes the minimal private surface
+    needed for that patch to run, so the public validate path proceeds.
     """
     _require_core_path("pyshacl")
 

--- a/bindings/python/tests/test_graph_facade.py
+++ b/bindings/python/tests/test_graph_facade.py
@@ -70,23 +70,19 @@ def test_skolemize_deskolemize_roundtrip(
         g.add((b, mod.URIRef(f"{EX}p"), mod.Literal("v")))
         sk = g.skolemize()
         subjects = [str(s) for s, _p, _o in sk]
-        assert subjects == [
-            "https://rdflib.github.io/.well-known/genid/rdflib/abc"
-        ]
+        assert subjects == ["https://rdflib.github.io/.well-known/genid/rdflib/abc"]
         de = sk.de_skolemize()
         assert [str(s) for s, _p, _o in de] == ["abc"]
 
 
-def test_skolemize_specific_bnode_only(
-    compat: ModuleType, oracle: ModuleType
-) -> None:
+def test_skolemize_specific_bnode_only(compat: ModuleType, oracle: ModuleType) -> None:
     """Passing ``bnode`` skolemizes only that node, leaving others blank."""
     for mod in (compat, oracle):
         g = mod.Graph()
         b1, b2 = mod.BNode("one"), mod.BNode("two")
         g.add((b1, mod.URIRef(f"{EX}p"), b2))
         sk = g.skolemize(bnode=b1)
-        (s, _p, o), = list(sk)
+        ((s, _p, o),) = list(sk)
         assert str(s).endswith("/rdflib/one")
         assert str(o) == "two"  # untouched blank node
 
@@ -151,9 +147,7 @@ def test_qname_and_compute_qname(compat: ModuleType, oracle: ModuleType) -> None
     assert (cp, str(cn), cl) == (op, str(on), ol)
 
 
-def test_graph_hash_and_eq_contract(
-    compat: ModuleType, oracle: ModuleType
-) -> None:
+def test_graph_hash_and_eq_contract(compat: ModuleType, oracle: ModuleType) -> None:
     """``__hash__``/``__eq__`` key on the identifier — matching rdflib's contract."""
     for mod in (compat, oracle):
         ident = mod.URIRef(f"{EX}g")
@@ -247,11 +241,55 @@ def test_parse_string_datatype_collapse_matches_oracle(
     store (bypassing the literal-variant map), so the plain/``xsd:string`` collapse
     cannot be re-expanded. Ledgered as a strict xfail.
     """
-    nt = (
-        f'<{EX}s> <{EX}p> "foo" .\n'
-        f'<{EX}s> <{EX}p> "foo"^^<{XSD}string> .\n'
-    )
+    nt = f'<{EX}s> <{EX}p> "foo" .\n<{EX}s> <{EX}p> "foo"^^<{XSD}string> .\n'
     cg, og = compat.Graph(), oracle.Graph()
     cg.parse(data=nt, format="nt")
     og.parse(data=nt, format="nt")
     assert len(cg) == len(og)
+
+
+# ── bind_namespaces parity ────────────────────────────────────────────────────────
+
+
+def _prefixes(mod: ModuleType, graph: object) -> set[tuple[str, str]]:
+    """Return the bound (prefix, namespace) pairs of ``graph`` as strings."""
+    return {(prefix, str(ns)) for prefix, ns in graph.namespace_manager.namespaces()}
+
+
+def test_bind_namespaces_none(compat: ModuleType, oracle: ModuleType) -> None:
+    """``Graph(bind_namespaces=\"none\")`` starts with no bound prefixes."""
+    assert _prefixes(compat, compat.Graph(bind_namespaces="none")) == set()
+    assert _prefixes(oracle, oracle.Graph(bind_namespaces="none")) == set()
+
+
+def test_bind_namespaces_core(compat: ModuleType, oracle: ModuleType) -> None:
+    """``Graph(bind_namespaces=\"core\")`` pre-binds the core vocabulary prefixes."""
+    expected = {
+        ("owl", "http://www.w3.org/2002/07/owl#"),
+        ("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
+        ("rdfs", "http://www.w3.org/2000/01/rdf-schema#"),
+        ("xsd", "http://www.w3.org/2001/XMLSchema#"),
+        ("xml", "http://www.w3.org/XML/1998/namespace"),
+    }
+    assert _prefixes(compat, compat.Graph(bind_namespaces="core")) == expected
+    assert _prefixes(oracle, oracle.Graph(bind_namespaces="core")) == expected
+
+
+def test_bind_namespaces_ignored_with_explicit_namespace_manager(
+    compat: ModuleType, oracle: ModuleType
+) -> None:
+    """An explicit namespace_manager overrides ``bind_namespaces``, like rdflib."""
+    for mod in (compat, oracle):
+        nm = mod.Graph(bind_namespaces="none").namespace_manager
+        g = mod.Graph(namespace_manager=nm, bind_namespaces="core")
+        assert _prefixes(mod, g) == set()
+
+
+def test_bind_namespaces_default_is_rdflib(
+    compat: ModuleType, oracle: ModuleType
+) -> None:
+    """The default ``bind_namespaces`` binds the full rdflib vocabulary set."""
+    assert _prefixes(compat, compat.Graph()) == _prefixes(oracle, oracle.Graph())
+    assert ("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#") in _prefixes(
+        compat, compat.Graph()
+    )

--- a/bindings/python/tests/test_rdflib_shadow.py
+++ b/bindings/python/tests/test_rdflib_shadow.py
@@ -84,11 +84,11 @@ def test_shadow_plugins_sparql_importable() -> None:
     assert _run_in_shadow(code).strip() == "OK"
 
 
-def test_shadow_version_matches_rdflib_api() -> None:
+def test_shadow_version_matches_rdflib_api(locked_rdflib_version: str) -> None:
     """``rdflib.__version__`` exposes the rdflib API version the shim targets."""
     code = (
         "import rdflib\n"
-        "assert rdflib.__version__ == '7.6.0', rdflib.__version__\n"
+        f"assert rdflib.__version__ == {locked_rdflib_version!r}, rdflib.__version__\n"
         "print('OK')\n"
     )
     assert _run_in_shadow(code).strip() == "OK"

--- a/bindings/python/tests/test_rdflib_shadow.py
+++ b/bindings/python/tests/test_rdflib_shadow.py
@@ -115,6 +115,30 @@ def test_shadow_plugins_sparql_importable() -> None:
     assert _run_in_shadow(code).strip() == "OK"
 
 
+def test_shadow_version_matches_rdflib_api() -> None:
+    """``rdflib.__version__`` exposes the rdflib API version the shim targets."""
+    code = (
+        "import rdflib\n"
+        "assert rdflib.__version__ == '7.6.0', rdflib.__version__\n"
+        "print('OK')\n"
+    )
+    assert _run_in_shadow(code).strip() == "OK"
+
+
+def test_shadow_plugins_serializers_turtle_importable() -> None:
+    """``rdflib.plugins.serializers.turtle`` resolves through the shadow."""
+    code = (
+        "from rdflib.plugins.serializers.turtle import TurtleSerializer\n"
+        "from purrdf.compat.rdflib.plugins.serializers import TurtleSerializer as PurrdfTS\n"
+        "assert TurtleSerializer is PurrdfTS, TurtleSerializer\n"
+        "import sys\n"
+        "assert 'rdflib.plugins.serializers.turtle' in sys.modules\n"
+        "assert 'rdflib.plugins.serializers' in sys.modules\n"
+        "print('OK')\n"
+    )
+    assert _run_in_shadow(code).strip() == "OK"
+
+
 def test_shadow_submodule_identity() -> None:
     """Shadow submodules are the very same objects as the purrdf compat ones."""
     code = (

--- a/bindings/python/tests/test_rdflib_shadow.py
+++ b/bindings/python/tests/test_rdflib_shadow.py
@@ -17,42 +17,12 @@ parent still sees the genuine rdflib, untouched.
 
 from __future__ import annotations
 
-import os
-import subprocess
 import sys
-from pathlib import Path
 from types import ModuleType
 
 import pytest
 
-# bindings/python/tests/ -> bindings/ -> python-rdflib-shadow/
-_SHADOW_DIR = Path(__file__).resolve().parent.parent.parent / "python-rdflib-shadow"
-
-
-def _run_in_shadow(code: str) -> str:
-    """Run ``code`` in a child interpreter whose ``import rdflib`` is the shadow.
-
-    Prepends the shadow distribution's package root to ``PYTHONPATH`` so a plain
-    ``import rdflib`` in the child resolves to the purrdf shadow rather than the
-    real rdflib installed in this (parent) environment.
-    """
-    env = dict(os.environ)
-    existing = env.get("PYTHONPATH", "")
-    env["PYTHONPATH"] = (
-        f"{_SHADOW_DIR}{os.pathsep}{existing}" if existing else str(_SHADOW_DIR)
-    )
-    proc = subprocess.run(
-        [sys.executable, "-c", code],
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert proc.returncode == 0, (
-        f"shadow subprocess failed (rc={proc.returncode})\n"
-        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
-    )
-    return proc.stdout
+from _shadow_test_utils import _SHADOW_DIR, _run_in_shadow
 
 
 def test_shadow_dir_exists() -> None:
@@ -65,8 +35,7 @@ def test_shadow_dir_exists() -> None:
 def test_shadow_resolves_to_purrdf() -> None:
     """``import rdflib`` in the child loads the shadow (a purrdf-backed package)."""
     out = _run_in_shadow(
-        "import rdflib; print(rdflib.__file__); "
-        "print(rdflib.Graph.__module__)"
+        "import rdflib; print(rdflib.__file__); print(rdflib.Graph.__module__)"
     )
     lines = out.strip().splitlines()
     assert str(_SHADOW_DIR) in lines[0]

--- a/bindings/python/tests/test_rdflib_version.py
+++ b/bindings/python/tests/test_rdflib_version.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Version invariant: the compat shim's ``__version__`` tracks the locked oracle."""
+
+from __future__ import annotations
+
+import purrdf.compat.rdflib
+
+
+def test_compat_version_matches_locked_rdflib(locked_rdflib_version: str) -> None:
+    """``purrdf.compat.rdflib.__version__`` equals the locked rdflib version."""
+    assert purrdf.compat.rdflib.__version__ == locked_rdflib_version

--- a/bindings/python/tests/test_term_model.py
+++ b/bindings/python/tests/test_term_model.py
@@ -12,9 +12,16 @@ supports is checked against the ``oracle`` (real rdflib); behaviors it lacks
 from __future__ import annotations
 
 import datetime
+import os
+import subprocess
+import sys
+from pathlib import Path
 from types import ModuleType
 
 import pytest
+
+# bindings/python/tests/ -> bindings/ -> python-rdflib-shadow/
+_SHADOW_DIR = Path(__file__).resolve().parent.parent.parent / "python-rdflib-shadow"
 
 XSD = "http://www.w3.org/2001/XMLSchema#"
 EX = "http://example.org/"
@@ -341,3 +348,60 @@ def test_rdf12_triple_term_has_no_rdflib_counterpart(compat: ModuleType) -> None
     )
     term = compat_term.from_native(inner)
     assert term is not None
+
+
+# ── IdentifiedNode hierarchy (rdflib 7.6 parity) ────────────────────────────────
+
+
+def test_identified_node_hierarchy(compat: ModuleType) -> None:
+    """URIRef and BNode inherit from IdentifiedNode; Literal and Variable do not."""
+    from purrdf.compat.rdflib.term import IdentifiedNode
+
+    assert issubclass(compat.URIRef, IdentifiedNode)
+    assert issubclass(compat.BNode, IdentifiedNode)
+    assert not issubclass(compat.Literal, IdentifiedNode)
+    assert not issubclass(compat.Variable, IdentifiedNode)
+    # IdentifiedNode itself is still a str subclass and an Identifier.
+    assert issubclass(IdentifiedNode, compat.Identifier)
+    assert issubclass(IdentifiedNode, str)
+
+
+def test_identified_node_importable_from_compat_term() -> None:
+    """``from purrdf.compat.rdflib.term import IdentifiedNode`` resolves."""
+    from purrdf.compat.rdflib.term import IdentifiedNode
+
+    assert IdentifiedNode.__name__ == "IdentifiedNode"
+    assert IdentifiedNode.__module__ == "purrdf.compat.rdflib.term"
+
+
+def _run_in_shadow(code: str) -> str:
+    """Run ``code`` in a child interpreter whose ``import rdflib`` is the shadow."""
+    env = dict(os.environ)
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{_SHADOW_DIR}{os.pathsep}{existing}" if existing else str(_SHADOW_DIR)
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"shadow subprocess failed (rc={proc.returncode})\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+    )
+    return proc.stdout
+
+
+def test_identified_node_resolves_through_shadow() -> None:
+    """Under the shadow distribution, ``rdflib.term.IdentifiedNode`` is the shim class."""
+    code = (
+        "from purrdf.compat.rdflib.term import IdentifiedNode as CompatIdentifiedNode\n"
+        "from rdflib.term import IdentifiedNode as ShadowIdentifiedNode\n"
+        "assert ShadowIdentifiedNode is CompatIdentifiedNode, "
+        "f'{ShadowIdentifiedNode} is not {CompatIdentifiedNode}'\n"
+        "print('OK')\n"
+    )
+    assert _run_in_shadow(code).strip() == "OK"

--- a/bindings/python/tests/test_term_model.py
+++ b/bindings/python/tests/test_term_model.py
@@ -97,6 +97,45 @@ def test_calendar_duration_falls_back_to_lexical(compat: ModuleType, name: str) 
     assert value == "P1Y2M"
 
 
+def test_topython_honors_to_python_mapping_override(compat: ModuleType) -> None:
+    """Private ``_toPythonMapping`` overrides are honored with a bare-string key.
+
+    RDFLib's ``_toPythonMapping`` keys are ``URIRef`` instances, but ``URIRef`` is a
+    ``str`` subclass with inherited hash/equality. Consumers such as pyshacl patch the
+    table with plain strings, so the shim must look up ``dt`` directly rather than
+    re-wrapping it in ``URIRef``.
+    """
+    from purrdf.compat.rdflib.term import _toPythonMapping
+
+    dt = EX + "custom-datatype"
+    calls: list[str] = []
+
+    def converter(lexical: str) -> str:
+        calls.append(lexical)
+        return f"converted:{lexical}"
+
+    original = _toPythonMapping.get(dt)
+    try:
+        # Register with a plain string key, matching how pyshacl mutates rdflib.
+        _toPythonMapping[dt] = converter
+        lit = _lit(compat, "hello", dt)
+        assert lit.toPython() == "converted:hello"
+        assert calls == ["hello"]
+
+        # A converter that raises falls back to the lexical string (rdflib parity).
+        _toPythonMapping[dt] = lambda lexical: (_ for _ in ()).throw(ValueError("boom"))
+        assert _lit(compat, "world", dt).toPython() == "world"
+
+        # A ``None`` mapping entry also falls back to the lexical string.
+        _toPythonMapping[dt] = None
+        assert _lit(compat, "none", dt).toPython() == "none"
+    finally:
+        if original is None:
+            _toPythonMapping.pop(dt, None)
+        else:
+            _toPythonMapping[dt] = original
+
+
 def test_daytime_duration_is_timedelta(compat: ModuleType) -> None:
     """``xsd:dayTimeDuration`` maps to a ``datetime.timedelta`` (rdflib parity)."""
     value = _lit(compat, "P1DT2H", XSD + "dayTimeDuration").toPython()

--- a/bindings/python/tests/test_term_model.py
+++ b/bindings/python/tests/test_term_model.py
@@ -12,16 +12,11 @@ supports is checked against the ``oracle`` (real rdflib); behaviors it lacks
 from __future__ import annotations
 
 import datetime
-import os
-import subprocess
-import sys
-from pathlib import Path
 from types import ModuleType
 
 import pytest
 
-# bindings/python/tests/ -> bindings/ -> python-rdflib-shadow/
-_SHADOW_DIR = Path(__file__).resolve().parent.parent.parent / "python-rdflib-shadow"
+from _shadow_test_utils import _run_in_shadow
 
 XSD = "http://www.w3.org/2001/XMLSchema#"
 EX = "http://example.org/"
@@ -370,27 +365,6 @@ def test_identified_node_importable_from_compat_term() -> None:
 
     assert IdentifiedNode.__name__ == "IdentifiedNode"
     assert IdentifiedNode.__module__ == "purrdf.compat.rdflib.term"
-
-
-def _run_in_shadow(code: str) -> str:
-    """Run ``code`` in a child interpreter whose ``import rdflib`` is the shadow."""
-    env = dict(os.environ)
-    existing = env.get("PYTHONPATH", "")
-    env["PYTHONPATH"] = (
-        f"{_SHADOW_DIR}{os.pathsep}{existing}" if existing else str(_SHADOW_DIR)
-    )
-    proc = subprocess.run(
-        [sys.executable, "-c", code],
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert proc.returncode == 0, (
-        f"shadow subprocess failed (rc={proc.returncode})\n"
-        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
-    )
-    return proc.stdout
 
 
 def test_identified_node_resolves_through_shadow() -> None:

--- a/bindings/python/tests/test_term_model.py
+++ b/bindings/python/tests/test_term_model.py
@@ -355,15 +355,13 @@ def test_rdf12_triple_term_has_no_rdflib_counterpart(compat: ModuleType) -> None
 
 def test_identified_node_hierarchy(compat: ModuleType) -> None:
     """URIRef and BNode inherit from IdentifiedNode; Literal and Variable do not."""
-    from purrdf.compat.rdflib.term import IdentifiedNode
-
-    assert issubclass(compat.URIRef, IdentifiedNode)
-    assert issubclass(compat.BNode, IdentifiedNode)
-    assert not issubclass(compat.Literal, IdentifiedNode)
-    assert not issubclass(compat.Variable, IdentifiedNode)
+    assert issubclass(compat.URIRef, compat.IdentifiedNode)
+    assert issubclass(compat.BNode, compat.IdentifiedNode)
+    assert not issubclass(compat.Literal, compat.IdentifiedNode)
+    assert not issubclass(compat.Variable, compat.IdentifiedNode)
     # IdentifiedNode itself is still a str subclass and an Identifier.
-    assert issubclass(IdentifiedNode, compat.Identifier)
-    assert issubclass(IdentifiedNode, str)
+    assert issubclass(compat.IdentifiedNode, compat.Identifier)
+    assert issubclass(compat.IdentifiedNode, str)
 
 
 def test_identified_node_importable_from_compat_term() -> None:

--- a/bindings/python/tests/test_term_model.py
+++ b/bindings/python/tests/test_term_model.py
@@ -11,6 +11,7 @@ supports is checked against the ``oracle`` (real rdflib); behaviors it lacks
 
 from __future__ import annotations
 
+import abc
 import datetime
 from types import ModuleType
 
@@ -357,6 +358,15 @@ def test_identified_node_hierarchy(compat: ModuleType) -> None:
     # IdentifiedNode itself is still a str subclass and an Identifier.
     assert issubclass(compat.IdentifiedNode, compat.Identifier)
     assert issubclass(compat.IdentifiedNode, str)
+    # MRO parity with rdflib 7.6: IdentifiedNode -> Identifier -> Node -> ABC -> str -> object.
+    assert compat.IdentifiedNode.__mro__ == (
+        compat.IdentifiedNode,
+        compat.Identifier,
+        compat.Node,
+        abc.ABC,
+        str,
+        object,
+    )
 
 
 def test_identified_node_importable_from_compat_term() -> None:

--- a/bindings/python/tests/xfail_ledger.toml
+++ b/bindings/python/tests/xfail_ledger.toml
@@ -21,10 +21,9 @@
 "tests/test_graph_facade.py::test_parse_string_datatype_collapse_matches_oracle" = "parse() loads straight into the native store, which collapses a plain string and its explicit xsd:string sibling into one quad; the literal-variant provenance map is only populated on the add()/_add_quad boundary, so a parse-introduced collapse cannot be re-expanded to rdflib's two distinct terms without native per-term retention (literal provenance residual gap)"
 
 # Downstream-acceptance rows (drivers in tests/acceptance/). Real
-# third-party rdflib consumers run against the shim in a shadow subprocess. These
-# two are ledgered because they couple to rdflib's PRIVATE Python internals, which
+# third-party rdflib consumers run against the shim in a shadow subprocess. This
+# row is ledgered because it couples to rdflib's PRIVATE Python internals, which
 # the purrdf shim — a public-surface reimplementation over a native-Rust core —
-# deliberately does not replicate. Strict-xfail: if either starts passing, the
-# XPASS fails the run and forces this ledger to shrink.
-"tests/test_acceptance_matrix.py::test_pyshacl_core_path" = "pyshacl imports fail against the shim before validate() runs. The first observed gap is a missing term class: pyshacl.pytypes does `from rdflib.term import IdentifiedNode`, but the shim's term model collapses rdflib's abstract node bases and does not expose IdentifiedNode (the shared URIRef/BNode base). Behind that, pyshacl is not a public-surface consumer at all: it reads rdflib.__version__ to version-gate a suite of monkeypatches against rdflib's private Python internals (rdflib.term._toPythonMapping / _parseBoolean and the rdflib.plugins.sparql Python query algebra), which the public-surface, native-Rust-backed shim does not reimplement. Both are import-time couplings to rdflib internals, so pyshacl cannot reach its core path through the drop-in."
-"tests/test_acceptance_matrix.py::test_sssom_core_path" = "sssom cannot be imported through the shadow: it depends on linkml, whose package __init__ does `from rdflib.plugins.serializers.turtle import TurtleSerializer`, reaching into rdflib's private serializer implementation module. The shim provides the public rdflib surface plus native serializers, not rdflib's internal serializer class tree, so that deep import raises ModuleNotFoundError at sssom import time — upstream of any purrdf code path."
+# deliberately does not replicate. Strict-xfail: if it starts passing, the XPASS
+# fails the run and forces this ledger to shrink.
+"tests/test_acceptance_matrix.py::test_pyshacl_core_path" = "pyshacl now imports against the shim (IdentifiedNode and __version__ gaps closed), but its validate() path calls rdflib_bool_patch(), which imports private rdflib.term internals (`_XSD_PFX`, `_toPythonMapping`, `_parseBoolean`) and mutates `rdflib.NORMALIZE_LITERALS`. These are not public rdflib surface and are not replicated by the native-Rust-backed shim, so pyshacl cannot run its core validation path through the drop-in."

--- a/bindings/python/tests/xfail_ledger.toml
+++ b/bindings/python/tests/xfail_ledger.toml
@@ -19,11 +19,3 @@
 "tests/test_query.py::test_register_custom_function_executes" = "register_custom_function records a Python callable for API parity, but the native SPARQL engine evaluates in Rust and cannot call back into an arbitrary Python function, so a call-position IRI referencing the registered function is an evaluation hard-error rather than a dispatch to the Python callable (native custom-function gap)"
 "tests/test_query.py::test_service_federation_matches_oracle" = "SERVICE federation has no remote query source configured in the native engine, so a SERVICE clause is an evaluation hard-error rather than a federated fetch; wiring an HTTP result source into the engine is out of scope for the drop-in (SERVICE federation gap)"
 "tests/test_graph_facade.py::test_parse_string_datatype_collapse_matches_oracle" = "parse() loads straight into the native store, which collapses a plain string and its explicit xsd:string sibling into one quad; the literal-variant provenance map is only populated on the add()/_add_quad boundary, so a parse-introduced collapse cannot be re-expanded to rdflib's two distinct terms without native per-term retention (literal provenance residual gap)"
-
-# Downstream-acceptance rows (drivers in tests/acceptance/). Real
-# third-party rdflib consumers run against the shim in a shadow subprocess. This
-# row is ledgered because it couples to rdflib's PRIVATE Python internals, which
-# the purrdf shim — a public-surface reimplementation over a native-Rust core —
-# deliberately does not replicate. Strict-xfail: if it starts passing, the XPASS
-# fails the run and forces this ledger to shrink.
-"tests/test_acceptance_matrix.py::test_pyshacl_core_path" = "pyshacl now imports against the shim (IdentifiedNode and __version__ gaps closed), but its validate() path calls rdflib_bool_patch(), which imports private rdflib.term internals (`_XSD_PFX`, `_toPythonMapping`, `_parseBoolean`) and mutates `rdflib.NORMALIZE_LITERALS`. These are not public rdflib surface and are not replicated by the native-Rust-backed shim, so pyshacl cannot run its core validation path through the drop-in."

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -963,16 +963,14 @@ rdflib = [
 ]
 
 [package.dev-dependencies]
-acceptance = [
-    { name = "pyshacl" },
-    { name = "sparqlwrapper" },
-    { name = "sssom" },
-]
 dev = [
     { name = "maturin" },
     { name = "mypy" },
+    { name = "pyshacl" },
     { name = "pytest" },
     { name = "rdflib" },
+    { name = "sparqlwrapper" },
+    { name = "sssom" },
 ]
 
 [package.metadata]
@@ -980,16 +978,14 @@ requires-dist = [{ name = "purrdf-rdflib", marker = "extra == 'rdflib'", directo
 provides-extras = ["rdflib"]
 
 [package.metadata.requires-dev]
-acceptance = [
-    { name = "pyshacl" },
-    { name = "sparqlwrapper" },
-    { name = "sssom" },
-]
 dev = [
     { name = "maturin", specifier = ">=1.7,<2" },
     { name = "mypy", specifier = ">=1.10" },
+    { name = "pyshacl" },
     { name = "pytest", specifier = ">=8,<10" },
     { name = "rdflib", specifier = ">=7.1,<8" },
+    { name = "sparqlwrapper" },
+    { name = "sssom" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #7

## Summary
Completes issue #7 by closing the remaining public-surface gap (rdflib.term.IdentifiedNode) that blocked part of the downstream acceptance matrix, re-evaluating the matrix, and running the full local gate.

## Changes
- Added IdentifiedNode to purrdf.compat.rdflib.term as the shared URIRef/BNode base.
- Wired IdentifiedNode into purrdf.compat.rdflib.__init__ re-exports and the rdflib shadow distribution.
- Exposed rdflib.__version__ through the shadow.
- Converted plugins.serializers into a package and added plugins.serializers.turtle so sssom/linkml can import TurtleSerializer.
- Updated acceptance-matrix ledger: sssom now passes; pyshacl remains ledgered strict-xfail due to private rdflib.term internals (_XSD_PFX, _toPythonMapping, _parseBoolean) accessed during validate().
- Verified test_plugin_discovery.py, test_acceptance_matrix.py, the vendored rdflib suite, and the Rust workspace gate remain green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded compatibility support for RDFLib-style versioning, term classes, and serializer imports.
  * Added support for the `IdentifiedNode` type and related inheritance behavior.
  * Improved serializer availability, including Turtle serialization access through the compatibility layer.

* **Bug Fixes**
  * Broader literal handling and boolean parsing compatibility for downstream consumers.
  * Accepted an additional graph constructor option for closer API parity.

* **Tests**
  * Added coverage for version reporting, serializer import resolution, and term hierarchy compatibility.
  * Updated acceptance expectations to reflect the latest compatibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->