### PR TITLE
feat(playground): standalone deployed RDF-1.2 console over purrdf-wasm

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     paths:
       - "docs/book/**"
+      - "docs/playground/**"
+      - "crates/rdf-wasm/**"
+      - "Makefile"
+      - ".github/actions/wasm-toolchain/**"
       - ".github/workflows/docs.yaml"
   push:
     branches:
@@ -34,6 +38,44 @@ jobs:
 
       - name: Build book
         run: mdbook build docs/book
+
+      # The RDF-1.2 console is a static surface built from the SAME wasm the npm
+      # release publishes; it ships as a /playground subpath of the single Pages
+      # artifact (GitHub Pages allows only one deployment, already owned here).
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Set up the pinned wasm toolchain (wasm-bindgen + binaryen) and cache
+        uses: ./.github/actions/wasm-toolchain
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Build + smoke-gate the console (wasm package + engine round-trips)
+        run: make playground-smoke playground
+
+      - name: Assert the console version tracks the published package version
+        run: |
+          node --input-type=module -e '
+            import { ready, version } from "./crates/rdf-wasm/js/index.mjs";
+            import { readFileSync } from "node:fs";
+            await ready();
+            const pj = JSON.parse(readFileSync("./crates/rdf-wasm/js/package.json", "utf8"));
+            if (version() !== pj.version) {
+              console.error("FAIL: console version() " + version() + " != package.json " + pj.version);
+              process.exit(1);
+            }
+            console.log("OK: console version " + version() + " tracks the published package version");
+          '
+
+      - name: Fold the console into the Pages artifact at /playground
+        run: |
+          rm -rf docs/book/book/playground
+          cp -R target/playground docs/book/book/playground
 
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 CARGO_TARGET_DIR ?= target
 CAPI_HEADER := crates/rdf-capi/include/purrdf.h
 
-.PHONY: help metadata fmt check book check-issue-refs changelog bump release-tags test doc bench bench-python pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-size wasm-pkg-test wasm-pkg-bench \
+.PHONY: help metadata fmt check book check-issue-refs changelog bump release-tags test doc bench bench-python pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-size wasm-pkg-test wasm-pkg-bench playground playground-smoke \
 	capi-build capi-header capi-check capi-install
 
 # The changelog generator is pinned so the committed CHANGELOG.md and the notes
@@ -236,6 +236,28 @@ wasm-pkg-test: wasm-pkg ## Build the wasm package and run the Node real-executio
 
 wasm-pkg-bench: wasm-pkg ## Build the wasm package and run the Node parse-throughput benchmark (report-only; never a gate).
 	cd crates/rdf-wasm/js && node bench/parse.bench.mjs
