### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/.github/workflows/release-cargo.yaml
+++ b/.github/workflows/release-cargo.yaml
@@ -75,6 +75,11 @@ jobs:
           cargo check --workspace --lib --tests --locked
           python3 scripts/check-no-features.py
           bash scripts/check-generated.sh
+          # Release-coherence gate at the point of no return: the tag-verify step
+          # above checks each crate's OWN version, but not its internal dependency
+          # requirements. This catches a partial bump (a stale ^x.y.z internal pin)
+          # before any crate is irreversibly published.
+          python3 scripts/check-versions.py
           cargo check --locked --target wasm32-unknown-unknown --lib \
             -p purrdf-events \
             -p purrdf-iri \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Crate map (all under `crates/`, published names in `Cargo.toml`):
 * **Kernel ring-fence.** `purrdf-core` must never depend on oxigraph or PyO3.
   `purrdf-iri`, `purrdf-xsd`, and `purrdf-events` must keep **zero runtime
   dependencies**.
-* **Everything is wasm-able.** Every release crate (all 13 published crates,
+* **Everything is wasm-able.** Every release crate (all 15 published crates,
   `purrdf-wasm` included) must build for `wasm32-unknown-unknown` — CI
   hard-fails otherwise (`make wasm` locally). Never add a dependency that
   drags in threads, the filesystem, C toolchains, or wall-clock/RNG syscalls
@@ -117,7 +117,7 @@ black-cat family system — `#cat-head-core` is shared verbatim; only the
 
 ## 6. Releases
 
-Tag-driven trusted publishing: `rust-v*` → crates.io (13 crates, ordered),
+Tag-driven trusted publishing: `rust-v*` → crates.io (15 crates, ordered),
 `py-v*` → PyPI (`purrdf`). See [`docs/RELEASE.md`](./docs/RELEASE.md). Version
 is single-sourced in `[workspace.package]`. `purrdf-capi` and
 `purrdf-sparql-conformance` are never published.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes to the PurRDF crate suite are recorded here. The suite
 ships one lockstep version across crates.io, PyPI, and npm; pre-1.0, a minor
 bump may carry breaking changes and a patch bump is bugfix-only.
 
-## [Unreleased]
+## [0.3.0] - 2026-07-05
 
 ### Benchmarks
 
+- **sparql-eval:** Isolate Solution row construction and join
 - **rdf:** Add report-only span-tracking arm for the NoSpans zero-cost claim
 
 ### Bug Fixes
@@ -44,12 +45,23 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 - **shacl-af:** Merge sh:SPARQLFunction body state back into the caller
 - **shapes:** Repair broken merge — stray conflict markers and missed run_select rename
 - **shapes:** Repair non-compiling SHACL-SPARQL component merge
+- **shapes:** Make the validation-report sort total for byte determinism
+- **entail:** Reject non-range-restricted RIF rules instead of panicking
+- **entail:** Deterministic RDFS/OWL inferred-triple emission order
 - **rdf:** Report located diagnostics at the offending token, not the next one
 - **rdf:** Report Turtle/TriG located diagnostics at the offending token
 - **rdf,validate:** Emit real byteOffset for N-Triples/N-Quads source spans
 - **validate:** Wire SarifOptions::source_root_uri into the emitted SARIF
-- **entail:** Reject non-range-restricted RIF rules instead of panicking
-- **entail:** Deterministic RDFS/OWL inferred-triple emission order
+- **rdf:** Standardize blanks apart on native quad merge to stop cross-source collapse
+- **release:** Stamp the pending version in the generated changelog
+- **release:** Treat registry-restricted crates as publishable
+- **release:** Anchor the package.json version bump to the top-level key
+- **release:** Ignore commented-out crates in the publish-list parser
+- **release:** Guard release-tags against a missing CHANGELOG section before tagging
+- **release:** Assert per-crate version coherence in check-versions.py
+- **hygiene:** Purge issue refs from python shim docstring and lint docstrings
+- **rdf:** Pass the span collector in the empty-namespace turtle test
+- **rdf-core:** Reject rdf:_0 and leading-zero container membership ordinals
 
 ### CI & Build
 
@@ -57,6 +69,9 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 - **wasm-pkg:** Hard-fail the build if the artifact carries no SIMD opcodes
 - **wasm-pkg:** Append to RUSTFLAGS instead of overwriting it
 - **release:** Enforce cross-registry version coherence and complete the publish list
+- **release:** Pin the git-cliff version in the changelog target
+- **release:** Make set-version.py rewrite every version location
+- **release:** Gate internal dependency pins, at commit AND publish time
 
 ### Documentation
 
@@ -79,11 +94,14 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 - **sparql:** Finalize W3C SPARQL 1.1 syntax-suite provenance
 - **conformance:** Reconcile the ledger and drift-guard the published matrix
 - **conformance:** Distinguish normative SHACL-AF node expressions from owned extensions
-- **validate:** Fix stale intra-doc link to a non-existent locate module
 - **conformance:** Correct stale SHACL first-party corpus count (64 to 69)
 - **entail:** Fix misleading comment in the RIF emit path
+- **validate:** Fix stale intra-doc link to a non-existent locate module
 - **release:** Document MSRV and pre-1.0 semver policy
 - **release:** Docs.rs metadata, front-page example, and workspace doc gate
+- **ci:** Reconcile doc-target crate count to 16 (15 publishable + purrdf-entail)
+- **rdf,shapes:** Fix private/broken intra-doc links failing the doc gate
+- **conformance:** Regenerate matrix block for the added SPARQL fixtures
 
 ### Features
 
@@ -147,6 +165,15 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 - **shacl-sparql:** Pre-binding substitution semantics and shapes-graph variables
 - **shacl-af:** Sh:SPARQLFunction user-defined SPARQL functions
 - **shapes:** Complete SHACL-AF validation coverage
+- **core:** Expose shared FastHasher/FastMap/FastSet + smallvec primitives
+- **shapes:** Id-native SHACL engine over interned TermIds
+- **sparql-algebra:** Zero-copy lexer tokens borrowing the source
+- **entail:** Bare-RDF axiomatic predicate-typing entailment (rdf01)
+- **entail:** ALCOIQ OWL-Direct tableau reasoner core (concept, parser, tableau)
+- **entail:** Query-directed OWL-Direct DL materialization clears 25 conformance cases
+- **entail:** RIF-Core rule engine clears rif01/03/04/06 (zero entailment xfails)
+- **entail:** Native OWL-DL tableau + RIF-Core engine + bare-RDF axiomatic entailment
+- Close public-maturity epic
 - **iri:** Add shared source-position primitive (LineIndex/Position)
 - **diagnostics:** Resolve lexer byte offsets to line/column
 - **codec:** Attach line/column locations to RDF text parse errors
@@ -158,13 +185,16 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 - **validate:** To_sarif surface + Python binding + schema validation
 - **bindings:** SARIF surfaces for WASM and C-ABI
 - **validate:** SARIF rule metadata with W3C SHACL help links
-- **entail:** Bare-RDF axiomatic predicate-typing entailment (rdf01)
-- **entail:** ALCOIQ OWL-Direct tableau reasoner core (concept, parser, tableau)
-- **entail:** Query-directed OWL-Direct DL materialization clears 25 conformance cases
-- **entail:** RIF-Core rule engine clears rif01/03/04/06 (zero entailment xfails)
-- **entail:** Native OWL-DL tableau + RIF-Core engine + bare-RDF axiomatic entailment
-- Close public-maturity epic
 - **validate:** SARIF 2.1.0 source-traced reporting
+- **perf:** Id-native SHACL engine, zero-copy lexer tokens, workspace small-vec + hasher sweep
+- **rdf-core:** Graph-scoped rdf:first/rest/nil + container traversal on DatasetView
+- **slice:** Graph-scoped nav cursor, RDF-1.2 triple-term interiors, list/container materializer
+- **release:** Generate the changelog and GitHub Release notes with git-cliff
+- **release:** Single-command version bump and coherent tag cut
+- **hygiene:** Extend issue-ref lint to workflow yaml and python comments
+- **python:** Complete rdflib drop-in epic
+- **release:** Docs.rs polish, MSRV/semver docs, version-coherence gate + changelog
+- **rdf-query:** Graph-scoped nav cursor, list/container materializer, one-path blank-safe merge, FILTER/UNION regressions
 
 ### Other
 
@@ -246,9 +276,15 @@ Verification:
 - **entail:** Genuine semi-naive delta chase with new-vertex reflexive derivation
 - **sparql:** Reuse blank-label set across update-operation iterations
 - **shacl-af:** Hoist recursion guard, reuse intersection set, cache sort keys
-- **rdf:** Validate UTF-8 lazily in the text-format span-tracking arm
+- **sparql-eval,shapes:** Adopt small-vectors for hot per-row/per-node collections
 - **entail:** Reuse frontier buffers in the RDFS chase loop
 - **entail:** Reuse frontier buffers in the RIF chase loop
+- **shapes:** Pre-resolve rdf:type id once per Class constraint
+- **shapes:** Carry id-native value nodes through the constraint layer
+- **shapes:** Adopt fixed-key ahash for the remaining membership sets
+- **shapes:** Cache report sort key and borrow the sparql dataset
+- **rdf:** Validate UTF-8 lazily in the text-format span-tracking arm
+- **rdf-core:** Resolve container type once in is_typed_container
 
 ### Refactor
 
@@ -257,8 +293,11 @@ Verification:
 - **rdf:** Reuse purrdf_gts::wire::hex in the verify bridge
 - **shex:** Route datatype checks through parse_xsd10
 - **shapes:** Fold double/float lexical check into purrdf-xsd
-- **validate:** Hoist shared validate-to-SARIF helper into purrdf-validate
 - **entail:** Split reasoner into vocab/interner/rdfs modules + Regime::Rif scaffolding
+- **shapes:** Collapse the non-interned path walker to reflexive inclusion
+- **validate:** Hoist shared validate-to-SARIF helper into purrdf-validate
+- **rdf:** Centralize native-codec format dispatch behind an RdfCodec trait
+- **rdf:** Centralize native-codec format dispatch behind an RdfCodec trait
 
 ### Testing
 
@@ -279,11 +318,13 @@ Verification:
 - **shacl-af:** End-to-end goldens for sh:min/max/distinct/offset
 - **shapes:** First-party sh:SPARQLFunction conformance corpus cases
 - **shacl-af:** Negative-path coverage for sh:SPARQLFunction
+- **bench:** Add SHACL pattern-lookup and value-token lexer micro-benches
+- **entail:** Lock in deterministic inferred-triple emission order
 - **validate:** Cover attribution UnitId -> slice IRI resolution (S0.5)
 - **rdf:** Lock parallel line numbering for a newline-less final line
 - **validate:** Lock SHACL helpUri anchors against the live spec format
 - **validate:** Avoid a literal #N token in the S0.5 test
-- **entail:** Lock in deterministic inferred-triple emission order
+- **sparql:** Regression-cover FILTER-NOT-EXISTS arithmetic and all-FILTER UNION branch
 ## [0.2.1] - 2026-07-02
 
 ### Benchmarks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "purrdf-events",
  "purrdf-gts",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "purrdf-core",
@@ -1102,11 +1102,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "0.2.1"
+version = "0.3.0"
 
 [[package]]
 name = "purrdf-gts"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "blake3",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "ciborium",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "hex",
  "insta",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "insta",
  "pretty_assertions",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "pretty_assertions",
  "purrdf",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -43,21 +43,21 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "0.2.1" }
