### PR TITLE
feat: close public-maturity epic (#10)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,11 @@ jobs:
 
   benchmarks:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 120
+    continue-on-error: true
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -131,6 +135,11 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Compile benchmark harnesses
         run: |
           cargo bench -p purrdf-gts --no-run --locked
@@ -139,6 +148,31 @@ jobs:
           cargo bench -p purrdf-sparql-eval --no-run --locked
           cargo bench -p purrdf-shapes --bench validate --no-run --locked
           cargo bench -p purrdf-entail --no-run --locked
+
+      - name: Run native criterion suites
+        run: |
+          cargo bench -p purrdf-gts --locked
+          cargo bench -p purrdf-core --locked
+          cargo bench -p purrdf-rdf --bench native_codecs --locked
+          cargo bench -p purrdf-sparql-eval --locked
+          cargo bench -p purrdf-shapes --bench validate --locked
+          cargo bench -p purrdf-entail --locked
+
+      - name: Run Python compat harness
+        working-directory: bindings/python
+        run: |
+          uv run maturin develop
+          uv run python benchmarks/bench_compat.py --json bench_compat.json
+
+      - name: Upload benchmark artifacts
+        if: success() || failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: benchmark-results
+          path: |
+            target/criterion/
+            bindings/python/bench_compat.json
+          if-no-files-found: warn
 
   # The Python binding gate — separate from the Rust `workspace`/`test` jobs above
   # (AGENTS.md §3: `make check` stays a pure-Rust gate). Builds the native module

--- a/crates/rdf-core/src/loss.rs
+++ b/crates/rdf-core/src/loss.rs
@@ -18,7 +18,7 @@
 /// In-band machine code: a `CONSTRUCT` whose `WHERE` bound an RDF-1.2 reifier (via
 /// an `rdf:reifies` triple pattern) but whose template drops that reifier — the
 /// reification layer is lost at the projection. Declared in-band on the output
-/// graph (a `logic:ProjectionLoss` node), NOT in this compile-time ledger.
+/// graph (a caller-configured `ProjectionLoss` node), NOT in this compile-time ledger.
 pub const LOSS_REIFIER_LAYER_DROPPED: &str = "reifier-layer-dropped";
 
 /// In-band machine code: a dropped reifier (see [`LOSS_REIFIER_LAYER_DROPPED`])
@@ -28,8 +28,8 @@ pub const LOSS_ANNOTATION_LAYER_DROPPED: &str = "annotation-layer-dropped";
 
 /// In-band machine code: a dropped, annotated reifier (see
 /// [`LOSS_ANNOTATION_LAYER_DROPPED`]) where one of the dropped annotation
-/// predicates was `purrdf:accordingTo` — the standpoint scope is lost. Emitted in
-/// addition to the annotation-layer code, never alone.
+/// predicates was the caller-configured standpoint `accordingTo` predicate — the
+/// standpoint scope is lost. Emitted in addition to the annotation-layer code, never alone.
 pub const LOSS_STANDPOINT_SCOPE_DROPPED: &str = "standpoint-scope-dropped";
 
 /// One enumerated, intentional conversion loss between two representations.

--- a/crates/sparql-conformance/src/compare.rs
+++ b/crates/sparql-conformance/src/compare.rs
@@ -55,6 +55,68 @@ pub fn compare(case: &SparqlTestCase, outcome: &RunOutcome) -> Result<(), String
     }
 }
 
+/// Compare two SPARQL results for equality.
+///
+/// `SELECT` solutions are compared as a multiset when `ordered` is `false` and as an
+/// ordered sequence when `ordered` is `true`. `ASK` booleans are compared directly.
+/// `CONSTRUCT`/`DESCRIBE` graphs are compared by RDFC-1.0 canonical N-Quads.
+///
+/// # Errors
+///
+/// Returns a human-readable mismatch description; `Ok(())` means the results are
+/// equal under the chosen comparison.
+pub fn compare_results(
+    left: &SparqlResult,
+    right: &SparqlResult,
+    ordered: bool,
+) -> Result<(), String> {
+    match (left, right) {
+        (SparqlResult::Boolean(l), SparqlResult::Boolean(r)) if l == r => Ok(()),
+        (SparqlResult::Boolean(l), SparqlResult::Boolean(r)) => {
+            Err(format!("ASK mismatch: {l} vs {r}"))
+        }
+        (
+            SparqlResult::Solutions {
+                variables: l_vars,
+                rows: l_rows,
+                ..
+            },
+            SparqlResult::Solutions {
+                variables: r_vars,
+                rows: r_rows,
+                ..
+            },
+        ) => {
+            if l_vars != r_vars {
+                return Err(format!("variable lists differ: {l_vars:?} vs {r_vars:?}"));
+            }
+            compare_solutions(
+                l_vars,
+                l_rows,
+                &ParsedSolutions {
+                    variables: r_vars.clone(),
+                    rows: r_rows.clone(),
+                },
+                ordered,
+            )
+        }
+        (SparqlResult::Graph(l), SparqlResult::Graph(r)) => {
+            let l_canon = purrdf_core::canonicalize(l).nquads;
+            let r_canon = purrdf_core::canonicalize(r).nquads;
+            if l_canon == r_canon {
+                Ok(())
+            } else {
+                Err("graph results differ (canonical N-Quads mismatch)".to_owned())
+            }
+        }
+        (l, r) => Err(format!(
+            "result kind mismatch: {} vs {}",
+            result_kind(l),
+            result_kind(r)
+        )),
+    }
+}
+
 /// Compare an UPDATE post-state dataset against the expected [`ExpectedResult::DatasetState`].
 ///
 /// The mutated dataset and the expected dataset are compared graph-preservingly

--- a/crates/sparql-conformance/src/run.rs
+++ b/crates/sparql-conformance/src/run.rs
@@ -9,7 +9,7 @@ use purrdf::{serialize_dataset, SerializeGraph};
 use purrdf_core::{RdfDataset, SparqlEngine, SparqlRequest, SparqlResult};
 use purrdf_sparql_algebra::{GraphPattern, Query, SparqlParser};
 use purrdf_sparql_eval::{
-    NativeSparqlEngine, ParserOptions, RemoteQuerySource, StandpointPredicates,
+    LossVocabulary, NativeSparqlEngine, ParserOptions, RemoteQuerySource, StandpointPredicates,
 };
 
 use crate::manifest::{SparqlTestCase, TestKind};
@@ -21,6 +21,10 @@ pub(crate) const BASE: &str = "http://purrdf.test/manifest/";
 /// configuration (a neutral example.org name), exactly as a real deployment
 /// supplies its own ontology namespace.
 const EXT_NS: &str = "https://example.org/ext/";
+
+/// The loss-declaration namespace used by the first-party loss-aware CONSTRUCT
+/// cases. Like `EXT_NS`, this is harness configuration, not an engine constant.
+const LOSS_NS: &str = "https://example.org/ext/loss/";
 
 /// The outcome of running a case (before comparison against the expected result).
 #[derive(Debug)]
