### PR TITLE
feat(shapes): SHACL-SPARQL custom constraint components

### DIFF
--- a/crates/shapes/src/components.rs
+++ b/crates/shapes/src/components.rs
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Data model for SHACL custom constraint components and their validator registry.
+//!
+//! A [`ComponentRegistry`] holds constraint components declared in a shapes graph
+//! (instances of `sh:ConstraintComponent`) together with their `sh:Parameter`
+//! declarations and SPARQL-based validators. The registry is populated at shape
+//! parse time and consulted by the engine when it encounters a predicate that is
+//! a declared component parameter path.
+//!
+//! These types are scaffolding for the custom component parser/evaluator added in
+//! later tasks; they are exported from a `pub(crate)` module now and will be
+//! constructed by the component loader once it lands.
+#![allow(dead_code, unreachable_pub)]
+
+use std::collections::HashMap;
+
+use crate::term::NamedNode;
+
+/// Discriminator for a SPARQL validator's query form.
+#[derive(Debug, Clone)]
+pub enum ValidatorKind {
+    /// An `ASK` query: a result of `true` means the focus node/value is valid.
+    Ask,
+    /// A `SELECT` query: each result row denotes a validation violation.
+    Select,
+}
+
+/// A SPARQL validator attached to a constraint component.
+#[derive(Debug, Clone)]
+pub struct Validator {
+    /// Whether the validator is an ASK or SELECT query.
+    pub kind: ValidatorKind,
+    /// Full query text with any `PREFIX` header already prepended.
+    pub query_text: String,
+}
+
+/// Declaration of a single `sh:Parameter` for a constraint component.
+#[derive(Debug, Clone)]
+pub struct Parameter {
+    /// The parameter predicate (`sh:path` of the parameter declaration).
+    pub path: NamedNode,
+    /// The SPARQL local name used to bind the parameter value in the validator.
+    pub name: String,
+    /// Whether the parameter is optional (`sh:optional true`).
+    pub optional: bool,
+}
+
+/// A SHACL custom constraint component.
+#[derive(Debug, Clone)]
+pub struct Component {
+    /// The component IRI (the `sh:ConstraintComponent` instance).
+    pub id: NamedNode,
+    /// Declared parameters, indexed in SHACL-specified order.
+    pub parameters: Vec<Parameter>,
+    /// Optional node-scope validator (`sh:nodeValidator`).
+    pub node_validator: Option<Validator>,
+    /// Optional property-scope validator (`sh:propertyValidator`).
+    pub property_validator: Option<Validator>,
+    /// Optional generic validator (`sh:validator`).
+    pub validator: Option<Validator>,
+}
+
+/// Registry of custom constraint components keyed by component IRI string.
+///
+/// `by_parameter_path` maps a declared parameter predicate IRI string to the
+/// IRI string of the component it belongs to, allowing the engine to recognize
+/// custom constraint predicates while parsing shapes.
+#[derive(Debug, Default, Clone)]
+pub struct ComponentRegistry {
+    /// Parameter predicate IRI string → owning component IRI string.
+    pub by_parameter_path: HashMap<String, String>,
+    /// Component IRI string → component definition.
+    pub components: HashMap<String, Component>,
+}
+
+/// Extract the SPARQL local name of an IRI: the longest suffix after the last
+/// `/`, `#`, or `:`.
+///
+/// ```ignore
+/// use purrdf_shapes::components::sparql_local_name;
+///
+/// assert_eq!(sparql_local_name("http://example.org/ns#requiredParam"), "requiredParam");
+/// assert_eq!(sparql_local_name("http://example.org/ns/requiredParam"), "requiredParam");
+/// assert_eq!(sparql_local_name("ex:requiredParam"), "requiredParam");
+/// ```
+#[must_use]
+pub fn sparql_local_name(iri: &str) -> String {
+    let mut idx = iri.rfind('/').map_or(0, |i| i + 1);
+    if let Some(i) = iri.rfind('#') {
+        idx = idx.max(i + 1);
+    }
+    if let Some(i) = iri.rfind(':') {
+        idx = idx.max(i + 1);
+    }
+    iri[idx..].to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sparql_local_name_extracts_suffix() {
+        assert_eq!(
+            sparql_local_name("http://example.org/ns#requiredParam"),
+            "requiredParam"
+        );
+        assert_eq!(
+            sparql_local_name("http://example.org/ns/requiredParam"),
+            "requiredParam"
+        );
+        assert_eq!(sparql_local_name("ex:requiredParam"), "requiredParam");
+        assert_eq!(sparql_local_name("requiredParam"), "requiredParam");
+    }
+
+    #[test]
+    fn component_registry_construction_round_trips() {
+        let mut registry = ComponentRegistry::default();
+        let component = Component {
+            id: NamedNode::from("http://example.org/ns#ExampleComponent"),
+            parameters: vec![Parameter {
+                path: NamedNode::from("http://example.org/ns#param"),
+                name: "param".to_owned(),
+                optional: false,
+            }],
+            node_validator: Some(Validator {
+                kind: ValidatorKind::Ask,
+                query_text: "ASK { ?this a ex:Thing }".to_owned(),
+            }),
+            property_validator: None,
+            validator: None,
+        };
+        let id = component.id.as_str().to_owned();
+        let param_path = component.parameters[0].path.as_str().to_owned();
+        registry.components.insert(id.clone(), component);
+        registry.by_parameter_path.insert(param_path, id);
+        assert_eq!(registry.components.len(), 1);
+        assert_eq!(registry.by_parameter_path.len(), 1);
+    }
+}

--- a/crates/shapes/src/components.rs
+++ b/crates/shapes/src/components.rs
@@ -312,8 +312,7 @@ pub fn eval_select_validator(
         let value = value_index
             .and_then(|i| row.get(i))
             .and_then(Option::as_ref)
-            .map(term_value_to_native)
-            .or_else(|| Some(focus.clone()));
+            .map(term_value_to_native);
 
         let mut template_bindings = row_bindings;
         for (name, value) in bindings {

--- a/crates/shapes/src/components.rs
+++ b/crates/shapes/src/components.rs
@@ -15,12 +15,18 @@
 #![allow(dead_code, unreachable_pub)]
 
 use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, OnceLock};
+
+use ::purrdf::RdfDataset;
+use ::purrdf::TermValue;
 
 use crate::data::{GraphFilter, IrDataGraph, ShaclDataGraph};
 use crate::model::{rdf, rdfs, sh};
-use crate::report::Severity;
-use crate::shapes::build_prefix_header;
-use crate::term::{NamedNode, Term};
+use crate::path;
+use crate::report::{Severity, ValidationResult};
+use crate::shapes::{build_prefix_header, ComponentValidator, Path};
+use crate::sparql::{run_ask_with_substitutions, run_select_with_substitutions};
+use crate::term::{term_value_to_native, NamedNode, Term};
 
 /// Discriminator for a SPARQL validator's query form.
 #[derive(Debug, Clone)]
@@ -163,8 +169,174 @@ pub(crate) fn severity_from_term(t: &Term) -> Option<Severity> {
     }
 }
 
