### PR TITLE
feat(shacl-sparql): pre-binding substitution semantics and shapes-graph variables

### DIFF
--- a/crates/shapes/src/components.rs
+++ b/crates/shapes/src/components.rs
@@ -22,7 +22,7 @@ use crate::model::{rdf, rdfs, sh};
 use crate::path;
 use crate::report::{Severity, ValidationResult};
 use crate::shapes::{build_prefix_header, ComponentValidator, Path};
-use crate::sparql::{run_ask_with_substitutions, run_select_with_substitutions};
+use crate::sparql::{run_ask_with_shacl_prebinding, run_select_with_shacl_prebinding};
 use crate::term::{term_value_to_native, NamedNode, Term};
 
 /// Discriminator for a SPARQL validator's query form.
@@ -211,6 +211,8 @@ pub(crate) fn eval_ask_validator(
     path: Option<&Path>,
     severity: &Severity,
     message: Option<&String>,
+    shapes_graph_iri: Option<&str>,
+    current_shape: Option<&Term>,
 ) -> Result<Vec<ValidationResult>, String> {
     let ComponentValidator::Ask { ask } = validator else {
         return Err("expected ASK validator, got SELECT".to_owned());
@@ -224,7 +226,8 @@ pub(crate) fn eval_ask_validator(
         for (name, value) in bindings {
             subs.push((name.clone(), value.to_term_value()));
         }
-        let conforms = run_ask_with_substitutions(dataset, ask, &subs)?;
+        let conforms =
+            run_ask_with_shacl_prebinding(dataset, ask, &subs, shapes_graph_iri, current_shape)?;
         if !conforms {
             let mut template_bindings: Vec<(String, Term)> = bindings.to_vec();
             template_bindings.push(("value".to_owned(), v.clone()));
@@ -265,6 +268,8 @@ pub(crate) fn eval_select_validator(
     path: Option<&Path>,
     severity: &Severity,
     message: Option<&String>,
+    shapes_graph_iri: Option<&str>,
+    current_shape: Option<&Term>,
 ) -> Result<Vec<ValidationResult>, String> {
     let ComponentValidator::Select { select } = validator else {
         return Err("expected SELECT validator, got ASK".to_owned());
@@ -275,7 +280,8 @@ pub(crate) fn eval_select_validator(
         subs.push((name.clone(), value.to_term_value()));
     }
     let query = crate::constraints::substitute_path_placeholder(select, path);
-    let (variables, rows) = run_select_with_substitutions(dataset, &query, &subs)?;
+    let (variables, rows) =
+        run_select_with_shacl_prebinding(dataset, &query, &subs, shapes_graph_iri, current_shape)?;
 
     let this_index = variables.iter().position(|v| v == "this");
     let path_index = variables.iter().position(|v| v == "path");

--- a/crates/shapes/src/constraints.rs
+++ b/crates/shapes/src/constraints.rs
@@ -554,6 +554,7 @@ fn eval_constraint<G: ShaclDataGraph>(
     let severity = shape.severity.clone();
     let message = shape.message.clone();
     let source_shape = shape.id.clone();
+    let shapes_graph_iri = store.shapes_graph_iri();
 
     macro_rules! result {
         ($component:expr, $value:expr) => {
@@ -1406,6 +1407,8 @@ fn eval_constraint<G: ShaclDataGraph>(
                 &source_shape,
                 &sev,
                 msg.as_ref(),
+                shapes_graph_iri,
+                Some(&source_shape),
             )
             .map_err(|e| format!("sh:sparql constraint on shape {source_shape}: {e}"))?
         }
@@ -1475,6 +1478,8 @@ fn eval_constraint<G: ShaclDataGraph>(
                     path,
                     &sev,
                     msg.as_ref(),
+                    shapes_graph_iri,
+                    Some(source_shape),
                 ),
                 ComponentValidator::Select { .. } => crate::components::eval_select_validator(
                     &dataset,
@@ -1486,6 +1491,8 @@ fn eval_constraint<G: ShaclDataGraph>(
                     path,
                     &sev,
                     msg.as_ref(),
+                    shapes_graph_iri,
+                    Some(source_shape),
                 ),
             }
             .map_err(|e| format!("component validator on shape {source_shape}: {e}"))?

--- a/crates/shapes/src/data.rs
+++ b/crates/shapes/src/data.rs
@@ -83,6 +83,12 @@ pub trait ShaclDataGraph: Send + Sync {
 
     /// The borrowed frozen dataset, for native SHACL-SPARQL evaluation.
     fn sparql_dataset(&self) -> Arc<RdfDataset>;
+
+    /// The IRI of the named graph under which the shapes graph is exposed to
+    /// SHACL-SPARQL queries, if any.
+    fn shapes_graph_iri(&self) -> Option<&str> {
+        None
+    }
 }
 
 // ── &RdfDataset backend (the IR-native path) ───────────────────────────────────

--- a/crates/shapes/src/engine.rs
+++ b/crates/shapes/src/engine.rs
@@ -350,6 +350,8 @@ struct IrDataGraphWithShapes {
     /// The combined dataset handed to the native SPARQL engine: data in the
     /// default graph, shapes in a named graph when a shapes-graph IRI is known.
     sparql_dataset: Arc<RdfDataset>,
+    /// The named-graph IRI under which the shapes dataset is exposed, when known.
+    shapes_graph_iri: Option<String>,
 }
 
 impl ShaclDataGraph for IrDataGraphWithShapes {
@@ -360,11 +362,16 @@ impl ShaclDataGraph for IrDataGraphWithShapes {
         object: Option<&Term>,
         graph: GraphFilter,
     ) -> Vec<Quad> {
-        self.data.quads_for_pattern(subject, predicate, object, graph)
+        self.data
+            .quads_for_pattern(subject, predicate, object, graph)
     }
 
     fn sparql_dataset(&self) -> Arc<RdfDataset> {
         Arc::clone(&self.sparql_dataset)
+    }
+
+    fn shapes_graph_iri(&self) -> Option<&str> {
+        self.shapes_graph_iri.as_deref()
     }
 }
 
@@ -373,17 +380,21 @@ impl ShaclDataGraph for IrDataGraphWithShapes {
 /// Data quads stay in their original graphs (the projected default graph). When
 /// a shapes-graph IRI is known, every quad from [`Shapes::shapes_dataset`] is
 /// placed into a named graph with that IRI.
+///
+/// Returns the combined dataset and the shapes-graph IRI actually used, if any.
 fn build_sparql_dataset(
     data: Arc<RdfDataset>,
     shapes: &Shapes,
     override_graph: Option<&str>,
-) -> Result<Arc<RdfDataset>, String> {
-    let graph_iri = override_graph.or(shapes.shapes_graph.as_deref());
-    let Some(graph_iri) = graph_iri else {
-        return Ok(data);
+) -> Result<(Arc<RdfDataset>, Option<String>), String> {
+    let graph_iri = override_graph
+        .map(ToOwned::to_owned)
+        .or_else(|| shapes.shapes_graph.clone());
+    let Some(ref graph_iri) = graph_iri else {
+        return Ok((data, None));
     };
     if shapes.shapes_dataset.quad_count() == 0 {
-        return Ok(data);
+        return Ok((data, None));
     }
 
     let mut builder = RdfDatasetBuilder::new();
@@ -395,7 +406,10 @@ fn build_sparql_dataset(
         builder.push_owned_quad(&quad);
     }
 
-    builder.freeze().map_err(|e| e.to_string())
+    builder
+        .freeze()
+        .map_err(|e| e.to_string())
+        .map(|ds| (ds, Some(graph_iri.clone())))
 }
 
 /// Validate a frozen [`RdfDataset`] against parsed SHACL shapes, exposing the
@@ -418,10 +432,12 @@ pub fn validate_projected_dataset_with_shapes_graph(
     shapes_graph_iri: Option<&str>,
 ) -> Result<ValidationReport, String> {
     let data_graph = IrDataGraph::new(Arc::clone(&projected));
-    let sparql_dataset = build_sparql_dataset(projected, shapes, shapes_graph_iri)?;
+    let (sparql_dataset, shapes_graph_iri) =
+        build_sparql_dataset(projected, shapes, shapes_graph_iri)?;
     let graph = IrDataGraphWithShapes {
         data: data_graph,
         sparql_dataset,
+        shapes_graph_iri,
     };
     validate_with(&graph, shapes)
 }

--- a/crates/shapes/src/engine.rs
+++ b/crates/shapes/src/engine.rs
@@ -9,12 +9,13 @@
 
 use std::sync::Arc;
 
-use crate::data::{GraphFilter, IrDataGraph, ShaclDataGraph};
+use ::purrdf::{RdfDataset, RdfDatasetBuilder, RdfTerm};
+
+use crate::data::{GraphFilter, IrDataGraph, Quad, ShaclDataGraph};
 use crate::model::{rdf, rdfs};
 use crate::report::ValidationReport;
 use crate::shapes::{Shape, Shapes, Target};
 use crate::term::{NamedNode, Term};
-use ::purrdf::RdfDataset;
 
 // ── Target resolution helpers ─────────────────────────────────────────────────
 
@@ -341,6 +342,90 @@ where
     validate_with_focus_filter(&reference, shapes, include_focus)
 }
 
+/// A [`ShaclDataGraph`] that evaluates SHACL Core constraints over a projected
+/// data graph while exposing a combined data+shapes dataset to SHACL-SPARQL.
+struct IrDataGraphWithShapes {
+    /// The data graph used for Core pattern lookups.
+    data: IrDataGraph,
+    /// The combined dataset handed to the native SPARQL engine: data in the
+    /// default graph, shapes in a named graph when a shapes-graph IRI is known.
+    sparql_dataset: Arc<RdfDataset>,
+}
+
+impl ShaclDataGraph for IrDataGraphWithShapes {
+    fn quads_for_pattern(
+        &self,
+        subject: Option<&Term>,
+        predicate: Option<&Term>,
+        object: Option<&Term>,
+        graph: GraphFilter,
+    ) -> Vec<Quad> {
+        self.data.quads_for_pattern(subject, predicate, object, graph)
+    }
+
+    fn sparql_dataset(&self) -> Arc<RdfDataset> {
+        Arc::clone(&self.sparql_dataset)
+    }
+}
+
+/// Build the dataset exposed to SHACL-SPARQL paths.
+///
+/// Data quads stay in their original graphs (the projected default graph). When
+/// a shapes-graph IRI is known, every quad from [`Shapes::shapes_dataset`] is
+/// placed into a named graph with that IRI.
+fn build_sparql_dataset(
+    data: Arc<RdfDataset>,
+    shapes: &Shapes,
+    override_graph: Option<&str>,
+) -> Result<Arc<RdfDataset>, String> {
+    let graph_iri = override_graph.or(shapes.shapes_graph.as_deref());
+    let Some(graph_iri) = graph_iri else {
+        return Ok(data);
+    };
+    if shapes.shapes_dataset.quad_count() == 0 {
+        return Ok(data);
+    }
+
+    let mut builder = RdfDatasetBuilder::new();
+    builder.push_dataset(data.as_ref());
+
+    let graph_term = RdfTerm::iri(graph_iri);
+    for mut quad in shapes.shapes_dataset.owned_quads() {
+        quad.graph_name = Some(graph_term.clone());
+        builder.push_owned_quad(&quad);
+    }
+
+    builder.freeze().map_err(|e| e.to_string())
+}
+
+/// Validate a frozen [`RdfDataset`] against parsed SHACL shapes, exposing the
+/// shapes graph as a named graph to SHACL-SPARQL paths.
+///
+/// `shapes_graph_iri` overrides [`Shapes::shapes_graph`] when both are present.
+pub fn validate_dataset_with_shapes_graph(
+    data: &RdfDataset,
+    shapes: &Shapes,
+    shapes_graph_iri: Option<&str>,
+) -> Result<ValidationReport, String> {
+    let projected = project_dataset(data)?;
+    validate_projected_dataset_with_shapes_graph(projected, shapes, shapes_graph_iri)
+}
+
+/// Validate an already-projected dataset with a shapes-graph overlay.
+pub fn validate_projected_dataset_with_shapes_graph(
+    projected: Arc<RdfDataset>,
+    shapes: &Shapes,
+    shapes_graph_iri: Option<&str>,
+) -> Result<ValidationReport, String> {
+    let data_graph = IrDataGraph::new(Arc::clone(&projected));
+    let sparql_dataset = build_sparql_dataset(projected, shapes, shapes_graph_iri)?;
+    let graph = IrDataGraphWithShapes {
+        data: data_graph,
+        sparql_dataset,
+    };
+    validate_with(&graph, shapes)
+}
+
 /// Build a SHACL-projection dataset from the source [`RdfDataset`], flattening
 /// every quad into the default graph and materializing reifier bindings as
 /// `rdf:reifies` triples and statement annotations as plain triples.
@@ -614,7 +699,7 @@ mod tests {
     #[test]
     fn validate_stub_always_conforms() {
         let data = load_data_nt("");
-        let shapes = crate::shapes::from_dataset(&data).expect("empty shapes graph parses");
+        let shapes = Shapes::default();
         let report = validate(&data, &shapes);
         assert!(report.conforms);
         assert!(report.results.is_empty());

--- a/crates/shapes/src/shapes.rs
+++ b/crates/shapes/src/shapes.rs
@@ -301,6 +301,10 @@ pub struct Shape {
 }
 
 /// The parsed shapes graph — a collection of top-level [`Shape`]s.
+#[allow(
+    clippy::struct_field_names,
+    reason = "field names mirror the public Shapes API contract (shapes_graph / shapes_dataset)"
+)]
 #[derive(Debug, Clone)]
 pub struct Shapes {
     /// Node shapes extracted from the shapes graph.
@@ -309,12 +313,25 @@ pub struct Shapes {
     /// carried into validation so data-graph role lookups use the same terms.
     /// `None` = the box-role feature is inactive.
     pub box_role_vocab: Option<BoxRoleVocab>,
-    /// The IRI of the named graph holding the shapes, threaded into SHACL-SPARQL
-    /// custom-component validator queries. `None` = the default graph.
+    /// The named-graph IRI under which the original shapes dataset is exposed
+    /// to SHACL-SPARQL queries, when known.
     pub shapes_graph: Option<String>,
-    /// The frozen dataset the shapes were parsed from, retained so SHACL-SPARQL
-    /// custom-component validators can query the shapes graph at validation time.
-    pub shapes_dataset: Arc<RdfDataset>,
+    /// The original frozen shapes dataset, retained so validation can expose it
+    /// as a named graph to SHACL-SPARQL paths.
+    pub(crate) shapes_dataset: Arc<RdfDataset>,
+}
+
+impl Default for Shapes {
+    fn default() -> Self {
+        Self {
+            node_shapes: Vec::new(),
+            box_role_vocab: None,
+            shapes_graph: None,
+            shapes_dataset: ::purrdf::RdfDatasetBuilder::new()
+                .freeze()
+                .expect("empty shapes dataset"),
+        }
+    }
 }
 
 // ── Public entry point ─────────────────────────────────────────────────────────
@@ -371,13 +388,26 @@ pub fn from_dataset_with_config(
     doc_prefixes: &[(String, String)],
     box_role_vocab: Option<BoxRoleVocab>,
 ) -> Result<Shapes, String> {
+    from_dataset_with_config_and_graph(dataset, doc_prefixes, box_role_vocab, None)
+}
+
+/// Parse shapes from a dataset with the full caller configuration plus an
+/// explicit shapes-graph IRI. The original `dataset` is retained as
+/// [`Shapes::shapes_dataset`] so the validation engine can expose it as a
+/// named graph to SHACL-SPARQL queries.
+pub fn from_dataset_with_config_and_graph(
+    dataset: &Arc<RdfDataset>,
+    doc_prefixes: &[(String, String)],
+    box_role_vocab: Option<BoxRoleVocab>,
+    shapes_graph: Option<String>,
+) -> Result<Shapes, String> {
     let data = IrDataGraph::new(Arc::clone(dataset));
     let mut parser = Parser::new(
         &data,
         doc_prefixes,
         box_role_vocab,
         Arc::clone(dataset),
-        None,
+        shapes_graph,
     );
     parser.parse()
 }
@@ -398,11 +428,10 @@ struct Parser<'s> {
     /// shapes graph. Populated before shape parsing so malformed components are
     /// rejected as hard failures.
     component_registry: ComponentRegistry,
-    /// The original frozen shapes dataset, used to build the SPARQL-visible
-    /// shapes-graph overlay.
+    /// The original frozen shapes dataset, retained so validation can expose it
+    /// as a named graph to SHACL-SPARQL paths.
     shapes_dataset: Arc<RdfDataset>,
-    /// The IRI of the named graph under which the shapes graph is exposed to
-    /// SHACL-SPARQL queries, or `None` if no shapes-graph overlay is configured.
+    /// The named-graph IRI under which the shapes dataset is exposed.
     shapes_graph: Option<String>,
 }
 

--- a/crates/shapes/src/sparql.rs
+++ b/crates/shapes/src/sparql.rs
@@ -39,8 +39,8 @@ use crate::term::{term_value_to_native, Literal, NamedNode, Term};
 /// (`Boolean` / `Graph` are rejected), or if any solution row has no `?this`
 /// binding.
 pub fn eval_target(dataset: &Arc<RdfDataset>, select: &str) -> Result<Vec<Term>, String> {
-    let solutions = run_select_with_substitutions(dataset, select, &[])
-        .map_err(|e| format!("SPARQLTarget {e}"))?;
+    let solutions =
+        run_select_generic(dataset, select, &[]).map_err(|e| format!("SPARQLTarget {e}"))?;
 
     let this_index = column_index(&solutions.0, "this");
 
@@ -64,8 +64,10 @@ pub fn eval_target(dataset: &Arc<RdfDataset>, select: &str) -> Result<Vec<Term>,
 /// Execute a SHACL-AF `sh:SPARQLConstraint` SELECT query for a single focus node,
 /// mapping each solution row to a [`ValidationResult`].
 ///
-/// `?this` / `$this` is pre-bound to `focus` before evaluation. Each solution row
-/// produces exactly one result:
+/// `$this` is pre-bound to `focus`, and when known `$shapesGraph` and
+/// `$currentShape` are pre-bound to `shapes_graph_iri` and `current_shape`, before
+/// the query is run through the SHACL-specific pre-binding rewrite. Each solution
+/// row produces exactly one result:
 ///
 /// | SPARQL binding | `ValidationResult` field |
 /// |---|---|
@@ -81,6 +83,7 @@ pub fn eval_target(dataset: &Arc<RdfDataset>, select: &str) -> Result<Vec<Term>,
 /// # Errors
 ///
 /// Returns `Err(String)` if execution fails or if the result is not a SELECT.
+#[allow(clippy::too_many_arguments)] // Signature mirrors the SHACL-SPARQL parameter set.
 pub fn eval_sparql_constraint(
     dataset: &Arc<RdfDataset>,
     focus: &Term,
@@ -89,6 +92,8 @@ pub fn eval_sparql_constraint(
     source_shape: &Term,
     severity: &Severity,
     message: Option<&String>,
+    shapes_graph_iri: Option<&str>,
+    current_shape: Option<&Term>,
 ) -> Result<Vec<ValidationResult>, String> {
     // Pre-bind `$this` to THIS focus node (GAP-A substitution — the native
     // replacement for oxigraph's per-focus `PreparedSparqlQuery::substitute_variable`).
@@ -99,8 +104,9 @@ pub fn eval_sparql_constraint(
     // is memoized by the thread-local engine's plan cache, so per-focus evaluation
     // re-runs the plan, not the parse.
     let subs = [("this".to_owned(), focus.to_term_value())];
-    let (variables, rows) = run_select_with_substitutions(dataset, select, &subs)
-        .map_err(|e| format!("SPARQLConstraint {e}"))?;
+    let (variables, rows) =
+        run_select_with_shacl_prebinding(dataset, select, &subs, shapes_graph_iri, current_shape)
+            .map_err(|e| format!("SPARQLConstraint {e}"))?;
     let path_index = column_index(&variables, "path");
     let value_index = column_index(&variables, "value");
 
@@ -166,7 +172,7 @@ pub fn eval_scalar_expr(
         .iter()
         .map(|(name, term)| (name.clone(), term.to_term_value()))
         .collect();
-    let (variables, rows) = run_select_with_substitutions(dataset, &select, &subs)
+    let (variables, rows) = run_select_generic(dataset, &select, &subs)
         .map_err(|e| format!("scalar expression {e}"))?;
 
     if rows.len() > 1 {
@@ -260,8 +266,8 @@ pub fn eval_aggregate(
     }
 
     let select = format!("SELECT ({agg}(?v) AS ?result) WHERE {{ VALUES (?v) {{ {rows}}} }}");
-    let (variables, result_rows) = run_select_with_substitutions(dataset, &select, &[])
-        .map_err(|e| format!("aggregate {e}"))?;
+    let (variables, result_rows) =
+        run_select_generic(dataset, &select, &[]).map_err(|e| format!("aggregate {e}"))?;
 
     if result_rows.len() > 1 {
         return Err(format!(
@@ -332,8 +338,8 @@ pub fn eval_order(
 
     let order = if descending { "DESC(?v)" } else { "?v" };
     let select = format!("SELECT ?v WHERE {{ VALUES (?v) {{ {rows}}} }} ORDER BY {order}");
-    let (variables, result_rows) = run_select_with_substitutions(dataset, &select, &[])
-        .map_err(|e| format!("order-by {e}"))?;
+    let (variables, result_rows) =
+        run_select_generic(dataset, &select, &[]).map_err(|e| format!("order-by {e}"))?;
 
     let v_index = column_index(&variables, "v");
     let mut out: Vec<Term> = Vec::with_capacity(result_rows.len());
@@ -364,9 +370,13 @@ thread_local! {
     static SPARQL_ENGINE: NativeSparqlEngine = NativeSparqlEngine::new();
 }
 
-/// Run a SELECT query over the dataset, returning `(variables, rows)`. Rejects
-/// non-SELECT result forms.
-pub(crate) fn run_select_with_substitutions(
+/// Run a SELECT query over the dataset using the generic SPARQL `query` path
+/// with variable substitutions.
+///
+/// This is the path used by SHACL-AF node expressions (scalar, aggregate,
+/// order-by). It does NOT apply the SHACL-specific pre-binding rewrite used for
+/// `sh:sparql` constraint/component bodies.
+pub(crate) fn run_select_generic(
     dataset: &Arc<RdfDataset>,
     select: &str,
     substitutions: &[(String, TermValue)],
@@ -396,24 +406,60 @@ pub(crate) fn run_select_with_substitutions(
     }
 }
 
-/// Run an ASK query over the dataset with the given variable substitutions.
-/// Rejects non-boolean result forms.
-pub(crate) fn run_ask_with_substitutions(
+/// Run a SELECT query over the dataset using SHACL-SPARQL pre-binding semantics.
+///
+/// Pre-binds `$this`, and when known `$shapesGraph` and `$currentShape`, then
+/// applies the SHACL-specific substitution rewrite (FILTER/EXISTS expression
+/// substitution and `BOUND($v)` → `true`).
+pub(crate) fn run_select_with_shacl_prebinding(
+    dataset: &Arc<RdfDataset>,
+    select: &str,
+    substitutions: &[(String, TermValue)],
+    shapes_graph_iri: Option<&str>,
+    current_shape: Option<&Term>,
+) -> Result<SelectRows, String> {
+    let mut subs: Vec<(String, TermValue)> = substitutions.to_vec();
+    if let Some(iri) = shapes_graph_iri {
+        subs.push(("shapesGraph".to_owned(), TermValue::Iri(iri.to_owned())));
+    }
+    if let Some(shape) = current_shape {
+        subs.push(("currentShape".to_owned(), shape.to_term_value()));
+    }
+
+    let result = SPARQL_ENGINE
+        .with(|engine| engine.query_with_shacl_prebinding(dataset, select, None, &subs))
+        .map_err(|e| format!("query evaluation error: {e}"))?;
+    match result {
+        SparqlResult::Solutions {
+            variables, rows, ..
+        } => Ok((variables, rows)),
+        SparqlResult::Boolean(_) => {
+            Err("query must be a SELECT, got a boolean (ASK) result".to_owned())
+        }
+        SparqlResult::Graph(_) => {
+            Err("query must be a SELECT, got a graph (CONSTRUCT/DESCRIBE) result".to_owned())
+        }
+    }
+}
+
+/// Run an ASK query using SHACL-SPARQL pre-binding semantics.
+pub(crate) fn run_ask_with_shacl_prebinding(
     dataset: &Arc<RdfDataset>,
     ask: &str,
     substitutions: &[(String, TermValue)],
+    shapes_graph_iri: Option<&str>,
+    current_shape: Option<&Term>,
 ) -> Result<bool, String> {
+    let mut subs: Vec<(String, TermValue)> = substitutions.to_vec();
+    if let Some(iri) = shapes_graph_iri {
+        subs.push(("shapesGraph".to_owned(), TermValue::Iri(iri.to_owned())));
+    }
+    if let Some(shape) = current_shape {
+        subs.push(("currentShape".to_owned(), shape.to_term_value()));
+    }
+
     let result = SPARQL_ENGINE
-        .with(|engine| {
-            engine.query(
-                dataset,
-                SparqlRequest {
-                    query: ask,
-                    base_iri: None,
-                    substitutions,
-                },
-            )
-        })
+        .with(|engine| engine.query_with_shacl_prebinding(dataset, ask, None, &subs))
         .map_err(|e| format!("query evaluation error: {e}"))?;
     match result {
         SparqlResult::Boolean(b) => Ok(b),
@@ -519,6 +565,8 @@ mod tests {
             &dummy_shape(),
             &Severity::Violation,
             None,
+            None,
+            None,
         )
         .expect("eval must succeed for self-referencing focus");
         assert_eq!(results.len(), 1);
@@ -538,6 +586,8 @@ mod tests {
             &dummy_component(),
             &dummy_shape(),
             &Severity::Violation,
+            None,
+            None,
             None,
         )
         .expect("eval must succeed for non-matching focus");
@@ -714,5 +764,50 @@ mod tests {
         let result = eval_scalar_expr(&dataset, "STRLEN(1 + 2)", &[])
             .expect("scalar eval must succeed despite the SPARQL type error");
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn eval_sparql_constraint_shapes_graph_and_current_shape() {
+        let shapes_ttl = r#"
+            @prefix ex: <http://example.org/> .
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            ex:Shape a sh:NodeShape ;
+                sh:targetNode ex:Node ;
+                ex:prop 42 ;
+                sh:sparql ex:Constraint .
+            ex:Constraint sh:select """
+                SELECT $this
+                WHERE {
+                    FILTER bound($shapesGraph)
+                    GRAPH $shapesGraph {
+                        FILTER bound($currentShape)
+                        $currentShape ex:prop 42 .
+                    }
+                }
+            """ .
+        "#;
+        let shapes_dataset =
+            crate::text_ingest::parse_turtle_to_dataset(shapes_ttl).expect("valid shapes");
+        let prefixes = crate::text_ingest::extract_prefixes(shapes_ttl);
+        let shapes = crate::shapes::from_dataset_with_config_and_graph(
+            &shapes_dataset,
+            &prefixes,
+            None,
+            Some("http://example.org/shapes".to_owned()),
+        )
+        .expect("parse shapes");
+
+        let data = dataset_from_ntriples(&[
+            "<http://example.org/Node> <http://example.org/p> <http://example.org/o> .",
+        ]);
+        let report =
+            crate::engine::validate_dataset_with_shapes_graph(data.as_ref(), &shapes, None)
+                .expect("validate");
+        assert!(!report.conforms, "constraint must fire");
+        assert_eq!(report.results.len(), 1);
+        assert_eq!(
+            report.results[0].focus_node,
+            named_term("http://example.org/Node")
+        );
     }
 }

--- a/crates/shapes/tests/w3c_conformance.rs
+++ b/crates/shapes/tests/w3c_conformance.rs
@@ -100,17 +100,6 @@ const RDF_NIL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
 const XFAIL: &[(&str, &str)] = &[
     // ── SHACL-SPARQL ──────────────────────────────────────────────────────────
     (
-        "sparql/pre-binding/pre-binding-002",
-        "$this pre-binding is not visible inside FILTER-only UNION branches \
-         (SPARQL pre-binding semantics); the query yields no solutions so no \
-         violation is produced",
-    ),
-    (
-        "sparql/pre-binding/pre-binding-005",
-        "$this pre-binding is not visible inside a FILTER-only group \
-         ({ FILTER(bound($this)) }); the query yields no solutions",
-    ),
-    (
         "sparql/pre-binding/shapesGraph-001",
         "$shapesGraph/$currentShape pre-bound variables are unsupported (the \
          SPARQL dataset carries no shapes graph), so the constraint never fires",

--- a/crates/shapes/tests/w3c_conformance.rs
+++ b/crates/shapes/tests/w3c_conformance.rs
@@ -97,14 +97,7 @@ const RDF_NIL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
 /// A test listed here MUST fail; when engine work fixes it, the harness errors
 /// with `XPASS` and the entry must be removed. This is the SHACL completion
 /// roadmap — keep reasons precise.
-const XFAIL: &[(&str, &str)] = &[
-    // ── SHACL-SPARQL ──────────────────────────────────────────────────────────
-    (
-        "sparql/pre-binding/shapesGraph-001",
-        "$shapesGraph/$currentShape pre-bound variables are unsupported (the \
-         SPARQL dataset carries no shapes graph), so the constraint never fires",
-    ),
-];
+const XFAIL: &[(&str, &str)] = &[];
 
 // ── Test-case model ───────────────────────────────────────────────────────────
 
@@ -129,6 +122,9 @@ struct TestCase {
     section: String,
     shapes_path: PathBuf,
     data_path: PathBuf,
+    /// IRI supplied by `sht:shapesGraph` (often `<>` resolving to the test file),
+    /// used as the named graph for `$shapesGraph` pre-binding in SHACL-SPARQL.
+    shapes_graph_iri: Option<String>,
     expected: Expected,
 }
 
@@ -277,6 +273,11 @@ fn parse_entry(
     let shapes_path = graph_path(sht::SHAPES_GRAPH, "sht:shapesGraph");
     let data_path = graph_path(sht::DATA_GRAPH, "sht:dataGraph");
 
+    let shapes_graph_iri = object(g, &action, sht::SHAPES_GRAPH).and_then(|t| match t {
+        Term::NamedNode(n) => Some(n.as_str().to_owned()),
+        _ => None,
+    });
+
     let result = object(g, entry, mf::RESULT)
         .unwrap_or_else(|| panic!("{id}: sht:Validate entry has no mf:result"));
     let expected = match &result {
@@ -292,6 +293,7 @@ fn parse_entry(
         section,
         shapes_path,
         data_path,
+        shapes_graph_iri,
         expected,
     })
 }
@@ -348,8 +350,14 @@ fn validate_case(tc: &TestCase) -> Result<purrdf_shapes::report::ValidationRepor
     )
     .map_err(|e| format!("shapes graph parse error: {e}"))?;
     let doc_prefixes = purrdf_shapes::text_ingest::extract_prefixes(&shapes_text);
-    let shapes = purrdf_shapes::shapes::from_dataset_with_prefixes(&shapes_dataset, &doc_prefixes)
-        .map_err(|e| format!("shapes parse error: {e}"))?;
+    let shapes_graph_iri = tc.shapes_graph_iri.as_deref();
+    let shapes = purrdf_shapes::shapes::from_dataset_with_config_and_graph(
+        &shapes_dataset,
+        &doc_prefixes,
+        None,
+        shapes_graph_iri.map(ToOwned::to_owned),
+    )
+    .map_err(|e| format!("shapes parse error: {e}"))?;
 
     let data_dataset = if tc.data_path == tc.shapes_path {
         shapes_dataset
@@ -357,8 +365,12 @@ fn validate_case(tc: &TestCase) -> Result<purrdf_shapes::report::ValidationRepor
         parse_turtle_file(&tc.data_path).map_err(|e| format!("data graph parse error: {e}"))?
     };
 
-    purrdf_shapes::engine::validate_dataset(data_dataset.as_ref(), &shapes)
-        .map_err(|e| format!("validation error: {e}"))
+    purrdf_shapes::engine::validate_dataset_with_shapes_graph(
+        data_dataset.as_ref(),
+        &shapes,
+        shapes_graph_iri,
+    )
+    .map_err(|e| format!("validation error: {e}"))
 }
 
 /// Multiset of comparison tuples the engine produced.

--- a/crates/sparql-eval/src/engine.rs
+++ b/crates/sparql-eval/src/engine.rs
@@ -185,6 +185,33 @@ impl NativeSparqlEngine {
         ctx
     }
 
+    /// Evaluate a SPARQL query under SHACL-SPARQL pre-binding semantics.
+    ///
+    /// Pre-bound variables are substituted into FILTER/EXISTS expressions and
+    /// `BOUND($v)` is rewritten to `true` for pre-bound variables, while
+    /// triple-pattern positions still receive the VALUES-join rewrite. This is
+    /// the path used by the SHACL validator for `sh:select` / `sh:ask` bodies;
+    /// normal SPARQL evaluation uses [`SparqlEngine::query`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates parse/evaluation errors as an [`RdfDiagnostic`].
+    pub fn query_with_shacl_prebinding(
+        &self,
+        dataset: &Arc<RdfDataset>,
+        query: &str,
+        base_iri: Option<&str>,
+        substitutions: &[(String, TermValue)],
+    ) -> Result<SparqlResult, RdfDiagnostic> {
+        let prepared =
+            self.cache
+                .borrow_mut()
+                .prepare_with(query, base_iri, &self.parser_options)?;
+        let mut ctx = self.eval_ctx(dataset);
+        let outcome = evaluate_with_shacl_prebinding(&prepared, substitutions, &mut ctx)?;
+        Ok(materialize(outcome, &ctx))
+    }
+
     /// Like [`SparqlEngine::query`], but with a
     /// [`RemoteQuerySource`](crate::remote::RemoteQuerySource) injected so
     /// `SERVICE` clauses resolve through it. Without this, the default
@@ -231,6 +258,17 @@ fn evaluate_with_substitutions(
     let substituted =
         crate::substitute::apply_substitutions(prepared.query.clone(), substitutions)?;
     evaluate_query(&substituted, ctx).map_err(eval_err)
+}
+
+fn evaluate_with_shacl_prebinding(
+    prepared: &PreparedQuery,
+    substitutions: &[(String, TermValue)],
+    ctx: &mut EvalCtx<'_>,
+) -> Result<Outcome, RdfDiagnostic> {
+    let substituted =
+        crate::substitute::apply_shacl_prebinding(prepared.query.clone(), substitutions)?;
+    evaluate_query(&substituted, ctx)
+        .map_err(|e| RdfDiagnostic::error("native-sparql-query-eval", e.to_string()))
 }
 
 impl SparqlEngine for NativeSparqlEngine {
@@ -535,6 +573,77 @@ mod tests {
             )
             .expect("query");
         assert_eq!(col0(all).len(), 3, "the cached parse is unmodified");
+    }
+
+    // ── SHACL-SPARQL pre-binding (Stage 1, issue #13) ─────────────────────────
+
+    /// Run a SELECT query through the SHACL pre-binding path and return the
+    /// sorted first-column debug strings.
+    fn run_shacl_subst(query: &str, substitutions: &[(String, TermValue)]) -> Vec<String> {
+        let ds = subst_ds();
+        let engine = NativeSparqlEngine::new();
+        let result = engine
+            .query_with_shacl_prebinding(&ds, query, None, substitutions)
+            .expect("shacl prebinding query");
+        col0(result)
+    }
+
+    #[test]
+    fn shacl_prebinding_bound_in_filter_only_group() {
+        // SHACL pre-binding-005 shape: a FILTER-only group that checks bound($this).
+        let got = run_shacl_subst(
+            "SELECT ?this WHERE { { FILTER(bound(?this)) } ?this <http://ex/p> ?o }",
+            &[("this".to_owned(), TermValue::Iri("http://ex/a".to_owned()))],
+        );
+        assert_eq!(
+            got.len(),
+            1,
+            "FILTER(bound($this)) must see the pre-bound focus"
+        );
+        assert!(got[0].contains("http://ex/a"), "{got:?}");
+    }
+
+    #[test]
+    fn shacl_prebinding_union_filter_only_branch() {
+        // SHACL pre-binding-002 shape: $this referenced only inside a FILTER-only
+        // UNION branch must be substituted, so the equality test succeeds.
+        let got = run_shacl_subst(
+            "SELECT ?this WHERE { \
+             { FILTER(false) } \
+             UNION \
+             { FILTER(?this = <http://ex/a>) } \
+             }",
+            &[("this".to_owned(), TermValue::Iri("http://ex/a".to_owned()))],
+        );
+        assert_eq!(
+            got.len(),
+            1,
+            "the UNION branch with FILTER($this = :a) must match"
+        );
+        assert!(got[0].contains("http://ex/a"), "{got:?}");
+    }
+
+    #[test]
+    fn shacl_prebinding_does_not_change_normal_query_path() {
+        // The same query on the generic `query` path with no substitutions must
+        // still evaluate normally (here it returns all three :p rows).
+        let q = "SELECT ?this ?o WHERE { ?this <http://ex/p> ?o }";
+        let ds = subst_ds();
+        let engine = NativeSparqlEngine::new();
+        let normal = engine
+            .query(
+                &ds,
+                SparqlRequest {
+                    query: q,
+                    base_iri: None,
+                    substitutions: &[],
+                },
+            )
+            .expect("normal query");
+        let SparqlResult::Solutions { rows, .. } = normal else {
+            panic!("expected solutions");
+        };
+        assert_eq!(rows.len(), 3, "normal path must see all three subjects");
     }
 
     #[test]

--- a/crates/sparql-eval/src/engine.rs
+++ b/crates/sparql-eval/src/engine.rs
@@ -575,7 +575,7 @@ mod tests {
         assert_eq!(col0(all).len(), 3, "the cached parse is unmodified");
     }
 
-    // ── SHACL-SPARQL pre-binding (Stage 1, issue #13) ─────────────────────────
+    // ── SHACL-SPARQL pre-binding (Stage 1) ───────────────────────────────────
 
     /// Run a SELECT query through the SHACL pre-binding path and return the
     /// sorted first-column debug strings.

--- a/crates/sparql-eval/src/substitute.rs
+++ b/crates/sparql-eval/src/substitute.rs
@@ -12,7 +12,7 @@
 //! The substitution is applied to a **clone** of the cached (un-substituted) parse,
 //! so the plan cache is never poisoned by a focus-node-specific binding.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use purrdf_core::{RdfDiagnostic, RdfTextDirection, TermValue};
 use purrdf_sparql_algebra::{
@@ -66,14 +66,12 @@ pub(crate) fn apply_shacl_prebinding(
     let query = apply_substitutions(query, substitutions)?;
 
     let mut expr_subs: HashMap<String, Option<Expression>> = HashMap::new();
-    let mut prebound: HashSet<String> = HashSet::new();
     for (name, value) in substitutions {
-        prebound.insert(name.clone());
         expr_subs.insert(name.clone(), expression_from_term_value(value)?);
     }
 
     Ok(map_patterns_in_query(query, |pattern| {
-        substitute_in_graph_pattern(pattern, &expr_subs, &prebound)
+        substitute_in_graph_pattern(pattern, &expr_subs)
     }))
 }
 
@@ -139,7 +137,6 @@ fn map_patterns_in_query(query: Query, mut f: impl FnMut(GraphPattern) -> GraphP
 fn substitute_in_graph_pattern(
     pattern: GraphPattern,
     expr_subs: &HashMap<String, Option<Expression>>,
-    prebound: &HashSet<String>,
 ) -> GraphPattern {
     match pattern {
         GraphPattern::Bgp { patterns } => GraphPattern::Bgp { patterns },
@@ -153,54 +150,54 @@ fn substitute_in_graph_pattern(
             object,
         },
         GraphPattern::Join { left, right } => GraphPattern::Join {
-            left: Box::new(substitute_in_graph_pattern(*left, expr_subs, prebound)),
-            right: Box::new(substitute_in_graph_pattern(*right, expr_subs, prebound)),
+            left: Box::new(substitute_in_graph_pattern(*left, expr_subs)),
+            right: Box::new(substitute_in_graph_pattern(*right, expr_subs)),
         },
         GraphPattern::LeftJoin {
             left,
             right,
             expression,
         } => GraphPattern::LeftJoin {
-            left: Box::new(substitute_in_graph_pattern(*left, expr_subs, prebound)),
-            right: Box::new(substitute_in_graph_pattern(*right, expr_subs, prebound)),
-            expression: expression.map(|e| substitute_in_expression(e, expr_subs, prebound)),
+            left: Box::new(substitute_in_graph_pattern(*left, expr_subs)),
+            right: Box::new(substitute_in_graph_pattern(*right, expr_subs)),
+            expression: expression.map(|e| substitute_in_expression(e, expr_subs)),
         },
         GraphPattern::Lateral { left, right } => GraphPattern::Lateral {
-            left: Box::new(substitute_in_graph_pattern(*left, expr_subs, prebound)),
-            right: Box::new(substitute_in_graph_pattern(*right, expr_subs, prebound)),
+            left: Box::new(substitute_in_graph_pattern(*left, expr_subs)),
+            right: Box::new(substitute_in_graph_pattern(*right, expr_subs)),
         },
         GraphPattern::Filter { expr, inner } => GraphPattern::Filter {
-            expr: substitute_in_expression(expr, expr_subs, prebound),
-            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            expr: substitute_in_expression(expr, expr_subs),
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs)),
         },
         GraphPattern::Union { left, right } => GraphPattern::Union {
-            left: Box::new(substitute_in_graph_pattern(*left, expr_subs, prebound)),
-            right: Box::new(substitute_in_graph_pattern(*right, expr_subs, prebound)),
+            left: Box::new(substitute_in_graph_pattern(*left, expr_subs)),
+            right: Box::new(substitute_in_graph_pattern(*right, expr_subs)),
         },
         GraphPattern::Graph { name, inner } => GraphPattern::Graph {
-            name: substitute_in_named_node_pattern(name, expr_subs, prebound),
-            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            name: substitute_in_named_node_pattern(name, expr_subs),
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs)),
         },
         GraphPattern::Extend {
             inner,
             variable,
             expression,
         } => GraphPattern::Extend {
-            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs)),
             variable,
-            expression: substitute_in_expression(expression, expr_subs, prebound),
+            expression: substitute_in_expression(expression, expr_subs),
         },
         GraphPattern::Minus { left, right } => GraphPattern::Minus {
-            left: Box::new(substitute_in_graph_pattern(*left, expr_subs, prebound)),
-            right: Box::new(substitute_in_graph_pattern(*right, expr_subs, prebound)),
+            left: Box::new(substitute_in_graph_pattern(*left, expr_subs)),
+            right: Box::new(substitute_in_graph_pattern(*right, expr_subs)),
         },
         GraphPattern::Service {
             name,
             inner,
             silent,
         } => GraphPattern::Service {
-            name: substitute_in_named_node_pattern(name, expr_subs, prebound),
-            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            name: substitute_in_named_node_pattern(name, expr_subs),
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs)),
             silent,
         },
         GraphPattern::Values {
@@ -211,28 +208,28 @@ fn substitute_in_graph_pattern(
             bindings,
         },
         GraphPattern::OrderBy { inner, expression } => GraphPattern::OrderBy {
-            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs)),
             expression: expression
                 .into_iter()
-                .map(|e| substitute_in_order_expression(e, expr_subs, prebound))
+                .map(|e| substitute_in_order_expression(e, expr_subs))
                 .collect(),
         },
         GraphPattern::Project { inner, variables } => GraphPattern::Project {
-            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs)),
             variables,
         },
         GraphPattern::Distinct { inner } => GraphPattern::Distinct {
-            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs)),
         },
         GraphPattern::Reduced { inner } => GraphPattern::Reduced {
-            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs)),
         },
         GraphPattern::Slice {
             inner,
             start,
             length,
         } => GraphPattern::Slice {
-            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs)),
             start,
             length,
         },
@@ -241,11 +238,11 @@ fn substitute_in_graph_pattern(
             variables,
             aggregates,
         } => GraphPattern::Group {
-            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs)),
             variables,
             aggregates: aggregates
                 .into_iter()
-                .map(|(var, agg)| (var, substitute_in_aggregate(agg, expr_subs, prebound)))
+                .map(|(var, agg)| (var, substitute_in_aggregate(agg, expr_subs)))
                 .collect(),
         },
     }
@@ -255,12 +252,11 @@ fn substitute_in_graph_pattern(
 fn substitute_in_named_node_pattern(
     pattern: NamedNodePattern,
     expr_subs: &HashMap<String, Option<Expression>>,
-    prebound: &HashSet<String>,
 ) -> NamedNodePattern {
     match pattern {
         NamedNodePattern::Variable(var) => {
             let name = var.as_str();
-            if prebound.contains(name) {
+            if expr_subs.contains_key(name) {
                 if let Some(Some(Expression::NamedNode(node))) = expr_subs.get(name) {
                     return NamedNodePattern::NamedNode(node.clone());
                 }
@@ -275,7 +271,6 @@ fn substitute_in_named_node_pattern(
 fn substitute_in_expression(
     expr: Expression,
     expr_subs: &HashMap<String, Option<Expression>>,
-    prebound: &HashSet<String>,
 ) -> Expression {
     match expr {
         Expression::Variable(var) => {
@@ -288,7 +283,7 @@ fn substitute_in_expression(
         }
         Expression::Bound(var) => {
             let name = var.as_str();
-            if prebound.contains(name) {
+            if expr_subs.contains_key(name) {
                 true_literal()
             } else {
                 Expression::Bound(var)
@@ -297,87 +292,87 @@ fn substitute_in_expression(
         Expression::NamedNode(node) => Expression::NamedNode(node),
         Expression::Literal(lit) => Expression::Literal(lit),
         Expression::Or(left, right) => Expression::Or(
-            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
-            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*left, expr_subs)),
+            Box::new(substitute_in_expression(*right, expr_subs)),
         ),
         Expression::And(left, right) => Expression::And(
-            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
-            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*left, expr_subs)),
+            Box::new(substitute_in_expression(*right, expr_subs)),
         ),
         Expression::Equal(left, right) => Expression::Equal(
-            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
-            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*left, expr_subs)),
+            Box::new(substitute_in_expression(*right, expr_subs)),
         ),
         Expression::SameTerm(left, right) => Expression::SameTerm(
-            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
-            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*left, expr_subs)),
+            Box::new(substitute_in_expression(*right, expr_subs)),
         ),
         Expression::Greater(left, right) => Expression::Greater(
-            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
-            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*left, expr_subs)),
+            Box::new(substitute_in_expression(*right, expr_subs)),
         ),
         Expression::GreaterOrEqual(left, right) => Expression::GreaterOrEqual(
-            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
-            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*left, expr_subs)),
+            Box::new(substitute_in_expression(*right, expr_subs)),
         ),
         Expression::Less(left, right) => Expression::Less(
-            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
-            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*left, expr_subs)),
+            Box::new(substitute_in_expression(*right, expr_subs)),
         ),
         Expression::LessOrEqual(left, right) => Expression::LessOrEqual(
-            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
-            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*left, expr_subs)),
+            Box::new(substitute_in_expression(*right, expr_subs)),
         ),
         Expression::Add(left, right) => Expression::Add(
-            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
-            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*left, expr_subs)),
+            Box::new(substitute_in_expression(*right, expr_subs)),
         ),
         Expression::Subtract(left, right) => Expression::Subtract(
-            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
-            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*left, expr_subs)),
+            Box::new(substitute_in_expression(*right, expr_subs)),
         ),
         Expression::Multiply(left, right) => Expression::Multiply(
-            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
-            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*left, expr_subs)),
+            Box::new(substitute_in_expression(*right, expr_subs)),
         ),
         Expression::Divide(left, right) => Expression::Divide(
-            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
-            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*left, expr_subs)),
+            Box::new(substitute_in_expression(*right, expr_subs)),
         ),
