### PR TITLE
Expose entailed SPARQL and RIF parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,137 @@ All notable changes to the PurRDF crate suite are recorded here. The suite
 ships one lockstep version across crates.io, PyPI, and npm; pre-1.0, a minor
 bump may carry breaking changes and a patch bump is bugfix-only.
 
+## [0.4.2] - 2026-07-10
+
+### Features
+
+- Expose entailed SPARQL and RIF parsing
+
+### Other
+
+- Harden npm wasm RDF 1.2 toolkit
+
+Harden npm wasm RDF 1.2 toolkit
+
+Summary
+
+This branch hardens the wasm npm package into a package-root RDF 1.2 TypeScript toolkit and offline SPARQL platform over the existing Rust engine. It adds package-correct RDF/JS declarations, dependency-free runtime ergonomics, a reusable query engine with native plan-cache lifetime, packed-package release gates, package-size budgets, and repeatable ecosystem evidence.
+
+Requirements Satisfied
+
+- Replaced package-root TypeScript declarations with hand-authored RDF/JS-compatible types for terms, quads, literals, directional language literals, datasets, streams, sinks, canonical graph identity, iteration, and null-safe equality.
+- Added dependency-free package-root helpers: `Dataset.from`, `Dataset#toStream`, `DataFactory#dataset`, chainable dataset mutation, and RDF 1.2 directional literal support.
+- Promoted SPARQL to a reusable TypeScript API through `QueryEngine`, typed SELECT/ASK/CONSTRUCT/DESCRIBE helpers, raw result serialization, atomic update support, and compatibility for `Dataset.query`.
+- Remote `SERVICE` and remote `LOAD` now produce explicit hard errors unless a host resolver is supplied by the embedding environment.
+- Added npm quality gates: TypeScript compile test, packed-tarball install/import smoke test, package-size checks, CI wiring, and release workflow wiring.
+- Added repeatable ecosystem probe evidence comparing current package behavior and footprint with N3.js, rdf-ext, graphy, Comunica, and Oxigraph JS, with exact installed package versions and commands.
+- Preserved PurRDF constraints: no new Cargo features, no optional dependencies, no semantic cfg split, no caller-vocabulary defaults, deterministic output paths left intact, and wasm/package-size gates passing.
+
+Files Changed
+
+- `.github/workflows/ci.yaml`: runs package and wasm benchmark gates in CI.
+- `.github/workflows/release-npm.yaml`: installs pinned npm dependencies before the npm release check.
+- `Cargo.lock`: records the wasm bench dev-dependency edge.
+- `Makefile`: wires npm package check, package-size reporting, and wasm benchmark coverage.
+- `crates/rdf-capi/include/purrdf.h`: regenerated C header version constants after the workspace version bump.
+- `crates/rdf-wasm/Cargo.toml`: adds the criterion bench target for query-engine reuse.
+- `crates/rdf-wasm/README.md`: updates wasm package surface notes.
+- `crates/rdf-wasm/benches/query_engine_reuse.rs`: measures reusable query-engine behavior.
+- `crates/rdf-wasm/js/README.md`: documents package-root import and toolkit usage.
+- `crates/rdf-wasm/js/bench/ecosystem-probe.mjs`: adds repeatable ecosystem and footprint probing.
+- `crates/rdf-wasm/js/index.d.ts`: replaces package-root declarations with package-correct RDF/JS and SPARQL types.
+- `crates/rdf-wasm/js/index.mjs`: adds package-root helpers, typed query engine wrappers, null-safe dataset creation, hard errors for remote operations, and package-size checks.
+- `crates/rdf-wasm/js/package-lock.json`: pins npm gate toolchain and probe dependencies.
+- `crates/rdf-wasm/js/package.json`: defines pinned checks, smoke tests, and package metadata scripts.
+- `crates/rdf-wasm/js/tests/ergonomics.test.mjs`: covers package-root RDF/JS ergonomics.
+- `crates/rdf-wasm/js/tests/pack-smoke.mjs`: validates the packed tarball in a temp project.
+- `crates/rdf-wasm/js/tests/query.test.mjs`: covers SPARQL query/update/runtime behavior.
+- `crates/rdf-wasm/js/tests/types/package-root.types.ts`: compile-only package-root TypeScript fixture.
+- `crates/rdf-wasm/js/tsconfig.types.json`: TypeScript config for declaration validation.
+- `crates/rdf-wasm/src/lib.rs`: exports the wasm query module.
+- `crates/rdf-wasm/src/query.rs`: implements typed query/update bindings, result serialization, hard errors for unsupported remote operations, and shared projection storage for SELECT rows.
+- `docs/BENCHMARKS.md`: documents the wasm query-engine bench.
+- `docs/NPM-ECOSYSTEM.md`: records generated package comparison evidence.
+- `docs/RELEASE.md`: documents the npm release gate.
+- `docs/book/src/getting-started/javascript.md`: updates JavaScript getting-started guidance.
+- `docs/book/src/interop/rdfjs.md`: updates RDF/JS interop documentation.
+
+Validation
+
+- `make capi-check`: passed after regenerating `crates/rdf-capi/include/purrdf.h`.
+- `cd crates/rdf-wasm/js && npm ci --ignore-scripts --no-audit --no-fund && npm run check`: passed, including TypeScript, 43 Node tests, packed-tarball smoke, and package-size checks.
+- `node crates/rdf-wasm/js/bench/ecosystem-probe.mjs --write-report docs/NPM-ECOSYSTEM.md`: passed.
+- `cargo test -p purrdf-wasm --lib --locked`: passed.
+- `cargo bench -p purrdf-wasm --bench query_engine_reuse --no-run --locked`: passed.
+- `cargo clippy -p purrdf-wasm --all-targets --locked -- -D warnings`: passed.
+- `make wasm-pkg-test`: passed; optimized wasm package build, TypeScript gate, 43 Node tests, packed smoke, npm tarball 1,130,515 bytes / 1,400,000 byte budget, unpacked package 3,174,729 bytes / 3,600,000 byte budget.
+- `make wasm-pkg-size`: passed; wasm artifact 3,061,875 bytes / 3,145,728 byte budget, gzip -9 1,109,590 bytes, SIMD verified.
+- `make conformance`: passed; 2,855 pass, 10 ledgered xfail/skip, 0 failures, GREEN verdict.
+- `make check`: passed; fmt, clippy, build, tests, hygiene, generated checks, issue-reference scan, version checks, and wasm build.
+- `gh pr checks 79` before the Stage 3 base sync: all visible non-skipped checks passed.
+- Stage 3 base sync: `git fetch origin main`, `git merge origin/main`, and `git push` completed cleanly at `05ad1a5`.
+- `gh pr checks 79` after the Stage 3 base sync: all visible non-skipped checks passed, including `benchmarks` in 29m53s.
+
+Goals And Constraints
+
+- GREENFIELD-FIRST / maximal utility: the package now exposes a serious package-root RDF 1.2 and SPARQL surface rather than thin generated bindings.
+- RUST-FIRST, PYTHON-SURFACE / maximal performance: query execution, update behavior, serialization, and projection storage stay in Rust-backed wasm bindings; JS wrappers provide ergonomic access without replacing engine behavior.
+- LOW/NO OPTIONALITY, HARD FAILS: no optional package dependencies or Cargo features were added; unavailable remote `SERVICE` and `LOAD` paths hard-error.
+- Maximal portability: wasm build, wasm package tests, wasm package-size gate, and full workspace check all passed.
+
+Deferral Gate
+
+- Branch diff scan over `git diff origin/main...HEAD`: no hits.
+- PR-comment scan produced two false positives from process comments: line 328 is a review table scope-status row that says the branch stayed focused and passed; line 496 is a completion status noting benchmark success and no extra code changes. Neither records uncompleted product work.
+
+Implementation Notes
+
+- `QueryEngine` owns native engine state so plan-cache reuse survives across JS calls.
+- SELECT rows share projection storage in Rust to avoid cloning the variable list for every row.
+- The ecosystem probe reads installed package metadata and preloads Oxigraph data before measured query runs so the comparison is reproducible and fairer.
+- Packed-package smoke tests install from the actual `npm pack` tarball and exercise RDF 1.2, SPARQL, SHACL, and graph identity behavior through the package root.
+- The Stage 3 merge from `origin/main` had no conflicts. The base branch contributed `CHANGELOG.md`; no conflict-resolution choices were required.
+
+parent_hashes: 05ad1a5f88576a7224a7a429fadb0bb1ca6ac373
+
+GhpRsq-Schema: 1
+GhpRsq-Merge-Style: structured-squash
+GhpRsq-GitHub-Repo: Blackcat-Informatics/purrdf
+GhpRsq-GitHub-Pull-Request: 79
+GhpRsq-GitHub-PR-URL: https://github.com/Blackcat-Informatics/purrdf/pull/79
+GhpRsq-Base-Ref: main
+GhpRsq-Base-OID: e0e7bb69e958dd12c2593394b1f18886e2d71059
+GhpRsq-Head-Ref: paudley/77-npm-wasm-toolkit-sparql
+GhpRsq-Head-OID: 05ad1a5f88576a7224a7a429fadb0bb1ca6ac373
+GhpRsq-Result-Tree: 41766d08e9333d888350a378be943e1580b89d02
+GhpRsq-Parent-Hashes: 05ad1a5f88576a7224a7a429fadb0bb1ca6ac373
+GhpRsq-Squash-Notes-SHA256: 1ab0881f6790db8d9c216ef1353767840569f6af90abcc1058989d530c52a110
 ## [0.4.1] - 2026-07-09
 
 ### Bug Fixes
 
 - **shapes:** Project external object-class values to a node-ref, not a string, in JSON Schema
+- **npm:** Align package-root RDFJS typings
+- **capi:** Refresh generated ABI header
+- **npm:** Accept null dataset inputs
+- **npm:** Correct ecosystem probe evidence
+
+### Documentation
+
+- **npm:** Add ecosystem probe evidence
+
+### Features
+
+- **npm:** Add reusable SPARQL query engine
+
+### Performance
+
+- **wasm:** Benchmark query engine reuse
+
+### Testing
+
+- **npm:** Gate packed wasm package
+- **npm:** Pin package gate toolchain
 ## [0.4.0] - 2026-07-07
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 
 ## [0.4.2] - 2026-07-10
 
+### Bug Fixes
+
+- Refresh lockfile for RIF parser
+
 ### Features
 
 - Expose entailed SPARQL and RIF parsing
@@ -14,101 +18,6 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 
 - Harden npm wasm RDF 1.2 toolkit
 
