### PR TITLE
feat(wasm): CI-gated wasm artifact size budget

### DIFF
--- a/.github/actions/wasm-toolchain/action.yml
+++ b/.github/actions/wasm-toolchain/action.yml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+name: wasm-toolchain
+description: >-
+  Install the pinned wasm build toolchain and a Rust build cache: the
+  wasm32-unknown-unknown target, wasm-bindgen-cli matched to the workspace
+  wasm-bindgen pin (Cargo.toml), and binaryen (wasm-opt/wasm-dis) matched to the
+  Makefile BINARYEN_VERSION. Both binaries are installed from pinned, checksum-
+  verified prebuilt release archives — no per-PR source builds — and both pins
+  are read from their single source of truth so CI and the npm release never
+  drift. Requires a prior Rust toolchain install and a checked-out repo.
+runs:
+  using: composite
+  steps:
+    - name: Add the wasm32 target
+      shell: bash
+      run: rustup target add wasm32-unknown-unknown
+
+    - name: Cache the Rust build
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      with:
+        key: wasm-toolchain
+
+    - name: Read the toolchain pins (single source of truth)
+      id: pins
+      shell: bash
+      run: |
+        set -euo pipefail
+        wb="$(grep -oP 'wasm-bindgen = "=\K[0-9.]+' Cargo.toml)"
+        test -n "$wb" || { echo "could not read the wasm-bindgen pin from Cargo.toml"; exit 1; }
+        bn="$(grep -oP '^BINARYEN_VERSION := \K[0-9]+' Makefile)"
+        test -n "$bn" || { echo "could not read BINARYEN_VERSION from Makefile"; exit 1; }
+        echo "wasm_bindgen=$wb" >> "$GITHUB_OUTPUT"
+        echo "binaryen=$bn" >> "$GITHUB_OUTPUT"
+
+    - name: Install wasm-bindgen-cli (prebuilt, matched to the workspace pin)
+      shell: bash
+      run: |
+        set -euo pipefail
+        ver="${{ steps.pins.outputs.wasm_bindgen }}"
+        base="wasm-bindgen-${ver}-x86_64-unknown-linux-musl"
+        url="https://github.com/rustwasm/wasm-bindgen/releases/download/${ver}/${base}.tar.gz"
+        curl -fsSL "$url" -o /tmp/wb.tar.gz
+        curl -fsSL "${url}.sha256sum" -o /tmp/wb.sha256
+        echo "$(awk '{print $1}' /tmp/wb.sha256)  /tmp/wb.tar.gz" | sha256sum -c -
+        mkdir -p /tmp/wb && tar -xzf /tmp/wb.tar.gz -C /tmp/wb --strip-components=1
+        install -Dm0755 /tmp/wb/wasm-bindgen "$HOME/.cargo/bin/wasm-bindgen"
+        found="$(wasm-bindgen --version | awk '{print $2}')"
+        test "$found" = "$ver" || { echo "wasm-bindgen version mismatch: got $found, expected $ver"; exit 1; }
+        echo "wasm-bindgen $found installed"
+
+    - name: Install binaryen (prebuilt, matched to BINARYEN_VERSION) and verify SIMD
+      shell: bash
+      run: |
+        set -euo pipefail
+        ver="${{ steps.pins.outputs.binaryen }}"
+        base="binaryen-version_${ver}-x86_64-linux"
+        url="https://github.com/WebAssembly/binaryen/releases/download/version_${ver}/${base}.tar.gz"
+        curl -fsSL "$url" -o /tmp/bn.tar.gz
+        curl -fsSL "${url}.sha256" -o /tmp/bn.sha256
+        echo "$(awk '{print $1}' /tmp/bn.sha256)  /tmp/bn.tar.gz" | sha256sum -c -
+        mkdir -p /tmp/binaryen && tar -xzf /tmp/bn.tar.gz -C /tmp/binaryen --strip-components=1
+        echo "/tmp/binaryen/bin" >> "$GITHUB_PATH"
+        export PATH="/tmp/binaryen/bin:$PATH"
+        found="$(wasm-opt --version | grep -oE '[0-9]+' | head -1)"
+        test "$found" = "$ver" || { echo "binaryen version mismatch: got $found, expected $ver"; exit 1; }
+        printf '(module)\n' | wasm-opt --enable-simd -o /dev/null - \
+          || { echo "FAIL: installed wasm-opt lacks --enable-simd support"; exit 1; }
+        echo "binaryen $found installed (wasm-opt --enable-simd verified)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,6 +144,9 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
+      - name: Set up the pinned wasm toolchain (wasm-bindgen + binaryen) and cache
+        uses: ./.github/actions/wasm-toolchain
+
       - name: Check release crates on wasm32
         run: |
           cargo check --locked --target wasm32-unknown-unknown --lib \
