### PR TITLE
refactor(rdf): centralize native-codec format dispatch behind an RdfCodec trait

### DIFF
--- a/crates/rdf/src/native_codecs/codec.rs
+++ b/crates/rdf/src/native_codecs/codec.rs
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Per-format codec dispatch for the native RDF text codecs.
+//!
+//! [`RdfCodec`] is the single object-safe seam the [`NativeRdfFormat`] router resolves
+//! to: [`codec_for`] maps each format to one `&'static dyn RdfCodec`, so the parse /
+//! serialize / star-capability / span-capability decisions live in ONE place instead of
+//! the parallel `match` arms that were scattered across [`parse`](super::parse) and
+//! [`serialize`](super::serialize).
+//!
+//! The four line/Turtle-family formats (N-Triples / N-Quads / Turtle / TriG) share ONE
+//! implementor ([`LineCodec`]) BY DESIGN — they share the [`text_parse`](super::text_parse)
+//! front-end and the [`ser_model`](super::ser_model) serializers, so splitting them into
+//! four codecs would shatter that fusion. RDF/XML, TriX and HexTuples are standalone
+//! codecs whose implementors live beside their own codec functions
+//! ([`super::rdfxml`], [`super::trix`], [`super::hextuples`]).
+//!
+//! This is a `pub(super)` INTERNAL organizing device, NOT a public seam — it never
+//! leaves the `native_codecs` module. The crate's public contract stays the
+//! `RdfParserBackend` / `RdfSerializer` traits in `purrdf-rdf-core`.
+
+use std::sync::Arc;
+
+use super::media_type::NativeRdfFormat;
+use super::ser_model::{self, SerGraph};
+use super::span::NoSpans;
+use super::text_parse::LineParseMode;
+use crate::{RdfDataset, RdfDiagnostic};
+
+/// One RDF text format's parse + serialize behavior, plus the two capability predicates
+/// the dispatch sites branch on. Object-safe so [`codec_for`] can hand back a
+/// `&'static dyn RdfCodec` — a COLD dispatch boundary (the media-type router), never the
+/// tokenizer hot loop, so the one indirect call it adds is not on any measured path.
+pub(super) trait RdfCodec {
+    /// Whether this format carries the RDF-1.2 statement layer (quoted-triple reifiers +
+    /// annotations) under the transcode loss contract. Star-capable formats emit it;
+    /// star-incapable formats drop it as declared loss. Kept aligned with the loss
+    /// ledger (`crates/rdf-core/src/loss.rs`).
+    fn carries_star(&self) -> bool;
+
+    /// Whether this format's parser can record per-statement source spans. Only the
+    /// line/Turtle-family text tokenizer does; the others return an empty span table
+    /// (physical-location fallback by design).
+    fn tokenizer_carries_spans(&self) -> bool;
+
+    /// Parse `text` into the frozen IR on the hot (span-free) path. `mode` is honored
+    /// only by [`LineCodec`] (the N-Triples/N-Quads chunk-parallel toggle); the
+    /// standalone codecs ignore it. Every implementor is panic-guarded, matching the
+    /// per-format guards the call sites applied before.
+    fn parse(
+        &self,
+        text: &str,
+        base_iri: Option<&str>,
+        mode: LineParseMode,
+    ) -> Result<Arc<RdfDataset>, RdfDiagnostic>;
+
+    /// Serialize a first-party [`SerGraph`] to this format's text.
+    fn serialize(&self, graph: &SerGraph) -> Result<String, RdfDiagnostic>;
+}
+
+/// The shared implementor for the four line/Turtle-family formats, keyed by the wrapped
+/// variant. They parse through one `text_parse` front-end and serialize through the
+/// matching `ser_model` writer, so a SINGLE codec — not four — preserves that fusion.
+pub(super) struct LineCodec(pub(super) NativeRdfFormat);
+
+impl RdfCodec for LineCodec {
+    fn carries_star(&self) -> bool {
+        // Every format `LineCodec` wraps (Turtle / N-Triples / N-Quads / TriG) is
+        // star-capable; the standalone codecs are the star-incapable ones.
+        true
+    }
+
+    fn tokenizer_carries_spans(&self) -> bool {
+        true
+    }
+
+    fn parse(
+        &self,
+        text: &str,
+        base_iri: Option<&str>,
+        mode: LineParseMode,
+    ) -> Result<Arc<RdfDataset>, RdfDiagnostic> {
+        // The hot path never records spans; the span-tracking path in
+        // `parse_dataset_with` calls `text_parse_without_panicking` with a `SpanTable`
+        // directly (a distinct monomorphization), so `NoSpans` stays zero-cost here.
+        let graph =
+            super::parse::text_parse_without_panicking(self.0, text, base_iri, mode, &mut NoSpans)?;
+        super::parse::dataset_from_ser_graph(&graph)
+    }
+
+    fn serialize(&self, graph: &SerGraph) -> Result<String, RdfDiagnostic> {
+        Ok(match self.0 {
+            NativeRdfFormat::Turtle => ser_model::to_turtle(graph)?,
+            NativeRdfFormat::TriG => ser_model::to_trig(graph),
+            NativeRdfFormat::NTriples => ser_model::to_ntriples(graph)?,
+            NativeRdfFormat::NQuads => ser_model::to_nquads(graph),
+            NativeRdfFormat::RdfXml | NativeRdfFormat::TriX | NativeRdfFormat::HexTuples => {
+                unreachable!("LineCodec only wraps line/Turtle-family formats")
+            }
+        })
+    }
+}
+
+/// Resolve a [`NativeRdfFormat`] to its codec — the SINGLE format→behavior chokepoint.
+///
+/// The returned reference is `'static` via rvalue static promotion: every implementor is
+/// a zero-sized (or `Copy`-enum-wrapping) value with no interior mutability and no
+/// destructor, so `&Codec` promotes to a `&'static` borrow of a constant.
+pub(super) fn codec_for(format: NativeRdfFormat) -> &'static dyn RdfCodec {
+    match format {
+        NativeRdfFormat::NTriples => &LineCodec(NativeRdfFormat::NTriples),
+        NativeRdfFormat::NQuads => &LineCodec(NativeRdfFormat::NQuads),
+        NativeRdfFormat::Turtle => &LineCodec(NativeRdfFormat::Turtle),
+        NativeRdfFormat::TriG => &LineCodec(NativeRdfFormat::TriG),
+        NativeRdfFormat::RdfXml => &super::rdfxml::RdfXmlCodec,
+        NativeRdfFormat::TriX => &super::trix::TriXCodec,
+        NativeRdfFormat::HexTuples => &super::hextuples::HexTuplesCodec,
+    }
+}