-Harden npm wasm RDF 1.2 toolkit
-
-Summary
-
-This branch hardens the wasm npm package into a package-root RDF 1.2 TypeScript toolkit and offline SPARQL platform over the existing Rust engine. It adds package-correct RDF/JS declarations, dependency-free runtime ergonomics, a reusable query engine with native plan-cache lifetime, packed-package release gates, package-size budgets, and repeatable ecosystem evidence.
-
-Requirements Satisfied
-
-- Replaced package-root TypeScript declarations with hand-authored RDF/JS-compatible types for terms, quads, literals, directional language literals, datasets, streams, sinks, canonical graph identity, iteration, and null-safe equality.
-- Added dependency-free package-root helpers: `Dataset.from`, `Dataset#toStream`, `DataFactory#dataset`, chainable dataset mutation, and RDF 1.2 directional literal support.
-- Promoted SPARQL to a reusable TypeScript API through `QueryEngine`, typed SELECT/ASK/CONSTRUCT/DESCRIBE helpers, raw result serialization, atomic update support, and compatibility for `Dataset.query`.
-- Remote `SERVICE` and remote `LOAD` now produce explicit hard errors unless a host resolver is supplied by the embedding environment.
-- Added npm quality gates: TypeScript compile test, packed-tarball install/import smoke test, package-size checks, CI wiring, and release workflow wiring.
-- Added repeatable ecosystem probe evidence comparing current package behavior and footprint with N3.js, rdf-ext, graphy, Comunica, and Oxigraph JS, with exact installed package versions and commands.
-- Preserved PurRDF constraints: no new Cargo features, no optional dependencies, no semantic cfg split, no caller-vocabulary defaults, deterministic output paths left intact, and wasm/package-size gates passing.
-
-Files Changed
-
-- `.github/workflows/ci.yaml`: runs package and wasm benchmark gates in CI.
-- `.github/workflows/release-npm.yaml`: installs pinned npm dependencies before the npm release check.
-- `Cargo.lock`: records the wasm bench dev-dependency edge.
-- `Makefile`: wires npm package check, package-size reporting, and wasm benchmark coverage.
-- `crates/rdf-capi/include/purrdf.h`: regenerated C header version constants after the workspace version bump.
-- `crates/rdf-wasm/Cargo.toml`: adds the criterion bench target for query-engine reuse.
-- `crates/rdf-wasm/README.md`: updates wasm package surface notes.
-- `crates/rdf-wasm/benches/query_engine_reuse.rs`: measures reusable query-engine behavior.
-- `crates/rdf-wasm/js/README.md`: documents package-root import and toolkit usage.
-- `crates/rdf-wasm/js/bench/ecosystem-probe.mjs`: adds repeatable ecosystem and footprint probing.
-- `crates/rdf-wasm/js/index.d.ts`: replaces package-root declarations with package-correct RDF/JS and SPARQL types.
-- `crates/rdf-wasm/js/index.mjs`: adds package-root helpers, typed query engine wrappers, null-safe dataset creation, hard errors for remote operations, and package-size checks.
-- `crates/rdf-wasm/js/package-lock.json`: pins npm gate toolchain and probe dependencies.
-- `crates/rdf-wasm/js/package.json`: defines pinned checks, smoke tests, and package metadata scripts.
-- `crates/rdf-wasm/js/tests/ergonomics.test.mjs`: covers package-root RDF/JS ergonomics.
-- `crates/rdf-wasm/js/tests/pack-smoke.mjs`: validates the packed tarball in a temp project.
-- `crates/rdf-wasm/js/tests/query.test.mjs`: covers SPARQL query/update/runtime behavior.
-- `crates/rdf-wasm/js/tests/types/package-root.types.ts`: compile-only package-root TypeScript fixture.
-- `crates/rdf-wasm/js/tsconfig.types.json`: TypeScript config for declaration validation.
-- `crates/rdf-wasm/src/lib.rs`: exports the wasm query module.
-- `crates/rdf-wasm/src/query.rs`: implements typed query/update bindings, result serialization, hard errors for unsupported remote operations, and shared projection storage for SELECT rows.
-- `docs/BENCHMARKS.md`: documents the wasm query-engine bench.
-- `docs/NPM-ECOSYSTEM.md`: records generated package comparison evidence.
-- `docs/RELEASE.md`: documents the npm release gate.
-- `docs/book/src/getting-started/javascript.md`: updates JavaScript getting-started guidance.
-- `docs/book/src/interop/rdfjs.md`: updates RDF/JS interop documentation.
-
-Validation
-
-- `make capi-check`: passed after regenerating `crates/rdf-capi/include/purrdf.h`.
-- `cd crates/rdf-wasm/js && npm ci --ignore-scripts --no-audit --no-fund && npm run check`: passed, including TypeScript, 43 Node tests, packed-tarball smoke, and package-size checks.
-- `node crates/rdf-wasm/js/bench/ecosystem-probe.mjs --write-report docs/NPM-ECOSYSTEM.md`: passed.
-- `cargo test -p purrdf-wasm --lib --locked`: passed.
-- `cargo bench -p purrdf-wasm --bench query_engine_reuse --no-run --locked`: passed.
-- `cargo clippy -p purrdf-wasm --all-targets --locked -- -D warnings`: passed.
-- `make wasm-pkg-test`: passed; optimized wasm package build, TypeScript gate, 43 Node tests, packed smoke, npm tarball 1,130,515 bytes / 1,400,000 byte budget, unpacked package 3,174,729 bytes / 3,600,000 byte budget.
-- `make wasm-pkg-size`: passed; wasm artifact 3,061,875 bytes / 3,145,728 byte budget, gzip -9 1,109,590 bytes, SIMD verified.
-- `make conformance`: passed; 2,855 pass, 10 ledgered xfail/skip, 0 failures, GREEN verdict.
-- `make check`: passed; fmt, clippy, build, tests, hygiene, generated checks, issue-reference scan, version checks, and wasm build.
-- `gh pr checks 79` before the Stage 3 base sync: all visible non-skipped checks passed.
-- Stage 3 base sync: `git fetch origin main`, `git merge origin/main`, and `git push` completed cleanly at `05ad1a5`.
-- `gh pr checks 79` after the Stage 3 base sync: all visible non-skipped checks passed, including `benchmarks` in 29m53s.
-
-Goals And Constraints
-
-- GREENFIELD-FIRST / maximal utility: the package now exposes a serious package-root RDF 1.2 and SPARQL surface rather than thin generated bindings.
-- RUST-FIRST, PYTHON-SURFACE / maximal performance: query execution, update behavior, serialization, and projection storage stay in Rust-backed wasm bindings; JS wrappers provide ergonomic access without replacing engine behavior.
-- LOW/NO OPTIONALITY, HARD FAILS: no optional package dependencies or Cargo features were added; unavailable remote `SERVICE` and `LOAD` paths hard-error.
-- Maximal portability: wasm build, wasm package tests, wasm package-size gate, and full workspace check all passed.
-
-Deferral Gate
-
-- Branch diff scan over `git diff origin/main...HEAD`: no hits.
-- PR-comment scan produced two false positives from process comments: line 328 is a review table scope-status row that says the branch stayed focused and passed; line 496 is a completion status noting benchmark success and no extra code changes. Neither records uncompleted product work.
-
-Implementation Notes
-
-- `QueryEngine` owns native engine state so plan-cache reuse survives across JS calls.
-- SELECT rows share projection storage in Rust to avoid cloning the variable list for every row.
-- The ecosystem probe reads installed package metadata and preloads Oxigraph data before measured query runs so the comparison is reproducible and fairer.
-- Packed-package smoke tests install from the actual `npm pack` tarball and exercise RDF 1.2, SPARQL, SHACL, and graph identity behavior through the package root.
-- The Stage 3 merge from `origin/main` had no conflicts. The base branch contributed `CHANGELOG.md`; no conflict-resolution choices were required.
-
-parent_hashes: 05ad1a5f88576a7224a7a429fadb0bb1ca6ac373
-
-GhpRsq-Schema: 1
-GhpRsq-Merge-Style: structured-squash
-GhpRsq-GitHub-Repo: Blackcat-Informatics/purrdf
-GhpRsq-GitHub-Pull-Request: 79
-GhpRsq-GitHub-PR-URL: https://github.com/Blackcat-Informatics/purrdf/pull/79
-GhpRsq-Base-Ref: main
-GhpRsq-Base-OID: e0e7bb69e958dd12c2593394b1f18886e2d71059
-GhpRsq-Head-Ref: paudley/77-npm-wasm-toolkit-sparql
-GhpRsq-Head-OID: 05ad1a5f88576a7224a7a429fadb0bb1ca6ac373
-GhpRsq-Result-Tree: 41766d08e9333d888350a378be943e1580b89d02
-GhpRsq-Parent-Hashes: 05ad1a5f88576a7224a7a429fadb0bb1ca6ac373
-GhpRsq-Squash-Notes-SHA256: 1ab0881f6790db8d9c216ef1353767840569f6af90abcc1058989d530c52a110
 ## [0.4.1] - 2026-07-09
 
 ### Bug Fixes
@@ -135,6 +44,7 @@ GhpRsq-Squash-Notes-SHA256: 1ab0881f6790db8d9c216ef1353767840569f6af90abcc105898
 
 - **npm:** Gate packed wasm package
 - **npm:** Pin package gate toolchain
+
 ## [0.4.0] - 2026-07-07
 
 ### Bug Fixes
@@ -193,6 +103,7 @@ GhpRsq-Squash-Notes-SHA256: 1ab0881f6790db8d9c216ef1353767840569f6af90abcc105898
 
 - **shapes:** Add trusted external JSON-Schema validator harness
 - **shapes:** Behavioral accept/reject tests for polarity-sound sh:not
+
 ## [0.3.3] - 2026-07-05
 
 ### Documentation
@@ -203,6 +114,7 @@ GhpRsq-Squash-Notes-SHA256: 1ab0881f6790db8d9c216ef1353767840569f6af90abcc105898
 
 - **rdf:** Memoize the line index so parser diagnostics stay linear
 - **rdf:** Memoize parser line index — fix quadratic diagnostics scan
+
 ## [0.3.2] - 2026-07-05
 
 ### Bug Fixes
@@ -212,6 +124,7 @@ GhpRsq-Squash-Notes-SHA256: 1ab0881f6790db8d9c216ef1353767840569f6af90abcc105898
 ### Features
 
 - **shapes:** SHACL Rules — 100% SHACL-AF coverage
+
 ## [0.3.1] - 2026-07-05
 
 ### Bug Fixes
@@ -245,6 +158,7 @@ GhpRsq-Squash-Notes-SHA256: 1ab0881f6790db8d9c216ef1353767840569f6af90abcc105898
 - **shapes:** SHACL Rules conformance corpus + inferred-graph harness
 - **shapes:** Audit every node-expression kind in sh:TripleRule subject/predicate/object positions
 - **shapes:** Cover blank-focus blank minting and multi-round fixpoint convergence
+
 ## [0.3.0] - 2026-07-05
 
 ### Benchmarks
@@ -448,45 +362,6 @@ GhpRsq-Squash-Notes-SHA256: 1ab0881f6790db8d9c216ef1353767840569f6af90abcc105898
 - **shapes:** Apply cargo fmt to the pinned-lexical test
 - Integrate main (parallel eval, content-addressed terms, XSD-1.0 float/double) into the W3C conformance branch
 - Strip stale gmeow-ontology issue refs from Rust comments + lint against regression