-/// Extract the SPARQL local name of an IRI: the longest suffix after the last
-/// `/`, `#`, or `:`.
+// ── Custom component validator evaluation ────────────────────────────────────
+
+/// Substitute SHACL message templates of the form `{?varName}` and `{$varName}`
+/// with the string rendering of the first matching binding. Unbound variables are
+/// left unchanged.
+fn substitute_message_templates(msg: &str, bindings: &[(String, Term)]) -> String {
+    static TEMPLATE_RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re = TEMPLATE_RE.get_or_init(|| {
+        regex::Regex::new(r"\{([$?])([A-Za-z_][A-Za-z0-9_]*)\}")
+            .expect("static template regex is valid")
+    });
+    re.replace_all(msg, |caps: &regex::Captures<'_>| {
+        let name = &caps[2];
+        match bindings.iter().find(|(n, _)| n == name) {
+            Some((_, term)) => term.to_string(),
+            None => caps[0].to_owned(),
+        }
+    })
+    .into_owned()
+}
+
+/// Evaluate an ASK validator for a custom constraint component.
+///
+/// Each value node is substituted as `$value` / `?value` alongside `$this` and the
+/// parameter bindings. A result of `true` means conforming; `false` emits one
+/// [`ValidationResult`].
+#[allow(clippy::too_many_arguments)] // Signature mirrors the SHACL-SPARQL parameter set.
+pub fn eval_ask_validator(
+    dataset: &Arc<RdfDataset>,
+    focus: &Term,
+    value_nodes: &[Term],
+    validator: &ComponentValidator,
+    bindings: &[(String, Term)],
+    component: &NamedNode,
+    source_shape: &Term,
+    path: Option<&Path>,
+    severity: &Severity,
+    message: Option<&String>,
+) -> Result<Vec<ValidationResult>, String> {
+    let ComponentValidator::Ask { ask } = validator else {
+        return Err("expected ASK validator, got SELECT".to_owned());
+    };
+    let mut results = Vec::with_capacity(value_nodes.len());
+    for v in value_nodes {
+        let mut subs: Vec<(String, TermValue)> = Vec::with_capacity(2 + bindings.len());
+        subs.push(("this".to_owned(), focus.to_term_value()));
+        subs.push(("value".to_owned(), v.to_term_value()));
+        for (name, value) in bindings {
+            subs.push((name.clone(), value.to_term_value()));
+        }
+        let conforms = run_ask_with_substitutions(dataset, ask, &subs)?;
+        if !conforms {
+            let mut template_bindings: Vec<(String, Term)> = bindings.to_vec();
+            template_bindings.push(("value".to_owned(), v.clone()));
+            results.push(ValidationResult {
+                focus_node: focus.clone(),
+                result_path: path.map(path::path_to_term),
+                path_structure: path.filter(|p| !matches!(p, Path::Predicate(_))).cloned(),
+                value: Some(v.clone()),
+                source_constraint_component: component.clone(),
+                source_shape: source_shape.clone(),
+                severity: severity.clone(),
+                message: message.map(|m| substitute_message_templates(m, &template_bindings)),
+                source_box_roles: vec![],
+                path_box_roles: vec![],
+                result_box_roles: vec![],
+                attributions: vec![],
+            });
+        }
+    }
+    Ok(results)
+}
+
+/// Evaluate a SELECT validator for a custom constraint component.
+///
+/// `$this` and the parameter bindings are substituted before evaluation. Each
+/// result row maps to a [`ValidationResult`]; the `?this`, `?path`, and `?value`
+/// columns override the default focus node, path, and value when present and
+/// bound. Row bindings take precedence over parameter bindings for message
+/// template substitution.
+#[allow(clippy::too_many_arguments)] // Signature mirrors the SHACL-SPARQL parameter set.
+pub fn eval_select_validator(
+    dataset: &Arc<RdfDataset>,
+    focus: &Term,
+    validator: &ComponentValidator,
+    bindings: &[(String, Term)],
+    component: &NamedNode,
+    source_shape: &Term,
+    path: Option<&Path>,
+    severity: &Severity,
+    message: Option<&String>,
+) -> Result<Vec<ValidationResult>, String> {
+    let ComponentValidator::Select { select } = validator else {
+        return Err("expected SELECT validator, got ASK".to_owned());
+    };
+    let mut subs: Vec<(String, TermValue)> = Vec::with_capacity(1 + bindings.len());
+    subs.push(("this".to_owned(), focus.to_term_value()));
+    for (name, value) in bindings {
+        subs.push((name.clone(), value.to_term_value()));
+    }
+    let query = crate::constraints::substitute_path_placeholder(select, path);
+    let (variables, rows) = run_select_with_substitutions(dataset, &query, &subs)?;
+
+    let this_index = variables.iter().position(|v| v == "this");
+    let path_index = variables.iter().position(|v| v == "path");
+    let value_index = variables.iter().position(|v| v == "value");
+
+    let path_term = path.map(path::path_to_term);
+    let path_structure = path.filter(|p| !matches!(p, Path::Predicate(_))).cloned();
+
+    let mut results = Vec::with_capacity(rows.len());
+    for row in &rows {
+        let row_bindings: Vec<(String, Term)> = variables
+            .iter()
+            .zip(row.iter())
+            .filter_map(|(var, cell)| {
+                cell.as_ref()
+                    .map(|tv| (var.clone(), term_value_to_native(tv)))
+            })
+            .collect();
+
+        let focus_node = this_index
+            .and_then(|i| row.get(i))
+            .and_then(Option::as_ref)
+            .map_or_else(|| focus.clone(), term_value_to_native);
+
+        let (result_path, result_path_structure) = if let Some(i) = path_index {
+            if let Some(Some(tv)) = row.get(i) {
+                (Some(term_value_to_native(tv)), None)
+            } else {
+                (path_term.clone(), path_structure.clone())
+            }
+        } else {
+            (path_term.clone(), path_structure.clone())
+        };
+
+        let value = value_index
+            .and_then(|i| row.get(i))
+            .and_then(Option::as_ref)
+            .map(term_value_to_native)
+            .or_else(|| Some(focus.clone()));
+
+        let mut template_bindings = row_bindings;
+        for (name, value) in bindings {
+            if !template_bindings.iter().any(|(n, _)| n == name) {
+                template_bindings.push((name.clone(), value.clone()));
+            }
+        }
+
+        results.push(ValidationResult {
+            focus_node,
+            result_path,
+            path_structure: result_path_structure,
+            value,
+            source_constraint_component: component.clone(),
+            source_shape: source_shape.clone(),
+            severity: severity.clone(),
+            message: message.map(|m| substitute_message_templates(m, &template_bindings)),
+            source_box_roles: vec![],
+            path_box_roles: vec![],
+            result_box_roles: vec![],
+            attributions: vec![],
+        });
+    }
+    Ok(results)
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
 ///
 /// ```ignore
 /// use purrdf_shapes::components::sparql_local_name;
@@ -526,6 +698,7 @@ mod tests {
 
     use super::*;
     use crate::data::IrDataGraph;
+    use crate::term::Literal;
     use crate::text_ingest::extract_prefixes;
 
     fn load_registry(ttl: &str, base_iri: &str) -> ComponentRegistry {
@@ -655,5 +828,101 @@ mod tests {
         let validator = component.validator.as_ref().expect("validator present");
         assert!(matches!(validator.kind, ValidatorKind::Ask));
         assert!(validator.query_text.contains("CONCAT"));
+    }
+
+    // ── Component validator evaluation (W3C fixtures) ──────────────────────────
+
+    fn lit(s: &str) -> Term {
+        Term::Literal(Literal::new_simple_literal(s))
+    }
+
+    fn validate_fixture(ttl: &str, base_iri: &str) -> crate::report::ValidationReport {
+        let prefixes = extract_prefixes(ttl);
+        let dataset: Arc<::purrdf::RdfDataset> =
+            ::purrdf::parse_dataset(ttl.as_bytes(), "text/turtle", Some(base_iri))
+                .expect("fixture parses");
+        let shapes =
+            crate::shapes::from_dataset_with_prefixes(&dataset, &prefixes).expect("shapes parse");
+        crate::engine::validate_dataset(&dataset, &shapes).expect("validation evaluates")
+    }
+
+    #[test]
+    fn eval_ask_validator_001() {
+        let ttl = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../vectors/shacl/sparql/component/validator-001.ttl"
+        ))
+        .expect("fixture exists");
+        let report = validate_fixture(
+            &ttl,
+            "http://datashapes.org/sh/tests/sparql/component/validator-001.test",
+        );
+        assert!(!report.conforms);
+        assert_eq!(report.results.len(), 1, "exactly one non-conforming target");
+        assert_eq!(report.results[0].focus_node, lit("Hallo Welt"));
+        assert_eq!(report.results[0].value, Some(lit("Hallo Welt")));
+        assert_eq!(
+            report.results[0].source_constraint_component.as_str(),
+            "http://datashapes.org/sh/tests/sparql/component/validator-001.test#TestConstraintComponent"
+        );
+    }
+
+    #[test]
+    fn eval_ask_validator_optional_001() {
+        let ttl = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../vectors/shacl/sparql/component/optional-001.ttl"
+        ))
+        .expect("fixture exists");
+        let report = validate_fixture(
+            &ttl,
+            "http://datashapes.org/sh/tests/sparql/component/optional-001.test",
+        );
+        assert!(!report.conforms);
+        assert_eq!(report.results.len(), 4, "four violating focus/value pairs");
+        let focus_values: Vec<(Option<String>, Option<String>)> = report
+            .results
+            .iter()
+            .map(|r| (Some(r.focus_value()), r.value.as_ref().map(Term::to_string)))
+            .collect();
+        assert!(focus_values.contains(&(Some("One".to_owned()), Some("\"One\"".to_owned()))));
+        assert!(focus_values.contains(&(Some("Three".to_owned()), Some("\"Three\"".to_owned()))));
+        assert!(focus_values.contains(&(Some("Two".to_owned()), Some("\"Two\"".to_owned()))));
+    }
+
+    #[test]
+    fn eval_select_property_validator_001() {
+        let ttl = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../vectors/shacl/sparql/component/propertyValidator-select-001.ttl"
+        ))
+        .expect("fixture exists");
+        let report = validate_fixture(
+            &ttl,
+            "http://datashapes.org/sh/tests/sparql/component/propertyValidator-select-001.test",
+        );
+        assert!(!report.conforms);
+        assert_eq!(report.results.len(), 2, "two violating property values");
+        let paths: Vec<&str> = report
+            .results
+            .iter()
+            .map(|r| match r.result_path.as_ref().expect("path present") {
+                Term::NamedNode(n) => n.as_str(),
+                other => panic!("expected named-node path, got {other}"),
+            })
+            .collect();
+        assert!(paths.contains(
+            &"http://datashapes.org/sh/tests/sparql/component/propertyValidator-select-001.test#englishLabel"));
+        assert!(paths.contains(
+            &"http://datashapes.org/sh/tests/sparql/component/propertyValidator-select-001.test#germanLabel"));
+        for r in &report.results {
+            assert!(
+                r.message
+                    .as_ref()
+                    .expect("message present")
+                    .contains("Values are literals with language"),
+                "message template should be substituted"
+            );
+        }
     }
 }