--- a/crates/rdf/src/native_codecs/hextuples.rs
+++ b/crates/rdf/src/native_codecs/hextuples.rs
@@ -22,9 +22,43 @@
 
 use std::sync::Arc;
 
+use super::codec::RdfCodec;
+use super::media_type::NativeRdfFormat;
 use super::parse::{fold_statement_layer, FoldNode, FoldRow, RDF_REIFIES};
 use super::ser_model::{SerGraph, SerTerm, SerTermKind};
+use super::text_parse::LineParseMode;
 use crate::{BlankScope, RdfDataset, RdfDatasetBuilder, RdfDiagnostic, RdfLiteral, TermId};
+
+/// The HexTuples codec: a standalone (non-line-family) [`RdfCodec`] over the
+/// line-oriented NDJSON quads syntax. A classic quad syntax with no RDF-1.2 triple-term
+/// surface, so it is star-INcapable, and its NDJSON parser carries no span-recording
+/// tokenizer.
+pub(super) struct HexTuplesCodec;
+
+impl RdfCodec for HexTuplesCodec {
+    fn carries_star(&self) -> bool {
+        false
+    }
+
+    fn tokenizer_carries_spans(&self) -> bool {
+        false
+    }
+
+    fn parse(
+        &self,
+        text: &str,
+        _base_iri: Option<&str>,
+        _mode: LineParseMode,
+    ) -> Result<Arc<RdfDataset>, RdfDiagnostic> {
+        super::parse::catch_codec_panic(NativeRdfFormat::HexTuples, || {
+            parse_hextuples_to_dataset(text)
+        })
+    }
+
+    fn serialize(&self, graph: &SerGraph) -> Result<String, RdfDiagnostic> {
+        serialize_ser_graph_to_hextuples(graph)
+    }
+}
 
 const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
 const RDF_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";