-purrdf-core = { path = "crates/rdf-core", version = "0.2.1" }
-purrdf-entail = { path = "crates/entail", version = "0.2.1" }
-purrdf-events = { path = "crates/rdf-events", version = "0.2.1" }
-purrdf-gts = { path = "crates/gts", version = "0.2.1" }
-purrdf-iri = { path = "crates/iri", version = "0.2.1" }
-purrdf-rdf = { path = "crates/rdf", version = "0.2.1" }
-purrdf-shapes = { path = "crates/shapes", version = "0.2.1" }
-purrdf-shex = { path = "crates/shex", version = "0.2.1" }
-purrdf-slice = { path = "crates/slice", version = "0.2.1" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.2.1" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.2.1" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "0.2.1" }
-purrdf-validate = { path = "crates/validate", version = "0.2.1" }
-purrdf-xsd = { path = "crates/xsd", version = "0.2.1" }
+purrdf = { path = "crates/purrdf", version = "0.3.0" }
+purrdf-core = { path = "crates/rdf-core", version = "0.3.0" }
+purrdf-entail = { path = "crates/entail", version = "0.3.0" }
+purrdf-events = { path = "crates/rdf-events", version = "0.3.0" }
+purrdf-gts = { path = "crates/gts", version = "0.3.0" }
+purrdf-iri = { path = "crates/iri", version = "0.3.0" }
+purrdf-rdf = { path = "crates/rdf", version = "0.3.0" }
+purrdf-shapes = { path = "crates/shapes", version = "0.3.0" }
+purrdf-shex = { path = "crates/shex", version = "0.3.0" }
+purrdf-slice = { path = "crates/slice", version = "0.3.0" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.3.0" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.3.0" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "0.3.0" }
+purrdf-validate = { path = "crates/validate", version = "0.3.0" }
+purrdf-xsd = { path = "crates/xsd", version = "0.3.0" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "0.2.1"
+version = "0.3.0"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "../../README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.2.1" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.3.0" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -67,4 +67,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "0.2.1"
+version = "0.3.0"

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -49,7 +49,7 @@ serde_json = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.2.1" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.3.0" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -27,7 +27,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.2.1" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.3.0" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.

--- a/scripts/check-versions.py
+++ b/scripts/check-versions.py
@@ -31,6 +31,14 @@ lint closes both gaps as a hard, no-optionality gate:
    three-file byte check while publishing at the wrong version; this assertion
    catches that drift and names every offending crate.
 
+4. **Internal dependency-requirement pins.** Every intra-workspace dependency
+   requirement (each ``{ path, version }`` pin, resolved via ``cargo metadata``)
+   must be pinned exactly to the canonical version (semver floor-equality). A
+   partial bump that leaves ``purrdf 0.3.0`` requiring ``purrdf-core ^0.2.1``
+   passes the three-file byte check AND per-crate coherence AND a local build
+   (path deps win locally), then publishes a crate wired to the OLD registry
+   crate — an irreversible break this gate catches before the tag is cut.
+
 The gate is deterministic and offline: it reads in-tree files plus
 ``cargo metadata`` and never touches the network.
 """
@@ -70,7 +78,24 @@ def npm_version(root: Path) -> str:
     return data["version"]
 
 
-def publishable_crates(root: Path) -> dict[str, str]:
+def workspace_metadata(root: Path) -> dict:
+    """The ``cargo metadata --no-deps`` document for the workspace.
+
+    ``--no-deps`` omits the resolved transitive graph but STILL carries each
+    member's declared ``dependencies`` (with their ``req``/``path``/``rename``),
+    which the internal-pin gate needs. Deterministic and offline.
+    """
+    out = subprocess.run(
+        ["cargo", "metadata", "--no-deps", "--format-version=1"],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=root,
+    ).stdout
+    return json.loads(out)
+
+
+def publishable_crates(meta: dict) -> dict[str, str]:
     """Map every publishable workspace member to its resolved version.
 
     In ``cargo metadata`` a member with no publish restriction has ``publish:
@@ -80,19 +105,46 @@ def publishable_crates(root: Path) -> dict[str, str]:
     caller can assert per-crate version coherence against the canonical
     workspace version.
     """
-    out = subprocess.run(
-        ["cargo", "metadata", "--no-deps", "--format-version=1"],
-        check=True,
-        capture_output=True,
-        text=True,
-        cwd=root,
-    ).stdout
-    meta = json.loads(out)
     publishable: dict[str, str] = {}
     for pkg in meta["packages"]:
         if pkg.get("publish") != []:
             publishable[pkg["name"]] = pkg["version"]
     return publishable
+
+
+def internal_pin_violations(meta: dict, version: str) -> list[str]:
+    """Every intra-workspace dependency whose version requirement is not pinned
+    exactly to ``version`` (semver **floor-equality**).
+
+    The trap: ``set-version.py`` (or a hand edit) bumps a crate's own version but
+    leaves an internal dependency requirement at the previous release
+    (``purrdf 0.3.0`` still requiring ``purrdf-core ^0.2.1``). ``make check`` and
+    local builds pass (path deps win locally), then the PUBLISHED crate wires to
+    the old registry crate — irreversible. This gate compares every intra-
+    workspace path dependency's ``req`` floor against the canonical version: a
+    caret/exact pin at ``version`` passes; a stale pin OR a loose ``>=``/``*``
+    that merely *satisfies* the version FAILS (low-optionality: pins are exact).
+
+    Scope: only path dependencies (intra-workspace) in the PUBLISHED graph
+    (normal + build deps; dev-dependencies are stripped from published crates and
+    legitimately carry no version). Renamed deps are handled via ``rename``.
+    """
+    members = {pkg["name"] for pkg in meta["packages"]}
+    violations: list[str] = []
+    for pkg in sorted(meta["packages"], key=lambda p: p["name"]):
+        for dep in pkg["dependencies"]:
+            if dep.get("path") is None or dep["name"] not in members:
+                continue
+            if dep.get("kind") not in (None, "build"):  # skip dev-dependencies
+                continue
+            floor = dep["req"].lstrip("^=~> ")
+            if floor != version:
+                alias = dep.get("rename") or dep["name"]
+                violations.append(
+                    f"    {pkg['name']} -> {alias} (package {dep['name']}): "
+                    f"req {dep['req']!r} (expected pin {version})"
+                )
+    return violations
 
 
 _CRATES_ARRAY_RE = re.compile(r"crates=\(\s*(.*?)\s*\)", re.DOTALL)
@@ -139,7 +191,8 @@ def main() -> int:
     version = next(iter(versions.values()))
 
     # 2. Publish-list completeness against the publishable set.
-    publishable_versions = publishable_crates(root)
+    meta = workspace_metadata(root)
+    publishable_versions = publishable_crates(meta)
     publishable = set(publishable_versions)
     lists = {
         ".github/workflows/release-cargo.yaml": root
@@ -179,6 +232,15 @@ def main() -> int:
         )
         for name, crate_version in mismatched:
             failures.append(f"    {name}: {crate_version} (expected {version})")
+
+    # 4. Internal dependency-requirement pins (the partial-bump publish trap).
+    pin_violations = internal_pin_violations(meta, version)
+    if pin_violations:
+        failures.append(
+            f"internal dependency requirement(s) not pinned to {version!r} "
+            "(a partial bump would publish a stale dependency graph):"
+        )
+        failures.extend(pin_violations)
 
     if failures:
         print("FAIL: release coherence check found problems:", file=sys.stderr)

--- a/scripts/set-version.py
+++ b/scripts/set-version.py
@@ -1,20 +1,41 @@
 # SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""Set the PurRDF release version across all three registries in lockstep.
+"""Set the PurRDF release version across EVERY version location in lockstep.
 
-The suite ships one version to crates.io, PyPI, and npm from three separate
-files. This script rewrites all three in one shot and then runs the
-version-coherence gate (``scripts/check-versions.py``) to prove they agree:
+The suite ships one version to crates.io, PyPI, and npm. A release must rewrite
+far more than the three top-level version strings: every internal path
+dependency carries its own ``version = "…"`` requirement, and a partial bump
+publishes a crate whose dependency requirements still point at the previous
+release (``purrdf 0.3.0`` depending on ``purrdf-core ^0.2.1``), which resolves
+against the OLD registry crate — an irreversible, silent break. This script
+rewrites all of them in one shot and then runs the version-coherence gate
+(``scripts/check-versions.py``) to prove they agree:
 
+Top-level version sources:
 * ``Cargo.toml``                         — ``[workspace.package] version``
 * ``bindings/python/pyproject.toml``     — ``[project] version``
 * ``crates/rdf-wasm/js/package.json``    — top-level ``version``
 
-Edits are line-scoped so file formatting and comments are preserved (only the
-version line changes). Usage::
+Internal dependency-requirement pins (every intra-workspace path dependency —
+a dependency line carrying BOTH ``path = "…"`` and ``version = "…"``):
+* ``Cargo.toml``                         — the ``[workspace.dependencies]`` pins
+* ``crates/*/Cargo.toml`` /
+  ``bindings/*/Cargo.toml``              — renamed-dep pins (e.g. shapes/slice's
+                                           ``purrdf = { package = "purrdf-rdf" }``
+                                           and rdf-capi's ``purrdf-rs``)
 
-    python3 scripts/set-version.py 0.2.2
+Other version locations:
+* ``crates/rdf-capi/Cargo.toml``         — ``[package.metadata.capi.library] version``
+* ``bindings/python/uv.lock``            — the editable ``purrdf`` package pin
+
+Edits are line-scoped so file formatting and comments are preserved (only the
+version value changes). Deps that inherit via ``version.workspace = true`` and
+external deps (no ``path``) are never touched, and unrelated ``0.2.x`` strings
+(e.g. ``wasm-bindgen = "=0.2.125"``) carry no ``path`` so they are inert here.
+Usage::
+
+    python3 scripts/set-version.py 0.3.0
 """
 
 from __future__ import annotations
@@ -25,6 +46,7 @@ import sys
 from pathlib import Path
 
 _SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$")
+_VERSION_VALUE_RE = re.compile(r'(version\s*=\s*")[^"]*(")')
 
 
 def repo_root() -> Path:
@@ -41,9 +63,7 @@ def set_toml_version(path: Path, section: str, version: str) -> None:
             in_section = stripped == section
             continue
         if in_section and re.match(r'\s*version\s*=\s*"', line):
-            lines[i] = re.sub(
-                r'(version\s*=\s*")[^"]*(")', rf"\g<1>{version}\g<2>", line, count=1
-            )
+            lines[i] = _VERSION_VALUE_RE.sub(rf"\g<1>{version}\g<2>", line, count=1)
             path.write_text("".join(lines), encoding="utf-8")
             return
     raise SystemExit(f"FAIL: no version key found in {section} of {path}")
@@ -68,6 +88,76 @@ def set_json_version(path: Path, version: str) -> None:
     path.write_text(new_text, encoding="utf-8")
 
 
+def set_path_dep_versions(path: Path, version: str) -> int:
+    """Rewrite the ``version = "…"`` pin on every intra-workspace path dependency.
+
+    An intra-workspace pin is any line carrying BOTH ``path = "…"`` and a quoted
+    ``version = "…"`` (the internal ``[workspace.dependencies]`` entries and the
+    renamed-dep pins in member manifests). External deps have no ``path`` and
+    ``version.workspace = true`` inheritors have no quoted version, so neither is
+    touched. Returns the number of lines changed.
+    """
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    changed = 0
+    for i, line in enumerate(lines):
+        if "path =" in line and _VERSION_VALUE_RE.search(line):
+            new = _VERSION_VALUE_RE.sub(rf"\g<1>{version}\g<2>", line, count=1)
+            if new != line:
+                lines[i] = new
+                changed += 1
+    if changed:
+        path.write_text("".join(lines), encoding="utf-8")
+    return changed
+
+
+def member_manifests(root: Path) -> list[Path]:
+    """Every workspace member ``Cargo.toml`` (crates/* and bindings/*)."""
+    manifests = sorted((root / "crates").glob("*/Cargo.toml"))
+    manifests += sorted((root / "bindings").glob("*/Cargo.toml"))
+    return manifests
+
+
+def set_uv_lock(root: Path, version: str) -> None:
+    """Sync ``bindings/python/uv.lock`` to the new version.
+
+    Prefer a scoped ``uv lock --upgrade-package purrdf`` (touches only the
+    editable ``purrdf`` pin, no unrelated transitive churn). ``uv.lock`` is
+    dev-facing reproducibility only — ``release-pypi.yaml`` builds with
+    ``uv run --no-project`` and never consumes it — so a targeted rewrite of the
+    editable ``purrdf`` package's ``version`` is a safe fallback when ``uv`` is
+    unavailable.
+    """
+    py_dir = root / "bindings" / "python"
+    lock = py_dir / "uv.lock"
+    try:
+        subprocess.run(
+            ["uv", "lock", "--upgrade-package", "purrdf"],
+            cwd=py_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return
+    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+        detail = exc.stderr if isinstance(exc, subprocess.CalledProcessError) else exc
+        print(f"WARN: `uv lock` unavailable ({detail}); rewriting uv.lock directly")
+
+    # Fallback: rewrite the version of the [[package]] block whose name = "purrdf".
+    text = lock.read_text(encoding="utf-8")
+    blocks = text.split("[[package]]")
+    for idx, block in enumerate(blocks):
+        if re.search(r'^\s*name\s*=\s*"purrdf"\s*$', block, flags=re.MULTILINE):
+            blocks[idx] = re.sub(
+                r'(^\s*version\s*=\s*")[^"]*(")',
+                rf"\g<1>{version}\g<2>",
+                block,
+                count=1,
+                flags=re.MULTILINE,
+            )
+            break
+    lock.write_text("[[package]]".join(blocks), encoding="utf-8")
+
+
 def main(argv: list[str]) -> int:
     if len(argv) != 2:
         print("usage: python3 scripts/set-version.py <x.y.z>", file=sys.stderr)
@@ -78,14 +168,33 @@ def main(argv: list[str]) -> int:
         return 2
 
     root = repo_root()
+
+    # 1. The three top-level version sources.
     set_toml_version(root / "Cargo.toml", "[workspace.package]", version)
     set_toml_version(
         root / "bindings" / "python" / "pyproject.toml", "[project]", version
     )
     set_json_version(root / "crates" / "rdf-wasm" / "js" / "package.json", version)
 
-    print(f"set version {version} across crates.io/PyPI/npm; verifying coherence…")
-    # Prove the three sources now agree (and the publish list stays complete).
+    # 2. Every intra-workspace path-dependency version pin: the
+    #    [workspace.dependencies] internal pins and the member renamed-dep pins.
+    pins = set_path_dep_versions(root / "Cargo.toml", version)
+    for manifest in member_manifests(root):
+        pins += set_path_dep_versions(manifest, version)
+
+    # 3. The capi C-ABI library version and the editable purrdf uv.lock pin.
+    set_toml_version(
+        root / "crates" / "rdf-capi" / "Cargo.toml",
+        "[package.metadata.capi.library]",
+        version,
+    )
+    set_uv_lock(root, version)
+
+    print(
+        f"set version {version} across crates.io/PyPI/npm "
+        f"(+{pins} internal path-dep pins); verifying coherence…"
+    )
+    # Prove the sources now agree (and the publish list stays complete).
     return subprocess.run(
         [sys.executable, str(root / "scripts" / "check-versions.py")], cwd=root
     ).returncode


### PR DESCRIPTION
Closes #60

## Summary
Cut release 0.3.0 across crates.io/PyPI/npm and **permanently close the partial-bump publish trap**.

## Changes
- **Fix `set-version.py`** to rewrite EVERY version location, not just the 3 top-level sources: the 15 internal `[workspace.dependencies]` pins, the renamed-dep pins (shapes/slice/rdf-capi), the capi library version, and `uv.lock` — via a generalized `path`+`version` scan (external deps and `workspace = true` inheritors untouched).
- **Extend `check-versions.py`** with a 4th gate: every intra-workspace dependency requirement must be pinned exactly to the canonical version (semver floor-equality). A stale `^0.2.1` internal pin now fails deterministically instead of shipping a broken dependency graph.
- **Wire that gate into `release-cargo.yaml`** (Verify step) — the irreversible actor — so a tag not produced by a green local `make check` is still caught at the point of no return.
- **Bump the suite 0.2.1 → 0.3.0** (18 internal pins + top-level sources + capi.library + uv.lock + Cargo.lock).
- **Regenerate CHANGELOG** for 0.3.0 (git-cliff 2.13.1); fix AGENTS.md `13 crates` → live 15.

## Verification
`make check` + `make wasm` green at 0.3.0; internal-pin gate #4 green; `cargo package --workspace --locked` verifies all crates at 0.3.0 (no residual `^0.2.1`). Negative-tested: a partial bump makes gate #4 fail loudly.

## Note
The tag/publish step (`make release-tags VERSION=0.3.0`) is **not** in this PR — it is a post-merge, irreversible, human-authorized action to run on CI-green `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version **0.3.0** across the project and published packages.

* **Bug Fixes**
  * Added stricter release checks to prevent publishing when dependency versions are only partially updated.
  * Improved version synchronization so all supported package formats stay aligned for releases.

* **Chores**
  * Updated release-related documentation and version references throughout the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->