### PR TITLE
perf(rdf): memoize parser line index — fix quadratic diagnostics scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,36 @@ All notable changes to the PurRDF crate suite are recorded here. The suite
 ships one lockstep version across crates.io, PyPI, and npm; pre-1.0, a minor
 bump may carry breaking changes and a patch bump is bugfix-only.
 
+## [0.3.3] - 2026-07-05
+
+### Performance
+
+- **rdf:** Memoize the line index so parser diagnostics stay linear
 ## [0.3.2] - 2026-07-05
+
+### Bug Fixes
+
+- **shapes:** Reconcile SHACL-AF work with the merged 0.3.1 baseline
+
+### Features
+
+- **shapes:** SHACL Rules — 100% SHACL-AF coverage
+## [0.3.1] - 2026-07-05
 
 ### Bug Fixes
 
 - **shapes:** Pre-bind $shapesGraph in sh:SPARQLRule CONSTRUCT execution
 - **build:** Optimize parse-hot workspace crates in dev/test profile to remove ~300x regression
 
+### CI & Build
+
+- **release:** Edition 2024, publish purrdf-entail, expose entail+validate, bump 0.3.1
+- **release:** Edition 2024, publish purrdf-entail, expose entail+validate, bump 0.3.1
+
 ### Documentation
 
 - **conformance:** Add SHACL Rules scoreboard row; SHACL-AF is 100% complete
+- **release:** Changelog for 0.3.1
 
 ### Features
 
@@ -31,11 +51,6 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 - **shapes:** SHACL Rules conformance corpus + inferred-graph harness
 - **shapes:** Audit every node-expression kind in sh:TripleRule subject/predicate/object positions
 - **shapes:** Cover blank-focus blank minting and multi-round fixpoint convergence
-## [0.3.1] - 2026-07-05
-
-### CI & Build
-
-- **release:** Edition 2024, publish purrdf-entail, expose entail+validate, bump 0.3.1
 ## [0.3.0] - 2026-07-05
 
 ### Benchmarks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "purrdf-entail",
  "purrdf-events",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ahash",
  "criterion",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion",
  "purrdf-core",
@@ -1104,11 +1104,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "0.3.2"
+version = "0.3.3"
 
 [[package]]
 name = "purrdf-gts"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aes-gcm",
  "blake3",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ahash",
  "ciborium",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion",
  "proptest",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "hex",
  "insta",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion",
  "insta",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ahash",
  "criterion",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "insta",
  "pretty_assertions",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "pretty_assertions",
  "purrdf",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -43,21 +43,21 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "0.3.2" }
