### PR TITLE
Add semantic RDF visualization exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,6 +1363,7 @@ dependencies = [
  "purrdf-xsd",
  "rayon",
  "roxmltree",
+ "serde",
  "serde_json",
  "serde_yaml_ng",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,6 +1501,7 @@ dependencies = [
  "purrdf-sparql-eval",
  "purrdf-sparql-results",
  "purrdf-validate",
+ "serde_json",
  "wasm-bindgen",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,12 @@ BINARYEN_VERSION := 130
 # HARD size ceiling (bytes) for the optimized npm artifact
 # crates/rdf-wasm/js/pkg/purrdf_wasm_bg.wasm (release +simd128 build, wasm-opt
 # -Oz). `make wasm-pkg-size` (and both CI and the npm release) fail if the built
-# artifact exceeds this. 3 MiB = 3145728; the measured baseline is 2_989_759
-# bytes, so this is ~5% headroom. The artifact's size is a joint function of
-# rustc (tracks stable), wasm-bindgen (pinned in Cargo.toml), and binaryen
-# (pinned via BINARYEN_VERSION), so a moved number is attributable.
+# artifact exceeds this. The current semantic-visualization wasm artifact measures
+# 3_289_152 bytes on rustc 1.96.1 / wasm-bindgen 0.2.125 / binaryen 130; this
+# ceiling leaves ~5% headroom for the new first-class visualization model/export/SVG
+# API. The artifact's size is a joint function of rustc (tracks stable),
+# wasm-bindgen (pinned in Cargo.toml), and binaryen (pinned via BINARYEN_VERSION),
+# so a moved number is attributable.
 #
 # TO RAISE DELIBERATELY: rebuild `make wasm-pkg`, read the size printed by
 # `make wasm-pkg-size`, and set this to that size rounded up with a few percent
@@ -34,7 +36,7 @@ BINARYEN_VERSION := 130
 # artifact grew: a new capability or dependency, or a routine rustc-stable /
 # binaryen bump (a valid, must-be-explained reason). Never raise it merely to
 # turn a red gate green.
-WASM_SIZE_BUDGET_BYTES := 3145728
+WASM_SIZE_BUDGET_BYTES := 3456000
 
 help: ## Show this help.
 	@grep -E '^[a-zA-Z_-]+:.*## ' $(MAKEFILE_LIST) | awk -F':.*## ' '{printf "  %-18s %s\n", $$1, $$2}'

--- a/crates/purrdf/src/lib.rs
+++ b/crates/purrdf/src/lib.rs
@@ -19,6 +19,7 @@
 //! | [`entail`] | [`purrdf_entail`] (RDFS / OWL-RL / OWL-Direct / RIF entailment) |
 //! | [`validate`](mod@validate) | [`purrdf_validate`] (SARIF 2.1.0 reporting boundary) |
 //! | [`slice`](mod@slice) | [`purrdf_slice`] |
+//! | [`viz`] | [`purrdf_rdf::viz`] |
 //! | [`xsd`] | [`purrdf_xsd`] |
 //! | [`iri`] | [`purrdf_iri`] |
 //! | [`events`] | [`purrdf_events`] |
@@ -120,6 +121,11 @@ pub mod events {
 /// Native slice catalog and dataset-wrapper support.
 pub mod slice {
     pub use purrdf_slice::*;
+}
+
+/// Statement-centric RDF 1.2 visualization projection and SVG export support.
+pub mod viz {
+    pub use purrdf_rdf::viz::*;
 }
 
 /// SHACL shape support.

--- a/crates/rdf-wasm/Cargo.toml
+++ b/crates/rdf-wasm/Cargo.toml
@@ -58,6 +58,9 @@ purrdf-validate = { workspace = true }
 # bindings must match the library version byte-for-byte or it refuses to run.
 # `make wasm-pkg` and the CI Node lane install `wasm-bindgen-cli@0.2.125` to match.
 wasm-bindgen = { workspace = true }
+# JSON option parsing for the wasm visualization methods. `serde_json` is already
+# in the engine dependency tree; the direct edge documents this crate's API use.
+serde_json = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/rdf-wasm/README.md
+++ b/crates/rdf-wasm/README.md
@@ -48,6 +48,9 @@ ds.add(f.quad(f.namedNode("https://ex/stmt"), f.namedNode("https://ex/asserts"),
 // Quoted triples + directions survive a round-trip through N-Quads.
 const nq = ds.serialize("nquads");
 const reparsed = Dataset.parse(nq, "nquads");
+
+const model = reparsed.visualModel({ mode: "compact", maxStatements: 500 });
+const svg = reparsed.visualSvg({ mode: "compact", width: 960 });
 ```
 
 ## API
@@ -63,6 +66,10 @@ const reparsed = Dataset.parse(nq, "nquads");
 - **Graph identity** — `Dataset.canonicalize()` returns the RDFC-1.0 canonical, flat
   N-Quads for the graph; `Dataset.isomorphic(other)` decides RDF graph equality under
   blank-node relabeling (an exact oracle backed by full RDFC-1.0 canonicalization).
+- **Visualization** — `Dataset.visualModel(options?)`, `Dataset.visualExport(options?)`,
+  and `Dataset.visualSvg(options?)` expose the same statement-centric projection as
+  the Rust crate. SVG output is deterministic and embeds the versioned
+  `purrdf-viz-export-1` metadata model it was rendered from.
 - **SHACL** — `shaclValidateToSarif(shapesTtl, dataNt)` validates an N-Triples data
   graph against a Turtle shapes graph and returns a SARIF 2.1.0 report;
   `shaclEntail(shapesTtl, dataNt)` materializes the SHACL-AF `sh:rule` inferences as

--- a/crates/rdf-wasm/js/README.md
+++ b/crates/rdf-wasm/js/README.md
@@ -74,6 +74,11 @@ const names = engine.select(
   "SELECT ?message WHERE { <https://ex/s> <https://ex/says> ?message }",
 );
 console.log(names.rows[0].message.value);
+
+// Renderer-neutral RDF 1.2 visualization data and deterministic SVG.
+const model = reparsed.visualModel({ mode: "compact", maxStatements: 500 });
+const svg = reparsed.visualSvg({ mode: "compact", width: 960 });
+console.log(model.statements.length, svg.includes("purrdf-viz-export"));
 ```
 
 ## API surface
@@ -87,6 +92,11 @@ console.log(names.rows[0].message.value);
   Formats: `turtle`, `ntriples`, `nquads`, `trig`, `rdfxml` (`serialize` also `jsonld`).
 - `Dataset.canonicalize()` / `Dataset.isomorphic(other)` — RDFC-1.0 canonical N-Quads
   and RDF graph-identity (isomorphism under blank-node relabeling).
+- `Dataset.visualModel(options?)`, `Dataset.visualExport(options?)`, and
+  `Dataset.visualSvg(options?)` — RDF 1.2 statement-centric visualization:
+  asserted triples stay distinct from quoted-only triple terms, reifiers and
+  annotations keep their own identities and graph contexts, and SVG embeds the
+  versioned `purrdf-viz-export-1` JSON metadata it was rendered from.
 - `QueryEngine` — a reusable SPARQL execution context with a native plan cache,
   typed `select` / `ask` / `construct` / `describe` helpers, atomic `update`,
   and `queryRaw` serialization for SPARQL Results JSON/XML/CSV/TSV plus graph

--- a/crates/rdf-wasm/js/index.d.ts
+++ b/crates/rdf-wasm/js/index.d.ts
@@ -81,6 +81,151 @@ export interface GraphResult {
 
 export type QueryResult = SelectResult | AskResult | GraphResult;
 
+export type VizMode = "compact" | "incidence" | "table";
+export type VizDialect = "rdf12" | "symmetricRdf12" | "generalizedRdf";
+export type VizRole =
+  | "focus"
+  | "reifier"
+  | "graphName"
+  | "predicate"
+  | "quotedStatement"
+  | "assertedStatement"
+  | "annotatedStatement"
+  | { custom: string };
+
+export interface VisualOptions {
+  readonly mode?: VizMode;
+  readonly focus?: string | null;
+  readonly graph?: string | readonly string[] | null;
+  readonly maxDepth?: number;
+  readonly maxStatements?: number;
+  readonly maxTerms?: number;
+  readonly width?: number;
+  readonly margin?: number;
+  readonly rowHeight?: number;
+  readonly embedMetadata?: boolean;
+  readonly includeStyles?: boolean;
+  readonly spec?: Record<string, unknown>;
+  readonly svg?: Record<string, unknown>;
+}
+
+export type VizValueRef =
+  | { readonly kind: "term"; readonly id: string }
+  | { readonly kind: "statement"; readonly id: string };
+
+export type VizTermValue =
+  | { readonly kind: "iri"; readonly value: string }
+  | { readonly kind: "blank"; readonly label: string; readonly scope: number }
+  | {
+      readonly kind: "literal";
+      readonly lexical_form: string;
+      readonly datatype: string;
+      readonly language: string | null;
+      readonly direction: LiteralDirection | null;
+    };
+
+export interface VizTerm {
+  readonly id: string;
+  readonly value: VizTermValue;
+  readonly label: string;
+  readonly roles: VizRole[];
+}
+
+export interface VizStatement {
+  readonly id: string;
+  readonly subject: VizValueRef;
+  readonly predicate: string;
+  readonly object: VizValueRef;
+  readonly asserted_in: string[];
+  readonly nesting_depth: number;
+  readonly incoming_references: number;
+  readonly dialect: VizDialect;
+  readonly roles: VizRole[];
+}
+
+export interface VizAssertion {
+  readonly id: string;
+  readonly statement: string;
+  readonly graph: string;
+}
+
+export type VizRelation =
+  | {
+      readonly kind: "reifies";
+      readonly id: string;
+      readonly reifier: string;
+      readonly statement: string;
+      readonly graph: string;
+    }
+  | {
+      readonly kind: "annotation";
+      readonly id: string;
+      readonly reifier: string;
+      readonly predicate: string;
+      readonly object: VizValueRef;
+      readonly graph: string;
+    };
+
+export interface VizGraph {
+  readonly id: string;
+  readonly term: string | null;
+  readonly label: string;
+}
+
+export interface VizReference {
+  readonly id: string;
+  readonly statement: string;
+  readonly source: string;
+}
+
+export interface VizTableRow {
+  readonly statement: string;
+  readonly asserted_in: string[];
+  readonly reifier_count: number;
+  readonly annotation_count: number;
+  readonly referenced_by: number;
+  readonly depth: number;
+}
+
+export interface VizDiagnostic {
+  readonly code: string;
+  readonly message: string;
+  readonly target: string | null;
+  readonly dialect: VizDialect;
+}
+
+export interface VizModel {
+  readonly terms: VizTerm[];
+  readonly statements: VizStatement[];
+  readonly assertions: VizAssertion[];
+  readonly relations: VizRelation[];
+  readonly graphs: VizGraph[];
+  readonly references: VizReference[];
+  readonly table: VizTableRow[];
+  readonly diagnostics: VizDiagnostic[];
+}
+
+export interface VizLayoutRecord {
+  readonly id: string;
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface VizElementIndexEntry {
+  readonly element_id: string;
+  readonly model_id: string;
+  readonly kind: string;
+}
+
+export interface VizExport {
+  readonly schema_version: "purrdf-viz-export-1";
+  readonly spec_hash: string;
+  readonly model: VizModel;
+  readonly layout: VizLayoutRecord[];
+  readonly element_index: VizElementIndexEntry[];
+  readonly diagnostics: VizDiagnostic[];
+}
+
 export class Term {
   private constructor();
   free(): void;
@@ -205,6 +350,11 @@ export class Dataset implements Iterable<Quad> {
   query(sparql: string, base?: string | null): string;
   canonicalize(): string;
   isomorphic(other: Dataset): boolean;
+  visualModel(options?: VisualOptions | string | null): VizModel;
+  visualExport(options?: VisualOptions | string | null): VizExport;
+  visualSvg(options?: VisualOptions | string | null): string;
+  visualModelJson(optionsJson?: string | null): string;
+  visualExportJson(optionsJson?: string | null): string;
   toStream(): AsyncIterableIterator<Quad>;
   [Symbol.iterator](): IterableIterator<Quad>;
   free(): void;

--- a/crates/rdf-wasm/js/index.mjs
+++ b/crates/rdf-wasm/js/index.mjs
@@ -60,6 +60,15 @@ function normalizeQueryOptions(options) {
   };
 }
 
+function normalizeVisualOptions(options) {
+  if (options == null) return undefined;
+  if (typeof options === "string") return options;
+  if (typeof options !== "object") {
+    throw new TypeError("visualization options must be an object when supplied");
+  }
+  return JSON.stringify(options);
+}
+
 function selectResultToObject(raw) {
   const variables = raw.variables;
   const rawRows = raw.rows;
@@ -235,6 +244,27 @@ export async function ready(wasmBytesOrUrl) {
       return wasmQueryRaw.call(this, dataset, sparql, base, format);
     };
     QueryEngine.prototype.__purrdfPackageRootApi = true;
+  }
+
+  if (!Dataset.prototype.__purrdfVisualApi) {
+    const wasmVisualModelJson = Dataset.prototype.visualModelJson;
+    const wasmVisualExportJson = Dataset.prototype.visualExportJson;
+    const wasmVisualSvg = Dataset.prototype.visualSvg;
+
+    Dataset.prototype.visualModel = function (options) {
+      return JSON.parse(
+        wasmVisualModelJson.call(this, normalizeVisualOptions(options)),
+      );
+    };
+    Dataset.prototype.visualExport = function (options) {
+      return JSON.parse(
+        wasmVisualExportJson.call(this, normalizeVisualOptions(options)),
+      );
+    };
+    Dataset.prototype.visualSvg = function (options) {
+      return wasmVisualSvg.call(this, normalizeVisualOptions(options));
+    };
+    Dataset.prototype.__purrdfVisualApi = true;
   }
 
   _ready = true;

--- a/crates/rdf-wasm/js/tests/ergonomics.test.mjs
+++ b/crates/rdf-wasm/js/tests/ergonomics.test.mjs
@@ -59,3 +59,31 @@ test("Dataset#toStream is the instance form of datasetToStream", async () => {
   assert.equal(streamed.length, 1);
   assert.equal(streamed[0].equals(q), true);
 });
+
+test("Dataset visual APIs expose RDF 1.2 statement metadata and SVG", () => {
+  const f = new DataFactory();
+  const rdfReifies = f.namedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies");
+  const claim = f.namedNode("https://e/claim");
+  const quoted = f.quotedTriple(
+    f.namedNode("https://e/alice"),
+    f.namedNode("https://e/knows"),
+    f.namedNode("https://e/bob"),
+  );
+  const ds = new Dataset();
+  ds.add(f.quad(claim, rdfReifies, quoted));
+
+  const model = ds.visualModel({ mode: "compact", maxStatements: 10 });
+  assert.equal(model.statements.length, 1);
+  assert.equal(model.statements[0].asserted_in.length, 0);
+  assert.equal(model.relations[0].kind, "reifies");
+
+  const exported = ds.visualExport({ mode: "compact", width: 720 });
+  assert.equal(exported.schema_version, "purrdf-viz-export-1");
+  assert.ok(exported.layout.length > 0);
+  assert.ok(exported.element_index.some((entry) => entry.kind === "statement"));
+
+  const svg = ds.visualSvg({ mode: "compact", width: 720 });
+  assert.match(svg, /<metadata id="purrdf-viz-export"/);
+  assert.match(svg, /class="viz-quoted"/);
+  assert.doesNotMatch(svg, /class="viz-assertion"/);
+});

--- a/crates/rdf-wasm/js/tests/types/package-root.types.ts
+++ b/crates/rdf-wasm/js/tests/types/package-root.types.ts
@@ -13,6 +13,9 @@ import {
   type QueryResult,
   type SelectResult,
   type RdfTerm,
+  type VisualOptions,
+  type VizExport,
+  type VizModel,
 } from "@blackcatinformatics/purrdf";
 
 await ready();
@@ -48,6 +51,11 @@ const stream: AsyncIterableIterator<Quad> = matched.toStream();
 const serialized: string = matched.serialize("nquads");
 const canonical: string = matched.canonicalize();
 const same: boolean = matched.isomorphic(Dataset.parse(serialized, "nquads"));
+const visualOptions: VisualOptions = { mode: "compact", maxStatements: 500, width: 960 };
+const visualModel: VizModel = matched.visualModel(visualOptions);
+const visualExport: VizExport = matched.visualExport(visualOptions);
+const visualSvg: string = matched.visualSvg(visualOptions);
+const visualModelJson: string = matched.visualModelJson(JSON.stringify(visualOptions));
 const queryJson: string = matched.query("ASK { ?s ?p ?o }");
 const engine = new QueryEngine();
 const select: SelectResult = engine.select(matched, "SELECT ?s WHERE { ?s ?p ?o }");
@@ -76,6 +84,10 @@ if (result.kind === "ask") {
 void stream;
 void canonical;
 void same;
+void visualModel;
+void visualExport;
+void visualSvg;
+void visualModelJson;
 void queryJson;
 void language;
 void maybeTerm;

--- a/crates/rdf-wasm/src/dataset.rs
+++ b/crates/rdf-wasm/src/dataset.rs
@@ -12,10 +12,15 @@
 
 use purrdf::dataset_view::{DatasetMut, GraphMatchValue};
 use purrdf::ir::MutableDataset;
+use purrdf::viz::{
+    VizGraphPolicy, VizMode, VizSpec, VizSvgOptions, project_dataset_export, project_dataset_json,
+    render_dataset_svg,
+};
 use purrdf::{
     RdfDatasetBuilder, RdfDiagnostic, SerializeGraph, TermValue, canonical_flat_nquads,
     datasets_isomorphic, parse_dataset, serialize_dataset,
 };
+use serde_json::Value;
 use wasm_bindgen::prelude::*;
 
 use crate::codec::resolve_media_type;
@@ -41,6 +46,125 @@ fn pattern_value(term: Option<&Term>) -> Result<Option<TermValue>, JsError> {
 /// Map an engine diagnostic to a JS error.
 pub(crate) fn diag_to_err(diag: &RdfDiagnostic) -> JsError {
     JsError::new(&diag.to_string())
+}
+
+fn viz_to_err(err: &purrdf::viz::VizError) -> JsError {
+    JsError::new(&err.to_string())
+}
+
+fn parse_visual_options(options_json: Option<String>) -> Result<(VizSpec, VizSvgOptions), JsError> {
+    let mut spec = VizSpec::default();
+    let mut svg = VizSvgOptions::default();
+    let Some(raw) = options_json else {
+        return Ok((spec, svg));
+    };
+    if raw.trim().is_empty() {
+        return Ok((spec, svg));
+    }
+    let value: Value = serde_json::from_str(&raw)
+        .map_err(|e| JsError::new(&format!("visualization options must be JSON: {e}")))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| JsError::new("visualization options must be a JSON object"))?;
+
+    if let Some(nested_spec) = object.get("spec") {
+        spec = serde_json::from_value(nested_spec.clone())
+            .map_err(|e| JsError::new(&format!("invalid visualization spec: {e}")))?;
+    }
+    if let Some(nested_svg) = object.get("svg") {
+        svg = serde_json::from_value(nested_svg.clone())
+            .map_err(|e| JsError::new(&format!("invalid SVG visualization options: {e}")))?;
+    }
+    if let Some(mode) = object.get("mode") {
+        spec.mode = parse_viz_mode(mode)?;
+    }
+    if let Some(focus) = object.get("focus") {
+        spec.focus = parse_optional_string(focus, "focus")?;
+    }
+    if let Some(graph) = object.get("graph") {
+        spec.graph_policy = parse_graph_policy(graph)?;
+    }
+    if let Some(max_statements) = object.get("maxStatements") {
+        spec.max_statements = parse_usize(max_statements, "maxStatements")?;
+    }
+    if let Some(max_terms) = object.get("maxTerms") {
+        spec.max_terms = parse_usize(max_terms, "maxTerms")?;
+    }
+    if let Some(width) = object.get("width") {
+        svg.width = parse_i32(width, "width")?;
+    }
+    if let Some(margin) = object.get("margin") {
+        svg.margin = parse_i32(margin, "margin")?;
+    }
+    if let Some(row_height) = object.get("rowHeight") {
+        svg.row_height = parse_i32(row_height, "rowHeight")?;
+    }
+    if let Some(embed_metadata) = object.get("embedMetadata") {
+        svg.embed_metadata = parse_bool(embed_metadata, "embedMetadata")?;
+    }
+    if let Some(include_styles) = object.get("includeStyles") {
+        svg.include_styles = parse_bool(include_styles, "includeStyles")?;
+    }
+    Ok((spec, svg))
+}
+
+fn parse_viz_mode(value: &Value) -> Result<VizMode, JsError> {
+    serde_json::from_value(value.clone())
+        .map_err(|e| JsError::new(&format!("invalid visualization mode: {e}")))
+}
+
+fn parse_optional_string(value: &Value, field: &str) -> Result<Option<String>, JsError> {
+    if value.is_null() {
+        return Ok(None);
+    }
+    value
+        .as_str()
+        .map(|s| Some(s.to_owned()))
+        .ok_or_else(|| JsError::new(&format!("{field} must be a string or null")))
+}
+
+fn parse_graph_policy(value: &Value) -> Result<VizGraphPolicy, JsError> {
+    if value.is_null() {
+        return Ok(VizGraphPolicy::All);
+    }
+    if let Some(graph) = value.as_str() {
+        return Ok(VizGraphPolicy::Include(vec![graph.to_owned()]));
+    }
+    let Some(items) = value.as_array() else {
+        return Err(JsError::new(
+            "graph must be null, a string, or a string array",
+        ));
+    };
+    let mut graphs = Vec::with_capacity(items.len());
+    for item in items {
+        let graph = item
+            .as_str()
+            .ok_or_else(|| JsError::new("graph array entries must be strings"))?;
+        graphs.push(graph.to_owned());
+    }
+    Ok(VizGraphPolicy::Include(graphs))
+}
+
+fn parse_usize(value: &Value, field: &str) -> Result<usize, JsError> {
+    let Some(number) = value.as_u64() else {
+        return Err(JsError::new(&format!(
+            "{field} must be a non-negative integer"
+        )));
+    };
+    usize::try_from(number).map_err(|_| JsError::new(&format!("{field} is too large")))
+}
+
+fn parse_i32(value: &Value, field: &str) -> Result<i32, JsError> {
+    let Some(number) = value.as_i64() else {
+        return Err(JsError::new(&format!("{field} must be an integer")));
+    };
+    i32::try_from(number).map_err(|_| JsError::new(&format!("{field} is out of range")))
+}
+
+fn parse_bool(value: &Value, field: &str) -> Result<bool, JsError> {
+    value
+        .as_bool()
+        .ok_or_else(|| JsError::new(&format!("{field} must be a boolean")))
 }
 
 /// An RDF/JS `DatasetCore` backed by the engine's COW mutable dataset.
@@ -135,6 +259,42 @@ impl Dataset {
         let a = self.inner.freeze().map_err(|e| diag_to_err(&e))?;
         let b = other.inner.freeze().map_err(|e| diag_to_err(&e))?;
         Ok(datasets_isomorphic(&a, &b))
+    }
+
+    /// `visualModelJson(optionsJson?)` → a deterministic JSON visualization model.
+    ///
+    /// The package-root JS wrapper exposes this as `visualModel(options?)` and parses
+    /// the returned JSON into a structured-clone-safe object.
+    #[wasm_bindgen(js_name = visualModelJson)]
+    #[allow(clippy::needless_pass_by_value)] // binding ABI receives owned values
+    pub fn visual_model_json(&self, options_json: Option<String>) -> Result<String, JsError> {
+        let (spec, _) = parse_visual_options(options_json)?;
+        let frozen = self.inner.freeze().map_err(|e| diag_to_err(&e))?;
+        project_dataset_json(&frozen, &spec).map_err(|err| viz_to_err(&err))
+    }
+
+    /// `visualExportJson(optionsJson?)` → a versioned JSON export with model + layout.
+    ///
+    /// The export is the same load-bearing metadata embedded by `visualSvg`.
+    #[wasm_bindgen(js_name = visualExportJson)]
+    #[allow(clippy::needless_pass_by_value)] // binding ABI receives owned values
+    pub fn visual_export_json(&self, options_json: Option<String>) -> Result<String, JsError> {
+        let (spec, svg_options) = parse_visual_options(options_json)?;
+        let frozen = self.inner.freeze().map_err(|e| diag_to_err(&e))?;
+        let export =
+            project_dataset_export(&frozen, &spec, &svg_options).map_err(|err| viz_to_err(&err))?;
+        serde_json::to_string(&export).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// `visualSvg(optionsJson?)` → deterministic semantic SVG with embedded metadata.
+    #[wasm_bindgen(js_name = visualSvg)]
+    #[allow(clippy::needless_pass_by_value)] // binding ABI receives owned values
+    pub fn visual_svg(&self, options_json: Option<String>) -> Result<String, JsError> {
+        let (spec, svg_options) = parse_visual_options(options_json)?;
+        let frozen = self.inner.freeze().map_err(|e| diag_to_err(&e))?;
+        let document =
+            render_dataset_svg(&frozen, &spec, &svg_options).map_err(|err| viz_to_err(&err))?;
+        Ok(document.svg)
     }
 
     /// `size` — the number of effective quads.
@@ -470,6 +630,38 @@ mod tests {
             !ds.has(&query).unwrap(),
             "a directional literal must NOT match a plain langString literal (RDF-1.2 distinguishes them)"
         );
+    }
+
+    #[test]
+    fn visual_model_export_and_svg_surface_statement_metadata() {
+        let factory = crate::factory::DataFactory::new();
+        let rdf_reifies =
+            factory.named_node("http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies".to_owned());
+        let claim = factory.named_node("https://e/claim".to_owned());
+        let quoted = factory
+            .quoted_triple(
+                &named("https://e/alice"),
+                &named("https://e/knows"),
+                &named("https://e/bob"),
+            )
+            .unwrap();
+        let reifies = factory.quad(&claim, &rdf_reifies, &quoted, None);
+        let mut ds = Dataset::new().unwrap();
+        ds.add(&reifies).unwrap();
+
+        let options = Some(r#"{"mode":"compact","maxStatements":10,"width":720}"#.to_owned());
+        let model = ds.visual_model_json(options.clone()).unwrap();
+        assert!(model.contains("\"statements\""));
+        assert!(model.contains("\"asserted_in\":[]"));
+
+        let export = ds.visual_export_json(options.clone()).unwrap();
+        assert!(export.contains("\"schema_version\":\"purrdf-viz-export-1\""));
+        assert!(export.contains("\"element_index\""));
+
+        let svg = ds.visual_svg(options).unwrap();
+        assert!(svg.contains("id=\"purrdf-viz-export\""));
+        assert!(svg.contains("class=\"viz-quoted\""));
+        assert!(!svg.contains("class=\"viz-assertion\""));
     }
 
     // The unsupported-format error path builds a JsError (wasm-only); the pure

--- a/crates/rdf/Cargo.toml
+++ b/crates/rdf/Cargo.toml
@@ -44,6 +44,7 @@ purrdf-xsd = { workspace = true }
 # (`native_codecs::jsonld`). Already in the validate + pipeline trees, so
 # this adds no new tree-wide dependency.
 serde_json = { workspace = true }
+serde = { workspace = true }
 serde_yaml = { workspace = true }
 ciborium = { workspace = true }
 # Store-once interning on the native text-codec hot path (fixed-key hashing +

--- a/crates/rdf/Cargo.toml
+++ b/crates/rdf/Cargo.toml
@@ -114,3 +114,9 @@ criterion = { workspace = true }
 # out through the first-party serializer. Report-only; excluded from check.
 name = "native_codecs"
 harness = false
+
+[[bench]]
+# Statement-centric RDF 1.2 visualization projection and deterministic SVG export.
+# Report-only; excluded from check.
+name = "viz_projection"
+harness = false

--- a/crates/rdf/benches/viz_projection.rs
+++ b/crates/rdf/benches/viz_projection.rs
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Bench targets are not public API: `criterion_group!` expands to a `pub fn`,
+// which would otherwise trip the workspace `missing_docs` lint.
+#![allow(missing_docs)]
+
+//! RDF 1.2 visualization projection and deterministic SVG export benchmark.
+//!
+//! Report-only, `cargo bench -p purrdf-rdf --bench viz_projection`. The fixture
+//! exercises asserted triples, quoted-only statements, reifiers, annotations,
+//! and named graph contexts through the graph-like API used by non-IR callers.
+
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use purrdf_rdf::TermValue;
+use purrdf_rdf::viz::{
+    VizGraphInput, VizInputAnnotation, VizInputQuad, VizInputReifier, VizInputStatement, VizSpec,
+    VizSvgOptions, project_graph_input, render_graph_input_svg,
+};
+
+const ROWS: usize = 2_000;
+const EX: &str = "https://example.org/";
+
+fn iri(local: impl std::fmt::Display) -> TermValue {
+    TermValue::Iri(format!("{EX}{local}"))
+}
+
+fn fixture(rows: usize) -> VizGraphInput {
+    let mut input = VizGraphInput::default();
+    for idx in 0..rows {
+        let subject = iri(format_args!("s{idx}"));
+        let object = iri(format_args!("o{}", idx % 256));
+        let predicate = format!("{EX}p{}", idx % 16);
+        let graph_name = Some(iri(format_args!("g{}", idx % 8)));
+        input.quads.push(VizInputQuad {
+            subject: subject.clone(),
+            predicate: predicate.clone(),
+            object: object.clone(),
+            graph_name,
+        });
+        if idx % 5 == 0 {
+            let reifier = iri(format_args!("claim{idx}"));
+            input.reifiers.push(VizInputReifier {
+                reifier: reifier.clone(),
+                statement: VizInputStatement {
+                    subject,
+                    predicate: predicate.clone(),
+                    object: object.clone(),
+                },
+                graph_name: Some(iri("claims")),
+            });
+            input.annotations.push(VizInputAnnotation {
+                reifier,
+                predicate: format!("{EX}confidence"),
+                object: TermValue::Literal {
+                    lexical_form: "0.8".to_owned(),
+                    datatype: "http://www.w3.org/2001/XMLSchema#decimal".to_owned(),
+                    language: None,
+                    direction: None,
+                },
+                graph_name: Some(iri("provenance")),
+            });
+        }
+    }
+    input
+}
+
+fn bench_projection(c: &mut Criterion) {
+    let input = fixture(ROWS);
+    let spec = VizSpec {
+        max_statements: ROWS + ROWS / 5,
+        max_terms: ROWS * 4,
+        ..VizSpec::default()
+    };
+    let mut group = c.benchmark_group("viz_projection");
+    group.throughput(Throughput::Elements(ROWS as u64));
+    group.bench_function("graph_input_2k", |bencher| {
+        bencher.iter(|| {
+            let projection =
+                project_graph_input(black_box(&input), black_box(&spec)).expect("project");
+            black_box(projection);
+        });
+    });
+    group.finish();
+}
+
+fn bench_svg_export(c: &mut Criterion) {
+    let input = fixture(ROWS);
+    let spec = VizSpec {
+        max_statements: ROWS + ROWS / 5,
+        max_terms: ROWS * 4,
+        ..VizSpec::default()
+    };
+    let options = VizSvgOptions::default();
+    let mut group = c.benchmark_group("viz_svg_export");
+    group.sample_size(10);
+    group.throughput(Throughput::Elements(ROWS as u64));
+    group.bench_function("graph_input_2k", |bencher| {
+        bencher.iter(|| {
+            let document =
+                render_graph_input_svg(black_box(&input), black_box(&spec), black_box(&options))
+                    .expect("render svg");
+            black_box(document);
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_projection, bench_svg_export);
+criterion_main!(benches);

--- a/crates/rdf/src/lib.rs
+++ b/crates/rdf/src/lib.rs
@@ -78,6 +78,8 @@ pub mod capture_support;
 // Canonical, review-friendly Turtle serializer over the IR (Task 9): the
 // native replacement for rdflib `longturtle` in `purrdf normalize`. Oxigraph-free.
 pub mod turtle_normalize;
+/// Statement-centric RDF 1.2 visualization projection and SVG export support.
+pub mod viz;
 
 // Mirror the kernel's root-level re-exports so `purrdf::RdfTerm`,
 // `purrdf::RdfDiagnostic`, … keep resolving exactly as before. The two

--- a/crates/rdf/src/viz.rs
+++ b/crates/rdf/src/viz.rs
@@ -1,0 +1,1659 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Statement-centric RDF 1.2 visualization projection.
+//!
+//! The core contract is the [`VizProjection`]: a renderer-neutral Statement
+//! Incidence Model that keeps structural statements separate from assertions,
+//! reifiers, annotations, graph context, and dialect diagnostics. Renderers use
+//! this model; they do not rediscover RDF 1.2 statement structure from flat quads.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::{self, Write as _};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{QuadRef, RdfDataset, RdfTextDirection, TermRef, TermValue};
+
+const DEFAULT_GRAPH_ID: &str = "graph:default";
+const DEFAULT_MAX_STATEMENTS: usize = 500;
+/// Visualization schema version embedded in structured exports.
+pub const VIZ_EXPORT_SCHEMA_VERSION: &str = "purrdf-viz-export-1";
+
+/// A typed term identifier within one deterministic visualization projection.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct VizTermId(pub String);
+
+/// A typed structural-statement identifier within one visualization projection.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct VizStatementId(pub String);
+
+/// A typed assertion identifier within one visualization projection.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct VizAssertionId(pub String);
+
+/// A typed relation identifier within one visualization projection.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct VizRelationId(pub String);
+
+/// A typed reference identifier within one visualization projection.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct VizReferenceId(pub String);
+
+/// A typed named-graph identifier within one visualization projection.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct VizGraphId(pub String);
+
+/// A reference to either an ordinary RDF term or a structural statement.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum VizValueRef {
+    /// A non-triple RDF term.
+    Term {
+        /// The referenced term id.
+        id: VizTermId,
+    },
+    /// An RDF 1.2 triple term represented by its structural statement id.
+    Statement {
+        /// The referenced structural statement id.
+        id: VizStatementId,
+    },
+}
+
+/// A JSON-friendly RDF term value used by visualization exports.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum VizTermValue {
+    /// An IRI term.
+    Iri {
+        /// The full IRI string.
+        value: String,
+    },
+    /// A blank node term.
+    Blank {
+        /// The blank-node label.
+        label: String,
+        /// The blank-node scope ordinal.
+        scope: u32,
+    },
+    /// A literal term, including RDF 1.2 base direction.
+    Literal {
+        /// The literal lexical form.
+        lexical_form: String,
+        /// The expanded datatype IRI.
+        datatype: String,
+        /// The language tag, when present.
+        language: Option<String>,
+        /// The RDF 1.2 base direction, when present.
+        direction: Option<VizTextDirection>,
+    },
+}
+
+/// RDF 1.2 base direction in exported visualization metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VizTextDirection {
+    /// Left-to-right base direction.
+    Ltr,
+    /// Right-to-left base direction.
+    Rtl,
+}
+
+/// Visualization role attached to a term or statement.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum VizRole {
+    /// The current focus selected by the caller.
+    Focus,
+    /// A term used as a reifier.
+    Reifier,
+    /// A term used as a graph name.
+    GraphName,
+    /// A term used as a predicate.
+    Predicate,
+    /// A statement represented by a quoted triple term.
+    QuotedStatement,
+    /// A statement represented by an assertion.
+    AssertedStatement,
+    /// A statement with explicit annotations.
+    AnnotatedStatement,
+    /// A caller-supplied role.
+    Custom(String),
+}
+
+/// RDF dialect/conformance state surfaced by the visualization projection.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum VizDialect {
+    /// Standard RDF 1.2 position.
+    Rdf12,
+    /// Symmetric RDF 1.2 position, such as a triple term in subject position.
+    SymmetricRdf12,
+    /// Generalized RDF position.
+    GeneralizedRdf,
+}
+
+/// A typed visualization diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct VizDiagnostic {
+    /// Stable machine-readable diagnostic code.
+    pub code: String,
+    /// Human-readable diagnostic message.
+    pub message: String,
+    /// Optional projection id the diagnostic refers to.
+    pub target: Option<String>,
+    /// Dialect classification for the diagnostic.
+    pub dialect: VizDialect,
+}
+
+/// A caller-supplied role rule.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct VizRoleRule {
+    /// Predicate IRI that activates this role.
+    pub predicate_iri: String,
+    /// Role to attach when the predicate is present.
+    pub role: VizRole,
+}
+
+/// A caller-supplied vocabulary mapping used by specs and labels.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct VizVocabularyMapping {
+    /// Compact prefix.
+    pub prefix: String,
+    /// IRI namespace.
+    pub namespace: String,
+}
+
+/// Graph-context filtering policy.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum VizGraphPolicy {
+    /// Include every graph context.
+    #[default]
+    All,
+    /// Include only the named/default graph ids listed here.
+    Include(Vec<String>),
+}
+
+/// Label generation policy.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum VizLabelPolicy {
+    /// Generate compact labels from term values.
+    #[default]
+    Compact,
+    /// Use full RDF term strings.
+    Full,
+}
+
+/// Visualization mode requested by a spec.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum VizMode {
+    /// Compact resource graph.
+    #[default]
+    Compact,
+    /// Exact statement/incidence graph.
+    Incidence,
+    /// Statement table/matrix rows.
+    Table,
+}
+
+/// Caller-provided semantic lens for visualization projection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VizSpec {
+    /// Requested visualization mode.
+    pub mode: VizMode,
+    /// Optional focus term or statement key.
+    pub focus: Option<String>,
+    /// Role rules keyed by caller vocabulary.
+    pub role_rules: Vec<VizRoleRule>,
+    /// Caller-provided vocabulary mappings.
+    pub vocabulary: Vec<VizVocabularyMapping>,
+    /// Graph filtering policy.
+    pub graph_policy: VizGraphPolicy,
+    /// Label policy.
+    pub label_policy: VizLabelPolicy,
+    /// Maximum structural statements accepted by this spec.
+    pub max_statements: usize,
+    /// Maximum visible terms accepted by this spec.
+    pub max_terms: usize,
+    /// Statement table fields requested by the caller.
+    pub table_fields: Vec<String>,
+}
+
+impl Default for VizSpec {
+    fn default() -> Self {
+        Self {
+            mode: VizMode::Compact,
+            focus: None,
+            role_rules: Vec::new(),
+            vocabulary: Vec::new(),
+            graph_policy: VizGraphPolicy::All,
+            label_policy: VizLabelPolicy::Compact,
+            max_statements: DEFAULT_MAX_STATEMENTS,
+            max_terms: DEFAULT_MAX_STATEMENTS * 3,
+            table_fields: vec![
+                "statement".to_owned(),
+                "assertedIn".to_owned(),
+                "reifiers".to_owned(),
+                "annotations".to_owned(),
+                "referencedBy".to_owned(),
+                "depth".to_owned(),
+            ],
+        }
+    }
+}
+
+/// A graph-like input quad for callers that do not already have an [`RdfDataset`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VizInputQuad {
+    /// Subject value.
+    pub subject: TermValue,
+    /// Predicate IRI.
+    pub predicate: String,
+    /// Object value.
+    pub object: TermValue,
+    /// Optional graph name.
+    pub graph_name: Option<TermValue>,
+}
+
+/// A graph-like reification relation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VizInputReifier {
+    /// Reifier value.
+    pub reifier: TermValue,
+    /// Reified structural statement.
+    pub statement: VizInputStatement,
+    /// Optional graph name for the reification relation.
+    pub graph_name: Option<TermValue>,
+}
+
+/// A graph-like annotation relation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VizInputAnnotation {
+    /// Reifier value.
+    pub reifier: TermValue,
+    /// Annotation predicate IRI.
+    pub predicate: String,
+    /// Annotation object.
+    pub object: TermValue,
+    /// Optional graph name for the annotation relation.
+    pub graph_name: Option<TermValue>,
+}
+
+/// A graph-like structural statement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VizInputStatement {
+    /// Subject value.
+    pub subject: TermValue,
+    /// Predicate IRI.
+    pub predicate: String,
+    /// Object value.
+    pub object: TermValue,
+}
+
+/// Graph-like visualization input for callers that do not hold an [`RdfDataset`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VizGraphInput {
+    /// Asserted quads.
+    pub quads: Vec<VizInputQuad>,
+    /// Reification relations.
+    pub reifiers: Vec<VizInputReifier>,
+    /// Annotation relations.
+    pub annotations: Vec<VizInputAnnotation>,
+}
+
+/// A projected ordinary RDF term.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VizTerm {
+    /// Deterministic term id.
+    pub id: VizTermId,
+    /// Term value.
+    pub value: VizTermValue,
+    /// Display label.
+    pub label: String,
+    /// Roles this term plays in the projection.
+    pub roles: Vec<VizRole>,
+}
+
+/// A projected RDF 1.2 structural statement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VizStatement {
+    /// Deterministic statement id.
+    pub id: VizStatementId,
+    /// Statement subject.
+    pub subject: VizValueRef,
+    /// Statement predicate.
+    pub predicate: VizTermId,
+    /// Statement object.
+    pub object: VizValueRef,
+    /// Graphs where this statement is asserted.
+    pub asserted_in: Vec<VizGraphId>,
+    /// Structural nesting depth.
+    pub nesting_depth: u32,
+    /// Number of places where this statement is referenced as a triple term.
+    pub incoming_references: u32,
+    /// Dialect/conformance classification for this statement.
+    pub dialect: VizDialect,
+    /// Roles this statement plays in the projection.
+    pub roles: Vec<VizRole>,
+}
+
+/// A concrete assertion occurrence for a structural statement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VizAssertion {
+    /// Deterministic assertion id.
+    pub id: VizAssertionId,
+    /// Asserted statement id.
+    pub statement: VizStatementId,
+    /// Assertion graph.
+    pub graph: VizGraphId,
+}
+
+/// A projected relation in the RDF 1.2 statement layer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum VizRelation {
+    /// A reifier term reifies a structural statement.
+    Reifies {
+        /// Deterministic relation id.
+        id: VizRelationId,
+        /// Reifier term.
+        reifier: VizTermId,
+        /// Reified statement.
+        statement: VizStatementId,
+        /// Relation graph context.
+        graph: VizGraphId,
+    },
+    /// An annotation is an ordinary predicate/object relation from a reifier.
+    Annotation {
+        /// Deterministic relation id.
+        id: VizRelationId,
+        /// Annotated reifier term.
+        reifier: VizTermId,
+        /// Annotation predicate term.
+        predicate: VizTermId,
+        /// Annotation object.
+        object: VizValueRef,
+        /// Relation graph context.
+        graph: VizGraphId,
+    },
+}
+
+/// A reference to a structural statement as a triple term.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VizReference {
+    /// Deterministic reference id.
+    pub id: VizReferenceId,
+    /// Referenced structural statement.
+    pub statement: VizStatementId,
+    /// Reference source category.
+    pub source: VizReferenceSource,
+}
+
+/// Source category for a structural-statement reference.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum VizReferenceSource {
+    /// Statement appears in asserted subject position.
+    AssertionSubject,
+    /// Statement appears in asserted object position.
+    AssertionObject,
+    /// Statement appears in graph-name position.
+    GraphName,
+    /// Statement is the target of a reification relation.
+    ReificationTarget,
+    /// Statement appears in an annotation object.
+    AnnotationObject,
+    /// Statement appears inside another triple term.
+    NestedStatement,
+}
+
+/// A graph context known to the visualization projection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VizGraph {
+    /// Deterministic graph id.
+    pub id: VizGraphId,
+    /// Graph term. `None` is the default graph.
+    pub term: Option<VizTermId>,
+    /// Display label.
+    pub label: String,
+}
+
+/// A statement table row derived from the projection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VizTableRow {
+    /// Statement id.
+    pub statement: VizStatementId,
+    /// Assertion graph ids.
+    pub asserted_in: Vec<VizGraphId>,
+    /// Reifier count.
+    pub reifier_count: usize,
+    /// Annotation count attached to all statement reifiers.
+    pub annotation_count: usize,
+    /// Reference count.
+    pub referenced_by: u32,
+    /// Nesting depth.
+    pub depth: u32,
+}
+
+/// The renderer-neutral Statement Incidence Model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VizProjection {
+    /// Terms in deterministic order.
+    pub terms: Vec<VizTerm>,
+    /// Structural statements in deterministic order.
+    pub statements: Vec<VizStatement>,
+    /// Assertions in deterministic order.
+    pub assertions: Vec<VizAssertion>,
+    /// Reification and annotation relations in deterministic order.
+    pub relations: Vec<VizRelation>,
+    /// Graph contexts in deterministic order.
+    pub graphs: Vec<VizGraph>,
+    /// Triple-term references in deterministic order.
+    pub references: Vec<VizReference>,
+    /// Statement table rows in deterministic order.
+    pub table: Vec<VizTableRow>,
+    /// Diagnostics in deterministic order.
+    pub diagnostics: Vec<VizDiagnostic>,
+}
+
+/// Backwards-friendly alias for the renderer-neutral visualization model.
+pub type VizModel = VizProjection;
+
+/// A versioned visualization export.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VizExport {
+    /// Export schema version.
+    pub schema_version: String,
+    /// Deterministic spec hash.
+    pub spec_hash: String,
+    /// Projected model.
+    pub model: VizProjection,
+    /// Layout records.
+    pub layout: Vec<VizLayoutRecord>,
+    /// SVG element to model-id index.
+    pub element_index: Vec<VizElementIndexEntry>,
+    /// Export diagnostics.
+    pub diagnostics: Vec<VizDiagnostic>,
+}
+
+/// Deterministic layout record for a projected entity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VizLayoutRecord {
+    /// Model id being positioned.
+    pub id: String,
+    /// Integer x coordinate in projection units.
+    pub x: i32,
+    /// Integer y coordinate in projection units.
+    pub y: i32,
+}
+
+/// SVG element to projection-id mapping.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VizElementIndexEntry {
+    /// SVG element id.
+    pub element_id: String,
+    /// Projection id.
+    pub model_id: String,
+    /// Element kind.
+    pub kind: String,
+}
+
+/// Visualization projection errors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VizError {
+    /// The requested projection exceeds explicit size limits.
+    TooLarge {
+        /// Limit name.
+        limit: &'static str,
+        /// Actual count.
+        actual: usize,
+        /// Allowed count.
+        allowed: usize,
+    },
+    /// A spec references an unknown role predicate.
+    UnknownRolePredicate(String),
+    /// A spec contains an invalid vocabulary mapping.
+    InvalidVocabulary(String),
+    /// A graph-like input contains an invalid predicate.
+    InvalidPredicate(String),
+    /// Serialization failed.
+    Serialize(String),
+}
+
+impl fmt::Display for VizError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooLarge {
+                limit,
+                actual,
+                allowed,
+            } => write!(
+                f,
+                "visualization {limit} limit exceeded: {actual} > {allowed}"
+            ),
+            Self::UnknownRolePredicate(iri) => {
+                write!(f, "visualization role predicate {iri:?} is not present")
+            }
+            Self::InvalidVocabulary(message) => f.write_str(message),
+            Self::InvalidPredicate(predicate) => {
+                write!(f, "visualization predicate {predicate:?} is not an IRI")
+            }
+            Self::Serialize(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for VizError {}
+
+/// Project a dataset into the renderer-neutral Statement Incidence Model.
+pub fn project_dataset(dataset: &RdfDataset, spec: &VizSpec) -> Result<VizProjection, VizError> {
+    let mut builder = ProjectionBuilder::new(spec);
+    builder.add_default_graph();
+    for quad in dataset.quad_refs() {
+        builder.add_dataset_quad(dataset, quad)?;
+    }
+    for (reifier, triple, graph) in dataset.reifiers_with_graph() {
+        builder.add_reifier(
+            dataset.term_value(reifier),
+            dataset.term_value(triple),
+            graph.map(|g| dataset.term_value(g)),
+        )?;
+    }
+    for (reifier, predicate, object, graph) in dataset.annotations_with_graph() {
+        let predicate_iri = match dataset.resolve(predicate) {
+            TermRef::Iri(iri) => iri.to_owned(),
+            _ => {
+                return Err(VizError::InvalidPredicate(term_key(
+                    &dataset.term_value(predicate),
+                )));
+            }
+        };
+        builder.add_annotation(
+            dataset.term_value(reifier),
+            &predicate_iri,
+            dataset.term_value(object),
+            graph.map(|g| dataset.term_value(g)),
+        )?;
+    }
+    builder.finish()
+}
+
+/// Project graph-like caller input into the renderer-neutral Statement Incidence Model.
+pub fn project_graph_input(
+    input: &VizGraphInput,
+    spec: &VizSpec,
+) -> Result<VizProjection, VizError> {
+    let mut builder = ProjectionBuilder::new(spec);
+    builder.add_default_graph();
+    for quad in &input.quads {
+        builder.add_assertion(
+            quad.subject.clone(),
+            quad.predicate.clone(),
+            quad.object.clone(),
+            quad.graph_name.clone(),
+        )?;
+    }
+    for reifier in &input.reifiers {
+        builder.add_reifier(
+            reifier.reifier.clone(),
+            TermValue::Triple {
+                s: Box::new(reifier.statement.subject.clone()),
+                p: Box::new(TermValue::Iri(reifier.statement.predicate.clone())),
+                o: Box::new(reifier.statement.object.clone()),
+            },
+            reifier.graph_name.clone(),
+        )?;
+    }
+    for annotation in &input.annotations {
+        builder.add_annotation(
+            annotation.reifier.clone(),
+            &annotation.predicate,
+            annotation.object.clone(),
+            annotation.graph_name.clone(),
+        )?;
+    }
+    builder.finish()
+}
+
+/// Project a dataset and serialize the model to deterministic JSON.
+pub fn project_dataset_json(dataset: &RdfDataset, spec: &VizSpec) -> Result<String, VizError> {
+    let projection = project_dataset(dataset, spec)?;
+    serde_json::to_string(&projection).map_err(|err| VizError::Serialize(err.to_string()))
+}
+
+#[derive(Debug, Clone)]
+struct TermDraft {
+    value: VizTermValue,
+    label: String,
+    roles: BTreeSet<VizRole>,
+}
+
+#[derive(Debug, Clone)]
+struct StatementDraft {
+    subject: VizValueRef,
+    predicate: VizTermId,
+    object: VizValueRef,
+    asserted_in: BTreeSet<VizGraphId>,
+    references: BTreeSet<VizReferenceSource>,
+    nesting_depth: u32,
+    dialect: VizDialect,
+    roles: BTreeSet<VizRole>,
+}
+
+#[derive(Debug, Clone)]
+struct AssertionDraft {
+    statement: VizStatementId,
+    graph: VizGraphId,
+}
+
+#[derive(Debug, Clone)]
+struct GraphDraft {
+    term: Option<VizTermId>,
+    label: String,
+}
+
+#[derive(Debug)]
+struct ProjectionBuilder<'a> {
+    spec: &'a VizSpec,
+    terms: BTreeMap<VizTermId, TermDraft>,
+    term_by_key: BTreeMap<String, VizTermId>,
+    statements: BTreeMap<VizStatementId, StatementDraft>,
+    statement_by_key: BTreeMap<String, VizStatementId>,
+    assertions: BTreeMap<VizAssertionId, AssertionDraft>,
+    relations: BTreeMap<VizRelationId, VizRelation>,
+    graphs: BTreeMap<VizGraphId, GraphDraft>,
+    graph_by_key: BTreeMap<String, VizGraphId>,
+    references: BTreeMap<VizReferenceId, VizReference>,
+    diagnostics: BTreeMap<String, VizDiagnostic>,
+    role_predicates_seen: BTreeSet<String>,
+}
+
+impl<'a> ProjectionBuilder<'a> {
+    fn new(spec: &'a VizSpec) -> Self {
+        Self {
+            spec,
+            terms: BTreeMap::new(),
+            term_by_key: BTreeMap::new(),
+            statements: BTreeMap::new(),
+            statement_by_key: BTreeMap::new(),
+            assertions: BTreeMap::new(),
+            relations: BTreeMap::new(),
+            graphs: BTreeMap::new(),
+            graph_by_key: BTreeMap::new(),
+            references: BTreeMap::new(),
+            diagnostics: BTreeMap::new(),
+            role_predicates_seen: BTreeSet::new(),
+        }
+    }
+
+    fn add_dataset_quad(
+        &mut self,
+        dataset: &RdfDataset,
+        quad: QuadRef<'_>,
+    ) -> Result<(), VizError> {
+        let subject = term_ref_value(dataset, quad.s);
+        let predicate = match quad.p {
+            TermRef::Iri(iri) => iri.to_owned(),
+            other => return Err(VizError::InvalidPredicate(format!("{other:?}"))),
+        };
+        let object = term_ref_value(dataset, quad.o);
+        let graph = quad.g.map(|g| term_ref_value(dataset, g));
+        self.add_assertion(subject, predicate, object, graph)
+    }
+
+    fn add_assertion(
+        &mut self,
+        subject: TermValue,
+        predicate: String,
+        object: TermValue,
+        graph_name: Option<TermValue>,
+    ) -> Result<(), VizError> {
+        let graph = self.graph_id(graph_name)?;
+        let statement = self.statement_id(subject, predicate, object)?;
+        self.apply_role_rules_to_value(&statement);
+        let assertion = VizAssertionId(format!("assertion:{}", self.assertions.len() + 1));
+        self.assertions.insert(
+            assertion,
+            AssertionDraft {
+                statement: statement.clone(),
+                graph: graph.clone(),
+            },
+        );
+        let draft = self
+            .statements
+            .get_mut(&statement)
+            .expect("statement inserted before assertion");
+        draft.asserted_in.insert(graph);
+        draft.roles.insert(VizRole::AssertedStatement);
+        Ok(())
+    }
+
+    fn add_reifier(
+        &mut self,
+        reifier: TermValue,
+        triple: TermValue,
+        graph_name: Option<TermValue>,
+    ) -> Result<(), VizError> {
+        let reifier_id = self.term_id(reifier)?;
+        self.add_term_role(&reifier_id, VizRole::Reifier);
+        let TermValue::Triple { s, p, o } = triple else {
+            return Err(VizError::InvalidPredicate(
+                "rdf:reifies object must be a triple term".to_owned(),
+            ));
+        };
+        let predicate = predicate_iri(*p)?;
+        let statement = self.statement_id(*s, predicate, *o)?;
+        self.add_statement_role(&statement, VizRole::QuotedStatement);
+        let graph = self.graph_id(graph_name)?;
+        let relation = VizRelationId(format!("relation:reifies:{}", self.relations.len() + 1));
+        self.relations.insert(
+            relation.clone(),
+            VizRelation::Reifies {
+                id: relation,
+                reifier: reifier_id,
+                statement: statement.clone(),
+                graph,
+            },
+        );
+        self.add_reference(&statement, VizReferenceSource::ReificationTarget);
+        Ok(())
+    }
+
+    fn add_annotation(
+        &mut self,
+        reifier: TermValue,
+        predicate: &str,
+        object: TermValue,
+        graph_name: Option<TermValue>,
+    ) -> Result<(), VizError> {
+        let reifier_id = self.term_id(reifier)?;
+        self.add_term_role(&reifier_id, VizRole::Reifier);
+        let predicate_id = self.term_id(TermValue::Iri(predicate.to_owned()))?;
+        self.add_term_role(&predicate_id, VizRole::Predicate);
+        self.role_predicates_seen.insert(predicate.to_owned());
+        self.apply_role_rules_to_term(&reifier_id, predicate);
+        let object_ref = self.value_ref(object, Some(VizReferenceSource::AnnotationObject))?;
+        let graph = self.graph_id(graph_name)?;
+        let relation = VizRelationId(format!("relation:annotation:{}", self.relations.len() + 1));
+        self.relations.insert(
+            relation.clone(),
+            VizRelation::Annotation {
+                id: relation,
+                reifier: reifier_id,
+                predicate: predicate_id,
+                object: object_ref,
+                graph,
+            },
+        );
+        Ok(())
+    }
+
+    fn add_default_graph(&mut self) {
+        self.graphs
+            .entry(VizGraphId(DEFAULT_GRAPH_ID.to_owned()))
+            .or_insert_with(|| GraphDraft {
+                term: None,
+                label: "default graph".to_owned(),
+            });
+        self.graph_by_key.insert(
+            "default".to_owned(),
+            VizGraphId(DEFAULT_GRAPH_ID.to_owned()),
+        );
+    }
+
+    fn graph_id(&mut self, graph: Option<TermValue>) -> Result<VizGraphId, VizError> {
+        match graph {
+            None => Ok(VizGraphId(DEFAULT_GRAPH_ID.to_owned())),
+            Some(value) => {
+                let key = term_key(&value);
+                if let Some(id) = self.graph_by_key.get(&key) {
+                    return Ok(id.clone());
+                }
+                let term = self.term_id(value)?;
+                self.add_term_role(&term, VizRole::GraphName);
+                let id = VizGraphId(format!("graph:{}", self.graphs.len() + 1));
+                let label = self
+                    .terms
+                    .get(&term)
+                    .map_or_else(|| id.0.clone(), |term| term.label.clone());
+                self.graphs.insert(
+                    id.clone(),
+                    GraphDraft {
+                        term: Some(term),
+                        label,
+                    },
+                );
+                self.graph_by_key.insert(key, id.clone());
+                Ok(id)
+            }
+        }
+    }
+
+    fn statement_id(
+        &mut self,
+        subject: TermValue,
+        predicate: String,
+        object: TermValue,
+    ) -> Result<VizStatementId, VizError> {
+        let subject_ref = self.value_ref(subject, Some(VizReferenceSource::AssertionSubject))?;
+        let predicate_id = self.term_id(TermValue::Iri(predicate))?;
+        self.add_term_role(&predicate_id, VizRole::Predicate);
+        let object_ref = self.value_ref(object, Some(VizReferenceSource::AssertionObject))?;
+        let key = statement_key(&subject_ref, &predicate_id, &object_ref);
+        if let Some(id) = self.statement_by_key.get(&key) {
+            return Ok(id.clone());
+        }
+        let id = VizStatementId(format!("statement:{}", self.statements.len() + 1));
+        let dialect = if matches!(subject_ref, VizValueRef::Statement { .. }) {
+            VizDialect::SymmetricRdf12
+        } else {
+            VizDialect::Rdf12
+        };
+        let nesting_depth = value_ref_depth(&subject_ref, &self.statements)
+            .max(value_ref_depth(&object_ref, &self.statements));
+        let mut roles = BTreeSet::new();
+        roles.insert(VizRole::QuotedStatement);
+        self.statements.insert(
+            id.clone(),
+            StatementDraft {
+                subject: subject_ref,
+                predicate: predicate_id,
+                object: object_ref,
+                asserted_in: BTreeSet::new(),
+                references: BTreeSet::new(),
+                nesting_depth,
+                dialect: dialect.clone(),
+                roles,
+            },
+        );
+        self.statement_by_key.insert(key, id.clone());
+        if dialect != VizDialect::Rdf12 {
+            self.diagnostics.insert(
+                format!("diagnostic:{}", self.diagnostics.len() + 1),
+                VizDiagnostic {
+                    code: "viz-dialect-symmetric-subject".to_owned(),
+                    message: "triple term appears in subject position".to_owned(),
+                    target: Some(id.0.clone()),
+                    dialect,
+                },
+            );
+        }
+        Ok(id)
+    }
+
+    fn value_ref(
+        &mut self,
+        value: TermValue,
+        reference: Option<VizReferenceSource>,
+    ) -> Result<VizValueRef, VizError> {
+        match value {
+            TermValue::Triple { s, p, o } => {
+                let predicate = predicate_iri(*p)?;
+                let statement = self.statement_id(*s, predicate, *o)?;
+                self.add_statement_role(&statement, VizRole::QuotedStatement);
+                if let Some(source) = reference {
+                    self.add_reference(&statement, source);
+                }
+                Ok(VizValueRef::Statement { id: statement })
+            }
+            other => Ok(VizValueRef::Term {
+                id: self.term_id(other)?,
+            }),
+        }
+    }
+
+    fn term_id(&mut self, value: TermValue) -> Result<VizTermId, VizError> {
+        let key = term_key(&value);
+        if let Some(id) = self.term_by_key.get(&key) {
+            return Ok(id.clone());
+        }
+        let id = VizTermId(format!("term:{}", self.terms.len() + 1));
+        let value = viz_term_value(value)?;
+        let label = label_for_term(&value, self.spec.label_policy.clone());
+        self.terms.insert(
+            id.clone(),
+            TermDraft {
+                value,
+                label,
+                roles: BTreeSet::new(),
+            },
+        );
+        self.term_by_key.insert(key, id.clone());
+        Ok(id)
+    }
+
+    fn add_term_role(&mut self, id: &VizTermId, role: VizRole) {
+        if let Some(term) = self.terms.get_mut(id) {
+            term.roles.insert(role);
+        }
+    }
+
+    fn add_statement_role(&mut self, id: &VizStatementId, role: VizRole) {
+        if let Some(statement) = self.statements.get_mut(id) {
+            statement.roles.insert(role);
+        }
+    }
+
+    fn apply_role_rules_to_value(&mut self, statement: &VizStatementId) {
+        let Some(draft) = self.statements.get(statement) else {
+            return;
+        };
+        let subject = draft.subject.clone();
+        let Some(predicate) = self
+            .terms
+            .get(&draft.predicate)
+            .and_then(|term| match &term.value {
+                VizTermValue::Iri { value } => Some(value.clone()),
+                _ => None,
+            })
+        else {
+            return;
+        };
+        let roles = self.roles_for_predicate(&predicate);
+        for role in roles {
+            self.add_role_to_value(&subject, role);
+        }
+    }
+
+    fn apply_role_rules_to_term(&mut self, term: &VizTermId, predicate: &str) {
+        for role in self.roles_for_predicate(predicate) {
+            self.add_term_role(term, role);
+        }
+    }
+
+    fn roles_for_predicate(&self, predicate: &str) -> Vec<VizRole> {
+        self.spec
+            .role_rules
+            .iter()
+            .filter(|rule| rule.predicate_iri == predicate)
+            .map(|rule| rule.role.clone())
+            .collect()
+    }
+
+    fn add_role_to_value(&mut self, value: &VizValueRef, role: VizRole) {
+        match value {
+            VizValueRef::Term { id } => self.add_term_role(id, role),
+            VizValueRef::Statement { id } => self.add_statement_role(id, role),
+        }
+    }
+
+    fn add_reference(&mut self, statement: &VizStatementId, source: VizReferenceSource) {
+        let id = VizReferenceId(format!("reference:{}", self.references.len() + 1));
+        self.references.insert(
+            id.clone(),
+            VizReference {
+                id,
+                statement: statement.clone(),
+                source: source.clone(),
+            },
+        );
+        if let Some(draft) = self.statements.get_mut(statement) {
+            draft.references.insert(source);
+        }
+    }
+
+    fn validate_spec(&self) -> Result<(), VizError> {
+        for mapping in &self.spec.vocabulary {
+            if mapping.prefix.is_empty() || mapping.namespace.is_empty() {
+                return Err(VizError::InvalidVocabulary(
+                    "visualization vocabulary mappings require non-empty prefix and namespace"
+                        .to_owned(),
+                ));
+            }
+        }
+        for rule in &self.spec.role_rules {
+            if !self.role_predicates_seen.contains(&rule.predicate_iri)
+                && !self
+                    .terms
+                    .values()
+                    .any(|term| matches!(&term.value, VizTermValue::Iri { value } if value == &rule.predicate_iri))
+            {
+                return Err(VizError::UnknownRolePredicate(rule.predicate_iri.clone()));
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(mut self) -> Result<VizProjection, VizError> {
+        self.validate_spec()?;
+        if self.statements.len() > self.spec.max_statements {
+            return Err(VizError::TooLarge {
+                limit: "statements",
+                actual: self.statements.len(),
+                allowed: self.spec.max_statements,
+            });
+        }
+        if self.terms.len() > self.spec.max_terms {
+            return Err(VizError::TooLarge {
+                limit: "terms",
+                actual: self.terms.len(),
+                allowed: self.spec.max_terms,
+            });
+        }
+
+        let mut relation_by_reifier: BTreeMap<VizTermId, usize> = BTreeMap::new();
+        let mut reifiers_by_statement: BTreeMap<VizStatementId, BTreeSet<VizTermId>> =
+            BTreeMap::new();
+        for relation in self.relations.values() {
+            match relation {
+                VizRelation::Reifies {
+                    reifier, statement, ..
+                } => {
+                    reifiers_by_statement
+                        .entry(statement.clone())
+                        .or_default()
+                        .insert(reifier.clone());
+                }
+                VizRelation::Annotation { reifier, .. } => {
+                    *relation_by_reifier.entry(reifier.clone()).or_default() += 1;
+                }
+            }
+        }
+
+        for (statement, reifiers) in &reifiers_by_statement {
+            if let Some(draft) = self.statements.get_mut(statement)
+                && reifiers
+                    .iter()
+                    .any(|reifier| relation_by_reifier.contains_key(reifier))
+            {
+                draft.roles.insert(VizRole::AnnotatedStatement);
+            }
+        }
+
+        let terms = self
+            .terms
+            .into_iter()
+            .map(|(id, draft)| VizTerm {
+                id,
+                value: draft.value,
+                label: draft.label,
+                roles: draft.roles.into_iter().collect(),
+            })
+            .collect();
+
+        let statements: Vec<VizStatement> = self
+            .statements
+            .iter()
+            .map(|(id, draft)| VizStatement {
+                id: id.clone(),
+                subject: draft.subject.clone(),
+                predicate: draft.predicate.clone(),
+                object: draft.object.clone(),
+                asserted_in: draft.asserted_in.iter().cloned().collect(),
+                nesting_depth: draft.nesting_depth,
+                incoming_references: draft.references.len() as u32,
+                dialect: draft.dialect.clone(),
+                roles: draft.roles.iter().cloned().collect(),
+            })
+            .collect();
+
+        let assertions = self
+            .assertions
+            .into_iter()
+            .map(|(id, draft)| VizAssertion {
+                id,
+                statement: draft.statement,
+                graph: draft.graph,
+            })
+            .collect();
+
+        let relations = self.relations.into_values().collect();
+
+        let graphs = self
+            .graphs
+            .into_iter()
+            .map(|(id, draft)| VizGraph {
+                id,
+                term: draft.term,
+                label: draft.label,
+            })
+            .collect();
+
+        let references = self.references.into_values().collect();
+
+        let table = statements
+            .iter()
+            .map(|statement| {
+                let reifiers = reifiers_by_statement
+                    .get(&statement.id)
+                    .cloned()
+                    .unwrap_or_default();
+                let annotation_count = reifiers
+                    .iter()
+                    .map(|reifier| {
+                        relation_by_reifier
+                            .get(reifier)
+                            .copied()
+                            .unwrap_or_default()
+                    })
+                    .sum();
+                VizTableRow {
+                    statement: statement.id.clone(),
+                    asserted_in: statement.asserted_in.clone(),
+                    reifier_count: reifiers.len(),
+                    annotation_count,
+                    referenced_by: statement.incoming_references,
+                    depth: statement.nesting_depth,
+                }
+            })
+            .collect();
+
+        Ok(VizProjection {
+            terms,
+            statements,
+            assertions,
+            relations,
+            graphs,
+            references,
+            table,
+            diagnostics: self.diagnostics.into_values().collect(),
+        })
+    }
+}
+
+fn term_ref_value(dataset: &RdfDataset, term: TermRef<'_>) -> TermValue {
+    match term {
+        TermRef::Iri(iri) => TermValue::Iri(iri.to_owned()),
+        TermRef::Blank { label, scope } => TermValue::Blank {
+            label: label.to_owned(),
+            scope,
+        },
+        TermRef::Literal {
+            lexical,
+            datatype,
+            language,
+            direction,
+        } => {
+            let datatype = match dataset.resolve(datatype) {
+                TermRef::Iri(iri) => iri.to_owned(),
+                other => unreachable!("literal datatype must be an IRI, got {other:?}"),
+            };
+            TermValue::Literal {
+                lexical_form: lexical.to_owned(),
+                datatype,
+                language: language.map(str::to_owned),
+                direction,
+            }
+        }
+        TermRef::Triple { s, p, o } => TermValue::Triple {
+            s: Box::new(dataset.term_value(s)),
+            p: Box::new(dataset.term_value(p)),
+            o: Box::new(dataset.term_value(o)),
+        },
+    }
+}
+
+fn predicate_iri(value: TermValue) -> Result<String, VizError> {
+    match value {
+        TermValue::Iri(iri) => Ok(iri),
+        other => Err(VizError::InvalidPredicate(term_key(&other))),
+    }
+}
+
+fn viz_term_value(value: TermValue) -> Result<VizTermValue, VizError> {
+    match value {
+        TermValue::Iri(value) => Ok(VizTermValue::Iri { value }),
+        TermValue::Blank { label, scope } => Ok(VizTermValue::Blank {
+            label,
+            scope: scope.ordinal(),
+        }),
+        TermValue::Literal {
+            lexical_form,
+            datatype,
+            language,
+            direction,
+        } => Ok(VizTermValue::Literal {
+            lexical_form,
+            datatype,
+            language,
+            direction: direction.map(viz_direction),
+        }),
+        TermValue::Triple { .. } => Err(VizError::InvalidPredicate(
+            "triple terms are represented as statements, not ordinary terms".to_owned(),
+        )),
+    }
+}
+
+fn viz_direction(direction: RdfTextDirection) -> VizTextDirection {
+    match direction {
+        RdfTextDirection::Ltr => VizTextDirection::Ltr,
+        RdfTextDirection::Rtl => VizTextDirection::Rtl,
+    }
+}
+
+fn statement_key(subject: &VizValueRef, predicate: &VizTermId, object: &VizValueRef) -> String {
+    format!(
+        "s={} p={} o={}",
+        value_ref_key(subject),
+        predicate.0,
+        value_ref_key(object)
+    )
+}
+
+fn value_ref_key(value: &VizValueRef) -> &str {
+    match value {
+        VizValueRef::Term { id } => &id.0,
+        VizValueRef::Statement { id } => &id.0,
+    }
+}
+
+fn value_ref_depth(
+    value: &VizValueRef,
+    statements: &BTreeMap<VizStatementId, StatementDraft>,
+) -> u32 {
+    match value {
+        VizValueRef::Term { .. } => 0,
+        VizValueRef::Statement { id } => statements
+            .get(id)
+            .map_or(1, |statement| statement.nesting_depth + 1),
+    }
+}
+
+fn term_key(value: &TermValue) -> String {
+    let mut out = String::new();
+    write_term_key(value, &mut out).expect("writing to String cannot fail");
+    out
+}
+
+fn write_term_key(value: &TermValue, out: &mut String) -> fmt::Result {
+    match value {
+        TermValue::Iri(iri) => {
+            out.write_str("iri:")?;
+            write_json_string(iri, out)
+        }
+        TermValue::Blank { label, scope } => {
+            write!(out, "blank:{}:", scope.ordinal())?;
+            write_json_string(label, out)
+        }
+        TermValue::Literal {
+            lexical_form,
+            datatype,
+            language,
+            direction,
+        } => {
+            out.write_str("literal:")?;
+            write_json_string(lexical_form, out)?;
+            out.write_char(':')?;
+            write_json_string(datatype, out)?;
+            out.write_char(':')?;
+            if let Some(language) = language {
+                write_json_string(language, out)?;
+            }
+            out.write_char(':')?;
+            if let Some(direction) = direction {
+                out.write_str(direction.as_str())?;
+            }
+            Ok(())
+        }
+        TermValue::Triple { s, p, o } => {
+            out.write_str("triple(")?;
+            write_term_key(s, out)?;
+            out.write_char('|')?;
+            write_term_key(p, out)?;
+            out.write_char('|')?;
+            write_term_key(o, out)?;
+            out.write_char(')')
+        }
+    }
+}
+
+fn write_json_string(value: &str, out: &mut String) -> fmt::Result {
+    let encoded = serde_json::to_string(value).expect("string serialization cannot fail");
+    out.write_str(&encoded)
+}
+
+fn label_for_term(value: &VizTermValue, policy: VizLabelPolicy) -> String {
+    match (policy, value) {
+        (VizLabelPolicy::Full, _) => {
+            serde_json::to_string(value).unwrap_or_else(|_| "?".to_owned())
+        }
+        (_, VizTermValue::Iri { value }) => compact_iri(value),
+        (_, VizTermValue::Blank { label, scope }) if *scope == 0 => format!("_:{label}"),
+        (_, VizTermValue::Blank { label, scope }) => format!("_:{label}.s{scope}"),
+        (
+            _,
+            VizTermValue::Literal {
+                lexical_form,
+                language,
+                direction,
+                ..
+            },
+        ) => {
+            let mut label = format!("\"{lexical_form}\"");
+            if let Some(language) = language {
+                label.push('@');
+                label.push_str(language);
+            }
+            if let Some(direction) = direction {
+                label.push(' ');
+                label.push_str(match direction {
+                    VizTextDirection::Ltr => "ltr",
+                    VizTextDirection::Rtl => "rtl",
+                });
+            }
+            label
+        }
+    }
+}
+
+fn compact_iri(iri: &str) -> String {
+    iri.rsplit(['#', '/'])
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(iri)
+        .to_owned()
+}
+
+/// Compute a deterministic non-cryptographic hash over text.
+pub fn stable_hash_hex(input: &str) -> String {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for byte in input.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{RdfDatasetBuilder, RdfLiteral};
+
+    const EX: &str = "https://example.org/";
+    const KNOWS: &str = "https://example.org/knows";
+    const CLAIM: &str = "https://example.org/claim";
+    const CAROL: &str = "https://example.org/carol";
+    const ATTRIBUTED_TO: &str = "https://example.org/attributedTo";
+    const CONFIDENCE: &str = "https://example.org/confidence";
+
+    fn iri(value: &str) -> TermValue {
+        TermValue::Iri(format!("{EX}{value}"))
+    }
+
+    fn example_dataset() -> std::sync::Arc<RdfDataset> {
+        let mut b = RdfDatasetBuilder::new();
+        let alice = b.intern_iri(&format!("{EX}alice"));
+        let bob = b.intern_iri(&format!("{EX}bob"));
+        let knows = b.intern_iri(KNOWS);
+        let claim = b.intern_iri(CLAIM);
+        let carol = b.intern_iri(CAROL);
+        let attributed_to = b.intern_iri(ATTRIBUTED_TO);
+        let confidence = b.intern_iri(CONFIDENCE);
+        let confidence_value = b.intern_literal(RdfLiteral::typed(
+            "0.8",
+            "http://www.w3.org/2001/XMLSchema#decimal",
+        ));
+        let statement = b.intern_triple(alice, knows, bob);
+        b.push_quad(alice, knows, bob, None);
+        b.push_reifier(claim, statement);
+        b.push_annotation(claim, attributed_to, carol);
+        b.push_annotation(claim, confidence, confidence_value);
+        b.freeze().expect("valid dataset")
+    }
+
+    #[test]
+    fn projection_separates_assertion_statement_reifier_and_annotations() {
+        let ds = example_dataset();
+        let projection = project_dataset(&ds, &VizSpec::default()).expect("project");
+        assert_eq!(projection.statements.len(), 1);
+        assert_eq!(projection.assertions.len(), 1);
+        assert_eq!(projection.relations.len(), 3);
+        let statement = &projection.statements[0];
+        assert_eq!(statement.asserted_in.len(), 1);
+        assert_eq!(statement.incoming_references, 1);
+        assert!(statement.roles.contains(&VizRole::AssertedStatement));
+        assert!(statement.roles.contains(&VizRole::AnnotatedStatement));
+        let row = &projection.table[0];
+        assert_eq!(row.reifier_count, 1);
+        assert_eq!(row.annotation_count, 2);
+    }
+
+    #[test]
+    fn quoted_only_triple_is_not_asserted() {
+        let input = VizGraphInput {
+            reifiers: vec![VizInputReifier {
+                reifier: iri("claim"),
+                statement: VizInputStatement {
+                    subject: iri("alice"),
+                    predicate: KNOWS.to_owned(),
+                    object: iri("bob"),
+                },
+                graph_name: None,
+            }],
+            ..VizGraphInput::default()
+        };
+        let projection = project_graph_input(&input, &VizSpec::default()).expect("project");
+        assert_eq!(projection.statements.len(), 1);
+        assert!(projection.assertions.is_empty());
+        assert!(projection.statements[0].asserted_in.is_empty());
+        assert!(
+            !projection.statements[0]
+                .roles
+                .contains(&VizRole::AnnotatedStatement)
+        );
+    }
+
+    #[test]
+    fn one_reifier_can_cover_multiple_statements() {
+        let input = VizGraphInput {
+            reifiers: vec![
+                VizInputReifier {
+                    reifier: iri("claim"),
+                    statement: VizInputStatement {
+                        subject: iri("alice"),
+                        predicate: KNOWS.to_owned(),
+                        object: iri("bob"),
+                    },
+                    graph_name: None,
+                },
+                VizInputReifier {
+                    reifier: iri("claim"),
+                    statement: VizInputStatement {
+                        subject: iri("bob"),
+                        predicate: KNOWS.to_owned(),
+                        object: iri("carol"),
+                    },
+                    graph_name: None,
+                },
+            ],
+            ..VizGraphInput::default()
+        };
+        let projection = project_graph_input(&input, &VizSpec::default()).expect("project");
+        assert_eq!(projection.statements.len(), 2);
+        assert_eq!(
+            projection
+                .table
+                .iter()
+                .map(|row| row.reifier_count)
+                .sum::<usize>(),
+            2
+        );
+    }
+
+    #[test]
+    fn directional_literals_keep_direction() {
+        let mut lit = RdfLiteral::language_tagged("مرحبا", "ar");
+        lit.direction = Some(RdfTextDirection::Rtl);
+        let input = VizGraphInput {
+            quads: vec![VizInputQuad {
+                subject: iri("alice"),
+                predicate: format!("{EX}says"),
+                object: TermValue::Literal {
+                    lexical_form: lit.lexical_form,
+                    datatype: "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString".to_owned(),
+                    language: Some("ar".to_owned()),
+                    direction: Some(RdfTextDirection::Rtl),
+                },
+                graph_name: None,
+            }],
+            ..VizGraphInput::default()
+        };
+        let projection = project_graph_input(&input, &VizSpec::default()).expect("project");
+        assert!(projection.terms.iter().any(|term| {
+            matches!(
+                &term.value,
+                VizTermValue::Literal {
+                    direction: Some(VizTextDirection::Rtl),
+                    ..
+                }
+            )
+        }));
+    }
+
+    #[test]
+    fn triple_term_subject_gets_symmetric_dialect_diagnostic() {
+        let nested = TermValue::Triple {
+            s: Box::new(iri("alice")),
+            p: Box::new(TermValue::Iri(KNOWS.to_owned())),
+            o: Box::new(iri("bob")),
+        };
+        let input = VizGraphInput {
+            quads: vec![VizInputQuad {
+                subject: nested,
+                predicate: format!("{EX}reportedBy"),
+                object: iri("carol"),
+                graph_name: None,
+            }],
+            ..VizGraphInput::default()
+        };
+        let projection = project_graph_input(&input, &VizSpec::default()).expect("project");
+        assert!(
+            projection
+                .diagnostics
+                .iter()
+                .any(|diag| diag.code == "viz-dialect-symmetric-subject")
+        );
+        assert!(
+            projection
+                .statements
+                .iter()
+                .any(|statement| statement.dialect == VizDialect::SymmetricRdf12)
+        );
+    }
+
+    #[test]
+    fn invalid_role_rule_hard_errors() {
+        let spec = VizSpec {
+            role_rules: vec![VizRoleRule {
+                predicate_iri: format!("{EX}missing"),
+                role: VizRole::Custom("important".to_owned()),
+            }],
+            ..VizSpec::default()
+        };
+        let err = project_graph_input(&VizGraphInput::default(), &spec).expect_err("bad spec");
+        assert!(matches!(err, VizError::UnknownRolePredicate(_)));
+    }
+
+    #[test]
+    fn role_rules_apply_to_assertion_subjects_and_annotation_reifiers() {
+        let important = VizRole::Custom("important".to_owned());
+        let reviewed = VizRole::Custom("reviewed".to_owned());
+        let spec = VizSpec {
+            role_rules: vec![
+                VizRoleRule {
+                    predicate_iri: KNOWS.to_owned(),
+                    role: important.clone(),
+                },
+                VizRoleRule {
+                    predicate_iri: ATTRIBUTED_TO.to_owned(),
+                    role: reviewed.clone(),
+                },
+            ],
+            ..VizSpec::default()
+        };
+        let input = VizGraphInput {
+            quads: vec![VizInputQuad {
+                subject: iri("alice"),
+                predicate: KNOWS.to_owned(),
+                object: iri("bob"),
+                graph_name: None,
+            }],
+            reifiers: vec![VizInputReifier {
+                reifier: iri("claim"),
+                statement: VizInputStatement {
+                    subject: iri("alice"),
+                    predicate: KNOWS.to_owned(),
+                    object: iri("bob"),
+                },
+                graph_name: None,
+            }],
+            annotations: vec![VizInputAnnotation {
+                reifier: iri("claim"),
+                predicate: ATTRIBUTED_TO.to_owned(),
+                object: iri("carol"),
+                graph_name: None,
+            }],
+        };
+        let projection = project_graph_input(&input, &spec).expect("project");
+        let alice = projection
+            .terms
+            .iter()
+            .find(|term| term.label == "alice")
+            .expect("alice term");
+        assert!(alice.roles.contains(&important));
+        let claim = projection
+            .terms
+            .iter()
+            .find(|term| term.label == "claim")
+            .expect("claim term");
+        assert!(claim.roles.contains(&reviewed));
+    }
+
+    #[test]
+    fn graph_like_inputs_are_deterministic() {
+        let input = VizGraphInput {
+            quads: vec![
+                VizInputQuad {
+                    subject: iri("bob"),
+                    predicate: KNOWS.to_owned(),
+                    object: iri("carol"),
+                    graph_name: None,
+                },
+                VizInputQuad {
+                    subject: iri("alice"),
+                    predicate: KNOWS.to_owned(),
+                    object: iri("bob"),
+                    graph_name: None,
+                },
+            ],
+            ..VizGraphInput::default()
+        };
+        let a = project_graph_input(&input, &VizSpec::default()).expect("project");
+        let b = project_graph_input(&input, &VizSpec::default()).expect("project");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn size_limits_hard_error() {
+        let spec = VizSpec {
+            max_statements: 0,
+            ..VizSpec::default()
+        };
+        let input = VizGraphInput {
+            quads: vec![VizInputQuad {
+                subject: iri("alice"),
+                predicate: KNOWS.to_owned(),
+                object: iri("bob"),
+                graph_name: None,
+            }],
+            ..VizGraphInput::default()
+        };
+        let err = project_graph_input(&input, &spec).expect_err("too large");
+        assert!(matches!(
+            err,
+            VizError::TooLarge {
+                limit: "statements",
+                ..
+            }
+        ));
+    }
+}

--- a/crates/rdf/src/viz.rs
+++ b/crates/rdf/src/viz.rs
@@ -507,6 +507,42 @@ pub struct VizElementIndexEntry {
     pub kind: String,
 }
 
+/// Options for deterministic SVG visualization export.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VizSvgOptions {
+    /// Requested SVG width in user units.
+    pub width: i32,
+    /// Left/right/top/bottom margin in user units.
+    pub margin: i32,
+    /// Vertical row height per structural statement.
+    pub row_height: i32,
+    /// Embed the versioned [`VizExport`] JSON in an SVG `<metadata>` element.
+    pub embed_metadata: bool,
+    /// Include deterministic first-party CSS in the SVG.
+    pub include_styles: bool,
+}
+
+impl Default for VizSvgOptions {
+    fn default() -> Self {
+        Self {
+            width: 960,
+            margin: 32,
+            row_height: 112,
+            embed_metadata: true,
+            include_styles: true,
+        }
+    }
+}
+
+/// A deterministic SVG document paired with its structured visualization export.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VizSvgDocument {
+    /// Complete SVG XML text.
+    pub svg: String,
+    /// The load-bearing structured export embedded in the SVG metadata.
+    pub export: VizExport,
+}
+
 /// Visualization projection errors.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VizError {
@@ -628,6 +664,775 @@ pub fn project_graph_input(
 pub fn project_dataset_json(dataset: &RdfDataset, spec: &VizSpec) -> Result<String, VizError> {
     let projection = project_dataset(dataset, spec)?;
     serde_json::to_string(&projection).map_err(|err| VizError::Serialize(err.to_string()))
+}
+
+/// Build a versioned visualization export from an existing projection.
+pub fn export_projection(
+    projection: &VizProjection,
+    spec: &VizSpec,
+    options: &VizSvgOptions,
+) -> Result<VizExport, VizError> {
+    let spec_json =
+        serde_json::to_string(spec).map_err(|err| VizError::Serialize(err.to_string()))?;
+    Ok(VizExport {
+        schema_version: VIZ_EXPORT_SCHEMA_VERSION.to_owned(),
+        spec_hash: stable_hash_hex(&spec_json),
+        model: projection.clone(),
+        layout: deterministic_layout(projection, options),
+        element_index: deterministic_element_index(projection),
+        diagnostics: projection.diagnostics.clone(),
+    })
+}
+
+/// Project a dataset and build a versioned visualization export.
+pub fn project_dataset_export(
+    dataset: &RdfDataset,
+    spec: &VizSpec,
+    options: &VizSvgOptions,
+) -> Result<VizExport, VizError> {
+    let projection = project_dataset(dataset, spec)?;
+    export_projection(&projection, spec, options)
+}
+
+/// Project graph-like caller input and build a versioned visualization export.
+pub fn project_graph_input_export(
+    input: &VizGraphInput,
+    spec: &VizSpec,
+    options: &VizSvgOptions,
+) -> Result<VizExport, VizError> {
+    let projection = project_graph_input(input, spec)?;
+    export_projection(&projection, spec, options)
+}
+
+/// Render an existing visualization projection as deterministic semantic SVG.
+pub fn render_projection_svg(
+    projection: &VizProjection,
+    spec: &VizSpec,
+    options: &VizSvgOptions,
+) -> Result<VizSvgDocument, VizError> {
+    let export = export_projection(projection, spec, options)?;
+    let svg = render_svg_document(&export, options)?;
+    Ok(VizSvgDocument { svg, export })
+}
+
+/// Project a dataset and render it as deterministic semantic SVG.
+pub fn render_dataset_svg(
+    dataset: &RdfDataset,
+    spec: &VizSpec,
+    options: &VizSvgOptions,
+) -> Result<VizSvgDocument, VizError> {
+    let projection = project_dataset(dataset, spec)?;
+    render_projection_svg(&projection, spec, options)
+}
+
+/// Project graph-like caller input and render it as deterministic semantic SVG.
+pub fn render_graph_input_svg(
+    input: &VizGraphInput,
+    spec: &VizSpec,
+    options: &VizSvgOptions,
+) -> Result<VizSvgDocument, VizError> {
+    let projection = project_graph_input(input, spec)?;
+    render_projection_svg(&projection, spec, options)
+}
+
+fn deterministic_layout(
+    projection: &VizProjection,
+    options: &VizSvgOptions,
+) -> Vec<VizLayoutRecord> {
+    let width = svg_width(options);
+    let margin = svg_margin(options);
+    let row_height = svg_row_height(options);
+    let center = width / 2;
+    let subject_x = margin + 104;
+    let predicate_x = center;
+    let object_x = width - margin - 104;
+    let mut records = Vec::new();
+    let mut term_positions: BTreeMap<VizTermId, (i32, i32)> = BTreeMap::new();
+
+    for (index, statement) in projection.statements.iter().enumerate() {
+        let y = row_y(index, options);
+        records.push(VizLayoutRecord {
+            id: statement.id.0.clone(),
+            x: center,
+            y,
+        });
+        first_term_position(&mut term_positions, &statement.subject, subject_x, y);
+        term_positions
+            .entry(statement.predicate.clone())
+            .or_insert((predicate_x, y - 24));
+        first_term_position(&mut term_positions, &statement.object, object_x, y);
+    }
+
+    let term_start_y = row_y(projection.statements.len(), options) + row_height / 2;
+    for (index, term) in projection.terms.iter().enumerate() {
+        let fallback_y = term_start_y + i32_from_usize(index) * 28;
+        let (x, y) = term_positions
+            .get(&term.id)
+            .copied()
+            .unwrap_or((margin + 104, fallback_y));
+        records.push(VizLayoutRecord {
+            id: term.id.0.clone(),
+            x,
+            y,
+        });
+    }
+
+    for (index, assertion) in projection.assertions.iter().enumerate() {
+        records.push(VizLayoutRecord {
+            id: assertion.id.0.clone(),
+            x: center,
+            y: row_y(index, options) + 18,
+        });
+    }
+
+    for (index, relation) in projection.relations.iter().enumerate() {
+        let statement_index = relation_statement_id(relation)
+            .and_then(|id| {
+                projection
+                    .statements
+                    .iter()
+                    .position(|statement| statement.id == *id)
+            })
+            .unwrap_or(index);
+        records.push(VizLayoutRecord {
+            id: relation_id(relation).0.clone(),
+            x: center,
+            y: row_y(statement_index, options) + 44,
+        });
+    }
+
+    for (index, graph) in projection.graphs.iter().enumerate() {
+        records.push(VizLayoutRecord {
+            id: graph.id.0.clone(),
+            x: width - margin - 112,
+            y: margin + 24 + i32_from_usize(index) * 26,
+        });
+    }
+
+    records
+}
+
+fn first_term_position(
+    positions: &mut BTreeMap<VizTermId, (i32, i32)>,
+    value: &VizValueRef,
+    x: i32,
+    y: i32,
+) {
+    if let VizValueRef::Term { id } = value {
+        positions.entry(id.clone()).or_insert((x, y));
+    }
+}
+
+fn deterministic_element_index(projection: &VizProjection) -> Vec<VizElementIndexEntry> {
+    let mut entries = Vec::new();
+    for statement in &projection.statements {
+        entries.push(index_entry("statement", &statement.id.0));
+        if !statement.asserted_in.is_empty() {
+            entries.push(index_entry("assertion-line", &statement.id.0));
+        }
+        push_value_index(&mut entries, &statement.id, "subject", &statement.subject);
+        entries.push(VizElementIndexEntry {
+            element_id: scoped_svg_id("predicate", &statement.id.0, "predicate"),
+            model_id: statement.predicate.0.clone(),
+            kind: "predicate".to_owned(),
+        });
+        push_value_index(&mut entries, &statement.id, "object", &statement.object);
+    }
+    for relation in &projection.relations {
+        entries.push(index_entry("relation", &relation_id(relation).0));
+    }
+    for graph in &projection.graphs {
+        entries.push(index_entry("graph", &graph.id.0));
+    }
+    entries
+}
+
+fn push_value_index(
+    entries: &mut Vec<VizElementIndexEntry>,
+    statement: &VizStatementId,
+    role: &str,
+    value: &VizValueRef,
+) {
+    let model_id = match value {
+        VizValueRef::Term { id } => id.0.clone(),
+        VizValueRef::Statement { id } => id.0.clone(),
+    };
+    entries.push(VizElementIndexEntry {
+        element_id: scoped_svg_id("value", &statement.0, role),
+        model_id,
+        kind: role.to_owned(),
+    });
+}
+
+fn index_entry(kind: &str, model_id: &str) -> VizElementIndexEntry {
+    VizElementIndexEntry {
+        element_id: svg_id(kind, model_id),
+        model_id: model_id.to_owned(),
+        kind: kind.to_owned(),
+    }
+}
+
+fn render_svg_document(export: &VizExport, options: &VizSvgOptions) -> Result<String, VizError> {
+    let projection = &export.model;
+    let width = svg_width(options);
+    let height = svg_height(projection, options);
+    let margin = svg_margin(options);
+    let row_height = svg_row_height(options);
+    let subject_x = margin + 104;
+    let center = width / 2;
+    let object_x = width - margin - 104;
+    let mut out = String::new();
+    writeln!(
+        out,
+        r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" role="img" aria-labelledby="purrdf-viz-title purrdf-viz-desc">"#
+    )
+    .expect("writing to String cannot fail");
+    out.push_str("<title id=\"purrdf-viz-title\">PurRDF semantic RDF visualization</title>\n");
+    writeln!(
+        out,
+        "<desc id=\"purrdf-viz-desc\">{} structural statements, {} assertions, {} RDF 1.2 relations.</desc>",
+        projection.statements.len(),
+        projection.assertions.len(),
+        projection.relations.len()
+    )
+    .expect("writing to String cannot fail");
+    if options.embed_metadata {
+        write_metadata(export, &mut out)?;
+    }
+    out.push_str("<defs><marker id=\"purrdf-viz-arrow\" markerWidth=\"10\" markerHeight=\"10\" refX=\"9\" refY=\"3\" orient=\"auto\" markerUnits=\"strokeWidth\"><path d=\"M0,0 L0,6 L9,3 z\" fill=\"#275c72\"/></marker></defs>\n");
+    if options.include_styles {
+        out.push_str(SVG_STYLE);
+    }
+    write_graph_chips(projection, width, margin, &mut out);
+
+    let terms = term_label_map(projection);
+    let graphs = graph_label_map(projection);
+    let relation_info = statement_relation_info(projection);
+    for (index, statement) in projection.statements.iter().enumerate() {
+        let y = row_y(index, options);
+        let row_top = y - row_height / 2 + 12;
+        let subject = value_label(&statement.subject, &terms);
+        let predicate = terms
+            .get(&statement.predicate)
+            .cloned()
+            .unwrap_or_else(|| statement.predicate.0.clone());
+        let object = value_label(&statement.object, &terms);
+        let summary = statement_summary(
+            statement,
+            &subject,
+            &predicate,
+            &object,
+            &graphs,
+            &relation_info,
+        );
+        let group_id = svg_id("statement", &statement.id.0);
+        writeln!(
+            out,
+            "<g id=\"{}\" class=\"viz-statement\" data-purrdf-id=\"{}\">",
+            escape_attr_string(&group_id),
+            escape_attr_string(&statement.id.0)
+        )
+        .expect("writing to String cannot fail");
+        write_title_desc(&group_id, &summary, &mut out);
+        writeln!(
+            out,
+            "<rect class=\"viz-row\" x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\"/>",
+            margin,
+            row_top,
+            width - margin * 2,
+            row_height - 18
+        )
+        .expect("writing to String cannot fail");
+        if statement.asserted_in.is_empty() {
+            write_quoted_capsule(
+                &statement.id,
+                &subject,
+                &predicate,
+                &object,
+                center,
+                y,
+                &mut out,
+            );
+        } else {
+            write_asserted_arrow(&statement.id, subject_x, object_x, y, &mut out);
+            write_value_label(&statement.id, "subject", subject_x, y, &subject, &mut out);
+            write_predicate_label(&statement.id, center, y - 18, &predicate, &mut out);
+            write_value_label(&statement.id, "object", object_x, y, &object, &mut out);
+            write_statement_anchor(statement, center, y, &relation_info, &mut out);
+        }
+        write_graph_badges(statement, &graphs, object_x - 18, y + 26, &mut out);
+        write_relation_summaries(statement, projection, &terms, center, y + 42, &mut out);
+        out.push_str("</g>\n");
+    }
+
+    if projection.statements.is_empty() {
+        writeln!(
+            out,
+            "<text class=\"viz-empty\" x=\"{}\" y=\"{}\">No structural statements in projection.</text>",
+            margin,
+            margin + 48
+        )
+        .expect("writing to String cannot fail");
+    }
+    out.push_str("</svg>\n");
+    Ok(out)
+}
+
+fn write_metadata(export: &VizExport, out: &mut String) -> Result<(), VizError> {
+    let json = serde_json::to_string(export).map_err(|err| VizError::Serialize(err.to_string()))?;
+    out.push_str("<metadata id=\"purrdf-viz-export\" type=\"application/vnd.purrdf.viz+json\">");
+    escape_xml_text(&json, out);
+    out.push_str("</metadata>\n");
+    Ok(())
+}
+
+const SVG_STYLE: &str = r"<style>
+.viz-row{fill:#fbfaf7;stroke:#d8dee4;stroke-width:1}
+.viz-assertion{stroke:#275c72;stroke-width:2.25;fill:none;marker-end:url(#purrdf-viz-arrow)}
+.viz-quoted{fill:#ffffff;stroke:#6f5f90;stroke-width:2;stroke-dasharray:5 4}
+.viz-anchor{fill:#12343f;stroke:#ffffff;stroke-width:1.5}
+.viz-anchor-text{font:600 11px ui-monospace,SFMono-Regular,Menlo,monospace;fill:#ffffff;text-anchor:middle;dominant-baseline:middle}
+.viz-term{font:500 13px system-ui,-apple-system,BlinkMacSystemFont,sans-serif;fill:#172026;text-anchor:middle;dominant-baseline:middle}
+.viz-predicate{font:600 12px ui-monospace,SFMono-Regular,Menlo,monospace;fill:#275c72;text-anchor:middle}
+.viz-capsule-text{font:600 12px ui-monospace,SFMono-Regular,Menlo,monospace;fill:#2f2a45;text-anchor:middle;dominant-baseline:middle}
+.viz-chip{fill:#e8f3f1;stroke:#8ab9ad;stroke-width:1}
+.viz-chip-text{font:600 10px ui-monospace,SFMono-Regular,Menlo,monospace;fill:#21433d;text-anchor:middle;dominant-baseline:middle}
+.viz-relation{fill:#fff7e6;stroke:#d9a441;stroke-width:1}
+.viz-relation-text{font:500 11px ui-monospace,SFMono-Regular,Menlo,monospace;fill:#4d3a11;text-anchor:middle;dominant-baseline:middle}
+.viz-empty{font:500 14px system-ui,-apple-system,BlinkMacSystemFont,sans-serif;fill:#5b6670}
+</style>
+";
+
+fn write_graph_chips(projection: &VizProjection, width: i32, margin: i32, out: &mut String) {
+    let graph_x = width - margin - 112;
+    for (index, graph) in projection.graphs.iter().enumerate() {
+        let y = margin + 24 + i32_from_usize(index) * 26;
+        let id = svg_id("graph", &graph.id.0);
+        writeln!(
+            out,
+            "<g id=\"{}\" data-purrdf-id=\"{}\"><rect class=\"viz-chip\" x=\"{}\" y=\"{}\" width=\"112\" height=\"18\" rx=\"4\"/><text class=\"viz-chip-text\" x=\"{}\" y=\"{}\">{}</text></g>",
+            escape_attr_string(&id),
+            escape_attr_string(&graph.id.0),
+            graph_x - 56,
+            y - 9,
+            graph_x,
+            y,
+            escape_text_string(&trim_label(&graph.label, 18))
+        )
+        .expect("writing to String cannot fail");
+    }
+}
+
+fn write_quoted_capsule(
+    statement: &VizStatementId,
+    subject: &str,
+    predicate: &str,
+    object: &str,
+    center: i32,
+    y: i32,
+    out: &mut String,
+) {
+    let label = format!(
+        "{} - {} -> {}",
+        trim_label(subject, 18),
+        trim_label(predicate, 18),
+        trim_label(object, 18)
+    );
+    let id = svg_id("assertion-line", &statement.0);
+    writeln!(
+        out,
+        "<rect id=\"{}\" class=\"viz-quoted\" x=\"{}\" y=\"{}\" width=\"360\" height=\"42\" rx=\"18\" data-purrdf-id=\"{}\"/><text class=\"viz-capsule-text\" x=\"{}\" y=\"{}\">{}</text>",
+        escape_attr_string(&id),
+        center - 180,
+        y - 21,
+        escape_attr_string(&statement.0),
+        center,
+        y,
+        escape_text_string(&label)
+    )
+    .expect("writing to String cannot fail");
+}
+
+fn write_asserted_arrow(
+    statement: &VizStatementId,
+    subject_x: i32,
+    object_x: i32,
+    y: i32,
+    out: &mut String,
+) {
+    let id = svg_id("assertion-line", &statement.0);
+    writeln!(
+        out,
+        "<line id=\"{}\" class=\"viz-assertion\" x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" data-purrdf-id=\"{}\"/>",
+        escape_attr_string(&id),
+        subject_x + 64,
+        y,
+        object_x - 64,
+        y,
+        escape_attr_string(&statement.0)
+    )
+    .expect("writing to String cannot fail");
+}
+
+fn write_value_label(
+    statement: &VizStatementId,
+    role: &str,
+    x: i32,
+    y: i32,
+    label: &str,
+    out: &mut String,
+) {
+    let id = scoped_svg_id("value", &statement.0, role);
+    writeln!(
+        out,
+        "<text id=\"{}\" class=\"viz-term\" x=\"{}\" y=\"{}\">{}</text>",
+        escape_attr_string(&id),
+        x,
+        y,
+        escape_text_string(&trim_label(label, 24))
+    )
+    .expect("writing to String cannot fail");
+}
+
+fn write_predicate_label(
+    statement: &VizStatementId,
+    x: i32,
+    y: i32,
+    label: &str,
+    out: &mut String,
+) {
+    let id = scoped_svg_id("predicate", &statement.0, "predicate");
+    writeln!(
+        out,
+        "<text id=\"{}\" class=\"viz-predicate\" x=\"{}\" y=\"{}\">{}</text>",
+        escape_attr_string(&id),
+        x,
+        y,
+        escape_text_string(&trim_label(label, 24))
+    )
+    .expect("writing to String cannot fail");
+}
+
+fn write_statement_anchor(
+    statement: &VizStatement,
+    x: i32,
+    y: i32,
+    relation_info: &BTreeMap<VizStatementId, StatementRelationInfo>,
+    out: &mut String,
+) {
+    let info = relation_info
+        .get(&statement.id)
+        .cloned()
+        .unwrap_or_default();
+    let label = format!(
+        "{} A{} R{} N{}",
+        statement_short_label(&statement.id),
+        statement.asserted_in.len(),
+        info.reifier_count,
+        info.annotation_count
+    );
+    writeln!(
+        out,
+        "<rect class=\"viz-anchor\" x=\"{}\" y=\"{}\" width=\"78\" height=\"22\" rx=\"5\"/><text class=\"viz-anchor-text\" x=\"{}\" y=\"{}\">{}</text>",
+        x - 39,
+        y + 9,
+        x,
+        y + 20,
+        escape_text_string(&label)
+    )
+    .expect("writing to String cannot fail");
+}
+
+fn write_graph_badges(
+    statement: &VizStatement,
+    graphs: &BTreeMap<VizGraphId, String>,
+    x: i32,
+    y: i32,
+    out: &mut String,
+) {
+    for (index, graph) in statement.asserted_in.iter().enumerate() {
+        let label = graphs
+            .get(graph)
+            .cloned()
+            .unwrap_or_else(|| graph.0.clone());
+        let chip_x = x - i32_from_usize(index) * 92;
+        writeln!(
+            out,
+            "<rect class=\"viz-chip\" x=\"{}\" y=\"{}\" width=\"84\" height=\"18\" rx=\"4\"/><text class=\"viz-chip-text\" x=\"{}\" y=\"{}\">in {}</text>",
+            chip_x - 42,
+            y - 9,
+            chip_x,
+            y,
+            escape_text_string(&trim_label(&label, 10))
+        )
+        .expect("writing to String cannot fail");
+    }
+}
+
+fn write_relation_summaries(
+    statement: &VizStatement,
+    projection: &VizProjection,
+    terms: &BTreeMap<VizTermId, String>,
+    x: i32,
+    y: i32,
+    out: &mut String,
+) {
+    let mut offset = 0;
+    for relation in &projection.relations {
+        let VizRelation::Reifies {
+            id,
+            reifier,
+            statement: target,
+            ..
+        } = relation
+        else {
+            continue;
+        };
+        if target != &statement.id {
+            continue;
+        }
+        let label = terms
+            .get(reifier)
+            .cloned()
+            .unwrap_or_else(|| reifier.0.clone());
+        let element_id = svg_id("relation", &id.0);
+        let rx = x + offset;
+        writeln!(
+            out,
+            "<g id=\"{}\" data-purrdf-id=\"{}\"><rect class=\"viz-relation\" x=\"{}\" y=\"{}\" width=\"120\" height=\"20\" rx=\"4\"/><text class=\"viz-relation-text\" x=\"{}\" y=\"{}\">reifier {}</text></g>",
+            escape_attr_string(&element_id),
+            escape_attr_string(&id.0),
+            rx - 60,
+            y - 10,
+            rx,
+            y,
+            escape_text_string(&trim_label(&label, 12))
+        )
+        .expect("writing to String cannot fail");
+        offset += 132;
+    }
+}
+
+fn write_title_desc(element_id: &str, summary: &str, out: &mut String) {
+    writeln!(
+        out,
+        "<title id=\"{}-title\">{}</title><desc id=\"{}-desc\">{}</desc>",
+        escape_attr_string(element_id),
+        escape_text_string(summary),
+        escape_attr_string(element_id),
+        escape_text_string(summary)
+    )
+    .expect("writing to String cannot fail");
+}
+
+#[derive(Debug, Clone, Default)]
+struct StatementRelationInfo {
+    reifier_count: usize,
+    annotation_count: usize,
+    reifiers: Vec<VizTermId>,
+}
+
+fn statement_relation_info(
+    projection: &VizProjection,
+) -> BTreeMap<VizStatementId, StatementRelationInfo> {
+    let mut annotation_count_by_reifier: BTreeMap<VizTermId, usize> = BTreeMap::new();
+    for relation in &projection.relations {
+        if let VizRelation::Annotation { reifier, .. } = relation {
+            *annotation_count_by_reifier
+                .entry(reifier.clone())
+                .or_default() += 1;
+        }
+    }
+    let mut info_by_statement: BTreeMap<VizStatementId, StatementRelationInfo> = BTreeMap::new();
+    for relation in &projection.relations {
+        if let VizRelation::Reifies {
+            reifier, statement, ..
+        } = relation
+        {
+            let info = info_by_statement.entry(statement.clone()).or_default();
+            info.reifier_count += 1;
+            info.annotation_count += annotation_count_by_reifier
+                .get(reifier)
+                .copied()
+                .unwrap_or_default();
+            info.reifiers.push(reifier.clone());
+        }
+    }
+    info_by_statement
+}
+
+fn statement_summary(
+    statement: &VizStatement,
+    subject: &str,
+    predicate: &str,
+    object: &str,
+    graphs: &BTreeMap<VizGraphId, String>,
+    relation_info: &BTreeMap<VizStatementId, StatementRelationInfo>,
+) -> String {
+    let asserted = if statement.asserted_in.is_empty() {
+        "not asserted".to_owned()
+    } else {
+        let labels = statement
+            .asserted_in
+            .iter()
+            .map(|graph| {
+                graphs
+                    .get(graph)
+                    .cloned()
+                    .unwrap_or_else(|| graph.0.clone())
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("asserted in {labels}")
+    };
+    let info = relation_info
+        .get(&statement.id)
+        .cloned()
+        .unwrap_or_default();
+    format!(
+        "{} {} {}. {asserted}. Reifiers: {}. Annotations: {}. Dialect: {:?}.",
+        subject, predicate, object, info.reifier_count, info.annotation_count, statement.dialect
+    )
+}
+
+fn term_label_map(projection: &VizProjection) -> BTreeMap<VizTermId, String> {
+    projection
+        .terms
+        .iter()
+        .map(|term| (term.id.clone(), term.label.clone()))
+        .collect()
+}
+
+fn graph_label_map(projection: &VizProjection) -> BTreeMap<VizGraphId, String> {
+    projection
+        .graphs
+        .iter()
+        .map(|graph| (graph.id.clone(), graph.label.clone()))
+        .collect()
+}
+
+fn value_label(value: &VizValueRef, terms: &BTreeMap<VizTermId, String>) -> String {
+    match value {
+        VizValueRef::Term { id } => terms.get(id).cloned().unwrap_or_else(|| id.0.clone()),
+        VizValueRef::Statement { id } => statement_short_label(id),
+    }
+}
+
+fn statement_short_label(id: &VizStatementId) -> String {
+    format!("S{}", id.0.strip_prefix("statement:").unwrap_or(&id.0))
+}
+
+fn relation_id(relation: &VizRelation) -> &VizRelationId {
+    match relation {
+        VizRelation::Reifies { id, .. } | VizRelation::Annotation { id, .. } => id,
+    }
+}
+
+fn relation_statement_id(relation: &VizRelation) -> Option<&VizStatementId> {
+    match relation {
+        VizRelation::Reifies { statement, .. } => Some(statement),
+        VizRelation::Annotation { .. } => None,
+    }
+}
+
+fn row_y(index: usize, options: &VizSvgOptions) -> i32 {
+    svg_margin(options) + 72 + i32_from_usize(index) * svg_row_height(options)
+}
+
+fn svg_height(projection: &VizProjection, options: &VizSvgOptions) -> i32 {
+    let rows = i32_from_usize(projection.statements.len().max(1));
+    svg_margin(options) * 2 + 96 + rows * svg_row_height(options)
+}
+
+fn svg_width(options: &VizSvgOptions) -> i32 {
+    options.width.max(640)
+}
+
+fn svg_margin(options: &VizSvgOptions) -> i32 {
+    options.margin.max(16)
+}
+
+fn svg_row_height(options: &VizSvgOptions) -> i32 {
+    options.row_height.max(84)
+}
+
+fn i32_from_usize(value: usize) -> i32 {
+    i32::try_from(value).unwrap_or(i32::MAX / 2)
+}
+
+fn scoped_svg_id(prefix: &str, model_id: &str, suffix: &str) -> String {
+    format!("{}-{}", svg_id(prefix, model_id), suffix)
+}
+
+fn svg_id(prefix: &str, model_id: &str) -> String {
+    let mut out = String::with_capacity(prefix.len() + model_id.len() + 1);
+    out.push_str(prefix);
+    out.push('-');
+    let mut previous_dash = false;
+    for ch in model_id.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            previous_dash = false;
+        } else if !previous_dash {
+            out.push('-');
+            previous_dash = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    out
+}
+
+fn trim_label(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let mut out = String::new();
+    for _ in 0..max_chars {
+        let Some(ch) = chars.next() else {
+            return out;
+        };
+        out.push(ch);
+    }
+    if chars.next().is_some() {
+        out.push_str("...");
+    }
+    out
+}
+
+fn escape_attr_string(value: &str) -> String {
+    let mut out = String::new();
+    escape_xml_attr(value, &mut out);
+    out
+}
+
+fn escape_text_string(value: &str) -> String {
+    let mut out = String::new();
+    escape_xml_text(value, &mut out);
+    out
+}
+
+fn escape_xml_attr(value: &str, out: &mut String) {
+    for ch in value.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(ch),
+        }
+    }
+}
+
+fn escape_xml_text(value: &str, out: &mut String) {
+    for ch in value.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            _ => out.push(ch),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1630,6 +2435,93 @@ mod tests {
         let a = project_graph_input(&input, &VizSpec::default()).expect("project");
         let b = project_graph_input(&input, &VizSpec::default()).expect("project");
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn svg_export_embeds_load_bearing_metadata_and_index() {
+        let input = VizGraphInput {
+            quads: vec![VizInputQuad {
+                subject: iri("alice"),
+                predicate: KNOWS.to_owned(),
+                object: iri("bob"),
+                graph_name: None,
+            }],
+            reifiers: vec![VizInputReifier {
+                reifier: iri("claim"),
+                statement: VizInputStatement {
+                    subject: iri("alice"),
+                    predicate: KNOWS.to_owned(),
+                    object: iri("bob"),
+                },
+                graph_name: None,
+            }],
+            annotations: vec![VizInputAnnotation {
+                reifier: iri("claim"),
+                predicate: ATTRIBUTED_TO.to_owned(),
+                object: iri("carol"),
+                graph_name: None,
+            }],
+        };
+        let doc = render_graph_input_svg(&input, &VizSpec::default(), &VizSvgOptions::default())
+            .expect("svg");
+        assert!(doc.svg.contains("id=\"purrdf-viz-export\""));
+        assert!(doc.svg.contains(VIZ_EXPORT_SCHEMA_VERSION));
+        assert!(doc.svg.contains("class=\"viz-assertion\""));
+        assert!(doc.svg.contains("reifier claim"));
+        assert_eq!(doc.export.schema_version, VIZ_EXPORT_SCHEMA_VERSION);
+        assert!(!doc.export.layout.is_empty());
+        assert!(
+            doc.export
+                .element_index
+                .iter()
+                .any(|entry| entry.kind == "statement")
+        );
+    }
+
+    #[test]
+    fn svg_distinguishes_quoted_only_from_asserted() {
+        let input = VizGraphInput {
+            reifiers: vec![VizInputReifier {
+                reifier: iri("claim"),
+                statement: VizInputStatement {
+                    subject: iri("alice"),
+                    predicate: KNOWS.to_owned(),
+                    object: iri("bob"),
+                },
+                graph_name: None,
+            }],
+            ..VizGraphInput::default()
+        };
+        let doc = render_graph_input_svg(&input, &VizSpec::default(), &VizSvgOptions::default())
+            .expect("svg");
+        assert!(doc.svg.contains("class=\"viz-quoted\""));
+        assert!(!doc.svg.contains("class=\"viz-assertion\""));
+    }
+
+    #[test]
+    fn svg_output_is_deterministic_and_escapes_xml() {
+        let input = VizGraphInput {
+            quads: vec![VizInputQuad {
+                subject: TermValue::Iri("https://example.org/a<&".to_owned()),
+                predicate: KNOWS.to_owned(),
+                object: TermValue::Literal {
+                    lexical_form: "Bob <&> \"quoted\"".to_owned(),
+                    datatype: "http://www.w3.org/2001/XMLSchema#string".to_owned(),
+                    language: None,
+                    direction: None,
+                },
+                graph_name: None,
+            }],
+            ..VizGraphInput::default()
+        };
+        let a = render_graph_input_svg(&input, &VizSpec::default(), &VizSvgOptions::default())
+            .expect("svg");
+        let b = render_graph_input_svg(&input, &VizSpec::default(), &VizSvgOptions::default())
+            .expect("svg");
+        assert_eq!(a, b);
+        assert!(a.svg.contains("a&lt;&amp;"));
+        assert!(a.svg.contains("Bob &lt;&amp;&gt;"));
+        assert!(!a.svg.contains("Bob <&>"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #80.

Adds a statement-centric RDF 1.2 visualization layer that keeps assertions, quoted triple terms, reifier identity, annotation attachment, graph context, directional literals, and dialect diagnostics separate.

- Adds `purrdf_rdf::viz` / `purrdf::viz` with a deterministic Statement Incidence Model, graph-like caller input, JSON projection/export helpers, and semantic SVG rendering with embedded `purrdf-viz-export-1` metadata.
- Adds wasm/npm `Dataset.visualModel`, `Dataset.visualExport`, and `Dataset.visualSvg` APIs, with TypeScript contracts and docs.
- Adds visualization benchmarks and raises the wasm size ceiling with measured-size rationale for the new wasm-visible visualization capability.

## Checklist

- [x] `cargo fmt --all` has been run and `make check` passes (fmt + clippy + build + tests + hygiene)
- [x] No new Cargo features introduced anywhere in the workspace
- [x] No hand-edits to `generated/` or `vectors/` (regenerate via `make metadata` instead)
- [x] If touching a release crate: wasm32 build stays clean (`make wasm`)
- [x] Docs / CHANGELOG updated where the change is user-visible
- [x] If claiming a performance improvement: criterion benches extended to cover it

## Validation

- `PATH="$HOME/.cargo/bin:$PATH" make check`
- `PATH="$HOME/.cargo/bin:$PATH" make wasm-pkg-test`
- `PATH="$HOME/.cargo/bin:$PATH" make wasm-pkg-size`
- `cargo bench -p purrdf-rdf --bench viz_projection --no-run --offline`