-        Expression::UnaryPlus(inner) => Expression::UnaryPlus(Box::new(substitute_in_expression(
-            *inner, expr_subs, prebound,
-        ))),
-        Expression::UnaryMinus(inner) => Expression::UnaryMinus(Box::new(
-            substitute_in_expression(*inner, expr_subs, prebound),
-        )),
-        Expression::Not(inner) => Expression::Not(Box::new(substitute_in_expression(
-            *inner, expr_subs, prebound,
-        ))),
+        Expression::UnaryPlus(inner) => {
+            Expression::UnaryPlus(Box::new(substitute_in_expression(*inner, expr_subs)))
+        }
+        Expression::UnaryMinus(inner) => {
+            Expression::UnaryMinus(Box::new(substitute_in_expression(*inner, expr_subs)))
+        }
+        Expression::Not(inner) => {
+            Expression::Not(Box::new(substitute_in_expression(*inner, expr_subs)))
+        }
         Expression::In(target, list) => Expression::In(
-            Box::new(substitute_in_expression(*target, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*target, expr_subs)),
             list.into_iter()
-                .map(|e| substitute_in_expression(e, expr_subs, prebound))
+                .map(|e| substitute_in_expression(e, expr_subs))
                 .collect(),
         ),
         Expression::If(cond, then_expr, else_expr) => Expression::If(
-            Box::new(substitute_in_expression(*cond, expr_subs, prebound)),
-            Box::new(substitute_in_expression(*then_expr, expr_subs, prebound)),
-            Box::new(substitute_in_expression(*else_expr, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*cond, expr_subs)),
+            Box::new(substitute_in_expression(*then_expr, expr_subs)),
+            Box::new(substitute_in_expression(*else_expr, expr_subs)),
         ),
         Expression::Coalesce(list) => Expression::Coalesce(
             list.into_iter()
-                .map(|e| substitute_in_expression(e, expr_subs, prebound))
+                .map(|e| substitute_in_expression(e, expr_subs))
                 .collect(),
         ),
         Expression::FunctionCall(function, args) => Expression::FunctionCall(
             function,
             args.into_iter()
-                .map(|e| substitute_in_expression(e, expr_subs, prebound))
+                .map(|e| substitute_in_expression(e, expr_subs))
                 .collect(),
         ),
