### PR TITLE
fix(shapes): polarity-sound sh:not projection (kill vacuous class negation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -127,6 +128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "appendlist"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e149dc73cd30538307e7ffa2acd3d2221148eaeed4871f246657b1c3eaa1cbd2"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +150,12 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -194,6 +207,32 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "boon"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baa187da765010b70370368c49f08244b1ae5cae1d5d33072f76c8cb7112fe3e"
+dependencies = [
+ "ahash",
+ "appendlist",
+ "base64",
+ "fluent-uri",
+ "idna",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "bumpalo"
@@ -539,6 +578,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +702,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,6 +722,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures-core"
@@ -788,6 +857,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +1059,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +1130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1179,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1178,6 +1371,7 @@ dependencies = [
 name = "purrdf-shapes"
 version = "0.3.3"
 dependencies = [
+ "boon",
  "criterion",
  "proptest",
  "purrdf-gts",
@@ -1468,6 +1662,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,6 +1905,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1940,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1772,6 +2003,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +2061,24 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1952,10 +2211,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1978,10 +2266,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,11 @@ ahash = { version = "0.8", default-features = false }
 # rayon feature: multi-threaded hashing for large inputs (rayon executes
 # inline-sequentially on wasm32 without atomics, so the wasm gate holds).
 blake3 = { version = "1", features = ["rayon"] }
+# Pure-Rust JSON Schema (draft 2020-12) validator. DEV-ONLY: crates/shapes tests
+# use it as a trusted external oracle to observe the emitted schema_json's real
+# accept/reject behaviour against JSON-LD instance nodes. Not a runtime/release
+# dependency, so the wasm gate is unaffected (`make wasm` builds `--lib` only).
+boon = "0.6"
 camino = "1"
 ciborium = "0.2"
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -63,6 +63,11 @@ purrdf-slice = { workspace = true }
 proptest = { workspace = true }
 # Acceleration-program baselines; light feature set, see crates/logic.
 criterion = { workspace = true }
+# Trusted external JSON Schema (draft 2020-12) validator: the negation tests
+# observe the emitted schema_json's real accept/reject behaviour against JSON-LD
+# instance nodes, rather than asserting the schema's JSON shape. Dev-only; never
+# enters the release/wasm build.
+boon = { workspace = true }
 
 [[bench]]
 name = "validate"

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -848,6 +848,23 @@ fn compile_object_schema(shape: &Shape, ctx: &mut Ctx<'_>) -> Value {
 /// the negand widens to "any node" — the vacuous-`not` bug. A `sh:not` property
 /// inner that carries `sh:maxCount` must therefore route to a recorded loss
 /// (the caller emits no `not`) rather than a base-negating vacuous negation.
+///
+/// Also deliberately excludes the value-restriction constraints whose scalar
+/// projection is a BARE JSON-Schema keyword with no `type` guard:
+/// `sh:pattern` (`pattern`), `sh:minLength`/`sh:maxLength`
+/// (`minLength`/`maxLength`), and the numeric bounds
+/// `sh:minInclusive`/`sh:maxInclusive`/`sh:minExclusive`/`sh:maxExclusive`
+/// (`minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`). JSON Schema
+/// applies each of these keywords only to instances of its target primitive
+/// (strings for `pattern`/length, numbers for the bounds) and passes every
+/// other type vacuously. So for an array-valued node the scalar alternative is
+/// vacuously satisfied by the array itself; under negation that widens the
+/// negand to reject EVERY array-valued node — a false-reject. They therefore
+/// route to a recorded loss rather than an unsound `not`. Only value
+/// constraints whose scalar schema is type-guarded (non-vacuous for a
+/// mismatched-type instance) remain negand-safe: `sh:datatype`/`sh:nodeKind`
+/// project `type`-tagged alternatives, `sh:in` an `enum`, `sh:hasValue` a
+/// `const`, and `sh:languageIn` a `type: "object"` literal shape.
 fn negand_value_constraint_ok(c: &Constraint) -> bool {
     matches!(
         c,
@@ -856,13 +873,6 @@ fn negand_value_constraint_ok(c: &Constraint) -> bool {
             | Constraint::NodeKind(_)
             | Constraint::In(_)
             | Constraint::HasValue(_)
-            | Constraint::Pattern { .. }
-            | Constraint::MinLength(_)
-            | Constraint::MaxLength(_)
-            | Constraint::MinInclusive(_)
-            | Constraint::MaxInclusive(_)
-            | Constraint::MinExclusive(_)
-            | Constraint::MaxExclusive(_)
             | Constraint::LanguageIn(_)
     )
 }
@@ -2114,6 +2124,145 @@ mod tests {
         assert!(
             !validates(&c.schema_json, &json!({ "@type": "meta:DtT" })),
             "a node with p absent must be REJECTED"
+        );
+    }
+
+    #[test]
+    fn test_not_property_datatype_array_sound() {
+        // The array cardinality path of the datatype negand stays sound: the
+        // scalar alternatives are `type`-guarded, so an array instance is NOT
+        // vacuously matched.
+        // `sh:not [ sh:property [ sh:path meta:p ; sh:datatype xsd:string ] ]`.
+        let c = compile_ttl(
+            r"
+            meta:DtArrShape a sh:NodeShape ;
+                sh:targetClass meta:DtArrT ;
+                sh:not [ sh:property [ sh:path meta:p ; sh:datatype xsd:string ] ] .
+            ",
+        );
+        assert!(
+            !c.losses.iter().any(|l| l.construct == "sh:not"),
+            "an expressible datatype negand must NOT record a loss, got {:?}",
+            c.losses
+        );
+        let schema = schema_of(&c);
+        let dtt = def(&schema, "DtArrT");
+        assert!(
+            dtt["allOf"]
+                .as_array()
+                .is_some_and(|a| a.iter().any(|e| e.get("not").is_some())),
+            "expected a sound structural `not` negation, got {dtt:?}"
+        );
+        // Every value a string ⇒ inner conforms ⇒ sh:not REJECTS.
+        assert!(
+            !validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:DtArrT", "meta:p": ["a", "b"] })
+            ),
+            "a node whose p is all strings must be REJECTED"
+        );
+        // A non-string value present ⇒ inner FAILS ⇒ sh:not ACCEPTS.
+        assert!(
+            validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:DtArrT", "meta:p": ["a", 5] })
+            ),
+            "a node whose p array contains a non-string must be ACCEPTED"
+        );
+        // p ABSENT ⇒ inner vacuously conforms ⇒ sh:not REJECTS.
+        assert!(
+            !validates(&c.schema_json, &json!({ "@type": "meta:DtArrT" })),
+            "a node with p absent must be REJECTED"
+        );
+    }
+
+    #[test]
+    fn test_not_property_pattern_records_loss() {
+        // F1 (value-restriction variant): `sh:pattern` projects a BARE
+        // JSON-Schema `pattern` keyword with no `type` guard. JSON Schema applies
+        // `pattern` only to strings and passes non-strings vacuously, so under
+        // negation the scalar alternative is vacuously satisfied by an
+        // array-valued node — widening the negand to false-reject EVERY array.
+        // It must route to a recorded loss and emit NO `not`.
+        let c = compile_ttl(
+            r#"
+            meta:PatShape a sh:NodeShape ;
+                sh:targetClass meta:PatT ;
+                sh:not [ sh:property [ sh:path meta:p ; sh:pattern "^A" ] ] .
+            "#,
+        );
+        assert!(
+            c.losses.iter().any(|l| l.construct == "sh:not"),
+            "a sh:pattern sh:not property inner must record a sh:not LossRecord, got {:?}",
+            c.losses
+        );
+        let schema = schema_of(&c);
+        let pat = def(&schema, "PatT");
+        assert!(
+            !serde_json::to_string(pat)
+                .expect("def serializes")
+                .contains("\"not\""),
+            "the vacuous `not` must be GONE from the def, got {pat:?}"
+        );
+        // Behavioural (boon): the false-reject is gone — the constraint is
+        // honestly dropped, so every array-valued node is ACCEPTED.
+        assert!(
+            validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:PatT", "meta:p": ["Apple", "Banana"] })
+            ),
+            "a node with one violating value must be ACCEPTED (no false-reject)"
+        );
+        assert!(
+            validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:PatT", "meta:p": ["Apple"] })
+            ),
+            "a node whose values all match ^A must be ACCEPTED (loss dropped)"
+        );
+        assert!(
+            validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:PatT", "meta:p": ["Banana"] })
+            ),
+            "a node whose value violates ^A must be ACCEPTED (no false-reject)"
+        );
+    }
+
+    #[test]
+    fn test_not_property_numeric_bound_records_loss() {
+        // F1 (numeric-bound variant): `sh:minInclusive` projects a BARE
+        // `minimum` keyword with no `type` guard; JSON Schema passes non-numbers
+        // vacuously, so under negation an array-valued node is vacuously matched
+        // and false-rejected. Must route to a recorded loss and emit NO `not`.
+        let c = compile_ttl(
+            r"
+            meta:NumShape a sh:NodeShape ;
+                sh:targetClass meta:NumT ;
+                sh:not [ sh:property [ sh:path meta:p ; sh:minInclusive 10 ] ] .
+            ",
+        );
+        assert!(
+            c.losses.iter().any(|l| l.construct == "sh:not"),
+            "a sh:minInclusive sh:not property inner must record a sh:not LossRecord, got {:?}",
+            c.losses
+        );
+        let schema = schema_of(&c);
+        let num = def(&schema, "NumT");
+        assert!(
+            !serde_json::to_string(num)
+                .expect("def serializes")
+                .contains("\"not\""),
+            "the vacuous `not` must be GONE from the def, got {num:?}"
+        );
+        // Behavioural (boon): a node with meta:p = [5] is ACCEPTED — the
+        // false-reject is gone.
+        assert!(
+            validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:NumT", "meta:p": [5] })
+            ),
+            "a node with meta:p = [5] must be ACCEPTED (no false-reject)"
         );
     }
 

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -860,11 +860,30 @@ fn compile_object_schema(shape: &Shape, ctx: &mut Ctx<'_>) -> Value {
 /// other type vacuously. So for an array-valued node the scalar alternative is
 /// vacuously satisfied by the array itself; under negation that widens the
 /// negand to reject EVERY array-valued node — a false-reject. They therefore
-/// route to a recorded loss rather than an unsound `not`. Only value
-/// constraints whose scalar schema is type-guarded (non-vacuous for a
-/// mismatched-type instance) remain negand-safe: `sh:datatype`/`sh:nodeKind`
-/// project `type`-tagged alternatives, `sh:in` an `enum`, `sh:hasValue` a
-/// `const`, and `sh:languageIn` a `type: "object"` literal shape.
+/// route to a recorded loss rather than an unsound `not`.
+///
+/// A value constraint is negand-safe only when it is BOTH (a) type-guarded
+/// (its scalar schema is non-vacuous for a mismatched-type/array instance, the
+/// array-vacuity axis above) AND (b) UNIVERSAL in SHACL — i.e. it holds iff
+/// EVERY value node satisfies it, so its per-value/array-items projection is an
+/// exact complement of the constraint under negation. The kept constraints are
+/// all both: `sh:datatype`/`sh:nodeKind` project `type`-tagged alternatives,
+/// `sh:in` an `enum`, and `sh:languageIn` a `type: "object"` literal shape, and
+/// each requires every value node to satisfy it; `sh:minCount` is a
+/// cardinality-only lower bound.
+///
+/// `sh:hasValue` is deliberately excluded because it fails axis (b): it is
+/// EXISTENTIAL — a node conforms iff AT LEAST ONE value node equals `V`.
+/// [`compile_property`] projects it as a `const` (array `items: {const}`)
+/// conjunct, which expresses the UNIVERSAL reading ("p absent, OR every value
+/// equals `V`"). Negating that universal projection is NOT negating the
+/// existential constraint: it false-accepts a node that carries `V` alongside
+/// other values (the inner conforms, so `sh:not` should reject) and
+/// false-rejects a node with `p` absent (no value equals `V`, so the inner
+/// fails and `sh:not` should accept). A single-value node is the lone case
+/// where universal and existential coincide, which is why it is not sound in
+/// general. `sh:hasValue` therefore routes to a recorded loss (the caller emits
+/// no `not`) rather than an unsound negation.
 fn negand_value_constraint_ok(c: &Constraint) -> bool {
     matches!(
         c,
@@ -872,7 +891,6 @@ fn negand_value_constraint_ok(c: &Constraint) -> bool {
             | Constraint::Datatype(_)
             | Constraint::NodeKind(_)
             | Constraint::In(_)
-            | Constraint::HasValue(_)
             | Constraint::LanguageIn(_)
     )
 }
@@ -2263,6 +2281,113 @@ mod tests {
                 &json!({ "@type": "meta:NumT", "meta:p": [5] })
             ),
             "a node with meta:p = [5] must be ACCEPTED (no false-reject)"
+        );
+    }
+
+    #[test]
+    fn test_not_property_hasvalue_records_loss() {
+        // F1 (existential variant): `sh:hasValue V` is EXISTENTIAL — a node
+        // conforms iff AT LEAST ONE value of p equals V. `compile_property`
+        // projects it as a `const` (array `items: {const}`) conjunct, which
+        // expresses the UNIVERSAL reading ("p absent, OR every value equals V").
+        // Negating that universal projection is NOT negating the existential
+        // constraint: it false-accepts a node carrying V alongside other values
+        // and false-rejects a node with p absent. It must therefore route to a
+        // recorded loss and emit NO `not`.
+        let c = compile_ttl(
+            r#"
+            meta:HasValShape a sh:NodeShape ;
+                sh:targetClass meta:Person ;
+                sh:not [ sh:property [ sh:path meta:p ; sh:hasValue "boss" ] ] .
+            "#,
+        );
+        assert!(
+            c.losses.iter().any(|l| l.construct == "sh:not"),
+            "a sh:hasValue sh:not property inner must record a sh:not LossRecord, got {:?}",
+            c.losses
+        );
+        let schema = schema_of(&c);
+        let person = def(&schema, "Person");
+        assert!(
+            !serde_json::to_string(person)
+                .expect("def serializes")
+                .contains("\"not\""),
+            "the unsound `not` must be GONE from the def, got {person:?}"
+        );
+        // Behavioural (boon): the multivalue + absent cases that expose the
+        // existential axis — single-value alone would NOT catch it. With the
+        // constraint honestly dropped, the node is unconstrained by this sh:not,
+        // so every case is ACCEPTED (no false-reject, no unsound `not`).
+        assert!(
+            validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:Person", "meta:p": ["boss", "peon"] })
+            ),
+            "a node whose p carries \"boss\" alongside other values must be \
+             ACCEPTED (was false-accepted by the unsound `not`; now a dropped loss)"
+        );
+        assert!(
+            validates(&c.schema_json, &json!({ "@type": "meta:Person" })),
+            "a node with p absent must be ACCEPTED (was false-rejected before)"
+        );
+        assert!(
+            validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:Person", "meta:p": ["boss"] })
+            ),
+            "a single-value node must be ACCEPTED (dropped loss)"
+        );
+    }
+
+    #[test]
+    fn test_not_property_in_array_sound() {
+        // LOCK that `sh:in` (UNIVERSAL — every value node must be a set member)
+        // stays negand-sound under the array cardinality path: its `enum`
+        // projection is `type`-guarded, so an array instance is NOT vacuously
+        // matched and the negation is an exact complement.
+        // `sh:not [ sh:property [ sh:path meta:p ; sh:in ( "a" "b" ) ] ]` means
+        // "NOT (every value of p is in {a, b})".
+        let c = compile_ttl(
+            r#"
+            meta:InArrShape a sh:NodeShape ;
+                sh:targetClass meta:InArrT ;
+                sh:not [ sh:property [ sh:path meta:p ; sh:in ( "a" "b" ) ] ] .
+            "#,
+        );
+        assert!(
+            !c.losses.iter().any(|l| l.construct == "sh:not"),
+            "an expressible sh:in negand must NOT record a loss, got {:?}",
+            c.losses
+        );
+        let schema = schema_of(&c);
+        let it = def(&schema, "InArrT");
+        assert!(
+            it["allOf"]
+                .as_array()
+                .is_some_and(|a| a.iter().any(|e| e.get("not").is_some())),
+            "expected a sound structural `not` negation, got {it:?}"
+        );
+        // A value outside the set present ⇒ inner "all in {a,b}" FAILS ⇒ sh:not
+        // ACCEPTS.
+        assert!(
+            validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:InArrT", "meta:p": ["a", "c"] })
+            ),
+            "a node whose p array contains an out-of-set value must be ACCEPTED"
+        );
+        // Every value in the set ⇒ inner conforms ⇒ sh:not REJECTS.
+        assert!(
+            !validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:InArrT", "meta:p": ["a", "b"] })
+            ),
+            "a node whose p array is all in-set must be REJECTED"
+        );
+        // p ABSENT ⇒ inner vacuously conforms ⇒ sh:not REJECTS.
+        assert!(
+            !validates(&c.schema_json, &json!({ "@type": "meta:InArrT" })),
+            "a node with p absent must be REJECTED"
         );
     }
 

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -944,7 +944,9 @@ fn compile_negand(inner: &Shape, ctx: &mut Ctx<'_>) -> Option<Vec<Value>> {
     }
 
     // Deterministic order, independent of constraint-vector position.