@@ -163,11 +166,23 @@ jobs:
             -p purrdf \
             -p purrdf-wasm
 
-      - name: Build wasm package artifact
+      - name: Build the optimized wasm package and gate its size
+        # Builds the +simd128 release artifact, runs wasm-bindgen + wasm-opt -Oz,
+        # verifies SIMD codegen, writes current-vs-budget size + toolchain
+        # identity to the job summary, and HARD-FAILS if the artifact exceeds
+        # WASM_SIZE_BUDGET_BYTES (raise it deliberately per the Makefile).
+        run: make wasm-pkg-size
+
+      - name: WASM size breakdown (diagnostics only, non-gating)
+        continue-on-error: true
         run: |
-          cargo build --locked --release --target wasm32-unknown-unknown \
-            -p purrdf-wasm --lib
-          test -s target/wasm32-unknown-unknown/release/purrdf_wasm.wasm
+          cargo install twiggy --locked || true
+          {
+            echo '### WASM size breakdown'
+            echo '```'
+            twiggy top -n 20 crates/rdf-wasm/js/pkg/purrdf_wasm_bg.wasm
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY" || true
 
   benchmarks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,17 +173,6 @@ jobs:
         # WASM_SIZE_BUDGET_BYTES (raise it deliberately per the Makefile).
         run: make wasm-pkg-size
 
-      - name: WASM size breakdown (diagnostics only, non-gating)
-        continue-on-error: true
-        run: |
-          cargo install twiggy --locked || true
-          {
-            echo '### WASM size breakdown'
-            echo '```'
-            twiggy top -n 20 crates/rdf-wasm/js/pkg/purrdf_wasm_bg.wasm
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY" || true
-
   benchmarks:
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -54,24 +54,19 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Install wasm-bindgen-cli (must match the workspace wasm-bindgen pin)
-        run: |
-          PIN="$(grep -oP 'wasm-bindgen = "=\K[0-9.]+' Cargo.toml)"
-          test -n "$PIN" || { echo "could not read the wasm-bindgen pin from Cargo.toml"; exit 1; }
-          cargo install wasm-bindgen-cli --version "$PIN" --locked
+      - name: Set up the pinned wasm toolchain (wasm-bindgen + binaryen) and cache
+        # Single source of truth shared with the CI wasm job: pinned, checksum-
+        # verified prebuilt wasm-bindgen-cli (matched to the Cargo.toml pin) and
+        # binaryen (matched to the Makefile BINARYEN_VERSION), with the SIMD
+        # capability verified. Replaces the previous source-built wasm-bindgen and
+        # unpinned apt binaryen so the released artifact is byte-reproducible.
+        uses: ./.github/actions/wasm-toolchain
 
-      - name: Install binaryen (wasm-opt)
-        # The wasm-pkg build emits +simd128; wasm-opt must accept --enable-simd
-        # or it would silently fall back to (or reject) a non-SIMD module. Fail
-        # fast here rather than shipping a scalar artifact.
-        run: |
-          sudo apt-get update && sudo apt-get install -y binaryen
-          wasm-opt --version
-          printf '(module)\n' | wasm-opt --enable-simd -o /dev/null - \
-            || { echo "FAIL: installed wasm-opt lacks --enable-simd support"; exit 1; }
-
-      - name: Build the wasm package
-        run: make wasm-pkg
+      - name: Build the wasm package and enforce the size budget
+        # wasm-pkg-size supersets wasm-pkg (build + wasm-opt -Oz + SIMD guard) and
+        # additionally hard-fails if the artifact exceeds WASM_SIZE_BUDGET_BYTES,
+        # so an oversized artifact can never be published. Same gate CI runs.
+        run: make wasm-pkg-size
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,18 @@ Crate map (all under `crates/`, published names in `Cargo.toml`):
   hard-fails otherwise (`make wasm` locally). Never add a dependency that
   drags in threads, the filesystem, C toolchains, or wall-clock/RNG syscalls
   on the wasm path; crypto stays pure-Rust for exactly this reason.
+* **wasm size is budgeted.** The optimized npm artifact
+  (`crates/rdf-wasm/js/pkg/purrdf_wasm_bg.wasm`, built with `+simd128` and
+  `wasm-opt -Oz`) is gated by `make wasm-pkg-size` against the
+  `WASM_SIZE_BUDGET_BYTES` ceiling in the Makefile; CI and the npm release both
+  hard-fail on overshoot and print current-vs-budget to the job summary. The
+  size is reproducible because binaryen is pinned via `BINARYEN_VERSION` (and
+  wasm-bindgen via the `Cargo.toml` pin) — the shared `.github/actions/wasm-toolchain`
+  action installs exactly those. **Raising the ceiling is a reviewed decision:**
+  rebuild, read the printed size, set the constant with a few percent of headroom,
+  and justify the growth in the commit — a new capability/dependency, or a routine
+  rustc-stable/binaryen bump (a valid reason that must still be stated). Never
+  raise it merely to turn a red gate green.
 * **Byte determinism.** Serializers and the GTS writer are byte-deterministic.
   If your change alters emitted bytes, you must update the affected goldens and
   say why in the PR. Never introduce iteration-order, time, or RNG dependence

--- a/Makefile
+++ b/Makefile
@@ -204,11 +204,11 @@ wasm-pkg-size: wasm-pkg ## Gate the optimized wasm artifact byte size against WA
 	 case "$$budget" in ''|*[!0-9]*) echo "ERROR: WASM_SIZE_BUDGET_BYTES ('$$budget') is not a positive integer"; exit 1;; esac; \
 	 [ "$$budget" -gt 0 ] || { echo "ERROR: WASM_SIZE_BUDGET_BYTES must be > 0"; exit 1; }; \
 	 test -s "$$art" || { echo "ERROR: $$art missing or empty — wasm-pkg did not produce the optimized artifact"; exit 1; }; \
-	 size=$$(wc -c < "$$art" | tr -d ' '); \
-	 gz=$$(gzip -9nc < "$$art" | wc -c | tr -d ' '); \
+	 size=$$(wc -c < "$$art" | awk '{print $$1}'); \
+	 gz=$$(gzip -9nc < "$$art" | wc -c | awk '{print $$1}'); \
 	 pct=$$(( size * 100 / budget )); \
 	 raw=target/wasm32-unknown-unknown/release/purrdf_wasm.wasm; \
-	 if [ -s "$$raw" ]; then rawsz=$$(wc -c < "$$raw" | tr -d ' '); reduc=$$(( (rawsz - size) * 100 / rawsz )); \
+	 if [ -s "$$raw" ]; then rawsz=$$(wc -c < "$$raw" | awk '{print $$1}'); reduc=$$(( (rawsz - size) * 100 / rawsz )); \
 	   ratio="cargo release wasm $$rawsz B -> optimized $$size B (-$$reduc%)"; \
 	 else ratio="cargo release wasm size unavailable (pre-opt module not on disk)"; fi; \
 	 rustcv=$$(rustc --version); \

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,37 @@
 CARGO_TARGET_DIR ?= target
 CAPI_HEADER := crates/rdf-capi/include/purrdf.h
 
-.PHONY: help metadata fmt check book check-issue-refs changelog bump release-tags test doc bench bench-python pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-test wasm-pkg-bench \
+.PHONY: help metadata fmt check book check-issue-refs changelog bump release-tags test doc bench bench-python pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-size wasm-pkg-test wasm-pkg-bench \
 	capi-build capi-header capi-check capi-install
 
 # The changelog generator is pinned so the committed CHANGELOG.md and the notes
 # the release workflow slices out of it stay byte-reproducible across machines.
 GIT_CLIFF_VERSION := 2.13.1
+
+# binaryen (wasm-opt / wasm-dis) is pinned so the optimized npm artifact's byte
+# size is reproducible: `wasm-opt -Oz` output — and therefore the size budget
+# below — depends on the binaryen version. `wasm-pkg` hard-fails if the local
+# wasm-opt does not report this version, exactly like the git-cliff pin above.
+# The CI wasm-toolchain composite action reads this same value, so the pin lives
+# in one place. Bump it deliberately (it can move the artifact size — see the
+# WASM_SIZE_BUDGET_BYTES raise procedure).
+BINARYEN_VERSION := 130
+
+# HARD size ceiling (bytes) for the optimized npm artifact
+# crates/rdf-wasm/js/pkg/purrdf_wasm_bg.wasm (release +simd128 build, wasm-opt
+# -Oz). `make wasm-pkg-size` (and both CI and the npm release) fail if the built
+# artifact exceeds this. 3 MiB = 3145728; the measured baseline is 2_989_759
+# bytes, so this is ~5% headroom. The artifact's size is a joint function of
+# rustc (tracks stable), wasm-bindgen (pinned in Cargo.toml), and binaryen
+# (pinned via BINARYEN_VERSION), so a moved number is attributable.
+#
+# TO RAISE DELIBERATELY: rebuild `make wasm-pkg`, read the size printed by
+# `make wasm-pkg-size`, and set this to that size rounded up with a few percent
+# of headroom. A raise is a reviewed decision — the commit MUST state WHY the
+# artifact grew: a new capability or dependency, or a routine rustc-stable /
+# binaryen bump (a valid, must-be-explained reason). Never raise it merely to
+# turn a red gate green.
+WASM_SIZE_BUDGET_BYTES := 3145728
 
 help: ## Show this help.
 	@grep -E '^[a-zA-Z_-]+:.*## ' $(MAKEFILE_LIST) | awk -F':.*## ' '{printf "  %-18s %s\n", $$1, $$2}'
@@ -150,7 +175,14 @@ wasm-pkg: ## Build the purrdf npm/ESM package (release wasm + wasm-bindgen web b
 	@# for wasm32-unknown-unknown; older binaryen builds (e.g. Ubuntu's apt
 	@# package) reject the module without them. --enable-simd is REQUIRED for the
 	@# +simd128 build above (binaryen rejects the SIMD-carrying module without it).
-	@command -v wasm-opt >/dev/null 2>&1 || { echo "ERROR: wasm-opt (binaryen) not found — it is a REQUIRED wasm build dependency"; exit 1; }
+	@command -v wasm-opt >/dev/null 2>&1 || { echo "ERROR: wasm-opt (binaryen) not found — it is a REQUIRED wasm build dependency:"; echo "  install binaryen version $(BINARYEN_VERSION)"; exit 1; }
+	@# Pin binaryen so the optimized artifact — and the size budget — is byte-reproducible.
+	@FOUND=$$(wasm-opt --version | grep -oE '[0-9]+' | head -1); \
+		test "$$FOUND" = "$(BINARYEN_VERSION)" || { \
+			echo "ERROR: binaryen (wasm-opt) version mismatch — found $$FOUND, expected $(BINARYEN_VERSION)."; \
+			echo "  wasm-opt output feeds WASM_SIZE_BUDGET_BYTES; install binaryen $(BINARYEN_VERSION) so the artifact size is reproducible."; \
+			exit 1; \
+		}
 	wasm-opt -Oz \
 		--enable-bulk-memory --enable-nontrapping-float-to-int \
 		--enable-sign-ext --enable-mutable-globals --enable-simd \
@@ -165,6 +197,39 @@ wasm-pkg: ## Build the purrdf npm/ESM package (release wasm + wasm-bindgen web b
 		[ "$$count" -gt 0 ] || { echo "ERROR: wasm-pkg produced NO SIMD opcodes (+simd128 regressed — refusing to ship a scalar artifact)"; exit 1; }; \
 		echo "OK: verified $$count SIMD opcode(s) present in the optimized wasm artifact"
 	@echo "OK: purrdf npm package built (crates/rdf-wasm/js/pkg/)"
+
+wasm-pkg-size: wasm-pkg ## Gate the optimized wasm artifact byte size against WASM_SIZE_BUDGET_BYTES (hard-fails on overshoot).
+	@art=crates/rdf-wasm/js/pkg/purrdf_wasm_bg.wasm; \
+	 budget=$(WASM_SIZE_BUDGET_BYTES); \
+	 case "$$budget" in ''|*[!0-9]*) echo "ERROR: WASM_SIZE_BUDGET_BYTES ('$$budget') is not a positive integer"; exit 1;; esac; \
+	 [ "$$budget" -gt 0 ] || { echo "ERROR: WASM_SIZE_BUDGET_BYTES must be > 0"; exit 1; }; \
+	 test -s "$$art" || { echo "ERROR: $$art missing or empty — wasm-pkg did not produce the optimized artifact"; exit 1; }; \
+	 size=$$(wc -c < "$$art" | tr -d ' '); \
+	 gz=$$(gzip -9nc < "$$art" | wc -c | tr -d ' '); \
+	 pct=$$(( size * 100 / budget )); \
+	 raw=target/wasm32-unknown-unknown/release/purrdf_wasm.wasm; \
+	 if [ -s "$$raw" ]; then rawsz=$$(wc -c < "$$raw" | tr -d ' '); reduc=$$(( (rawsz - size) * 100 / rawsz )); \
+	   ratio="cargo release wasm $$rawsz B -> optimized $$size B (-$$reduc%)"; \
+	 else ratio="cargo release wasm size unavailable (pre-opt module not on disk)"; fi; \
+	 rustcv=$$(rustc --version); \
+	 wbver=$$(grep -oP 'wasm-bindgen = "=\K[0-9.]+' Cargo.toml); \
+	 woptver=$$(wasm-opt --version); \
+	 line="wasm artifact: $$size bytes / budget $$budget bytes ($$pct%); gzip -9: $$gz bytes"; \
+	 echo "$$line"; echo "  $$ratio"; \
+	 echo "  toolchain: $$rustcv | wasm-bindgen =$$wbver | $$woptver"; \
+	 if [ -n "$${GITHUB_STEP_SUMMARY:-}" ]; then \
+	   { printf '### WASM size budget\n\n'; \
+	     printf -- '- %s\n' "$$line"; \
+	     printf -- '- %s\n' "$$ratio"; \
+	     printf -- '- toolchain: %s | wasm-bindgen =%s | %s\n' "$$rustcv" "$$wbver" "$$woptver"; \
+	   } >> "$$GITHUB_STEP_SUMMARY"; \
+	 fi; \
+	 if [ "$$size" -gt "$$budget" ]; then \
+	   echo "FAIL: wasm artifact $$size bytes exceeds budget $$budget bytes."; \
+	   echo "  If this growth is intended, raise WASM_SIZE_BUDGET_BYTES in the Makefile per the documented procedure (justify WHY in the commit)."; \
+	   exit 1; \
+	 fi; \
+	 echo "OK: wasm artifact within budget"
 
 wasm-pkg-test: wasm-pkg ## Build the wasm package and run the Node real-execution round-trip suite.
 	cd crates/rdf-wasm/js && node --test tests/*.test.mjs

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ wasm-pkg-size: wasm-pkg ## Gate the optimized wasm artifact byte size against WA
 	   ratio="cargo release wasm $$rawsz B -> optimized $$size B (-$$reduc%)"; \
 	 else ratio="cargo release wasm size unavailable (pre-opt module not on disk)"; fi; \
 	 rustcv=$$(rustc --version); \
-	 wbver=$$(grep -oP 'wasm-bindgen = "=\K[0-9.]+' Cargo.toml); \
+	 wbver=$$(sed -n 's/.*wasm-bindgen[[:space:]]*=[[:space:]]*"=\([0-9.]*\)".*/\1/p' Cargo.toml); \
 	 woptver=$$(wasm-opt --version); \
 	 line="wasm artifact: $$size bytes / budget $$budget bytes ($$pct%); gzip -9: $$gz bytes"; \
 	 echo "$$line"; echo "  $$ratio"; \