-        Expression::Exists(inner) => Expression::Exists(Box::new(substitute_in_graph_pattern(
-            *inner, expr_subs, prebound,
-        ))),
+        Expression::Exists(inner) => {
+            Expression::Exists(Box::new(substitute_in_graph_pattern(*inner, expr_subs)))
+        }
     }
 }
 
@@ -385,14 +380,13 @@ fn substitute_in_expression(
 fn substitute_in_order_expression(
     order: OrderExpression,
     expr_subs: &HashMap<String, Option<Expression>>,
-    prebound: &HashSet<String>,
 ) -> OrderExpression {
     match order {
         OrderExpression::Asc(expr) => {
-            OrderExpression::Asc(substitute_in_expression(expr, expr_subs, prebound))
+            OrderExpression::Asc(substitute_in_expression(expr, expr_subs))
         }
         OrderExpression::Desc(expr) => {
-            OrderExpression::Desc(substitute_in_expression(expr, expr_subs, prebound))
+            OrderExpression::Desc(substitute_in_expression(expr, expr_subs))
         }
     }
 }
@@ -401,7 +395,6 @@ fn substitute_in_order_expression(
 fn substitute_in_aggregate(
     agg: AggregateExpression,
     expr_subs: &HashMap<String, Option<Expression>>,
-    prebound: &HashSet<String>,
 ) -> AggregateExpression {
     match agg {
         AggregateExpression::CountStar { distinct } => AggregateExpression::CountStar { distinct },
@@ -411,7 +404,7 @@ fn substitute_in_aggregate(
             distinct,
         } => AggregateExpression::FunctionCall {
             function,
-            expression: Box::new(substitute_in_expression(*expression, expr_subs, prebound)),
+            expression: Box::new(substitute_in_expression(*expression, expr_subs)),
             distinct,
         },
     }

--- a/crates/sparql-eval/src/substitute.rs
+++ b/crates/sparql-eval/src/substitute.rs
@@ -12,9 +12,12 @@
 //! The substitution is applied to a **clone** of the cached (un-substituted) parse,
 //! so the plan cache is never poisoned by a focus-node-specific binding.
 
+use std::collections::{HashMap, HashSet};
+
 use purrdf_core::{RdfDiagnostic, RdfTextDirection, TermValue};
 use purrdf_sparql_algebra::{
-    BaseDirection, BlankNode, GroundTerm, GroundTriple, Literal, NamedNode, Query, Variable,
+    AggregateExpression, BaseDirection, BlankNode, Expression, GraphPattern, GroundTerm,
+    GroundTriple, Literal, NamedNode, NamedNodePattern, OrderExpression, Query, Variable,
 };
 
 /// Apply every `(name, value)` substitution to `query` as a pre-binding rewrite,
@@ -39,6 +42,387 @@ pub(crate) fn apply_substitutions(
         query = query.substitute_variable(&var, ground);
     }
     Ok(query)
+}
+
+/// Apply SHACL-SPARQL pre-binding to `query`.
+///
+/// First performs the ordinary VALUES-join rewrite via [`apply_substitutions`]
+/// (so triple-pattern positions and projectable variables work exactly like the
+/// generic pre-binding path). Then walks the algebra and, for every pre-bound
+/// variable whose value is an IRI or literal:
+///
+/// * replaces `Expression::Variable(v)` with the constant IRI/literal,
+/// * replaces `Expression::Bound(v)` with the `true` boolean literal,
+///
+/// recursing into nested graph patterns (`EXISTS`, `GRAPH`, sub-queries, etc.).
+/// Blank-node and quoted-triple values are deliberately left unsubstituted in
+/// expression positions; the VALUES-join binds them.
+///
+/// Returns a diagnostic on the same error conditions as [`apply_substitutions`].
+pub(crate) fn apply_shacl_prebinding(
+    query: Query,
+    substitutions: &[(String, TermValue)],
+) -> Result<Query, RdfDiagnostic> {
+    let query = apply_substitutions(query, substitutions)?;
+
+    let mut expr_subs: HashMap<String, Option<Expression>> = HashMap::new();
+    let mut prebound: HashSet<String> = HashSet::new();
+    for (name, value) in substitutions {
+        prebound.insert(name.clone());
+        expr_subs.insert(name.clone(), expression_from_term_value(value)?);
+    }
+
+    Ok(map_patterns_in_query(query, |pattern| {
+        substitute_in_graph_pattern(pattern, &expr_subs, &prebound)
+    }))
+}
+
+/// Convert a dataset-independent [`TermValue`] to an [`Expression`] when it is an
+/// IRI or literal; return `None` for blank nodes or quoted triples, which must be
+/// handled via the VALUES-join path.
+fn expression_from_term_value(value: &TermValue) -> Result<Option<Expression>, RdfDiagnostic> {
+    match ground_term_from_value(value)? {
+        GroundTerm::NamedNode(node) => Ok(Some(Expression::NamedNode(node))),
+        GroundTerm::Literal(lit) => Ok(Some(Expression::Literal(lit))),
+        GroundTerm::BlankNode(_) | GroundTerm::Triple(_) => Ok(None),
+    }
+}
+
+/// Walk and rebuild the whole [`Query`], applying `f` to every [`GraphPattern`]
+/// contained in it (including sub-queries).
+fn map_patterns_in_query(query: Query, mut f: impl FnMut(GraphPattern) -> GraphPattern) -> Query {
+    match query {
+        Query::Select {
+            pattern,
+            dataset,
+            base_iri,
+        } => Query::Select {
+            pattern: f(pattern),
+            dataset,
+            base_iri,
+        },
+        Query::Construct {
+            template,
+            pattern,
+            dataset,
+            base_iri,
+        } => Query::Construct {
+            template,
+            pattern: f(pattern),
+            dataset,
+            base_iri,
+        },
+        Query::Describe {
+            pattern,
+            targets,
+            dataset,
+            base_iri,
+        } => Query::Describe {
+            pattern: f(pattern),
+            targets,
+            dataset,
+            base_iri,
+        },
+        Query::Ask {
+            pattern,
+            dataset,
+            base_iri,
+        } => Query::Ask {
+            pattern: f(pattern),
+            dataset,
+            base_iri,
+        },
+    }
+}
+
+/// Recursively substitute pre-bound variables into a [`GraphPattern`].
+fn substitute_in_graph_pattern(
+    pattern: GraphPattern,
+    expr_subs: &HashMap<String, Option<Expression>>,
+    prebound: &HashSet<String>,
+) -> GraphPattern {
+    match pattern {
+        GraphPattern::Bgp { patterns } => GraphPattern::Bgp { patterns },
+        GraphPattern::Path {
+            subject,
+            path,
+            object,
+        } => GraphPattern::Path {
+            subject,
+            path,
+            object,
+        },
+        GraphPattern::Join { left, right } => GraphPattern::Join {
+            left: Box::new(substitute_in_graph_pattern(*left, expr_subs, prebound)),
+            right: Box::new(substitute_in_graph_pattern(*right, expr_subs, prebound)),
+        },
+        GraphPattern::LeftJoin {
+            left,
+            right,
+            expression,
+        } => GraphPattern::LeftJoin {
+            left: Box::new(substitute_in_graph_pattern(*left, expr_subs, prebound)),
+            right: Box::new(substitute_in_graph_pattern(*right, expr_subs, prebound)),
+            expression: expression.map(|e| substitute_in_expression(e, expr_subs, prebound)),
+        },
+        GraphPattern::Lateral { left, right } => GraphPattern::Lateral {
+            left: Box::new(substitute_in_graph_pattern(*left, expr_subs, prebound)),
+            right: Box::new(substitute_in_graph_pattern(*right, expr_subs, prebound)),
+        },
+        GraphPattern::Filter { expr, inner } => GraphPattern::Filter {
+            expr: substitute_in_expression(expr, expr_subs, prebound),
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+        },
+        GraphPattern::Union { left, right } => GraphPattern::Union {
+            left: Box::new(substitute_in_graph_pattern(*left, expr_subs, prebound)),
+            right: Box::new(substitute_in_graph_pattern(*right, expr_subs, prebound)),
+        },
+        GraphPattern::Graph { name, inner } => GraphPattern::Graph {
+            name: substitute_in_named_node_pattern(name, expr_subs, prebound),
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+        },
+        GraphPattern::Extend {
+            inner,
+            variable,
+            expression,
+        } => GraphPattern::Extend {
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            variable,
+            expression: substitute_in_expression(expression, expr_subs, prebound),
+        },
+        GraphPattern::Minus { left, right } => GraphPattern::Minus {
+            left: Box::new(substitute_in_graph_pattern(*left, expr_subs, prebound)),
+            right: Box::new(substitute_in_graph_pattern(*right, expr_subs, prebound)),
+        },
+        GraphPattern::Service {
+            name,
+            inner,
+            silent,
+        } => GraphPattern::Service {
+            name: substitute_in_named_node_pattern(name, expr_subs, prebound),
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            silent,
+        },
+        GraphPattern::Values {
+            variables,
+            bindings,
+        } => GraphPattern::Values {
+            variables,
+            bindings,
+        },
+        GraphPattern::OrderBy { inner, expression } => GraphPattern::OrderBy {
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            expression: expression
+                .into_iter()
+                .map(|e| substitute_in_order_expression(e, expr_subs, prebound))
+                .collect(),
+        },
+        GraphPattern::Project { inner, variables } => GraphPattern::Project {
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            variables,
+        },
+        GraphPattern::Distinct { inner } => GraphPattern::Distinct {
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+        },
+        GraphPattern::Reduced { inner } => GraphPattern::Reduced {
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+        },
+        GraphPattern::Slice {
+            inner,
+            start,
+            length,
+        } => GraphPattern::Slice {
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            start,
+            length,
+        },
+        GraphPattern::Group {
+            inner,
+            variables,
+            aggregates,
+        } => GraphPattern::Group {
+            inner: Box::new(substitute_in_graph_pattern(*inner, expr_subs, prebound)),
+            variables,
+            aggregates: aggregates
+                .into_iter()
+                .map(|(var, agg)| (var, substitute_in_aggregate(agg, expr_subs, prebound)))
+                .collect(),
+        },
+    }
+}
+
+/// Replace a pre-bound variable in a `GRAPH`/`SERVICE` name with its IRI constant.
+fn substitute_in_named_node_pattern(
+    pattern: NamedNodePattern,
+    expr_subs: &HashMap<String, Option<Expression>>,
+    prebound: &HashSet<String>,
+) -> NamedNodePattern {
+    match pattern {
+        NamedNodePattern::Variable(var) => {
+            let name = var.as_str();
+            if prebound.contains(name) {
+                if let Some(Some(Expression::NamedNode(node))) = expr_subs.get(name) {
+                    return NamedNodePattern::NamedNode(node.clone());
+                }
+            }
+            NamedNodePattern::Variable(var)
+        }
+        named @ NamedNodePattern::NamedNode(_) => named,
+    }
+}
+
+/// Recursively substitute pre-bound variables into an [`Expression`].
+fn substitute_in_expression(
+    expr: Expression,
+    expr_subs: &HashMap<String, Option<Expression>>,
+    prebound: &HashSet<String>,
+) -> Expression {
+    match expr {
+        Expression::Variable(var) => {
+            let name = var.as_str();
+            if let Some(Some(subst)) = expr_subs.get(name) {
+                subst.clone()
+            } else {
+                Expression::Variable(var)
+            }
+        }
+        Expression::Bound(var) => {
+            let name = var.as_str();
+            if prebound.contains(name) {
+                true_literal()
+            } else {
+                Expression::Bound(var)
+            }
+        }
+        Expression::NamedNode(node) => Expression::NamedNode(node),
+        Expression::Literal(lit) => Expression::Literal(lit),
+        Expression::Or(left, right) => Expression::Or(
+            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+        ),
+        Expression::And(left, right) => Expression::And(
+            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+        ),
+        Expression::Equal(left, right) => Expression::Equal(
+            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+        ),
+        Expression::SameTerm(left, right) => Expression::SameTerm(
+            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+        ),
+        Expression::Greater(left, right) => Expression::Greater(
+            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+        ),
+        Expression::GreaterOrEqual(left, right) => Expression::GreaterOrEqual(
+            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+        ),
+        Expression::Less(left, right) => Expression::Less(
+            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+        ),
+        Expression::LessOrEqual(left, right) => Expression::LessOrEqual(
+            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+        ),
+        Expression::Add(left, right) => Expression::Add(
+            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+        ),
+        Expression::Subtract(left, right) => Expression::Subtract(
+            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+        ),
+        Expression::Multiply(left, right) => Expression::Multiply(
+            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+        ),
+        Expression::Divide(left, right) => Expression::Divide(
+            Box::new(substitute_in_expression(*left, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*right, expr_subs, prebound)),
+        ),
+        Expression::UnaryPlus(inner) => Expression::UnaryPlus(Box::new(substitute_in_expression(
+            *inner, expr_subs, prebound,
+        ))),
+        Expression::UnaryMinus(inner) => Expression::UnaryMinus(Box::new(
+            substitute_in_expression(*inner, expr_subs, prebound),
+        )),
+        Expression::Not(inner) => Expression::Not(Box::new(substitute_in_expression(
+            *inner, expr_subs, prebound,
+        ))),
+        Expression::In(target, list) => Expression::In(
+            Box::new(substitute_in_expression(*target, expr_subs, prebound)),
+            list.into_iter()
+                .map(|e| substitute_in_expression(e, expr_subs, prebound))
+                .collect(),
+        ),
+        Expression::If(cond, then_expr, else_expr) => Expression::If(
+            Box::new(substitute_in_expression(*cond, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*then_expr, expr_subs, prebound)),
+            Box::new(substitute_in_expression(*else_expr, expr_subs, prebound)),
+        ),
+        Expression::Coalesce(list) => Expression::Coalesce(
+            list.into_iter()
+                .map(|e| substitute_in_expression(e, expr_subs, prebound))
+                .collect(),
+        ),
+        Expression::FunctionCall(function, args) => Expression::FunctionCall(
+            function,
+            args.into_iter()
+                .map(|e| substitute_in_expression(e, expr_subs, prebound))
+                .collect(),
+        ),
+        Expression::Exists(inner) => Expression::Exists(Box::new(substitute_in_graph_pattern(
+            *inner, expr_subs, prebound,
+        ))),
+    }
+}
+
+/// Substitute inside an [`OrderExpression`] sort key.
+fn substitute_in_order_expression(
+    order: OrderExpression,
+    expr_subs: &HashMap<String, Option<Expression>>,
+    prebound: &HashSet<String>,
+) -> OrderExpression {
+    match order {
+        OrderExpression::Asc(expr) => {
+            OrderExpression::Asc(substitute_in_expression(expr, expr_subs, prebound))
+        }
+        OrderExpression::Desc(expr) => {
+            OrderExpression::Desc(substitute_in_expression(expr, expr_subs, prebound))
+        }
+    }
+}
+
+/// Substitute inside a [`GROUP BY`][`AggregateExpression`] aggregate.
+fn substitute_in_aggregate(
+    agg: AggregateExpression,
+    expr_subs: &HashMap<String, Option<Expression>>,
+    prebound: &HashSet<String>,
+) -> AggregateExpression {
+    match agg {
+        AggregateExpression::CountStar { distinct } => AggregateExpression::CountStar { distinct },
+        AggregateExpression::FunctionCall {
+            function,
+            expression,
+            distinct,
+        } => AggregateExpression::FunctionCall {
+            function,
+            expression: Box::new(substitute_in_expression(*expression, expr_subs, prebound)),
+            distinct,
+        },
+    }
+}
+
+/// The SPARQL `true` boolean literal (`"true"^^xsd:boolean`).
+fn true_literal() -> Expression {
+    Expression::Literal(Literal::new_typed(
+        "true",
+        NamedNode::new_unchecked("http://www.w3.org/2001/XMLSchema#boolean"),
+    ))
 }
 
 /// Convert a dataset-independent [`TermValue`] to the algebra's [`GroundTerm`].


### PR DESCRIPTION
Closes #13

## Summary
Implements SHACL-SPARQL pre-binding as substitution semantics and exposes the shapes graph via `$shapesGraph` / `$currentShape`.

## Changes
- Add `NativeSparqlEngine::query_with_shacl_prebinding` and `apply_shacl_prebinding` in `purrdf-sparql-eval`, which rewrite pre-bound IRI/literal variables into FILTER/EXISTS expressions and `BOUND($v)` to `true`, while keeping the VALUES-join rewrite for triple-pattern positions.
- Carry the original shapes dataset and graph IRI in `Shapes::shapes_dataset` / `Shapes::shapes_graph`; add `from_dataset_with_config_and_graph`.
- Add `IrDataGraphWithShapes`, `build_sparql_dataset`, and `validate_dataset_with_shapes_graph` so SHACL-SPARQL sees data in the default graph and shapes in a named graph.
- Pre-bind `$this`, `$shapesGraph`, and `$currentShape` in `eval_sparql_constraint` and custom component validators.
- Wire the W3C SHACL conformance harness to capture `sht:shapesGraph` and use the shapes-graph-aware entry point.
- Clear the W3C SHACL XFAIL ledger: all 120 tests now pass.
- Fix a one-line issue-ref lint violation.

## Verification
- `make check` green
- `make test` green
- `make metadata` green
- `make wasm` green
- W3C SHACL conformance: 120 passed, 0 xfailed