-    parts.sort_by_key(ToString::to_string);
+    // `sort_by_cached_key` serializes each part once instead of on every
+    // comparison.
+    parts.sort_by_cached_key(ToString::to_string);
     Some(parts)
 }
 

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -450,22 +450,6 @@ fn root_schema(defs: &Map<String, Value>, ns: &Namespaces) -> Value {
     })
 }
 
-/// Build the `@type`-discriminated `Node` schema.
-///
-/// A node carries `@id`/`@type`/`@annotation` permissively, then an `allOf` of
-/// per-class conditionals (sorted by class name for determinism). Each entry
-/// reads: *if* `@type` includes the class CURIE — `<primary>:<Class>` for a
-/// primary-namespace class, or the full `prefix:<Class>` for any other declared
-/// namespace (e.g. `logic:FormalizationCandidate`) — as a bare string OR an
-/// array member, *then* the node MUST satisfy that class's `#/$defs` body.
-///
-/// Closed-world semantics:
-/// * An instance typed `<primary>:Foo` that is MISSING a required property
-///   triggers Foo's `then` (`#/$defs/Foo`), fails Foo's `required`, and is
-///   REJECTED.
-/// * A node typed only by an UNMODELED class (no `$def`) fires no `if`, so no
-///   `then` applies and it stays permissively allowed — keeping the slice
-///   example sweep (Task 6) green on unmodeled types.
 /// The `@type`-discriminated match for a single class CURIE: a node whose
 /// `@type` is (or contains) `curie`, either as a bare string or an array member.
 ///
@@ -488,6 +472,22 @@ fn type_discriminator(curie: &str) -> Value {
     })
 }
 