@@ -248,6 +252,11 @@ pub fn run(
                 .with_standpoint_predicates(StandpointPredicates::new(
                     format!("{EXT_NS}accordingTo"),
                     format!("{EXT_NS}sharpens"),
+                ))
+                .with_loss_vocabulary(LossVocabulary::new(
+                    format!("{LOSS_NS}ProjectionLoss"),
+                    format!("{LOSS_NS}lossCode"),
+                    format!("{LOSS_NS}lostReifies"),
                 ));
             let request = SparqlRequest {
                 query: &query_text,

--- a/crates/sparql-conformance/suite/purrdf-extend/loss-control.ttl
+++ b/crates/sparql-conformance/suite/purrdf-extend/loss-control.ttl
@@ -3,7 +3,7 @@
 #
 # The no-loss control: the template carries the reifier `?r` (and the triple term
 # as a quoted-triple object under a plain `ex:asserts` predicate), so the reifier
-# layer is NOT dropped and NO `logic:ProjectionLoss` triple is emitted. The output
+# layer is NOT dropped and NO `ext:ProjectionLoss` triple is emitted. The output
 # is exactly the one re-projected quad.
 @prefix ex:  <http://ex/> .
 

--- a/crates/sparql-conformance/suite/purrdf-extend/loss-lossy.ttl
+++ b/crates/sparql-conformance/suite/purrdf-extend/loss-lossy.ttl
@@ -3,16 +3,16 @@
 #
 # Expected graph for the loss-aware CONSTRUCT. The template kept only the inner
 # triple `ex:alice ex:age 42`, dropping the reifier `ex:r1`, so the engine emits
-# an in-band `logic:ProjectionLoss` declaration recording the dropped reifier
+# an in-band `ext:ProjectionLoss` declaration recording the dropped reifier
 # layer. The loss node is a deterministic content-derived blank node; canonical
 # N-Quads comparison relabels blanks, so any blank label here is fine.
 @prefix ex:    <http://ex/> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
-@prefix logic: <https://blackcatinformatics.ca/logic/> .
+@prefix ext:   <https://example.org/ext/loss/> .
 
 ex:alice ex:age 42 .
 
-_:loss a logic:ProjectionLoss ;
-       logic:lossCode "reifier-layer-dropped"^^xsd:string ;
-       logic:lostReifies <<( ex:alice ex:age 42 )>> .
+_:loss a ext:ProjectionLoss ;
+       ext:lossCode "reifier-layer-dropped"^^xsd:string ;
+       ext:lostReifies <<( ex:alice ex:age 42 )>> .

--- a/crates/sparql-conformance/suite/purrdf-extend/manifest.ttl
+++ b/crates/sparql-conformance/suite/purrdf-extend/manifest.ttl
@@ -10,7 +10,7 @@
 #   3. annotation querying   — bind a reifier's annotation value
 #   4. standpoint poset      — ext:heldIn is poset-aware (held / not-held controls)
 #   5. loss-aware CONSTRUCT   — dropping the reifier layer emits an in-band
-#                               logic:ProjectionLoss declaration (+ no-loss control)
+#                               ext:ProjectionLoss declaration (+ no-loss control)
 #   6. world × standpoint     — a named-graph world triple joins a standpoint-held
 #                               reifier, proving both scoping axes in one query
 #
@@ -64,12 +64,12 @@
     mf:result <standpoint-not-held.srx> .
 
 :lossAwareConstruct a mf:QueryEvaluationTest ;
-    mf:name "loss-aware CONSTRUCT emits in-band logic:ProjectionLoss when the reifier layer is dropped" ;
+    mf:name "loss-aware CONSTRUCT emits in-band ext:ProjectionLoss when the reifier layer is dropped" ;
     mf:action [ qt:query <loss-lossy.rq> ; qt:data <reified.ttl> ] ;
     mf:result <loss-lossy.ttl> .
 
 :lossControlConstruct a mf:QueryEvaluationTest ;
-    mf:name "no-loss control: carrying the reifier emits no logic:ProjectionLoss" ;
+    mf:name "no-loss control: carrying the reifier emits no ext:ProjectionLoss" ;
     mf:action [ qt:query <loss-control.rq> ; qt:data <reified.ttl> ] ;
     mf:result <loss-control.ttl> .
 

--- a/crates/sparql-conformance/tests/cost_planner_corpus.rs
+++ b/crates/sparql-conformance/tests/cost_planner_corpus.rs
@@ -10,18 +10,21 @@
 //! reifiers, and GRAPH scopes.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
-use purrdf_core::{SparqlEngine, SparqlRequest, SparqlResult};
+use purrdf_core::{RdfDataset, SparqlEngine, SparqlRequest, SparqlResult};
 use purrdf_sparql_algebra::{GraphPattern, Query, SparqlParser};
 use purrdf_sparql_conformance::manifest::{SparqlTestCase, TestKind};
-use purrdf_sparql_eval::{EvalOptions, NativeSparqlEngine, ParserOptions, StandpointPredicates};
+use purrdf_sparql_eval::{
+    EvalOptions, LocalRemoteQuerySource, NativeSparqlEngine, ParserOptions, StandpointPredicates,
+};
 
 const BASE: &str = "http://purrdf.test/manifest/";
 const EXT_NS: &str = "https://example.org/ext/";
 
 /// Build an engine with the requested planner mode. Both engines share the same
 /// parse-time configuration the conformance harness uses.
-fn engine(cost: bool) -> NativeSparqlEngine {
+fn make_engine(cost: bool) -> NativeSparqlEngine {
     let options = EvalOptions {
         exists_memo: true,
         force_structural_bgp_order: !cost,
@@ -37,22 +40,24 @@ fn engine(cost: bool) -> NativeSparqlEngine {
         .with_eval_options(options)
 }
 
-/// Evaluate `case` with `cost` planner (`true`) or forced structural order
-/// (`false`). Mirrors the conformance harness's evaluation path, including the
-/// in-memory SERVICE source when the case is federated.
-fn eval_case(case: &SparqlTestCase, cost: bool) -> Result<SparqlResult, String> {
-    let dataset = purrdf_sparql_conformance::run::load_dataset(case)?;
-    let query_text = std::fs::read_to_string(&case.query)
-        .map_err(|e| format!("read query {}: {e}", case.query.display()))?;
+/// Evaluate `case` using a pre-built `engine`, a pre-loaded `dataset`, and the
+/// already-read `query_text`. The in-memory SERVICE `remote` source is reused when
+/// the case is federated, so fixture parsing is not repeated between planner runs.
+fn eval_case(
+    engine: &NativeSparqlEngine,
+    case: &SparqlTestCase,
+    dataset: &Arc<RdfDataset>,
+    query_text: &str,
+    remote: Option<&LocalRemoteQuerySource>,
+) -> Result<SparqlResult, String> {
     let request = SparqlRequest {
-        query: &query_text,
+        query: query_text,
         base_iri: Some(BASE),
         substitutions: &[],
     };
-    let remote = purrdf_sparql_conformance::service::build(case)?;
     let result = match remote {
-        Some(source) => engine(cost).query_with_source(&dataset, request, &source),
-        None => engine(cost).query(&dataset, request),
+        Some(source) => engine.query_with_source(dataset, request, source),
+        None => engine.query(dataset, request),
     }
     .map_err(|e| format!("evaluate {}: {e}", case.iri))?;
     Ok(result)
@@ -103,6 +108,11 @@ fn cost_and_structural_planner_produce_identical_results() {
         manifests.len()
     );
 
+    // Build each planner variant once. Query plans are cached per engine, and both
+    // engines share the same parser/eval configuration the conformance harness uses.
+    let cost_engine = make_engine(true);
+    let structural_engine = make_engine(false);
+
     let mut cases = 0usize;
     let mut skipped = 0usize;
     let mut mismatches: Vec<(String, String)> = Vec::new();
@@ -119,22 +129,47 @@ fn cost_and_structural_planner_produce_identical_results() {
                 .unwrap_or_else(|e| panic!("read query {}: {e}", case.query.display()));
             let ordered = query_is_top_level_ordered(&query_text);
 
-            let cost_result = match eval_case(&case, true) {
-                Ok(r) => r,
-                Err(msg) => {
-                    // If both planners error, the case is not a planner-differential
-                    // failure (e.g. an unsupported feature). Record a skip.
-                    match eval_case(&case, false) {
-                        Ok(_) => mismatches.push((
-                            case.iri.clone(),
-                            format!("cost planner errored while structural succeeded: {msg}"),
-                        )),
-                        Err(_) => skipped += 1,
-                    }
-                    continue;
-                }
+            // Load the dataset and federated SERVICE source once per case and reuse
+            // them across both planner runs.
+            let Ok(dataset) = purrdf_sparql_conformance::run::load_dataset(&case) else {
+                // Both planners would fail with the same broken input.
+                skipped += 1;
+                continue;
             };
-            let structural_result = match eval_case(&case, false) {
+            let Ok(remote) = purrdf_sparql_conformance::service::build(&case) else {
+                skipped += 1;
+                continue;
+            };
+
+            let cost_result =
+                match eval_case(&cost_engine, &case, &dataset, &query_text, remote.as_ref()) {
+                    Ok(r) => r,
+                    Err(msg) => {
+                        // If both planners error, the case is not a planner-differential
+                        // failure (e.g. an unsupported feature). Record a skip.
+                        match eval_case(
+                            &structural_engine,
+                            &case,
+                            &dataset,
+                            &query_text,
+                            remote.as_ref(),
+                        ) {
+                            Ok(_) => mismatches.push((
+                                case.iri.clone(),
+                                format!("cost planner errored while structural succeeded: {msg}"),
+                            )),
+                            Err(_) => skipped += 1,
+                        }
+                        continue;
+                    }
+                };
+            let structural_result = match eval_case(
+                &structural_engine,
+                &case,
+                &dataset,
+                &query_text,
+                remote.as_ref(),
+            ) {
                 Ok(r) => r,
                 Err(msg) => {
                     mismatches.push((
@@ -150,7 +185,7 @@ fn cost_and_structural_planner_produce_identical_results() {
                 &structural_result,
                 ordered,
             ) {
-                mismatches.push((case.iri.clone(), msg));
+                mismatches.push((case.iri.clone(), format!("result mismatch: {msg}")));
             }
         }
     }

--- a/crates/sparql-conformance/tests/cost_planner_corpus.rs
+++ b/crates/sparql-conformance/tests/cost_planner_corpus.rs
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Differential planner-correctness test for the cost-based BGP planner.
+//!
+//! Runs every vendored W3C SPARQL query-evaluation case twice — once with the
+//! production cost-based planner and once with the retired structural heuristic
+//! forced — and asserts that the result multiset is identical. This proves that
+//! reordering BGP patterns never changes semantics across quoted triples,
+//! reifiers, and GRAPH scopes.
+
+use std::path::{Path, PathBuf};
+
+use purrdf_core::{SparqlEngine, SparqlRequest, SparqlResult};
+use purrdf_sparql_algebra::{GraphPattern, Query, SparqlParser};
+use purrdf_sparql_conformance::manifest::{SparqlTestCase, TestKind};
+use purrdf_sparql_eval::{EvalOptions, NativeSparqlEngine, ParserOptions, StandpointPredicates};
+
+const BASE: &str = "http://purrdf.test/manifest/";
+const EXT_NS: &str = "https://example.org/ext/";
+
+/// Build an engine with the requested planner mode. Both engines share the same
+/// parse-time configuration the conformance harness uses.
+fn engine(cost: bool) -> NativeSparqlEngine {
+    let options = EvalOptions {
+        exists_memo: true,
+        force_structural_bgp_order: !cost,
+    };
+    NativeSparqlEngine::new()
+        .with_parser_options(ParserOptions {
+            extension_fn_namespaces: vec![EXT_NS.to_owned()],
+        })
+        .with_standpoint_predicates(StandpointPredicates::new(
+            format!("{EXT_NS}accordingTo"),
+            format!("{EXT_NS}sharpens"),
+        ))
+        .with_eval_options(options)
+}
+
+/// Evaluate `case` with `cost` planner (`true`) or forced structural order
+/// (`false`). Mirrors the conformance harness's evaluation path, including the
+/// in-memory SERVICE source when the case is federated.
+fn eval_case(case: &SparqlTestCase, cost: bool) -> Result<SparqlResult, String> {
+    let dataset = purrdf_sparql_conformance::run::load_dataset(case)?;
+    let query_text = std::fs::read_to_string(&case.query)
+        .map_err(|e| format!("read query {}: {e}", case.query.display()))?;
+    let request = SparqlRequest {
+        query: &query_text,
+        base_iri: Some(BASE),
+        substitutions: &[],
+    };
+    let remote = purrdf_sparql_conformance::service::build(case)?;
+    let result = match remote {
+        Some(source) => engine(cost).query_with_source(&dataset, request, &source),
+        None => engine(cost).query(&dataset, request),
+    }
+    .map_err(|e| format!("evaluate {}: {e}", case.iri))?;
+    Ok(result)
+}
+
+/// Whether `query_text` is a `SELECT` with a top-level `ORDER BY`, so row order
+/// is observable and must be compared as an ordered sequence.
+fn query_is_top_level_ordered(query_text: &str) -> bool {
+    let Ok(Query::Select { pattern, .. }) = SparqlParser::new().parse_query(query_text) else {
+        return false;
+    };
+    let mut node = &pattern;
+    loop {
+        match node {
+            GraphPattern::OrderBy { .. } => return true,
+            GraphPattern::Project { inner, .. }
+            | GraphPattern::Distinct { inner }
+            | GraphPattern::Reduced { inner }
+            | GraphPattern::Slice { inner, .. } => node = inner,
+            _ => return false,
+        }
+    }
+}
+
+/// Recursively list every `manifest.ttl` under `suite/`.
+fn discover_manifests(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                out.extend(discover_manifests(&path));
+            } else if path.file_name().and_then(|n| n.to_str()) == Some("manifest.ttl") {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn cost_and_structural_planner_produce_identical_results() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("suite");
+    let manifests = discover_manifests(&root);
+    assert!(
+        manifests.len() >= 10,
+        "suite inventory shrank: found only {} manifests",
+        manifests.len()
+    );
+
+    let mut cases = 0usize;
+    let mut skipped = 0usize;
+    let mut mismatches: Vec<(String, String)> = Vec::new();
+
+    for manifest in &manifests {
+        let loaded = purrdf_sparql_conformance::manifest::load(manifest)
+            .unwrap_or_else(|e| panic!("load {}: {e}", manifest.display()));
+        for case in loaded {
+            if !matches!(case.kind, TestKind::QueryEval) {
+                continue;
+            }
+            cases += 1;
+            let query_text = std::fs::read_to_string(&case.query)
+                .unwrap_or_else(|e| panic!("read query {}: {e}", case.query.display()));
+            let ordered = query_is_top_level_ordered(&query_text);
+
+            let cost_result = match eval_case(&case, true) {
+                Ok(r) => r,
+                Err(msg) => {
+                    // If both planners error, the case is not a planner-differential
+                    // failure (e.g. an unsupported feature). Record a skip.
+                    match eval_case(&case, false) {
+                        Ok(_) => mismatches.push((
+                            case.iri.clone(),
+                            format!("cost planner errored while structural succeeded: {msg}"),
+                        )),
+                        Err(_) => skipped += 1,
+                    }
+                    continue;
+                }
+            };
+            let structural_result = match eval_case(&case, false) {
+                Ok(r) => r,
+                Err(msg) => {
+                    mismatches.push((
+                        case.iri.clone(),
+                        format!("structural planner errored while cost succeeded: {msg}"),
+                    ));
+                    continue;
+                }
+            };
+
+            if let Err(msg) = purrdf_sparql_conformance::compare::compare_results(
+                &cost_result,
+                &structural_result,
+                ordered,
+            ) {
+                mismatches.push((case.iri.clone(), msg));
+            }
+        }
+    }
+
+    println!(
+        "differential planner corpus: {cases} query-eval cases, {skipped} skipped (both errored), {} mismatches",
+        mismatches.len()
+    );
+
+    assert!(
+        mismatches.is_empty(),
+        "{} case(s) produced different results under cost vs structural BGP order:\n{}",
+        mismatches.len(),
+        mismatches
+            .iter()
+            .map(|(iri, msg)| format!("  {iri}\n    -> {msg}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+    assert!(
+        cases >= 100,
+        "differential corpus shrank: only {cases} query-eval cases"
+    );
+}

--- a/crates/sparql-eval/src/bgp.rs
+++ b/crates/sparql-eval/src/bgp.rs
@@ -32,10 +32,12 @@
 //! never accidentally share a join variable.
 
 use purrdf_core::{DatasetView, GraphMatch, QuadIds, QuadProbePlan, RdfDataset, TermId, TermRef};
-use purrdf_sparql_algebra::{NamedNodePattern, TermPattern, TriplePattern, Variable};
+use purrdf_sparql_algebra::{
+    GraphPattern, Literal, NamedNodePattern, TermPattern, TriplePattern, Variable,
+};
 
 use crate::convert::{ground_term_pattern_to_value, named_node_to_value};
-use crate::dataset_spec::GraphScope;
+use crate::dataset_spec::{ActiveDataset, GraphScope};
 use crate::error::EvalError;
 use crate::eval::{BgpOrderCache, EvalCtx};
 use crate::scratch::SolutionTerm;
@@ -122,7 +124,15 @@ pub(crate) fn eval_bgp(
     // commutative join: `Pos::Slot` is an absolute column index into `working`, so
     // reordering cannot change which columns bind — the multiset result is identical,
     // only the join shape (and so the cost) changes.
-    let order = plan_or_cached_order(&compiled, ctx.dataset, &scope, ctx.bgp_order_cache);
+    //
+    // The differential planner-correctness test can force the retired structural
+    // heuristic instead; because the reorder is still just a permutation, the result
+    // multiset must stay identical.
+    let order = if ctx.options.force_structural_bgp_order {
+        Arc::from(structural_order(&compiled))
+    } else {
+        plan_or_cached_order(&compiled, ctx.dataset, &scope, ctx.bgp_order_cache)
+    };
 
     // The interned id of `rdf:reifies`, resolved once. `None` ⇒ the dataset has no
     // reifier layer at all (the predicate was never interned), so no virtual reifier
@@ -205,6 +215,60 @@ pub(crate) fn eval_bgp(
     }
 
     Ok(project_out_blanks(&working, rows))
+}
+
+/// The retired most-constrained-first STRUCTURAL heuristic, reproduced here as
+/// the baseline the cost planner must beat and as the forced order used by the
+/// differential planner-correctness corpus test. Schedule greedily by the count
+/// of bound positions, keep the join connected, break ties on lowest index.
+///
+/// This is the S7 behaviour `cost_based_order` replaced; it is intentionally
+/// deterministic and never materialises a plan as triples.
+fn structural_order(compiled: &[CompiledPattern]) -> Vec<usize> {
+    fn constrained(pos: &Pos, bound: &[bool]) -> bool {
+        match pos {
+            Pos::Bound(_) => true,
+            Pos::Slot(c) => bound[*c],
+            Pos::Triple(t) => {
+                constrained(&t.s, bound) && constrained(&t.p, bound) && constrained(&t.o, bound)
+            }
+        }
+    }
+    let n = compiled.len();
+    let mut n_cols = 0usize;
+    for cp in compiled {
+        for pos in [&cp.s, &cp.p, &cp.o] {
+            for_each_slot(pos, &mut |c| n_cols = n_cols.max(c + 1));
+        }
+    }
+    let mut bound = vec![false; n_cols];
+    let mut scheduled = vec![false; n];
+    let mut order = Vec::with_capacity(n);
+    for _ in 0..n {
+        let any_connected =
+            (0..n).any(|i| !scheduled[i] && pattern_connected(&compiled[i], &bound));
+        let mut best: Option<usize> = None;
+        let mut best_score = 0usize;
+        for i in 0..n {
+            if scheduled[i] || (any_connected && !pattern_connected(&compiled[i], &bound)) {
+                continue;
+            }
+            let cp = &compiled[i];
+            let score = [&cp.s, &cp.p, &cp.o]
+                .into_iter()
+                .filter(|p| constrained(p, &bound))
+                .count();
+            if best.is_none() || score > best_score {
+                best = Some(i);
+                best_score = score;
+            }
+        }
+        let chosen = best.expect("an unscheduled pattern always remains");
+        scheduled[chosen] = true;
+        mark_bound(&compiled[chosen], &mut bound);
+        order.push(chosen);
+    }
+    order
 }
 
 /// The BGP-size ceiling for exhaustive join-order search. At or below this many
@@ -962,6 +1026,134 @@ fn object_can_be_triple_term(pos: &Pos, dataset: &RdfDataset) -> bool {
         // term; an IRI/literal/blank object can never match a reifier row.
         Pos::Bound(id) => matches!(dataset.resolve(*id), TermRef::Triple { .. }),
     }
+}
+
+// ---------------------------------------------------------------------------
+// EXPLAIN / plan introspection helpers
+// ---------------------------------------------------------------------------
+
+/// Format a triple pattern as a compact SPARQL-like string for plan-introspection
+/// output. The format is human-readable and stable; it is not a round-trippable
+/// serializer.
+fn triple_pattern_to_string(tp: &TriplePattern) -> String {
+    format!(
+        "{} {} {} .",
+        term_pattern_to_string(&tp.subject),
+        named_node_pattern_to_string(&tp.predicate),
+        term_pattern_to_string(&tp.object)
+    )
+}
+
+/// Format a term pattern as a compact SPARQL-like string.
+fn term_pattern_to_string(term: &TermPattern) -> String {
+    match term {
+        TermPattern::Variable(v) => format!("?{}", v.as_str()),
+        TermPattern::BlankNode(b) => format!("_:{}", b.as_str()),
+        TermPattern::NamedNode(n) => format!("<{}>", n.as_str()),
+        TermPattern::Literal(l) => literal_to_string(l),
+        TermPattern::Triple(t) => format!(
+            "<<({} {} {})>>",
+            term_pattern_to_string(&t.subject),
+            named_node_pattern_to_string(&t.predicate),
+            term_pattern_to_string(&t.object)
+        ),
+    }
+}
+
+/// Format a named-node pattern (IRI or variable) as a compact string.
+fn named_node_pattern_to_string(nn: &NamedNodePattern) -> String {
+    match nn {
+        NamedNodePattern::Variable(v) => format!("?{}", v.as_str()),
+        NamedNodePattern::NamedNode(n) => format!("<{}>", n.as_str()),
+    }
+}
+
+/// Format a literal as a compact SPARQL-like string.
+fn literal_to_string(l: &Literal) -> String {
+    let escaped = l.value().replace('"', "\\\"");
+    match (l.language(), l.direction()) {
+        (Some(lang), Some(dir)) => format!("\"{escaped}\"@{lang}--{dir:?}"),
+        (Some(lang), None) => format!("\"{escaped}\"@{lang}"),
+        (None, _) => format!("\"{escaped}\"^^<{}>", l.datatype().as_str()),
+    }
+}
+
+/// Recursively walk `pattern`, compute the cost-based order for every BGP with at
+/// least two triple patterns, and append human-readable triple-pattern strings to
+/// `out` in the order the planner chose. Scope changes from `GRAPH` blocks are
+/// tracked so cardinality estimates use the right graph filter.
+///
+/// This is a pure-introspection path: it does not evaluate the query, and it
+/// falls back to source order for BGPs whose constants are absent from the dataset
+/// (those BGPs are empty regardless of order).
+pub(crate) fn explain_pattern_orders(
+    dataset: &RdfDataset,
+    active_dataset: &ActiveDataset,
+    active_graph: GraphMatch,
+    pattern: &GraphPattern,
+    out: &mut Vec<String>,
+) -> Result<(), EvalError> {
+    match pattern {
+        GraphPattern::Bgp { patterns } => {
+            if patterns.len() >= 2 {
+                let scope = active_dataset.scope_for(active_graph);
+                let mut working = VarSchema::new();
+                for pattern in patterns {
+                    for key in slot_keys(pattern) {
+                        working.push(key);
+                    }
+                }
+                let mut compiled = Vec::with_capacity(patterns.len());
+                let mut any_absent = false;
+                for pattern in patterns {
+                    match compile_pattern(pattern, &working, dataset)? {
+                        Some(cp) => compiled.push(cp),
+                        None => {
+                            any_absent = true;
+                            break;
+                        }
+                    }
+                }
+                let order: Vec<usize> = if any_absent {
+                    (0..patterns.len()).collect()
+                } else {
+                    cost_based_order(&compiled, dataset, &scope)
+                };
+                for &i in &order {
+                    out.push(triple_pattern_to_string(&patterns[i]));
+                }
+            }
+        }
+        GraphPattern::Join { left, right }
+        | GraphPattern::Union { left, right }
+        | GraphPattern::LeftJoin { left, right, .. }
+        | GraphPattern::Minus { left, right }
+        | GraphPattern::Lateral { left, right } => {
+            explain_pattern_orders(dataset, active_dataset, active_graph, left, out)?;
+            explain_pattern_orders(dataset, active_dataset, active_graph, right, out)?;
+        }
+        GraphPattern::Filter { inner, .. }
+        | GraphPattern::Extend { inner, .. }
+        | GraphPattern::Project { inner, .. }
+        | GraphPattern::Distinct { inner }
+        | GraphPattern::Reduced { inner }
+        | GraphPattern::Slice { inner, .. }
+        | GraphPattern::OrderBy { inner, .. }
+        | GraphPattern::Group { inner, .. } => {
+            explain_pattern_orders(dataset, active_dataset, active_graph, inner, out)?;
+        }
+        GraphPattern::Graph { name, inner } => {
+            let inner_graph = match name {
+                NamedNodePattern::NamedNode(n) => dataset
+                    .term_id_by_value(&named_node_to_value(n))
+                    .map_or(GraphMatch::Default, GraphMatch::Named),
+                NamedNodePattern::Variable(_) => GraphMatch::Any,
+            };
+            explain_pattern_orders(dataset, active_dataset, inner_graph, inner, out)?;
+        }
+        GraphPattern::Path { .. } | GraphPattern::Values { .. } | GraphPattern::Service { .. } => {}
+    }
+    Ok(())
 }
 
 /// An empty solution sequence over only the real (non-blank) variables of `working`.
@@ -1748,57 +1940,6 @@ mod tests {
     }
 
     // ---- measurable win vs the retired structural heuristic -------------------
-
-    /// The retired most-constrained-first STRUCTURAL heuristic, reproduced here ONLY as
-    /// the baseline the cost planner must beat: schedule greedily by the count of bound
-    /// positions, keep the join connected, break ties on lowest index. (This is the S7
-    /// behaviour `cost_based_order` replaced.)
-    fn structural_order(compiled: &[CompiledPattern]) -> Vec<usize> {
-        fn constrained(pos: &Pos, bound: &[bool]) -> bool {
-            match pos {
-                Pos::Bound(_) => true,
-                Pos::Slot(c) => bound[*c],
-                Pos::Triple(t) => {
-                    constrained(&t.s, bound) && constrained(&t.p, bound) && constrained(&t.o, bound)
-                }
-            }
-        }
-        let n = compiled.len();
-        let mut n_cols = 0usize;
-        for cp in compiled {
-            for pos in [&cp.s, &cp.p, &cp.o] {
-                for_each_slot(pos, &mut |c| n_cols = n_cols.max(c + 1));
-            }
-        }
-        let mut bound = vec![false; n_cols];
-        let mut scheduled = vec![false; n];
-        let mut order = Vec::with_capacity(n);
-        for _ in 0..n {
-            let any_connected =
-                (0..n).any(|i| !scheduled[i] && pattern_connected(&compiled[i], &bound));
-            let mut best: Option<usize> = None;
-            let mut best_score = 0usize;
-            for i in 0..n {
-                if scheduled[i] || (any_connected && !pattern_connected(&compiled[i], &bound)) {
-                    continue;
-                }
-                let cp = &compiled[i];
-                let score = [&cp.s, &cp.p, &cp.o]
-                    .into_iter()
-                    .filter(|p| constrained(p, &bound))
-                    .count();
-                if best.is_none() || score > best_score {
-                    best = Some(i);
-                    best_score = score;
-                }
-            }
-            let chosen = best.expect("an unscheduled pattern always remains");
-            scheduled[chosen] = true;
-            mark_bound(&compiled[chosen], &mut bound);
-            order.push(chosen);
-        }
-        order
-    }
 
     /// GROUND TRUTH: the total number of intermediate solution rows a left-deep
     /// execution in `order` materialises — the sum over each prefix of the REAL result

--- a/crates/sparql-eval/src/construct.rs
+++ b/crates/sparql-eval/src/construct.rs
@@ -41,28 +41,21 @@ use crate::DetHashMap;
 const RDF_REIFIES: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies";
 /// `rdf:type`.
 const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
-/// `xsd:string` — the datatype of an emitted `logic:lossCode` literal.
+/// `xsd:string` — the datatype of an emitted loss-code literal.
 const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
-
-/// The canonical in-band loss-declaration vocabulary IRIs. These are declared in the
-/// `logic` slice (projection loss is a logic-domain concept); the strings here MUST
-/// match the ontology exactly.
-/// `logic:ProjectionLoss` — `rdf:type` of an in-band loss node.
-const LOGIC_PROJECTION_LOSS: &str = "https://blackcatinformatics.ca/logic/ProjectionLoss";
-/// `logic:lossCode` — the machine code (an `xsd:string`).
-const LOGIC_LOSS_CODE: &str = "https://blackcatinformatics.ca/logic/lossCode";
-/// `logic:lostReifies` — object is the triple term whose reification was dropped.
-const LOGIC_LOST_REIFIES: &str = "https://blackcatinformatics.ca/logic/lostReifies";
 
 /// Evaluate a `CONSTRUCT` query to a frozen IR dataset.
 ///
 /// **Loss-aware projection:** when the `WHERE` bound an RDF-1.2 reifier (via
 /// an `rdf:reifies` triple pattern) and the template drops it, the dropped
-/// reification layer is declared **in-band** as `logic:ProjectionLoss` triples on
-/// the SAME output graph — GTS is lossless, so loss is declared at the projection,
-/// never silently swallowed. When the `WHERE` has no `rdf:reifies` pattern at all
-/// the detection does zero extra work and the output is byte-identical to a plain
-/// `CONSTRUCT`.
+/// reification layer can be declared **in-band** as `ProjectionLoss` triples on
+/// the SAME output graph — but only when a caller-supplied
+/// [`LossVocabulary`](crate::eval::LossVocabulary) is configured. GTS is lossless,
+/// so a configured loss vocabulary lets projection loss be declared at the
+/// projection rather than silently swallowed; without a vocabulary the query
+/// behaves like a plain `CONSTRUCT`. When the `WHERE` has no `rdf:reifies`
+/// pattern at all the detection does zero extra work and the output is
+/// byte-identical to a plain `CONSTRUCT`.
 pub(crate) fn eval_construct(
     template: &[TriplePattern],
     pattern: &GraphPattern,
@@ -72,21 +65,27 @@ pub(crate) fn eval_construct(
     let schema = seq.schema.clone();
     let mut builder = RdfDatasetBuilder::new();
 
-    // Loss detection. FAST NO-OP PATH: collect the dropped reifies-patterns
-    // ONCE, before the row loop. With no `rdf:reifies` pattern in the WHERE the set
-    // is empty and the per-row emission below is skipped entirely — the output is
-    // byte-identical to today's plain CONSTRUCT.
+    // Loss detection. Only run when a caller-supplied loss vocabulary is configured;
+    // otherwise loss declarations stay inactive and the output behaves like a plain
+    // `CONSTRUCT`. With no `rdf:reifies` pattern in the WHERE the set is empty and
+    // the per-row emission below is skipped entirely.
     //
     // Standpoint attribution reads the SAME caller-supplied predicate table as
     // `heldIn` (see [`crate::eval::StandpointPredicates`]): with no table
     // configured, a dropped annotation cannot be attributed to a standpoint scope
     // and only the generic annotation-layer loss code is emitted — the engine never
     // fabricates a default domain predicate.
-    let standpoint_according_to: Option<String> = ctx
-        .standpoint_predicates
+    let loss_vocab = ctx.loss_vocabulary.clone();
+    let dropped: Vec<DroppedReifier> = loss_vocab
         .as_ref()
-        .map(|p| p.according_to.clone());
-    let dropped = collect_dropped_reifiers(template, pattern, standpoint_according_to.as_deref());
+        .map(|_| {
+            let standpoint_according_to: Option<String> = ctx
+                .standpoint_predicates
+                .as_ref()
+                .map(|p| p.according_to.clone());
+            collect_dropped_reifiers(template, pattern, standpoint_according_to.as_deref())
+        })
+        .unwrap_or_default();
 
     // Identify which template triple indices are reifier declarations
     // (predicate == rdf:reifies, object == TermPattern::Triple).  This scan is
@@ -169,8 +168,10 @@ pub(crate) fn eval_construct(
             }
         }
 
-        if !dropped.is_empty() {
-            emit_dropped_losses(&dropped, row, &schema, &mut builder, ctx);
+        if let Some(vocab) = loss_vocab.as_ref() {
+            if !dropped.is_empty() {
+                emit_dropped_losses(&dropped, row, &schema, &mut builder, ctx, vocab);
+            }
         }
     }
 
@@ -361,9 +362,9 @@ fn collect_term_pattern_vars(term: &TermPattern, out: &mut BTreeSet<String>) {
 /// from the row's bindings and emits, into the SAME builder:
 ///
 /// ```text
-/// <lossNode> rdf:type        logic:ProjectionLoss .
-/// <lossNode> logic:lossCode  "reifier-layer-dropped"^^xsd:string .
-/// <lossNode> logic:lostReifies <<( s p o )>> .
+/// <lossNode> rdf:type        <projectionLoss> .
+/// <lossNode> <lossCode>      "reifier-layer-dropped"^^xsd:string .
+/// <lossNode> <lostReifies>   <<( s p o )>> .
 /// ```
 ///
 /// plus the `annotation-layer-dropped` / `standpoint-scope-dropped` sub-codes when
@@ -378,6 +379,7 @@ fn emit_dropped_losses(
     schema: &VarSchema,
     builder: &mut RdfDatasetBuilder,
     ctx: &mut EvalCtx<'_>,
+    vocab: &crate::eval::LossVocabulary,
 ) {
     for d in dropped {
         // Materialize the concrete reified triple term for this row. An unbound
@@ -393,31 +395,36 @@ fn emit_dropped_losses(
         let loss_node = builder.intern_blank_value(&label, purrdf_core::BlankScope::DEFAULT);
 
         let rdf_type = builder.intern_iri_value(RDF_TYPE);
-        let projection_loss = builder.intern_iri_value(LOGIC_PROJECTION_LOSS);
+        let projection_loss = builder.intern_iri_value(&vocab.projection_loss);
         builder.push_quad(loss_node, rdf_type, projection_loss, None);
 
-        // logic:lossCode "reifier-layer-dropped"
-        push_loss_code(builder, loss_node, LOSS_REIFIER_LAYER_DROPPED);
+        // <lossCode> "reifier-layer-dropped"
+        push_loss_code(builder, loss_node, LOSS_REIFIER_LAYER_DROPPED, vocab);
 
-        // logic:lostReifies <<( s p o )>>
-        let lost_reifies = builder.intern_iri_value(LOGIC_LOST_REIFIES);
+        // <lostReifies> <<( s p o )>>
+        let lost_reifies = builder.intern_iri_value(&vocab.lost_reifies);
         let triple_id = builder.intern_value(&inner_term);
         builder.push_quad(loss_node, lost_reifies, triple_id, None);
 
         // Sub-codes on the SAME loss node (keyed deterministically by the same
         // content-derived label, so they coalesce across rows too).
         if d.has_annotation {
-            push_loss_code(builder, loss_node, LOSS_ANNOTATION_LAYER_DROPPED);
+            push_loss_code(builder, loss_node, LOSS_ANNOTATION_LAYER_DROPPED, vocab);
         }
         if d.has_standpoint {
-            push_loss_code(builder, loss_node, LOSS_STANDPOINT_SCOPE_DROPPED);
+            push_loss_code(builder, loss_node, LOSS_STANDPOINT_SCOPE_DROPPED, vocab);
         }
     }
 }
 
-/// Push `<loss_node> logic:lossCode "<code>"^^xsd:string .` into `builder`.
-fn push_loss_code(builder: &mut RdfDatasetBuilder, loss_node: TermId, code: &str) {
-    let loss_code = builder.intern_iri_value(LOGIC_LOSS_CODE);
+/// Push `<loss_node> <lossCode> "<code>"^^xsd:string .` into `builder`.
+fn push_loss_code(
+    builder: &mut RdfDatasetBuilder,
+    loss_node: TermId,
+    code: &str,
+    vocab: &crate::eval::LossVocabulary,
+) {
+    let loss_code = builder.intern_iri_value(&vocab.loss_code);
     let code_lit = builder.intern_literal_value(RdfLiteral {
         lexical_form: code.to_owned(),
         datatype: Some(XSD_STRING.to_owned()),
@@ -602,6 +609,17 @@ mod tests {
         crate::eval::StandpointPredicates::new(ACCORDING_TO, SHARPENS)
     }
 
+    /// A pure-fixture (example.org) loss-declaration vocabulary. These IRIs are
+    /// caller-supplied configuration, not engine constants.
+    const PROJECTION_LOSS: &str = "http://example.org/loss/ProjectionLoss";
+    const LOSS_CODE: &str = "http://example.org/loss/lossCode";
+    const LOST_REIFIES: &str = "http://example.org/loss/lostReifies";
+
+    /// The fixture's caller-supplied loss vocabulary.
+    fn ex_loss_vocab() -> crate::eval::LossVocabulary {
+        crate::eval::LossVocabulary::new(PROJECTION_LOSS, LOSS_CODE, LOST_REIFIES)
+    }
+
     /// A dataset with one reifier `:r rdf:reifies <<( :alice :age 42 )>>`, with two
     /// annotations on `:r` (confidence + accordingTo). The reifier query layer comes
     /// from the BGP virtual-candidate machinery (Task 1).
@@ -616,7 +634,7 @@ mod tests {
         let triple = b.intern_triple(alice, age, forty_two);
         let r = b.intern_iri("http://ex/r");
         b.push_reifier(r, triple);
-        // Annotation: :r :confidence "0.9" ; :r purrdf:accordingTo :sourceX .
+        // Annotation: :r :confidence "0.9" ; :r example:accordingTo :sourceX .
         let confidence = b.intern_iri("http://ex/confidence");
         let conf_val = b.intern_literal(RdfLiteral::simple("0.9"));
         b.push_annotation(r, confidence, conf_val);
@@ -641,11 +659,11 @@ mod tests {
         }
     }
 
-    /// Count quads whose predicate is `logic:lossCode` and object the given code.
+    /// Count quads whose predicate is the fixture's `lossCode` and object the given code.
     fn count_loss_code(out: &RdfDataset, code: &str) -> usize {
         out.quads()
             .filter(|q| {
-                matches!(out.resolve(q.p), TermRef::Iri(p) if p == LOGIC_LOSS_CODE)
+                matches!(out.resolve(q.p), TermRef::Iri(p) if p == LOSS_CODE)
                     && matches!(out.resolve(q.o), TermRef::Literal { lexical, .. } if lexical == code)
             })
             .count()
@@ -656,7 +674,7 @@ mod tests {
         // CONSTRUCT { ?s ?p ?o } WHERE { ?r rdf:reifies <<( ?s ?p ?o )>> } — the
         // reifier ?r is dropped, so the reification layer loss is declared in-band.
         let ds = reified_graph();
-        let mut ctx = EvalCtx::new(&ds);
+        let mut ctx = EvalCtx::new(&ds).with_loss_vocabulary(ex_loss_vocab());
         let template = vec![TriplePattern {
             subject: var("s"),
             predicate: NamedNodePattern::Variable(Variable::new("p")),
@@ -674,7 +692,7 @@ mod tests {
         // A logic:ProjectionLoss declaration of type with the reifier-layer code.
         let has_loss_type = out.quads().any(|q| {
             matches!(out.resolve(q.p), TermRef::Iri(p) if p == RDF_TYPE_IRI)
-                && matches!(out.resolve(q.o), TermRef::Iri(o) if o == LOGIC_PROJECTION_LOSS)
+                && matches!(out.resolve(q.o), TermRef::Iri(o) if o == PROJECTION_LOSS)
         });
         assert!(has_loss_type, "a logic:ProjectionLoss node is declared");
         assert_eq!(
@@ -685,7 +703,7 @@ mod tests {
 
         // logic:lostReifies points at the concrete triple term <<( :alice :age 42 )>>.
         let lost = out.quads().any(|q| {
-            matches!(out.resolve(q.p), TermRef::Iri(p) if p == LOGIC_LOST_REIFIES)
+            matches!(out.resolve(q.p), TermRef::Iri(p) if p == LOST_REIFIES)
                 && matches!(out.resolve(q.o), TermRef::Triple { .. })
         });
         assert!(lost, "logic:lostReifies carries the dropped triple term");
@@ -698,7 +716,9 @@ mod tests {
         // standpoint attribution reads the CONFIGURED predicate table (example.org
         // here), proving the vocabulary flows through configuration, not a const.
         let ds = reified_graph();
-        let mut ctx = EvalCtx::new(&ds).with_standpoint_predicates(ex_standpoints());
+        let mut ctx = EvalCtx::new(&ds)
+            .with_standpoint_predicates(ex_standpoints())
+            .with_loss_vocabulary(ex_loss_vocab());
         let where_pat = GraphPattern::Bgp {
             patterns: vec![
                 TriplePattern {
@@ -716,7 +736,7 @@ mod tests {
                     predicate: pred("http://ex/confidence"),
                     object: var("c"),
                 },
-                // ?r purrdf:accordingTo ?stand  (the standpoint annotation)
+                // ?r example:accordingTo ?stand  (the standpoint annotation)
                 TriplePattern {
                     subject: var("r"),
                     predicate: pred(ACCORDING_TO),
@@ -743,7 +763,7 @@ mod tests {
         // configured: the engine cannot (and must not) guess a domain predicate, so
         // the generic annotation-layer code is emitted WITHOUT the standpoint sub-code.
         let ds = reified_graph();
-        let mut ctx = EvalCtx::new(&ds); // no table configured
+        let mut ctx = EvalCtx::new(&ds).with_loss_vocabulary(ex_loss_vocab()); // no standpoint table
         let where_pat = GraphPattern::Bgp {
             patterns: vec![
                 TriplePattern {
@@ -801,7 +821,7 @@ mod tests {
         );
         let any_loss = out
             .quads()
-            .any(|q| matches!(out.resolve(q.o), TermRef::Iri(o) if o == LOGIC_PROJECTION_LOSS));
+            .any(|q| matches!(out.resolve(q.o), TermRef::Iri(o) if o == PROJECTION_LOSS));
         assert!(
             !any_loss,
             "no ProjectionLoss node when the reifier is carried"
@@ -823,8 +843,8 @@ mod tests {
         let out = eval_construct(&template, &where_knows(), &mut ctx).expect("construct");
         // No loss triples at all.
         let any_loss = out.quads().any(|q| {
-            matches!(out.resolve(q.p), TermRef::Iri(p) if p == LOGIC_LOSS_CODE)
-                || matches!(out.resolve(q.o), TermRef::Iri(o) if o == LOGIC_PROJECTION_LOSS)
+            matches!(out.resolve(q.p), TermRef::Iri(p) if p == LOSS_CODE)
+                || matches!(out.resolve(q.o), TermRef::Iri(o) if o == PROJECTION_LOSS)
         });
         assert!(
             !any_loss,
@@ -937,9 +957,9 @@ mod tests {
             object: var("o"),
         }];
 
-        let mut ctx1 = EvalCtx::new(&ds);
+        let mut ctx1 = EvalCtx::new(&ds).with_loss_vocabulary(ex_loss_vocab());
         let out1 = eval_construct(&template, &where_reifies(), &mut ctx1).expect("construct");
-        let mut ctx2 = EvalCtx::new(&ds);
+        let mut ctx2 = EvalCtx::new(&ds).with_loss_vocabulary(ex_loss_vocab());
         let out2 = eval_construct(&template, &where_reifies(), &mut ctx2).expect("construct");
 
         // Identical canonical N-Quads across two runs.

--- a/crates/sparql-eval/src/construct.rs
+++ b/crates/sparql-eval/src/construct.rs
@@ -87,6 +87,17 @@ pub(crate) fn eval_construct(
         })
         .unwrap_or_default();
 
+    // Pre-intern the caller-supplied loss vocabulary IRIs once, before the
+    // per-solution row loop, so the loss-node emission path does not repeat
+    // the lookup work for every row.
+    let loss_term_ids: Option<(TermId, TermId, TermId)> = loss_vocab.as_ref().map(|vocab| {
+        (
+            builder.intern_iri_value(&vocab.projection_loss),
+            builder.intern_iri_value(&vocab.loss_code),
+            builder.intern_iri_value(&vocab.lost_reifies),
+        )
+    });
+
     // Identify which template triple indices are reifier declarations
     // (predicate == rdf:reifies, object == TermPattern::Triple).  This scan is
     // done ONCE before the row loop so that per-row emit can fast-path to plain
@@ -168,9 +179,9 @@ pub(crate) fn eval_construct(
             }
         }
 
-        if let Some(vocab) = loss_vocab.as_ref() {
+        if let Some(ids) = loss_term_ids {
             if !dropped.is_empty() {
-                emit_dropped_losses(&dropped, row, &schema, &mut builder, ctx, vocab);
+                emit_dropped_losses(&dropped, row, &schema, &mut builder, ctx, ids);
             }
         }
     }
@@ -379,7 +390,7 @@ fn emit_dropped_losses(
     schema: &VarSchema,
     builder: &mut RdfDatasetBuilder,
     ctx: &mut EvalCtx<'_>,
-    vocab: &crate::eval::LossVocabulary,
+    (proj_loss_id, loss_code_id, lost_reifies_id): (TermId, TermId, TermId),
 ) {
     for d in dropped {
         // Materialize the concrete reified triple term for this row. An unbound
@@ -395,24 +406,32 @@ fn emit_dropped_losses(
         let loss_node = builder.intern_blank_value(&label, purrdf_core::BlankScope::DEFAULT);
 
         let rdf_type = builder.intern_iri_value(RDF_TYPE);
-        let projection_loss = builder.intern_iri_value(&vocab.projection_loss);
-        builder.push_quad(loss_node, rdf_type, projection_loss, None);
+        builder.push_quad(loss_node, rdf_type, proj_loss_id, None);
 
         // <lossCode> "reifier-layer-dropped"
-        push_loss_code(builder, loss_node, LOSS_REIFIER_LAYER_DROPPED, vocab);
+        push_loss_code(builder, loss_node, LOSS_REIFIER_LAYER_DROPPED, loss_code_id);
 
         // <lostReifies> <<( s p o )>>
-        let lost_reifies = builder.intern_iri_value(&vocab.lost_reifies);
         let triple_id = builder.intern_value(&inner_term);
-        builder.push_quad(loss_node, lost_reifies, triple_id, None);
+        builder.push_quad(loss_node, lost_reifies_id, triple_id, None);
 
         // Sub-codes on the SAME loss node (keyed deterministically by the same
         // content-derived label, so they coalesce across rows too).
         if d.has_annotation {
-            push_loss_code(builder, loss_node, LOSS_ANNOTATION_LAYER_DROPPED, vocab);
+            push_loss_code(
+                builder,
+                loss_node,
+                LOSS_ANNOTATION_LAYER_DROPPED,
+                loss_code_id,
+            );
         }
         if d.has_standpoint {
-            push_loss_code(builder, loss_node, LOSS_STANDPOINT_SCOPE_DROPPED, vocab);
+            push_loss_code(
+                builder,
+                loss_node,
+                LOSS_STANDPOINT_SCOPE_DROPPED,
+                loss_code_id,
+            );
         }
     }
 }
@@ -422,16 +441,15 @@ fn push_loss_code(
     builder: &mut RdfDatasetBuilder,
     loss_node: TermId,
     code: &str,
-    vocab: &crate::eval::LossVocabulary,
+    loss_code_id: TermId,
 ) {
-    let loss_code = builder.intern_iri_value(&vocab.loss_code);
     let code_lit = builder.intern_literal_value(RdfLiteral {
         lexical_form: code.to_owned(),
         datatype: Some(XSD_STRING.to_owned()),
         language: None,
         direction: None,
     });
-    builder.push_quad(loss_node, loss_code, code_lit, None);
+    builder.push_quad(loss_node, loss_code_id, code_lit, None);
 }
 
 /// A deterministic blank-node label for a loss node, derived PURELY from the loss

--- a/crates/sparql-eval/src/engine.rs
+++ b/crates/sparql-eval/src/engine.rs
@@ -24,7 +24,8 @@ use purrdf_sparql_algebra::{ParserOptions, Query, SparqlParser};
 
 use crate::dataset_spec::ActiveDataset;
 use crate::eval::{
-    evaluate_query, BgpOrderCache, EvalCtx, EvalOptions, Outcome, StandpointPredicates,
+    evaluate_query, BgpOrderCache, EvalCtx, EvalOptions, LossVocabulary, Outcome,
+    StandpointPredicates,
 };
 use crate::update::{eval_update, GraphResolver};
 use crate::DetHashMap;
@@ -98,12 +99,16 @@ impl PlanCache {
 ///
 /// - [`Self::with_parser_options`] configures the extension-function namespace
 ///   set (default: EMPTY — extension functions are off and a call-position IRI
-///   is an ordinary custom function). A gmeow deployment supplies its
-///   `https://blackcatinformatics.ca/gmeow/` namespace here so
-///   `gmeow:heldIn(...)` queries parse as extension calls.
+///   is an ordinary custom function). A deployment whose queries spell the closed
+///   function set under its own namespace (e.g. `http://example.org/ns/gmeow/`)
+///   supplies that namespace here so that prefix's function calls parse as
+///   extension calls.
 /// - [`Self::with_standpoint_predicates`] supplies the `accordingTo`/`sharpens`
 ///   predicate table that `heldIn` and loss-aware `CONSTRUCT` read from
 ///   the caller's data. Without it, `heldIn` is a hard evaluation error.
+/// - [`Self::with_loss_vocabulary`] supplies the `ProjectionLoss` vocabulary IRIs
+///   emitted by loss-aware `CONSTRUCT` when a reifier is dropped. Without it,
+///   loss declarations stay inactive.
 #[derive(Default)]
 pub struct NativeSparqlEngine {
     cache: RefCell<PlanCache>,
@@ -119,6 +124,10 @@ pub struct NativeSparqlEngine {
     /// evaluation context. `None` (the default) means `heldIn` hard-errors
     /// and `CONSTRUCT` emits no standpoint-scope loss attribution.
     standpoint_predicates: Option<StandpointPredicates>,
+    /// The caller-supplied loss-declaration vocabulary threaded into every
+    /// evaluation context. `None` (the default) means loss-aware `CONSTRUCT`
+    /// emits no in-band loss declarations.
+    loss_vocabulary: Option<LossVocabulary>,
     /// Evaluation-time options threaded into every per-query context. Defaults to
     /// production settings; tests and benches override individual flags through
     /// [`Self::with_eval_options`].
@@ -141,6 +150,7 @@ impl std::fmt::Debug for NativeSparqlEngine {
             )
             .field("parser_options", &self.parser_options)
             .field("standpoint_predicates", &self.standpoint_predicates)
+            .field("loss_vocabulary", &self.loss_vocabulary)
             .field("eval_options", &self.eval_options)
             .finish()
     }
@@ -182,6 +192,17 @@ impl NativeSparqlEngine {
         self
     }
 
+    /// Supply the caller's loss-declaration vocabulary (see [`LossVocabulary`]):
+    /// the `ProjectionLoss`/`lossCode`/`lostReifies` IRIs emitted by loss-aware
+    /// `CONSTRUCT` when a reifier is dropped by the template. There is **no
+    /// built-in default** — without this configuration loss declarations stay
+    /// inactive and a dropped reifier is projected like a plain `CONSTRUCT`.
+    #[must_use]
+    pub fn with_loss_vocabulary(mut self, vocab: LossVocabulary) -> Self {
+        self.loss_vocabulary = Some(vocab);
+        self
+    }
+
     /// Set the evaluation-time options threaded into every per-query context.
     /// Production callers should leave the defaults; tests and benchmarks use
     /// this to flip individual measurement seams (e.g. the differential planner-
@@ -193,16 +214,19 @@ impl NativeSparqlEngine {
     }
 
     /// Build the per-query evaluation context, threading the engine-level
-    /// configuration (order cache + standpoint predicate table + eval options)
-    /// into it. `NOW()`/`RAND()`/`UUID()`/`STRUUID()` are already correct by
-    /// construction: [`EvalCtx::new`] samples the real host wall clock and OS
-    /// entropy itself.
+    /// configuration (order cache + standpoint predicate table + loss vocabulary +
+    /// eval options) into it. `NOW()`/`RAND()`/`UUID()`/`STRUUID()` are already
+    /// correct by construction: [`EvalCtx::new`] samples the real host wall clock
+    /// and OS entropy itself.
     fn eval_ctx<'d>(&'d self, dataset: &'d RdfDataset) -> EvalCtx<'d> {
         let mut ctx = EvalCtx::new(dataset)
             .with_order_cache(&self.order_cache)
             .with_eval_options(self.eval_options);
         if let Some(predicates) = &self.standpoint_predicates {
             ctx = ctx.with_standpoint_predicates(predicates.clone());
+        }
+        if let Some(vocab) = &self.loss_vocabulary {
+            ctx = ctx.with_loss_vocabulary(vocab.clone());
         }
         ctx
     }
@@ -1341,7 +1365,7 @@ mod tests {
 
     /// The gmeow ontology namespace — a deployment alias for the same closed
     /// extension-function set, with its own domain standpoint predicates.
-    const GMEOW_NS: &str = "https://blackcatinformatics.ca/gmeow/";
+    const GMEOW_NS: &str = "http://example.org/ns/gmeow/";
 
     /// A standpoint dataset in the GMEOW vocabulary: reifier `:r` held in `:T1`
     /// (via `gmeow:accordingTo`), and `:T1 gmeow:sharpens :T2`.

--- a/crates/sparql-eval/src/engine.rs
+++ b/crates/sparql-eval/src/engine.rs
@@ -17,11 +17,15 @@ use std::cell::RefCell;
 use std::sync::Arc;
 
 use purrdf_core::{
-    MutableDataset, RdfDataset, RdfDiagnostic, SparqlEngine, SparqlRequest, SparqlResult, TermValue,
+    GraphMatch, MutableDataset, RdfDataset, RdfDiagnostic, SparqlEngine, SparqlRequest,
+    SparqlResult, TermValue,
 };
 use purrdf_sparql_algebra::{ParserOptions, Query, SparqlParser};
 
-use crate::eval::{evaluate_query, BgpOrderCache, EvalCtx, Outcome, StandpointPredicates};
+use crate::dataset_spec::ActiveDataset;
+use crate::eval::{
+    evaluate_query, BgpOrderCache, EvalCtx, EvalOptions, Outcome, StandpointPredicates,
+};
 use crate::update::{eval_update, GraphResolver};
 use crate::DetHashMap;
 
@@ -115,6 +119,10 @@ pub struct NativeSparqlEngine {
     /// evaluation context. `None` (the default) means `heldIn` hard-errors
     /// and `CONSTRUCT` emits no standpoint-scope loss attribution.
     standpoint_predicates: Option<StandpointPredicates>,
+    /// Evaluation-time options threaded into every per-query context. Defaults to
+    /// production settings; tests and benches override individual flags through
+    /// [`Self::with_eval_options`].
+    eval_options: EvalOptions,
 }
 
 // `dyn GraphResolver` is not `Debug`, so derive can't apply; report its presence by
@@ -133,6 +141,7 @@ impl std::fmt::Debug for NativeSparqlEngine {
             )
             .field("parser_options", &self.parser_options)
             .field("standpoint_predicates", &self.standpoint_predicates)
+            .field("eval_options", &self.eval_options)
             .finish()
     }
 }
@@ -173,16 +182,69 @@ impl NativeSparqlEngine {
         self
     }
 
+    /// Set the evaluation-time options threaded into every per-query context.
+    /// Production callers should leave the defaults; tests and benchmarks use
+    /// this to flip individual measurement seams (e.g. the differential planner-
+    /// correctness test forces the structural BGP order).
+    #[must_use]
+    pub fn with_eval_options(mut self, options: EvalOptions) -> Self {
+        self.eval_options = options;
+        self
+    }
+
     /// Build the per-query evaluation context, threading the engine-level
-    /// configuration (order cache + standpoint predicate table) into it.
-    /// `NOW()`/`RAND()`/`UUID()`/`STRUUID()` are already correct by construction:
-    /// [`EvalCtx::new`] samples the real host wall clock and OS entropy itself.
+    /// configuration (order cache + standpoint predicate table + eval options)
+    /// into it. `NOW()`/`RAND()`/`UUID()`/`STRUUID()` are already correct by
+    /// construction: [`EvalCtx::new`] samples the real host wall clock and OS
+    /// entropy itself.
     fn eval_ctx<'d>(&'d self, dataset: &'d RdfDataset) -> EvalCtx<'d> {
-        let mut ctx = EvalCtx::new(dataset).with_order_cache(&self.order_cache);
+        let mut ctx = EvalCtx::new(dataset)
+            .with_order_cache(&self.order_cache)
+            .with_eval_options(self.eval_options);
         if let Some(predicates) = &self.standpoint_predicates {
             ctx = ctx.with_standpoint_predicates(predicates.clone());
         }
         ctx
+    }
+
+    /// Explain the cost-based BGP join order the engine would choose for
+    /// `query_text` against `dataset`.
+    ///
+    /// Returns an ordered list of triple-pattern strings: for every BGP in the
+    /// query with at least two triple patterns, the patterns are listed in the
+    /// order the planner selected. BGPs are visited in a left-to-right DFS over
+    /// the algebra, so subqueries, OPTIONAL/UNION branches, and GRAPH blocks are
+    /// all represented in query-text order. This is a pure-introspection API: it
+    /// does not evaluate the query and does not mutate the engine state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`RdfDiagnostic`] if the query text does not parse.
+    pub fn explain_query(
+        &self,
+        dataset: &Arc<RdfDataset>,
+        query_text: &str,
+        base_iri: Option<&str>,
+    ) -> Result<Vec<String>, RdfDiagnostic> {
+        let prepared =
+            self.cache
+                .borrow_mut()
+                .prepare_with(query_text, base_iri, &self.parser_options)?;
+        let active_dataset = ActiveDataset::from_query_dataset(prepared.query.dataset(), dataset);
+        let mut out = Vec::new();
+        let pattern = match &prepared.query {
+            Query::Select { pattern, .. } | Query::Ask { pattern, .. } => pattern,
+            Query::Construct { pattern, .. } | Query::Describe { pattern, .. } => pattern,
+        };
+        crate::bgp::explain_pattern_orders(
+            dataset,
+            &active_dataset,
+            GraphMatch::Default,
+            pattern,
+            &mut out,
+        )
+        .map_err(|e| RdfDiagnostic::error("native-sparql-query-explain", e.to_string()))?;
+        Ok(out)
     }
 
     /// Evaluate a SPARQL query under SHACL-SPARQL pre-binding semantics.
@@ -1717,6 +1779,43 @@ mod tests {
             }
             other => panic!("expected solutions, got {other:?}"),
         }
+    }
+
+    /// The `explain_query` API returns a non-empty ordered list of triple-pattern
+    /// strings for a multi-pattern BGP, proving the planner chose an order and that
+    /// the introspection path does not leak internal types.
+    #[test]
+    fn explain_query_returns_non_empty_order_for_multi_pattern_bgp() {
+        let ds = social();
+        let engine = NativeSparqlEngine::new();
+        let plan = engine
+            .explain_query(
+                &ds,
+                "SELECT ?o ?n WHERE { \
+                 <http://ex/a> <http://ex/knows> ?o . \
+                 <http://ex/a> <http://ex/name> ?n }",
+                None,
+            )
+            .expect("explain");
+        assert!(
+            plan.len() >= 2,
+            "expected at least two triple-pattern strings, got {plan:?}"
+        );
+        // Both patterns are present (order may vary with cardinality, but both IRIs
+        // are constants so the planner still has to schedule both).
+        let has_knows = plan.iter().any(|s| s.contains("<http://ex/knows>"));
+        let has_name = plan.iter().any(|s| s.contains("<http://ex/name>"));
+        assert!(has_knows, "explain output missing knows pattern: {plan:?}");
+        assert!(has_name, "explain output missing name pattern: {plan:?}");
+    }
+
+    /// `explain_query` errors cleanly on malformed SPARQL.
+    #[test]
+    fn explain_query_rejects_malformed_sparql() {
+        let ds = social();
+        let engine = NativeSparqlEngine::new();
+        let err = engine.explain_query(&ds, "SELECT ?x WHERE { not sparql }", None);
+        assert!(err.is_err(), "malformed query must produce a diagnostic");
     }
 
     /// `RAND()`/`UUID()`/`STRUUID()` are seeded from live OS entropy, not a fixed

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -27,8 +27,9 @@ use crate::solution::SolutionSeq;
 use crate::DetHashMap;
 
 /// Tunable evaluation behavior. Every flag defaults to the production-optimal
-/// value; the criterion benches flip individual flags to measure their effect
-/// (the flags are a measurement seam, never a degraded production mode).
+/// value; the criterion benches and differential tests flip individual flags to
+/// measure their effect (the flags are a measurement seam, never a degraded
+/// production mode).
 #[derive(Debug, Clone, Copy)]
 pub struct EvalOptions {
     /// Memoize each `EXISTS`/`NOT EXISTS` inner-pattern evaluation. The inner
@@ -36,11 +37,19 @@ pub struct EvalOptions {
     /// seed, so its result is **independent of the outer row**: a `FILTER` over N
     /// rows can evaluate it once instead of N times. Always `true` in production.
     pub exists_memo: bool,
+    /// Evaluate BGPs in the retired structural (most-constrained-first) order
+    /// instead of the cost-based order. Used only by the differential planner-
+    /// correctness corpus test to prove that reordering does not change the
+    /// result multiset. Always `false` in production.
+    pub force_structural_bgp_order: bool,
 }
 
 impl Default for EvalOptions {
     fn default() -> Self {
-        Self { exists_memo: true }
+        Self {
+            exists_memo: true,
+            force_structural_bgp_order: false,
+        }
     }
 }
 
@@ -451,6 +460,15 @@ impl<'d> EvalCtx<'d> {
     #[must_use]
     pub fn with_order_cache(mut self, cache: &'d BgpOrderCache) -> Self {
         self.bgp_order_cache = Some(cache);
+        self
+    }
+
+    /// Replace the evaluation options for this context. Used by the engine to thread
+    /// its configured options into each per-query context, and by tests that need to
+    /// flip a measurement seam.
+    #[must_use]
+    pub fn with_eval_options(mut self, options: EvalOptions) -> Self {
+        self.options = options;
         self
     }
 

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -63,8 +63,8 @@ impl Default for EvalOptions {
 /// default**, and evaluating `heldIn` without a configured table is a hard
 /// [`crate::EvalError`] (never a silently-wrong answer against fabricated IRIs).
 ///
-/// Callers supply their own vocabulary, e.g. the gmeow ontology's
-/// (`https://blackcatinformatics.ca/gmeow/accordingTo` / `…/sharpens`), via
+/// Callers supply their own vocabulary, e.g. a deployment namespace such as
+/// `http://example.org/ns/gmeow/accordingTo` / `…/sharpens`, via
 /// [`crate::NativeSparqlEngine::with_standpoint_predicates`] (engine-level) or
 /// [`EvalCtx::with_standpoint_predicates`] (a directly-built context).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -83,6 +83,41 @@ impl StandpointPredicates {
         Self {
             according_to: according_to.into(),
             sharpens: sharpens.into(),
+        }
+    }
+}
+
+/// The caller-supplied **loss-declaration vocabulary** used by loss-aware
+/// `CONSTRUCT`.
+///
+/// When a `CONSTRUCT` template drops an RDF-1.2 reifier that was bound in the
+/// `WHERE`, the engine emits in-band loss declarations. The IRIs for the loss
+/// node type (`projection_loss`), the code predicate (`loss_code`), and the
+/// dropped-reifier pointer (`lost_reifies`) are caller-supplied configuration:
+/// PurRDF mints no vocabulary IRIs. If no vocabulary is configured, loss
+/// declarations stay inactive and the query behaves like a plain `CONSTRUCT`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LossVocabulary {
+    /// `rdf:type` of an in-band loss node (e.g. `…/ProjectionLoss`).
+    pub projection_loss: String,
+    /// Predicate carrying the machine loss code (e.g. `…/lossCode`).
+    pub loss_code: String,
+    /// Predicate pointing from the loss node to the dropped triple term
+    /// (e.g. `…/lostReifies`).
+    pub lost_reifies: String,
+}
+
+impl LossVocabulary {
+    /// A vocabulary from the caller's three predicate IRIs.
+    pub fn new(
+        projection_loss: impl Into<String>,
+        loss_code: impl Into<String>,
+        lost_reifies: impl Into<String>,
+    ) -> Self {
+        Self {
+            projection_loss: projection_loss.into(),
+            loss_code: loss_code.into(),
+            lost_reifies: lost_reifies.into(),
         }
     }
 }
@@ -175,12 +210,11 @@ pub struct EvalCtx<'d> {
     /// never revisits an earlier row's ordinal within the same `Extend` chain.
     pub(crate) bnode_memo: DetHashMap<(u64, String), SolutionTerm>,
     /// The evaluation-time value of NOW() — an xsd:dateTime, captured once at
-    /// context construction (from the host platform's real wall clock, see
-    /// [`crate::clock::wall_clock_now`]) so all NOW() calls in a query return the
-    /// same instant (SPARQL 1.1 §17.4.5.1).
+    /// context construction from the host platform's real wall clock so all NOW()
+    /// calls in a query return the same instant (SPARQL 1.1 §17.4.5.1).
     pub now: purrdf_xsd::XsdValue,
     /// Splitmix64 PRNG state for RAND()/UUID()/STRUUID(), seeded once at context
-    /// construction from real OS/platform entropy (see [`crate::clock::entropy_seed`]).
+    /// construction from real OS/platform entropy.
     pub rng_state: u64,
     /// Tunable evaluation behavior (see [`EvalOptions`]). Production default.
     pub options: EvalOptions,
@@ -191,6 +225,11 @@ pub struct EvalCtx<'d> {
     /// annotation to a standpoint scope — deliberately, since these are domain
     /// predicates from the caller's ontology, never engine defaults.
     pub standpoint_predicates: Option<StandpointPredicates>,
+    /// The caller-supplied loss-declaration vocabulary (see [`LossVocabulary`])
+    /// used by loss-aware `CONSTRUCT`. `None` (the default) means loss
+    /// declarations are inactive: a dropped reifier is projected silently, like
+    /// a plain `CONSTRUCT`.
+    pub loss_vocabulary: Option<LossVocabulary>,
     /// Memoized `EXISTS`/`NOT EXISTS` inner patterns **and their probe index**
     /// ([`ExistsInner`]), keyed by [`ExistsCacheKey`]. The inner eval and the index
     /// over it are outer-row-independent, so this turns `expr::exists`'s per-row
@@ -326,6 +365,7 @@ impl core::fmt::Debug for EvalCtx<'_> {
             .field("rng_state", &self.rng_state)
             .field("options", &self.options)
             .field("standpoint_predicates", &self.standpoint_predicates)
+            .field("loss_vocabulary", &self.loss_vocabulary)
             .finish_non_exhaustive()
     }
 }
@@ -348,6 +388,7 @@ impl<'d> EvalCtx<'d> {
             rng_state: rng_seed,
             options: EvalOptions::default(),
             standpoint_predicates: None,
+            loss_vocabulary: None,
             exists_inner_cache: DetHashMap::default(),
             exists_expr_vars_cache: DetHashMap::default(),
             regex_cache: DetHashMap::default(),
@@ -388,6 +429,16 @@ impl<'d> EvalCtx<'d> {
     #[must_use]
     pub fn with_standpoint_predicates(mut self, predicates: StandpointPredicates) -> Self {
         self.standpoint_predicates = Some(predicates);
+        self
+    }
+
+    /// Supply the caller's loss-declaration vocabulary (see [`LossVocabulary`])
+    /// so loss-aware `CONSTRUCT` can emit in-band `ProjectionLoss` declarations
+    /// when a reifier is dropped by the template. Without it, loss declarations
+    /// stay inactive.
+    #[must_use]
+    pub fn with_loss_vocabulary(mut self, vocab: LossVocabulary) -> Self {
+        self.loss_vocabulary = Some(vocab);
         self
     }
 
@@ -546,6 +597,7 @@ impl<'d> EvalCtx<'d> {
             rng_state: self.rng_state,
             options: self.options,
             standpoint_predicates: self.standpoint_predicates.clone(),
+            loss_vocabulary: self.loss_vocabulary.clone(),
             exists_inner_cache: self.exists_inner_cache.clone(),
             exists_expr_vars_cache: self.exists_expr_vars_cache.clone(),
             regex_cache: DetHashMap::default(),
@@ -582,9 +634,9 @@ impl<'d> EvalCtx<'d> {
     }
 
     /// Build a child context for evaluating a SHACL-AF function body: it shares the
-    /// dataset, clock/entropy, order cache, standpoint table, remote source and
-    /// function registry, but starts fresh mutable evaluation state (the body is an
-    /// independent query) and increments the call depth.
+    /// dataset, clock/entropy, order cache, standpoint table, loss vocabulary,
+    /// remote source and function registry, but starts fresh mutable evaluation state
+    /// (the body is an independent query) and increments the call depth.
     ///
     /// # Errors
     ///
@@ -616,6 +668,7 @@ impl<'d> EvalCtx<'d> {
             rng_state: self.rng_state,
             options: self.options,
             standpoint_predicates: self.standpoint_predicates.clone(),
+            loss_vocabulary: self.loss_vocabulary.clone(),
             exists_inner_cache: DetHashMap::default(),
             exists_expr_vars_cache: DetHashMap::default(),
             regex_cache: DetHashMap::default(),

--- a/crates/sparql-eval/src/lib.rs
+++ b/crates/sparql-eval/src/lib.rs
@@ -71,7 +71,9 @@ pub mod user_fn;
 
 pub use engine::{NativeSparqlEngine, PlanCache, PreparedQuery};
 pub use error::EvalError;
-pub use eval::{eval, evaluate_query, EvalCtx, EvalOptions, Outcome, StandpointPredicates};
+pub use eval::{
+    eval, evaluate_query, EvalCtx, EvalOptions, LossVocabulary, Outcome, StandpointPredicates,
+};
 // Re-exported so engine hosts can configure the extension-function namespace set
 // (see [`NativeSparqlEngine::with_parser_options`]) without depending on the
 // front-end crate directly.

--- a/crates/sparql-eval/src/remote.rs
+++ b/crates/sparql-eval/src/remote.rs
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! SPARQL `SERVICE` federation: the [`RemoteQuerySource`] seam and the
-//! [`eval_service`] handler.
+//! SPARQL `SERVICE` federation: the `eval_service` handler and the
+//! [`RemoteQuerySource`] seam.
 //!
 //! `SERVICE [SILENT] <endpoint> { pattern }` evaluates `pattern` at a remote
 //! endpoint and joins the result into the surrounding query. The evaluator stays
@@ -49,7 +49,7 @@ pub struct ResolvedBindings {
 }
 
 /// A failure while resolving a `SERVICE` step. Whether it aborts the query or is
-/// swallowed is decided by [`eval_service`] from the `SILENT` flag, not here.
+/// swallowed is decided by `eval_service` from the `SILENT` flag, not here.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RemoteError {
     /// The endpoint was unreachable / the request failed at the transport layer.

--- a/crates/sparql-eval/src/remote.rs
+++ b/crates/sparql-eval/src/remote.rs
@@ -230,6 +230,7 @@ mod tests {
     use super::*;
     use crate::NativeSparqlEngine;
     use purrdf_core::{RdfDatasetBuilder, RdfLiteral, SparqlEngine, SparqlRequest, SparqlResult};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// `:a :knows :x`, `:a :knows :y` (the local graph).
     fn local() -> Arc<RdfDataset> {
@@ -376,5 +377,108 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, EvalError::Remote(_)), "got {err:?}");
+    }
+
+    // ── LATERAL variable-endpoint SERVICE forwarding counts ───────────────────
+
+    /// `:row{i} :endpoint <http://ex/ep{i}>` for `i` in `0..n`.
+    fn multi_endpoint_local(n: usize) -> Arc<RdfDataset> {
+        let mut b = RdfDatasetBuilder::new();
+        let endpoint = b.intern_iri("http://ex/endpoint");
+        for i in 0..n {
+            let row = b.intern_iri(&format!("http://ex/row{i}"));
+            let ep = b.intern_iri(&format!("http://ex/ep{i}"));
+            b.push_quad(row, endpoint, ep, None);
+        }
+        b.freeze().expect("freeze")
+    }
+
+    /// Endpoint `i` contains `:s :name "ep{i}"`.
+    fn multi_endpoint(i: usize) -> Arc<RdfDataset> {
+        let mut b = RdfDatasetBuilder::new();
+        let name = b.intern_iri("http://ex/name");
+        let s = b.intern_iri("http://ex/s");
+        let lit = b.intern_literal(RdfLiteral::simple(format!("ep{i}")));
+        b.push_quad(s, name, lit, None);
+        b.freeze().expect("freeze")
+    }
+
+    /// Register `n` distinct in-memory endpoints.
+    fn multi_source(n: usize) -> LocalRemoteQuerySource {
+        let mut src = LocalRemoteQuerySource::new();
+        for i in 0..n {
+            src = src.with_endpoint(format!("http://ex/ep{i}"), multi_endpoint(i));
+        }
+        src
+    }
+
+    /// A `RemoteQuerySource` wrapper that counts `query()` calls.
+    struct CountingSource<'a> {
+        inner: &'a (dyn RemoteQuerySource + Sync),
+        count: AtomicUsize,
+    }
+
+    impl<'a> CountingSource<'a> {
+        fn new(inner: &'a (dyn RemoteQuerySource + Sync)) -> Self {
+            Self {
+                inner,
+                count: AtomicUsize::new(0),
+            }
+        }
+        fn count(&self) -> usize {
+            self.count.load(Ordering::SeqCst)
+        }
+    }
+
+    impl RemoteQuerySource for CountingSource<'_> {
+        fn query(&self, endpoint: &str, query_text: &str) -> Result<ResolvedBindings, RemoteError> {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            self.inner.query(endpoint, query_text)
+        }
+    }
+
+    #[test]
+    fn variable_service_forwards_once_per_distinct_endpoint_binding() {
+        // Four left rows, each binding `?g` to a distinct endpoint → the LATERAL
+        // path must forward once for every distinct endpoint (four forwards).
+        let n = 4;
+        let ds = multi_endpoint_local(n);
+        let source = multi_source(n);
+        let counting = CountingSource::new(&source);
+        let result = run_with_source(
+            &ds,
+            &counting,
+            "SELECT * WHERE { ?x <http://ex/endpoint> ?g \
+             SERVICE ?g { ?s <http://ex/name> ?name } }",
+        )
+        .expect("query");
+        assert_eq!(
+            counting.count(),
+            n,
+            "variable SERVICE should forward once per distinct endpoint"
+        );
+        assert_eq!(row_strings(&result).len(), n);
+    }
+
+    #[test]
+    fn fixed_service_forwards_exactly_once_regardless_of_left_rows() {
+        // Four left rows, but the endpoint is fixed → one forward total.
+        let n = 4;
+        let ds = multi_endpoint_local(n);
+        let source = multi_source(n);
+        let counting = CountingSource::new(&source);
+        let result = run_with_source(
+            &ds,
+            &counting,
+            "SELECT * WHERE { ?x <http://ex/endpoint> ?g \
+             SERVICE <http://ex/ep0> { ?s <http://ex/name> ?name } }",
+        )
+        .expect("query");
+        assert_eq!(
+            counting.count(),
+            1,
+            "fixed SERVICE should forward exactly once"
+        );
+        assert_eq!(row_strings(&result).len(), n);
     }
 }

--- a/crates/sparql-eval/src/remote.rs
+++ b/crates/sparql-eval/src/remote.rs
@@ -426,13 +426,13 @@ mod tests {
             }
         }
         fn count(&self) -> usize {
-            self.count.load(Ordering::SeqCst)
+            self.count.load(Ordering::Relaxed)
         }
     }
 
     impl RemoteQuerySource for CountingSource<'_> {
         fn query(&self, endpoint: &str, query_text: &str) -> Result<ResolvedBindings, RemoteError> {
-            self.count.fetch_add(1, Ordering::SeqCst);
+            self.count.fetch_add(1, Ordering::Relaxed);
             self.inner.query(endpoint, query_text)
         }
     }

--- a/crates/sparql-eval/src/update.rs
+++ b/crates/sparql-eval/src/update.rs
@@ -3,7 +3,7 @@
 
 //! SPARQL 1.1 **UPDATE** evaluation over a [`MutableDataset`].
 //!
-//! [`eval_update`] applies a parsed [`Update`] to a copy-on-write
+//! `eval_update` applies a parsed [`Update`] to a copy-on-write
 //! [`MutableDataset`] in request order — each operation observes the effects of the
 //! earlier ones through the shared `m`. The engine seam ([`engine`](crate::engine))
 //! drives this; the read query path is unchanged.
@@ -31,7 +31,7 @@
 //!   for the whole op (they co-refer within the op). `DELETE DATA` is blank-free (a
 //!   parser invariant). Template (`DELETE`/`INSERT … WHERE`) blanks are minted fresh
 //!   per solution row, exactly like `CONSTRUCT`. All of this mints from ONE
-//!   monotonic counter threaded across the whole request ([`eval_update`]'s
+//!   monotonic counter threaded across the whole request (`eval_update`'s
 //!   `bnode_counter`), never reset between operations, so a `_:b` label in one
 //!   operation is a distinct blank from the same label in another operation
 //!   (SPARQL 1.1 Update §4.1.1 / §19.6).

--- a/crates/sparql-eval/src/user_fn.rs
+++ b/crates/sparql-eval/src/user_fn.rs
@@ -15,7 +15,7 @@
 //!
 //! The registry is pure data (parsed bodies + parameter metadata); executing a
 //! call binds the arguments to the parameter variables as a pre-binding rewrite
-//! (the same [`crate::substitute`] path `$this` injection uses) and evaluates the
+//! (the same `crate::substitute` path `$this` injection uses) and evaluates the
 //! body in a recursion-bounded child context. This keeps SPARQL execution inside
 //! the evaluator and the registry free of any engine coupling.
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -28,21 +28,53 @@ They live under `crates/*/benches/`:
 - `crates/rdf-core/benches/ir_layout.rs` — AoS vs. SoA vs. predicate-adjacency
   IR layouts (allocation counts, high-water mark, end-to-end latency).
 - `crates/rdf-core/benches/mutable.rs` — copy-on-write mutation paths.
+- `crates/rdf-core/benches/intern_content_id.rs` — content-addressing
+  recognition cost for ordinary vs. genuine content-id IRIs.
 - `crates/rdf/benches/native_codecs.rs` — text/XML/JSON-LD codec throughput.
-- `crates/sparql-eval/benches/{query_eval,cost_based_bgp_planner,exists_decorrelation}.rs`
-  — SPARQL evaluation and planner costs. The `cost_based_bgp_planner` bench is a
-  regression watch on the cost-based BGP join planner; the deterministic win over
-  the retired structural heuristic is gated by the `bgp` unit tests (which count
-  real intermediate rows) and by the differential corpus test in
+- `crates/sparql-algebra/benches/tokenize.rs` — SPARQL/Turtle lexer hot path
+  (`IRIREF`, string literals, comments).
+- `crates/sparql-eval/benches/query_eval.rs` — end-to-end SPARQL SELECT
+  evaluation over synthetic datasets.
+- `crates/sparql-eval/benches/cost_based_bgp_planner.rs` — regression watch on
+  the cost-based BGP join planner; the deterministic win over the retired
+  structural heuristic is gated by the `bgp` unit tests (which count real
+  intermediate rows) and by the differential corpus test in
   `crates/sparql-conformance/tests/cost_planner_corpus.rs`.
+- `crates/sparql-eval/benches/exists_decorrelation.rs` — `FILTER NOT EXISTS`
+  anti-join cost with and without the `exists_memo` decorrelation path.
+- `crates/sparql-eval/benches/lateral_service.rs` — variable-endpoint
+  `SERVICE ?g` evaluated as a LATERAL join vs. a fixed-IRI `SERVICE <ep>`.
+- `crates/shapes/benches/validate.rs` — SHACL validation.
+- `crates/entail/benches/chase.rs` — RDFS forward-materialization chase scaling.
+- `crates/gts/benches/authoring.rs` — GTS container authoring.
+- `crates/iri/benches/parse.rs` — IRI parse/validate hot path over a mixed
+  character-class corpus.
 
 `NativeSparqlEngine::explain_query` exposes the chosen BGP order as an ordered
 list of triple-pattern strings, so callers can audit planner decisions without
 running the query.
-- `crates/shapes/benches/validate.rs` — SHACL validation.
-- `crates/gts/benches/authoring.rs` — GTS container authoring.
 
-Run them all with `make bench` (report-only; never part of `make check`).
+Run the default set with `make bench` (report-only; never part of `make check`).
+Additional benches are run package-by-package, e.g.
+`cargo bench -p purrdf-iri --bench parse`.
+
+### Native criterion benchmark inventory
+
+| Bench | What it measures |
+| --- | --- |
+| `crates/rdf-core/benches/ir_layout.rs` | AoS / SoA / predicate-adjacency IR layout trade-offs (latency, allocations, peak RSS). |
+| `crates/rdf-core/benches/mutable.rs` | Copy-on-write mutation paths on the immutable IR. |
+| `crates/rdf-core/benches/intern_content_id.rs` | Extra intern-time cost when content-addressing is enabled: prefix-miss baseline, prefix-hit decode, and side-table insert. |
+| `crates/rdf/benches/native_codecs.rs` | Throughput of the native Turtle, TriG, N-Triples, N-Quads, RDF/XML, and JSON-LD serializers/parsers. |
+| `crates/sparql-algebra/benches/tokenize.rs` | Lexer throughput on long IRI bodies, escaped string literals, and comment tails. |
+| `crates/sparql-eval/benches/query_eval.rs` | End-to-end SPARQL SELECT latency including BGP joins, filters, and aggregates. |
+| `crates/sparql-eval/benches/cost_based_bgp_planner.rs` | Planner regression watch: cost-based BGP ordering vs. the retired structural heuristic. |
+| `crates/sparql-eval/benches/exists_decorrelation.rs` | `FILTER NOT EXISTS` inner-pattern re-evaluation and index-rebuild cost with/without memoization. |
+| `crates/sparql-eval/benches/lateral_service.rs` | `SERVICE ?g` LATERAL substitute-and-forward cost as the number of distinct endpoint bindings grows. |
+| `crates/shapes/benches/validate.rs` | SHACL Core validation latency on synthetic shapes/graphs. |
+| `crates/entail/benches/chase.rs` | RDFS semi-naive materialization scaling on subclass chains. |
+| `crates/gts/benches/authoring.rs` | GTS container authoring: append, hash, and CBOR-log construction throughput. |
+| `crates/iri/benches/parse.rs` | `purrdf_iri::parse` component validation across scheme, authority, path, query, and fragment classes. |
 
 ## Python compat harness (`bench_compat.py`)
 
@@ -94,32 +126,32 @@ guarantee** — your numbers will differ. Reproduce with `make bench-python`.
 
 | size | operation | purrdf ms | rdflib ms | ratio (p/r) |
 | ---: | --- | ---: | ---: | ---: |
-| 1,000 | parse_nt | 9.9 | 6.7 | 1.48 |
-| 1,000 | parse_ttl | 8.9 | 12.2 | 0.73 |
-| 1,000 | serialize_nt | 5.3 | 1.3 | 4.10 |
-| 1,000 | serialize_ttl | 18.7 | 11.8 | 1.59 |
-| 1,000 | query_bgp | 3.0 | 1.0 | 2.99 |
-| 1,000 | query_agg | 3.0 | 3.6 | 0.84 |
-| 1,000 | triples_scan | 2.2 | 0.3 | 6.42 |
-| 10,000 | parse_nt | 95.3 | 71.9 | 1.33 |
-| 10,000 | parse_ttl | 87.3 | 125.6 | 0.70 |
-| 10,000 | serialize_nt | 55.8 | 13.6 | 4.11 |
-| 10,000 | serialize_ttl | 196.4 | 127.4 | 1.54 |
-| 10,000 | query_bgp | 31.2 | 2.4 | 13.14 |
-| 10,000 | query_agg | 30.8 | 10.2 | 3.01 |
-| 10,000 | triples_scan | 22.7 | 3.6 | 6.28 |
-| 100,000 | parse_nt | 777.9 | 1863.5 | 0.42 |
-| 100,000 | parse_ttl | 1110.0 | 2894.3 | 0.38 |
-| 100,000 | serialize_nt | 746.4 | 202.0 | 3.69 |
-| 100,000 | serialize_ttl | 2550.6 | 1693.3 | 1.51 |
-| 100,000 | query_bgp | 432.5 | 17.1 | 25.34 |
-| 100,000 | query_agg | 426.7 | 76.9 | 5.55 |
-| 100,000 | triples_scan | 303.3 | 59.3 | 5.11 |
+| 1,000 | parse_nt | 16.8 | 13.8 | 1.22 |
+| 1,000 | parse_ttl | 17.5 | 30.4 | 0.58 |
+| 1,000 | serialize_nt | 9.5 | 2.7 | 3.53 |
+| 1,000 | serialize_ttl | 32.5 | 24.9 | 1.31 |
+| 1,000 | query_bgp | 6.7 | 2.2 | 3.13 |
+| 1,000 | query_agg | 7.1 | 8.4 | 0.85 |
+| 1,000 | triples_scan | 5.5 | 0.7 | 8.20 |
+| 10,000 | parse_nt | 178.6 | 93.5 | 1.91 |
+| 10,000 | parse_ttl | 187.1 | 244.8 | 0.76 |
+| 10,000 | serialize_nt | 64.9 | 34.3 | 1.89 |
+| 10,000 | serialize_ttl | 214.3 | 195.6 | 1.10 |
+| 10,000 | query_bgp | 41.7 | 4.9 | 8.47 |
+| 10,000 | query_agg | 40.0 | 15.2 | 2.63 |
+| 10,000 | triples_scan | 41.8 | 7.9 | 5.29 |
+| 100,000 | parse_nt | 964.1 | 2081.3 | 0.46 |
+| 100,000 | parse_ttl | 1429.9 | 3033.4 | 0.47 |
+| 100,000 | serialize_nt | 825.0 | 210.2 | 3.93 |
+| 100,000 | serialize_ttl | 2869.9 | 1947.1 | 1.47 |
+| 100,000 | query_bgp | 488.1 | 36.4 | 13.42 |
+| 100,000 | query_agg | 494.0 | 98.6 | 5.01 |
+| 100,000 | triples_scan | 358.6 | 77.6 | 4.62 |
 
 Reading this honestly, on this host and this run:
 
 - **Bulk N-Triples/Turtle parsing** scales better in the shim — at 100k triples
-  it parsed both formats roughly 2.4–2.6× faster than real `rdflib`, and it was
+  it parsed both formats roughly 2.1–2.2× faster than real `rdflib`, and it was
   already ahead on Turtle at every size.
 - **Per-item operations that cross the Python↔native boundary once per result or
   per triple** — `serialize`, `triples()` iteration, and the SELECT queries —

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -30,7 +30,15 @@ They live under `crates/*/benches/`:
 - `crates/rdf-core/benches/mutable.rs` — copy-on-write mutation paths.
 - `crates/rdf/benches/native_codecs.rs` — text/XML/JSON-LD codec throughput.
 - `crates/sparql-eval/benches/{query_eval,cost_based_bgp_planner,exists_decorrelation}.rs`
-  — SPARQL evaluation and planner costs.
+  — SPARQL evaluation and planner costs. The `cost_based_bgp_planner` bench is a
+  regression watch on the cost-based BGP join planner; the deterministic win over
+  the retired structural heuristic is gated by the `bgp` unit tests (which count
+  real intermediate rows) and by the differential corpus test in
+  `crates/sparql-conformance/tests/cost_planner_corpus.rs`.
+
+`NativeSparqlEngine::explain_query` exposes the chosen BGP order as an ordered
+list of triple-pattern strings, so callers can audit planner decisions without
+running the query.
 - `crates/shapes/benches/validate.rs` — SHACL validation.
 - `crates/gts/benches/authoring.rs` — GTS container authoring.
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -80,8 +80,11 @@ Additional benches are run package-by-package, e.g.
 
 `bindings/python/benchmarks/bench_compat.py` times the shim and the genuine
 `rdflib` **in one process** and prints a side-by-side table with the
-purrdf/rdflib ratio. It is deliberately kept out of `make pytest` and CI: it is
-slow and timing-sensitive, so it is never collected as a test.
+purrdf/rdflib ratio. It is deliberately kept out of `make pytest` because it is
+slow and timing-sensitive, but it is run in the separate, report-only
+`benchmarks` CI job. That job produces `bench_compat.json` and uploads it
+alongside the Criterion artifacts. The job uses `continue-on-error: true`, so it
+never fails the main gate.
 
 ### Methodology
 

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -152,7 +152,7 @@ The ledgers themselves (each entry = one node id + a concrete, self-describing
 reason):
 
 - `bindings/python/tests/xfail_ledger.toml` — the first-party
-  `purrdf.compat` parity ledger (7 strict xfails).
+  `purrdf.compat` parity ledger (5 strict xfails).
 - `bindings/python/tests/rdflib_suite/xfail_ledger.toml` — the rdflib
   drop-in (LSP) gate ledger governing rdflib's own vendored tests (24 strict
   xfails). Both are applied as **strict** xfails, so an XPASS or a stale key
@@ -225,7 +225,7 @@ The node-expression kinds split into two tiers:
   separate boolean `sh:desc` flag. The owned semantics are pinned by the
   first-party corpus and unit tests, while the vendored `vectors/shacl/af/`
   suite provides additional coverage for the overlapping normative surface.
-- **rdflib drop-in residuals** — 23 rdflib-suite + 7 compat-parity strict
+- **rdflib drop-in residuals** — 24 rdflib-suite + 5 compat-parity strict
   xfails cover Graph-subclass identity through set operators, rdf:List /
   Collection mutation, `Result.bindings` / `SELECT *` subselect projection,
   graph-prefix forwarding, aggregate/nested-FILTER evaluation, and


### PR DESCRIPTION
Closes #10

## Summary
Closes the public-maturity epic. The five filed child issues (#6, #7, #8, #9, #30) were already merged; this branch verifies their completion, audits and closes the remaining unfiled gaps (SPARQL engine completion, cost-based planner demonstration, published benchmarks), and cleans up hygiene/docs drift.

## Changes
- Verified full local gate, conformance matrix, wasm gate, and Python gate are green.
- Audited SPARQL engine completion: SERVICE/lateral, deep-subquery decorrelation, exotic aggregation.
- Added federated SERVICE forward-count tests using `LocalRemoteQuerySource`.
- Verified cost-based BGP planner is implemented and benchmarked.
- Added differential planner-correctness test over the W3C SPARQL corpus (333 cases, 0 mismatches).
- Added public `NativeSparqlEngine::explain_query` plan-introspection API.
- Extended CI `benchmarks` job to run native criterion suites and the Python compat harness and upload artifacts.
- Published/updated benchmark documentation for native criterion suites and the rdflib compat harness.
- Refactored `purrdf-sparql-eval` to use a caller-supplied loss vocabulary instead of a hard-coded namespace.
- Regenerated conformance matrix and removed stale issue references.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added query explanation that returns the selected BGP join-order as an ordered triple-pattern sequence.
  * Added configurable “loss vocabulary” support for loss-aware `CONSTRUCT`.
* **Bug Fixes**
  * Improved conformance result comparison with clearer, type-aware mismatch reporting.
  * Reduced redundant `SERVICE` endpoint evaluations by matching forwarding to endpoint binding behavior.
* **Documentation**
  * Updated benchmarks and conformance docs for revised loss terminology and refreshed figures.
* **Tests / CI**
  * Expanded conformance testing with differential planner checks and `SERVICE` call-count assertions.
  * Updated CI benchmarks to run full suites longer and publish results as artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->