--- a/scripts/check-issue-refs.py
+++ b/scripts/check-issue-refs.py
@@ -252,6 +252,26 @@ def rust_comments(src: str) -> list[tuple[int, int, str]]:
     return comments
 
 
+def is_rust_doc_comment(text: str) -> bool:
+    """Return whether a Rust comment renders as Markdown (i.e. is a doc comment).
+
+    Only doc comments are Markdown, so only they get inline-code-span exclusion.
+    Outer/inner line docs are ``///`` and ``//!``; block docs are ``/**`` and
+    ``/*!``. Rust treats ``////`` (four-plus slashes), ``/***`` and the empty
+    ``/**/`` as *ordinary* comments, not docs — so those must NOT be excluded and
+    are matched out here.
+    """
+    if text.startswith("///") and not text.startswith("////"):
+        return True
+    if text.startswith("//!"):
+        return True
+    if text.startswith("/*!"):
+        return True
+    if text.startswith("/**") and not text.startswith(("/***", "/**/")):
+        return True
+    return False
+
+
 def scan_comments(
     comments: list[tuple[int, int, str]],
     *,
@@ -264,23 +284,25 @@ def scan_comments(
     are translated back into absolute file coordinates.
 
     When ``exclude_inline_code`` is set, matches inside a Markdown inline-code
-    span (backtick-delimited) are skipped, mirroring ``scan_markdown``. Rust doc
-    comments (``///``/``//!``) render as Markdown, so an issue-shaped token
-    inside a code span like ```term#3``` is a code literal — the exact
-    output ``RdfLocation::display`` emits — not a stale issue reference. Without
-    this, the Rust scan flagged what the Markdown scan already (correctly)
-    excludes.
+    span (backtick-delimited) are skipped **only for Rust doc comments**
+    (``///``/``//!``/``/**``/``/*!``), which render as Markdown, mirroring
+    ``scan_markdown``. In a doc comment an issue-shaped token inside a code span
+    like ```term#3``` is a code literal — the exact output
+    ``RdfLocation::display`` emits — not a stale issue reference. Ordinary
+    ``//``/``/* */`` comments are NOT Markdown, so backticks carry no special
+    meaning there and a ``#NNN`` token inside them is still flagged.
     """
     violations: list[tuple[int, int, str, str]] = []
 
     for start_line, start_col, text in comments:
         text_lines = text.split("\n")
+        doc_comment = exclude_inline_code and is_rust_doc_comment(text)
         for match in ISSUE_RE.finditer(text):
             offset = match.start()
             rel_line = text.count("\n", 0, offset) + 1
             last_nl = text.rfind("\n", 0, offset)
             rel_col = offset - last_nl
-            if exclude_inline_code:
+            if doc_comment:
                 col0 = rel_col - 1
                 spans = find_inline_code_spans(text_lines[rel_line - 1])
                 if any(s <= col0 < e for s, e in spans):
@@ -297,9 +319,11 @@ def scan_comments(
 def scan_rust(path: Path) -> list[tuple[int, int, str, str]]:
     """Return violations found in a Rust source file.
 
-    Rust doc comments are rendered as Markdown, so inline-code spans are excluded
-    exactly as ``scan_markdown`` excludes them — an issue-shaped token inside
-    backticks is a code literal, not a stale issue reference.
+    ``exclude_inline_code`` is requested, but ``scan_comments`` applies the
+    inline-code-span exclusion only to Rust *doc* comments (which render as
+    Markdown) — an issue-shaped token inside backticks in a doc comment is a code
+    literal, not a stale issue reference. Ordinary ``//``/``/* */`` comments are
+    not Markdown, so a ``#NNN`` inside backticks there is still flagged.
     """
     src = path.read_text(encoding="utf-8")
     return scan_comments(rust_comments(src), exclude_inline_code=True)

--- a/scripts/check-issue-refs.py
+++ b/scripts/check-issue-refs.py
@@ -254,21 +254,37 @@ def rust_comments(src: str) -> list[tuple[int, int, str]]:
 
 def scan_comments(
     comments: list[tuple[int, int, str]],
+    *,
+    exclude_inline_code: bool = False,
 ) -> list[tuple[int, int, str, str]]:
     """Scan extracted ``(start_line, start_col, text)`` comments for tokens.
 
     Shared by every comment-based scanner (Rust, Python, YAML): each comment
     carries the 1-based line/column of its first character, and match positions
     are translated back into absolute file coordinates.
+
+    When ``exclude_inline_code`` is set, matches inside a Markdown inline-code
+    span (backtick-delimited) are skipped, mirroring ``scan_markdown``. Rust doc
+    comments (``///``/``//!``) render as Markdown, so an issue-shaped token
+    inside a code span like ```term#3``` is a code literal — the exact
+    output ``RdfLocation::display`` emits — not a stale issue reference. Without
+    this, the Rust scan flagged what the Markdown scan already (correctly)
+    excludes.
     """
     violations: list[tuple[int, int, str, str]] = []
 
     for start_line, start_col, text in comments:
+        text_lines = text.split("\n")
         for match in ISSUE_RE.finditer(text):
             offset = match.start()
             rel_line = text.count("\n", 0, offset) + 1
             last_nl = text.rfind("\n", 0, offset)
             rel_col = offset - last_nl
+            if exclude_inline_code:
+                col0 = rel_col - 1
+                spans = find_inline_code_spans(text_lines[rel_line - 1])
+                if any(s <= col0 < e for s, e in spans):
+                    continue
             line = start_line + rel_line - 1
             col = start_col + rel_col - 1 if rel_line == 1 else rel_col
             violations.append(
@@ -279,9 +295,14 @@ def scan_comments(
 
 
 def scan_rust(path: Path) -> list[tuple[int, int, str, str]]:
-    """Return violations found in a Rust source file."""
+    """Return violations found in a Rust source file.
+
+    Rust doc comments are rendered as Markdown, so inline-code spans are excluded
+    exactly as ``scan_markdown`` excludes them — an issue-shaped token inside
+    backticks is a code literal, not a stale issue reference.
+    """
     src = path.read_text(encoding="utf-8")
-    return scan_comments(rust_comments(src))
+    return scan_comments(rust_comments(src), exclude_inline_code=True)
 
 
 def skip_py_string(src: str, i: int, n: int) -> int:


### PR DESCRIPTION
Closes #1

## Summary
Turns the best-effort `wasm-opt -Oz` step into a **hard, reproducible, single-sourced size gate** on the optimized npm artifact (`crates/rdf-wasm/js/pkg/purrdf_wasm_bg.wasm`). The CI `wasm` job previously never built the optimized artifact (it only checked the raw `.wasm` was non-empty); it now produces it, measures it, reports it, and fails on regression — and the npm release enforces the identical ceiling.

## What it does
- **`make wasm-pkg-size`** (Makefile): builds the optimized artifact, then reports raw + gzip size, the cargo→optimized reduction, and full toolchain identity to `$GITHUB_STEP_SUMMARY` **unconditionally before** comparing, and hard-fails when the artifact exceeds `WASM_SIZE_BUDGET_BYTES`. The summary is written even on the failing (red) run.
- **`WASM_SIZE_BUDGET_BYTES := 3145728`** (3 MiB) — one documented constant with an in-Makefile deliberate-raise procedure. Measured baseline: **2,989,759 B** (gzip-9 1,084,978 B; cargo raw 3,810,659 B, −21%), so ~5% headroom.
- **Determinism made real:** binaryen is pinned + verified via `BINARYEN_VERSION` (reusing the repo's `GIT_CLIFF_VERSION` pin-and-verify idiom); wasm-bindgen stays pinned to the `Cargo.toml` version. A moved number is attributable to a toolchain bump vs. real code growth.
- **Single source of truth:** a new `.github/actions/wasm-toolchain` composite action installs both tools from pinned, **checksum-verified prebuilt** archives (no per-PR source builds) with a rust-cache; used by **both** the CI wasm job and the npm release, so the size pipeline can't drift and the released artifact is byte-reproducible.

## Changes
- `Makefile`: `BINARYEN_VERSION` pin + verify, `WASM_SIZE_BUDGET_BYTES` + raise doc, new `wasm-pkg-size` gate target.
- `.github/actions/wasm-toolchain/action.yml`: pinned, cached, checksum-verified, single-sourced toolchain install.
- `.github/workflows/ci.yaml`: wasm job uses the action + `make wasm-pkg-size` (the hard size gate).
- `.github/workflows/release-npm.yaml`: uses the same action + enforces the budget (replaces source-built wasm-bindgen and **unpinned apt binaryen**).
- `AGENTS.md`: documents the gate, the pin, and the deliberate-raise procedure.
- `scripts/check-issue-refs.py`: **pre-existing main regression fix** — the issue-ref lint's Rust scanner now excludes rustdoc inline-code spans (matching its markdown scanner), so accurate docs like `` `term#3 quad#7` `` (the real output of `RdfLocation::display`) are no longer flagged as issue references. Without this, `make check` was red on `main`.

## Verification (run locally)
- `make wasm-pkg-size`: within budget → exit 0 with the summary block written.
- Overshoot (`WASM_SIZE_BUDGET_BYTES=1000`): non-zero exit **and** the current-vs-budget block still present in the summary (ordering invariant).
- binaryen pin mismatch → `wasm-pkg` hard-fails.
- Both prebuilt tarballs downloaded, **checksums verified**, and extraction layout confirmed.
- `actionlint` clean; `make check` green.