--- a/crates/shapes/src/components.rs
+++ b/crates/shapes/src/components.rs
@@ -65,12 +65,12 @@ pub(crate) struct Component {
     pub id: NamedNode,
     /// Declared parameters, sorted by path IRI string for determinism.
     pub parameters: Vec<Parameter>,
-    /// Optional node-scope validator (`sh:nodeValidator`).
-    pub node_validator: Option<Validator>,
-    /// Optional property-scope validator (`sh:propertyValidator`).
-    pub property_validator: Option<Validator>,
-    /// Optional generic validator (`sh:validator`).
-    pub validator: Option<Validator>,
+    /// Node-scope validators (`sh:nodeValidator`).
+    pub node_validators: Vec<Validator>,
+    /// Property-scope validators (`sh:propertyValidator`).
+    pub property_validators: Vec<Validator>,
+    /// Generic validators (`sh:validator`).
+    pub validators: Vec<Validator>,
     /// Optional human-readable message declared on the component node.
     pub message: Option<String>,
     /// Optional severity declared on the component node.
@@ -637,48 +637,25 @@ fn parse_component(
     parameters.sort_by(|a, b| a.path.as_str().cmp(b.path.as_str()));
     let param_names: Vec<String> = parameters.iter().map(|p| p.name.clone()).collect();
 
-    let node_validator = objects_of(data, component, sh::NODE_VALIDATOR)
+    let mut node_validator_nodes: Vec<Term> = objects_of(data, component, sh::NODE_VALIDATOR);
+    node_validator_nodes.sort_by_key(ToString::to_string);
+    let node_validators = node_validator_nodes
         .into_iter()
-        .next()
-        .map(|v| {
-            parse_validator(
-                data,
-                doc_prefixes,
-                component,
-                &v,
-                &param_names,
-                subclass_memo,
-            )
-        })
-        .transpose()?;
-    let property_validator = objects_of(data, component, sh::PROPERTY_VALIDATOR)
+        .map(|v| parse_validator(data, doc_prefixes, component, &v, &param_names, subclass_memo))
+        .collect::<Result<Vec<Validator>, _>>()?;
+    let mut property_validator_nodes: Vec<Term> =
+        objects_of(data, component, sh::PROPERTY_VALIDATOR);
+    property_validator_nodes.sort_by_key(ToString::to_string);
+    let property_validators = property_validator_nodes
         .into_iter()
-        .next()
-        .map(|v| {
-            parse_validator(
-                data,
-                doc_prefixes,
-                component,
-                &v,
-                &param_names,
-                subclass_memo,
-            )
-        })
-        .transpose()?;
-    let validator = objects_of(data, component, sh::VALIDATOR)
+        .map(|v| parse_validator(data, doc_prefixes, component, &v, &param_names, subclass_memo))
+        .collect::<Result<Vec<Validator>, _>>()?;
+    let mut validator_nodes: Vec<Term> = objects_of(data, component, sh::VALIDATOR);
+    validator_nodes.sort_by_key(ToString::to_string);
+    let validators = validator_nodes
         .into_iter()
-        .next()
-        .map(|v| {
-            parse_validator(
-                data,
-                doc_prefixes,
-                component,
-                &v,
-                &param_names,
-                subclass_memo,
-            )
-        })
-        .transpose()?;
+        .map(|v| parse_validator(data, doc_prefixes, component, &v, &param_names, subclass_memo))
+        .collect::<Result<Vec<Validator>, _>>()?;
 
     let mut component_messages: Vec<String> = objects_of(data, component, sh::MESSAGE)
         .into_iter()
@@ -695,9 +672,9 @@ fn parse_component(
     Ok(Component {
         id: NamedNode::from(component_iri),
         parameters,
-        node_validator,
-        property_validator,
-        validator,
+        node_validators,
+        property_validators,
+        validators,
         message,
         severity,
     })
@@ -745,14 +722,14 @@ mod tests {
                 name: "param".to_owned(),
                 optional: false,
             }],
-            node_validator: Some(Validator {
+            node_validators: vec![Validator {
                 kind: ValidatorKind::Ask,
                 query_text: "ASK { ?this a ex:Thing }".to_owned(),
                 message: None,
                 severity: None,
-            }),
-            property_validator: None,
-            validator: None,
+            }],
+            property_validators: vec![],
+            validators: vec![],
             message: None,
             severity: None,
         };
@@ -786,7 +763,7 @@ mod tests {
         assert!(component.parameters[0].optional);
         assert_eq!(component.parameters[1].name, "requiredParam");
         assert!(!component.parameters[1].optional);
-        let validator = component.validator.as_ref().expect("validator present");
+        let validator = component.validators.first().expect("validator present");
         assert!(matches!(validator.kind, ValidatorKind::Ask));
         assert!(validator.query_text.contains("PREFIX ex:"));
     }
@@ -811,8 +788,8 @@ mod tests {
         assert_eq!(component.parameters[0].name, "lang");
         assert!(!component.parameters[0].optional);
         let validator = component
-            .property_validator
-            .as_ref()
+            .property_validators
+            .first()
             .expect("propertyValidator present");
         assert!(matches!(validator.kind, ValidatorKind::Select));
         assert!(validator.query_text.contains("PREFIX ex:"));
@@ -837,7 +814,7 @@ mod tests {
         assert_eq!(component.parameters.len(), 2);
         assert_eq!(component.parameters[0].name, "test1");
         assert_eq!(component.parameters[1].name, "test2");
-        let validator = component.validator.as_ref().expect("validator present");
+        let validator = component.validators.first().expect("validator present");
         assert!(matches!(validator.kind, ValidatorKind::Ask));
         assert!(validator.query_text.contains("CONCAT"));
     }

--- a/crates/shapes/src/components.rs
+++ b/crates/shapes/src/components.rs
@@ -14,9 +14,12 @@
 //! constructed by the component loader once it lands.
 #![allow(dead_code, unreachable_pub)]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use crate::term::NamedNode;
+use crate::data::{GraphFilter, IrDataGraph, ShaclDataGraph};
+use crate::model::{rdf, rdfs, sh};
+use crate::shapes::build_prefix_header;
+use crate::term::{NamedNode, Term};
 
 /// Discriminator for a SPARQL validator's query form.
 #[derive(Debug, Clone)]
@@ -52,7 +55,7 @@ pub struct Parameter {
 pub struct Component {
     /// The component IRI (the `sh:ConstraintComponent` instance).
     pub id: NamedNode,
-    /// Declared parameters, indexed in SHACL-specified order.
+    /// Declared parameters, sorted by path IRI string for determinism.
     pub parameters: Vec<Parameter>,
     /// Optional node-scope validator (`sh:nodeValidator`).
     pub node_validator: Option<Validator>,
@@ -73,6 +76,70 @@ pub struct ComponentRegistry {
     pub by_parameter_path: HashMap<String, String>,
     /// Component IRI string → component definition.
     pub components: HashMap<String, Component>,
+}
+
+impl ComponentRegistry {
+    /// Parse all `sh:ConstraintComponent` (and subclass) declarations from the
+    /// shapes graph into a registry.
+    ///
+    /// Discovery walks every `rdf:type` triple and keeps the subject when its
+    /// class is `sh:ConstraintComponent` or a subclass thereof. Each discovered
+    /// component's `sh:parameter` declarations and `sh:nodeValidator` /
+    /// `sh:propertyValidator` / `sh:validator` SPARQL validators are parsed and
+    /// validated (query must parse to the declared form and satisfy SHACL-SPARQL
+    /// pre-binding restrictions). Any malformed component is a hard error.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(String)` when a component, parameter, or validator is
+    /// malformed or when a validator query violates the pre-binding restrictions.
+    pub fn parse(data: &IrDataGraph, doc_prefixes: &[(String, String)]) -> Result<Self, String> {
+        let rdf_type = Term::NamedNode(NamedNode::from(rdf::TYPE));
+        let mut component_iris: Vec<String> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut subclass_memo: HashMap<(String, String), bool> = HashMap::new();
+
+        for q in data.quads_for_pattern(None, Some(&rdf_type), None, GraphFilter::AnyGraph) {
+            let Term::NamedNode(class) = q.object else {
+                continue;
+            };
+            if !is_subclass_of(
+                data,
+                class.as_str(),
+                sh::CONSTRAINT_COMPONENT,
+                &mut subclass_memo,
+            ) {
+                continue;
+            }
+            let Term::NamedNode(component) = q.subject else {
+                continue;
+            };
+            if seen.insert(component.as_str().to_owned()) {
+                component_iris.push(component.as_str().to_owned());
+            }
+        }
+        component_iris.sort();
+
+        let mut registry = Self::default();
+        for component_iri in component_iris {
+            let component_term = Term::NamedNode(NamedNode::from(component_iri.as_str()));
+            let component = parse_component(
+                data,
+                doc_prefixes,
+                &component_term,
+                &component_iri,
+                &mut subclass_memo,
+            )?;
+            let id = component.id.as_str().to_owned();
+            for param in &component.parameters {
+                registry
+                    .by_parameter_path
+                    .insert(param.path.as_str().to_owned(), id.clone());
+            }
+            registry.components.insert(id, component);
+        }
+        Ok(registry)
+    }
 }
 
 /// Extract the SPARQL local name of an IRI: the longest suffix after the last
@@ -97,9 +164,326 @@ pub fn sparql_local_name(iri: &str) -> String {
     iri[idx..].to_owned()
 }
 
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/// Return all objects for `(subject, predicate, ?)`.
+fn objects_of(data: &IrDataGraph, subject: &Term, predicate: &str) -> Vec<Term> {
+    if !subject.is_subject() {
+        return vec![];
+    }
+    let pred = Term::NamedNode(NamedNode::from(predicate));
+    data.quads_for_pattern(Some(subject), Some(&pred), None, GraphFilter::AnyGraph)
+        .into_iter()
+        .map(|q| q.object)
+        .collect()
+}
+
+/// Return the first object for `(subject, predicate, ?)`, if any.
+fn first_object_of(data: &IrDataGraph, subject: &Term, predicate: &str) -> Option<Term> {
+    objects_of(data, subject, predicate).into_iter().next()
+}
+
+/// Whether `class_iri` is `target_iri` or a subclass thereof under
+/// `rdfs:subClassOf` (reflexive transitive closure).
+///
+/// A memo table avoids repeated superclass walks; `false` is inserted before
+/// recursion to break `rdfs:subClassOf` cycles.
+fn is_subclass_of(
+    data: &IrDataGraph,
+    class_iri: &str,
+    target_iri: &str,
+    memo: &mut HashMap<(String, String), bool>,
+) -> bool {
+    if class_iri == target_iri {
+        return true;
+    }
+    let key = (class_iri.to_owned(), target_iri.to_owned());
+    if let Some(&result) = memo.get(&key) {
+        return result;
+    }
+    memo.insert(key.clone(), false);
+    let class_term = Term::NamedNode(NamedNode::from(class_iri));
+    let sub_class_of = Term::NamedNode(NamedNode::from(rdfs::SUB_CLASS_OF));
+    let mut result = false;
+    for q in data.quads_for_pattern(
+        Some(&class_term),
+        Some(&sub_class_of),
+        None,
+        GraphFilter::AnyGraph,
+    ) {
+        let Term::NamedNode(super_class) = q.object else {
+            continue;
+        };
+        if is_subclass_of(data, super_class.as_str(), target_iri, memo) {
+            result = true;
+            break;
+        }
+    }
+    memo.insert(key, result);
+    result
+}
+
+/// Determine the validator kind from its `rdf:type` declarations, respecting
+/// subclasses of `sh:SPARQLAskValidator` and `sh:SPARQLSelectValidator`.
+fn validator_kind(
+    data: &IrDataGraph,
+    validator: &Term,
+    memo: &mut HashMap<(String, String), bool>,
+) -> Result<ValidatorKind, String> {
+    let mut is_ask = false;
+    let mut is_select = false;
+    for q in objects_of(data, validator, rdf::TYPE) {
+        let Term::NamedNode(class) = q else {
+            continue;
+        };
+        if is_subclass_of(data, class.as_str(), sh::SPARQL_ASK_VALIDATOR, memo) {
+            is_ask = true;
+        }
+        if is_subclass_of(data, class.as_str(), sh::SPARQL_SELECT_VALIDATOR, memo) {
+            is_select = true;
+        }
+    }
+    if is_ask && is_select {
+        return Err(format!(
+            "validator {validator} is typed as both ASK and SELECT"
+        ));
+    }
+    if is_ask {
+        return Ok(ValidatorKind::Ask);
+    }
+    if is_select {
+        return Ok(ValidatorKind::Select);
+    }
+    Err(format!(
+        "validator {validator} must be typed as sh:SPARQLAskValidator or \
+         sh:SPARQLSelectValidator (or a subclass)"
+    ))
+}
+
+/// Whether `name` is a legal SPARQL VARNAME and not one of the reserved names
+/// banned for SHACL-SPARQL parameter bindings.
+fn is_valid_varname(name: &str) -> bool {
+    const BANNED: &[&str] = &["this", "path", "PATH", "value"];
+    if BANNED.contains(&name) {
+        return false;
+    }
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_alphabetic() && first != '_' {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Parse a single `sh:parameter` declaration for a component.
+fn parse_parameter(
+    data: &IrDataGraph,
+    param_node: &Term,
+    component_iri: &str,
+) -> Result<Parameter, String> {
+    let paths: Vec<NamedNode> = objects_of(data, param_node, sh::PATH)
+        .into_iter()
+        .filter_map(|t| match t {
+            Term::NamedNode(n) => Some(n),
+            _ => None,
+        })
+        .collect();
+    if paths.len() != 1 {
+        return Err(format!(
+            "component {component_iri} parameter {param_node} must have exactly one sh:path IRI"
+        ));
+    }
+    let path = paths.into_iter().next().expect("paths length checked");
+    let name = sparql_local_name(path.as_str());
+    if !is_valid_varname(&name) {
+        return Err(format!(
+            "component {component_iri} parameter path <{}> yields invalid SPARQL variable name \
+             {name:?}",
+            path.as_str()
+        ));
+    }
+    let optional = objects_of(data, param_node, sh::OPTIONAL)
+        .iter()
+        .any(|t| matches!(t, Term::Literal(lit) if lit.value() == "true"));
+    Ok(Parameter {
+        path,
+        name,
+        optional,
+    })
+}
+
+/// Parse a single SPARQL validator node attached to a component.
+fn parse_validator(
+    data: &IrDataGraph,
+    doc_prefixes: &[(String, String)],
+    component: &Term,
+    validator: &Term,
+    param_names: &[String],
+    subclass_memo: &mut HashMap<(String, String), bool>,
+) -> Result<Validator, String> {
+    let component_iri = match component {
+        Term::NamedNode(n) => n.as_str(),
+        _ => return Err(format!("component {component} is not a named node")),
+    };
+    let kind = validator_kind(data, validator, subclass_memo)
+        .map_err(|e| format!("component {component_iri} validator {validator}: {e}"))?;
+
+    let query_pred = match kind {
+        ValidatorKind::Ask => sh::ASK,
+        ValidatorKind::Select => sh::SELECT,
+    };
+    let raw_queries: Vec<String> = objects_of(data, validator, query_pred)
+        .into_iter()
+        .filter_map(|t| match t {
+            Term::Literal(lit) => Some(lit.value().to_owned()),
+            _ => None,
+        })
+        .collect();
+    if raw_queries.len() != 1 {
+        return Err(format!(
+            "component {component_iri} validator {validator} must have exactly one {} literal",
+            match kind {
+                ValidatorKind::Ask => "sh:ask",
+                ValidatorKind::Select => "sh:select",
+            }
+        ));
+    }
+    let raw_query = raw_queries.into_iter().next().expect("length checked");
+    let query_text = format!(
+        "{}{raw_query}",
+        build_prefix_header(data, doc_prefixes, &[component, validator])
+    );
+
+    let query = match purrdf_sparql_algebra::SparqlParser::new().parse_query(&query_text) {
+        Ok(q) => q,
+        Err(e) => {
+            return Err(format!(
+                "component {component_iri} validator {validator} has an unparsable query: {e}"
+            ))
+        }
+    };
+
+    let got_form = match &query {
+        purrdf_sparql_algebra::Query::Ask { .. } => "ASK",
+        purrdf_sparql_algebra::Query::Select { .. } => "SELECT",
+        _ => "non-ASK/SELECT",
+    };
+    let expected_form = match kind {
+        ValidatorKind::Ask => "ASK",
+        ValidatorKind::Select => "SELECT",
+    };
+    if got_form != expected_form {
+        return Err(format!(
+            "component {component_iri} validator {validator} is declared as {kind:?} but the \
+             query text parses to a {got_form} query"
+        ));
+    }
+
+    let mut prebound: Vec<&str> = vec!["this"];
+    if matches!(kind, ValidatorKind::Ask) {
+        prebound.push("value");
+    }
+    prebound.extend(param_names.iter().map(String::as_str));
+    let prebinding_result = match kind {
+        ValidatorKind::Ask => crate::prebinding::check_ask(&query, &prebound),
+        ValidatorKind::Select => crate::prebinding::check_select(&query, &prebound),
+    };
+    prebinding_result.map_err(|e| {
+        format!(
+            "component {component_iri} validator {validator} violates pre-binding restrictions: \
+             {e}"
+        )
+    })?;
+
+    Ok(Validator { kind, query_text })
+}
+
+/// Parse a single constraint component node and its parameters / validators.
+fn parse_component(
+    data: &IrDataGraph,
+    doc_prefixes: &[(String, String)],
+    component: &Term,
+    component_iri: &str,
+    subclass_memo: &mut HashMap<(String, String), bool>,
+) -> Result<Component, String> {
+    let param_nodes: Vec<Term> = objects_of(data, component, sh::PARAMETER_PROPERTY);
+    let mut parameters = Vec::with_capacity(param_nodes.len());
+    for param_node in param_nodes {
+        parameters.push(parse_parameter(data, &param_node, component_iri)?);
+    }
+    parameters.sort_by(|a, b| a.path.as_str().cmp(b.path.as_str()));
+    let param_names: Vec<String> = parameters.iter().map(|p| p.name.clone()).collect();
+
+    let node_validator = objects_of(data, component, sh::NODE_VALIDATOR)
+        .into_iter()
+        .next()
+        .map(|v| {
+            parse_validator(
+                data,
+                doc_prefixes,
+                component,
+                &v,
+                &param_names,
+                subclass_memo,
+            )
+        })
+        .transpose()?;
+    let property_validator = objects_of(data, component, sh::PROPERTY_VALIDATOR)
+        .into_iter()
+        .next()
+        .map(|v| {
+            parse_validator(
+                data,
+                doc_prefixes,
+                component,
+                &v,
+                &param_names,
+                subclass_memo,
+            )
+        })
+        .transpose()?;
+    let validator = objects_of(data, component, sh::VALIDATOR)
+        .into_iter()
+        .next()
+        .map(|v| {
+            parse_validator(
+                data,
+                doc_prefixes,
+                component,
+                &v,
+                &param_names,
+                subclass_memo,
+            )
+        })
+        .transpose()?;
+
+    Ok(Component {
+        id: NamedNode::from(component_iri),
+        parameters,
+        node_validator,
+        property_validator,
+        validator,
+    })
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+    use crate::data::IrDataGraph;
+    use crate::text_ingest::extract_prefixes;
+
+    fn load_registry(ttl: &str, base_iri: &str) -> ComponentRegistry {
+        let prefixes = extract_prefixes(ttl);
+        let dataset: Arc<::purrdf::RdfDataset> =
+            ::purrdf::parse_dataset(ttl.as_bytes(), "text/turtle", Some(base_iri))
+                .expect("fixture parses");
+        let data = IrDataGraph::new(dataset);
+        ComponentRegistry::parse(&data, &prefixes).expect("registry parses")
+    }
 
     #[test]
     fn sparql_local_name_extracts_suffix() {
@@ -138,5 +522,82 @@ mod tests {
         registry.by_parameter_path.insert(param_path, id);
         assert_eq!(registry.components.len(), 1);
         assert_eq!(registry.by_parameter_path.len(), 1);
+    }
+
+    #[test]
+    fn parses_optional_001_component() {
+        let ttl = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../vectors/shacl/sparql/component/optional-001.ttl"
+        ))
+        .expect("fixture exists");
+        let registry = load_registry(
+            &ttl,
+            "http://datashapes.org/sh/tests/sparql/component/optional-001.test",
+        );
+
+        let component = registry
+            .components
+            .get("http://datashapes.org/sh/tests/sparql/component/optional-001.test#TestConstraintComponent")
+            .expect("TestConstraintComponent present");
+        assert_eq!(component.parameters.len(), 2);
+        assert_eq!(component.parameters[0].name, "optionalParam");
+        assert!(component.parameters[0].optional);
+        assert_eq!(component.parameters[1].name, "requiredParam");
+        assert!(!component.parameters[1].optional);
+        let validator = component.validator.as_ref().expect("validator present");
+        assert!(matches!(validator.kind, ValidatorKind::Ask));
+        assert!(validator.query_text.contains("PREFIX ex:"));
+    }
+
+    #[test]
+    fn parses_property_validator_select_001_component() {
+        let ttl = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../vectors/shacl/sparql/component/propertyValidator-select-001.ttl"
+        ))
+        .expect("fixture exists");
+        let registry = load_registry(
+            &ttl,
+            "http://datashapes.org/sh/tests/sparql/component/propertyValidator-select-001.test",
+        );
+
+        let component = registry
+            .components
+            .get("http://datashapes.org/sh/tests/sparql/component/propertyValidator-select-001.test#LanguageConstraintComponentUsingSELECT")
+            .expect("LanguageConstraintComponentUsingSELECT present");
+        assert_eq!(component.parameters.len(), 1);
+        assert_eq!(component.parameters[0].name, "lang");
+        assert!(!component.parameters[0].optional);
+        let validator = component
+            .property_validator
+            .as_ref()
+            .expect("propertyValidator present");
+        assert!(matches!(validator.kind, ValidatorKind::Select));
+        assert!(validator.query_text.contains("PREFIX ex:"));
+    }
+
+    #[test]
+    fn parses_validator_001_component() {
+        let ttl = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../vectors/shacl/sparql/component/validator-001.ttl"
+        ))
+        .expect("fixture exists");
+        let registry = load_registry(
+            &ttl,
+            "http://datashapes.org/sh/tests/sparql/component/validator-001.test",
+        );
+
+        let component = registry
+            .components
+            .get("http://datashapes.org/sh/tests/sparql/component/validator-001.test#TestConstraintComponent")
+            .expect("TestConstraintComponent present");
+        assert_eq!(component.parameters.len(), 2);
+        assert_eq!(component.parameters[0].name, "test1");
+        assert_eq!(component.parameters[1].name, "test2");
+        let validator = component.validator.as_ref().expect("validator present");
+        assert!(matches!(validator.kind, ValidatorKind::Ask));
+        assert!(validator.query_text.contains("CONCAT"));
     }
 }

--- a/crates/shapes/src/components.rs
+++ b/crates/shapes/src/components.rs
@@ -282,15 +282,20 @@ pub(crate) fn eval_select_validator(
     let path_structure = path.filter(|p| !matches!(p, Path::Predicate(_))).cloned();
 
     let mut results = Vec::with_capacity(rows.len());
+    let mut row_bindings: Vec<(String, Term)> = Vec::with_capacity(variables.len());
+    let mut template_bindings: Vec<(String, Term)> =
+        Vec::with_capacity(variables.len() + bindings.len());
     for row in &rows {
-        let row_bindings: Vec<(String, Term)> = variables
-            .iter()
-            .zip(row.iter())
-            .filter_map(|(var, cell)| {
-                cell.as_ref()
-                    .map(|tv| (var.clone(), term_value_to_native(tv)))
-            })
-            .collect();
+        row_bindings.clear();
+        row_bindings.extend(
+            variables
+                .iter()
+                .zip(row.iter())
+                .filter_map(|(var, cell)| {
+                    cell.as_ref()
+                        .map(|tv| (var.clone(), term_value_to_native(tv)))
+                }),
+        );
 
         let focus_node = this_index
             .and_then(|i| row.get(i))
@@ -312,7 +317,8 @@ pub(crate) fn eval_select_validator(
             .and_then(Option::as_ref)
             .map(term_value_to_native);
 
-        let mut template_bindings = row_bindings;
+        template_bindings.clear();
+        template_bindings.extend_from_slice(&row_bindings);
         for (name, value) in bindings {
             if !template_bindings.iter().any(|(n, _)| n == name) {
                 template_bindings.push((name.clone(), value.clone()));

--- a/crates/shapes/src/components.rs
+++ b/crates/shapes/src/components.rs
@@ -183,7 +183,11 @@ fn substitute_message_templates(msg: &str, bindings: &[(String, Term)]) -> Strin
     re.replace_all(msg, |caps: &regex::Captures<'_>| {
         let name = &caps[2];
         match bindings.iter().find(|(n, _)| n == name) {
-            Some((_, term)) => term.to_string(),
+            Some((_, term)) => match term {
+                Term::Literal(lit) => lit.value().to_owned(),
+                Term::NamedNode(n) => n.as_str().to_owned(),
+                other => other.to_string(),
+            },
             None => caps[0].to_owned(),
         }
     })

--- a/crates/shapes/src/components.rs
+++ b/crates/shapes/src/components.rs
@@ -216,8 +216,9 @@ pub fn eval_ask_validator(
         return Err("expected ASK validator, got SELECT".to_owned());
     };
     let mut results = Vec::with_capacity(value_nodes.len());
+    let mut subs: Vec<(String, TermValue)> = Vec::with_capacity(2 + bindings.len());
     for v in value_nodes {
-        let mut subs: Vec<(String, TermValue)> = Vec::with_capacity(2 + bindings.len());
+        subs.clear();
         subs.push(("this".to_owned(), focus.to_term_value()));
         subs.push(("value".to_owned(), v.to_term_value()));
         for (name, value) in bindings {

--- a/crates/shapes/src/components.rs
+++ b/crates/shapes/src/components.rs
@@ -1,18 +1,15 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Data model for SHACL custom constraint components and their validator registry.
+//! SHACL-SPARQL custom constraint component registry, parsing, and evaluation.
 //!
-//! A [`ComponentRegistry`] holds constraint components declared in a shapes graph
-//! (instances of `sh:ConstraintComponent`) together with their `sh:Parameter`
-//! declarations and SPARQL-based validators. The registry is populated at shape
-//! parse time and consulted by the engine when it encounters a predicate that is
-//! a declared component parameter path.
-//!
-//! These types are scaffolding for the custom component parser/evaluator added in
-//! later tasks; they are exported from a `pub(crate)` module now and will be
-//! constructed by the component loader once it lands.
-#![allow(dead_code, unreachable_pub)]
+//! This module implements the machinery for user-declared constraint components
+//! (`sh:ConstraintComponent`): discovering them in a shapes graph, parsing their
+//! `sh:Parameter` declarations and SPARQL validators (`sh:nodeValidator`,
+//! `sh:propertyValidator`, `sh:validator`), and evaluating those validators at
+//! validation time. A [`ComponentRegistry`] is populated while the shapes graph is
+//! parsed and is later consulted by the engine to bind component parameters and
+//! run the matching ASK or SELECT query for each shape usage.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
@@ -30,7 +27,7 @@ use crate::term::{term_value_to_native, NamedNode, Term};
 
 /// Discriminator for a SPARQL validator's query form.
 #[derive(Debug, Clone)]
-pub enum ValidatorKind {
+pub(crate) enum ValidatorKind {
     /// An `ASK` query: a result of `true` means the focus node/value is valid.
     Ask,
     /// A `SELECT` query: each result row denotes a validation violation.
@@ -39,7 +36,7 @@ pub enum ValidatorKind {
 
 /// A SPARQL validator attached to a constraint component.
 #[derive(Debug, Clone)]
-pub struct Validator {
+pub(crate) struct Validator {
     /// Whether the validator is an ASK or SELECT query.
     pub kind: ValidatorKind,
     /// Full query text with any `PREFIX` header already prepended.
@@ -52,7 +49,7 @@ pub struct Validator {
 
 /// Declaration of a single `sh:Parameter` for a constraint component.
 #[derive(Debug, Clone)]
-pub struct Parameter {
+pub(crate) struct Parameter {
     /// The parameter predicate (`sh:path` of the parameter declaration).
     pub path: NamedNode,
     /// The SPARQL local name used to bind the parameter value in the validator.
@@ -63,7 +60,7 @@ pub struct Parameter {
 
 /// A SHACL custom constraint component.
 #[derive(Debug, Clone)]
-pub struct Component {
+pub(crate) struct Component {
     /// The component IRI (the `sh:ConstraintComponent` instance).
     pub id: NamedNode,
     /// Declared parameters, sorted by path IRI string for determinism.
@@ -83,12 +80,12 @@ pub struct Component {
 /// Registry of custom constraint components keyed by component IRI string.
 ///
 /// `by_parameter_path` maps a declared parameter predicate IRI string to the
-/// IRI string of the component it belongs to, allowing the engine to recognize
-/// custom constraint predicates while parsing shapes.
+/// owning component IRI (`NamedNode`), allowing the engine to recognize custom
+/// constraint predicates while parsing shapes.
 #[derive(Debug, Default, Clone)]
-pub struct ComponentRegistry {
-    /// Parameter predicate IRI string → owning component IRI string.
-    pub by_parameter_path: HashMap<String, String>,
+pub(crate) struct ComponentRegistry {
+    /// Parameter predicate IRI string → owning component IRI.
+    pub by_parameter_path: HashMap<String, NamedNode>,
     /// Component IRI string → component definition.
     pub components: HashMap<String, Component>,
 }
@@ -108,7 +105,7 @@ impl ComponentRegistry {
     ///
     /// Returns `Err(String)` when a component, parameter, or validator is
     /// malformed or when a validator query violates the pre-binding restrictions.
-    pub fn parse(data: &IrDataGraph, doc_prefixes: &[(String, String)]) -> Result<Self, String> {
+    pub(crate) fn parse(data: &IrDataGraph, doc_prefixes: &[(String, String)]) -> Result<Self, String> {
         let rdf_type = Term::NamedNode(NamedNode::from(rdf::TYPE));
         let mut component_iris: Vec<String> = Vec::new();
         let mut seen: HashSet<String> = HashSet::new();
@@ -145,12 +142,12 @@ impl ComponentRegistry {
                 &component_iri,
                 &mut subclass_memo,
             )?;
-            let id = component.id.as_str().to_owned();
             for param in &component.parameters {
                 registry
                     .by_parameter_path
-                    .insert(param.path.as_str().to_owned(), id.clone());
+                    .insert(param.path.as_str().to_owned(), component.id.clone());
             }
+            let id = component.id.as_str().to_owned();
             registry.components.insert(id, component);
         }
         Ok(registry)
@@ -200,7 +197,7 @@ fn substitute_message_templates(msg: &str, bindings: &[(String, Term)]) -> Strin
 /// parameter bindings. A result of `true` means conforming; `false` emits one
 /// [`ValidationResult`].
 #[allow(clippy::too_many_arguments)] // Signature mirrors the SHACL-SPARQL parameter set.
-pub fn eval_ask_validator(
+pub(crate) fn eval_ask_validator(
     dataset: &Arc<RdfDataset>,
     focus: &Term,
     value_nodes: &[Term],
@@ -255,7 +252,7 @@ pub fn eval_ask_validator(
 /// bound. Row bindings take precedence over parameter bindings for message
 /// template substitution.
 #[allow(clippy::too_many_arguments)] // Signature mirrors the SHACL-SPARQL parameter set.
-pub fn eval_select_validator(
+pub(crate) fn eval_select_validator(
     dataset: &Arc<RdfDataset>,
     focus: &Term,
     validator: &ComponentValidator,
@@ -342,15 +339,19 @@ pub fn eval_select_validator(
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
 ///
+/// Extract the SPARQL local name for an IRI: the substring after the last `/`,
+/// `#`, or `:` delimiter. This is used to derive the variable name bound to a
+/// declared component parameter.
+///
 /// ```ignore
-/// use purrdf_shapes::components::sparql_local_name;
+/// use crate::components::sparql_local_name;
 ///
 /// assert_eq!(sparql_local_name("http://example.org/ns#requiredParam"), "requiredParam");
 /// assert_eq!(sparql_local_name("http://example.org/ns/requiredParam"), "requiredParam");
 /// assert_eq!(sparql_local_name("ex:requiredParam"), "requiredParam");
 /// ```
 #[must_use]
-pub fn sparql_local_name(iri: &str) -> String {
+pub(crate) fn sparql_local_name(iri: &str) -> String {
     let mut idx = iri.rfind('/').map_or(0, |i| i + 1);
     if let Some(i) = iri.rfind('#') {
         idx = idx.max(i + 1);
@@ -750,9 +751,10 @@ mod tests {
             severity: None,
         };
         let id = component.id.as_str().to_owned();
+        let component_iri = component.id.clone();
         let param_path = component.parameters[0].path.as_str().to_owned();
-        registry.components.insert(id.clone(), component);
-        registry.by_parameter_path.insert(param_path, id);
+        registry.components.insert(id, component);
+        registry.by_parameter_path.insert(param_path, component_iri);
         assert_eq!(registry.components.len(), 1);
         assert_eq!(registry.by_parameter_path.len(), 1);
     }

--- a/crates/shapes/src/components.rs
+++ b/crates/shapes/src/components.rs
@@ -18,6 +18,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::data::{GraphFilter, IrDataGraph, ShaclDataGraph};
 use crate::model::{rdf, rdfs, sh};
+use crate::report::Severity;
 use crate::shapes::build_prefix_header;
 use crate::term::{NamedNode, Term};
 
@@ -37,6 +38,10 @@ pub struct Validator {
     pub kind: ValidatorKind,
     /// Full query text with any `PREFIX` header already prepended.
     pub query_text: String,
+    /// Optional human-readable message declared on the validator node.
+    pub message: Option<String>,
+    /// Optional severity declared on the validator node.
+    pub severity: Option<Severity>,
 }
 
 /// Declaration of a single `sh:Parameter` for a constraint component.
@@ -63,6 +68,10 @@ pub struct Component {
     pub property_validator: Option<Validator>,
     /// Optional generic validator (`sh:validator`).
     pub validator: Option<Validator>,
+    /// Optional human-readable message declared on the component node.
+    pub message: Option<String>,
+    /// Optional severity declared on the component node.
+    pub severity: Option<Severity>,
 }
 
 /// Registry of custom constraint components keyed by component IRI string.
@@ -139,6 +148,18 @@ impl ComponentRegistry {
             registry.components.insert(id, component);
         }
         Ok(registry)
+    }
+}
+
+/// Map an `sh:severity` object term to a [`Severity`]: the three built-in
+/// `sh:` severities map to their variants, any OTHER IRI is preserved verbatim
+/// (SHACL allows custom severity IRIs), and a non-IRI object yields `None`.
+pub(crate) fn severity_from_term(t: &Term) -> Option<Severity> {
+    match t {
+        Term::NamedNode(n) => {
+            Some(Severity::from_iri(n.as_str()).unwrap_or_else(|| Severity::Other(n.clone())))
+        }
+        _ => None,
     }
 }
 
@@ -397,7 +418,24 @@ fn parse_validator(
         )
     })?;
 
-    Ok(Validator { kind, query_text })
+    let mut messages: Vec<String> = objects_of(data, validator, sh::MESSAGE)
+        .into_iter()
+        .filter_map(|t| match t {
+            Term::Literal(lit) => Some(lit.value().to_owned()),
+            _ => None,
+        })
+        .collect();
+    messages.sort();
+    let message = messages.into_iter().next();
+    let severity =
+        first_object_of(data, validator, sh::SEVERITY).and_then(|t| severity_from_term(&t));
+
+    Ok(Validator {
+        kind,
+        query_text,
+        message,
+        severity,
+    })
 }
 
 /// Parse a single constraint component node and its parameters / validators.
@@ -459,12 +497,26 @@ fn parse_component(
         })
         .transpose()?;
 
+    let mut component_messages: Vec<String> = objects_of(data, component, sh::MESSAGE)
+        .into_iter()
+        .filter_map(|t| match t {
+            Term::Literal(lit) => Some(lit.value().to_owned()),
+            _ => None,
+        })
+        .collect();
+    component_messages.sort();
+    let message = component_messages.into_iter().next();
+    let severity =
+        first_object_of(data, component, sh::SEVERITY).and_then(|t| severity_from_term(&t));
+
     Ok(Component {
         id: NamedNode::from(component_iri),
         parameters,
         node_validator,
         property_validator,
         validator,
+        message,
+        severity,
     })
 }
 
@@ -512,9 +564,13 @@ mod tests {
             node_validator: Some(Validator {
                 kind: ValidatorKind::Ask,
                 query_text: "ASK { ?this a ex:Thing }".to_owned(),
+                message: None,
+                severity: None,
             }),
             property_validator: None,
             validator: None,
+            message: None,
+            severity: None,
         };
         let id = component.id.as_str().to_owned();
         let param_path = component.parameters[0].path.as_str().to_owned();

--- a/crates/shapes/src/constraints.rs
+++ b/crates/shapes/src/constraints.rs
@@ -13,7 +13,7 @@ use crate::data::{GraphFilter, ShaclDataGraph};
 use crate::model::{rdf, sh, BoxRoleVocab};
 use crate::path;
 use crate::report::ValidationResult;
-use crate::shapes::{Constraint, NodeKindValue, Path, PropertyShape, Shape};
+use crate::shapes::{ComponentValidator, Constraint, NodeKindValue, Path, PropertyShape, Shape};
 use crate::term::{NamedNode, Term, Triple};
 
 // ── Public surface ─────────────────────────────────────────────────────────────
@@ -1453,11 +1453,43 @@ fn eval_constraint<G: ShaclDataGraph>(
         }
 
         // ── Custom constraint components (SHACL-SPARQL) ─────────────────────────
-        // Task 4 will implement evaluation; the placeholder keeps the crate
-        // compiling and makes the new variant reachable for parsing tests.
-        Constraint::Component { .. } => {
-            // TODO(#12)
-            vec![]
+        Constraint::Component {
+            ref component,
+            ref source_shape,
+            ref bindings,
+            ref validator,
+            message: ref cmsg,
+            severity: ref csev,
+        } => {
+            let sev = csev.clone().unwrap_or_else(|| severity.clone());
+            let msg = cmsg.clone().or_else(|| message.clone());
+            let dataset = store.sparql_dataset();
+            match validator {
+                ComponentValidator::Ask { .. } => crate::components::eval_ask_validator(
+                    &dataset,
+                    focus_node,
+                    value_nodes,
+                    validator,
+                    bindings,
+                    component,
+                    source_shape,
+                    path,
+                    &sev,
+                    msg.as_ref(),
+                ),
+                ComponentValidator::Select { .. } => crate::components::eval_select_validator(
+                    &dataset,
+                    focus_node,
+                    validator,
+                    bindings,
+                    component,
+                    source_shape,
+                    path,
+                    &sev,
+                    msg.as_ref(),
+                ),
+            }
+            .map_err(|e| format!("component validator on shape {source_shape}: {e}"))?
         }
     })
 }
@@ -1466,7 +1498,7 @@ fn eval_constraint<G: ShaclDataGraph>(
 /// shape's path rendered in SPARQL property-path surface syntax. A node-shape
 /// constraint (`path == None`) and a query without the placeholder pass
 /// through unchanged.
-fn substitute_path_placeholder(select: &str, path: Option<&Path>) -> String {
+pub(crate) fn substitute_path_placeholder(select: &str, path: Option<&Path>) -> String {
     static PATH_PLACEHOLDER: OnceLock<regex::Regex> = OnceLock::new();
     let Some(path) = path else {
         return select.to_owned();

--- a/crates/shapes/src/constraints.rs
+++ b/crates/shapes/src/constraints.rs
@@ -1409,6 +1409,7 @@ fn eval_constraint<G: ShaclDataGraph>(
             )
             .map_err(|e| format!("sh:sparql constraint on shape {source_shape}: {e}"))?
         }
+<<<<<<< HEAD
 
         // ── Expression (SHACL-AF §5.7) ─────────────────────────────────────────
         // Each value node is evaluated as the focus of the node expression; the
@@ -1449,6 +1450,14 @@ fn eval_constraint<G: ShaclDataGraph>(
                 }
             }
             results
+        }
+
+        // ── Custom constraint components (SHACL-SPARQL) ─────────────────────────
+        // Task 4 will implement evaluation; the placeholder keeps the crate
+        // compiling and makes the new variant reachable for parsing tests.
+        Constraint::Component { .. } => {
+            // TODO(#12)
+            vec![]
         }
     })
 }

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -10,6 +10,7 @@
 //! targets (`sh:SPARQLTarget`) are implemented in the [`sparql`] module,
 //! delegated to oxigraph's SPARQL 1.1 engine.
 
+pub(crate) mod components;
 pub mod constraints;
 pub mod data;
 pub mod engine;

--- a/crates/shapes/src/model.rs
+++ b/crates/shapes/src/model.rs
@@ -256,6 +256,8 @@ pub mod sh {
 
     pub const PARAMETER: &str = "http://www.w3.org/ns/shacl#Parameter";
 
+    pub const PARAMETER_PROPERTY: &str = "http://www.w3.org/ns/shacl#parameter";
+
     pub const NODE_VALIDATOR: &str = "http://www.w3.org/ns/shacl#nodeValidator";
 
     pub const PROPERTY_VALIDATOR: &str = "http://www.w3.org/ns/shacl#propertyValidator";

--- a/crates/shapes/src/model.rs
+++ b/crates/shapes/src/model.rs
@@ -250,6 +250,24 @@ pub mod sh {
 
     pub const FUNCTION: &str = "http://www.w3.org/ns/shacl#Function";
 
+    // ── Custom constraint-component vocabulary ───────────────────────────────
+
+    pub const CONSTRAINT_COMPONENT: &str = "http://www.w3.org/ns/shacl#ConstraintComponent";
+
+    pub const PARAMETER: &str = "http://www.w3.org/ns/shacl#Parameter";
+
+    pub const NODE_VALIDATOR: &str = "http://www.w3.org/ns/shacl#nodeValidator";
+
+    pub const PROPERTY_VALIDATOR: &str = "http://www.w3.org/ns/shacl#propertyValidator";
+
+    pub const VALIDATOR: &str = "http://www.w3.org/ns/shacl#validator";
+
+    pub const OPTIONAL: &str = "http://www.w3.org/ns/shacl#optional";
+
+    pub const SPARQL_ASK_VALIDATOR: &str = "http://www.w3.org/ns/shacl#SPARQLAskValidator";
+
+    pub const SPARQL_SELECT_VALIDATOR: &str = "http://www.w3.org/ns/shacl#SPARQLSelectValidator";
+
     // ── Constraint component IRIs (sh:*ConstraintComponent) ──────────────────
 
     pub const MIN_COUNT_CONSTRAINT_COMPONENT: &str =

--- a/crates/shapes/src/shapes.rs
+++ b/crates/shapes/src/shapes.rs
@@ -1282,7 +1282,16 @@ impl<'s> Parser<'s> {
             let mut bindings: Vec<(String, Term)> = Vec::new();
             let mut missing_required = false;
             for param in &component.parameters {
-                if let Some(value) = self.first_object_of(id, param.path.as_str()) {
+                let values = self.objects_of(id, param.path.as_str());
+                if values.len() > 1 {
+                    return Err(format!(
+                        "shape {id} declares {count} values for parameter <{path}> of component <{component}>, only one is allowed",
+                        count = values.len(),
+                        path = param.path,
+                        component = component.id
+                    ));
+                }
+                if let Some(value) = values.into_iter().next() {
                     bindings.push((param.name.clone(), value));
                 } else if !param.optional {
                     missing_required = true;

--- a/crates/shapes/src/shapes.rs
+++ b/crates/shapes/src/shapes.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, OnceLock};
 
 use ::purrdf::RdfDataset;
 
+use crate::components::ComponentRegistry;
 use crate::data::{GraphFilter, IrDataGraph, ShaclDataGraph};
 use crate::expression::{FnCall, NodeExpr};
 use crate::model::{rdf, rdfs, sh, BoxRoleVocab};
@@ -353,6 +354,78 @@ struct Parser<'s> {
     doc_prefixes: Vec<(String, String)>,
     /// The caller-supplied box-role vocabulary; `None` = feature inactive.
     box_role_vocab: Option<BoxRoleVocab>,
+    /// Registry of SHACL-SPARQL custom constraint components declared in the
+    /// shapes graph. Populated before shape parsing so malformed components are
+    /// rejected as hard failures.
+    component_registry: ComponentRegistry,
+}
+
+// ── Prefix-header helper (used by shapes and component registry) ───────────────
+
+/// Return all objects for `(subject, predicate, ?)`.
+fn objects_of(data: &IrDataGraph, subject: &Term, predicate: &str) -> Vec<Term> {
+    if !subject.is_subject() {
+        return vec![];
+    }
+    let pred = Term::NamedNode(NamedNode::from(predicate));
+    data.quads_for_pattern(Some(subject), Some(&pred), None, GraphFilter::AnyGraph)
+        .into_iter()
+        .map(|q| q.object)
+        .collect()
+}
+
+/// Return the first object for `(subject, predicate, ?)`, if any.
+fn first_object_of(data: &IrDataGraph, subject: &Term, predicate: &str) -> Option<Term> {
+    objects_of(data, subject, predicate).into_iter().next()
+}
+
+/// Build the SPARQL `PREFIX` header prepended to a SHACL-SPARQL query.
+///
+/// Two sources contribute, lowest precedence first:
+///
+/// 1. The shapes **document's** `@prefix` declarations (the pySHACL-compatible
+///    fallback — real shapes rely on these without `sh:prefixes`).
+/// 2. SHACL-AF `sh:prefixes` → `sh:declare` on the `owners` (spec §5.2.1), which
+///    **override** the document fallback for any colliding prefix.
+///
+/// Output is one `PREFIX p: <ns>` line per prefix, sorted (a `BTreeMap` keeps
+/// it deterministic and one-entry-per-prefix). Empty when nothing is declared.
+pub(crate) fn build_prefix_header(
+    data: &IrDataGraph,
+    doc_prefixes: &[(String, String)],
+    owners: &[&Term],
+) -> String {
+    let mut map: std::collections::BTreeMap<String, String> = doc_prefixes
+        .iter()
+        .map(|(p, ns)| (p.clone(), ns.clone()))
+        .collect();
+    // `sh:prefix` is a string literal; `sh:namespace` is typically an
+    // `xsd:anyURI` literal but the SHACL spec also permits a bare IRI
+    // (NamedNode). Accept both lexical forms so an IRI-valued namespace is
+    // not silently dropped (which would omit a PREFIX line and break the
+    // dependent SHACL-AF query — a silent under-validation, P11/§11).
+    let term_value = |t: Term| match t {
+        Term::Literal(lit) => Some(lit.value().to_owned()),
+        Term::NamedNode(node) => Some(node.as_str().to_owned()),
+        _ => None, // blank node / quoted triple: not a prefix or namespace value
+    };
+    for owner in owners {
+        for prefixes_node in objects_of(data, owner, sh::PREFIXES) {
+            for declare in objects_of(data, &prefixes_node, sh::DECLARE) {
+                let prefix = first_object_of(data, &declare, sh::PREFIX).and_then(term_value);
+                let namespace = first_object_of(data, &declare, sh::NAMESPACE).and_then(term_value);
+                if let (Some(p), Some(ns)) = (prefix, namespace) {
+                    map.insert(p, ns); // sh:prefixes overrides the document fallback
+                }
+            }
+        }
+    }
+    use std::fmt::Write as _;
+    let mut header = String::new();
+    for (prefix, namespace) in map {
+        let _ = writeln!(header, "PREFIX {prefix}: <{namespace}>");
+    }
+    header
 }
 
 impl<'s> Parser<'s> {
@@ -366,6 +439,7 @@ impl<'s> Parser<'s> {
             in_flight: HashSet::new(),
             doc_prefixes: doc_prefixes.to_vec(),
             box_role_vocab,
+            component_registry: ComponentRegistry::default(),
         }
     }
 
@@ -426,10 +500,9 @@ impl<'s> Parser<'s> {
             }
         }
 
-        // The pre-binding restrictions gate every SHACL-SPARQL ASK validator in
-        // the graph (custom constraint components are otherwise unsupported,
-        // but a restricted query must still hard-fail per SHACL-SPARQL §5.2.1).
-        self.check_ask_validators()?;
+        // Custom SHACL-SPARQL constraint components are parsed up-front; any
+        // malformed component, parameter, or validator query is a hard failure.
+        self.component_registry = ComponentRegistry::parse(self.data, &self.doc_prefixes)?;
 
         // Parse each top-level shape in stable (sorted) order. A node with
         // sh:path is a (standalone) PROPERTY shape: its path-scoped constraints
@@ -575,42 +648,7 @@ impl<'s> Parser<'s> {
     /// Output is one `PREFIX p: <ns>` line per prefix, sorted (a `BTreeMap` keeps
     /// it deterministic and one-entry-per-prefix). Empty when nothing is declared.
     fn prefix_header(&self, owners: &[&Term]) -> String {
-        let mut map: std::collections::BTreeMap<String, String> = self
-            .doc_prefixes
-            .iter()
-            .map(|(p, ns)| (p.clone(), ns.clone()))
-            .collect();
-        // `sh:prefix` is a string literal; `sh:namespace` is typically an
-        // `xsd:anyURI` literal but the SHACL spec also permits a bare IRI
-        // (NamedNode). Accept both lexical forms so an IRI-valued namespace is
-        // not silently dropped (which would omit a PREFIX line and break the
-        // dependent SHACL-AF query — a silent under-validation, P11/§11).
-        let term_value = |t: Term| match t {
-            Term::Literal(lit) => Some(lit.value().to_owned()),
-            Term::NamedNode(node) => Some(node.as_str().to_owned()),
-            _ => None, // blank node / quoted triple: not a prefix or namespace value
-        };
-        for owner in owners {
-            for prefixes_node in self.objects_of(owner, sh::PREFIXES) {
-                for declare in self.objects_of(&prefixes_node, sh::DECLARE) {
-                    let prefix = self
-                        .first_object_of(&declare, sh::PREFIX)
-                        .and_then(term_value);
-                    let namespace = self
-                        .first_object_of(&declare, sh::NAMESPACE)
-                        .and_then(term_value);
-                    if let (Some(p), Some(ns)) = (prefix, namespace) {
-                        map.insert(p, ns); // sh:prefixes overrides the document fallback
-                    }
-                }
-            }
-        }
-        use std::fmt::Write as _;
-        let mut header = String::new();
-        for (prefix, namespace) in map {
-            let _ = writeln!(header, "PREFIX {prefix}: <{namespace}>");
-        }
-        header
+        build_prefix_header(self.data, &self.doc_prefixes, owners)
     }
 
     /// Parse a top-level node shape.
@@ -1283,37 +1321,6 @@ impl<'s> Parser<'s> {
             siblings.push(self.parse_inline_shape(node)?);
         }
         Ok(siblings)
-    }
-
-    /// Enforce the SHACL-SPARQL §5.2.1 pre-binding restrictions on every
-    /// `sh:ask` validator in the shapes graph.
-    ///
-    /// Custom SPARQL constraint components are otherwise unsupported by this
-    /// engine, but a validator whose ASK query is ILLEGAL under pre-binding
-    /// (its `$this`/`$value` variables are pre-bound at execution) must still
-    /// be rejected as a hard failure (W3C `unsupported-sparql-006`). An
-    /// UNPARSABLE ask query is skipped — the component never executes here, so
-    /// only well-formed-but-restricted queries hard-fail.
-    fn check_ask_validators(&self) -> Result<(), String> {
-        let mut asks: Vec<(Term, String)> = self
-            .quads_with(None, Some(sh::ASK), None)
-            .into_iter()
-            .filter_map(|q| match q.object {
-                Term::Literal(lit) => Some((q.subject, lit.value().to_owned())),
-                _ => None,
-            })
-            .collect();
-        asks.sort_by(|a, b| (a.0.to_string(), &a.1).cmp(&(b.0.to_string(), &b.1)));
-        for (validator, raw_ask) in asks {
-            let query_text = format!("{}{raw_ask}", self.prefix_header(&[&validator]));
-            let Ok(query) = purrdf_sparql_algebra::SparqlParser::new().parse_query(&query_text)
-            else {
-                continue; // unsupported component — never executed by this engine
-            };
-            crate::prebinding::check_ask(&query, &["this", "value"])
-                .map_err(|e| format!("sh:ask validator {validator}: {e}"))?;
-        }
-        Ok(())
     }
 
     /// Parse a property shape node.

--- a/crates/shapes/src/shapes.rs
+++ b/crates/shapes/src/shapes.rs
@@ -1260,6 +1260,20 @@ impl<'s> Parser<'s> {
         // order; parameter bindings follow the component's declared parameter
         // order. If no applicable validator exists for this shape scope the
         // component is skipped silently.
+        let shape_severity = self
+            .first_object_of(id, sh::SEVERITY)
+            .and_then(|t| severity_from_term(&t));
+        let mut shape_messages: Vec<String> = self
+            .objects_of(id, sh::MESSAGE)
+            .into_iter()
+            .filter_map(|t| match t {
+                Term::Literal(lit) => Some(lit.value().to_owned()),
+                _ => None,
+            })
+            .collect();
+        shape_messages.sort();
+        let shape_message = shape_messages.into_iter().next();
+
         let mut components: Vec<&crate::components::Component> =
             self.component_registry.components.values().collect();
         components.sort_by(|a, b| a.id.as_str().cmp(b.id.as_str()));
@@ -1302,24 +1316,12 @@ impl<'s> Parser<'s> {
                 },
             };
 
-            let shape_severity = self
-                .first_object_of(id, sh::SEVERITY)
-                .and_then(|t| severity_from_term(&t));
-            let mut shape_messages: Vec<String> = self
-                .objects_of(id, sh::MESSAGE)
-                .into_iter()
-                .filter_map(|t| match t {
-                    Term::Literal(lit) => Some(lit.value().to_owned()),
-                    _ => None,
-                })
-                .collect();
-            shape_messages.sort();
-            let shape_message = shape_messages.into_iter().next();
-
             let severity = shape_severity
+                .clone()
                 .or_else(|| validator.severity.clone())
                 .or_else(|| component.severity.clone());
             let message = shape_message
+                .clone()
                 .or_else(|| validator.message.clone())
                 .or_else(|| component.message.clone());
 

--- a/crates/shapes/src/shapes.rs
+++ b/crates/shapes/src/shapes.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, OnceLock};
 
 use ::purrdf::RdfDataset;
 
-use crate::components::ComponentRegistry;
+use crate::components::{severity_from_term, ComponentRegistry, ValidatorKind};
 use crate::data::{GraphFilter, IrDataGraph, ShaclDataGraph};
 use crate::expression::{FnCall, NodeExpr};
 use crate::model::{rdf, rdfs, sh, BoxRoleVocab};
@@ -85,6 +85,15 @@ pub enum Target {
         /// The SPARQL SELECT query text (with any injected PREFIX header).
         select: String,
     },
+}
+
+/// The SPARQL validator form carried by a custom constraint component constraint.
+#[derive(Debug, Clone)]
+pub enum ComponentValidator {
+    /// An `ASK` query validator (`sh:SPARQLAskValidator`).
+    Ask { ask: String },
+    /// A `SELECT` query validator (`sh:SPARQLSelectValidator`).
+    Select { select: String },
 }
 
 /// A single SHACL constraint on a shape or property shape.
@@ -206,6 +215,7 @@ pub enum Constraint {
         /// any sibling qualified shape are excluded before counting.
         disjoint: bool,
     },
+<<<<<<< HEAD
     /// `sh:expression <node expression>` — SHACL-AF §5.7 expression constraint.
     ///
     /// For each value node the expression is evaluated with that value node as
@@ -219,6 +229,25 @@ pub enum Constraint {
         message: Option<String>,
         /// Optional per-constraint severity override (from `sh:severity` on the
         /// expression node).
+        severity: Option<Severity>,
+    },
+    /// A SHACL-SPARQL custom constraint component usage.
+    ///
+    /// Emitted when a shape node carries values for all required parameters of a
+    /// declared `sh:ConstraintComponent`. The validator query text already has
+    /// any needed `PREFIX` header prepended.
+    Component {
+        /// The component IRI (`sh:ConstraintComponent` instance).
+        component: NamedNode,
+        /// The shape node that sourced this component usage.
+        source_shape: Term,
+        /// Parameter bindings: SPARQL variable local name → value term.
+        bindings: Vec<(String, Term)>,
+        /// The selected validator (ASK or SELECT).
+        validator: ComponentValidator,
+        /// Optional message override (shape → validator → component).
+        message: Option<String>,
+        /// Optional severity override (shape → validator → component).
         severity: Option<Severity>,
     },
 }
@@ -716,7 +745,7 @@ impl<'s> Parser<'s> {
         }
 
         // -- Node-level constraints --
-        let constraints = self.parse_constraints(id)?;
+        let constraints = self.parse_constraints(id, false)?;
         let box_roles = self.box_roles_of(id);
 
         Ok(Shape {
@@ -841,10 +870,17 @@ impl<'s> Parser<'s> {
         Ok(targets)
     }
 
-    /// Parse node-level (non-path-scoped) constraints from a shape node.
+    /// Parse all constraints declared directly on a shape node.
     ///
     /// Does NOT include `sh:property` sub-shapes (handled separately).
-    fn parse_constraints(&mut self, id: &Term) -> Result<Vec<Constraint>, String> {
+    /// `is_property_shape` selects the right custom-component validator
+    /// (`sh:propertyValidator` vs `sh:nodeValidator`) and is passed down from
+    /// both node shapes and property shapes.
+    fn parse_constraints(
+        &mut self,
+        id: &Term,
+        is_property_shape: bool,
+    ) -> Result<Vec<Constraint>, String> {
         let mut constraints: Vec<Constraint> = Vec::new();
 
         // sh:class — sorted for determinism
@@ -1218,6 +1254,85 @@ impl<'s> Parser<'s> {
         // dangling half of the pair is malformed and hard-fails.
         constraints.extend(self.parse_qualified_value_shapes(id)?);
 
+        // Custom SHACL-SPARQL constraint components. A shape that carries values
+        // for all required parameters of a declared component is treated as a
+        // usage of that component. Components are processed in deterministic
+        // order; parameter bindings follow the component's declared parameter
+        // order. If no applicable validator exists for this shape scope the
+        // component is skipped silently.
+        let mut components: Vec<&crate::components::Component> =
+            self.component_registry.components.values().collect();
+        components.sort_by(|a, b| a.id.as_str().cmp(b.id.as_str()));
+        for component in components {
+            let mut bindings: Vec<(String, Term)> = Vec::new();
+            let mut missing_required = false;
+            for param in &component.parameters {
+                if let Some(value) = self.first_object_of(id, param.path.as_str()) {
+                    bindings.push((param.name.clone(), value));
+                } else if !param.optional {
+                    missing_required = true;
+                    break;
+                }
+            }
+            if missing_required {
+                continue;
+            }
+
+            let validator = if is_property_shape {
+                component
+                    .property_validator
+                    .as_ref()
+                    .or(component.validator.as_ref())
+            } else {
+                component
+                    .node_validator
+                    .as_ref()
+                    .or(component.validator.as_ref())
+            };
+            let Some(validator) = validator else {
+                continue;
+            };
+
+            let component_validator = match &validator.kind {
+                ValidatorKind::Ask => ComponentValidator::Ask {
+                    ask: validator.query_text.clone(),
+                },
+                ValidatorKind::Select => ComponentValidator::Select {
+                    select: validator.query_text.clone(),
+                },
+            };
+
+            let shape_severity = self
+                .first_object_of(id, sh::SEVERITY)
+                .and_then(|t| severity_from_term(&t));
+            let mut shape_messages: Vec<String> = self
+                .objects_of(id, sh::MESSAGE)
+                .into_iter()
+                .filter_map(|t| match t {
+                    Term::Literal(lit) => Some(lit.value().to_owned()),
+                    _ => None,
+                })
+                .collect();
+            shape_messages.sort();
+            let shape_message = shape_messages.into_iter().next();
+
+            let severity = shape_severity
+                .or_else(|| validator.severity.clone())
+                .or_else(|| component.severity.clone());
+            let message = shape_message
+                .or_else(|| validator.message.clone())
+                .or_else(|| component.message.clone());
+
+            constraints.push(Constraint::Component {
+                component: component.id.clone(),
+                source_shape: id.clone(),
+                bindings,
+                validator: component_validator,
+                message,
+                severity,
+            });
+        }
+
         Ok(constraints)
     }
 
@@ -1358,7 +1473,7 @@ impl<'s> Parser<'s> {
             .is_some_and(|t| matches!(&t, Term::Literal(lit) if lit.value() == "true"));
 
         // constraints on the property shape
-        let constraints = self.parse_constraints(ps_node)?;
+        let constraints = self.parse_constraints(ps_node, true)?;
 
         // Nested sh:property on a property shape (spec §2.1: sh:property may
         // appear on ANY shape) — each nested property shape applies to THIS
@@ -1962,19 +2077,6 @@ impl<'s> Parser<'s> {
 
 // ── Helper functions ───────────────────────────────────────────────────────────
 
-/// Map an `sh:severity` object term to a [`Severity`]: the three built-in
-/// `sh:` severities map to their variants, any OTHER IRI is preserved verbatim
-/// (SHACL allows custom severity IRIs — W3C core/misc/severity-002), and a
-/// non-IRI object yields `None` (caller falls back to `sh:Violation`).
-fn severity_from_term(t: &Term) -> Option<Severity> {
-    match t {
-        Term::NamedNode(n) => {
-            Some(Severity::from_iri(n.as_str()).unwrap_or_else(|| Severity::Other(n.clone())))
-        }
-        _ => None,
-    }
-}
-
 /// Parse `sh:nodeKind` object IRI into a [`NodeKindValue`].
 fn parse_node_kind(iri: &str) -> Option<NodeKindValue> {
     match iri {
@@ -2535,6 +2637,58 @@ mod tests {
         assert_eq!(shape.severity, Severity::Warning);
         assert_eq!(shape.message.as_deref(), Some("This is a warning"));
         assert!(shape.deactivated);
+    }
+
+    // ── Test 6b: custom SHACL-SPARQL constraint component detection ────────────
+
+    #[test]
+    fn test_custom_component_constraint_detected() {
+        let ttl = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../vectors/shacl/sparql/component/optional-001.ttl"
+        ))
+        .expect("fixture exists");
+        let dataset: Arc<RdfDataset> = ::purrdf::parse_dataset(
+            ttl.as_bytes(),
+            "text/turtle",
+            Some("http://datashapes.org/sh/tests/sparql/component/optional-001.test"),
+        )
+        .expect("fixture parses");
+        let shapes = from_dataset(&dataset).expect("shapes with custom component must parse");
+
+        let test_shape1 = shapes
+            .node_shapes
+            .iter()
+            .find(|s| s.id.to_string().contains("TestShape1"))
+            .expect("TestShape1 present");
+        let (component, bindings, validator) = test_shape1
+            .constraints
+            .iter()
+            .find_map(|c| match c {
+                Constraint::Component {
+                    component,
+                    bindings,
+                    validator,
+                    ..
+                } => Some((component, bindings, validator)),
+                _ => None,
+            })
+            .expect("TestShape1 should have a Constraint::Component");
+
+        assert_eq!(
+            component.as_str(),
+            "http://datashapes.org/sh/tests/sparql/component/optional-001.test#TestConstraintComponent"
+        );
+        assert_eq!(bindings.len(), 1, "only requiredParam is bound");
+        assert_eq!(bindings[0].0, "requiredParam");
+        assert!(
+            matches!(bindings[0].1, Term::Literal(_)),
+            "binding value should be a literal"
+        );
+        assert!(
+            matches!(validator, ComponentValidator::Ask { .. }),
+            "optional-001 validator is ASK"
+        );
     }
 
     // ── Test 7: sh:in list ─────────────────────────────────────────────────────

--- a/crates/shapes/src/shapes.rs
+++ b/crates/shapes/src/shapes.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, OnceLock};
 
 use ::purrdf::RdfDataset;
 
-use crate::components::{severity_from_term, ComponentRegistry, ValidatorKind};
+use crate::components::{severity_from_term, ComponentRegistry, Validator, ValidatorKind};
 use crate::data::{GraphFilter, IrDataGraph, ShaclDataGraph};
 use crate::expression::{FnCall, NodeExpr};
 use crate::model::{rdf, rdfs, sh, BoxRoleVocab};
@@ -1258,8 +1258,9 @@ impl<'s> Parser<'s> {
         // for all required parameters of a declared component is treated as a
         // usage of that component. Components are processed in deterministic
         // order; parameter bindings follow the component's declared parameter
-        // order. If no applicable validator exists for this shape scope the
-        // component is skipped silently.
+        // order. All validators applicable to the current shape scope are
+        // emitted as separate constraints; if none apply, the component is
+        // skipped silently.
         let shape_severity = self
             .first_object_of(id, sh::SEVERITY)
             .and_then(|t| severity_from_term(&t));
@@ -1292,47 +1293,51 @@ impl<'s> Parser<'s> {
                 continue;
             }
 
-            let validator = if is_property_shape {
+            let matching: Vec<&Validator> = if is_property_shape {
                 component
-                    .property_validator
-                    .as_ref()
-                    .or(component.validator.as_ref())
+                    .property_validators
+                    .iter()
+                    .chain(component.validators.iter())
+                    .collect()
             } else {
                 component
-                    .node_validator
-                    .as_ref()
-                    .or(component.validator.as_ref())
+                    .node_validators
+                    .iter()
+                    .chain(component.validators.iter())
+                    .collect()
             };
-            let Some(validator) = validator else {
+            if matching.is_empty() {
                 continue;
-            };
+            }
 
-            let component_validator = match &validator.kind {
-                ValidatorKind::Ask => ComponentValidator::Ask {
-                    ask: validator.query_text.clone(),
-                },
-                ValidatorKind::Select => ComponentValidator::Select {
-                    select: validator.query_text.clone(),
-                },
-            };
+            for validator in matching {
+                let component_validator = match &validator.kind {
+                    ValidatorKind::Ask => ComponentValidator::Ask {
+                        ask: validator.query_text.clone(),
+                    },
+                    ValidatorKind::Select => ComponentValidator::Select {
+                        select: validator.query_text.clone(),
+                    },
+                };
 
-            let severity = shape_severity
-                .clone()
-                .or_else(|| validator.severity.clone())
-                .or_else(|| component.severity.clone());
-            let message = shape_message
-                .clone()
-                .or_else(|| validator.message.clone())
-                .or_else(|| component.message.clone());
+                let severity = shape_severity
+                    .clone()
+                    .or_else(|| validator.severity.clone())
+                    .or_else(|| component.severity.clone());
+                let message = shape_message
+                    .clone()
+                    .or_else(|| validator.message.clone())
+                    .or_else(|| component.message.clone());
 
-            constraints.push(Constraint::Component {
-                component: component.id.clone(),
-                source_shape: id.clone(),
-                bindings,
-                validator: component_validator,
-                message,
-                severity,
-            });
+                constraints.push(Constraint::Component {
+                    component: component.id.clone(),
+                    source_shape: id.clone(),
+                    bindings: bindings.clone(),
+                    validator: component_validator,
+                    message,
+                    severity,
+                });
+            }
         }
 
         Ok(constraints)

--- a/crates/shapes/src/sparql.rs
+++ b/crates/shapes/src/sparql.rs
@@ -39,7 +39,8 @@ use crate::term::{term_value_to_native, Literal, NamedNode, Term};
 /// (`Boolean` / `Graph` are rejected), or if any solution row has no `?this`
 /// binding.
 pub fn eval_target(dataset: &Arc<RdfDataset>, select: &str) -> Result<Vec<Term>, String> {
-    let solutions = run_select(dataset, select, &[]).map_err(|e| format!("SPARQLTarget {e}"))?;
+    let solutions = run_select_with_substitutions(dataset, select, &[])
+        .map_err(|e| format!("SPARQLTarget {e}"))?;
 
     let this_index = column_index(&solutions.0, "this");
 
@@ -98,8 +99,8 @@ pub fn eval_sparql_constraint(
     // is memoized by the thread-local engine's plan cache, so per-focus evaluation
     // re-runs the plan, not the parse.
     let subs = [("this".to_owned(), focus.to_term_value())];
-    let (variables, rows) =
-        run_select(dataset, select, &subs).map_err(|e| format!("SPARQLConstraint {e}"))?;
+    let (variables, rows) = run_select_with_substitutions(dataset, select, &subs)
+        .map_err(|e| format!("SPARQLConstraint {e}"))?;
     let path_index = column_index(&variables, "path");
     let value_index = column_index(&variables, "value");
 
@@ -365,7 +366,7 @@ thread_local! {
 
 /// Run a SELECT query over the dataset, returning `(variables, rows)`. Rejects
 /// non-SELECT result forms.
-fn run_select(
+pub(crate) fn run_select_with_substitutions(
     dataset: &Arc<RdfDataset>,
     select: &str,
     substitutions: &[(String, TermValue)],
@@ -391,6 +392,36 @@ fn run_select(
         }
         SparqlResult::Graph(_) => {
             Err("query must be a SELECT, got a graph (CONSTRUCT/DESCRIBE) result".to_owned())
+        }
+    }
+}
+
+/// Run an ASK query over the dataset with the given variable substitutions.
+/// Rejects non-boolean result forms.
+pub(crate) fn run_ask_with_substitutions(
+    dataset: &Arc<RdfDataset>,
+    ask: &str,
+    substitutions: &[(String, TermValue)],
+) -> Result<bool, String> {
+    let result = SPARQL_ENGINE
+        .with(|engine| {
+            engine.query(
+                dataset,
+                SparqlRequest {
+                    query: ask,
+                    base_iri: None,
+                    substitutions,
+                },
+            )
+        })
+        .map_err(|e| format!("query evaluation error: {e}"))?;
+    match result {
+        SparqlResult::Boolean(b) => Ok(b),
+        SparqlResult::Solutions { .. } => {
+            Err("query must be an ASK, got a SELECT result".to_owned())
+        }
+        SparqlResult::Graph(_) => {
+            Err("query must be an ASK, got a graph (CONSTRUCT/DESCRIBE) result".to_owned())
         }
     }
 }

--- a/crates/shapes/tests/w3c_conformance.rs
+++ b/crates/shapes/tests/w3c_conformance.rs
@@ -100,23 +100,6 @@ const RDF_NIL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
 const XFAIL: &[(&str, &str)] = &[
     // ── SHACL-SPARQL ──────────────────────────────────────────────────────────
     (
-        "sparql/component/optional-001",
-        "custom SPARQL constraint components (sh:ConstraintComponent with \
-         sh:parameter and a sh:SPARQLAskValidator sh:ask validator) are \
-         unsupported — only sh:sparql/sh:SPARQLConstraint SELECTs run",
-    ),
-    (
-        "sparql/component/propertyValidator-select-001",
-        "custom SPARQL constraint components (sh:ConstraintComponent with a \
-         sh:propertyValidator SELECT validator and $PATH substitution) are \
-         unsupported",
-    ),
-    (
-        "sparql/component/validator-001",
-        "custom SPARQL constraint components (sh:ConstraintComponent with a \
-         sh:SPARQLAskValidator sh:ask validator over $value) are unsupported",
-    ),
-    (
         "sparql/pre-binding/pre-binding-002",
         "$this pre-binding is not visible inside FILTER-only UNION branches \
          (SPARQL pre-binding semantics); the query yields no solutions so no \


### PR DESCRIPTION
Closes #12

## Summary
Implement SHACL-SPARQL custom constraint components (sh:ConstraintComponent) with ASK and SELECT validators, parameter pre-binding, and /home/paudley/.local/bin:/home/paudley/.bun/bin:/home/paudley/perl5/bin:/home/paudley/.kimi-code/bin:/home/paudley/.local/bin:/run/user/1000/fnm_multishells/2250200_1783098922347/bin:/home/paudley/.local/share/fnm:/home/paudley/.local/bin:/run/user/1000/fnm_multishells/2250199_1783098922346/bin:/home/paudley/.local/share/fnm:/home/paudley/stage/root/bin:/home/paudley/.scripts:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/opt/rocm/bin substitution.

## Changes
- Add SHACL vocabulary constants for constraint components and validators.
- Add components module that parses the component registry from the shapes graph.
- Detect component usage during shape parsing and emit Constraint::Component.
- Evaluate ASK validators (false → violation, one per value node) and SELECT validators (one per solution row).
- Implement /home/paudley/.local/bin:/home/paudley/.bun/bin:/home/paudley/perl5/bin:/home/paudley/.kimi-code/bin:/home/paudley/.local/bin:/run/user/1000/fnm_multishells/2250200_1783098922347/bin:/home/paudley/.local/share/fnm:/home/paudley/.local/bin:/run/user/1000/fnm_multishells/2250199_1783098922346/bin:/home/paudley/.local/share/fnm:/home/paudley/stage/root/bin:/home/paudley/.scripts:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/opt/rocm/bin textual substitution for property-shape SELECT validators.
- Pre-bind component parameters by parameter name.
- Remove three passing component tests from the W3C SHACL XFAIL ledger.
- Reach 117/120 SHACL-SPARQL conformance tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom SHACL-SPARQL constraint components, including ASK and SELECT validators.
  * Improved handling of component parameters, messages, severities, and property/node shape usage.
  * SPARQL queries now support substitution-based evaluation for more accurate validation results.

* **Bug Fixes**
  * Corrected validation behavior for custom components, including optional parameters and result reporting.
  * Reduced false failures by updating conformance expectations for several SHACL-SPARQL cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->