-
-This change removes every stale `#NNN` GitHub issue-reference token from
-Rust comments and in-tree markdown documentation, then adds a CI/pre-commit
-lint that rejects new ones so the convention holds.
-
-What changed:
-- `scripts/check-issue-refs.py` (new): Rust-aware linter that scans `//`,
- `///`, and `//!` comments plus `.md` files under `crates/`, `bindings/`,
- and `docs/`. String literals, character literals, raw strings, fenced code
- blocks, inline code spans, hex colors, markdown anchors, and section numbers
- like `.1` are excluded. The regex matches `#` followed by 1–5 decimal
- digits.
-- `.github/workflows/ci.yaml`: runs the new lint in CI.
-- `Makefile`: wires the lint into `make check` and provides a standalone
- `check-issue-refs` target.
-- Rust comments (138 files): stripped stale `#NNN` tokens while preserving
- explanatory prose, then repaired the broken parentheses, dangling slashes,
- and sentence fragments left by the initial mechanical pass.
-- Markdown docs (READMEs, test fixture SOURCE.md, etc.): stripped stale
- issue-reference tokens.
-
-Requirements satisfied (issue ):
-1. `#NNN` tokens removed from `//`/`///` comments across the workspace.
-2. `#NNN` refs swept from in-tree READMEs and design docs.
-3. CI/pre-commit lint added to block new `#NNN` tokens in comments and docs.
-
-Standing constraints respected (`.goals`):
-- No optional features or `cfg`-gated behavior was introduced.
-- Core Rust semantics are unchanged; the Python surface is untouched except
- for comment-only cleanups in bindings source files.
-- Wasm-able crate set remains wasm-buildable.
-- No new namespaces or ontology terms were minted.
-
-Verification:
-- `make check` passes (fmt, clippy, check, tests, license/generated/issue-ref
- hygiene).
-- `make rdf-core-hygiene` passes.
-- `make wasm` passes.
-- `python3 scripts/check-issue-refs.py` reports no violations.
 - **conformance:** Integrate origin/main; fix issue-ref lint to scan only tracked source
 - **shacl-af:** Rustfmt wrapping and register new corpus fixtures
 - Rustfmt normalization across the SARIF work
@@ -567,6 +442,7 @@ Verification:
 - **validate:** Lock SHACL helpUri anchors against the live spec format
 - **validate:** Avoid a literal #N token in the S0.5 test
 - **sparql:** Regression-cover FILTER-NOT-EXISTS arithmetic and all-FILTER UNION branch
+
 ## [0.2.1] - 2026-07-02
 
 ### Benchmarks
@@ -613,39 +489,22 @@ Verification:
 - **python:** Rustfmt the native SPARQL-results + term-direction bindings
 - Release 0.2.1: rdflib drop-in hardening — native xsd coercion + TriX/HexTuples codecs
 
-Bumps the workspace, python, capi, and npm package versions to 0.2.1. Ships
-the stage-2 hardening of the rdflib drop-in: mandatory acceptance-matrix gate,
-the three reviewer fixes (bare-form xsd:duration, SPARQL processor kwarg
-forwarding, Resource predicate/index unwrapping), in-repo tracker-reference
-cleanup, native purrdf-xsd binary/whitespace value coercion, and first-party
-native TriX and HexTuples codecs replacing the NotImplementedError plugin stubs.
-
 ### Testing
 
 - **python:** Gate — rdflib's own test suite against the compat shim
 - **python:** Downstream acceptance matrix (pyshacl / SPARQLWrapper / sssom)
+
 ## [0.2.0] - 2026-07-02
 
 ### Other
 
 - Release 0.2.0: complete umbrella facade, OntologyProfile, ShExC serializer, drop openEHR OPT
 
