### PR TITLE
fix(shapes): project external object-class values to a node-ref, not a string, in JSON Schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "purrdf-entail",
  "purrdf-events",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "purrdf-core",
@@ -1297,11 +1297,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "purrdf-gts"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes-gcm",
  "blake3",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ahash",
  "ciborium",
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "boon",
  "criterion",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "hex",
  "insta",
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "insta",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "insta",
  "pretty_assertions",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pretty_assertions",
  "purrdf",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -43,21 +43,21 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "0.4.0" }
-purrdf-core = { path = "crates/rdf-core", version = "0.4.0" }
-purrdf-entail = { path = "crates/entail", version = "0.4.0" }
-purrdf-events = { path = "crates/rdf-events", version = "0.4.0" }
-purrdf-gts = { path = "crates/gts", version = "0.4.0" }
-purrdf-iri = { path = "crates/iri", version = "0.4.0" }
-purrdf-rdf = { path = "crates/rdf", version = "0.4.0" }
-purrdf-shapes = { path = "crates/shapes", version = "0.4.0" }
-purrdf-shex = { path = "crates/shex", version = "0.4.0" }
-purrdf-slice = { path = "crates/slice", version = "0.4.0" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.4.0" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.4.0" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "0.4.0" }
-purrdf-validate = { path = "crates/validate", version = "0.4.0" }
-purrdf-xsd = { path = "crates/xsd", version = "0.4.0" }
+purrdf = { path = "crates/purrdf", version = "0.4.1" }
+purrdf-core = { path = "crates/rdf-core", version = "0.4.1" }
+purrdf-entail = { path = "crates/entail", version = "0.4.1" }
+purrdf-events = { path = "crates/rdf-events", version = "0.4.1" }
+purrdf-gts = { path = "crates/gts", version = "0.4.1" }
+purrdf-iri = { path = "crates/iri", version = "0.4.1" }
+purrdf-rdf = { path = "crates/rdf", version = "0.4.1" }
+purrdf-shapes = { path = "crates/shapes", version = "0.4.1" }
+purrdf-shex = { path = "crates/shex", version = "0.4.1" }
+purrdf-slice = { path = "crates/slice", version = "0.4.1" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.4.1" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.4.1" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "0.4.1" }
+purrdf-validate = { path = "crates/validate", version = "0.4.1" }
+purrdf-xsd = { path = "crates/xsd", version = "0.4.1" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "0.4.0"
+version = "0.4.1"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.4.0" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.4.1" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -78,4 +78,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "0.4.0"
+version = "0.4.1"

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -51,7 +51,7 @@ serde_json = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.4.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.4.1" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -1028,10 +1028,19 @@ fn compile_property(
                         alts.push(node_ref);
                     }
                 } else {
-                    alts.push(json!({
-                        "type": "string",
-                        "$comment": format!("external class {}", c.as_str())
-                    }));
+                    // External (non-primary) class: the value is an RDF node
+                    // reference, never a string literal. A `$ref` would dangle
+                    // (external classes have no `$def`), so emit the permissive
+                    // node-reference form that accepts an `@id` object, keeping a
+                    // `$comment` noting the external class.
+                    let mut node_ref = node_ref_schema();
+                    if let Value::Object(map) = &mut node_ref {
+                        map.insert(
+                            "$comment".to_owned(),
+                            json!(format!("external class {}", c.as_str())),
+                        );
+                    }
+                    alts.push(node_ref);
                 }
             }
             Constraint::NodeKind(nk) => match nk {
@@ -1591,6 +1600,91 @@ mod tests {
         );
         // The property key compacts through the declared prefix.
         assert!(def(&schema, "Cat")["properties"]["gmeow:name"].is_object());
+    }
+
+    #[test]
+    fn external_object_class_projects_to_node_ref_not_string() {
+        // Soundness: a value constrained by `sh:class` to an EXTERNAL (non-primary)
+        // class is always an RDF node reference (`@id`), never a string literal.
+        // The old projection emitted `{"type":"string"}`, which REJECTS valid
+        // `{"@id":..}` instance data. It must project to a permissive node ref
+        // (no dangling `$ref`, since external classes have no `$def`) while a
+        // genuine `xsd:string` datatype value keeps its string projection.
+        let schema = schema_of(&compile_ttl(
+            r"
+            @prefix math: <https://blackcatinformatics.ca/math/> .
+            meta:BasisShape a sh:NodeShape ;
+                sh:targetClass meta:BasisHolder ;
+                sh:property [ sh:path meta:basis ; sh:maxCount 1 ; sh:class math:Basis ] ;
+                sh:property [ sh:path meta:label ; sh:maxCount 1 ; sh:datatype xsd:string ] .
+        ",
+        ));
+        let basis = &def(&schema, "BasisHolder")["properties"]["meta:basis"];
+        // NOT the unsound string projection.
+        assert_ne!(
+            basis["type"],
+            json!("string"),
+            "external object class must NOT project to a string: {basis}"
+        );
+        // A permissive node reference: an object requiring `@id`.
+        assert_eq!(
+            basis["type"],
+            json!("object"),
+            "external object class projects to a node-ref object: {basis}"
+        );
+        assert!(
+            basis["properties"]["@id"].is_object(),
+            "node ref carries an @id property: {basis}"
+        );
+        assert!(
+            basis["required"]
+                .as_array()
+                .is_some_and(|r| r.iter().any(|v| v == "@id")),
+            "node ref requires @id: {basis}"
+        );
+        // The external-class provenance comment is preserved.
+        assert!(
+            basis["$comment"]
+                .as_str()
+                .is_some_and(|s| s.contains("external class")),
+            "external-class comment preserved: {basis}"
+        );
+        // No dangling $ref to a nonexistent external $def.
+        assert!(
+            basis["$ref"].is_null(),
+            "external class must NOT emit a dangling $ref: {basis}"
+        );
+
+        // Production surface: the value schema ACCEPTS an @id object and REJECTS a
+        // bare string, verified with a trusted draft-2020-12 validator.
+        let basis_json = serde_json::to_string(basis).expect("value schema serializes");
+        assert!(
+            validates(
+                &basis_json,
+                &json!({ "@id": "https://blackcatinformatics.ca/x" })
+            ),
+            "external object class must accept an @id node reference"
+        );
+        assert!(
+            !validates(&basis_json, &json!("https://blackcatinformatics.ca/x")),
+            "external object class must reject a bare string literal"
+        );
+
+        // Guard against over-correction: a genuine xsd:string datatype value still
+        // projects to a string (a bare-scalar string alternative), and the value
+        // schema still accepts a plain string literal.
+        let label = &def(&schema, "BasisHolder")["properties"]["meta:label"];
+        assert!(
+            label["anyOf"]
+                .as_array()
+                .is_some_and(|alts| alts.iter().any(|a| a["type"] == json!("string"))),
+            "datatype xsd:string still projects to a string alternative: {label}"
+        );
+        let label_json = serde_json::to_string(label).expect("value schema serializes");
+        assert!(
+            validates(&label_json, &json!("hello")),
+            "datatype xsd:string must still accept a bare string literal"
+        );
     }
 
     #[test]

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.4.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.4.1" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.