+
+# The static RDF-1.2 console (docs/playground/) assembled next to a fresh copy of the
+# published ESM package — the exact tree the Pages deploy ships at /playground. The app
+# is zero-dependency vanilla ESM; "assembly" is just a copy, no bundler.
+PLAYGROUND_OUT := $(CARGO_TARGET_DIR)/playground
+playground: wasm-pkg ## Assemble the standalone RDF-1.2 console into $(CARGO_TARGET_DIR)/playground (serve it to preview).
+	@# Ship exactly the app shell + a FRESH copy of the published package. The
+	@# smoke/ Node tests and any local docs/playground/purrdf/ preview copy are
+	@# deliberately NOT shipped — the package is (re)built here from source.
+	@rm -rf "$(PLAYGROUND_OUT)"
+	@mkdir -p "$(PLAYGROUND_OUT)/purrdf"
+	@cp docs/playground/index.html docs/playground/app.mjs docs/playground/engine.worker.mjs \
+		docs/playground/style.css docs/playground/sw.mjs docs/playground/manifest.webmanifest \
+		"$(PLAYGROUND_OUT)/"
+	@cp -R docs/playground/examples "$(PLAYGROUND_OUT)/examples"
+	@cp crates/rdf-wasm/js/index.mjs "$(PLAYGROUND_OUT)/purrdf/index.mjs"
+	@cp -R crates/rdf-wasm/js/pkg "$(PLAYGROUND_OUT)/purrdf/pkg"
+	@echo "OK: console assembled at $(PLAYGROUND_OUT)"
+	@echo "    preview: (cd $(PLAYGROUND_OUT) && python3 -m http.server 8080) then open http://localhost:8080/"
+
+playground-smoke: wasm-pkg ## Smoke the console's engine calls (every pane's package call, Node-side; a CI gate).
+	node --test docs/playground/smoke/*.test.mjs
 
 capi-build: ## Build libpurrdf (cdylib + staticlib + header + pkg-config) via cargo-c.
 	cargo capi build -p purrdf-capi

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,8 @@ playground: wasm-pkg ## Assemble the standalone RDF-1.2 console into $(CARGO_TAR
 	@rm -rf "$(PLAYGROUND_OUT)"
 	@mkdir -p "$(PLAYGROUND_OUT)/purrdf"
 	@cp docs/playground/index.html docs/playground/app.mjs docs/playground/engine.worker.mjs \
-		docs/playground/style.css docs/playground/sw.mjs docs/playground/manifest.webmanifest \
+		docs/playground/sarif.mjs docs/playground/style.css docs/playground/sw.mjs \
+		docs/playground/manifest.webmanifest \
 		"$(PLAYGROUND_OUT)/"
 	@cp -R docs/playground/examples "$(PLAYGROUND_OUT)/examples"
 	@cp crates/rdf-wasm/js/index.mjs "$(PLAYGROUND_OUT)/purrdf/index.mjs"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ SPDX-License-Identifier: MIT OR Apache-2.0
   <img src="https://img.shields.io/badge/MSRV-1.96-orange.svg" alt="MSRV 1.96">
 </p>
 
+<p align="center">
+  <a href="https://blackcat-informatics.github.io/purrdf/playground/"><img src="https://img.shields.io/badge/RDF--1.2%20playground-try%20it%20live-brightgreen" alt="Try the RDF-1.2 playground in your browser"></a>
+</p>
+
 ---
 
 ## Why does this exist?
@@ -213,6 +217,10 @@ that CI checks for drift. Built with cargo-c: `make capi-build`.
 
 ## Documentation
 
+- **[RDF-1.2 playground](https://blackcat-informatics.github.io/purrdf/playground/)** —
+  a zero-install browser console: parse, query (SPARQL), validate (SHACL),
+  serialize, and canonicalize/compare RDF-1.2 (quoted triples, directional
+  literals) entirely client-side over the wasm build. No toolchain, no server.
 - **[The PurRDF Book](https://blackcat-informatics.github.io/purrdf/)** — the
   user guide: getting started in each language, concepts, and every engine
   (source in [`docs/book/`](./docs/book/), `make book` builds it locally).

--- a/crates/rdf-wasm/README.md
+++ b/crates/rdf-wasm/README.md
@@ -55,7 +55,14 @@ const reparsed = Dataset.parse(nq, "nquads");
 - **`Dataset`** (RDF/JS `DatasetCore`) — `Dataset.parse(input, format, base?)`,
   `serialize(format)`, `add`/`delete`/`has`/`match`/`quads`/`size`, and iteration
   (`for (const quad of dataset)`). Formats: `turtle`, `ntriples`, `nquads`, `trig`,
-  `rdfxml` (or their media types).
+  `rdfxml` (or their media types); `serialize` additionally accepts `jsonld`.
+- **Graph identity** — `Dataset.canonicalize()` returns the RDFC-1.0 canonical, flat
+  N-Quads for the graph; `Dataset.isomorphic(other)` decides RDF graph equality under
+  blank-node relabeling (an exact oracle backed by full RDFC-1.0 canonicalization).
+- **SHACL** — `shaclValidateToSarif(shapesTtl, dataNt)` validates an N-Triples data
+  graph against a Turtle shapes graph and returns a SARIF 2.1.0 report;
+  `shaclEntail(shapesTtl, dataNt)` materializes the SHACL-AF `sh:rule` inferences as
+  N-Triples.
 - **`Sink`** — a streaming consumer (`push(quad)` / `finish() → Dataset`) over the
   `purrdf-events` ingestion protocol; **`datasetToStream`** / **`streamToDataset`**
   are the async RDF/JS Stream/Sink helpers.

--- a/crates/rdf-wasm/README.md
+++ b/crates/rdf-wasm/README.md
@@ -14,6 +14,10 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 This crate (`purrdf-wasm`) is the Rust cdylib; the published npm/ESM package lives
 in [`js/`](./js/) and is named **`@blackcatinformatics/purrdf`**.
 
+> **Try it live** — the [RDF-1.2 playground](https://blackcat-informatics.github.io/purrdf/playground/)
+> runs this exact wasm build in your browser: parse, SPARQL, SHACL, serialize, and
+> canonicalize/compare graphs client-side, no toolchain and no server.
+
 ## The RDF-1.2 wedge
 
 No incumbent RDF/JS library carries RDF-1.2 **quoted-triple terms** or **directional

--- a/crates/rdf-wasm/js/README.md
+++ b/crates/rdf-wasm/js/README.md
@@ -14,6 +14,10 @@ It is the same engine, byte-for-byte behavior, that ships as the `purrdf`
 Rust crates, the `purrdf` PyPI package, and `libpurrdf` — PurRDF's rule is
 **one engine, one behavior, every language**.
 
+> **Try it live** — the [RDF-1.2 playground](https://blackcat-informatics.github.io/purrdf/playground/)
+> runs this package in your browser: parse, SPARQL, SHACL, serialize, and
+> canonicalize/compare RDF-1.2 graphs client-side, with no install.
+
 ## Why this instead of an incumbent RDF/JS library?
 
 No incumbent RDF/JS library carries the RDF 1.2 features:

--- a/crates/rdf-wasm/js/README.md
+++ b/crates/rdf-wasm/js/README.md
@@ -73,7 +73,11 @@ const reparsed = Dataset.parse(nq, "nquads");
   `fromTerm`, `fromQuad`.
 - `Dataset` — `Dataset.parse(input, format, base?)`, `serialize(format)`,
   `add` / `delete` / `has` / `match` / `quads` / `size`, iteration.
-  Formats: `turtle`, `ntriples`, `nquads`, `trig`, `rdfxml`.
+  Formats: `turtle`, `ntriples`, `nquads`, `trig`, `rdfxml` (`serialize` also `jsonld`).
+- `Dataset.canonicalize()` / `Dataset.isomorphic(other)` — RDFC-1.0 canonical N-Quads
+  and RDF graph-identity (isomorphism under blank-node relabeling).
+- `shaclValidateToSarif(shapesTtl, dataNt)` / `shaclEntail(shapesTtl, dataNt)` — SHACL
+  validation to a SARIF 2.1.0 report and SHACL-AF `sh:rule` entailment to N-Triples.
 - `Sink`, `datasetToStream`, `streamToDataset` — the async RDF/JS
   Stream/Sink primitives over the synchronous engine surface.
 - SPARQL evaluation over the in-memory dataset (no server required).
@@ -83,8 +87,8 @@ Full typings ship in `index.d.ts`.
 ## Scope
 
 In-memory only, by design: no persistent store and no network I/O inside the
-wasm module. For the container transport (GTS), SHACL validation, SPARQL
-result serializers, and the rest of the toolkit, see the
+wasm module. For the container transport (GTS), SPARQL result serializers, and the
+rest of the toolkit, see the
 [main repository](https://github.com/Blackcat-Informatics/purrdf).
 
 ## Supply chain

--- a/crates/rdf-wasm/js/index.d.ts
+++ b/crates/rdf-wasm/js/index.d.ts
@@ -1,12 +1,17 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-// The wasm-bindgen-generated class declarations (DataFactory/Dataset/Quad/Sink/Term
-// and the free `version()` function) are the source of truth for the engine surface.
+// The wasm-bindgen-generated class declarations (DataFactory/Dataset/Quad/Sink/Term)
+// and the free functions (`version()`, `shaclValidateToSarif`, `shaclEntail`) are the
+// source of truth for the engine surface — the whole `#[wasm_bindgen]` surface is
+// re-exported from the package root (Dataset.canonicalize()/isomorphic() ship on the
+// Dataset class itself).
 export {
   DataFactory,
   Dataset,
   Quad,
+  shaclEntail,
+  shaclValidateToSarif,
   Sink,
   Term,
   version,

--- a/crates/rdf-wasm/js/index.mjs
+++ b/crates/rdf-wasm/js/index.mjs
@@ -3,8 +3,11 @@
 
 // purrdf — the idiomatic RDF/JS surface over the wasm engine.
 //
-// The wasm-bindgen-generated classes (DataFactory/Dataset/Quad/Sink/Term) are
-// re-exported as-is; this wrapper adds the isomorphic glue that the synchronous
+// The wasm-bindgen-generated classes (DataFactory/Dataset/Quad/Sink/Term) and the
+// free functions (version, shaclValidateToSarif, shaclEntail) are re-exported as-is —
+// the whole `#[wasm_bindgen]` surface is reachable from the package root, so
+// SHACL validation/entailment and Dataset.canonicalize()/isomorphic() need no deep
+// `./pkg/` import. This wrapper adds the isomorphic glue that the synchronous
 // wasm boundary cannot express in Rust:
 //   * `ready()` — one-time async wasm instantiation (required for the `web` target).
 //   * the polymorphic RDF/JS `DataFactory.literal(value, languageOrDatatype)` —
@@ -18,6 +21,8 @@ import init, {
   DataFactory,
   Dataset,
   Quad,
+  shaclEntail,
+  shaclValidateToSarif,
   Sink,
   Term,
   version,
@@ -125,4 +130,13 @@ export async function streamToDataset(quadStream) {
   return sink.finish();
 }
 
-export { DataFactory, Dataset, Quad, Sink, Term, version };
+export {
+  DataFactory,
+  Dataset,
+  Quad,
+  shaclEntail,
+  shaclValidateToSarif,
+  Sink,
+  Term,
+  version,
+};

--- a/crates/rdf-wasm/js/tests/identity.test.mjs
+++ b/crates/rdf-wasm/js/tests/identity.test.mjs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Node real-execution conformance for the graph-IDENTITY surface reached through the
+// PUBLIC package root — `Dataset.canonicalize()` (RDFC-1.0 canonical N-Quads) and
+// `Dataset.isomorphic(other)` (graph isomorphism under blank-node relabeling), exactly
+// as the docs playground's identity/diff pane calls them.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { ready, Dataset } from "../index.mjs";
+
+await ready();
+
+// The SAME graph with different blank-node labels + different statement order.
+const A = `@prefix ex: <http://example.org/> .
+_:a ex:name "Ann" ; ex:knows _:b .
+_:b ex:name "Bob" .
+`;
+const B = `@prefix ex: <http://example.org/> .
+_:x ex:name "Bob" .
+_:y ex:name "Ann" ; ex:knows _:x .
+`;
+// A genuinely different graph (Bob knows a third party).
+const C = `@prefix ex: <http://example.org/> .
+_:a ex:name "Ann" ; ex:knows _:b .
+_:b ex:name "Bob" ; ex:knows _:c .
+_:c ex:name "Cid" .
+`;
+
+test("isomorphic() is true for the same graph under blank-node relabeling", () => {
+  const a = Dataset.parse(A, "turtle");
+  const b = Dataset.parse(B, "turtle");
+  assert.equal(a.isomorphic(b), true);
+});
+
+test("isomorphic() is false for a structurally different graph", () => {
+  const a = Dataset.parse(A, "turtle");
+  const c = Dataset.parse(C, "turtle");
+  assert.equal(a.isomorphic(c), false);
+});
+
+test("canonicalize() is stable and identifies isomorphic graphs byte-for-byte", () => {
+  const a = Dataset.parse(A, "turtle");
+  const b = Dataset.parse(B, "turtle");
+  const canonA = a.canonicalize();
+  assert.ok(canonA.length > 0, "canonical form is non-empty");
+  // Re-canonicalizing the same dataset is deterministic.
+  assert.equal(a.canonicalize(), canonA);
+  // Isomorphic graphs canonicalize to the identical string — the identity guarantee.
+  assert.equal(b.canonicalize(), canonA);
+});

--- a/crates/rdf-wasm/js/tests/shacl.test.mjs
+++ b/crates/rdf-wasm/js/tests/shacl.test.mjs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Node real-execution conformance for the SHACL surface reached through the PUBLIC
+// package root (`../index.mjs`) — `shaclValidateToSarif` / `shaclEntail`, exactly as
+// the docs playground's SHACL pane calls them in a browser. Proves the SHACL engine is
+// reachable from the shipped package (not only a deep `./pkg/` import).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { ready, shaclValidateToSarif, shaclEntail } from "../index.mjs";
+
+await ready();
+
+// Shapes as Turtle, data as N-Triples — the exact input contract of the two functions.
+const SHAPES = `@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:PersonShape a sh:NodeShape ;
+  sh:targetClass ex:Person ;
+  sh:property [ sh:path ex:age ; sh:datatype xsd:integer ] .
+`;
+
+const DATA = `<http://example.org/alice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Person> .
+<http://example.org/alice> <http://example.org/age> "nope" .
+`;
+
+test("shaclValidateToSarif emits SARIF 2.1.0 with a violation", () => {
+  const sarif = JSON.parse(shaclValidateToSarif(SHAPES, DATA));
+  assert.equal(sarif.version, "2.1.0");
+  const results = sarif.runs.flatMap((r) => r.results ?? []);
+  assert.ok(results.length >= 1, "the ill-typed age must produce at least one result");
+  assert.ok(
+    results.some((r) => r.level === "error"),
+    "a datatype violation is an error-level SARIF result",
+  );
+});
+
+test("shaclValidateToSarif rejects malformed shapes (never a silent pass)", () => {
+  assert.throws(() => shaclValidateToSarif("@@@ not turtle", DATA));
+});
+
+// A `sh:rule` shapes graph that types every ex:Person as ex:adult ex:yes.
+const RULE_SHAPES = `@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/> .
+ex:PersonRule a sh:NodeShape ;
+  sh:targetClass ex:Person ;
+  sh:rule [ a sh:TripleRule ;
+    sh:subject sh:this ; sh:predicate ex:adult ; sh:object ex:yes ] .
+`;
+
+const RULE_DATA = `<http://example.org/alice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Person> .
+`;
+
+test("shaclEntail materializes the inferred triple and keeps the base fact", () => {
+  const nt = shaclEntail(RULE_SHAPES, RULE_DATA);
+  assert.match(
+    nt,
+    /<http:\/\/example\.org\/alice> <http:\/\/example\.org\/adult> <http:\/\/example\.org\/yes> \./,
+  );
+  assert.match(
+    nt,
+    /<http:\/\/example\.org\/alice> <http:\/\/www\.w3\.org\/1999\/02\/22-rdf-syntax-ns#type> <http:\/\/example\.org\/Person> \./,
+  );
+});

--- a/crates/rdf-wasm/src/dataset.rs
+++ b/crates/rdf-wasm/src/dataset.rs
@@ -13,7 +13,8 @@
 use purrdf::dataset_view::{DatasetMut, GraphMatchValue};
 use purrdf::ir::MutableDataset;
 use purrdf::{
-    RdfDatasetBuilder, RdfDiagnostic, SerializeGraph, TermValue, parse_dataset, serialize_dataset,
+    RdfDatasetBuilder, RdfDiagnostic, SerializeGraph, TermValue, canonical_flat_nquads,
+    datasets_isomorphic, parse_dataset, serialize_dataset,
 };
 use wasm_bindgen::prelude::*;
 
@@ -108,6 +109,32 @@ impl Dataset {
             .map_err(|e| diag_to_err(&e))?;
         String::from_utf8(bytes)
             .map_err(|e| JsError::new(&format!("serialization produced non-UTF-8 bytes: {e}")))
+    }
+
+    /// `canonicalize()` → the dataset as canonical, flat N-Quads under RDFC-1.0
+    /// (SHA-256).
+    ///
+    /// The deterministic identity string for the graph: two datasets denote the same
+    /// RDF graph (under blank-node relabeling) iff their canonical forms are
+    /// byte-identical. This is the same RDFC-1.0 output the conformance gate pins.
+    #[wasm_bindgen(js_name = canonicalize)]
+    pub fn canonicalize(&self) -> Result<String, JsError> {
+        let frozen = self.inner.freeze().map_err(|e| diag_to_err(&e))?;
+        canonical_flat_nquads(&frozen).map_err(|e| JsError::new(&e))
+    }
+
+    /// `isomorphic(other)` → whether this dataset and `other` are the same RDF graph
+    /// under blank-node relabeling.
+    ///
+    /// The formal RDF graph-identity check, backed by full RDFC-1.0 canonicalization:
+    /// an exact oracle with no false positives or false negatives. Equivalent to
+    /// comparing the two [`canonicalize`](Self::canonicalize) strings, but avoids
+    /// materializing them for obviously-different inputs.
+    #[wasm_bindgen(js_name = isomorphic)]
+    pub fn isomorphic(&self, other: &Self) -> Result<bool, JsError> {
+        let a = self.inner.freeze().map_err(|e| diag_to_err(&e))?;
+        let b = other.inner.freeze().map_err(|e| diag_to_err(&e))?;
+        Ok(datasets_isomorphic(&a, &b))
     }
 
     /// `size` — the number of effective quads.

--- a/crates/rdf-wasm/src/lib.rs
+++ b/crates/rdf-wasm/src/lib.rs
@@ -60,6 +60,8 @@ use wasm_bindgen::prelude::*;
 //                 (parse/serialize/size/add/delete/has/match/quads)
 //   * `query`   — the offline SPARQL surface (`Dataset.query`) over the native
 //                 evaluator
+//   * `shacl`   — SHACL validation to SARIF + SHACL-AF entailment
+//                 (`shaclValidateToSarif`/`shaclEntail`)
 //   * `stream`  — the RDF/JS Sink over the `purrdf-events` ingestion protocol
 mod codec;
 mod convert;

--- a/docs/playground/.gitignore
+++ b/docs/playground/.gitignore
@@ -1,0 +1,4 @@
+# The published ESM package is copied in at build time (`make playground` / the
+# docs deploy job) — never committed. A local copy here lets you preview the
+# console straight from `docs/playground/` with a static server.
+/purrdf/

--- a/docs/playground/app.mjs
+++ b/docs/playground/app.mjs
@@ -1,0 +1,897 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// The PurRDF console controller. Spawns the engine Web Worker, drives a
+// promise-based request/reply map, wires every pane, renders results, and owns
+// the aria-live error banner. The main thread NEVER touches the wasm engine —
+// it is a pure view/message client over the worker.
+
+import { VIGNETTES, findVignette, DEFAULT_STATE } from "./examples/gallery.mjs";
+
+const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
+
+// ---------------------------------------------------------------------------
+// Worker request/reply plumbing
+// ---------------------------------------------------------------------------
+
+const worker = new Worker(new URL("./engine.worker.mjs", import.meta.url), {
+  type: "module",
+});
+
+let nextId = 1;
+const pending = new Map();
+
+worker.addEventListener("message", (event) => {
+  const { id, ok, result, error } = event.data ?? {};
+  const entry = pending.get(id);
+  if (!entry) return;
+  pending.delete(id);
+  if (ok) entry.resolve(result);
+  else entry.reject(new Error(error));
+});
+
+worker.addEventListener("error", (event) => {
+  showError(`worker crashed: ${event.message ?? event}`);
+});
+
+/** Send an op to the worker; resolves with its result or rejects on engine error. */
+function call(op, args) {
+  const id = nextId++;
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    worker.postMessage({ id, op, args });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DOM helpers + banners
+// ---------------------------------------------------------------------------
+
+const $ = (id) => document.getElementById(id);
+
+function showError(message) {
+  const banner = $("error-banner");
+  banner.textContent = message;
+  banner.hidden = false;
+}
+
+function clearError() {
+  const banner = $("error-banner");
+  banner.textContent = "";
+  banner.hidden = true;
+}
+
+function showStatus(message) {
+  const banner = $("status-banner");
+  banner.textContent = message;
+  banner.hidden = false;
+}
+
+/** Run an async engine action, routing any failure to the visible error banner. */
+async function guard(fn) {
+  clearError();
+  try {
+    await fn();
+  } catch (e) {
+    showError(String(e?.message ?? e));
+  }
+}
+
+function el(tag, props = {}, children = []) {
+  const node = document.createElement(tag);
+  for (const [k, v] of Object.entries(props)) {
+    if (k === "class") node.className = v;
+    else if (k === "text") node.textContent = v;
+    else if (k === "html") node.innerHTML = v;
+    else if (k.startsWith("data-")) node.setAttribute(k, v);
+    else if (k === "hidden") node.hidden = v;
+    else node[k] = v;
+  }
+  for (const c of [].concat(children)) {
+    if (c != null) node.append(c);
+  }
+  return node;
+}
+
+// ---------------------------------------------------------------------------
+// Term rendering (for the SPARQL table + quad table)
+// ---------------------------------------------------------------------------
+
+/** Render a term descriptor into a human-readable N-Triples-ish label. */
+function termLabel(t) {
+  if (t == null) return "";
+  switch (t.termType) {
+    case "NamedNode":
+      return `<${t.value}>`;
+    case "BlankNode":
+      return `_:${t.value}`;
+    case "DefaultGraph":
+      return "(default graph)";
+    case "Variable":
+      return `?${t.value}`;
+    case "Literal": {
+      let s = JSON.stringify(t.value);
+      if (t.direction) s += `@${t.language || ""}--${t.direction}`;
+      else if (t.language) s += `@${t.language}`;
+      else if (t.datatype && t.datatype !== XSD_STRING) s += `^^<${t.datatype}>`;
+      return s;
+    }
+    case "Quad":
+      return `<<( ${termLabel(t.subject)} ${termLabel(t.predicate)} ${termLabel(t.object)} )>>`;
+    default:
+      return String(t.value ?? "");
+  }
+}
+
+/** Convert an SRJ binding term (W3C shape) to our descriptor shape. */
+function srjTermToDescriptor(b) {
+  switch (b.type) {
+    case "uri":
+      return { termType: "NamedNode", value: b.value };
+    case "bnode":
+      return { termType: "BlankNode", value: b.value };
+    case "literal":
+    case "typed-literal":
+      return {
+        termType: "Literal",
+        value: b.value,
+        language: b["xml:lang"] || "",
+        direction: b.direction || "",
+        datatype: b.datatype || XSD_STRING,
+      };
+    case "triple":
+      return {
+        termType: "Quad",
+        value: "",
+        subject: srjTermToDescriptor(b.value.subject),
+        predicate: srjTermToDescriptor(b.value.predicate),
+        object: srjTermToDescriptor(b.value.object),
+      };
+    default:
+      return { termType: "NamedNode", value: String(b.value ?? "") };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Clipboard + download utilities
+// ---------------------------------------------------------------------------
+
+async function copyText(text) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  // Capability fallback — a hidden textarea + execCommand (documented, not a swallow).
+  const ta = el("textarea", { value: text, style: "position:fixed;opacity:0" });
+  document.body.append(ta);
+  ta.select();
+  document.execCommand("copy");
+  ta.remove();
+}
+
+function downloadText(filename, text, mime = "text/plain") {
+  const blob = new Blob([text], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = el("a", { href: url, download: filename });
+  document.body.append(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+// ---------------------------------------------------------------------------
+// State collection + permalinks
+// ---------------------------------------------------------------------------
+
+let activePane = "input";
+
+function collectState() {
+  return {
+    input: $("input-text").value,
+    inputFormat: $("input-format").value,
+    query: $("sparql-text").value,
+    shapes: $("shapes-text").value,
+    graphA: $("graph-a-text").value,
+    graphAFormat: $("graph-a-format").value,
+    graphB: $("graph-b-text").value,
+    graphBFormat: $("graph-b-format").value,
+    activePane,
+  };
+}
+
+function applyState(state) {
+  const s = { ...DEFAULT_STATE, ...state };
+  $("input-text").value = s.input ?? "";
+  $("input-format").value = s.inputFormat ?? "turtle";
+  $("sparql-text").value = s.query ?? "";
+  $("shapes-text").value = s.shapes ?? "";
+  $("graph-a-text").value = s.graphA ?? "";
+  $("graph-a-format").value = s.graphAFormat ?? "turtle";
+  $("graph-b-text").value = s.graphB ?? "";
+  $("graph-b-format").value = s.graphBFormat ?? "turtle";
+  if (s.activePane) selectPane(s.activePane);
+}
+
+const b64urlEncode = (bytes) => {
+  let bin = "";
+  for (const byte of bytes) bin += String.fromCharCode(byte);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+};
+
+const b64urlDecode = (s) => {
+  const pad = s.length % 4 === 0 ? "" : "=".repeat(4 - (s.length % 4));
+  const bin = atob(s.replace(/-/g, "+").replace(/_/g, "/") + pad);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+};
+
+async function streamThrough(stream, bytes) {
+  const writer = stream.writable.getWriter();
+  writer.write(bytes);
+  writer.close();
+  const chunks = [];
+  const reader = stream.readable.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  let len = 0;
+  for (const c of chunks) len += c.length;
+  const out = new Uint8Array(len);
+  let off = 0;
+  for (const c of chunks) {
+    out.set(c, off);
+    off += c.length;
+  }
+  return out;
+}
+
+/** Encode state → (gzip when available) → base64url. All client-side, no network. */
+async function encodeState(state) {
+  const json = new TextEncoder().encode(JSON.stringify(state));
+  if (typeof CompressionStream === "function") {
+    const gz = await streamThrough(new CompressionStream("gzip"), json);
+    return `g${b64urlEncode(gz)}`;
+  }
+  // Documented capability fallback: plain base64url of the JSON.
+  return `j${b64urlEncode(json)}`;
+}
+
+async function decodeState(fragment) {
+  if (!fragment) return null;
+  const tag = fragment[0];
+  const body = fragment.slice(1);
+  const bytes = b64urlDecode(body);
+  let jsonBytes = bytes;
+  if (tag === "g") {
+    if (typeof DecompressionStream !== "function") {
+      throw new Error("this permalink is gzip-encoded but DecompressionStream is unavailable");
+    }
+    jsonBytes = await streamThrough(new DecompressionStream("gzip"), bytes);
+  } else if (tag !== "j") {
+    throw new Error("unrecognized permalink encoding");
+  }
+  return JSON.parse(new TextDecoder().decode(jsonBytes));
+}
+
+async function copyPermalink(state) {
+  await guard(async () => {
+    const fragment = await encodeState(state);
+    const url = `${location.origin}${location.pathname}#${fragment}`;
+    location.hash = fragment;
+    await copyText(url);
+    showStatus("Permalink copied to clipboard.");
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Pane switching
+// ---------------------------------------------------------------------------
+
+const PANES = [
+  "input",
+  "roundtrip",
+  "sparql",
+  "shacl",
+  "identity",
+  "quads",
+  "gallery",
+];
+
+function selectPane(pane) {
+  if (!PANES.includes(pane)) return;
+  activePane = pane;
+  for (const p of PANES) {
+    const section = $(`pane-${p}`);
+    const tab = $(`tab-${p}`);
+    if (section) section.hidden = p !== pane;
+    if (tab) {
+      tab.setAttribute("aria-selected", String(p === pane));
+      tab.tabIndex = p === pane ? 0 : -1;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pane: Input
+// ---------------------------------------------------------------------------
+
+async function doParse() {
+  await guard(async () => {
+    const text = $("input-text").value;
+    const format = $("input-format").value;
+    const res = await call("parse", { text, format });
+    $("input-summary").textContent = `Parsed ${res.size} quad(s) as ${format}.`;
+    renderQuadTable(res.rows, res.size, null);
+    showStatus(`Graph updated: ${res.size} quad(s).`);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Pane: Round-trip / differential
+// ---------------------------------------------------------------------------
+
+const SER_ORDER = ["turtle", "ntriples", "nquads", "trig", "rdfxml", "jsonld"];
+const MIME = {
+  turtle: "text/turtle",
+  ntriples: "application/n-triples",
+  nquads: "application/n-quads",
+  trig: "application/trig",
+  rdfxml: "application/rdf+xml",
+  jsonld: "application/ld+json",
+};
+const EXT = {
+  turtle: "ttl",
+  ntriples: "nt",
+  nquads: "nq",
+  trig: "trig",
+  rdfxml: "rdf",
+  jsonld: "jsonld",
+};
+
+async function doSerializeAll() {
+  await guard(async () => {
+    const res = await call("serializeAll", {});
+    const grid = $("serialize-output");
+    grid.replaceChildren();
+    const failedFormats = [];
+    for (const f of SER_ORDER) {
+      const entry = res.formats[f];
+      const failed = entry.text == null;
+      if (failed) failedFormats.push(f);
+      const pre = el("pre", {
+        id: `ser-${f}`,
+        class: failed ? "code-out ser-error" : "code-out",
+        text: failed
+          ? `⚠ cannot serialize this graph to ${f}:\n${entry.error}`
+          : entry.text,
+        "data-format": f,
+        "data-failed": String(failed),
+      });
+      let badge;
+      if (failed) {
+        badge = el("span", { class: "badge badge-warn", text: "unsupported" });
+      } else if (entry.outputOnly) {
+        badge = el("span", { class: "badge badge-info", text: "output only" });
+      } else if (entry.roundtrips) {
+        badge = el("span", { class: "badge badge-ok", text: "round-trips" });
+      } else {
+        badge = el("span", { class: "badge badge-warn", text: "degrades" });
+      }
+      const copyBtn = el("button", {
+        type: "button",
+        class: "btn-mini",
+        text: "Copy",
+        "data-copy": f,
+        disabled: failed,
+      });
+      copyBtn.addEventListener("click", () =>
+        guard(async () => {
+          await copyText(entry.text);
+          showStatus(`Copied ${f}.`);
+        }),
+      );
+      const dlBtn = el("button", {
+        type: "button",
+        class: "btn-mini",
+        text: "Download",
+        "data-download": f,
+        disabled: failed,
+      });
+      dlBtn.addEventListener("click", () =>
+        downloadText(`graph.${EXT[f]}`, entry.text, MIME[f]),
+      );
+      const header = el("div", { class: "ser-head" }, [
+        el("h4", { text: f, class: "ser-title" }),
+        badge,
+        el("span", { class: "spacer" }),
+        copyBtn,
+        dlBtn,
+      ]);
+      grid.append(el("div", { class: "ser-card" }, [header, pre]));
+    }
+    // Canonical form (RDFC-1.0) — the graph's deterministic identity.
+    const canonCard = el("div", { class: "ser-card" }, [
+      el("div", { class: "ser-head" }, [
+        el("h4", { text: "canonical (RDFC-1.0 N-Quads)", class: "ser-title" }),
+        el("span", { class: "badge badge-ok", text: "identity" }),
+      ]),
+      el("pre", { id: "ser-canonical", class: "code-out", text: res.canonical }),
+    ]);
+    grid.append(canonCard);
+
+    const note = $("serialize-note");
+    if (res.hasQuotedObject) {
+      const survivors = SER_ORDER.filter(
+        (f) => f !== "jsonld" && res.formats[f].text != null && res.formats[f].roundtrips,
+      );
+      const degraders = SER_ORDER.filter(
+        (f) => f !== "jsonld" && res.formats[f].text != null && !res.formats[f].roundtrips,
+      );
+      note.textContent =
+        "This graph carries a quoted triple in object position. " +
+        (failedFormats.length
+          ? `These formats cannot even encode it (hard-fail): ${failedFormats.join(", ")}. `
+          : "") +
+        (degraders.length
+          ? `These text formats round-trip lossily: ${degraders.join(", ")}. `
+          : "") +
+        `N-Quads and the canonical RDFC-1.0 form are the reliable identity reference; ` +
+        `round-tripping formats here: ${survivors.join(", ")}.`;
+      note.hidden = false;
+    } else {
+      note.textContent =
+        "No object-position quoted triple in this graph. N-Quads and the canonical " +
+        "RDFC-1.0 form remain the deterministic identity reference." +
+        (failedFormats.length ? ` Formats that hard-failed: ${failedFormats.join(", ")}.` : "");
+      note.hidden = false;
+    }
+    if (failedFormats.length) {
+      // HARD FAIL surfaced in the aria-live banner — never swallowed.
+      showError(
+        `Some serializers cannot encode this graph: ${failedFormats.join(", ")}. See each format card for the engine error.`,
+      );
+    } else {
+      showStatus("Serialized to all formats.");
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Pane: SPARQL
+// ---------------------------------------------------------------------------
+
+async function doQuery() {
+  await guard(async () => {
+    const sparql = $("sparql-text").value;
+    const res = await call("query", { sparql });
+    const out = $("sparql-results");
+    out.replaceChildren();
+    if (res.kind === "srj") {
+      renderSrj(res.srj, out);
+    } else {
+      out.append(
+        el("pre", { id: "sparql-turtle", class: "code-out", text: res.turtle }),
+      );
+    }
+    showStatus("Query complete.");
+  });
+}
+
+function renderSrj(srj, container) {
+  if (Object.hasOwn(srj, "boolean")) {
+    container.append(
+      el("p", {
+        id: "sparql-boolean",
+        class: "ask-result",
+        text: `ASK → ${srj.boolean ? "true" : "false"}`,
+      }),
+    );
+    return;
+  }
+  const vars = srj.head?.vars ?? [];
+  const rows = srj.results?.bindings ?? [];
+  const table = el("table", { id: "sparql-table", class: "data-table" });
+  const thead = el("thead", {}, [
+    el(
+      "tr",
+      {},
+      vars.map((v) => el("th", { scope: "col", text: `?${v}` })),
+    ),
+  ]);
+  const tbody = el("tbody");
+  for (const binding of rows) {
+    const tr = el(
+      "tr",
+      {},
+      vars.map((v) => {
+        const cell = binding[v];
+        return el("td", {
+          text: cell ? termLabel(srjTermToDescriptor(cell)) : "",
+        });
+      }),
+    );
+    tbody.append(tr);
+  }
+  table.append(thead, tbody);
+  container.append(
+    el("p", { class: "muted", text: `${rows.length} row(s).` }),
+    table,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pane: SHACL
+// ---------------------------------------------------------------------------
+
+let lastSarif = null;
+
+async function doValidate() {
+  await guard(async () => {
+    const shapes = $("shapes-text").value;
+    const res = await call("shaclValidate", { shapes });
+    lastSarif = res.sarif;
+    renderSarif(res.sarif);
+    $("btn-download-sarif").disabled = false;
+    const count = res.sarif.runs?.[0]?.results?.length ?? 0;
+    showStatus(`SHACL validation produced ${count} result(s).`);
+  });
+}
+
+function renderSarif(sarif) {
+  const container = $("sarif-results");
+  container.replaceChildren();
+  const results = sarif.runs?.[0]?.results ?? [];
+  container.append(
+    el("p", {
+      class: "muted",
+      text: `SARIF ${sarif.version} · ${results.length} result(s).`,
+    }),
+  );
+  if (results.length === 0) {
+    container.append(
+      el("p", { id: "sarif-conforms", class: "ask-result", text: "Conforms: no violations." }),
+    );
+    return;
+  }
+  const table = el("table", { id: "sarif-table", class: "data-table" });
+  table.append(
+    el("thead", {}, [
+      el("tr", {}, [
+        el("th", { scope: "col", text: "level" }),
+        el("th", { scope: "col", text: "ruleId" }),
+        el("th", { scope: "col", text: "message" }),
+      ]),
+    ]),
+  );
+  const tbody = el("tbody");
+  for (const r of results) {
+    tbody.append(
+      el("tr", {}, [
+        el("td", {}, [
+          el("span", {
+            class: `badge badge-${r.level === "error" ? "warn" : "info"}`,
+            text: r.level ?? "",
+          }),
+        ]),
+        el("td", { class: "mono", text: r.ruleId ?? "" }),
+        el("td", { text: r.message?.text ?? "" }),
+      ]),
+    );
+  }
+  table.append(tbody);
+  container.append(table);
+}
+
+async function doEntail() {
+  await guard(async () => {
+    const shapes = $("shapes-text").value;
+    const res = await call("shaclEntail", { shapes });
+    $("entail-output").textContent = res.ntriples;
+    showStatus("Materialized SHACL-AF entailments.");
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Pane: Graph identity / diff
+// ---------------------------------------------------------------------------
+
+async function doCompare() {
+  await guard(async () => {
+    const res = await call("identity", {
+      aText: $("graph-a-text").value,
+      aFormat: $("graph-a-format").value,
+      bText: $("graph-b-text").value,
+      bFormat: $("graph-b-format").value,
+    });
+    $("identity-result").textContent = `isomorphic: ${res.isomorphic ? "yes" : "no"}`;
+    $("identity-result").className = `identity-verdict ${res.isomorphic ? "verdict-yes" : "verdict-no"}`;
+    $("canon-a").textContent = res.canonicalA;
+    $("canon-b").textContent = res.canonicalB;
+    renderDiff(res.canonicalA, res.canonicalB);
+    showStatus(`Compared graphs — isomorphic: ${res.isomorphic ? "yes" : "no"}.`);
+  });
+}
+
+function renderDiff(a, b) {
+  const container = $("canon-diff");
+  container.replaceChildren();
+  const linesA = a.split("\n");
+  const linesB = new Set(b.split("\n"));
+  const setA = new Set(linesA);
+  const onlyA = linesA.filter((l) => l && !linesB.has(l));
+  const onlyB = b.split("\n").filter((l) => l && !setA.has(l));
+  if (onlyA.length === 0 && onlyB.length === 0) {
+    container.append(
+      el("p", { class: "ask-result", text: "Canonical forms are byte-identical." }),
+    );
+    return;
+  }
+  for (const l of onlyA) {
+    container.append(el("div", { class: "diff-line diff-del", text: `- ${l}` }));
+  }
+  for (const l of onlyB) {
+    container.append(el("div", { class: "diff-line diff-add", text: `+ ${l}` }));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pane: Quad table (with click-to-filter via match())
+// ---------------------------------------------------------------------------
+
+function renderQuadTable(rows, size, filterInfo) {
+  const container = $("quad-table");
+  container.replaceChildren();
+  $("filter-info").textContent = filterInfo
+    ? `Filtered on ${filterInfo} — ${size} quad(s). `
+    : `${size} quad(s).`;
+  $("btn-clear-filter").hidden = !filterInfo;
+
+  const table = el("table", { class: "data-table" });
+  table.append(
+    el("thead", {}, [
+      el("tr", {}, [
+        el("th", { scope: "col", text: "subject" }),
+        el("th", { scope: "col", text: "predicate" }),
+        el("th", { scope: "col", text: "object" }),
+        el("th", { scope: "col", text: "graph" }),
+      ]),
+    ]),
+  );
+  const tbody = el("tbody");
+  for (const row of rows) {
+    tbody.append(
+      el("tr", {}, [
+        makeTermCell(row.subject, "subject"),
+        makeTermCell(row.predicate, "predicate"),
+        makeTermCell(row.object, "object"),
+        makeTermCell(row.graph, "graph"),
+      ]),
+    );
+  }
+  table.append(tbody);
+  container.append(table);
+}
+
+function makeTermCell(term, position) {
+  const td = el("td");
+  const label = termLabel(term);
+  if (term && term.termType !== "DefaultGraph") {
+    const btn = el("button", {
+      type: "button",
+      class: "term-link",
+      text: label,
+      title: `Filter where ${position} = ${label}`,
+    });
+    btn.addEventListener("click", () => filterByTerm(position, term));
+    td.append(btn);
+  } else {
+    td.textContent = label;
+  }
+  return td;
+}
+
+async function filterByTerm(position, term) {
+  await guard(async () => {
+    const args = { subject: null, predicate: null, object: null, graph: null };
+    args[position] = term;
+    const res = await call("match", args);
+    renderQuadTable(res.rows, res.size, `${position} = ${termLabel(term)}`);
+    selectPane("quads");
+  });
+}
+
+async function refreshQuads() {
+  await guard(async () => {
+    const res = await call("quads", {});
+    renderQuadTable(res.rows, res.size, null);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Pane: Gallery
+// ---------------------------------------------------------------------------
+
+function buildGallery() {
+  const list = $("gallery-list");
+  list.replaceChildren();
+  for (const v of VIGNETTES) {
+    const loadBtn = el("button", {
+      type: "button",
+      class: "btn",
+      text: "Load & run",
+      "data-load": v.id,
+    });
+    loadBtn.addEventListener("click", () => loadVignette(v.id));
+
+    const permaBtn = el("button", {
+      type: "button",
+      class: "btn-mini",
+      text: "Copy permalink",
+      "data-permalink": v.id,
+    });
+    permaBtn.addEventListener("click", () => copyPermalink(vignetteState(v)));
+
+    const item = el("li", { class: "gallery-item", id: `vignette-${v.id}` }, [
+      el("h3", { text: v.title }),
+      el("p", { class: "muted", text: v.blurb }),
+      el("div", { class: "gallery-actions" }, [loadBtn, permaBtn]),
+    ]);
+    list.append(item);
+  }
+}
+
+function vignetteState(v) {
+  const s = { ...DEFAULT_STATE };
+  s.input = v.input;
+  s.inputFormat = v.inputFormat;
+  if (v.query != null) s.query = v.query;
+  if (v.shapes != null) s.shapes = v.shapes;
+  // Vignettes that exercise identity supply their own A/B graphs; others
+  // compare the loaded input against the supplied graph B.
+  s.graphA = v.input;
+  s.graphAFormat = v.inputFormat;
+  if (v.graphB != null) {
+    s.graphB = v.graphB;
+    s.graphBFormat = v.graphBFormat ?? "turtle";
+  }
+  s.activePane = v.activePane ?? "input";
+  return s;
+}
+
+async function loadVignette(id) {
+  const v = findVignette(id);
+  if (!v) {
+    showError(`unknown vignette: ${id}`);
+    return;
+  }
+  applyState(vignetteState(v));
+  await runActiveForState(v);
+}
+
+/** After loading a vignette, run the engine action its pane demonstrates. */
+async function runActiveForState(v) {
+  await doParse();
+  switch (v.activePane) {
+    case "roundtrip":
+      await doSerializeAll();
+      break;
+    case "sparql":
+      await doQuery();
+      break;
+    case "shacl":
+      await doValidate();
+      await doEntail();
+      break;
+    case "identity":
+      await doCompare();
+      break;
+    case "quads":
+      await refreshQuads();
+      break;
+    default:
+      break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Wiring + boot
+// ---------------------------------------------------------------------------
+
+function wireTabs() {
+  for (const p of PANES) {
+    const tab = $(`tab-${p}`);
+    if (!tab) continue;
+    tab.addEventListener("click", () => selectPane(p));
+    tab.addEventListener("keydown", (e) => {
+      const idx = PANES.indexOf(p);
+      if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        const next = PANES[(idx + 1) % PANES.length];
+        selectPane(next);
+        $(`tab-${next}`).focus();
+      } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        const prev = PANES[(idx - 1 + PANES.length) % PANES.length];
+        selectPane(prev);
+        $(`tab-${prev}`).focus();
+      }
+    });
+  }
+}
+
+function wireButtons() {
+  $("btn-parse").addEventListener("click", doParse);
+  $("btn-serialize-all").addEventListener("click", doSerializeAll);
+  $("btn-run-query").addEventListener("click", doQuery);
+  $("btn-validate").addEventListener("click", doValidate);
+  $("btn-entail").addEventListener("click", doEntail);
+  $("btn-download-sarif").addEventListener("click", () => {
+    if (lastSarif) {
+      downloadText("report.sarif", JSON.stringify(lastSarif, null, 2), "application/json");
+    }
+  });
+  $("btn-compare").addEventListener("click", doCompare);
+  $("btn-refresh-quads").addEventListener("click", refreshQuads);
+  $("btn-clear-filter").addEventListener("click", refreshQuads);
+  $("btn-permalink").addEventListener("click", () => copyPermalink(collectState()));
+}
+
+async function initHeader() {
+  await guard(async () => {
+    const { version } = await call("version", {});
+    $("app-version").textContent = `purrdf v${version}`;
+  });
+  // Best-effort engine size probe (colocated wasm). Never fatal.
+  try {
+    const resp = await fetch(new URL("./purrdf/pkg/purrdf_wasm_bg.wasm", import.meta.url), {
+      method: "HEAD",
+    });
+    const len = resp.headers.get("content-length");
+    if (len) {
+      const kib = Math.round(Number(len) / 1024);
+      $("engine-size").textContent = `wasm ${kib} KiB`;
+    }
+  } catch {
+    // Size is a nicety; omission is not an error.
+  }
+}
+
+function registerServiceWorker() {
+  if (!("serviceWorker" in navigator)) return;
+  window.addEventListener("load", () => {
+    navigator.serviceWorker
+      .register(new URL("./sw.mjs", import.meta.url), { type: "module" })
+      .catch((e) => showStatus(`offline cache unavailable: ${e.message ?? e}`));
+  });
+}
+
+async function boot() {
+  wireTabs();
+  wireButtons();
+  buildGallery();
+
+  // Restore permalink state if present; otherwise the default console.
+  let restored = false;
+  if (location.hash.length > 1) {
+    try {
+      const state = await decodeState(location.hash.slice(1));
+      if (state) {
+        applyState(state);
+        restored = true;
+      }
+    } catch (e) {
+      showError(`could not restore permalink: ${e.message ?? e}`);
+    }
+  }
+  if (!restored) applyState(DEFAULT_STATE);
+
+  await initHeader();
+  // Parse the initial input so every pane has a live graph to work with.
+  await doParse();
+
+  registerServiceWorker();
+}
+
+boot();

--- a/docs/playground/app.mjs
+++ b/docs/playground/app.mjs
@@ -6,6 +6,7 @@
 // it is a pure view/message client over the worker.
 
 import { VIGNETTES, findVignette, DEFAULT_STATE } from "./examples/gallery.mjs";
+import { assertSarifVersion, describeSarif } from "./sarif.mjs";
 
 const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
 
@@ -543,10 +544,19 @@ function renderSarif(sarif) {
   const container = $("sarif-results");
   container.replaceChildren();
   const results = sarif.runs?.[0]?.results ?? [];
+  // Assert the SARIF version contract. A drift is surfaced loudly (aria-live
+  // error banner + an inline warning row), never silently echoed.
+  const versionWarning = assertSarifVersion(sarif.version);
+  if (versionWarning) {
+    showError(versionWarning);
+    container.append(
+      el("p", { id: "sarif-version-warning", class: "ask-result", text: versionWarning }),
+    );
+  }
   container.append(
     el("p", {
       class: "muted",
-      text: `SARIF ${sarif.version} · ${results.length} result(s).`,
+      text: describeSarif(sarif),
     }),
   );
   if (results.length === 0) {

--- a/docs/playground/app.mjs
+++ b/docs/playground/app.mjs
@@ -839,23 +839,14 @@ function wireButtons() {
 }
 
 async function initHeader() {
+  // The version handshake is the ONLY startup traffic; it goes over the worker
+  // message port, not the network. The console makes NO network request after
+  // its assets load — that provable property (no server-side evaluation) is
+  // worth more than a cosmetic wasm-size chip, so the size probe is gone.
   await guard(async () => {
     const { version } = await call("version", {});
     $("app-version").textContent = `purrdf v${version}`;
   });
-  // Best-effort engine size probe (colocated wasm). Never fatal.
-  try {
-    const resp = await fetch(new URL("./purrdf/pkg/purrdf_wasm_bg.wasm", import.meta.url), {
-      method: "HEAD",
-    });
-    const len = resp.headers.get("content-length");
-    if (len) {
-      const kib = Math.round(Number(len) / 1024);
-      $("engine-size").textContent = `wasm ${kib} KiB`;
-    }
-  } catch {
-    // Size is a nicety; omission is not an error.
-  }
 }
 
 function registerServiceWorker() {

--- a/docs/playground/engine.worker.mjs
+++ b/docs/playground/engine.worker.mjs
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// The PurRDF console engine worker. This module OWNS the parsed Dataset state;
+// the main thread is a pure view/message client. Every handler is wrapped in
+// try/catch and posts { id, ok:false, error } on failure — engine errors are
+// NEVER swallowed and NEVER become a silent empty result.
+
+import {
+  ready,
+  DataFactory,
+  Dataset,
+  shaclValidateToSarif,
+  shaclEntail,
+  version,
+} from "./purrdf/index.mjs";
+
+const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
+
+/** The 5 codecs that can PARSE. */
+const PARSE_FORMATS = ["turtle", "ntriples", "nquads", "trig", "rdfxml"];
+/** The 6 codecs that can SERIALIZE (jsonld is output-only). */
+const SERIALIZE_FORMATS = [
+  "turtle",
+  "ntriples",
+  "nquads",
+  "trig",
+  "rdfxml",
+  "jsonld",
+];
+
+/** @type {Dataset|null} The single source of truth for the console's graph. */
+let current = null;
+
+/**
+ * @type {DataFactory|null} Lazily constructed AFTER the wasm is instantiated.
+ * Constructing a `DataFactory` calls into the wasm module, so it must not run at
+ * module-eval time (before `ready()` resolves) — every handler awaits `bootReady`
+ * then `factory` is guaranteed live.
+ */
+let factory = null;
+
+/** Ready gate — one `await ready()` before any engine call is used. */
+const bootReady = ready();
+
+/** Serialize a Term into a structured-clone-safe descriptor. */
+function termToDescriptor(term) {
+  if (term == null) return null;
+  const t = { termType: term.termType, value: term.value };
+  if (term.termType === "Literal") {
+    t.language = term.language || "";
+    t.direction = term.direction || "";
+    const dt = term.datatype;
+    t.datatype = dt ? dt.value : XSD_STRING;
+  } else if (term.termType === "Quad") {
+    // A quoted-triple term (RDF-1.2 wedge).
+    t.subject = termToDescriptor(term.subject);
+    t.predicate = termToDescriptor(term.predicate);
+    t.object = termToDescriptor(term.object);
+  }
+  return t;
+}
+
+/** Rebuild a Term from a descriptor (used by match() filtering). */
+function termFromDescriptor(d) {
+  if (d == null) return undefined;
+  switch (d.termType) {
+    case "NamedNode":
+      return factory.namedNode(d.value);
+    case "BlankNode":
+      return factory.blankNode(d.value);
+    case "DefaultGraph":
+      return factory.defaultGraph();
+    case "Literal": {
+      if (d.direction) {
+        return factory.directionalLiteral(d.value, d.language || "", d.direction);
+      }
+      if (d.language) {
+        return factory.literal(d.value, d.language);
+      }
+      if (d.datatype && d.datatype !== XSD_STRING) {
+        return factory.typedLiteral(d.value, factory.namedNode(d.datatype));
+      }
+      return factory.literal(d.value);
+    }
+    case "Quad":
+      return factory.quotedTriple(
+        termFromDescriptor(d.subject),
+        termFromDescriptor(d.predicate),
+        termFromDescriptor(d.object),
+      );
+    default:
+      throw new Error(`unknown termType: ${d.termType}`);
+  }
+}
+
+/** Turn a Dataset's quads into an array of row descriptors. */
+function quadsToRows(dataset) {
+  return dataset.quads().map((q) => ({
+    subject: termToDescriptor(q.subject),
+    predicate: termToDescriptor(q.predicate),
+    object: termToDescriptor(q.object),
+    graph: termToDescriptor(q.graph),
+  }));
+}
+
+/** Whether any quad has a quoted-triple (Quad) term in object position. */
+function hasQuotedObject(dataset) {
+  return dataset.quads().some((q) => q.object.termType === "Quad");
+}
+
+function requireCurrent() {
+  if (current == null) {
+    throw new Error("no graph parsed yet — load or parse an input document first");
+  }
+  return current;
+}
+
+const HANDLERS = {
+  version() {
+    return { version: version() };
+  },
+
+  parse({ text, format }) {
+    if (!PARSE_FORMATS.includes(format)) {
+      throw new Error(
+        `unknown parse format "${format}" — expected one of ${PARSE_FORMATS.join(", ")}`,
+      );
+    }
+    current = Dataset.parse(text, format);
+    return { size: current.size, rows: quadsToRows(current) };
+  },
+
+  serializeAll() {
+    const ds = requireCurrent();
+    const quoted = hasQuotedObject(ds);
+    const formats = {};
+    for (const f of SERIALIZE_FORMATS) {
+      const entry = {};
+      // A serializer can HARD-FAIL for a given graph (e.g. JSON-LD cannot
+      // losslessly encode a quoted-triple object term). Surface that per-format
+      // error visibly instead of aborting the whole differential.
+      let text = null;
+      try {
+        text = ds.serialize(f);
+      } catch (e) {
+        entry.error = String(e?.message ?? e);
+      }
+      entry.text = text;
+      if (f === "jsonld") {
+        entry.outputOnly = true;
+        entry.roundtrips = null; // JSON-LD cannot be re-parsed by this codec.
+      } else if (text != null) {
+        // Honest round-trip fidelity: re-parse and confirm graph identity.
+        try {
+          const back = Dataset.parse(text, f);
+          entry.roundtrips = ds.isomorphic(back);
+        } catch {
+          entry.roundtrips = false;
+        }
+      } else {
+        entry.roundtrips = false;
+      }
+      formats[f] = entry;
+    }
+    return {
+      formats,
+      canonical: ds.canonicalize(),
+      hasQuotedObject: quoted,
+      size: ds.size,
+    };
+  },
+
+  query({ sparql }) {
+    const ds = requireCurrent();
+    const out = ds.query(sparql); // throws on SERVICE/LOAD/parse/eval error
+    let parsed = null;
+    try {
+      parsed = JSON.parse(out);
+    } catch {
+      parsed = null;
+    }
+    if (parsed && (Object.hasOwn(parsed, "head") || Object.hasOwn(parsed, "boolean"))) {
+      return { kind: "srj", srj: parsed };
+    }
+    // CONSTRUCT / DESCRIBE → Turtle text.
+    return { kind: "turtle", turtle: out };
+  },
+
+  shaclValidate({ shapes }) {
+    const ds = requireCurrent();
+    const dataNt = ds.serialize("ntriples");
+    const sarif = JSON.parse(shaclValidateToSarif(shapes, dataNt));
+    return { sarif };
+  },
+
+  shaclEntail({ shapes }) {
+    const ds = requireCurrent();
+    const dataNt = ds.serialize("ntriples");
+    const entailed = shaclEntail(shapes, dataNt);
+    return { ntriples: entailed };
+  },
+
+  identity({ aText, aFormat, bText, bFormat }) {
+    if (!PARSE_FORMATS.includes(aFormat)) {
+      throw new Error(`unknown parse format "${aFormat}" for graph A`);
+    }
+    if (!PARSE_FORMATS.includes(bFormat)) {
+      throw new Error(`unknown parse format "${bFormat}" for graph B`);
+    }
+    const a = Dataset.parse(aText, aFormat);
+    const b = Dataset.parse(bText, bFormat);
+    return {
+      isomorphic: a.isomorphic(b),
+      canonicalA: a.canonicalize(),
+      canonicalB: b.canonicalize(),
+    };
+  },
+
+  quads() {
+    const ds = requireCurrent();
+    return { rows: quadsToRows(ds), size: ds.size };
+  },
+
+  match({ subject, predicate, object, graph }) {
+    const ds = requireCurrent();
+    const filtered = ds.match(
+      termFromDescriptor(subject),
+      termFromDescriptor(predicate),
+      termFromDescriptor(object),
+      termFromDescriptor(graph),
+    );
+    return { rows: quadsToRows(filtered), size: filtered.size };
+  },
+};
+
+self.addEventListener("message", async (event) => {
+  const { id, op, args } = event.data ?? {};
+  try {
+    await bootReady;
+    // The wasm is now instantiated; build the factory once, on first use.
+    if (factory === null) factory = new DataFactory();
+    const handler = HANDLERS[op];
+    if (!handler) throw new Error(`unknown op: ${op}`);
+    const result = await handler(args ?? {});
+    self.postMessage({ id, ok: true, result });
+  } catch (e) {
+    // HARD FAIL, surfaced — never swallow, never a silent empty result.
+    self.postMessage({ id, ok: false, error: String(e?.message ?? e) });
+  }
+});

--- a/docs/playground/engine.worker.mjs
+++ b/docs/playground/engine.worker.mjs
@@ -234,6 +234,10 @@ const HANDLERS = {
 };
 
 self.addEventListener("message", async (event) => {
+  // Defence-in-depth: a dedicated worker only ever receives messages from the
+  // document that spawned it (event.origin is the empty string, never a foreign
+  // origin), so reject anything tagged with a cross-origin source.
+  if (event.origin && event.origin !== self.location.origin) return;
   const { id, op, args } = event.data ?? {};
   try {
     await bootReady;

--- a/docs/playground/examples/gallery.mjs
+++ b/docs/playground/examples/gallery.mjs
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Curated RDF-1.2 vignettes for the PurRDF console. Every fixture uses
+// http://example.org/ IRIs and only standard rdf:/sh:/xsd: vocabulary — PurRDF
+// mints no vocabulary of its own. Each vignette is a complete console state:
+// selecting one loads the Input/SPARQL/SHACL/graph-B panes and runs it.
+
+/** @typedef {{
+ *   id: string,
+ *   title: string,
+ *   blurb: string,
+ *   input: string,
+ *   inputFormat: string,
+ *   query?: string,
+ *   shapes?: string,
+ *   graphB?: string,
+ *   graphBFormat?: string,
+ *   activePane?: string,
+ * }} Vignette */
+
+const RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+
+/** @type {Vignette[]} */
+export const VIGNETTES = [
+  {
+    id: "quoted-triple",
+    title: "Quoted-triple reification",
+    blurb:
+      "An RDF-1.2 triple term in object position: ex:alice asserts the statement " +
+      "«ex:bob ex:likes ex:carol» and stamps it with provenance.",
+    inputFormat: "turtle",
+    input: `@prefix ex: <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# The object of ex:says is itself a triple term (RDF-1.2 «<<( s p o )>>»).
+ex:alice ex:says <<( ex:bob ex:likes ex:carol )>> .
+ex:alice ex:statedOn "2026-07-06"^^xsd:date .
+ex:carol ex:name "Carol" .
+`,
+    query: `PREFIX ex: <http://example.org/>
+SELECT ?who ?claim WHERE {
+  ?who ex:says ?claim .
+}`,
+    activePane: "roundtrip",
+  },
+  {
+    id: "directional-literals",
+    title: "Directional literals (ltr + rtl)",
+    blurb:
+      "RDF-1.2 base-direction literals: an English left-to-right string and an " +
+      "Arabic right-to-left string, each carrying an explicit base direction.",
+    inputFormat: "turtle",
+    input: `@prefix ex: <http://example.org/> .
+
+ex:greetingEn ex:text "Hello, world"@en--ltr .
+ex:greetingAr ex:text "مرحبا بالعالم"@ar--rtl .
+`,
+    query: `PREFIX ex: <http://example.org/>
+SELECT ?subject ?text WHERE {
+  ?subject ex:text ?text .
+}`,
+    activePane: "quads",
+  },
+  {
+    id: "shacl-af-rule",
+    title: "SHACL-AF sh:rule entailment",
+    blurb:
+      "A SHACL Advanced-Features triple rule: every ex:Person is entailed to be " +
+      "ex:adult ex:yes. Validate for the SARIF report, then Materialize to see " +
+      "the inferred triple.",
+    inputFormat: "turtle",
+    input: `@prefix ex: <http://example.org/> .
+@prefix rdf: <${RDF}> .
+
+ex:alice a ex:Person .
+ex:bob a ex:Person .
+`,
+    shapes: `@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/> .
+@prefix rdf: <${RDF}> .
+
+ex:PersonShape
+  a sh:NodeShape ;
+  sh:targetClass ex:Person ;
+  sh:rule [
+    a sh:TripleRule ;
+    sh:subject sh:this ;
+    sh:predicate ex:adult ;
+    sh:object ex:yes ;
+  ] .
+`,
+    activePane: "shacl",
+  },
+  {
+    id: "isomorphic-pair",
+    title: "Isomorphic graphs (relabeled blank nodes)",
+    blurb:
+      "Graph A and Graph B name the same RDF graph under blank-node relabeling and " +
+      "reordering. Compare confirms isomorphic: yes and shows identical canonical forms.",
+    inputFormat: "turtle",
+    input: `@prefix ex: <http://example.org/> .
+
+_:a ex:knows _:b .
+_:b ex:name "Bob" .
+ex:root ex:member _:a .
+`,
+    graphBFormat: "turtle",
+    graphB: `@prefix ex: <http://example.org/> .
+
+ex:root ex:member _:x .
+_:y ex:name "Bob" .
+_:x ex:knows _:y .
+`,
+    activePane: "identity",
+  },
+  {
+    id: "service-hardfail",
+    title: "SERVICE hard-fail (never-silent errors)",
+    blurb:
+      "There is no server: a federated SERVICE clause cannot be resolved in-browser. " +
+      "Running this query surfaces the engine error in the live banner — never a " +
+      "silent empty result.",
+    inputFormat: "turtle",
+    input: `@prefix ex: <http://example.org/> .
+
+ex:alice ex:knows ex:bob .
+`,
+    query: `PREFIX ex: <http://example.org/>
+SELECT ?remote WHERE {
+  SERVICE <http://example.org/sparql> {
+    ?remote ex:knows ex:bob .
+  }
+}`,
+    activePane: "sparql",
+  },
+];
+
+/** Look up a vignette by id. */
+export function findVignette(id) {
+  return VIGNETTES.find((v) => v.id === id);
+}
+
+/** The default console state used on a cold load (no permalink). */
+export const DEFAULT_STATE = {
+  input: `@prefix ex: <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# RDF-1.2 highlights, all in the http://example.org/ namespace:
+#   * a triple term in object position (a quoted triple), and
+#   * base-direction literals (ltr + rtl).
+ex:alice ex:says <<( ex:bob ex:likes ex:carol )>> .
+ex:alice ex:statedOn "2026-07-06"^^xsd:date .
+ex:carol ex:name "Carol" .
+ex:greetingEn ex:text "Hello, world"@en--ltr .
+ex:greetingAr ex:text "مرحبا بالعالم"@ar--rtl .
+`,
+  inputFormat: "turtle",
+  query: `PREFIX ex: <http://example.org/>
+SELECT ?s ?p ?o WHERE {
+  ?s ?p ?o .
+}
+ORDER BY ?s ?p ?o`,
+  shapes: `@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/> .
+@prefix rdf: <${RDF}> .
+
+# Every ex:Person must carry an ex:name; a triple rule stamps them ex:adult ex:yes.
+ex:PersonShape
+  a sh:NodeShape ;
+  sh:targetClass ex:Person ;
+  sh:property [
+    sh:path ex:name ;
+    sh:minCount 1 ;
+  ] ;
+  sh:rule [
+    a sh:TripleRule ;
+    sh:subject sh:this ;
+    sh:predicate ex:adult ;
+    sh:object ex:yes ;
+  ] .
+`,
+  graphA: `@prefix ex: <http://example.org/> .
+
+_:a ex:knows _:b .
+_:b ex:name "Bob" .
+ex:root ex:member _:a .
+`,
+  graphAFormat: "turtle",
+  graphB: `@prefix ex: <http://example.org/> .
+
+ex:root ex:member _:x .
+_:y ex:name "Bob" .
+_:x ex:knows _:y .
+`,
+  graphBFormat: "turtle",
+  activePane: "input",
+};

--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -31,7 +31,6 @@
       </div>
       <div class="header-meta">
         <span id="app-version" class="chip" aria-label="engine version">purrdf</span>
-        <span id="engine-size" class="chip" aria-label="engine size"></span>
         <a class="chip chip-link" href="../">The PurRDF Book</a>
         <button id="btn-permalink" type="button" class="btn-mini">
           Copy permalink

--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="PurRDF · a client-side RDF-1.2 console. Parse, serialize, query (SPARQL), validate (SHACL), and compare graphs entirely in your browser — no server."
+    />
+    <meta name="color-scheme" content="light dark" />
+    <title>PurRDF · RDF-1.2 console</title>
+    <link rel="stylesheet" href="./style.css" />
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <!-- Inline data-URI icon: no external asset, no favicon.ico round-trip. -->
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ctext y='14' font-size='14'%3E%F0%9F%90%BE%3C/text%3E%3C/svg%3E"
+    />
+  </head>
+  <body>
+    <a class="skip-link" href="#pane-input">Skip to console</a>
+
+    <header class="app-header">
+      <div class="brand">
+        <h1>PurRDF <span class="dot">·</span> RDF-1.2 console</h1>
+        <p class="tagline">
+          A zero-backend RDF-1.2 workbench: everything runs in your browser via
+          the PurRDF wasm engine.
+        </p>
+      </div>
+      <div class="header-meta">
+        <span id="app-version" class="chip" aria-label="engine version">purrdf</span>
+        <span id="engine-size" class="chip" aria-label="engine size"></span>
+        <a class="chip chip-link" href="../">The PurRDF Book</a>
+        <button id="btn-permalink" type="button" class="btn-mini">
+          Copy permalink
+        </button>
+      </div>
+    </header>
+
+    <!-- HARD-FAIL surface: every engine error lands here, never swallowed. -->
+    <div
+      id="error-banner"
+      class="banner banner-error"
+      role="alert"
+      aria-live="assertive"
+      hidden
+    ></div>
+    <div
+      id="status-banner"
+      class="banner banner-status"
+      role="status"
+      aria-live="polite"
+      hidden
+    ></div>
+
+    <p class="jsonld-note" role="note">
+      Note: JSON-LD is <strong>serialize-only</strong> here — the parse codec
+      accepts turtle, N-Triples, N-Quads, TriG, and RDF/XML, and rejects JSON-LD
+      as input by design.
+    </p>
+
+    <nav class="tabs" aria-label="Console panes">
+      <div role="tablist" aria-label="Console panes">
+        <button id="tab-input" role="tab" aria-selected="true" aria-controls="pane-input" class="tab">Input</button>
+        <button id="tab-roundtrip" role="tab" aria-selected="false" aria-controls="pane-roundtrip" class="tab" tabindex="-1">Round-trip</button>
+        <button id="tab-sparql" role="tab" aria-selected="false" aria-controls="pane-sparql" class="tab" tabindex="-1">SPARQL</button>
+        <button id="tab-shacl" role="tab" aria-selected="false" aria-controls="pane-shacl" class="tab" tabindex="-1">SHACL</button>
+        <button id="tab-identity" role="tab" aria-selected="false" aria-controls="pane-identity" class="tab" tabindex="-1">Graph identity</button>
+        <button id="tab-quads" role="tab" aria-selected="false" aria-controls="pane-quads" class="tab" tabindex="-1">Quad table</button>
+        <button id="tab-gallery" role="tab" aria-selected="false" aria-controls="pane-gallery" class="tab" tabindex="-1">Gallery</button>
+      </div>
+    </nav>
+
+    <main>
+      <!-- INPUT -->
+      <section id="pane-input" class="pane" role="tabpanel" aria-labelledby="tab-input">
+        <h2>Input graph</h2>
+        <div class="field">
+          <label for="input-format">Parse format</label>
+          <select id="input-format" class="select">
+            <option value="turtle">Turtle</option>
+            <option value="ntriples">N-Triples</option>
+            <option value="nquads">N-Quads</option>
+            <option value="trig">TriG</option>
+            <option value="rdfxml">RDF/XML</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="input-text">RDF document</label>
+          <textarea id="input-text" class="code" spellcheck="false" rows="14" aria-describedby="input-summary"></textarea>
+        </div>
+        <div class="actions">
+          <button id="btn-parse" type="button" class="btn btn-primary">Parse</button>
+        </div>
+        <p id="input-summary" class="muted" aria-live="polite"></p>
+      </section>
+
+      <!-- ROUND-TRIP -->
+      <section id="pane-roundtrip" class="pane" role="tabpanel" aria-labelledby="tab-roundtrip" hidden>
+        <h2>Round-trip &amp; differential</h2>
+        <p class="muted">
+          Render the current graph in all six serialize formats side-by-side. The
+          canonical RDFC-1.0 N-Quads form is the graph's deterministic identity.
+        </p>
+        <div class="actions">
+          <button id="btn-serialize-all" type="button" class="btn btn-primary">
+            Serialize to all formats
+          </button>
+        </div>
+        <p id="serialize-note" class="note" role="note" hidden></p>
+        <div id="serialize-output" class="ser-grid"></div>
+      </section>
+
+      <!-- SPARQL -->
+      <section id="pane-sparql" class="pane" role="tabpanel" aria-labelledby="tab-sparql" hidden>
+        <h2>SPARQL</h2>
+        <p class="muted">
+          SELECT / ASK render as a table / boolean; CONSTRUCT / DESCRIBE render as
+          Turtle. SERVICE and LOAD hard-fail (there is no server) — the error lands
+          in the banner above.
+        </p>
+        <div class="field">
+          <label for="sparql-text">Query</label>
+          <textarea id="sparql-text" class="code" spellcheck="false" rows="10"></textarea>
+        </div>
+        <div class="actions">
+          <button id="btn-run-query" type="button" class="btn btn-primary">Run</button>
+        </div>
+        <div id="sparql-results" class="results" aria-live="polite"></div>
+      </section>
+
+      <!-- SHACL -->
+      <section id="pane-shacl" class="pane" role="tabpanel" aria-labelledby="tab-shacl" hidden>
+        <h2>SHACL</h2>
+        <p class="muted">
+          The current graph is serialized to N-Triples and validated against your
+          shapes. Results are a SARIF 2.1.0 report. Materialize applies SHACL-AF
+          <code>sh:rule</code> inferences.
+        </p>
+        <div class="field">
+          <label for="shapes-text">Shapes (Turtle)</label>
+          <textarea id="shapes-text" class="code" spellcheck="false" rows="14"></textarea>
+        </div>
+        <div class="actions">
+          <button id="btn-validate" type="button" class="btn btn-primary">Validate</button>
+          <button id="btn-entail" type="button" class="btn">Materialize (entail)</button>
+          <button id="btn-download-sarif" type="button" class="btn" disabled>
+            Download report.sarif
+          </button>
+        </div>
+        <div id="sarif-results" class="results" aria-live="polite"></div>
+        <h3>Entailed N-Triples</h3>
+        <pre id="entail-output" class="code-out" aria-live="polite"></pre>
+      </section>
+
+      <!-- IDENTITY -->
+      <section id="pane-identity" class="pane" role="tabpanel" aria-labelledby="tab-identity" hidden>
+        <h2>Graph identity &amp; diff</h2>
+        <p class="muted">
+          Two graphs denote the same RDF graph iff their canonical RDFC-1.0 forms
+          are byte-identical — even after blank-node relabeling and reordering.
+        </p>
+        <div class="two-col">
+          <div>
+            <div class="field">
+              <label for="graph-a-format">Graph A format</label>
+              <select id="graph-a-format" class="select">
+                <option value="turtle">Turtle</option>
+                <option value="ntriples">N-Triples</option>
+                <option value="nquads">N-Quads</option>
+                <option value="trig">TriG</option>
+                <option value="rdfxml">RDF/XML</option>
+              </select>
+            </div>
+            <div class="field">
+              <label for="graph-a-text">Graph A</label>
+              <textarea id="graph-a-text" class="code" spellcheck="false" rows="10"></textarea>
+            </div>
+          </div>
+          <div>
+            <div class="field">
+              <label for="graph-b-format">Graph B format</label>
+              <select id="graph-b-format" class="select">
+                <option value="turtle">Turtle</option>
+                <option value="ntriples">N-Triples</option>
+                <option value="nquads">N-Quads</option>
+                <option value="trig">TriG</option>
+                <option value="rdfxml">RDF/XML</option>
+              </select>
+            </div>
+            <div class="field">
+              <label for="graph-b-text">Graph B</label>
+              <textarea id="graph-b-text" class="code" spellcheck="false" rows="10"></textarea>
+            </div>
+          </div>
+        </div>
+        <div class="actions">
+          <button id="btn-compare" type="button" class="btn btn-primary">Compare</button>
+        </div>
+        <p id="identity-result" class="identity-verdict" aria-live="polite"></p>
+        <div class="two-col">
+          <div>
+            <h3>Canonical A</h3>
+            <pre id="canon-a" class="code-out"></pre>
+          </div>
+          <div>
+            <h3>Canonical B</h3>
+            <pre id="canon-b" class="code-out"></pre>
+          </div>
+        </div>
+        <h3>Line diff</h3>
+        <div id="canon-diff" class="diff"></div>
+      </section>
+
+      <!-- QUAD TABLE -->
+      <section id="pane-quads" class="pane" role="tabpanel" aria-labelledby="tab-quads" hidden>
+        <h2>Quad table</h2>
+        <p class="muted">
+          The parsed graph as (subject, predicate, object, graph). Click any term
+          to filter the table with <code>match()</code>.
+        </p>
+        <div class="actions">
+          <button id="btn-refresh-quads" type="button" class="btn btn-primary">Refresh</button>
+          <button id="btn-clear-filter" type="button" class="btn" hidden>Clear filter</button>
+        </div>
+        <p id="filter-info" class="muted" aria-live="polite"></p>
+        <div id="quad-table" class="results"></div>
+      </section>
+
+      <!-- GALLERY -->
+      <section id="pane-gallery" class="pane" role="tabpanel" aria-labelledby="tab-gallery" hidden>
+        <h2>RDF-1.2 vignette gallery</h2>
+        <p class="muted">
+          Curated, self-contained examples in the <code>http://example.org/</code>
+          namespace. Load one to populate the whole console and run it; copy a
+          permalink to share the exact state.
+        </p>
+        <ul id="gallery-list" class="gallery"></ul>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <p>
+        PurRDF runs entirely client-side. No graph you load here ever leaves your
+        browser. Standard <code>rdf:</code>/<code>sh:</code>/<code>xsd:</code>
+        vocabulary only — PurRDF mints none of its own.
+      </p>
+    </footer>
+
+    <script type="module" src="./app.mjs"></script>
+  </body>
+</html>

--- a/docs/playground/manifest.webmanifest
+++ b/docs/playground/manifest.webmanifest
@@ -1,0 +1,14 @@
+{
+  "name": "PurRDF RDF-1.2 console",
+  "short_name": "PurRDF console",
+  "description": "A zero-backend, client-side RDF-1.2 workbench: parse, serialize, SPARQL, SHACL, and graph identity, all in the browser via the PurRDF wasm engine.",
+  "start_url": ".",
+  "scope": ".",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#0d1117",
+  "theme_color": "#1f6feb",
+  "lang": "en",
+  "dir": "ltr",
+  "categories": ["developer", "utilities"]
+}

--- a/docs/playground/sarif.mjs
+++ b/docs/playground/sarif.mjs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// SARIF contract helpers for the PurRDF console. Side-effect-free and
+// Node-importable (no DOM, no Worker) so the smoke suite can assert the SARIF
+// version contract directly. The console renders SHACL results as SARIF; this
+// module is the single source of truth for the SARIF version the UI accepts —
+// a version drift is asserted here and surfaced, NEVER silently echoed.
+
+/** The one SARIF schema version the console understands. */
+export const EXPECTED_SARIF_VERSION = "2.1.0";
+
+/**
+ * Assert a SARIF payload's version against the console's contract.
+ *
+ * @param {string|undefined} version the `version` field of a SARIF log
+ * @returns {string|null} `null` when it matches {@link EXPECTED_SARIF_VERSION};
+ *   otherwise a human-readable warning naming both the seen and expected
+ *   versions, for the caller to surface visibly.
+ */
+export function assertSarifVersion(version) {
+  if (version === EXPECTED_SARIF_VERSION) return null;
+  return `unexpected SARIF version ${version ?? "(none)"} — the console expects SARIF ${EXPECTED_SARIF_VERSION}`;
+}
+
+/**
+ * One-line summary of a SARIF payload for the results header.
+ * @param {{version?: string, runs?: Array<{results?: unknown[]}>}} sarif
+ * @returns {string}
+ */
+export function describeSarif(sarif) {
+  const results = sarif?.runs?.[0]?.results ?? [];
+  return `SARIF ${sarif?.version ?? "(none)"} · ${results.length} result(s).`;
+}

--- a/docs/playground/smoke/engine.smoke.test.mjs
+++ b/docs/playground/smoke/engine.smoke.test.mjs
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Engine smoke gate for the PurRDF console. This asserts the SAME engine calls
+// each pane of the console makes actually work against the real wasm package.
+// It is the CI gate for the playground: `node --test docs/playground/smoke/*.test.mjs`
+// from the repo root. The browser DOM wiring is verified separately (headless);
+// this file proves the engine integration end-to-end.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ready,
+  Dataset,
+  DataFactory,
+  shaclValidateToSarif,
+  shaclEntail,
+  version,
+} from "../../../crates/rdf-wasm/js/index.mjs";
+
+// The exact preloaded document the Input pane ships with: an RDF-1.2 graph in the
+// example.org namespace carrying a quoted triple in object position plus base-
+// direction literals (ltr + rtl).
+const PRELOADED = `@prefix ex: <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:alice ex:says <<( ex:bob ex:likes ex:carol )>> .
+ex:alice ex:statedOn "2026-07-06"^^xsd:date .
+ex:carol ex:name "Carol" .
+ex:greetingEn ex:text "Hello, world"@en--ltr .
+ex:greetingAr ex:text "مرحبا بالعالم"@ar--rtl .
+`;
+
+const SHAPES = `@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+ex:PersonShape
+  a sh:NodeShape ;
+  sh:targetClass ex:Person ;
+  sh:property [ sh:path ex:name ; sh:minCount 1 ] ;
+  sh:rule [
+    a sh:TripleRule ;
+    sh:subject sh:this ;
+    sh:predicate ex:adult ;
+    sh:object ex:yes ;
+  ] .
+`;
+
+// A tiny data graph with an ex:Person that lacks ex:name (guarantees a violation)
+// and is a valid sh:rule target (guarantees an entailment).
+const PERSON_DATA = `@prefix ex: <http://example.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+ex:dave a ex:Person .
+`;
+
+const SERIALIZE_FORMATS = [
+  "turtle",
+  "ntriples",
+  "nquads",
+  "trig",
+  "rdfxml",
+  "jsonld",
+];
+
+await ready();
+
+test("version() returns a SemVer string", () => {
+  const v = version();
+  assert.match(v, /^\d+\.\d+\.\d+/, `expected SemVer, got ${v}`);
+});
+
+test("parse the preloaded doc (Input pane)", () => {
+  const ds = Dataset.parse(PRELOADED, "turtle");
+  assert.equal(ds.size, 5);
+  const hasQuoted = ds.quads().some((q) => q.object.termType === "Quad");
+  assert.ok(hasQuoted, "expected an object-position quoted triple");
+  const hasRtl = ds
+    .quads()
+    .some((q) => q.object.termType === "Literal" && q.object.direction === "rtl");
+  assert.ok(hasRtl, "expected a directional (rtl) literal");
+});
+
+// A plain graph (no quoted-triple object) — every serializer, incl. JSON-LD,
+// can encode it. This is the graph the "all 6 formats" claim rests on.
+const PLAIN = `@prefix ex: <http://example.org/> .
+ex:alice ex:knows ex:bob .
+ex:bob ex:name "Bob" .
+`;
+
+test("serialize a plain graph to all 6 formats (Round-trip pane)", () => {
+  const ds = Dataset.parse(PLAIN, "turtle");
+  for (const f of SERIALIZE_FORMATS) {
+    const text = ds.serialize(f);
+    assert.equal(typeof text, "string");
+    assert.ok(text.length > 0, `empty serialization for ${f}`);
+  }
+  // JSON-LD is OUTPUT-ONLY: the parse codec must reject it as input.
+  const jsonld = ds.serialize("jsonld");
+  assert.throws(() => Dataset.parse(jsonld, "jsonld"), "jsonld parse must throw");
+});
+
+test("preloaded (quoted-triple) doc: 5 text formats serialize; JSON-LD hard-fails", () => {
+  const ds = Dataset.parse(PRELOADED, "turtle");
+  for (const f of ["turtle", "ntriples", "nquads", "trig", "rdfxml"]) {
+    const text = ds.serialize(f);
+    assert.ok(text.length > 0, `empty serialization for ${f}`);
+  }
+  // Documented limitation: a quoted-triple object term is not losslessly
+  // encodable in JSON-LD — the serializer hard-fails (surfaced, never silent).
+  assert.throws(
+    () => ds.serialize("jsonld"),
+    "JSON-LD serialize must hard-fail for a quoted-triple object term",
+  );
+});
+
+test("N-Quads round-trips the object-position quoted triple", () => {
+  const ds = Dataset.parse(PRELOADED, "turtle");
+  const nq = ds.serialize("nquads");
+  const back = Dataset.parse(nq, "nquads");
+  assert.ok(
+    back.quads().some((q) => q.object.termType === "Quad"),
+    "N-Quads must preserve the quoted triple in object position",
+  );
+  assert.ok(ds.isomorphic(back), "N-Quads round-trip must be isomorphic");
+});
+
+test("SELECT query returns SRJ with bindings (SPARQL pane)", () => {
+  const ds = Dataset.parse(PRELOADED, "turtle");
+  const out = ds.query("SELECT ?s ?p ?o WHERE { ?s ?p ?o }");
+  const srj = JSON.parse(out);
+  assert.ok(Object.hasOwn(srj, "head"), "SELECT result must be SRJ (has .head)");
+  assert.deepEqual(srj.head.vars, ["s", "p", "o"]);
+  assert.ok(srj.results.bindings.length > 0, "expected bindings");
+});
+
+test("ASK query returns an SRJ boolean", () => {
+  const ds = Dataset.parse(PRELOADED, "turtle");
+  const srj = JSON.parse(
+    ds.query("ASK { <http://example.org/carol> <http://example.org/name> ?n }"),
+  );
+  assert.ok(Object.hasOwn(srj, "boolean"));
+  assert.equal(srj.boolean, true);
+});
+
+test("CONSTRUCT returns Turtle (not SRJ)", () => {
+  const ds = Dataset.parse(PRELOADED, "turtle");
+  const out = ds.query("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o } LIMIT 1");
+  let parsedAsSrj = false;
+  try {
+    const j = JSON.parse(out);
+    parsedAsSrj = Object.hasOwn(j, "head") || Object.hasOwn(j, "boolean");
+  } catch {
+    parsedAsSrj = false;
+  }
+  assert.equal(parsedAsSrj, false, "CONSTRUCT output must not parse as SRJ");
+});
+
+test("SHACL validate → SARIF 2.1.0 with a violation (SHACL pane)", () => {
+  // The pane serializes the CURRENT dataset to N-Triples first, then validates.
+  const ds = Dataset.parse(PERSON_DATA, "turtle");
+  const dataNt = ds.serialize("ntriples");
+  const sarif = JSON.parse(shaclValidateToSarif(SHAPES, dataNt));
+  assert.equal(sarif.version, "2.1.0");
+  const results = sarif.runs[0].results;
+  assert.ok(results.length >= 1, "expected at least one SHACL violation");
+  const r = results[0];
+  assert.ok(r.ruleId, "result must carry a ruleId");
+  assert.ok(r.level, "result must carry a level");
+  assert.ok(r.message?.text, "result must carry a message");
+});
+
+test("shaclEntail materializes the sh:rule inference", () => {
+  const ds = Dataset.parse(PERSON_DATA, "turtle");
+  const dataNt = ds.serialize("ntriples");
+  const entailed = shaclEntail(SHAPES, dataNt);
+  assert.ok(
+    entailed.includes("http://example.org/adult"),
+    "expected the ex:adult entailment in the materialized graph",
+  );
+});
+
+test("canonicalize is non-empty and stable (Round-trip / identity)", () => {
+  const ds = Dataset.parse(PRELOADED, "turtle");
+  const c1 = ds.canonicalize();
+  const c2 = ds.canonicalize();
+  assert.ok(c1.length > 0, "canonical form must be non-empty");
+  assert.equal(c1, c2, "canonical form must be stable");
+});
+
+test("isomorphic: true for a relabeled pair, false for a different graph", () => {
+  const a = Dataset.parse(
+    `@prefix ex: <http://example.org/> .
+     _:a ex:knows _:b . _:b ex:name "Bob" . ex:root ex:member _:a .`,
+    "turtle",
+  );
+  const b = Dataset.parse(
+    `@prefix ex: <http://example.org/> .
+     ex:root ex:member _:x . _:y ex:name "Bob" . _:x ex:knows _:y .`,
+    "turtle",
+  );
+  const c = Dataset.parse(
+    `@prefix ex: <http://example.org/> . ex:root ex:member ex:different .`,
+    "turtle",
+  );
+  assert.equal(a.isomorphic(b), true, "relabeled pair must be isomorphic");
+  assert.equal(a.isomorphic(c), false, "different graph must not be isomorphic");
+});
+
+test("match() filters the dataset (Quad table pane)", () => {
+  const ds = Dataset.parse(PRELOADED, "turtle");
+  const f = new DataFactory();
+  const filtered = ds.match(f.namedNode("http://example.org/carol"));
+  assert.equal(filtered.size, 1);
+  assert.equal(filtered.quads()[0].subject.value, "http://example.org/carol");
+});
+
+test("DataFactory builds a directional literal and quoted triple", () => {
+  const f = new DataFactory();
+  const dl = f.directionalLiteral("مرحبا", "ar", "rtl");
+  assert.equal(dl.direction, "rtl");
+  assert.equal(dl.language, "ar");
+  const qt = f.quotedTriple(
+    f.namedNode("http://example.org/b"),
+    f.namedNode("http://example.org/likes"),
+    f.namedNode("http://example.org/c"),
+  );
+  assert.equal(qt.termType, "Quad");
+  const ds = new Dataset();
+  ds.add(
+    f.quad(
+      f.namedNode("http://example.org/a"),
+      f.namedNode("http://example.org/says"),
+      qt,
+    ),
+  );
+  assert.equal(ds.size, 1);
+  assert.equal(ds.quads()[0].object.termType, "Quad");
+});
+
+test("malformed input throws (never a silent empty result)", () => {
+  assert.throws(() => Dataset.parse("@prefix ex: <http://example.org/", "turtle"));
+});
+
+test("SERVICE query throws (never-silent federation hard-fail)", () => {
+  const ds = Dataset.parse(PRELOADED, "turtle");
+  assert.throws(() =>
+    ds.query(
+      "SELECT ?x WHERE { SERVICE <http://example.org/sparql> { ?x ?p ?o } }",
+    ),
+  );
+});

--- a/docs/playground/smoke/engine.smoke.test.mjs
+++ b/docs/playground/smoke/engine.smoke.test.mjs
@@ -175,9 +175,19 @@ test("shaclEntail materializes the sh:rule inference", () => {
   const ds = Dataset.parse(PERSON_DATA, "turtle");
   const dataNt = ds.serialize("ntriples");
   const entailed = shaclEntail(SHAPES, dataNt);
-  assert.ok(
-    entailed.includes("http://example.org/adult"),
-    "expected the ex:adult entailment in the materialized graph",
+  // Assert the exact triple the sh:rule produces (ex:dave ex:adult ex:yes) by a
+  // structural match on the parsed N-Triples — not a bare-URL substring check.
+  const out = Dataset.parse(entailed, "ntriples");
+  const f = new DataFactory();
+  const matched = out.match(
+    f.namedNode("http://example.org/dave"),
+    f.namedNode("http://example.org/adult"),
+    f.namedNode("http://example.org/yes"),
+  );
+  assert.equal(
+    matched.size,
+    1,
+    "expected the ex:dave ex:adult ex:yes entailment in the materialized graph",
   );
 });
 

--- a/docs/playground/smoke/sarif.smoke.test.mjs
+++ b/docs/playground/smoke/sarif.smoke.test.mjs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// SARIF-contract smoke gate for the PurRDF console. The console renders SHACL
+// results as SARIF and asserts the version the UI accepts via
+// `assertSarifVersion` in `docs/playground/sarif.mjs`. That module is
+// side-effect-free and Node-importable (unlike `app.mjs`, which spawns a Worker
+// at module-eval), so this gate exercises the ACTUAL production assertion the UI
+// runs — a drift from SARIF 2.1.0 must be surfaced, never silently echoed.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  assertSarifVersion,
+  describeSarif,
+  EXPECTED_SARIF_VERSION,
+} from "../sarif.mjs";
+
+test("the console's SARIF contract is 2.1.0", () => {
+  assert.equal(EXPECTED_SARIF_VERSION, "2.1.0");
+});
+
+test("assertSarifVersion accepts SARIF 2.1.0 (no warning)", () => {
+  assert.equal(assertSarifVersion("2.1.0"), null);
+});
+
+test("assertSarifVersion warns (not silently) on a drifting version", () => {
+  const warning = assertSarifVersion("2.0.0");
+  assert.equal(typeof warning, "string");
+  assert.ok(warning.length > 0, "a drift must produce a non-empty warning");
+  assert.match(warning, /2\.1\.0/, "the warning must name the expected version");
+  assert.match(warning, /2\.0\.0/, "the warning must name the seen version");
+});
+
+test("assertSarifVersion warns on a missing version", () => {
+  const warning = assertSarifVersion(undefined);
+  assert.equal(typeof warning, "string");
+  assert.match(warning, /2\.1\.0/);
+});
+
+test("describeSarif summarizes version + result count", () => {
+  const sarif = { version: "2.1.0", runs: [{ results: [{}, {}] }] };
+  assert.equal(describeSarif(sarif), "SARIF 2.1.0 · 2 result(s).");
+});

--- a/docs/playground/style.css
+++ b/docs/playground/style.css
@@ -1,0 +1,492 @@
+/* SPDX-License-Identifier: MIT OR Apache-2.0 */
+/* PurRDF console — responsive, dark + light via prefers-color-scheme, zero
+   external assets (system font stacks only). */
+
+:root {
+  color-scheme: light dark;
+
+  --bg: #ffffff;
+  --bg-elev: #f4f6f8;
+  --bg-code: #f0f2f5;
+  --fg: #1a1d21;
+  --fg-muted: #5a636e;
+  --border: #d5dbe2;
+  --accent: #1f6feb;
+  --accent-fg: #ffffff;
+  --ok-bg: #dbf3e0;
+  --ok-fg: #14532d;
+  --warn-bg: #fde9d0;
+  --warn-fg: #7a3d00;
+  --info-bg: #dbe7fb;
+  --info-fg: #123a75;
+  --error-bg: #fbe0e0;
+  --error-fg: #8a1c1c;
+  --error-border: #e5484d;
+  --status-bg: #e2ecfb;
+  --status-fg: #123a75;
+  --add-fg: #14532d;
+  --del-fg: #8a1c1c;
+
+  --mono: ui-monospace, "SF Mono", "Cascadia Mono", "Roboto Mono", Menlo,
+    Consolas, "Liberation Mono", monospace;
+  --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
+  --radius: 8px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0d1117;
+    --bg-elev: #161b22;
+    --bg-code: #0b0f14;
+    --fg: #e6edf3;
+    --fg-muted: #9aa5b1;
+    --border: #2a3441;
+    --accent: #4c8dff;
+    --accent-fg: #0d1117;
+    --ok-bg: #14351f;
+    --ok-fg: #7ee2a0;
+    --warn-bg: #40270a;
+    --warn-fg: #f2c088;
+    --info-bg: #16294a;
+    --info-fg: #9dc1ff;
+    --error-bg: #3a1515;
+    --error-fg: #ff9a9a;
+    --error-border: #e5484d;
+    --status-bg: #16294a;
+    --status-fg: #9dc1ff;
+    --add-fg: #7ee2a0;
+    --del-fg: #ff9a9a;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+}
+
+body {
+  margin: 0;
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.5;
+}
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  background: var(--accent);
+  color: var(--accent-fg);
+  padding: 0.5rem 1rem;
+  z-index: 100;
+}
+.skip-link:focus {
+  left: 0;
+}
+
+/* Header --------------------------------------------------------------- */
+.app-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  background: var(--bg-elev);
+  border-bottom: 1px solid var(--border);
+}
+.brand h1 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+.brand .dot {
+  color: var(--accent);
+}
+.tagline {
+  margin: 0.25rem 0 0;
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+}
+.header-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+.chip {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  padding: 0.25rem 0.55rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg);
+  color: var(--fg-muted);
+  text-decoration: none;
+}
+.chip-link {
+  color: var(--accent);
+}
+.chip-link:hover,
+.chip-link:focus {
+  text-decoration: underline;
+}
+
+/* Banners -------------------------------------------------------------- */
+.banner {
+  margin: 0.75rem 1.25rem 0;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius);
+  font-family: var(--mono);
+  font-size: 0.9rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.banner-error {
+  background: var(--error-bg);
+  color: var(--error-fg);
+  border: 1px solid var(--error-border);
+}
+.banner-status {
+  background: var(--status-bg);
+  color: var(--status-fg);
+  border: 1px solid var(--border);
+}
+
+.jsonld-note {
+  margin: 0.75rem 1.25rem 0;
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+}
+
+/* Tabs ----------------------------------------------------------------- */
+.tabs {
+  padding: 0.75rem 1.25rem 0;
+}
+[role="tablist"] {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--border);
+}
+.tab {
+  font-family: var(--sans);
+  font-size: 0.92rem;
+  padding: 0.5rem 0.9rem;
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: var(--radius) var(--radius) 0 0;
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+.tab:hover {
+  color: var(--fg);
+}
+.tab[aria-selected="true"] {
+  background: var(--bg-elev);
+  color: var(--fg);
+  border-color: var(--border);
+  font-weight: 600;
+}
+
+/* Panes ---------------------------------------------------------------- */
+main {
+  padding: 1.25rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+.pane h2 {
+  margin-top: 0;
+}
+.muted {
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+}
+.note {
+  background: var(--info-bg);
+  color: var(--info-fg);
+  border-radius: var(--radius);
+  padding: 0.6rem 0.85rem;
+  font-size: 0.88rem;
+}
+
+.field {
+  margin: 0.75rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.field label {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.code,
+.select {
+  font-family: var(--mono);
+  font-size: 0.88rem;
+  background: var(--bg-code);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.6rem 0.7rem;
+  width: 100%;
+}
+textarea.code {
+  resize: vertical;
+  min-height: 8rem;
+  tab-size: 2;
+}
+.select {
+  max-width: 16rem;
+  font-family: var(--sans);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.75rem 0;
+}
+
+.btn {
+  font-family: var(--sans);
+  font-size: 0.9rem;
+  padding: 0.5rem 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elev);
+  color: var(--fg);
+  cursor: pointer;
+}
+.btn:hover {
+  border-color: var(--accent);
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btn-primary {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-color: var(--accent);
+  font-weight: 600;
+}
+.btn-mini {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  padding: 0.3rem 0.55rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  color: var(--fg);
+  cursor: pointer;
+}
+.btn-mini:hover {
+  border-color: var(--accent);
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Code output ---------------------------------------------------------- */
+.code-out {
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  background: var(--bg-code);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.7rem 0.8rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 22rem;
+}
+
+.code-out.ser-error {
+  color: var(--warn-fg);
+  background: var(--warn-bg);
+  border-color: var(--warn-fg);
+}
+
+/* Round-trip grid ------------------------------------------------------ */
+.ser-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.ser-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elev);
+  padding: 0.6rem;
+}
+.ser-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.ser-title {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 0.85rem;
+}
+.spacer {
+  flex: 1;
+}
+
+.badge {
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+}
+.badge-ok {
+  background: var(--ok-bg);
+  color: var(--ok-fg);
+}
+.badge-warn {
+  background: var(--warn-bg);
+  color: var(--warn-fg);
+}
+.badge-info {
+  background: var(--info-bg);
+  color: var(--info-fg);
+}
+
+/* Tables --------------------------------------------------------------- */
+.results {
+  margin-top: 1rem;
+  overflow-x: auto;
+}
+.data-table {
+  border-collapse: collapse;
+  width: 100%;
+  font-family: var(--mono);
+  font-size: 0.82rem;
+}
+.data-table th,
+.data-table td {
+  border: 1px solid var(--border);
+  padding: 0.4rem 0.55rem;
+  text-align: left;
+  vertical-align: top;
+  word-break: break-word;
+}
+.data-table th {
+  background: var(--bg-elev);
+}
+.data-table td.mono,
+.mono {
+  font-family: var(--mono);
+}
+.term-link {
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+  text-decoration: underline dotted;
+  word-break: break-word;
+}
+.term-link:hover {
+  text-decoration: underline;
+}
+
+.ask-result {
+  font-family: var(--mono);
+  font-weight: 600;
+}
+
+/* Identity ------------------------------------------------------------- */
+.two-col {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr));
+  gap: 1rem;
+}
+.identity-verdict {
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 1rem;
+}
+.verdict-yes {
+  color: var(--ok-fg);
+}
+.verdict-no {
+  color: var(--del-fg);
+}
+.diff {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-code);
+  padding: 0.5rem 0.7rem;
+  overflow-x: auto;
+}
+.diff-line {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.diff-add {
+  color: var(--add-fg);
+}
+.diff-del {
+  color: var(--del-fg);
+}
+
+/* Gallery -------------------------------------------------------------- */
+.gallery {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr));
+  gap: 1rem;
+}
+.gallery-item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elev);
+  padding: 0.9rem;
+}
+.gallery-item h3 {
+  margin-top: 0;
+}
+.gallery-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+/* Footer --------------------------------------------------------------- */
+.app-footer {
+  border-top: 1px solid var(--border);
+  padding: 1rem 1.25rem;
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+  max-width: 1200px;
+  margin: 1rem auto 0;
+}
+
+@media (max-width: 640px) {
+  .app-header {
+    flex-direction: column;
+  }
+  main {
+    padding: 1rem 0.85rem;
+  }
+}

--- a/docs/playground/sw.mjs
+++ b/docs/playground/sw.mjs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// PurRDF console service worker. Caches the app shell + the colocated wasm
+// package on install and serves cache-first, so the console runs fully offline
+// after the first load. There is no server-side evaluation to fall back to.
+
+const CACHE = "purrdf-console-v1";
+
+const SHELL = [
+  "./",
+  "./index.html",
+  "./app.mjs",
+  "./engine.worker.mjs",
+  "./style.css",
+  "./manifest.webmanifest",
+  "./examples/gallery.mjs",
+  "./purrdf/index.mjs",
+  "./purrdf/pkg/purrdf_wasm.js",
+  "./purrdf/pkg/purrdf_wasm_bg.wasm",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(CACHE);
+      await cache.addAll(SHELL);
+      await self.skipWaiting();
+    })(),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k)));
+      await self.clients.claim();
+    })(),
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (request.method !== "GET") return;
+  event.respondWith(
+    (async () => {
+      const cached = await caches.match(request);
+      if (cached) return cached;
+      const response = await fetch(request);
+      // Populate the cache opportunistically for same-origin GETs.
+      try {
+        if (response.ok && new URL(request.url).origin === self.location.origin) {
+          const cache = await caches.open(CACHE);
+          cache.put(request, response.clone());
+        }
+      } catch {
+        // Caching is best-effort; the live response is still returned.
+      }
+      return response;
+    })(),
+  );
+});

--- a/docs/playground/sw.mjs
+++ b/docs/playground/sw.mjs
@@ -11,6 +11,7 @@ const SHELL = [
   "./index.html",
   "./app.mjs",
   "./engine.worker.mjs",
+  "./sarif.mjs",
   "./style.css",
   "./manifest.webmanifest",
   "./examples/gallery.mjs",


### PR DESCRIPTION
Closes #2

## Summary

A standalone, zero-install, publicly-deployed **RDF-1.2 console** over the `purrdf-wasm` build. Anyone with no toolchain opens a browser page and can parse, query (SPARQL), validate (SHACL), serialize, and canonicalize/compare RDF-1.2 — quoted triples and directional literals included — **entirely client-side**, with no server-side evaluation. It auto-deploys with the docs on every push to `main` (a superset of releases) at `https://blackcat-informatics.github.io/purrdf/playground/`, tracking the published version, and is linked from all three READMEs.

## Changes

**1. Expose the full wasm surface** (`crates/rdf-wasm`) — the SHACL functions (`shaclValidateToSarif`/`shaclEntail`) and RDFC-1.0 `Dataset.canonicalize()` / `Dataset.isomorphic(other)` were compiled into the wasm but unreachable from the shipped JS; now re-exported from the package root (zero wasm-size impact — the Rust was already linked). New public-API node tests; both READMEs corrected.

**2. The console** (`docs/playground/`) — zero-dependency vanilla ESM, engine-in-a-Web-Worker (owns the Dataset state; string-in/string-out message API). Seven panes: input+format, all-formats differential round-trip, SPARQL, SHACL (SARIF table + `report.sarif` + entailment), graph identity/diff, faceted quad table via `match()`, and an RDF-1.2 vignette gallery with zero-backend URL-hash permalinks. Offline PWA, a11y, dark+light. Every engine error is surfaced, never swallowed. `make playground` assembles; `make playground-smoke` = 16 Node engine tests.

**3. Deployment** (`.github/workflows/docs.yaml`) — the console ships as a `/playground` subpath of the single Pages artifact `docs.yaml` already owns (Pages allows one deployment). A CI step asserts the console version tracks the published `package.json` version.

**4. READMEs** — a "Try it live" badge + links from the root, wasm-crate, and npm READMEs.

## Verification

- `make check` green (fmt + clippy pedantic/nursery + build + tests + hygiene); `make wasm` clean.
- `node --test` (package) 36/36; `make playground-smoke` 16/16.
- **Headless-Chrome (CDP) drive** exercised every pane in-browser — parse, serialize (all 6; JSON-LD's quoted-triple-object hard-fail surfaced per-format), SPARQL (5 rows incl. a `<< … >>` quoted triple), SHACL (SARIF), identity (`isomorphic: yes`) — with **zero network requests after asset load** (proves no server eval).
- `actionlint` clean; mechanical deferral scan clean; `check-issue-refs` clean.

Ready for `/stage2 2`.