+/// Build the `@type`-discriminated `Node` schema.
+///
+/// A node carries `@id`/`@type`/`@annotation` permissively, then an `allOf` of
+/// per-class conditionals (sorted by class name for determinism). Each entry
+/// reads: *if* `@type` includes the class CURIE — `<primary>:<Class>` for a
+/// primary-namespace class, or the full `prefix:<Class>` for any other declared
+/// namespace (e.g. `logic:FormalizationCandidate`) — as a bare string OR an
+/// array member, *then* the node MUST satisfy that class's `#/$defs` body.
+///
+/// Closed-world semantics:
+/// * An instance typed `<primary>:Foo` that is MISSING a required property
+///   triggers Foo's `then` (`#/$defs/Foo`), fails Foo's `required`, and is
+///   REJECTED.
+/// * A node typed only by an UNMODELED class (no `$def`) fires no `if`, so no
+///   `then` applies and it stays permissively allowed — keeping the slice
+///   example sweep (Task 6) green on unmodeled types.
 fn node_def(class_names: &[String], ns: &Namespaces) -> Value {
     // class_names arrives sorted (BTree-ordered defs iter); keep it explicit so
     // the conditional list is deterministic regardless of caller.
@@ -1672,7 +1672,7 @@ mod tests {
 
     #[test]
     fn test_not_class_accepts_own_instance() {
-        // The issue #73 reproduction: PersonShape carries
+        // The reported reproduction: PersonShape carries
         // `sh:not [ sh:class meta:Organization ]`. A node typed only meta:Person
         // MUST be accepted by $defs/Person; a node ALSO typed meta:Organization
         // MUST be rejected (the constraint is preserved, not silently dropped).
@@ -1691,8 +1691,10 @@ mod tests {
         let person = def(&schema, "Person");
         let all_of = person["allOf"].as_array().expect("Person has an allOf");
         assert!(
-            all_of.iter().any(|e| e["not"]["properties"]["@type"]["anyOf"][0]["const"]
-                == json!("meta:Organization")),
+            all_of
+                .iter()
+                .any(|e| e["not"]["properties"]["@type"]["anyOf"][0]["const"]
+                    == json!("meta:Organization")),
             "expected an allOf `not` over the meta:Organization @type discriminator, got {all_of:?}"
         );
 

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -466,6 +466,28 @@ fn root_schema(defs: &Map<String, Value>, ns: &Namespaces) -> Value {
 /// * A node typed only by an UNMODELED class (no `$def`) fires no `if`, so no
 ///   `then` applies and it stays permissively allowed — keeping the slice
 ///   example sweep (Task 6) green on unmodeled types.
+/// The `@type`-discriminated match for a single class CURIE: a node whose
+/// `@type` is (or contains) `curie`, either as a bare string or an array member.
+///
+/// This is the SOLE source of the identity model. `node_def` uses it as the
+/// `if` of each positive per-class conditional, and the `sh:not` negation
+/// (`compile_negand`) negates it (`{"not": type_discriminator(..)}`), so a
+/// negation rejects EXACTLY the nodes the positive path would type-match — the
+/// two can never drift.
+fn type_discriminator(curie: &str) -> Value {
+    json!({
+        "required": ["@type"],
+        "properties": {
+            "@type": {
+                "anyOf": [
+                    { "const": curie },
+                    { "type": "array", "contains": { "const": curie } }
+                ]
+            }
+        }
+    })
+}
+
 fn node_def(class_names: &[String], ns: &Namespaces) -> Value {
     // class_names arrives sorted (BTree-ordered defs iter); keep it explicit so
     // the conditional list is deterministic regardless of caller.
@@ -485,17 +507,7 @@ fn node_def(class_names: &[String], ns: &Namespaces) -> Value {
                 format!("{}:{name}", ns.primary_prefix)
             };
             json!({
-                "if": {
-                    "required": ["@type"],
-                    "properties": {
-                        "@type": {
-                            "anyOf": [
-                                { "const": type_const },
-                                { "type": "array", "contains": { "const": type_const } }
-                            ]
-                        }
-                    }
-                },
+                "if": type_discriminator(&type_const),
                 "then": { "$ref": format!("#/$defs/{name}") }
             })
         })
@@ -670,7 +682,6 @@ fn compile_object_schema(shape: &Shape, ctx: &mut Ctx<'_>) -> Value {
     let mut all_of: Vec<Value> = Vec::new();
     let mut any_of: Vec<Value> = Vec::new();
     let mut one_of: Vec<Value> = Vec::new();
-    let mut not_schema: Option<Value> = None;
     let mut additional_properties_false = false;
     let mut closed_ignored: Vec<String> = Vec::new();
 
@@ -694,9 +705,36 @@ fn compile_object_schema(shape: &Shape, ctx: &mut Ctx<'_>) -> Value {
             Constraint::Node(inner) => {
                 all_of.push(compile_object_schema(inner, ctx));
             }
-            Constraint::Not(inner) => {
-                not_schema = Some(compile_object_schema(inner, ctx));
-            }
+            Constraint::Not(inner) => match compile_negand(inner, ctx) {
+                // The inner is losslessly expressible: negate each AND-conjunct
+                // independently. `sh:class` conjuncts become `@type`-discriminated
+                // negations; multiple `sh:not` (the `owl:AllDisjointClasses`
+                // projection) each land as their own `allOf` entry, so they never
+                // clobber one another.
+                Some(parts) => {
+                    for part in parts {
+                        all_of.push(json!({ "not": part }));
+                    }
+                }
+                // Negative position is unsound to widen: an inner constraint the
+                // object projection would silently drop turns `not` into a negation
+                // of the permissive base — rejecting every node. Record the loss
+                // and emit no `not` (the SHACL/JSON-Schema Option-2 outcome).
+                None => {
+                    ctx.record(
+                        "sh:not",
+                        &shape_iri,
+                        "sh:not inner shape is not losslessly expressible in the \
+                         object projection; omitted rather than emitting a \
+                         base-negating (vacuous) not",
+                    );
+                    comments.push(
+                        "a node-level sh:not was dropped (inner shape not soundly \
+                         expressible in the object projection)"
+                            .to_owned(),
+                    );
+                }
+            },
             Constraint::Closed { ignored } => {
                 additional_properties_false = true;
                 for n in ignored {
@@ -769,9 +807,6 @@ fn compile_object_schema(shape: &Shape, ctx: &mut Ctx<'_>) -> Value {
     if !one_of.is_empty() {
         obj.insert("oneOf".to_owned(), Value::Array(one_of));
     }
-    if let Some(ns) = not_schema {
-        obj.insert("not".to_owned(), ns);
-    }
 
     if !comments.is_empty() {
         comments.sort();
@@ -783,6 +818,120 @@ fn compile_object_schema(shape: &Shape, ctx: &mut Ctx<'_>) -> Value {
 }
 
 // ── Per-property value schema ────────────────────────────────────────────────
+
+/// Whether a value-level constraint is expressed *losslessly* by
+/// [`compile_property`] — i.e. it has a dedicated arm there and never falls
+/// through to that function's silent `_ => {}` drop.
+///
+/// Used to gate the negation projector: a `sh:not` over a property shape may
+/// only be emitted when EVERY value constraint round-trips, because a dropped
+/// constraint under negation would widen the negand to the permissive base and
+/// re-introduce the vacuous-`not` bug. Deliberately excludes `sh:class` (its
+/// value projection is a node-ref/`$ref`, whose negation semantics are not the
+/// clean value-restriction this projector guarantees) and `sh:uniqueLang`
+/// (which `compile_property` does not express — it would be silently dropped).
+fn negand_value_constraint_ok(c: &Constraint) -> bool {
+    matches!(
+        c,
+        Constraint::MinCount(_)
+            | Constraint::MaxCount(_)
+            | Constraint::Datatype(_)
+            | Constraint::NodeKind(_)
+            | Constraint::In(_)
+            | Constraint::HasValue(_)
+            | Constraint::Pattern { .. }
+            | Constraint::MinLength(_)
+            | Constraint::MaxLength(_)
+            | Constraint::MinInclusive(_)
+            | Constraint::MaxInclusive(_)
+            | Constraint::MinExclusive(_)
+            | Constraint::MaxExclusive(_)
+            | Constraint::LanguageIn(_)
+    )
+}
+
+/// Losslessly project the inner shape of a `sh:not` into the list of AND-conjunct
+/// schemas a conforming node must satisfy — or `None` if any part of the inner
+/// cannot be expressed exactly.
+///
+/// SOUND BY CONSTRUCTION: this is the polarity contract for negation. In negative
+/// position every silently-dropped constraint *widens* the negand, so a single
+/// unhandled construct turns the assembled `{"not": …}` into a negation of the
+/// permissive "any node" base — rejecting every node. This projector therefore
+/// returns `Some(parts)` ONLY when it can express the whole inner, and `None`
+/// (⇒ record a loss, emit no `not`) otherwise. It never drops-and-negates.
+///
+/// Expressible parts:
+/// * node-level `sh:class X` ⇒ [`type_discriminator`] on `X`'s CURIE — but only
+///   when `X` is in a declared namespace; an undeclared-namespace class would
+///   compact to a full IRI that no instance's compacted `@type` can match (a
+///   silently never-firing negation), so it is a loss instead.
+/// * a direct-predicate `sh:property` whose value constraints are all
+///   [`negand_value_constraint_ok`] ⇒ a `{properties, required}` conjunct.
+///
+/// Everything else (`sh:nodeKind`/`sh:datatype`/`sh:in`/… at node level, nested
+/// `sh:not`/`sh:and`/`sh:or`/`sh:xone`/`sh:node`, non-predicate paths, nested or
+/// reifier property shapes, an empty inner) ⇒ `None`.
+fn compile_negand(inner: &Shape, ctx: &mut Ctx<'_>) -> Option<Vec<Value>> {
+    // An empty inner is the permissive base; negating it rejects everything.
+    // Never emit a vacuous negation for it.
+    if inner.constraints.is_empty() && inner.property_shapes.is_empty() {
+        return None;
+    }
+
+    let mut parts: Vec<Value> = Vec::new();
+
+    // Node-level constraints: only `sh:class` is a losslessly-expressible
+    // node-identity discriminator; anything else is not expressible in the
+    // object projection and forces the whole negation to a loss.
+    for c in &inner.constraints {
+        let Constraint::Class(class) = c else {
+            return None;
+        };
+        if !ctx.ns.is_known(class.as_str()) {
+            return None;
+        }
+        parts.push(type_discriminator(&ctx.ns.compact_iri(class.as_str())));
+    }
+
+    // Property shapes: express only direct-predicate paths whose every value
+    // constraint round-trips through `compile_property`.
+    let inner_iri = inner.id.to_string();
+    for ps in &inner.property_shapes {
+        if ps.deactivated
+            || !ps.property_shapes.is_empty()
+            || !ps.reifier_shapes.is_empty()
+            || ps.reification_required
+        {
+            return None;
+        }
+        let Path::Predicate(pred) = &ps.path else {
+            return None;
+        };
+        if !ps.constraints.iter().all(negand_value_constraint_ok) {
+            return None;
+        }
+        let key = ctx.ns.compact_iri(pred.as_str());
+        let (value_schema, is_required) = compile_property(&ps.constraints, &inner_iri, &key, ctx);
+        let mut props: Map<String, Value> = Map::new();
+        props.insert(key.clone(), value_schema);
+        let mut obj: Map<String, Value> = Map::new();
+        obj.insert("type".to_owned(), json!("object"));
+        obj.insert("properties".to_owned(), Value::Object(props));
+        if is_required {
+            obj.insert("required".to_owned(), json!([key]));
+        }
+        parts.push(Value::Object(obj));
+    }
+
+    if parts.is_empty() {
+        return None;
+    }
+
+    // Deterministic order, independent of constraint-vector position.
+    parts.sort_by_key(ToString::to_string);
+    Some(parts)
+}
 
 /// Compile one property shape's constraints into `(value_schema, is_required)`.
 ///
@@ -909,6 +1058,20 @@ fn compile_property(
                 );
                 comments.push(format!(
                     "a sh:expression constraint on property {key} was dropped (no JSON Schema equivalent)"
+                ));
+            }
+            Constraint::Not(_) => {
+                // A value-position `sh:not` has no lossless value-schema
+                // projection here. Surface it (never swallow it): emitting a
+                // negation off a base value schema would be vacuous, exactly the
+                // node-level bug this change removes.
+                ctx.record(
+                    "sh:not",
+                    shape_iri,
+                    "property-level sh:not has no lossless value-schema projection",
+                );
+                comments.push(format!(
+                    "a sh:not constraint on property {key} was dropped (no lossless value-schema projection)"
                 ));
             }
             // Counts handled above; node-shape-only constraints (Closed/And/…)
@@ -1485,7 +1648,12 @@ mod tests {
     }
 
     #[test]
-    fn test_not_constraint() {
+    fn test_not_nodekind_records_loss_no_vacuous_not() {
+        // `sh:not [ sh:nodeKind sh:Literal ]` is not losslessly expressible in
+        // the object projection (a JSON-LD node is always an object, never a
+        // literal), so the old emitter produced a `not` over the permissive base
+        // that rejected EVERY node. The sound outcome is Option 2: record a loss
+        // and emit no `not`.
         let c = compile_ttl(
             r"
             meta:NotShape a sh:NodeShape ;
@@ -1493,9 +1661,26 @@ mod tests {
                 sh:not [ sh:nodeKind sh:Literal ] .
             ",
         );
+        assert!(
+            c.losses.iter().any(|l| l.construct == "sh:not"),
+            "sh:not over a non-expressible inner must record a LossRecord, got {:?}",
+            c.losses
+        );
         let schema = schema_of(&c);
         let thing = def(&schema, "Thing");
-        assert!(thing["not"].is_object(), "expected a `not` subschema");
+        assert!(
+            thing.get("not").is_none(),
+            "no `not` may be emitted for a non-expressible inner, got {:?}",
+            thing.get("not")
+        );
+        assert!(
+            thing["$comment"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("sh:not"),
+            "expected a $comment noting the dropped sh:not, got {:?}",
+            thing.get("$comment")
+        );
     }
 
     #[test]

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -706,15 +706,24 @@ fn compile_object_schema(shape: &Shape, ctx: &mut Ctx<'_>) -> Value {
                 all_of.push(compile_object_schema(inner, ctx));
             }
             Constraint::Not(inner) => match compile_negand(inner, ctx) {
-                // The inner is losslessly expressible: negate each AND-conjunct
-                // independently. `sh:class` conjuncts become `@type`-discriminated
-                // negations; multiple `sh:not` (the `owl:AllDisjointClasses`
-                // projection) each land as their own `allOf` entry, so they never
-                // clobber one another.
-                Some(parts) => {
-                    for part in parts {
-                        all_of.push(json!({ "not": part }));
-                    }
+                // The inner is losslessly expressible as the conjunction
+                // `A ∧ B ∧ …` of its parts. SHACL's `sh:not` conforms iff a node
+                // fails AT LEAST ONE conjunct — i.e. `¬(A ∧ B ∧ …)`, the negation
+                // of the whole conjunction (De Morgan: `¬A ∨ ¬B ∨ …`), NOT each
+                // conjunct negated independently (`¬A ∧ ¬B`, which is strictly
+                // too narrow and false-rejects a node failing only one conjunct).
+                // A single part negates directly; several parts negate their
+                // `allOf`. Multiple SEPARATE `sh:not` constraints (the
+                // `owl:AllDisjointClasses` projection) each still emit their own
+                // independent `{"not": …}` entry, so they never clobber one
+                // another.
+                Some(mut parts) => {
+                    let negand = if parts.len() == 1 {
+                        parts.pop().expect("len == 1")
+                    } else {
+                        json!({ "allOf": parts })
+                    };
+                    all_of.push(json!({ "not": negand }));
                 }
                 // Negative position is unsound to widen: an inner constraint the
                 // object projection would silently drop turns `not` into a negation
@@ -851,15 +860,21 @@ fn negand_value_constraint_ok(c: &Constraint) -> bool {
 }
 
 /// Losslessly project the inner shape of a `sh:not` into the list of AND-conjunct
-/// schemas a conforming node must satisfy — or `None` if any part of the inner
-/// cannot be expressed exactly.
+/// schemas — the parts whose conjunction `A ∧ B ∧ …` IS the inner (a node
+/// conforms to the inner iff it satisfies EVERY part) — or `None` if any part of
+/// the inner cannot be expressed exactly.
+///
+/// This function only returns the inner's conjuncts; it does NOT negate them.
+/// The CALLER negates their conjunction as a whole (`¬(A ∧ B ∧ …)`), which is the
+/// correct SHACL `sh:not` semantics — negating each part independently would be
+/// strictly too narrow.
 ///
 /// SOUND BY CONSTRUCTION: this is the polarity contract for negation. In negative
 /// position every silently-dropped constraint *widens* the negand, so a single
-/// unhandled construct turns the assembled `{"not": …}` into a negation of the
-/// permissive "any node" base — rejecting every node. This projector therefore
-/// returns `Some(parts)` ONLY when it can express the whole inner, and `None`
-/// (⇒ record a loss, emit no `not`) otherwise. It never drops-and-negates.
+/// unhandled construct turns the caller's assembled `{"not": …}` into a negation
+/// of the permissive "any node" base — rejecting every node. This projector
+/// therefore returns `Some(parts)` ONLY when it can express the whole inner, and
+/// `None` (⇒ record a loss, emit no `not`) otherwise. It never drops-and-negates.
 ///
 /// Expressible parts:
 /// * node-level `sh:class X` ⇒ [`type_discriminator`] on `X`'s CURIE — but only
@@ -1755,6 +1770,100 @@ mod tests {
                 &json!({ "@type": ["meta:Person", "meta:Event"] })
             ),
             "a meta:Person also typed meta:Event must be REJECTED"
+        );
+    }
+
+    #[test]
+    fn test_not_multi_conjunct_inner() {
+        // A SINGLE `sh:not` whose inner is a multi-conjunct shape
+        // (`sh:class meta:X ; sh:class meta:Y`). The inner is `X ∧ Y`, so
+        // `sh:not` conforms iff a node fails AT LEAST ONE conjunct
+        // (`¬(X ∧ Y)`), NOT `¬X ∧ ¬Y`. A node typed only meta:X must be
+        // ACCEPTED (it fails the Y conjunct); a node typed both must be
+        // REJECTED.
+        let c = compile_ttl(
+            r"
+            meta:PersonShape a sh:NodeShape ;
+                sh:targetClass meta:Person ;
+                sh:not [ sh:class meta:X ; sh:class meta:Y ] .
+            meta:XShape a sh:NodeShape ;
+                sh:targetClass meta:X .
+            meta:YShape a sh:NodeShape ;
+                sh:targetClass meta:Y .
+            ",
+        );
+        let schema = schema_of(&c);
+        let person = def(&schema, "Person");
+        let all_of = person["allOf"].as_array().expect("Person has an allOf");
+        // Exactly ONE `{"not": {"allOf": […]}}` entry for this inner — the
+        // conjunction is negated as a whole, NOT split into two independent
+        // `{"not": …}` entries.
+        let whole_conjunction_nots = all_of
+            .iter()
+            .filter(|e| e.get("not").and_then(|n| n.get("allOf")).is_some())
+            .count();
+        assert_eq!(
+            whole_conjunction_nots, 1,
+            "expected exactly one `not` over the inner's `allOf`, got {all_of:?}"
+        );
+        // No independent per-conjunct `{"not": {"properties": {"@type": …}}}`
+        // entries were emitted for this inner.
+        let independent_type_nots = all_of
+            .iter()
+            .filter(|e| e["not"]["properties"]["@type"].is_object())
+            .count();
+        assert_eq!(
+            independent_type_nots, 0,
+            "the multi-conjunct inner must NOT be split into per-conjunct negations, got {all_of:?}"
+        );
+
+        // Behaviour on the production surface. The `sh:not` lives in the Person
+        // body, so instances must be typed meta:Person for it to apply (matching
+        // the sibling `test_not_*` tests). The ADDED types drive the inner.
+        assert!(
+            validates(
+                &c.schema_json,
+                &json!({ "@type": ["meta:Person", "meta:X"] })
+            ),
+            "a node typed only meta:X (not meta:Y) fails the meta:Y conjunct, so \
+             `not(X ∧ Y)` must ACCEPT it"
+        );
+        assert!(
+            !validates(
+                &c.schema_json,
+                &json!({ "@type": ["meta:Person", "meta:X", "meta:Y"] })
+            ),
+            "a node typed both meta:X and meta:Y satisfies the inner, so \
+             `not(X ∧ Y)` must REJECT it"
+        );
+
+        // A mixed class + property-shape inner: `X ∧ (has meta:p)`. `sh:not`
+        // conforms iff a node fails at least one conjunct.
+        let c2 = compile_ttl(
+            r"
+            meta:ThingShape a sh:NodeShape ;
+                sh:targetClass meta:Thing ;
+                sh:not [ sh:class meta:X ;
+                         sh:property [ sh:path meta:p ; sh:minCount 1 ] ] .
+            meta:XShape a sh:NodeShape ;
+                sh:targetClass meta:X .
+            ",
+        );
+        assert!(
+            validates(
+                &c2.schema_json,
+                &json!({ "@type": ["meta:Thing", "meta:X"] })
+            ),
+            "typed meta:X but WITHOUT meta:p fails the property conjunct, so it \
+             must be ACCEPTED"
+        );
+        assert!(
+            !validates(
+                &c2.schema_json,
+                &json!({ "@type": ["meta:Thing", "meta:X"], "meta:p": "v" })
+            ),
+            "typed meta:X and WITH meta:p satisfies the inner, so it must be \
+             REJECTED"
         );
     }
 

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -839,11 +839,19 @@ fn compile_object_schema(shape: &Shape, ctx: &mut Ctx<'_>) -> Value {
 /// value projection is a node-ref/`$ref`, whose negation semantics are not the
 /// clean value-restriction this projector guarantees) and `sh:uniqueLang`
 /// (which `compile_property` does not express — it would be silently dropped).
+///
+/// Also deliberately excludes `sh:maxCount`: its cardinality UPPER bound is not
+/// faithfully expressible under negation. [`compile_property`] projects a bare
+/// `sh:maxCount` to the permissive base (`max_count == Some(1)` selects the
+/// `single` scalar, an empty `{}`; `max_count >= 2` yields an `anyOf` whose `{}`
+/// alternative is likewise permissive), so the upper-count bound is dropped and
+/// the negand widens to "any node" — the vacuous-`not` bug. A `sh:not` property
+/// inner that carries `sh:maxCount` must therefore route to a recorded loss
+/// (the caller emits no `not`) rather than a base-negating vacuous negation.
 fn negand_value_constraint_ok(c: &Constraint) -> bool {
     matches!(
         c,
         Constraint::MinCount(_)
-            | Constraint::MaxCount(_)
             | Constraint::Datatype(_)
             | Constraint::NodeKind(_)
             | Constraint::In(_)
@@ -928,6 +936,17 @@ fn compile_negand(inner: &Shape, ctx: &mut Ctx<'_>) -> Option<Vec<Value>> {
         }
         let key = ctx.ns.compact_iri(pred.as_str());
         let (value_schema, is_required) = compile_property(&ps.constraints, &inner_iri, &key, ctx);
+        // A property conjunct that neither requires the key nor restricts its
+        // value matches every node (the permissive base); negating it would
+        // reject all — the vacuous-not bug. Route such a bare/zero-cardinality
+        // inner (only `sh:minCount 0`, or an empty constraint set) to a loss.
+        let restricts_value = ps
+            .constraints
+            .iter()
+            .any(|c| !matches!(c, Constraint::MinCount(_)));
+        if !is_required && !restricts_value {
+            return None;
+        }
         let mut props: Map<String, Value> = Map::new();
         props.insert(key.clone(), value_schema);
         let mut obj: Map<String, Value> = Map::new();
@@ -1962,6 +1981,139 @@ mod tests {
                 &json!({ "@type": "meta:NoP", "meta:p": "x" })
             ),
             "a node WITH meta:p must be REJECTED"
+        );
+    }
+
+    #[test]
+    fn test_not_property_maxcount_records_loss() {
+        // F1 (the vacuous-total false-reject, reintroduced via the property
+        // path): a `sh:not`
+        // property inner whose ONLY constraint is `sh:maxCount` is NOT faithfully
+        // negatable — `compile_property` widens a bare maxCount to the permissive
+        // base, so emitting a `not` would reject EVERY node of the target class (a
+        // vacuous-total false-reject). It must route to a recorded loss instead.
+        let c = compile_ttl(
+            r"
+            meta:MaxShape a sh:NodeShape ;
+                sh:targetClass meta:MaxT ;
+                sh:not [ sh:property [ sh:path meta:p ; sh:maxCount 1 ] ] .
+            ",
+        );
+        assert!(
+            c.losses.iter().any(|l| l.construct == "sh:not"),
+            "a bare-maxCount sh:not property inner must record a sh:not LossRecord, got {:?}",
+            c.losses
+        );
+        let schema = schema_of(&c);
+        let maxt = def(&schema, "MaxT");
+        assert!(
+            !serde_json::to_string(maxt)
+                .expect("def serializes")
+                .contains("\"not\""),
+            "the vacuous-total `not` must be GONE from the def, got {maxt:?}"
+        );
+        // Behavioural: the sh:not is honestly DROPPED (a recorded loss), so the
+        // total false-reject is gone — every node of the target class is accepted
+        // regardless of how many values it has for meta:p.
+        assert!(
+            validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:MaxT", "meta:p": ["a", "b"] })
+            ),
+            "a node with 2 values for meta:p must be ACCEPTED (sh:not[maxCount 1] must accept it)"
+        );
+        assert!(
+            validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:MaxT", "meta:p": "a" })
+            ),
+            "a node with 1 value for meta:p must be ACCEPTED"
+        );
+        assert!(
+            validates(&c.schema_json, &json!({ "@type": "meta:MaxT" })),
+            "a node with 0 values for meta:p must be ACCEPTED"
+        );
+    }
+
+    #[test]
+    fn test_not_property_mincount_maxcount_records_loss() {
+        // `sh:not [ sh:property [ sh:path meta:p ; sh:minCount 1 ; sh:maxCount 1 ] ]`:
+        // the maxCount upper bound is not faithfully expressible under negation
+        // (the `required` presence alone would reject nodes that HAVE the key,
+        // which is unsound — SHACL's inner `1..1` fails for a node with 2 values,
+        // so sh:not must ACCEPT it). Must route to a recorded loss, not a `not`.
+        let c = compile_ttl(
+            r"
+            meta:ExactShape a sh:NodeShape ;
+                sh:targetClass meta:ExactT ;
+                sh:not [ sh:property [ sh:path meta:p ; sh:minCount 1 ; sh:maxCount 1 ] ] .
+            ",
+        );
+        assert!(
+            c.losses.iter().any(|l| l.construct == "sh:not"),
+            "a minCount+maxCount sh:not property inner must record a sh:not LossRecord, got {:?}",
+            c.losses
+        );
+        let schema = schema_of(&c);
+        let exact = def(&schema, "ExactT");
+        assert!(
+            !serde_json::to_string(exact)
+                .expect("def serializes")
+                .contains("\"not\""),
+            "the vacuous `not` must be GONE from the def, got {exact:?}"
+        );
+        assert!(
+            validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:ExactT", "meta:p": ["a", "b"] })
+            ),
+            "a node with 2 values for meta:p must be ACCEPTED (no false-reject)"
+        );
+    }
+
+    #[test]
+    fn test_not_property_datatype_sound() {
+        // LOCK the value-restriction negand path as genuinely sound under
+        // composition. `sh:not [ sh:property [ sh:path meta:p ; sh:datatype
+        // xsd:string ] ]` means "NOT (every value of p is a string)".
+        let c = compile_ttl(
+            r"
+            meta:DtShape a sh:NodeShape ;
+                sh:targetClass meta:DtT ;
+                sh:not [ sh:property [ sh:path meta:p ; sh:datatype xsd:string ] ] .
+            ",
+        );
+        assert!(
+            !c.losses.iter().any(|l| l.construct == "sh:not"),
+            "an expressible value-restriction inner must NOT record a loss, got {:?}",
+            c.losses
+        );
+        let schema = schema_of(&c);
+        let dtt = def(&schema, "DtT");
+        assert!(
+            dtt["allOf"]
+                .as_array()
+                .is_some_and(|a| a.iter().any(|e| e.get("not").is_some())),
+            "expected a sound structural `not` negation, got {dtt:?}"
+        );
+        // p is a NON-string (integer) ⇒ inner "all p are strings" FAILS ⇒ sh:not
+        // ACCEPTS.
+        assert!(
+            validates(&c.schema_json, &json!({ "@type": "meta:DtT", "meta:p": 5 })),
+            "a node whose p is a non-string must be ACCEPTED"
+        );
+        // p is a string ⇒ inner conforms ⇒ sh:not REJECTS.
+        assert!(
+            !validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:DtT", "meta:p": "hello" })
+            ),
+            "a node whose p is a string must be REJECTED"
+        );
+        // p ABSENT ⇒ inner vacuously conforms (0 values) ⇒ sh:not REJECTS.
+        assert!(
+            !validates(&c.schema_json, &json!({ "@type": "meta:DtT" })),
+            "a node with p absent must be REJECTED"
         );
     }
 

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -1671,6 +1671,234 @@ mod tests {
     }
 
     #[test]
+    fn test_not_class_accepts_own_instance() {
+        // The issue #73 reproduction: PersonShape carries
+        // `sh:not [ sh:class meta:Organization ]`. A node typed only meta:Person
+        // MUST be accepted by $defs/Person; a node ALSO typed meta:Organization
+        // MUST be rejected (the constraint is preserved, not silently dropped).
+        let c = compile_ttl(
+            r"
+            meta:PersonShape a sh:NodeShape ;
+                sh:targetClass meta:Person ;
+                sh:not [ sh:class meta:Organization ] .
+            meta:OrganizationShape a sh:NodeShape ;
+                sh:targetClass meta:Organization .
+            ",
+        );
+        // Structure: Person's def carries an `allOf` negation of the
+        // Organization @type discriminator — not a base-negating `not`.
+        let schema = schema_of(&c);
+        let person = def(&schema, "Person");
+        let all_of = person["allOf"].as_array().expect("Person has an allOf");
+        assert!(
+            all_of.iter().any(|e| e["not"]["properties"]["@type"]["anyOf"][0]["const"]
+                == json!("meta:Organization")),
+            "expected an allOf `not` over the meta:Organization @type discriminator, got {all_of:?}"
+        );
+
+        // Behaviour, on the production surface (validate against schema_json):
+        assert!(
+            validates(&c.schema_json, &json!({ "@type": "meta:Person" })),
+            "a node typed only meta:Person must be ACCEPTED"
+        );
+        assert!(
+            !validates(
+                &c.schema_json,
+                &json!({ "@type": ["meta:Person", "meta:Organization"] })
+            ),
+            "a node also typed meta:Organization must be REJECTED"
+        );
+    }
+
+    #[test]
+    fn test_not_class_multi_disjoint() {
+        // The owl:AllDisjointClasses projection: one shape carries SEVERAL
+        // `sh:not [ sh:class … ]`. Each must become its own independent `allOf`
+        // negation (no clobber), and an instance of the shape's own class is
+        // accepted while an instance also carrying either disjoint class is
+        // rejected.
+        let c = compile_ttl(
+            r"
+            meta:PersonShape a sh:NodeShape ;
+                sh:targetClass meta:Person ;
+                sh:not [ sh:class meta:Organization ] ;
+                sh:not [ sh:class meta:Event ] .
+            meta:OrganizationShape a sh:NodeShape ;
+                sh:targetClass meta:Organization .
+            meta:EventShape a sh:NodeShape ;
+                sh:targetClass meta:Event .
+            ",
+        );
+        let schema = schema_of(&c);
+        let person = def(&schema, "Person");
+        let negated: Vec<Value> = person["allOf"]
+            .as_array()
+            .expect("Person has an allOf")
+            .iter()
+            .filter(|e| e.get("not").is_some())
+            .map(|e| e["not"]["properties"]["@type"]["anyOf"][0]["const"].clone())
+            .collect();
+        assert!(
+            negated.contains(&json!("meta:Organization")) && negated.contains(&json!("meta:Event")),
+            "both disjoint classes must be negated independently, got {negated:?}"
+        );
+
+        assert!(
+            validates(&c.schema_json, &json!({ "@type": "meta:Person" })),
+            "a plain meta:Person must be ACCEPTED"
+        );
+        assert!(
+            !validates(
+                &c.schema_json,
+                &json!({ "@type": ["meta:Person", "meta:Event"] })
+            ),
+            "a meta:Person also typed meta:Event must be REJECTED"
+        );
+    }
+
+    #[test]
+    fn test_not_mixed_inner_records_loss() {
+        // Rb1: an inner mixing `sh:class` with an off-allowlist node constraint
+        // (`sh:nodeKind`) is NOT losslessly expressible. The whole `sh:not` must
+        // become a recorded loss with no `not` emitted — the vacuous-negation bug
+        // must NOT reappear via a "structural" fallback.
+        let c = compile_ttl(
+            r"
+            meta:PersonShape a sh:NodeShape ;
+                sh:targetClass meta:Person ;
+                sh:not [ sh:class meta:Organization ; sh:nodeKind sh:IRI ] .
+            ",
+        );
+        assert!(
+            c.losses.iter().any(|l| l.construct == "sh:not"),
+            "a mixed inner must record a sh:not LossRecord, got {:?}",
+            c.losses
+        );
+        let schema = schema_of(&c);
+        let person = def(&schema, "Person");
+        assert!(
+            person.get("allOf").is_none() && person.get("not").is_none(),
+            "no negation may be emitted for a non-expressible mixed inner, got {person:?}"
+        );
+        // The bug does not reappear: a plain Person still validates.
+        assert!(
+            validates(&c.schema_json, &json!({ "@type": "meta:Person" })),
+            "a plain meta:Person must still be ACCEPTED (no vacuous rejection)"
+        );
+    }
+
+    #[test]
+    fn test_not_undeclared_namespace_class_records_loss() {
+        // F6: an inner `sh:class` in an UNDECLARED namespace compacts to a full
+        // IRI that no instance's compacted @type can match — a silently
+        // never-firing negation. It must be a recorded loss instead, never an
+        // emitted (never-matching) const.
+        let c = compile_ttl(
+            r"
+            @prefix ex: <https://example.org/> .
+            meta:PersonShape a sh:NodeShape ;
+                sh:targetClass meta:Person ;
+                sh:not [ sh:class <http://unknown.example/Foo> ] .
+            ",
+        );
+        assert!(
+            c.losses.iter().any(|l| l.construct == "sh:not"),
+            "an undeclared-namespace inner class must record a sh:not LossRecord, got {:?}",
+            c.losses
+        );
+        let schema = schema_of(&c);
+        let person = def(&schema, "Person");
+        assert!(
+            person.get("allOf").is_none() && person.get("not").is_none(),
+            "no never-matching negation may be emitted, got {person:?}"
+        );
+    }
+
+    #[test]
+    fn test_not_structural_property_preserved() {
+        // An expressible property-shape inner keeps a SOUND structural negation:
+        // `sh:not [ sh:property [ sh:path meta:p ; sh:minCount 1 ] ]` rejects
+        // nodes that HAVE meta:p and accepts nodes that lack it.
+        let c = compile_ttl(
+            r"
+            meta:NoPShape a sh:NodeShape ;
+                sh:targetClass meta:NoP ;
+                sh:not [ sh:property [ sh:path meta:p ; sh:minCount 1 ] ] .
+            ",
+        );
+        assert!(
+            !c.losses.iter().any(|l| l.construct == "sh:not"),
+            "an expressible property-shape inner must NOT record a loss, got {:?}",
+            c.losses
+        );
+        let schema = schema_of(&c);
+        let nop = def(&schema, "NoP");
+        assert!(
+            nop["allOf"]
+                .as_array()
+                .is_some_and(|a| a.iter().any(|e| e.get("not").is_some())),
+            "expected a structural `not` negation, got {nop:?}"
+        );
+        assert!(
+            validates(&c.schema_json, &json!({ "@type": "meta:NoP" })),
+            "a node WITHOUT meta:p must be ACCEPTED"
+        );
+        assert!(
+            !validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:NoP", "meta:p": "x" })
+            ),
+            "a node WITH meta:p must be REJECTED"
+        );
+    }
+
+    #[test]
+    fn test_not_self_disjoint() {
+        // Rb4: a (contradictory) self-disjoint shape must reject its own
+        // instances soundly, without panic or dangling refs.
+        let c = compile_ttl(
+            r"
+            meta:PersonShape a sh:NodeShape ;
+                sh:targetClass meta:Person ;
+                sh:not [ sh:class meta:Person ] .
+            ",
+        );
+        assert!(
+            !validates(&c.schema_json, &json!({ "@type": "meta:Person" })),
+            "a self-disjoint Person must reject every Person instance"
+        );
+    }
+
+    #[test]
+    fn test_not_class_without_nodeshape() {
+        // Rb5: the negated class need not have its own NodeShape — the @type
+        // discriminator needs no `$def`, so no `$ref` dangles.
+        let c = compile_ttl(
+            r"
+            meta:PersonShape a sh:NodeShape ;
+                sh:targetClass meta:Person ;
+                sh:not [ sh:class meta:Ghost ] .
+            ",
+        );
+        assert!(
+            !c.losses.iter().any(|l| l.construct == "sh:not"),
+            "a declared-namespace class needs no NodeShape to be negated, got {:?}",
+            c.losses
+        );
+        assert!(
+            validates(&c.schema_json, &json!({ "@type": "meta:Person" })),
+            "a plain meta:Person must be ACCEPTED"
+        );
+        assert!(
+            !validates(
+                &c.schema_json,
+                &json!({ "@type": ["meta:Person", "meta:Ghost"] })
+            ),
+            "a meta:Person also typed meta:Ghost must be REJECTED"
+        );
+    }
+
+    #[test]
     fn test_not_nodekind_records_loss_no_vacuous_not() {
         // `sh:not [ sh:nodeKind sh:Literal ]` is not losslessly expressible in
         // the object projection (a JSON-LD node is always an object, never a

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -828,71 +828,44 @@ fn compile_object_schema(shape: &Shape, ctx: &mut Ctx<'_>) -> Value {
 
 // ── Per-property value schema ────────────────────────────────────────────────
 
-/// Whether a value-level constraint is expressed *losslessly* by
-/// [`compile_property`] — i.e. it has a dedicated arm there and never falls
-/// through to that function's silent `_ => {}` drop.
+/// Whether a value-level constraint is an EXACT complement under negation — the
+/// only case in which a `sh:not` property inner may be emitted rather than
+/// routed to a recorded loss.
 ///
-/// Used to gate the negation projector: a `sh:not` over a property shape may
-/// only be emitted when EVERY value constraint round-trips, because a dropped
-/// constraint under negation would widen the negand to the permissive base and
-/// re-introduce the vacuous-`not` bug. Deliberately excludes `sh:class` (its
-/// value projection is a node-ref/`$ref`, whose negation semantics are not the
-/// clean value-restriction this projector guarantees) and `sh:uniqueLang`
-/// (which `compile_property` does not express — it would be silently dropped).
+/// Reduced to `sh:minCount` ALONE. Cardinality PRESENCE (`sh:minCount >= 1`) is
+/// the sole value-level constraint whose positive projection is an exact
+/// complement of the SHACL constraint under negation: it is expressed purely as
+/// `required`, with NO value schema to widen. "Key present" is logically
+/// equivalent to "the property has >= 1 value", so negating it is exactly "key
+/// absent" ⟺ "< 1 value" — the SHACL complement.
 ///
-/// Also deliberately excludes `sh:maxCount`: its cardinality UPPER bound is not
-/// faithfully expressible under negation. [`compile_property`] projects a bare
-/// `sh:maxCount` to the permissive base (`max_count == Some(1)` selects the
-/// `single` scalar, an empty `{}`; `max_count >= 2` yields an `anyOf` whose `{}`
-/// alternative is likewise permissive), so the upper-count bound is dropped and
-/// the negand widens to "any node" — the vacuous-`not` bug. A `sh:not` property
-/// inner that carries `sh:maxCount` must therefore route to a recorded loss
-/// (the caller emits no `not`) rather than a base-negating vacuous negation.
+/// Every VALUE constraint (`sh:datatype`, `sh:nodeKind`, `sh:in`,
+/// `sh:languageIn`, `sh:pattern`, `sh:minLength`/`sh:maxLength`, the numeric
+/// bounds `sh:minInclusive`/`sh:maxInclusive`/`sh:minExclusive`/`sh:maxExclusive`,
+/// `sh:hasValue`) is deliberately excluded, because its positive projection
+/// through [`compile_property`] is NOT an exact complement:
+/// * Array/type vacuity — `sh:pattern`, the length bounds and the numeric
+///   bounds project to a BARE JSON-Schema keyword that JSON Schema applies only
+///   to its target primitive and passes vacuously for every other type. For an
+///   array-valued node the scalar alternative is vacuously satisfied, so under
+///   negation the negand widens to reject EVERY array-valued node — a
+///   false-reject.
+/// * Encoding mismatch — `sh:in` over IRI members and `sh:datatype`'s
+///   typed-literal object form project an instance encoding (enum members,
+///   `@type`-tagged objects) that does not line up value-for-value with the
+///   negated instance, so the complement is not exact.
+/// * Quantifier mismatch — `sh:hasValue` is EXISTENTIAL ("at least one value
+///   equals `V`"), yet its `const` projection expresses the UNIVERSAL reading
+///   ("p absent, OR every value equals `V`"). Negating the universal projection
+///   is not negating the existential constraint; the two coincide only for a
+///   single-value node, not in general.
 ///
-/// Also deliberately excludes the value-restriction constraints whose scalar
-/// projection is a BARE JSON-Schema keyword with no `type` guard:
-/// `sh:pattern` (`pattern`), `sh:minLength`/`sh:maxLength`
-/// (`minLength`/`maxLength`), and the numeric bounds
-/// `sh:minInclusive`/`sh:maxInclusive`/`sh:minExclusive`/`sh:maxExclusive`
-/// (`minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`). JSON Schema
-/// applies each of these keywords only to instances of its target primitive
-/// (strings for `pattern`/length, numbers for the bounds) and passes every
-/// other type vacuously. So for an array-valued node the scalar alternative is
-/// vacuously satisfied by the array itself; under negation that widens the
-/// negand to reject EVERY array-valued node — a false-reject. They therefore
-/// route to a recorded loss rather than an unsound `not`.
-///
-/// A value constraint is negand-safe only when it is BOTH (a) type-guarded
-/// (its scalar schema is non-vacuous for a mismatched-type/array instance, the
-/// array-vacuity axis above) AND (b) UNIVERSAL in SHACL — i.e. it holds iff
-/// EVERY value node satisfies it, so its per-value/array-items projection is an
-/// exact complement of the constraint under negation. The kept constraints are
-/// all both: `sh:datatype`/`sh:nodeKind` project `type`-tagged alternatives,
-/// `sh:in` an `enum`, and `sh:languageIn` a `type: "object"` literal shape, and
-/// each requires every value node to satisfy it; `sh:minCount` is a
-/// cardinality-only lower bound.
-///
-/// `sh:hasValue` is deliberately excluded because it fails axis (b): it is
-/// EXISTENTIAL — a node conforms iff AT LEAST ONE value node equals `V`.
-/// [`compile_property`] projects it as a `const` (array `items: {const}`)
-/// conjunct, which expresses the UNIVERSAL reading ("p absent, OR every value
-/// equals `V`"). Negating that universal projection is NOT negating the
-/// existential constraint: it false-accepts a node that carries `V` alongside
-/// other values (the inner conforms, so `sh:not` should reject) and
-/// false-rejects a node with `p` absent (no value equals `V`, so the inner
-/// fails and `sh:not` should accept). A single-value node is the lone case
-/// where universal and existential coincide, which is why it is not sound in
-/// general. `sh:hasValue` therefore routes to a recorded loss (the caller emits
-/// no `not`) rather than an unsound negation.
+/// So node-identity (`sh:class` → the shared `@type` [`type_discriminator`]) and
+/// property presence (`sh:minCount >= 1` → `required`) are the ONLY two exact
+/// projections under negation. Any other value constraint MUST route to a
+/// recorded `sh:not` loss rather than an unsound `not`.
 fn negand_value_constraint_ok(c: &Constraint) -> bool {
-    matches!(
-        c,
-        Constraint::MinCount(_)
-            | Constraint::Datatype(_)
-            | Constraint::NodeKind(_)
-            | Constraint::In(_)
-            | Constraint::LanguageIn(_)
-    )
+    matches!(c, Constraint::MinCount(_))
 }
 
 /// Losslessly project the inner shape of a `sh:not` into the list of AND-conjunct
@@ -917,8 +890,11 @@ fn negand_value_constraint_ok(c: &Constraint) -> bool {
 ///   when `X` is in a declared namespace; an undeclared-namespace class would
 ///   compact to a full IRI that no instance's compacted `@type` can match (a
 ///   silently never-firing negation), so it is a loss instead.
-/// * a direct-predicate `sh:property` whose value constraints are all
-///   [`negand_value_constraint_ok`] ⇒ a `{properties, required}` conjunct.
+/// * a direct-predicate `sh:property` whose ONLY constraints are `sh:minCount`
+///   (with at least one n >= 1) ⇒ a `{properties, required}` conjunct expressing
+///   pure PRESENCE via `required` (see [`negand_value_constraint_ok`]). A
+///   property inner carrying ANY value constraint routes to a loss instead — no
+///   value projection is an exact complement under negation.
 ///
 /// Everything else (`sh:nodeKind`/`sh:datatype`/`sh:in`/… at node level, nested
 /// `sh:not`/`sh:and`/`sh:or`/`sh:xone`/`sh:node`, non-predicate paths, nested or
@@ -2100,10 +2076,12 @@ mod tests {
     }
 
     #[test]
-    fn test_not_property_datatype_sound() {
-        // LOCK the value-restriction negand path as genuinely sound under
-        // composition. `sh:not [ sh:property [ sh:path meta:p ; sh:datatype
-        // xsd:string ] ]` means "NOT (every value of p is a string)".
+    fn test_not_property_datatype_records_loss() {
+        // A value-restriction inner is NOT an exact complement under negation:
+        // `sh:datatype`'s positive projection through `compile_property` widens
+        // (typed-literal object form; array-type vacuity), so it routes to a
+        // recorded loss rather than an unsound `not`.
+        // `sh:not [ sh:property [ sh:path meta:p ; sh:datatype xsd:string ] ]`.
         let c = compile_ttl(
             r"
             meta:DtShape a sh:NodeShape ;
@@ -2112,44 +2090,38 @@ mod tests {
             ",
         );
         assert!(
-            !c.losses.iter().any(|l| l.construct == "sh:not"),
-            "an expressible value-restriction inner must NOT record a loss, got {:?}",
+            c.losses.iter().any(|l| l.construct == "sh:not"),
+            "a sh:datatype sh:not property inner must record a sh:not LossRecord, got {:?}",
             c.losses
         );
         let schema = schema_of(&c);
         let dtt = def(&schema, "DtT");
         assert!(
-            dtt["allOf"]
-                .as_array()
-                .is_some_and(|a| a.iter().any(|e| e.get("not").is_some())),
-            "expected a sound structural `not` negation, got {dtt:?}"
+            !serde_json::to_string(dtt)
+                .expect("def serializes")
+                .contains("\"not\""),
+            "no `not` must be emitted for a dropped value-restriction negand, got {dtt:?}"
         );
-        // p is a NON-string (integer) ⇒ inner "all p are strings" FAILS ⇒ sh:not
-        // ACCEPTS.
+        // The constraint is honestly DROPPED (recorded loss): a node WITH the
+        // property is ACCEPTED regardless of value type — no false-reject.
         assert!(
-            validates(&c.schema_json, &json!({ "@type": "meta:DtT", "meta:p": 5 })),
-            "a node whose p is a non-string must be ACCEPTED"
-        );
-        // p is a string ⇒ inner conforms ⇒ sh:not REJECTS.
-        assert!(
-            !validates(
+            validates(
                 &c.schema_json,
                 &json!({ "@type": "meta:DtT", "meta:p": "hello" })
             ),
-            "a node whose p is a string must be REJECTED"
+            "a node whose p is a string must be ACCEPTED (constraint dropped)"
         );
-        // p ABSENT ⇒ inner vacuously conforms (0 values) ⇒ sh:not REJECTS.
         assert!(
-            !validates(&c.schema_json, &json!({ "@type": "meta:DtT" })),
-            "a node with p absent must be REJECTED"
+            validates(&c.schema_json, &json!({ "@type": "meta:DtT", "meta:p": 5 })),
+            "a node whose p is a non-string must be ACCEPTED (constraint dropped)"
         );
     }
 
     #[test]
-    fn test_not_property_datatype_array_sound() {
-        // The array cardinality path of the datatype negand stays sound: the
-        // scalar alternatives are `type`-guarded, so an array instance is NOT
-        // vacuously matched.
+    fn test_not_property_datatype_array_records_loss() {
+        // The array cardinality path is likewise routed to a loss — no value
+        // projection of `sh:datatype` is an exact complement under negation, so
+        // an array-valued node must not be false-rejected.
         // `sh:not [ sh:property [ sh:path meta:p ; sh:datatype xsd:string ] ]`.
         let c = compile_ttl(
             r"
@@ -2159,38 +2131,100 @@ mod tests {
             ",
         );
         assert!(
-            !c.losses.iter().any(|l| l.construct == "sh:not"),
-            "an expressible datatype negand must NOT record a loss, got {:?}",
+            c.losses.iter().any(|l| l.construct == "sh:not"),
+            "a sh:datatype sh:not property inner must record a sh:not LossRecord, got {:?}",
             c.losses
         );
         let schema = schema_of(&c);
         let dtt = def(&schema, "DtArrT");
         assert!(
-            dtt["allOf"]
-                .as_array()
-                .is_some_and(|a| a.iter().any(|e| e.get("not").is_some())),
-            "expected a sound structural `not` negation, got {dtt:?}"
+            !serde_json::to_string(dtt)
+                .expect("def serializes")
+                .contains("\"not\""),
+            "no `not` must be emitted for a dropped value-restriction negand, got {dtt:?}"
         );
-        // Every value a string ⇒ inner conforms ⇒ sh:not REJECTS.
+        // Both an all-string array and a mixed array must be ACCEPTED (dropped).
         assert!(
-            !validates(
+            validates(
                 &c.schema_json,
                 &json!({ "@type": "meta:DtArrT", "meta:p": ["a", "b"] })
             ),
-            "a node whose p is all strings must be REJECTED"
+            "an all-string array node must be ACCEPTED (constraint dropped)"
         );
-        // A non-string value present ⇒ inner FAILS ⇒ sh:not ACCEPTS.
         assert!(
             validates(
                 &c.schema_json,
                 &json!({ "@type": "meta:DtArrT", "meta:p": ["a", 5] })
             ),
-            "a node whose p array contains a non-string must be ACCEPTED"
+            "a mixed array node must be ACCEPTED (constraint dropped)"
         );
-        // p ABSENT ⇒ inner vacuously conforms ⇒ sh:not REJECTS.
+    }
+
+    #[test]
+    fn test_not_property_nodekind_records_loss() {
+        // A `sh:nodeKind` value restriction is not an exact complement under
+        // negation (its `type`-tagged alternatives widen), so it routes to a
+        // recorded loss: a node WITH the property is ACCEPTED.
+        let c = compile_ttl(
+            r"
+            meta:NkShape a sh:NodeShape ;
+                sh:targetClass meta:NkT ;
+                sh:not [ sh:property [ sh:path meta:p ; sh:nodeKind sh:Literal ] ] .
+            ",
+        );
         assert!(
-            !validates(&c.schema_json, &json!({ "@type": "meta:DtArrT" })),
-            "a node with p absent must be REJECTED"
+            c.losses.iter().any(|l| l.construct == "sh:not"),
+            "a sh:nodeKind sh:not property inner must record a sh:not LossRecord, got {:?}",
+            c.losses
+        );
+        let schema = schema_of(&c);
+        let nk = def(&schema, "NkT");
+        assert!(
+            !serde_json::to_string(nk)
+                .expect("def serializes")
+                .contains("\"not\""),
+            "no `not` must be emitted for a dropped value-restriction negand, got {nk:?}"
+        );
+        assert!(
+            validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:NkT", "meta:p": "x" })
+            ),
+            "a node with p must be ACCEPTED (constraint dropped)"
+        );
+    }
+
+    #[test]
+    fn test_not_property_languagein_records_loss() {
+        // A `sh:languageIn` value restriction is not an exact complement under
+        // negation, so it routes to a recorded loss: a node WITH the property is
+        // ACCEPTED.
+        let c = compile_ttl(
+            r#"
+            meta:LiShape a sh:NodeShape ;
+                sh:targetClass meta:LiT ;
+                sh:not [ sh:property [ sh:path meta:p ; sh:languageIn ( "en" ) ] ] .
+            "#,
+        );
+        assert!(
+            c.losses.iter().any(|l| l.construct == "sh:not"),
+            "a sh:languageIn sh:not property inner must record a sh:not LossRecord, got {:?}",
+            c.losses
+        );
+        let schema = schema_of(&c);
+        let li = def(&schema, "LiT");
+        assert!(
+            !serde_json::to_string(li)
+                .expect("def serializes")
+                .contains("\"not\""),
+            "no `not` must be emitted for a dropped value-restriction negand, got {li:?}"
+        );
+        assert!(
+            validates(
+                &c.schema_json,
+                &json!({ "@type": "meta:LiT", "meta:p": "x" })
+            ),
+            "a node with p must be ACCEPTED (constraint dropped)"
         );
     }
 
@@ -2340,54 +2374,45 @@ mod tests {
     }
 
     #[test]
-    fn test_not_property_in_array_sound() {
-        // LOCK that `sh:in` (UNIVERSAL — every value node must be a set member)
-        // stays negand-sound under the array cardinality path: its `enum`
-        // projection is `type`-guarded, so an array instance is NOT vacuously
-        // matched and the negation is an exact complement.
-        // `sh:not [ sh:property [ sh:path meta:p ; sh:in ( "a" "b" ) ] ]` means
-        // "NOT (every value of p is in {a, b})".
+    fn test_not_property_in_records_loss() {
+        // `sh:in` value restriction is not an exact complement under negation
+        // (IRI-member/enum encoding mismatch; array vacuity), so it routes to a
+        // recorded loss: both an in-set and an out-of-set node are ACCEPTED
+        // (the constraint is honestly dropped).
+        // `sh:not [ sh:property [ sh:path meta:p ; sh:in ( "a" "b" ) ] ]`.
         let c = compile_ttl(
             r#"
-            meta:InArrShape a sh:NodeShape ;
-                sh:targetClass meta:InArrT ;
+            meta:InShape a sh:NodeShape ;
+                sh:targetClass meta:InT ;
                 sh:not [ sh:property [ sh:path meta:p ; sh:in ( "a" "b" ) ] ] .
             "#,
         );
         assert!(
-            !c.losses.iter().any(|l| l.construct == "sh:not"),
-            "an expressible sh:in negand must NOT record a loss, got {:?}",
+            c.losses.iter().any(|l| l.construct == "sh:not"),
+            "a sh:in sh:not property inner must record a sh:not LossRecord, got {:?}",
             c.losses
         );
         let schema = schema_of(&c);
-        let it = def(&schema, "InArrT");
+        let it = def(&schema, "InT");
         assert!(
-            it["allOf"]
-                .as_array()
-                .is_some_and(|a| a.iter().any(|e| e.get("not").is_some())),
-            "expected a sound structural `not` negation, got {it:?}"
+            !serde_json::to_string(it)
+                .expect("def serializes")
+                .contains("\"not\""),
+            "no `not` must be emitted for a dropped value-restriction negand, got {it:?}"
         );
-        // A value outside the set present ⇒ inner "all in {a,b}" FAILS ⇒ sh:not
-        // ACCEPTS.
         assert!(
             validates(
                 &c.schema_json,
-                &json!({ "@type": "meta:InArrT", "meta:p": ["a", "c"] })
+                &json!({ "@type": "meta:InT", "meta:p": "a" })
             ),
-            "a node whose p array contains an out-of-set value must be ACCEPTED"
+            "an in-set node must be ACCEPTED (constraint dropped)"
         );
-        // Every value in the set ⇒ inner conforms ⇒ sh:not REJECTS.
         assert!(
-            !validates(
+            validates(
                 &c.schema_json,
-                &json!({ "@type": "meta:InArrT", "meta:p": ["a", "b"] })
+                &json!({ "@type": "meta:InT", "meta:p": "c" })
             ),
-            "a node whose p array is all in-set must be REJECTED"
-        );
-        // p ABSENT ⇒ inner vacuously conforms ⇒ sh:not REJECTS.
-        assert!(
-            !validates(&c.schema_json, &json!({ "@type": "meta:InArrT" })),
-            "a node with p absent must be REJECTED"
+            "an out-of-set node must be ACCEPTED (constraint dropped)"
         );
     }
 

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -517,7 +517,7 @@ fn node_def(class_names: &[String], ns: &Namespaces) -> Value {
         "type": "object",
         "title": "A single discriminated PURRDF instance node",
         "description": format!(
-            "Validated by @type: a node typed {}:Foo MUST satisfy #/$defs/Foo (closed-world, #700). Nodes typed only by unmodeled classes are permissively allowed.",
+            "Validated by @type: a node typed {}:Foo MUST satisfy #/$defs/Foo (closed-world). Nodes typed only by unmodeled classes are permissively allowed.",
             ns.primary_prefix
         ),
         "properties": {
@@ -579,7 +579,7 @@ fn annotation_def() -> Value {
     json!({
         "type": "object",
         "title": "RDF-1.2 statement metadata (reifier annotation)",
-        "description": "Free-form metadata about an asserted triple (e.g. meta:accordingTo, meta:confidence, meta:assertedAt). Permissive; tightened by #699.",
+        "description": "Free-form metadata about an asserted triple (e.g. meta:accordingTo, meta:confidence, meta:assertedAt). Permissive.",
         "additionalProperties": {
             "anyOf": [
                 { "type": "string" },

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -1341,6 +1341,29 @@ mod tests {
         &schema["$defs"][name]
     }
 
+    /// Validate a JSON-LD instance node against the emitted `schema_json` with a
+    /// trusted external JSON-Schema (draft 2020-12) validator, returning whether
+    /// the instance is ACCEPTED.
+    ///
+    /// This is the production-surface observation the acceptance criteria demand:
+    /// it exercises the exact string `CompiledSchema.schema_json` the way a
+    /// downstream consumer (e.g. gmeow-ontology) would, rather than asserting the
+    /// schema's JSON shape.
+    fn validates(schema_json: &str, instance: &Value) -> bool {
+        use boon::{Compiler, Schemas};
+        let schema_val: Value = serde_json::from_str(schema_json).expect("schema is valid JSON");
+        let loc = "mem:///instance.schema.json";
+        let mut schemas = Schemas::new();
+        let mut compiler = Compiler::new();
+        compiler
+            .add_resource(loc, schema_val)
+            .expect("schema registers as a boon resource");
+        let sch = compiler
+            .compile(loc, &mut schemas)
+            .expect("emitted schema compiles under draft 2020-12");
+        schemas.validate(instance, sch).is_ok()
+    }
+
     #[test]
     #[should_panic(expected = "declare its prefix in the shapes document / Namespaces")]
     fn unknown_namespace_target_class_hard_fails() {


### PR DESCRIPTION
Closes #73

## Summary
Node-level `sh:not [ sh:class X ]` — the SHACL projection of `owl:disjointWith` / `owl:AllDisjointClasses` / `owl:complementOf` — previously compiled to a `"not"` over the permissive "any node" base object, so **every** instance of the target class was rejected. This is a soundness bug across all disjointness/complement shapes.

The deeper cause is **polarity**: `compile_object_schema` only widens safely in positive position, so any silently-dropped inner constraint under `not` negates the permissive base and rejects everything. The fix replaces the class special-case with a polarity contract: **express the inner exactly, or emit no `not` and record a loss — never drop-and-negate.**

## Changes
- **Shared `type_discriminator`** — the `@type` match extracted from `node_def`, now the single source of the identity model, used by both `node_def`'s positive `if` and negation, so `{"not": …}` negates *exactly* what the positive path matches (`test_determinism_byte_stable` confirms `node_def`'s bytes are unchanged).
- **`compile_negand`** — a self-contained, sound-by-construction negation projector: `sh:class` (declared namespace) → `@type` discriminator, emitted as independent `allOf` negations (multi-class disjointness, no clobber); expressible property-shape inners → sound structural `not`; everything else (nodeKind, undeclared-namespace class, nested not/and/or, mixed inner) → recorded `LossRecord` + `$comment`, no `not`.
- **Property-level `sh:not`** now records a loss instead of a silent drop. Removed the dead single `not_schema` slot.
- **Real validation** — `boon` (pure-Rust draft-2020-12 validator) added as a **dev-only** dependency; tests assert accept/reject against the emitted `schema_json` (the production surface), not its JSON shape.

## Verification
- `make check` green (fmt, workspace pedantic/nursery clippy, build, 348 tests, hygiene); `make wasm` clean (dev-dep excluded from the `--lib` wasm build).
- Reproduction validated end-to-end: `{"@type":"meta:Person"}` accepted; `{"@type":["meta:Person","meta:Organization"]}` rejected. Plus multi-class, mixed-inner loss, undeclared-namespace loss, structural-not preserved, self-disjoint, and no-NodeShape cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON Schema generation for `not`-style constraints to avoid vacuous/unsound negations and better match SHACL intent.
  * Corrected how multiple and conjunctive negations are projected so accepted/rejected instances behave consistently.
  * Added clearer, in-output explanations when a negation can’t be represented losslessly (with fallback behavior).

* **Tests**
  * Expanded end-to-end schema validation coverage for `not`, including class/property negations and loss-recording scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->