### PR DESCRIPTION
## Summary

Fixes a **JSON-Schema projection soundness bug** in the SHACL→JSON-Schema deriver (`crates/shapes/src/json_schema.rs`).

An object-property value whose `sh:class` is in a **non-primary (external) namespace** was projected as `{"type":"string"}` (with a `$comment: external class <IRI>`). That is unsound: the value of such a property is always an RDF node reference (an `@id`), never a string literal, so the projected schema **rejected valid `{"@id":..}` instance data**.

Concretely, a shape `sh:path P ; sh:class <https://blackcatinformatics.ca/math/Basis>` (where `math:` is not the primary namespace) emitted `"P": {"type":"string"}`, which rejects `{"@id":"..."}`.

## Fix

In the external (non-primary) `Constraint::Class` branch, an object-class value now projects to the **permissive node-reference** (`node_ref_schema()` — the same one the primary case uses as its non-`$ref` alternative), which accepts an `@id` object. The `$comment` noting the external class is preserved. No `$ref` to `#/$defs/<external>` is emitted (external classes have no `$def`, so it would dangle).

**Before**
```rust
} else {
    alts.push(json!({
        "type": "string",
        "$comment": format!("external class {}", c.as_str())
    }));
}
```

**After**
```rust
} else {
    // External (non-primary) class: the value is an RDF node
    // reference, never a string literal. A `$ref` would dangle
    // (external classes have no `$def`), so emit the permissive
    // node-reference form that accepts an `@id` object, keeping a
    // `$comment` noting the external class.
    let mut node_ref = node_ref_schema();
    if let Value::Object(map) = &mut node_ref {
        map.insert(
            "$comment".to_owned(),
            json!(format!("external class {}", c.as_str())),
        );
    }
    alts.push(node_ref);
}
```

### Preserved behavior
- Primary-class values still get `node_ref` + `$ref` to `#/$defs/<name>`.
- Datatype-constrained values (`sh:datatype xsd:string`, numeric, etc.) still project to their correct JSON type — a genuine `xsd:string` value stays a string. Only the external object-class path changes.
- The `sh:nodeKind sh:IRI` / `sh:BlankNodeOrIRI` path already used `node_ref_schema()` and is unchanged.

## Test

Adds `external_object_class_projects_to_node_ref_not_string`: compiles a shape with an external `sh:class` (`https://blackcatinformatics.ca/math/Basis`, primary ns `https://example.org/meta/`) and asserts the value schema is a node-ref that **accepts an `@id` object and rejects a bare string** (verified with the trusted `boon` draft-2020-12 validator), while a sibling `sh:datatype xsd:string` property still accepts a string (guard against over-correction).

## Version bump

Workspace version `0.4.0` → `0.4.1`, single-sourced via `scripts/set-version.py` (all path-dep pins + lockfiles); `scripts/check-versions.py` exit 0.

## Verification
- `cargo build -p purrdf-shapes` green
- `cargo test -p purrdf-shapes` green (360 lib tests + doctests)
- `cargo fmt` + `cargo clippy -p purrdf-shapes` clean

Does not merge or publish — the maintainer merges and cuts the release separately.