### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the PurRDF crate suite are recorded here. The suite
 ships one lockstep version across crates.io, PyPI, and npm; pre-1.0, a minor
 bump may carry breaking changes and a patch bump is bugfix-only.
 
+## [0.4.0] - 2026-07-07
+
+### Bug Fixes
+
+- **shapes:** Polarity-sound sh:not projection (kill vacuous class negation)
+
+### Documentation
+
+- Uplift product docs to top-tier Rust project standard
+
+### Features
+
+- **capi:** Make purrdf.h reproducible via cargo-c `capi` marker + gate it in CI
+- **wasm:** CI-gated wasm artifact size budget
+- **playground:** Standalone deployed RDF-1.2 console over purrdf-wasm
 ## [0.3.3] - 2026-07-05
 
 ### Performance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "purrdf-entail",
  "purrdf-events",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "purrdf-core",
@@ -1297,11 +1297,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "0.3.3"
+version = "0.4.0"
 
 [[package]]
 name = "purrdf-gts"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "blake3",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "ahash",
  "ciborium",
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "boon",
  "criterion",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "hex",
  "insta",
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "insta",
  "pretty_assertions",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "pretty_assertions",
  "purrdf",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -43,21 +43,21 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "0.3.3" }
-purrdf-core = { path = "crates/rdf-core", version = "0.3.3" }
-purrdf-entail = { path = "crates/entail", version = "0.3.3" }
-purrdf-events = { path = "crates/rdf-events", version = "0.3.3" }
-purrdf-gts = { path = "crates/gts", version = "0.3.3" }
-purrdf-iri = { path = "crates/iri", version = "0.3.3" }
-purrdf-rdf = { path = "crates/rdf", version = "0.3.3" }
-purrdf-shapes = { path = "crates/shapes", version = "0.3.3" }
-purrdf-shex = { path = "crates/shex", version = "0.3.3" }
-purrdf-slice = { path = "crates/slice", version = "0.3.3" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.3.3" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.3.3" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "0.3.3" }
-purrdf-validate = { path = "crates/validate", version = "0.3.3" }
-purrdf-xsd = { path = "crates/xsd", version = "0.3.3" }
+purrdf = { path = "crates/purrdf", version = "0.4.0" }
+purrdf-core = { path = "crates/rdf-core", version = "0.4.0" }
+purrdf-entail = { path = "crates/entail", version = "0.4.0" }
+purrdf-events = { path = "crates/rdf-events", version = "0.4.0" }
+purrdf-gts = { path = "crates/gts", version = "0.4.0" }
+purrdf-iri = { path = "crates/iri", version = "0.4.0" }
+purrdf-rdf = { path = "crates/rdf", version = "0.4.0" }
+purrdf-shapes = { path = "crates/shapes", version = "0.4.0" }
+purrdf-shex = { path = "crates/shex", version = "0.4.0" }
+purrdf-slice = { path = "crates/slice", version = "0.4.0" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.4.0" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.4.0" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "0.4.0" }
+purrdf-validate = { path = "crates/validate", version = "0.4.0" }
+purrdf-xsd = { path = "crates/xsd", version = "0.4.0" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/README.md
+++ b/README.md
@@ -185,14 +185,18 @@ const nq = ds.serialize("nquads");           // directions survive the round-tri
 const reparsed = Dataset.parse(nq, "nquads");
 ```
 
-See [`crates/rdf-wasm`](./crates/rdf-wasm/) (`make wasm-pkg` builds the ESM package).
+The same browser bundle also exposes SHACL validation (`shaclValidateToSarif`,
+`shaclEntail`) and RDFC-1.0 graph identity (`Dataset.canonicalize()`,
+`Dataset.isomorphic()`). See [`crates/rdf-wasm`](./crates/rdf-wasm/)
+(`make wasm-pkg` builds the ESM package).
 
 ### C
 
 `libpurrdf` ([`crates/rdf-capi`](./crates/rdf-capi/)) exposes parse, serialize,
-pattern iteration, copy-on-write mutation, SPARQL, and GTS round-trips behind a
-panic-safe C ABI with a committed header ([`include/purrdf.h`](./crates/rdf-capi/include/purrdf.h))
-that CI checks for drift. Built with cargo-c: `make capi-build`.
+pattern iteration, copy-on-write mutation, SPARQL, SHACL validation/entailment,
+and GTS round-trips behind a panic-safe C ABI with a committed, reproducible
+header ([`include/purrdf.h`](./crates/rdf-capi/include/purrdf.h)) that CI checks
+for drift. Built with cargo-c: `make capi-build`.
 
 ## Crate map
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "0.3.3"
+version = "0.4.0"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.3.3" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.4.0" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -78,4 +78,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "0.3.3"
+version = "0.4.0"

--- a/crates/rdf-capi/README.md
+++ b/crates/rdf-capi/README.md
@@ -9,7 +9,8 @@ The **purrdf semantic C-ABI** (purrdf parcel P8): a stable,
 SemVer-disciplined `extern "C"` surface over the native `purrdf` RDF-1.2
 stack. It is the rich companion to the permissive `libgts` C-ABI — where
 `libgts` is transport/format only, **libpurrdf** exposes parse, serialize,
-pattern iteration, copy-on-write mutation, SPARQL, and GTS container round-trip.
+pattern iteration, copy-on-write mutation, SPARQL, SHACL validation/entailment,
+and GTS container round-trip.
 
 **One shared library, not two.** libpurrdf statically reuses the permissive
 `purrdf-gts` Rust crate, so a language shim links **`libpurrdf` alone** and still

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -51,7 +51,7 @@ serde_json = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.3.3" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.4.0" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.3.3" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.4.0" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.

--- a/docs/book/src/getting-started/c.md
+++ b/docs/book/src/getting-started/c.md
@@ -7,7 +7,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 `libpurrdf` is a stable, SemVer-disciplined `extern "C"` surface over the
 native PurRDF stack: parse, serialize, pattern iteration, copy-on-write
-mutation, SPARQL, and GTS container round-trips. The committed header
+mutation, SPARQL, SHACL validation/entailment, and GTS container round-trips.
+The committed, reproducible header
 [`include/purrdf.h`](https://github.com/Blackcat-Informatics/purrdf/blob/main/crates/rdf-capi/include/purrdf.h)
 **is the ABI contract** — CI fails if it drifts from the crate.
 

--- a/docs/book/src/getting-started/javascript.md
+++ b/docs/book/src/getting-started/javascript.md
@@ -15,6 +15,11 @@ is the same Rust engine compiled to `wasm32` and surfaced through an
 npm install @blackcatinformatics/purrdf
 ```
 
+Prefer to try it before installing anything? The
+[RDF-1.2 playground](https://blackcat-informatics.github.io/purrdf/playground/)
+runs this exact wasm build in your browser — parse, SPARQL, SHACL, serialize, and
+canonicalize/compare RDF-1.2 graphs client-side, with no toolchain and no server.
+
 ## First dataset
 
 Await `ready()` once before anything else — it performs the one-time async
@@ -62,7 +67,16 @@ const hello = f.directionalLiteral("مرحبا", "ar", "rtl");
 - **`Dataset`** (RDF/JS `DatasetCore`) — `Dataset.parse(input, format, base?)`,
   `serialize(format)`, `add`/`delete`/`has`/`match`/`quads`/`size`, and
   iteration (`for (const quad of dataset)`). Formats: `turtle`, `ntriples`,
-  `nquads`, `trig`, `rdfxml` (or their media types).
+  `nquads`, `trig`, `rdfxml` (or their media types); `serialize` additionally
+  accepts `jsonld`.
+- **Graph identity** — `Dataset.canonicalize()` returns the RDFC-1.0 canonical,
+  flat N-Quads for the graph; `Dataset.isomorphic(other)` decides RDF graph
+  equality under blank-node relabeling (an exact oracle backed by full RDFC-1.0
+  canonicalization).
+- **SHACL** — `shaclValidateToSarif(shapesTtl, dataNt)` validates an N-Triples
+  data graph against a Turtle shapes graph and returns a SARIF 2.1.0 report;
+  `shaclEntail(shapesTtl, dataNt)` materializes the SHACL-AF `sh:rule`
+  inferences as N-Triples.
 - **`Sink`** — a streaming consumer (`push(quad)` / `finish() → Dataset`);
   `datasetToStream` / `streamToDataset` are the async RDF/JS Stream/Sink
   helpers.


### PR DESCRIPTION
Closes #72

## Summary
Cut the PurRDF suite **0.4.0** release (from 0.3.3; 37 commits on `main` since `rust-v0.3.3`).

## Changes
- **Version bump** (`e681188`): single-sourced 0.3.3→0.4.0 via `scripts/set-version.py` across all locations (workspace.package, workspace.dependencies pins, renamed-dep pins, `rdf-capi` capi metadata, pyproject.toml, package.json, uv.lock) + `cargo update --workspace` for Cargo.lock. `scripts/check-versions.py` exit 0 ("version 0.4.0 coherent across crates.io/PyPI/npm; release lane publishes all 16 publishable crates").
- **Changelog** (`818f9e6`): added the `## [0.4.0]` section (sh:not soundness fix, docs uplift, C-ABI header reproducibility gate, wasm size-budget gate, RDF-1.2 playground). Hand-stamped to git-cliff's grouping because the `ghprsq` structured squash-merge topology makes cliff duplicate squash subjects with their unsquashed children; historical sections left byte-identical.
- **Docs** (`c92e6b1`): reconciled README + book + rdf-capi README with the shipped surface — browser wasm SHACL + RDFC-1.0 canonicalize/isomorphic exports, C-ABI SHACL validate/entail with a reproducible `purrdf.h`, and the playground link. Conformance matrix already current (`make conformance` GREEN, drift-clean).

This release ships the #73 `sh:not` JSON-Schema soundness fix to crates.io (`purrdf-shapes`).

## Note
The full `make check` gate was not run in stage 1 (skipped per maintainer request); it must be confirmed green on `main` before the irreversible `make release-tags VERSION=0.4.0` tag-cut.