-- purrdf umbrella now re-exports the full published surface (gts, sparql, xsd, iri, events) so consumers depend on purrdf alone; merges the purrdf_gts engine with the purrdf_rdf GTS adapter under one gts module.
-- Surface SliceVocab / Namespaces / StatementMetadataVocab at the root and unify them behind purrdf::OntologyProfile (build once, project into each emitter's native config).
-- purrdf-shex: add to_shexc (compact-syntax serializer); round-trips all 425 shexTest schemas.
-- purrdf-shapes: remove openehr_opt (healthcare-domain vocabulary) + its test/fixture and the now-unused roxmltree dep.
-- Bump workspace + bindings + capi + js package to 0.2.0.
 ## [0.1.5] - 2026-07-02
 
 ### Bug Fixes
 
 - Fix release lanes: wasm-opt post-MVP features, workspace-inherited version
-
-- release-npm: Ubuntu's binaryen rejects the bulk-memory/nontrapping-fptoint
- ops rustc emits by default for wasm32; pass the --enable flags to wasm-opt
-- release-pypi: bindings/python inherits version.workspace = true, so the
- tag check must resolve the crate version via cargo metadata, not read the
- member Cargo.toml directly
 
 ### Documentation
 
@@ -656,145 +515,11 @@ native TriX and HexTuples codecs replacing the NotImplementedError plugin stubs.
 - Package README + metadata, js package 0.1.4
 - Shex in flight
 - Full ShEx 2.1 + complete SHACL Core + de-gmeow the library namespaces
-
-ShEx (new crate purrdf-shex, gated on vendored shexTest v2.1.0):
-- ShExC lexer/parser + ShExJ serde + structural checks (dangling refs,
- ref cycles, negation stratification via hand-rolled Tarjan SCC):
- 99/99 negativeSyntax, 14/14 negativeStructure, 425/425 schemas parse,
- 420/420 ShExJ round-trips, 419/420 ShExC==ShExJ AST ground truth
- (1 documented upstream corpus bug)
-- validator: node constraints (purrdf-xsd lexical/numeric machinery),
- value sets with stems/ranges/exclusions, EachOf/OneOf/TC matching with
- EXTRA/CLOSED (interval fast path covers 98.9%; budget-bounded
- backtracker for the rest), coinductive typing recursion, fixed shape
- maps: 1051/1051 attempted validation tests pass, zero xfails
- (54 skipped: Import/SemanticAction traits, phase 2)
-
-SHACL (crates/shapes):
-- full property paths (sequence/alternative/zeroOrMore/oneOrMore/
- zeroOrOne, cycle-safe closures, algebraic inverse rewriting),
- property-pair constraints (equals/disjoint/lessThan/lessThanOrEquals),
- qualified value shapes with sibling-disjoint semantics, property-shape
- deactivation; frozen corpus 42 -> 48 cases
-- W3C data-shapes suite vendored (vectors/shacl) + manifest-driven
- harness: 113 passed / 7 xfailed (standalone property shapes,
- sh:value defaults, pre-binding rejection, dateTime value-space,
- custom severities, structured sh:resultPath all fixed)
-
-Namespace integrity (the extraction had blind-renamed the published
-gmeow: namespace to an unpublished purrdf: one inside library code):
-- vocab/purrdf.ttl: a real, tiny purrdf carrier vocabulary (JSON-LD-star
- qSubject/qPredicate/qObject/qObjectLiteral encoding keys, the 7 SPARQL
- extension functions, neutral StatementMetadata fallback)
-- json_schema: compile(&shapes, &Namespaces) - caller-supplied prefix
- map + primary namespace (unblocks gmeow regenerate)
-- SPARQL: extension-fn namespaces are ParserOptions (gmeow aliases its
- ns); heldIn standpoint predicates are a caller-supplied table with a
- hard error when unconfigured
-- slice: SliceVocab::for_namespace threads through catalog/ownership/
- fix_deps/analysis/emitters + Python bindings (discover takes the
- namespace); gts_view LanguageVocab; fno ProjectionFunction from the
- catalog namespace; test fixtures moved to example.org
-
-Also vendored shexTest v2.1.0 + W3C data-shapes with provenance READMEs;
-purrdf-shex added to the wasm gates; 11 library-scoped issues migrated
-from gmeow-ontology (purrdf-).
-
-1523 tests passing; clippy -D warnings clean; fmt/no-features/generated/
-kernel-hygiene/wasm32 gates green.
 - Purge the invented namespace: purrdf is a toolkit, not an ontology
-
-Policy (final): purrdf mints no vocabulary IRIs. Every vocabulary the
-library reads or writes is caller-supplied configuration with no
-fabricated default — a feature exercised unconfigured hard-errors or
-stays inactive. The GMEOW ontology is a consumer; the dependency arrow
-never points from purrdf to it. (vocab/purrdf.ttl, briefly authored, is
-gone.)
-
-- sparql-algebra: ParserOptions::default = no extension namespaces;
- Function::Purrdf(PurrdfCall) keeps the ORIGINAL call IRI so output
- round-trips the caller's namespace verbatim; PURRDF_NS deleted
-- sparql-eval/conformance: engine defaults namespace-free; extension +
- standpoint suites rewritten to example.org/ext/ with harness config
-- jsonld codec: StatementMetadataVocab has no Default; star downcast
- without a configured vocab hard-fails; @vocab no longer emitted;
- the W3C rdf:reifies/@annotation lane mints nothing and stays free
-- shapes: BoxRoleVocab::for_namespace caller config (unconfigured =
- roles inactive; conformance unaffected); openehr emitter takes
- caller prefixes; corpus 38-42 fixtures moved to example.org/meta/
-- slice: ownership dependency edges use the parsed original extension
- IRI; template prose renaming (PURRDF -> caller prefix, `purrdf
- regenerate` -> `{prefix} regenerate`) so emitted artifacts carry no
- template label; parity tests point at the gmeow namespace
-- reverted the extraction's blind namespace rename in committed
- fixtures: generated/queries (54), queries/ (~90), the accessibility
- SSSOM mapping (renamed gmeow-accessibility.sssom.tsv), gts
- agent_memory example -> example.org/memory/
-- docs/CONFORMANCE.md: full scoreboard + ledger discipline; README
- conformance table (SHACL 114/120 after the lessThan per-pair fix);
- AGENTS.md/CLAUDE.md carry the not-an-ontology doctrine; purrdf-shex
- wired into the umbrella crate (purrdf::shex), release lanes, and
- wasm gates; issues - filed for the remaining ledger/roadmap
-
-grep 'blackcatinformatics.ca/purrdf' across crates/bindings/generated/
-queries = the project homepage URL only. Full gate green: 1,600+ tests,
-clippy -D warnings, fmt, no-features, generated, hygiene, wasm32.
 - Parallel parse + parallel GTS verification (deterministic by construction)
-
-- N-Triples/N-Quads: two-phase chunk-parallel parse — line-aligned chunks
- tokenized in parallel through the untouched per-line pipeline, then
- collected in document order into the store-once interner, so term ids,
- quad order, diagnostics (first error in document order), and canonical
- bytes are identical to the sequential path. 1 MiB threshold; Turtle/TriG
- stay sequential (documented: prefix/bnode state). ~1.75x on the 50k-row
- bench (55 -> 96 MiB/s); proof tests compare every pipeline stage and
- sweep chunk geometries 1..4096.
-- GTS: frame content-ids recomputed concurrently per spec §9.1 with a
- sequential prev-equality pass; cross-segment folds parallel per §3.1;
- payloads >= 128 KiB hash via blake3 update_rayon (workspace blake3 gains
- the rayon feature — inline-sequential on wasm32, gates unaffected).
- ~1.83x on the new 32 MiB gts_verify bench (1.50 -> 2.75 GiB/s); the
- 35-vector corpus folds byte-identically at RAYON_NUM_THREADS=1/3/32.
-- README: ShEx quickstart line for the Python bindings.
 - Python bindings: shex module, engine configuration, GIL release
-
-- purrdf_native.shex: validate (fixed shape maps over ShExC/ShExJ +
- Turtle/N-Triples/N-Quads; focus nodes as IRIs, _:blanks, or Turtle
- literal tokens decoded through the native codec) and parse (canonical
- ShExJ), mirroring the shacl submodule; typed stubs in the .pyi
-- Store/MutableDataset query+update gain keyword-only extension_namespaces
- and standpoint_predicates (the caller-supplied SPARQL seam config —
- purrdf mints no vocabulary); from_json_ld gains statement_vocab
-- every heavy entry point (47: parse/serialize/canonicalize, SPARQL
- query/update, GTS emit/fold/relational, SHACL/ShEx validate, slice
- discovery/analysis, SSSOM) releases the GIL via Python::detach — a
- second Python thread ran ~21.6M loop iterations during a 0.41s parse
- in the two-thread smoke (previously blocked)
 - Release 0.1.5: full SHACL/ShEx, de-gmeow'd namespaces, SPARQL eval speedups
 
-Feature work (landed across this cycle, gated at 0.1.5):
-- ShEx 2.1: new purrdf-shex crate (ShExC + ShExJ schema layer, structural
- checks, fixed-shape-map validator) — 1,051/1,051 attempted shexTest
- validation tests, 99/99 negative-syntax, 14/14 negative-structure, empty
- xfail ledgers; exposed via the Python purrdf_native.shex submodule.
-- SHACL Core completed: full property paths (sequence/alternative/
- zero-or-more/one-or-more/zero-or-one), property-pair constraints,
- qualified value shapes; W3C data-shapes harness at 114/120 with a
- 6-entry reasoned xfail ledger (custom SPARQL components + pre-binding
- corners tracked in /).
-- Namespaces are caller-supplied everywhere (Namespaces/SliceVocab/
- LanguageVocab/StandpointPredicates/ParserOptions); purrdf mints no
- vocabulary IRIs. Fixes downstream json_schema::compile for any target
- namespace.
-- SPARQL evaluation speedups (measurement-driven, results byte-identical,
- W3C conformance green): shared Rc<Regex> two-level cache (no per-row DFA
- pool churn), precomputed ORDER BY sort keys, pre-interned boolean
- constants, borrowed xsd_of_term on the compare hot path, u64-packed
- hash-join keys.
-
-Version: 0.1.5 across all crates, PyPI, and the npm js package; CITATION
-and RELEASE docs updated. purrdf-shex is a new crates.io record — its
-first publish needs the token bootstrap before trusted publishing.
 ## [0.1.3] - 2026-07-02
 
 ### Bug Fixes
@@ -806,60 +531,8 @@ first publish needs the token bootstrap before trusted publishing.
 
 - Parameterize jsonld prefix
 - Release 0.1.3: brand, first-class docs, strict lints, perf, npm lane
-
-Brand & repo:
-- PurRDF casing standardized; docs/BRAND.md defines the family rule
-- logo rebuilt with the purrdf service object (RDF triple) replacing the
- copied GTS chain; social preview corrected and re-rendered
-- first-class README (badges, quickstarts kept honest by a twin test,
- crate map, measured-perf story); CITATION.cff, SECURITY.md,
- CONTRIBUTING.md, CODE_OF_CONDUCT.md, LICENSING.md, AGENTS.md, CLAUDE.md
-
-Rust workspace:
-- [workspace.dependencies] single-sources every version; sha1 0.10/0.11
- skew fixed; hashbrown unified on 0.15; serde_yaml migrated to the
- maintained serde_yaml_ng via package rename
-- [workspace.lints]: clippy pedantic+nursery with a reasoned allow list;
- 4341 warnings fixed to zero; MSRV 1.96 declared; clippy.toml msrv pin
-- API shape: intern_iri/intern_blank take &str (~480 call sites,
- caller-side clones removed); ref_option/needless_pass_by_value fixed
- workspace-wide with only 6 scoped binding-ABI allows
-- codec hot path: tokens moved (not cloned) out of the buffer; codec
- interner rebuilt on the store-once ahash pattern: +45-50% N-Quads
- parse throughput; format_push_string swept from all serializers
-- profiles: bench keeps symbols for profiling; dev deps at opt-level 2
-
-CI & release:
-- CI now runs the test suite (previously compile-only), clippy
- -D warnings, and an MSRV job
-- Makefile rebuilt as the real gate (fmt+clippy+tests+hygiene+wasm) and
- recovers the lost wasm-pkg/capi-*/rdf-core-hygiene targets
-- npm lane: package renamed @blackcatinformatics/purrdf, release-npm.yaml
- publishes on npm-v* tags (NPM_TOKEN bootstrap, then OIDC trusted
- publishing) with provenance + SBOM attestations
-- version 0.1.3 across all 16 crates, PyPI, npm, and citation metadata
-
-Removed: vendored_asset.test.mjs (gated a gmeow-ontology playground
-asset that is not part of this extraction).
 - Stabilize the toolchain: stable-Rust-clean workspace, real MSRV
 
-purrdf-iri was the workspace's only nightly dependency
-(#![feature(portable_simd)] for the IRI delimiter scan). CI silently ran
-nightly everywhere because rustup obeys rust-toolchain.toml over the
-action's toolchain input, which made the "CI builds on stable" story and
-the MSRV job fiction.
-
-- replace the portable_simd scan with a zero-dep SWAR scan over u64
- words (from_le_bytes lane order: platform-independent, wasm-clean);
- scalar-tail behavior and the full RFC 3986/3987 suite unchanged
-- drop #![feature(portable_simd)]; the workspace now builds on stable
-- pin rust-toolchain.toml to stable so local dev, CI, and rust-version
- (MSRV 1.96) agree; release-pypi builds on stable too
-- gts: chunks_exact(2) -> as_chunks::<2> (clippy on current toolchains)
-- docs: correct the nightly claims (CONTRIBUTING, AGENTS, shapes README)
-
-Full gate green on stable: fmt, clippy -D warnings, tests, no-features,
-generated artifacts, kernel hygiene, wasm32.
 ## [0.1.1] - 2026-07-01
 
 ### Bug Fixes
@@ -873,4 +546,5 @@ generated artifacts, kernel hygiene, wasm32.
 ### Other
 
 - First commit
+
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,7 @@ version = "0.4.1"
 dependencies = [
  "criterion",
  "purrdf-core",
+ "roxmltree",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "purrdf-entail",
  "purrdf-events",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ahash",
  "criterion",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "criterion",
  "purrdf-core",
@@ -1298,11 +1298,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "0.4.1"
+version = "0.4.2"
 
 [[package]]
 name = "purrdf-gts"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aes-gcm",
  "blake3",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ahash",
  "ciborium",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "boon",
  "criterion",
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "hex",
  "insta",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "criterion",
  "insta",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ahash",
  "criterion",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "insta",
  "pretty_assertions",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -43,21 +43,21 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "0.4.1" }
-purrdf-core = { path = "crates/rdf-core", version = "0.4.1" }
-purrdf-entail = { path = "crates/entail", version = "0.4.1" }
-purrdf-events = { path = "crates/rdf-events", version = "0.4.1" }
-purrdf-gts = { path = "crates/gts", version = "0.4.1" }
-purrdf-iri = { path = "crates/iri", version = "0.4.1" }
-purrdf-rdf = { path = "crates/rdf", version = "0.4.1" }
-purrdf-shapes = { path = "crates/shapes", version = "0.4.1" }
-purrdf-shex = { path = "crates/shex", version = "0.4.1" }
-purrdf-slice = { path = "crates/slice", version = "0.4.1" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.4.1" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.4.1" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "0.4.1" }
-purrdf-validate = { path = "crates/validate", version = "0.4.1" }
-purrdf-xsd = { path = "crates/xsd", version = "0.4.1" }
+purrdf = { path = "crates/purrdf", version = "0.4.2" }
+purrdf-core = { path = "crates/rdf-core", version = "0.4.2" }
+purrdf-entail = { path = "crates/entail", version = "0.4.2" }
+purrdf-events = { path = "crates/rdf-events", version = "0.4.2" }
+purrdf-gts = { path = "crates/gts", version = "0.4.2" }
+purrdf-iri = { path = "crates/iri", version = "0.4.2" }
+purrdf-rdf = { path = "crates/rdf", version = "0.4.2" }
+purrdf-shapes = { path = "crates/shapes", version = "0.4.2" }
+purrdf-shex = { path = "crates/shex", version = "0.4.2" }
+purrdf-slice = { path = "crates/slice", version = "0.4.2" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.4.2" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.4.2" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "0.4.2" }
+purrdf-validate = { path = "crates/validate", version = "0.4.2" }
+purrdf-xsd = { path = "crates/xsd", version = "0.4.2" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "0.4.1"
+version = "0.4.2"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/cliff.toml
+++ b/cliff.toml
@@ -27,8 +27,9 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
 {% for commit in commits %}
-- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | upper_first | trim }}
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | upper_first | trim }}
 {%- endfor %}