-purrdf-core = { path = "crates/rdf-core", version = "0.3.2" }
-purrdf-entail = { path = "crates/entail", version = "0.3.2" }
-purrdf-events = { path = "crates/rdf-events", version = "0.3.2" }
-purrdf-gts = { path = "crates/gts", version = "0.3.2" }
-purrdf-iri = { path = "crates/iri", version = "0.3.2" }
-purrdf-rdf = { path = "crates/rdf", version = "0.3.2" }
-purrdf-shapes = { path = "crates/shapes", version = "0.3.2" }
-purrdf-shex = { path = "crates/shex", version = "0.3.2" }
-purrdf-slice = { path = "crates/slice", version = "0.3.2" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.3.2" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.3.2" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "0.3.2" }
-purrdf-validate = { path = "crates/validate", version = "0.3.2" }
-purrdf-xsd = { path = "crates/xsd", version = "0.3.2" }
+purrdf = { path = "crates/purrdf", version = "0.3.3" }
+purrdf-core = { path = "crates/rdf-core", version = "0.3.3" }
+purrdf-entail = { path = "crates/entail", version = "0.3.3" }
+purrdf-events = { path = "crates/rdf-events", version = "0.3.3" }
+purrdf-gts = { path = "crates/gts", version = "0.3.3" }
+purrdf-iri = { path = "crates/iri", version = "0.3.3" }
+purrdf-rdf = { path = "crates/rdf", version = "0.3.3" }
+purrdf-shapes = { path = "crates/shapes", version = "0.3.3" }
+purrdf-shex = { path = "crates/shex", version = "0.3.3" }
+purrdf-slice = { path = "crates/slice", version = "0.3.3" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.3.3" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.3.3" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "0.3.3" }
+purrdf-validate = { path = "crates/validate", version = "0.3.3" }
+purrdf-xsd = { path = "crates/xsd", version = "0.3.3" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "0.3.2"
+version = "0.3.3"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "../../README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.3.2" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.3.3" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -67,4 +67,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "0.3.2"
+version = "0.3.3"

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/rdf/src/native_codecs/text_parse.rs
+++ b/crates/rdf/src/native_codecs/text_parse.rs
@@ -761,9 +761,12 @@ struct DocParser<'a, 'c, S: SpanCollector> {
     /// captured when the subject term is parsed and resolved at emit time. Only read
     /// when `S::ENABLED`.
     subject_off: usize,
-    /// Newline table over `src`, built lazily on the FIRST recorded subject and reused
-    /// for the rest of the parse. Never built when `S::ENABLED` is false.
-    line_index: Option<purrdf_iri::LineIndex>,
+    /// Newline table over `src`, built lazily on the FIRST position lookup (a recorded
+    /// subject under `S::ENABLED`, or any `loc()` diagnostic) and reused for the rest of
+    /// the parse. A `OnceCell` so the `&self` `loc()` path can memoize it too — otherwise
+    /// a document with many diagnostics-adjacent lookups rebuilds the whole-buffer scan
+    /// per call, which is quadratic in the source length.
+    line_index: std::cell::OnceCell<purrdf_iri::LineIndex>,
 }
 
 impl<'a, 'c, S: SpanCollector> DocParser<'a, 'c, S> {
@@ -786,7 +789,7 @@ impl<'a, 'c, S: SpanCollector> DocParser<'a, 'c, S> {
             src: text,
             collector,
             subject_off: 0,
-            line_index: None,
+            line_index: std::cell::OnceCell::new(),
         }
     }
 
@@ -1428,7 +1431,7 @@ impl<'a, 'c, S: SpanCollector> DocParser<'a, 'c, S> {
             let src = self.src;
             let index = self
                 .line_index
-                .get_or_insert_with(|| purrdf_iri::LineIndex::new(src));
+                .get_or_init(|| purrdf_iri::LineIndex::new(src));
             let position = index.locate(src, self.subject_off);
             self.collector.record(&key, position);
         }
@@ -1476,9 +1479,10 @@ impl<'a, 'c, S: SpanCollector> DocParser<'a, 'c, S> {
     // token cursor helpers
 
     /// Resolve the current token's document-global 1-based `(line, column)` by
-    /// scanning the full source with the shared [`purrdf_iri::LineIndex`]. Built
-    /// lazily on the error path only (the tokens carry document-global byte spans),
-    /// so the happy path never pays for it.
+    /// scanning the full source with the shared [`purrdf_iri::LineIndex`]. The index is
+    /// memoized in `self.line_index` (a `OnceCell`), so the FIRST lookup pays one
+    /// whole-buffer scan and every subsequent lookup is an `O(log lines)` locate — a
+    /// document with many lookups is linear, not quadratic, in the source length.
     fn loc(&self) -> (u32, u32) {
         let off = self
             .tokens
@@ -1486,7 +1490,10 @@ impl<'a, 'c, S: SpanCollector> DocParser<'a, 'c, S> {
             .map(|s| s.start)
             .or_else(|| self.tokens.last().map(|s| s.end))
             .unwrap_or(0);
-        let p = purrdf_iri::LineIndex::new(self.src).locate(self.src, off);
+        let p = self
+            .line_index
+            .get_or_init(|| purrdf_iri::LineIndex::new(self.src))
+            .locate(self.src, off);
         (p.line, p.column)
     }
 

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -49,7 +49,7 @@ serde_json = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.3.2" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.3.3" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -27,7 +27,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.3.2" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.3.3" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.


### PR DESCRIPTION
## Critical hotfix — quadratic parse on diagnostics-heavy documents

`DocParser::loc()` (the token → `(line, column)` resolver for parser diagnostics) takes `&self` and rebuilt the whole-buffer `purrdf_iri::LineIndex` newline scan on **every call**. A document that triggers many diagnostic-adjacent lookups therefore paid an **O(n) scan per lookup — quadratic in source length**, a real cliff on large/pathological inputs.

## Fix
`DocParser::line_index` becomes `std::cell::OnceCell<LineIndex>` instead of `Option<LineIndex>`, so the `&self` paths (`loc()` and the span-recording path) can memoize it. First lookup builds the index once; every subsequent lookup is an `O(log lines)` locate. **Linear, not quadratic.**

## Safety / correctness
- **Behaviour identical** — `LineIndex` is deterministic for a fixed source; memoizing only avoids rebuilding it. Computed positions are unchanged.
- No new dependency; `OnceCell` is `wasm32-unknown-unknown`-clean.
- `cargo clippy -p purrdf-rdf --all-targets -D warnings` clean; `purrdf-rdf` test suite (175+ tests) green.

Ships as the **0.3.3** patch release (release-prep commits follow on this PR).