### PR TITLE
Make SPARQL conformance counts deterministic

### DIFF
--- a/scripts/conformance-matrix.py
+++ b/scripts/conformance-matrix.py
@@ -237,9 +237,19 @@ def _suite_shex_validation() -> SuiteResult:
 
 
 def _suite_sparql() -> SuiteResult:
+    # The datatest harness writes each manifest tally to stderr.  Serialise its
+    # cases so libtest progress output cannot splice through those tally lines.
     cmd = [
-        "cargo", "test", "-p", "purrdf-sparql-conformance", "--locked",
-        "--", "--nocapture",
+        "cargo",
+        "test",
+        "-p",
+        "purrdf-sparql-conformance",
+        "--locked",
+        "--test",
+        "sparql_conformance",
+        "--",
+        "--nocapture",
+        "--test-threads=1",
     ]
     rc, out = _run(cmd, _REPO_ROOT)
     _, _, cargo_failed = _cargo_tally(out)


### PR DESCRIPTION
## Summary

- run only the manifest-driven SPARQL conformance test binary in the matrix
- serialize its datatest cases so stderr tally lines cannot interleave with test progress output

## Validation

- reproduced nondeterministic totals of 767 and 787 instead of 800
- five consecutive targeted runs: 800 pass, 5 xfail, 0 fail
- full `make conformance`: GREEN, 2855 total pass, 10 ledgered, 0 fail

This is a release blocker for 0.4.3: the suites pass, but interleaved output made the generated documentation check fail nondeterministically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conformance test output consistency by running tests sequentially, preventing progress messages from interleaving with result totals.
  * Preserved accurate reporting of passed, expected-failure, unexpected, and failed test counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->