+
 {% endfor %}
 """
 footer = ""

--- a/cliff.toml
+++ b/cliff.toml
@@ -46,7 +46,7 @@ split_commits = false
 # Strip issue/PR references before parsing so no `#NNN` reaches the changelog.
 commit_preprocessors = [
   { pattern = '\((?:closes?|fixes?|resolves?)\s+#\d+\)', replace = "" },
-  { pattern = '\(#\d+\)', replace = "" },
+  { pattern = '\s*\(#\d+\)', replace = "" },
   { pattern = '#\d+', replace = "" },
   { pattern = '\(\s*\)', replace = "" },
   { pattern = ' {2,}', replace = " " },

--- a/crates/entail/Cargo.toml
+++ b/crates/entail/Cargo.toml
@@ -31,6 +31,7 @@ path = "src/lib.rs"
 # string round-trip. purrdf-core is wasm32-unknown-unknown-clean, keeping this
 # crate wasm-clean (MAXIMAL PORTABILITY).
 purrdf-core = { workspace = true }
+roxmltree = { workspace = true }
 
 [dev-dependencies]
 # Report-only chase microbenchmark; `make bench` lane, excluded from `make check`.

--- a/crates/entail/README.md
+++ b/crates/entail/README.md
@@ -40,9 +40,9 @@ external reasoner, no `tokio`, and no string round-trip.
 * **No minted vocabulary.** Every constant in `vocab` is a standard
   `rdf:`/`rdfs:`/`owl:` IRI drawn from the entailment spec itself — this crate
   fabricates none.
-* **wasm-clean and dependency-lean.** The only dependency is `purrdf-core`
-  (itself `wasm32-unknown-unknown`-clean), so this crate carries into Rust,
-  WebAssembly, and C without a threads/filesystem/RNG dependency.
+* **wasm-clean and dependency-lean.** Dependencies are `purrdf-core` and
+  `roxmltree` (both `wasm32-unknown-unknown`-clean), so this crate carries into
+  Rust, WebAssembly, and C without a threads/filesystem/RNG dependency.
 * **Determinism.** The chase is a fixpoint over the frozen IR; a given input and
   regime always yields the same closure.
 

--- a/crates/entail/README.md
+++ b/crates/entail/README.md
@@ -29,6 +29,7 @@ external reasoner, no `tokio`, and no string round-trip.
 | `materialize(ds, regime)` | `Simple`, `RDF`, `RDFS`, `OWL-RL` | Forward-materialization ("chase") over a fixed rule set via a native semi-naive fixpoint. |
 | `materialize_dl(...)` | `OWL-Direct` | Open-world OWL DL over an ALCOIQ tableau — needs the query's class expressions, so it is not reachable through the plain `materialize` façade. |
 | `materialize_rif(...)` | `RIF` | RIF-Core rule entailment over a parsed `RuleSet`. |
+| `parse_rif_xml(...)` / `resolve_rif_imports(...)` | `RIF` | Normative RIF-XML parsing with caller-owned, I/O-free import resolution. |
 | `Regime::from_iri(iri)` | — | Parse a `sparql:entailmentRegime` IRI to its enum. |
 
 `D` (datatype) entailment is a typed, spec-inherent boundary

--- a/crates/entail/src/lib.rs
+++ b/crates/entail/src/lib.rs
@@ -34,10 +34,12 @@ pub(crate) mod interner;
 pub(crate) mod owl_dl;
 pub(crate) mod rdfs;
 pub mod rif;
+mod rif_xml;
 pub(crate) mod vocab;
 
 pub use owl_dl::query::{QNode, QTriple, materialize_dl};
 pub use rif::{Atom, Fact, RifTerm, Rule, RuleSet, materialize_rif};
+pub use rif_xml::{ParsedRifDocument, RifImport, parse_rif_xml, resolve_rif_imports};
 
 /// A SPARQL entailment regime (`sparql:entailmentRegime`), by its W3C IRI's local
 /// name.

--- a/crates/entail/src/rif_xml.rs
+++ b/crates/entail/src/rif_xml.rs
@@ -1,0 +1,360 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! RIF-in-XML parsing with caller-owned import resolution.
+
+use std::sync::Arc;
+
+use purrdf_core::{RdfDataset, TermValue};
+use roxmltree::{Document, Node, ParsingOptions};
+
+use crate::{Atom, EntailError, Fact, Regime, RifTerm, Rule, RuleSet, materialize};
+
+const RIF_NS: &str = "http://www.w3.org/2007/rif#";
+const XSD_NS: &str = "http://www.w3.org/2001/XMLSchema#";
+
+/// One RIF `Import` directive. Resolving its location is deliberately caller-owned.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RifImport {
+    /// The import location exactly as authored.
+    pub location: String,
+    /// Optional W3C entailment-profile IRI.
+    pub profile: Option<String>,
+}
+
+/// A parsed RIF document before external imports are resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedRifDocument {
+    /// Facts and rules carried directly by the document.
+    pub ruleset: RuleSet,
+    /// Imports in document order.
+    pub imports: Vec<RifImport>,
+}
+
+/// Parse normative RIF XML into PurRDF's monotonic definite-Horn model.
+///
+/// # Errors
+///
+/// Returns [`EntailError::Parse`] for malformed XML and every unsupported or
+/// unexpected construct; the parser never skips unknown semantics.
+pub fn parse_rif_xml(text: &str) -> Result<ParsedRifDocument, EntailError> {
+    parse_document(text).map_err(EntailError::Parse)
+}
+
+/// Resolve imports through a caller callback and merge their materialized
+/// default-graph facts into the rule set.
+///
+/// The callback owns all I/O. `OWL-Direct` imports use OWL-RL's sound atomic-fact
+/// subset; RDF, RDFS, and OWL-RL imports use their corresponding closure.
+///
+/// # Errors
+///
+/// Propagates resolver and entailment failures.
+pub fn resolve_rif_imports<F>(
+    parsed: ParsedRifDocument,
+    mut resolver: F,
+) -> Result<RuleSet, EntailError>
+where
+    F: FnMut(&RifImport) -> Result<Arc<RdfDataset>, EntailError>,
+{
+    let mut ruleset = parsed.ruleset;
+    for import in &parsed.imports {
+        let source = resolver(import)?;
+        let closed = materialize(&source, import_regime(import.profile.as_deref()))?;
+        ruleset.facts.extend(dataset_facts(&closed));
+    }
+    Ok(ruleset)
+}
+
+fn parse_document(text: &str) -> Result<ParsedRifDocument, String> {
+    let document = Document::parse_with_options(
+        text,
+        ParsingOptions {
+            allow_dtd: true,
+            ..ParsingOptions::default()
+        },
+    )
+    .map_err(|error| error.to_string())?;
+    let root = document.root_element();
+    require(&root, "Document")?;
+    let mut ruleset = RuleSet::new();
+    let mut imports = Vec::new();
+    for child in elements(&root) {
+        match local_name(&child)? {
+            "directive" => collect_import(&child, &mut imports)?,
+            "payload" => parse_payload(&child, &mut ruleset)?,
+            other => return Err(format!("unexpected Document child <{other}>")),
+        }
+    }
+    Ok(ParsedRifDocument { ruleset, imports })
+}
+
+fn collect_import(directive: &Node<'_, '_>, imports: &mut Vec<RifImport>) -> Result<(), String> {
+    let import = only_element(directive, "Import")?;
+    let mut location = None;
+    let mut profile = None;
+    for child in elements(&import) {
+        match local_name(&child)? {
+            "location" => location = Some(text_of(&child)),
+            "profile" => profile = Some(text_of(&child)),
+            other => return Err(format!("unexpected Import child <{other}>")),
+        }
+    }
+    imports.push(RifImport {
+        location: location.ok_or("Import without a <location>")?,
+        profile,
+    });
+    Ok(())
+}
+
+fn parse_payload(payload: &Node<'_, '_>, ruleset: &mut RuleSet) -> Result<(), String> {
+    let group = only_element(payload, "Group")?;
+    for child in elements(&group) {
+        match local_name(&child)? {
+            "sentence" => parse_sentence(&child, ruleset)?,
+            other => return Err(format!("unexpected Group child <{other}>")),
+        }
+    }
+    Ok(())
+}
+
+fn parse_sentence(sentence: &Node<'_, '_>, ruleset: &mut RuleSet) -> Result<(), String> {
+    let inner = single_element(sentence, "sentence")?;
+    match local_name(&inner)? {
+        "Frame" => {
+            for atom in parse_frame(&inner)? {
+                ruleset.push_fact(ground_fact(atom)?);
+            }
+            Ok(())
+        }
+        "Forall" => {
+            ruleset.push_rule(parse_forall(&inner)?);
+            Ok(())
+        }
+        other => Err(format!("unexpected sentence body <{other}>")),
+    }
+}
+
+fn parse_forall(forall: &Node<'_, '_>) -> Result<Rule, String> {
+    let mut formula = None;
+    for child in elements(forall) {
+        match local_name(&child)? {
+            "declare" | "meta" => {}
+            "formula" => formula = Some(child),
+            other => return Err(format!("unexpected Forall child <{other}>")),
+        }
+    }
+    let formula = formula.ok_or("Forall without a <formula>")?;
+    let implies = single_element(&formula, "formula")?;
+    require(&implies, "Implies")?;
+    let mut body = None;
+    let mut head = None;
+    for child in elements(&implies) {
+        match local_name(&child)? {
+            "if" => body = Some(parse_conjunction(&single_element(&child, "if")?)?),
+            "then" => head = Some(parse_conjunction(&single_element(&child, "then")?)?),
+            other => return Err(format!("unexpected Implies child <{other}>")),
+        }
+    }
+    Ok(Rule {
+        body: body.ok_or("Implies without an <if>")?,
+        head: head.ok_or("Implies without a <then>")?,
+    })
+}
+
+fn parse_conjunction(node: &Node<'_, '_>) -> Result<Vec<Atom>, String> {
+    match local_name(node)? {
+        "Frame" => parse_frame(node),
+        "And" => {
+            let mut atoms = Vec::new();
+            for child in elements(node) {
+                match local_name(&child)? {
+                    "formula" => atoms.extend(parse_frame(&single_element(&child, "formula")?)?),
+                    other => return Err(format!("unexpected And child <{other}>")),
+                }
+            }
+            Ok(atoms)
+        }
+        other => Err(format!("unexpected conjunction node <{other}>")),
+    }
+}
+
+fn parse_frame(frame: &Node<'_, '_>) -> Result<Vec<Atom>, String> {
+    require(frame, "Frame")?;
+    let mut object = None;
+    let mut slots = Vec::new();
+    for child in elements(frame) {
+        match local_name(&child)? {
+            "object" => object = Some(parse_term(&single_element(&child, "object")?)?),
+            "slot" => slots.push(parse_slot(&child)?),
+            other => return Err(format!("unexpected Frame child <{other}>")),
+        }
+    }
+    let subject = object.ok_or("Frame without an <object>")?;
+    if slots.is_empty() {
+        return Err("Frame without any <slot>".to_owned());
+    }
+    Ok(slots
+        .into_iter()
+        .map(|(predicate, object)| Atom {
+            s: subject.clone(),
+            p: predicate,
+            o: object,
+        })
+        .collect())
+}
+
+fn parse_slot(slot: &Node<'_, '_>) -> Result<(RifTerm, RifTerm), String> {
+    let mut children = elements(slot);
+    let predicate = parse_term(&children.next().ok_or("slot without a predicate")?)?;
+    let value = parse_term(&children.next().ok_or("slot without a value")?)?;
+    if children.next().is_some() {
+        return Err("slot with more than two children".to_owned());
+    }
+    Ok((predicate, value))
+}
+
+fn parse_term(node: &Node<'_, '_>) -> Result<RifTerm, String> {
+    match local_name(node)? {
+        "Var" => Ok(RifTerm::Var(text_of(node))),
+        "Const" => Ok(RifTerm::Const(parse_const(node)?)),
+        other => Err(format!("unexpected term node <{other}>")),
+    }
+}
+
+fn parse_const(node: &Node<'_, '_>) -> Result<TermValue, String> {
+    let kind = node
+        .attribute("type")
+        .ok_or("Const without a type attribute")?;
+    let value = text_of(node);
+    if kind == format!("{RIF_NS}iri") {
+        Ok(TermValue::iri(value))
+    } else if kind.starts_with(XSD_NS) {
+        Ok(TermValue::typed_literal(value, kind))
+    } else if kind == format!("{RIF_NS}local") {
+        Err("rif:local const outside <meta> is unsupported".to_owned())
+    } else {
+        Err(format!("unsupported Const type {kind}"))
+    }
+}
+
+fn ground_fact(atom: Atom) -> Result<Fact, String> {
+    Ok((const_of(atom.s)?, const_of(atom.p)?, const_of(atom.o)?))
+}
+
+fn const_of(term: RifTerm) -> Result<TermValue, String> {
+    match term {
+        RifTerm::Const(value) => Ok(value),
+        RifTerm::Var(name) => Err(format!("variable ?{name} in a ground fact")),
+    }
+}
+
+fn import_regime(profile: Option<&str>) -> Regime {
+    match profile.and_then(Regime::from_iri) {
+        Some(Regime::OwlDirect | Regime::OwlRl) => Regime::OwlRl,
+        Some(Regime::Rdfs) => Regime::Rdfs,
+        Some(Regime::Rdf) => Regime::Rdf,
+        _ => Regime::Simple,
+    }
+}
+
+fn dataset_facts(dataset: &RdfDataset) -> Vec<Fact> {
+    dataset
+        .quads()
+        .filter(|quad| quad.g.is_none())
+        .map(|quad| {
+            (
+                dataset.term_value(quad.s),
+                dataset.term_value(quad.p),
+                dataset.term_value(quad.o),
+            )
+        })
+        .collect()
+}
+
+fn elements<'a, 'input>(
+    node: &Node<'a, 'input>,
+) -> impl Iterator<Item = Node<'a, 'input>> + use<'a, 'input> {
+    node.children().filter(Node::is_element)
+}
+
+fn local_name<'a>(node: &Node<'a, '_>) -> Result<&'a str, String> {
+    let tag = node.tag_name();
+    match tag.namespace() {
+        Some(RIF_NS) => Ok(tag.name()),
+        other => Err(format!(
+            "element <{}> is not in the RIF namespace (found {other:?})",
+            tag.name()
+        )),
+    }
+}
+
+fn require(node: &Node<'_, '_>, expected: &str) -> Result<(), String> {
+    let actual = local_name(node)?;
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(format!("expected <{expected}>, found <{actual}>"))
+    }
+}
+
+fn single_element<'a, 'input>(
+    node: &Node<'a, 'input>,
+    parent: &str,
+) -> Result<Node<'a, 'input>, String> {
+    let mut children = elements(node);
+    let first = children
+        .next()
+        .ok_or_else(|| format!("<{parent}> is empty"))?;
+    if children.next().is_some() {
+        return Err(format!("<{parent}> has more than one child element"));
+    }
+    Ok(first)
+}
+
+fn only_element<'a, 'input>(
+    node: &Node<'a, 'input>,
+    name: &str,
+) -> Result<Node<'a, 'input>, String> {
+    let child = single_element(node, name)?;
+    require(&child, name)?;
+    Ok(child)
+}
+
+fn text_of(node: &Node<'_, '_>) -> String {
+    let mut text = String::new();
+    for child in node.children() {
+        if let Some(value) = child.text() {
+            text.push_str(value);
+        }
+    }
+    text.trim().to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RIF: &str = r#"<Document xmlns="http://www.w3.org/2007/rif#">
+  <directive><Import><location>facts.ttl</location><profile>http://www.w3.org/ns/entailment/RDFS</profile></Import></directive>
+  <payload><Group><sentence><Frame>
+    <object><Const type="http://www.w3.org/2007/rif#iri">https://example.org/s</Const></object>
+    <slot ordered="yes"><Const type="http://www.w3.org/2007/rif#iri">https://example.org/p</Const><Const type="http://www.w3.org/2001/XMLSchema#string">value</Const></slot>
+  </Frame></sentence></Group></payload>
+</Document>"#;
+
+    #[test]
+    fn parses_fact_and_leaves_import_to_caller() {
+        let parsed = parse_rif_xml(RIF).unwrap();
+        assert_eq!(parsed.ruleset.facts.len(), 1);
+        assert_eq!(parsed.imports[0].location, "facts.ttl");
+    }
+
+    #[test]
+    fn rejects_unknown_construct() {
+        let text = RIF
+            .replace("<Frame>", "<Atom>")
+            .replace("</Frame>", "</Atom>");
+        assert!(matches!(parse_rif_xml(&text), Err(EntailError::Parse(_))));
+    }
+}

--- a/crates/entail/src/rif_xml.rs
+++ b/crates/entail/src/rif_xml.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use purrdf_core::{RdfDataset, TermValue};
-use roxmltree::{Document, Node, ParsingOptions};
+use roxmltree::{Document, Node};
 
 use crate::{Atom, EntailError, Fact, Regime, RifTerm, Rule, RuleSet, materialize};
 
@@ -58,23 +58,20 @@ where
     F: FnMut(&RifImport) -> Result<Arc<RdfDataset>, EntailError>,
 {
     let mut ruleset = parsed.ruleset;
+    let mut imported_facts = Vec::new();
     for import in &parsed.imports {
         let source = resolver(import)?;
         let closed = materialize(&source, import_regime(import.profile.as_deref()))?;
-        ruleset.facts.extend(dataset_facts(&closed));
+        imported_facts.clear();
+        fill_dataset_facts(&closed, &mut imported_facts);
+        ruleset.facts.append(&mut imported_facts);
     }
     Ok(ruleset)
 }
 
 fn parse_document(text: &str) -> Result<ParsedRifDocument, String> {
-    let document = Document::parse_with_options(
-        text,
-        ParsingOptions {
-            allow_dtd: true,
-            ..ParsingOptions::default()
-        },
-    )
-    .map_err(|error| error.to_string())?;
+    // RIF imports are resolved by the caller; XML DTD/entity expansion is never needed.
+    let document = Document::parse(text).map_err(|error| error.to_string())?;
     let root = document.root_element();
     require(&root, "Document")?;
     let mut ruleset = RuleSet::new();
@@ -83,6 +80,7 @@ fn parse_document(text: &str) -> Result<ParsedRifDocument, String> {
         match local_name(&child)? {
             "directive" => collect_import(&child, &mut imports)?,
             "payload" => parse_payload(&child, &mut ruleset)?,
+            "meta" | "id" => {}
             other => return Err(format!("unexpected Document child <{other}>")),
         }
     }
@@ -97,6 +95,7 @@ fn collect_import(directive: &Node<'_, '_>, imports: &mut Vec<RifImport>) -> Res
         match local_name(&child)? {
             "location" => location = Some(text_of(&child)),
             "profile" => profile = Some(text_of(&child)),
+            "meta" | "id" => {}
             other => return Err(format!("unexpected Import child <{other}>")),
         }
     }
@@ -112,6 +111,7 @@ fn parse_payload(payload: &Node<'_, '_>, ruleset: &mut RuleSet) -> Result<(), St
     for child in elements(&group) {
         match local_name(&child)? {
             "sentence" => parse_sentence(&child, ruleset)?,
+            "meta" | "id" | "behavior" => {}
             other => return Err(format!("unexpected Group child <{other}>")),
         }
     }
@@ -139,7 +139,7 @@ fn parse_forall(forall: &Node<'_, '_>) -> Result<Rule, String> {
     let mut formula = None;
     for child in elements(forall) {
         match local_name(&child)? {
-            "declare" | "meta" => {}
+            "declare" | "meta" | "id" => {}
             "formula" => formula = Some(child),
             other => return Err(format!("unexpected Forall child <{other}>")),
         }
@@ -153,6 +153,7 @@ fn parse_forall(forall: &Node<'_, '_>) -> Result<Rule, String> {
         match local_name(&child)? {
             "if" => body = Some(parse_conjunction(&single_element(&child, "if")?)?),
             "then" => head = Some(parse_conjunction(&single_element(&child, "then")?)?),
+            "meta" | "id" => {}
             other => return Err(format!("unexpected Implies child <{other}>")),
         }
     }
@@ -170,6 +171,7 @@ fn parse_conjunction(node: &Node<'_, '_>) -> Result<Vec<Atom>, String> {
             for child in elements(node) {
                 match local_name(&child)? {
                     "formula" => atoms.extend(parse_frame(&single_element(&child, "formula")?)?),
+                    "meta" | "id" => {}
                     other => return Err(format!("unexpected And child <{other}>")),
                 }
             }
@@ -187,6 +189,7 @@ fn parse_frame(frame: &Node<'_, '_>) -> Result<Vec<Atom>, String> {
         match local_name(&child)? {
             "object" => object = Some(parse_term(&single_element(&child, "object")?)?),
             "slot" => slots.push(parse_slot(&child)?),
+            "meta" | "id" => {}
             other => return Err(format!("unexpected Frame child <{other}>")),
         }
     }
@@ -227,11 +230,11 @@ fn parse_const(node: &Node<'_, '_>) -> Result<TermValue, String> {
         .attribute("type")
         .ok_or("Const without a type attribute")?;
     let value = text_of(node);
-    if kind == format!("{RIF_NS}iri") {
+    if kind.strip_prefix(RIF_NS) == Some("iri") {
         Ok(TermValue::iri(value))
     } else if kind.starts_with(XSD_NS) {
         Ok(TermValue::typed_literal(value, kind))
-    } else if kind == format!("{RIF_NS}local") {
+    } else if kind.strip_prefix(RIF_NS) == Some("local") {
         Err("rif:local const outside <meta> is unsupported".to_owned())
     } else {
         Err(format!("unsupported Const type {kind}"))
@@ -258,18 +261,14 @@ fn import_regime(profile: Option<&str>) -> Regime {
     }
 }
 
-fn dataset_facts(dataset: &RdfDataset) -> Vec<Fact> {
-    dataset
-        .quads()
-        .filter(|quad| quad.g.is_none())
-        .map(|quad| {
-            (
-                dataset.term_value(quad.s),
-                dataset.term_value(quad.p),
-                dataset.term_value(quad.o),
-            )
-        })
-        .collect()
+fn fill_dataset_facts(dataset: &RdfDataset, facts: &mut Vec<Fact>) {
+    facts.extend(dataset.quads().filter(|quad| quad.g.is_none()).map(|quad| {
+        (
+            dataset.term_value(quad.s),
+            dataset.term_value(quad.p),
+            dataset.term_value(quad.o),
+        )
+    }));
 }
 
 fn elements<'a, 'input>(
@@ -333,6 +332,8 @@ fn text_of(node: &Node<'_, '_>) -> String {
 
 #[cfg(test)]
 mod tests {
+    use purrdf_core::RdfDatasetBuilder;
+
     use super::*;
 
     const RIF: &str = r#"<Document xmlns="http://www.w3.org/2007/rif#">
@@ -356,5 +357,65 @@ mod tests {
             .replace("<Frame>", "<Atom>")
             .replace("</Frame>", "</Atom>");
         assert!(matches!(parse_rif_xml(&text), Err(EntailError::Parse(_))));
+    }
+
+    #[test]
+    fn accepts_rif_metadata_without_interpreting_it() {
+        let text = RIF
+            .replace(
+                "<Document xmlns=\"http://www.w3.org/2007/rif#\">",
+                "<Document xmlns=\"http://www.w3.org/2007/rif#\"><id/>",
+            )
+            .replace("<Group>", "<Group><meta/><behavior/>")
+            .replace("<Frame>", "<Frame><id/><meta/>");
+        let parsed = parse_rif_xml(&text).unwrap();
+        assert_eq!(parsed.ruleset.facts.len(), 1);
+    }
+
+    #[test]
+    fn rejects_dtds() {
+        let text = RIF.replacen(
+            "<Document",
+            "<!DOCTYPE Document [<!ENTITY x \"expanded\">]><Document",
+            1,
+        );
+        assert!(matches!(parse_rif_xml(&text), Err(EntailError::Parse(_))));
+    }
+
+    #[test]
+    fn resolves_imports_and_merges_default_graph_facts() {
+        let mut builder = RdfDatasetBuilder::new();
+        let subject = builder.intern_iri("https://example.org/imported");
+        let predicate = builder.intern_iri("https://example.org/p");
+        let object = builder.intern_iri("https://example.org/o");
+        builder.push_quad(subject, predicate, object, None);
+        let imported = builder.freeze().unwrap();
+
+        let parsed = parse_rif_xml(RIF).unwrap();
+        let ruleset = resolve_rif_imports(parsed, |_| Ok(Arc::clone(&imported))).unwrap();
+        assert!(ruleset.facts.iter().any(|fact| {
+            fact == &(
+                TermValue::iri("https://example.org/imported"),
+                TermValue::iri("https://example.org/p"),
+                TermValue::iri("https://example.org/o"),
+            )
+        }));
+    }
+
+    #[test]
+    fn maps_import_profiles_to_supported_materializers() {
+        let profile = |name: &str| Some(format!("http://www.w3.org/ns/entailment/{name}"));
+        for (name, expected) in [
+            ("OWL-Direct", Regime::OwlRl),
+            ("OWL-RL", Regime::OwlRl),
+            ("RDFS", Regime::Rdfs),
+            ("RDF", Regime::Rdf),
+            ("Simple", Regime::Simple),
+            ("RIF", Regime::Simple),
+        ] {
+            let value = profile(name);
+            assert_eq!(import_regime(value.as_deref()), expected);
+        }
+        assert_eq!(import_regime(None), Regime::Simple);
     }
 }

--- a/crates/purrdf/README.md
+++ b/crates/purrdf/README.md
@@ -61,8 +61,10 @@ caller-supplied configuration.
   and targets, on PurRDF's own engine.
 - **ShEx 2.1** — ShExC/ShExJ schemas and shape-map validation, gated against the
   official shexTest suite.
-- **Entailment** — RDFS / OWL-RL forward materialization plus OWL-Direct and
-  RIF entry points, entirely in interned `TermId` space.
+- **Entailment** — RDFS / OWL-RL forward materialization plus query-directed
+  OWL-Direct and RIF, entirely in interned `TermId` space. The umbrella
+  `query_with_entailment` façade keeps query parsing and the selected regime
+  together; RIF-XML imports stay caller-resolved and network-free.
 - **GTS graph transport** — a single-file, content-addressed, append-only
   container for RDF 1.2 graphs: BLAKE3-chained CBOR segments, deterministic fold,
   COSE signing/encryption, pure-Rust crypto (wasm-friendly).

--- a/crates/purrdf/src/lib.rs
+++ b/crates/purrdf/src/lib.rs
@@ -70,6 +70,8 @@ pub use purrdf_rdf::*;
 
 pub mod profile;
 pub use profile::{OntologyProfile, ReifierVocab};
+pub mod reasoning;
+pub use reasoning::{QueryEntailment, ReasoningError, query_with_entailment};
 
 // ── consumer-config types, surfaced directly ────────────────────────────────
 // A consumer parameterizes an emitter without reaching into a sub-crate.

--- a/crates/purrdf/src/reasoning.rs
+++ b/crates/purrdf/src/reasoning.rs
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Entailment-aware SPARQL orchestration over the native PurRDF engines.
+
+use std::sync::Arc;
+
+use purrdf_entail::{EntailError, QNode, QTriple, Regime, RuleSet};
+use purrdf_rdf::{
+    RdfDataset, RdfDiagnostic, RdfTextDirection, SparqlEngine, SparqlRequest, SparqlResult,
+    TermValue,
+};
+use purrdf_sparql_algebra::{
+    BaseDirection, GraphPattern, Literal, NamedNodePattern, Query, SparqlParser, TermPattern,
+    TriplePattern,
+};
+use purrdf_sparql_eval::NativeSparqlEngine;
+
+/// Entailment behavior applied before evaluating one SPARQL query.
+#[derive(Debug, Clone, Copy)]
+pub enum QueryEntailment<'a> {
+    /// Query asserted data directly.
+    Simple,
+    /// Materialize RDF entailment.
+    Rdf,
+    /// Materialize RDFS entailment.
+    Rdfs,
+    /// Materialize OWL 2 RL entailment.
+    OwlRl,
+    /// Perform query-directed OWL Direct-Semantics augmentation.
+    OwlDirect,
+    /// Materialize the supplied RIF-Core rule set.
+    Rif(&'a RuleSet),
+}
+
+/// Failure from entailment-aware query preparation or evaluation.
+#[derive(Debug)]
+pub enum ReasoningError {
+    /// SPARQL parsing or evaluation failed.
+    Query(RdfDiagnostic),
+    /// Entailment or rule materialization failed.
+    Entailment(EntailError),
+}
+
+impl std::fmt::Display for ReasoningError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Query(error) => write!(f, "SPARQL query failed: {error}"),
+            Self::Entailment(error) => write!(f, "entailment failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for ReasoningError {}
+
+impl From<RdfDiagnostic> for ReasoningError {
+    fn from(value: RdfDiagnostic) -> Self {
+        Self::Query(value)
+    }
+}
+
+impl From<EntailError> for ReasoningError {
+    fn from(value: EntailError) -> Self {
+        Self::Entailment(value)
+    }
+}
+
+/// Evaluate SPARQL under an explicit native entailment regime.
+///
+/// # Errors
+///
+/// Returns [`ReasoningError::Query`] for SPARQL failures and
+/// [`ReasoningError::Entailment`] for malformed or inconsistent knowledge bases.
+pub fn query_with_entailment(
+    engine: &NativeSparqlEngine,
+    dataset: &Arc<RdfDataset>,
+    request: SparqlRequest<'_>,
+    entailment: QueryEntailment<'_>,
+) -> Result<SparqlResult, ReasoningError> {
+    let prepared = match entailment {
+        QueryEntailment::Simple => Arc::clone(dataset),
+        QueryEntailment::Rdf => purrdf_entail::materialize(dataset, Regime::Rdf)?,
+        QueryEntailment::Rdfs => purrdf_entail::materialize(dataset, Regime::Rdfs)?,
+        QueryEntailment::OwlRl => purrdf_entail::materialize(dataset, Regime::OwlRl)?,
+        QueryEntailment::OwlDirect => {
+            let pattern =
+                collect_query_bgp(request.query, request.base_iri, engine.parser_options())?;
+            purrdf_entail::materialize_dl(dataset, &pattern)?
+        }
+        QueryEntailment::Rif(ruleset) => purrdf_entail::materialize_rif(dataset, ruleset)?,
+    };
+    engine.query(&prepared, request).map_err(Into::into)
+}
+
+fn collect_query_bgp(
+    query_text: &str,
+    base_iri: Option<&str>,
+    options: &purrdf_sparql_algebra::ParserOptions,
+) -> Result<Vec<QTriple>, RdfDiagnostic> {
+    let mut parser = SparqlParser::new();
+    if let Some(base) = base_iri {
+        parser = parser.with_base_iri(base);
+    }
+    let query = parser
+        .parse_query_with(query_text, options)
+        .map_err(|error| RdfDiagnostic::error("entailed-sparql-query-parse", error.to_string()))?;
+    let pattern = match &query {
+        Query::Select { pattern, .. }
+        | Query::Construct { pattern, .. }
+        | Query::Describe { pattern, .. }
+        | Query::Ask { pattern, .. } => pattern,
+    };
+    let mut triples = Vec::new();
+    collect_bgp(pattern, &mut triples);
+    Ok(triples
+        .into_iter()
+        .filter_map(|pattern| {
+            Some(QTriple {
+                s: term_to_qnode(&pattern.subject)?,
+                p: named_node_pattern_to_qnode(&pattern.predicate),
+                o: term_to_qnode(&pattern.object)?,
+            })
+        })
+        .collect())
+}
+
+fn collect_bgp<'a>(pattern: &'a GraphPattern, output: &mut Vec<&'a TriplePattern>) {
+    match pattern {
+        GraphPattern::Bgp { patterns } => output.extend(patterns),
+        GraphPattern::Join { left, right }
+        | GraphPattern::Union { left, right }
+        | GraphPattern::Minus { left, right }
+        | GraphPattern::Lateral { left, right }
+        | GraphPattern::LeftJoin { left, right, .. } => {
+            collect_bgp(left, output);
+            collect_bgp(right, output);
+        }
+        GraphPattern::Filter { inner, .. }
+        | GraphPattern::Graph { inner, .. }
+        | GraphPattern::Extend { inner, .. }
+        | GraphPattern::Service { inner, .. }
+        | GraphPattern::OrderBy { inner, .. }
+        | GraphPattern::Project { inner, .. }
+        | GraphPattern::Distinct { inner }
+        | GraphPattern::Reduced { inner }
+        | GraphPattern::Slice { inner, .. }
+        | GraphPattern::Group { inner, .. } => collect_bgp(inner, output),
+        GraphPattern::Path { .. } | GraphPattern::Values { .. } => {}
+    }
+}
+
+fn term_to_qnode(term: &TermPattern) -> Option<QNode> {
+    Some(match term {
+        TermPattern::Variable(variable) => QNode::Var(variable.as_str().to_owned()),
+        TermPattern::NamedNode(node) => QNode::Term(TermValue::iri(node.as_str())),
+        TermPattern::BlankNode(node) => QNode::Term(TermValue::blank(node.as_str())),
+        TermPattern::Literal(literal) => QNode::Term(literal_to_term_value(literal)),
+        TermPattern::Triple(_) => return None,
+    })
+}
+
+fn named_node_pattern_to_qnode(pattern: &NamedNodePattern) -> QNode {
+    match pattern {
+        NamedNodePattern::NamedNode(node) => QNode::Term(TermValue::iri(node.as_str())),
+        NamedNodePattern::Variable(variable) => QNode::Var(variable.as_str().to_owned()),
+    }
+}
+
+fn literal_to_term_value(literal: &Literal) -> TermValue {
+    match literal.language() {
+        Some(language) => TermValue::Literal {
+            lexical_form: literal.value().to_owned(),
+            datatype: literal.datatype().as_str().to_owned(),
+            language: Some(language.to_ascii_lowercase()),
+            direction: literal.direction().map(|direction| match direction {
+                BaseDirection::Ltr => RdfTextDirection::Ltr,
+                BaseDirection::Rtl => RdfTextDirection::Rtl,
+            }),
+        },
+        None => TermValue::typed_literal(literal.value(), literal.datatype().as_str()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use purrdf_entail::{Atom, RifTerm, Rule, RuleSet};
+    use purrdf_rdf::{RdfDatasetBuilder, TermValue};
+
+    use super::*;
+
+    const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+    const RDFS_SUBCLASS: &str = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
+
+    fn hierarchy() -> Arc<RdfDataset> {
+        let mut builder = RdfDatasetBuilder::new();
+        let cat = builder.intern_iri("https://example.org/Cat");
+        let animal = builder.intern_iri("https://example.org/Animal");
+        let lillith = builder.intern_iri("https://example.org/lillith");
+        let rdf_type = builder.intern_iri(RDF_TYPE);
+        let subclass = builder.intern_iri(RDFS_SUBCLASS);
+        builder.push_quad(cat, subclass, animal, None);
+        builder.push_quad(lillith, rdf_type, cat, None);
+        builder.freeze().unwrap()
+    }
+
+    fn ask(mode: QueryEntailment<'_>) -> SparqlResult {
+        let query = "ASK { <https://example.org/lillith> a <https://example.org/Animal> }";
+        query_with_entailment(
+            &NativeSparqlEngine::new(),
+            &hierarchy(),
+            SparqlRequest {
+                query,
+                base_iri: None,
+                substitutions: &[],
+            },
+            mode,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn rdfs_query_sees_derived_type() {
+        assert!(matches!(
+            ask(QueryEntailment::Rdfs),
+            SparqlResult::Boolean(true)
+        ));
+    }
+
+    #[test]
+    fn simple_query_does_not_invent_closure() {
+        assert!(matches!(
+            ask(QueryEntailment::Simple),
+            SparqlResult::Boolean(false)
+        ));
+    }
+
+    #[test]
+    fn rif_query_sees_rule_derived_fact() {
+        let mut rules = RuleSet::new();
+        rules.push_rule(Rule {
+            body: vec![Atom {
+                s: RifTerm::Var("subject".to_owned()),
+                p: RifTerm::Const(TermValue::iri(RDF_TYPE)),
+                o: RifTerm::Const(TermValue::iri("https://example.org/Cat")),
+            }],
+            head: vec![Atom {
+                s: RifTerm::Var("subject".to_owned()),
+                p: RifTerm::Const(TermValue::iri(RDF_TYPE)),
+                o: RifTerm::Const(TermValue::iri("https://example.org/Animal")),
+            }],
+        });
+        assert!(matches!(
+            ask(QueryEntailment::Rif(&rules)),
+            SparqlResult::Boolean(true)
+        ));
+    }
+}

--- a/crates/purrdf/src/reasoning.rs
+++ b/crates/purrdf/src/reasoning.rs
@@ -7,12 +7,10 @@ use std::sync::Arc;
 
 use purrdf_entail::{EntailError, QNode, QTriple, Regime, RuleSet};
 use purrdf_rdf::{
-    RdfDataset, RdfDiagnostic, RdfTextDirection, SparqlEngine, SparqlRequest, SparqlResult,
-    TermValue,
+    RdfDataset, RdfDiagnostic, RdfTextDirection, SparqlRequest, SparqlResult, TermValue,
 };
 use purrdf_sparql_algebra::{
-    BaseDirection, GraphPattern, Literal, NamedNodePattern, Query, SparqlParser, TermPattern,
-    TriplePattern,
+    BaseDirection, GraphPattern, Literal, NamedNodePattern, Query, TermPattern,
 };
 use purrdf_sparql_eval::NativeSparqlEngine;
 
@@ -77,34 +75,27 @@ pub fn query_with_entailment(
     request: SparqlRequest<'_>,
     entailment: QueryEntailment<'_>,
 ) -> Result<SparqlResult, ReasoningError> {
+    // Parse first so invalid queries fail before potentially expensive closure work.
+    // OWL Direct also inspects this same cached plan, avoiding a second parse/cache lookup.
+    let prepared_query = engine.prepare_query(request.query, request.base_iri)?;
     let prepared = match entailment {
         QueryEntailment::Simple => Arc::clone(dataset),
         QueryEntailment::Rdf => purrdf_entail::materialize(dataset, Regime::Rdf)?,
         QueryEntailment::Rdfs => purrdf_entail::materialize(dataset, Regime::Rdfs)?,
         QueryEntailment::OwlRl => purrdf_entail::materialize(dataset, Regime::OwlRl)?,
         QueryEntailment::OwlDirect => {
-            let pattern =
-                collect_query_bgp(request.query, request.base_iri, engine.parser_options())?;
+            let pattern = collect_query_bgp(&prepared_query.query);
             purrdf_entail::materialize_dl(dataset, &pattern)?
         }
         QueryEntailment::Rif(ruleset) => purrdf_entail::materialize_rif(dataset, ruleset)?,
     };
-    engine.query(&prepared, request).map_err(Into::into)
+    engine
+        .query_prepared(&prepared, &prepared_query, request.substitutions)
+        .map_err(Into::into)
 }
 
-fn collect_query_bgp(
-    query_text: &str,
-    base_iri: Option<&str>,
-    options: &purrdf_sparql_algebra::ParserOptions,
-) -> Result<Vec<QTriple>, RdfDiagnostic> {
-    let mut parser = SparqlParser::new();
-    if let Some(base) = base_iri {
-        parser = parser.with_base_iri(base);
-    }
-    let query = parser
-        .parse_query_with(query_text, options)
-        .map_err(|error| RdfDiagnostic::error("entailed-sparql-query-parse", error.to_string()))?;
-    let pattern = match &query {
+fn collect_query_bgp(query: &Query) -> Vec<QTriple> {
+    let pattern = match query {
         Query::Select { pattern, .. }
         | Query::Construct { pattern, .. }
         | Query::Describe { pattern, .. }
@@ -112,21 +103,18 @@ fn collect_query_bgp(
     };
     let mut triples = Vec::new();
     collect_bgp(pattern, &mut triples);
-    Ok(triples
-        .into_iter()
-        .filter_map(|pattern| {
+    triples
+}
+
+fn collect_bgp(pattern: &GraphPattern, output: &mut Vec<QTriple>) {
+    match pattern {
+        GraphPattern::Bgp { patterns } => output.extend(patterns.iter().filter_map(|pattern| {
             Some(QTriple {
                 s: term_to_qnode(&pattern.subject)?,
                 p: named_node_pattern_to_qnode(&pattern.predicate),
                 o: term_to_qnode(&pattern.object)?,
             })
-        })
-        .collect())
-}
-
-fn collect_bgp<'a>(pattern: &'a GraphPattern, output: &mut Vec<&'a TriplePattern>) {
-    match pattern {
-        GraphPattern::Bgp { patterns } => output.extend(patterns),
+        })),
         GraphPattern::Join { left, right }
         | GraphPattern::Union { left, right }
         | GraphPattern::Minus { left, right }
@@ -224,6 +212,41 @@ mod tests {
             ask(QueryEntailment::Rdfs),
             SparqlResult::Boolean(true)
         ));
+    }
+
+    #[test]
+    fn owl_rl_query_sees_derived_type() {
+        assert!(matches!(
+            ask(QueryEntailment::OwlRl),
+            SparqlResult::Boolean(true)
+        ));
+    }
+
+    #[test]
+    fn owl_direct_query_uses_the_query_bgp() {
+        assert!(matches!(
+            ask(QueryEntailment::OwlDirect),
+            SparqlResult::Boolean(true)
+        ));
+    }
+
+    #[test]
+    fn rdf_query_types_predicates_as_properties() {
+        let query = format!(
+            "ASK {{ <{RDFS_SUBCLASS}> a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> }}"
+        );
+        let result = query_with_entailment(
+            &NativeSparqlEngine::new(),
+            &hierarchy(),
+            SparqlRequest {
+                query: &query,
+                base_iri: None,
+                substitutions: &[],
+            },
+            QueryEntailment::Rdf,
+        )
+        .unwrap();
+        assert!(matches!(result, SparqlResult::Boolean(true)));
     }
 
     #[test]

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.4.1" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.4.2" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -78,4 +78,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "0.4.1"
+version = "0.4.2"

--- a/crates/rdf-capi/include/purrdf.h
+++ b/crates/rdf-capi/include/purrdf.h
@@ -10,7 +10,7 @@
 /* WARNING: generated file — edit crates/rdf-capi instead. */
 #define PURRDF_MAJOR 0
 #define PURRDF_MINOR 4
-#define PURRDF_PATCH 1
+#define PURRDF_PATCH 2
 
 
 #include <stdarg.h>

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -51,7 +51,7 @@ serde_json = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.4.1" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.4.2" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.4.1" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.4.2" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.

--- a/crates/sparql-eval/src/engine.rs
+++ b/crates/sparql-eval/src/engine.rs
@@ -157,6 +157,15 @@ impl std::fmt::Debug for NativeSparqlEngine {
 }
 
 impl NativeSparqlEngine {
+    /// Parser configuration applied to every query this engine evaluates.
+    ///
+    /// Entailment façades use this when inspecting query algebra before handing
+    /// the query back to the engine, preventing extension-namespace drift.
+    #[must_use]
+    pub fn parser_options(&self) -> &ParserOptions {
+        &self.parser_options
+    }
+
     /// A fresh engine with an empty plan cache and no `LOAD` resolver.
     pub fn new() -> Self {
         Self::default()

--- a/crates/sparql-eval/src/engine.rs
+++ b/crates/sparql-eval/src/engine.rs
@@ -157,13 +157,39 @@ impl std::fmt::Debug for NativeSparqlEngine {
 }
 
 impl NativeSparqlEngine {
-    /// Parser configuration applied to every query this engine evaluates.
+    /// Parse a query through this engine's memoizing plan cache.
     ///
-    /// Entailment façades use this when inspecting query algebra before handing
-    /// the query back to the engine, preventing extension-namespace drift.
-    #[must_use]
-    pub fn parser_options(&self) -> &ParserOptions {
-        &self.parser_options
+    /// Callers that inspect query algebra before evaluation can retain the
+    /// returned plan and pass it to [`Self::query_prepared`], avoiding a second
+    /// parse or cache lookup.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`RdfDiagnostic`] if the query text does not parse.
+    pub fn prepare_query(
+        &self,
+        query: &str,
+        base_iri: Option<&str>,
+    ) -> Result<Arc<PreparedQuery>, RdfDiagnostic> {
+        self.cache
+            .borrow_mut()
+            .prepare_with(query, base_iri, &self.parser_options)
+    }
+
+    /// Evaluate a plan returned by [`Self::prepare_query`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates evaluation errors as an [`RdfDiagnostic`].
+    pub fn query_prepared(
+        &self,
+        dataset: &Arc<RdfDataset>,
+        prepared: &PreparedQuery,
+        substitutions: &[(String, TermValue)],
+    ) -> Result<SparqlResult, RdfDiagnostic> {
+        let mut ctx = self.eval_ctx(dataset);
+        let outcome = evaluate_with_substitutions(prepared, substitutions, &mut ctx)?;
+        Ok(materialize(outcome, &ctx))
     }
 
     /// A fresh engine with an empty plan cache and no `LOAD` resolver.
@@ -422,14 +448,8 @@ impl SparqlEngine for NativeSparqlEngine {
         dataset: &Self::Dataset,
         request: SparqlRequest<'_>,
     ) -> Result<SparqlResult, RdfDiagnostic> {
-        let prepared = self.cache.borrow_mut().prepare_with(
-            request.query,
-            request.base_iri,
-            &self.parser_options,
-        )?;
-        let mut ctx = self.eval_ctx(dataset);
-        let outcome = evaluate_with_substitutions(&prepared, request.substitutions, &mut ctx)?;
-        Ok(materialize(outcome, &ctx))
+        let prepared = self.prepare_query(request.query, request.base_iri)?;
+        self.query_prepared(dataset, &prepared, request.substitutions)
     }
 
     fn update(


### PR DESCRIPTION
## Summary

- add a public `query_with_entailment` facade for Simple, RDF, RDFS, OWL-RL, OWL-Direct, and RIF query execution
- promote strict RIF-XML parsing with caller-owned import resolution and no engine-side I/O
- bump the coherent Rust/Python/npm suite version to 0.4.2
- fix changelog PR-token stripping at the generator source

## Validation

- `make check`
- focused `purrdf` and `purrdf-entail` tests cover asserted, RDFS-derived, RIF-derived, and strict RIF-XML behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RIF-XML parsing with caller-controlled import resolution.
  * Added entailment-aware SPARQL querying for RDF, RDFS, OWL-RL, OWL Direct, and RIF reasoning modes.
  * Exposed parser configuration access for SPARQL engines.

* **Documentation**
  * Expanded documentation for RIF-XML support, imports, and entailment-aware querying.

* **Release**
  * Updated the project and published package versions to 0.4.2.
  * Improved changelog reference cleanup during release generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->