--- a/crates/rdf/src/native_codecs/mod.rs
+++ b/crates/rdf/src/native_codecs/mod.rs
@@ -54,6 +54,11 @@ mod hextuples;
 // NOT a Cargo feature; the default `NoSpans` collector monomorphizes the recording out
 // so the pre-existing parse path is byte-identical.
 mod span;
+// Per-format codec dispatch: the single `NativeRdfFormat` → behavior chokepoint. Holds
+// the `RdfCodec` trait, the shared `LineCodec` for the line/Turtle family, and the
+// `codec_for` resolver every parse/serialize call site routes through (replacing the
+// scattered match-on-format arms). `pub(super)`, never part of the public API.
+mod codec;
 
 pub use media_type::{classify, NativeRdfFormat};
 pub use parse::{parse_dataset, parse_dataset_with};

--- a/crates/rdf/src/native_codecs/parse.rs
+++ b/crates/rdf/src/native_codecs/parse.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 use super::media_type::{classify, NativeRdfFormat};
 use super::ser_model::{SerGraph, SerTermKind};
-use super::span::{NoSpans, ParseOptions, SpanCollector, SpanTable};
+use super::span::{ParseOptions, SpanCollector, SpanTable};
 use super::text_parse::LineParseMode;
 use crate::{
     BlankScope, RdfDataset, RdfDatasetBuilder, RdfDiagnostic, RdfLiteral, RdfTextDirection, TermId,
@@ -156,34 +156,30 @@ pub fn parse_dataset_with(
 
     let format = classify(media_type)?;
 
-    match format {
-        NativeRdfFormat::NTriples
-        | NativeRdfFormat::NQuads
-        | NativeRdfFormat::Turtle
-        | NativeRdfFormat::TriG => {
-            // UTF-8 is only required by the text tokenizer; the byte-oriented formats
-            // below never touch `text`, so validate it lazily inside this arm.
-            let text = std::str::from_utf8(bytes)
-                .map_err(|e| RdfDiagnostic::error("native-codec-utf8", e.to_string()))?;
-            // Force sequential so subject spans are captured (the parallel path is
-            // `NoSpans`-only), then fold into the SAME frozen IR `parse_dataset` builds.
-            let mut table = SpanTable::default();
-            let graph = text_parse_without_panicking(
-                format,
-                text,
-                base_iri,
-                LineParseMode::ForceSequential,
-                &mut table,
-            )?;
-            let dataset = dataset_from_ser_graph(&graph)?;
-            Ok((dataset, Some(table)))
-        }
+    if super::codec::codec_for(format).tokenizer_carries_spans() {
+        // Line/Turtle family: UTF-8 is only required by the text tokenizer, so validate
+        // it here where the span-carrying pipeline consumes it.
+        let text = std::str::from_utf8(bytes)
+            .map_err(|e| RdfDiagnostic::error("native-codec-utf8", e.to_string()))?;
+        // Force sequential so subject spans are captured (the parallel path is
+        // `NoSpans`-only), then fold into the SAME frozen IR `parse_dataset` builds. This
+        // is a distinct `SpanTable` monomorphization of `text_parse_without_panicking`,
+        // so the hot `NoSpans` path the codec's `parse` drives stays zero-cost.
+        let mut table = SpanTable::default();
+        let graph = text_parse_without_panicking(
+            format,
+            text,
+            base_iri,
+            LineParseMode::ForceSequential,
+            &mut table,
+        )?;
+        let dataset = dataset_from_ser_graph(&graph)?;
+        Ok((dataset, Some(table)))
+    } else {
         // RDF/XML, TriX, HexTuples: no span-carrying text tokenizer, so return an empty
         // table alongside the identical dataset (physical-location fallback by design).
-        NativeRdfFormat::RdfXml | NativeRdfFormat::TriX | NativeRdfFormat::HexTuples => {
-            let dataset = parse_dataset_mode(bytes, media_type, base_iri, LineParseMode::Auto)?;
-            Ok((dataset, Some(SpanTable::default())))
-        }
+        let dataset = parse_dataset_mode(bytes, media_type, base_iri, LineParseMode::Auto)?;
+        Ok((dataset, Some(SpanTable::default())))
     }
 }
 
@@ -213,43 +209,24 @@ fn parse_dataset_mode(
     let text = std::str::from_utf8(bytes)
         .map_err(|e| RdfDiagnostic::error("native-codec-utf8", e.to_string()))?;
 
-    match format {
-        // The line/Turtle family parses FIRST-PARTY straight into the first-party
-        // in-memory SerGraph the statement-layer fold consumes — no purrdf-gts text
-        // codec, no text→bytes→reader indirection. This also decodes `\uXXXX` UCHAR
-        // escapes inside IRIREFs (W3C test060), which the purrdf-gts IRIREF readers
-        // rejected. N-Triples/N-Quads above the `text_parse` size threshold tokenize
-        // their line-aligned chunks in PARALLEL (phase 1) and re-join in document
-        // order before interning (phase 2), so the frozen IR — term ids, quad order,
-        // diagnostics — is byte-identical to the sequential pipeline. Turtle/TriG stay
-        // sequential (stateful `@prefix`/`@base` + document-ordered bnode minting; see
-        // `text_parse::parse_to_gts_graph_mode`).
-        NativeRdfFormat::NTriples
-        | NativeRdfFormat::NQuads
-        | NativeRdfFormat::Turtle
-        | NativeRdfFormat::TriG => {
-            let graph = text_parse_without_panicking(format, text, base_iri, mode, &mut NoSpans)?;
-            dataset_from_ser_graph(&graph)
-        }
-        // RDF/XML parses FIRST-PARTY through the in-repo `rdfxml` codec (W3C RDF/XML
-        // grammar over a pure-Rust XML DOM), which interns straight into the frozen IR
-        // through the SAME shared statement-layer fold — no intermediate GTS graph.
-        NativeRdfFormat::RdfXml => parse_rdfxml_without_panicking(text, base_iri),
-        // TriX / HexTuples parse FIRST-PARTY through their in-repo codecs (XML DOM /
-        // NDJSON), interning straight into the frozen IR through the SAME shared
-        // statement-layer fold.
-        NativeRdfFormat::TriX => catch_codec_panic(NativeRdfFormat::TriX, || {
-            super::trix::parse_trix_to_dataset(text)
-        }),
-        NativeRdfFormat::HexTuples => catch_codec_panic(NativeRdfFormat::HexTuples, || {
-            super::hextuples::parse_hextuples_to_dataset(text)
-        }),
-    }
+    // Dispatch to the format's codec (the single `codec_for` chokepoint). Each codec is
+    // FIRST-PARTY and panic-guarded: the line/Turtle family parses into the in-memory
+    // SerGraph the statement-layer fold consumes (N-Triples/N-Quads above the
+    // `text_parse` size threshold tokenize line-aligned chunks in PARALLEL and re-join
+    // in document order, so the frozen IR is byte-identical to the sequential pipeline;
+    // Turtle/TriG stay sequential for stateful `@prefix`/`@base` + document-ordered
+    // bnode minting — see `text_parse::parse_to_gts_graph_mode`); RDF/XML, TriX and
+    // HexTuples intern straight into the frozen IR through the SAME shared fold, no
+    // intermediate GTS graph. `mode` is honored only by the line/Turtle family.
+    super::codec::codec_for(format).parse(text, base_iri, mode)
 }
 
 /// Run a first-party codec parse under a panic guard, converting any unwind into a
 /// structured `native-codec-panic` diagnostic (mirrors the RDF/XML guard).
-fn catch_codec_panic<F>(format: NativeRdfFormat, parse: F) -> Result<Arc<RdfDataset>, RdfDiagnostic>
+pub(super) fn catch_codec_panic<F>(
+    format: NativeRdfFormat,
+    parse: F,
+) -> Result<Arc<RdfDataset>, RdfDiagnostic>
 where
     F: FnOnce() -> Result<Arc<RdfDataset>, RdfDiagnostic>,
 {
@@ -266,7 +243,7 @@ where
     }
 }
 
-fn text_parse_without_panicking<S: SpanCollector>(
+pub(super) fn text_parse_without_panicking<S: SpanCollector>(
     format: NativeRdfFormat,
     text: &str,
     base_iri: Option<&str>,
@@ -289,7 +266,7 @@ fn text_parse_without_panicking<S: SpanCollector>(
     }
 }
 
-fn parse_rdfxml_without_panicking(
+pub(super) fn parse_rdfxml_without_panicking(
     text: &str,
     base_iri: Option<&str>,
 ) -> Result<Arc<RdfDataset>, RdfDiagnostic> {

--- a/crates/rdf/src/native_codecs/rdfxml.rs
+++ b/crates/rdf/src/native_codecs/rdfxml.rs
@@ -41,11 +41,42 @@ use std::sync::Arc;
 
 use roxmltree::{Document, Node};
 
+use super::codec::RdfCodec;
 use super::parse::{fold_statement_layer, FoldNode, FoldRow, RDF_REIFIES as RDF_REIFIES_IRI};
 use super::ser_model::{deterministic_blank_label_with_prefix, SerGraph, SerTerm, SerTermKind};
+use super::text_parse::LineParseMode;
 use crate::{
     BlankScope, RdfDataset, RdfDatasetBuilder, RdfDiagnostic, RdfLiteral, RdfTextDirection, TermId,
 };
+
+/// The RDF/XML codec: a standalone (non-line-family) [`RdfCodec`] over the in-repo W3C
+/// RDF/XML grammar. RDF/XML is treated as star-INcapable under the transcode loss
+/// contract (`*→rdfxml` is `rdf12-star-unrepresentable`), and its parser carries no
+/// span-recording tokenizer.
+pub(super) struct RdfXmlCodec;
+
+impl RdfCodec for RdfXmlCodec {
+    fn carries_star(&self) -> bool {
+        false
+    }
+
+    fn tokenizer_carries_spans(&self) -> bool {
+        false
+    }
+
+    fn parse(
+        &self,
+        text: &str,
+        base_iri: Option<&str>,
+        _mode: LineParseMode,
+    ) -> Result<Arc<RdfDataset>, RdfDiagnostic> {
+        super::parse::parse_rdfxml_without_panicking(text, base_iri)
+    }
+
+    fn serialize(&self, graph: &SerGraph) -> Result<String, RdfDiagnostic> {
+        serialize_ser_graph_to_rdfxml(graph)
+    }
+}
 
 const RDF_NS: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
 const XML_NS: &str = "http://www.w3.org/XML/1998/namespace";

--- a/crates/rdf/src/native_codecs/serialize.rs
+++ b/crates/rdf/src/native_codecs/serialize.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use std::io::Write;
 
 use super::media_type::{classify, NativeRdfFormat};
-use super::ser_model::{self, SerAnnotationRow, SerGraph, SerReifierRow, SerTerm, SerTermKind};
+use super::ser_model::{SerAnnotationRow, SerGraph, SerReifierRow, SerTerm, SerTermKind};
 use crate::ir::TermRef;
 use crate::{RdfDataset, RdfDiagnostic, RdfTextDirection, SerializeGraph, TermId, TermValue};
 
@@ -70,19 +70,11 @@ fn serialize_dataset_inner(
 ) -> Result<Vec<u8>, RdfDiagnostic> {
     let format = classify(media_type)?;
     let graph = build_ser_graph(dataset, format, selection, include_statement_layer)?;
-    let text = match format {
-        NativeRdfFormat::Turtle => ser_model::to_turtle(&graph)?,
-        NativeRdfFormat::TriG => ser_model::to_trig(&graph),
-        NativeRdfFormat::NTriples => ser_model::to_ntriples(&graph)?,
-        NativeRdfFormat::NQuads => ser_model::to_nquads(&graph),
-        // RDF/XML serializes FIRST-PARTY from the same `SerGraph`, walking its base
-        // quads (the star layer is declared loss for the star-incapable target).
-        NativeRdfFormat::RdfXml => super::rdfxml::serialize_ser_graph_to_rdfxml(&graph)?,
-        // TriX / HexTuples serialize FIRST-PARTY from the same `SerGraph`, walking its
-        // quads (with named-graph slots) through their in-repo emitters.
-        NativeRdfFormat::TriX => super::trix::serialize_ser_graph_to_trix(&graph)?,
-        NativeRdfFormat::HexTuples => super::hextuples::serialize_ser_graph_to_hextuples(&graph)?,
-    };
+    // Dispatch to the format's codec (the single `codec_for` chokepoint): the line/Turtle
+    // family walks the shared `ser_model` writers, and RDF/XML, TriX and HexTuples walk
+    // the SAME `SerGraph` through their in-repo emitters (the star layer is declared loss
+    // for the star-incapable XML/NDJSON targets).
+    let text = super::codec::codec_for(format).serialize(&graph)?;
     Ok(text.into_bytes())
 }
 
@@ -111,26 +103,6 @@ pub struct SerializeOutcome {
     pub statement_rows_dropped: usize,
 }
 
-/// Whether a [`NativeRdfFormat`] carries the RDF-1.2 statement layer (quoted-triple
-/// reifiers + annotations) under the transcode loss contract.
-///
-/// Turtle, N-Triples, N-Quads and TriG are star-capable. RDF/XML is treated as
-/// star-INcapable here even though the native serializer *can* emit classic
-/// `rdf:Statement` reification: the loss ledger
-/// (`crates/rdf-core/src/loss.rs`) declares `*→rdfxml` as `rdf12-star-unrepresentable`
-/// because classic reification is a lossy projection, not faithful RDF-1.2 star.
-/// Keeping the predicate aligned with the ledger keeps the realized-loss accounting
-/// honest.
-fn is_star_capable(format: NativeRdfFormat) -> bool {
-    matches!(
-        format,
-        NativeRdfFormat::Turtle
-            | NativeRdfFormat::NTriples
-            | NativeRdfFormat::NQuads
-            | NativeRdfFormat::TriG
-    )
-}
-
 /// Serialize the frozen IR to a concrete [`NativeRdfFormat`], returning the bytes and
 /// the count of RDF-1.2 statement-layer rows dropped because the target format does
 /// not carry the star layer (the projection doctrine).
@@ -152,7 +124,7 @@ pub fn serialize_dataset_to_format(
     _base_iri: Option<&str>,
 ) -> Result<SerializeOutcome, RdfDiagnostic> {
     let media_type = format.media_type();
-    if is_star_capable(format) {
+    if super::codec::codec_for(format).carries_star() {
         let bytes = serialize_dataset(dataset, media_type, SerializeGraph::Dataset)?;
         Ok(SerializeOutcome {
             bytes,

--- a/crates/rdf/src/native_codecs/trix.rs
+++ b/crates/rdf/src/native_codecs/trix.rs
@@ -22,9 +22,40 @@ use std::sync::Arc;
 
 use roxmltree::{Document, Node};
 
+use super::codec::RdfCodec;
+use super::media_type::NativeRdfFormat;
 use super::parse::{fold_statement_layer, FoldNode, FoldRow, RDF_REIFIES};
 use super::ser_model::{SerGraph, SerTerm, SerTermKind};
+use super::text_parse::LineParseMode;
 use crate::{BlankScope, RdfDataset, RdfDatasetBuilder, RdfDiagnostic, RdfLiteral, TermId};
+
+/// The TriX codec: a standalone (non-line-family) [`RdfCodec`] over the "Triples in XML"
+/// quads syntax. A classic quad syntax with no RDF-1.2 triple-term surface, so it is
+/// star-INcapable, and its XML-DOM parser carries no span-recording tokenizer.
+pub(super) struct TriXCodec;
+
+impl RdfCodec for TriXCodec {
+    fn carries_star(&self) -> bool {
+        false
+    }
+
+    fn tokenizer_carries_spans(&self) -> bool {
+        false
+    }
+
+    fn parse(
+        &self,
+        text: &str,
+        _base_iri: Option<&str>,
+        _mode: LineParseMode,
+    ) -> Result<Arc<RdfDataset>, RdfDiagnostic> {
+        super::parse::catch_codec_panic(NativeRdfFormat::TriX, || parse_trix_to_dataset(text))
+    }
+
+    fn serialize(&self, graph: &SerGraph) -> Result<String, RdfDiagnostic> {
+        serialize_ser_graph_to_trix(graph)
+    }
+}
 
 /// The TriX namespace (W3C member submission `trix-1`).
 const TRIX_NS: &str = "http://www.w3.org/2004/03/trix/trix-1/";


### PR DESCRIPTION
## Context

Prompted by a design question: *should PurRDF use more traits and async?*

- **Async: excluded, no change.** The library is CPU-bound, has no I/O in these crates (synchronous push/pull event protocol over `&str`/`&[u8]`/`W: Write`), and must build clean on `wasm32-unknown-unknown` — a target with no async runtime, where `AGENTS.md` bans threads/syscalls/deps and Cargo features. Any async need belongs to the host layer.
- **Traits: already right-sized**, with one defensible cleanup — this PR.

## What changed

The native text codecs dispatched on the `NativeRdfFormat` enum in several parallel `match` sites (`parse.rs`, `serialize.rs`), so adding a format meant editing every site. This replaces them with a single object-safe `RdfCodec` seam and a `codec_for()` resolver — now the one format→behavior chokepoint for parse, serialize, star-capability, and span-capability.

- **New** `crates/rdf/src/native_codecs/codec.rs` — the `RdfCodec` trait, a shared `LineCodec` for the four line/Turtle-family formats (preserving their deliberate fusion: one `text_parse` front-end, one `ser_model` writer), and `codec_for()` returning `&'static dyn RdfCodec` via rvalue static promotion.
- **Standalone codec impls** (`RdfXmlCodec`, `TriXCodec`, `HexTuplesCodec`) beside their existing functions.
- **Collapsed dispatch** in `parse_dataset_mode`, the span-tracking path, and `serialize_dataset_inner`; deleted the `is_star_capable` helper in favor of `carries_star()`.

`pub(crate)` internal organizing device only — the public `RdfParserBackend`/`RdfSerializer` contract is unchanged.

## Notes / design decisions

- `SpanCollector` has an associated `const`, so it is **not object-safe** — the trait's `parse` handles only the hot `NoSpans` path; the span path stays a separate concrete `SpanTable` monomorphization gated by `tokenizer_carries_spans()`, keeping span capture zero-cost.
- `text_parse.rs` is left untouched: its internal match is `LineCodec`'s own implementation body, not scattered dispatch.

## Verification

Behavior-preserving — identical bytes, diagnostics, and IR.

- `make check` passes (EXIT 0): pedantic/nursery clippy clean (warnings-as-errors), full workspace tests green (incl. the 89 `native_codecs` round-trip/isomorphism tests), hygiene clean.
- `make wasm` clean — the `&'static dyn` table adds no threads/syscalls/deps.