### PR TITLE
chore(release): bump CITATION.cff to 0.5.0 and pin it to the version lane

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,8 +21,8 @@ authors:
   - family-names: "Audley"
     given-names: "Patrick"
     orcid: "https://orcid.org/0000-0003-4382-7625"
-version: "0.2.1"
-date-released: "2026-07-02"
+version: "0.5.0"
+date-released: "2026-07-12"
 license:
   - Apache-2.0
   - MIT

--- a/scripts/check-versions.py
+++ b/scripts/check-versions.py
@@ -12,9 +12,12 @@ lint closes both gaps as a hard, no-optionality gate:
 
 1. **Version coherence.** The workspace version (``Cargo.toml``
    ``[workspace.package].version``), the PyPI project version
-   (``bindings/python/pyproject.toml`` ``[project].version``), and the npm
-   package version (``crates/rdf-wasm/js/package.json`` ``version``) must be
-   byte-identical. A single tag then names one coherent release.
+   (``bindings/python/pyproject.toml`` ``[project].version``), the npm
+   package version (``crates/rdf-wasm/js/package.json`` ``version``), and the
+   cited version (``CITATION.cff`` ``version``) must be byte-identical. A single
+   tag then names one coherent release. ``CITATION.cff`` is not a build input, so
+   it drifted out of the lane between 0.2.1 and 0.5.0; pinning it here keeps the
+   cited version honest for every future release.
 
 2. **Publish-list completeness.** The ordered crate list the crates.io release
    lane publishes (the ``crates=( … )`` array in
@@ -76,6 +79,21 @@ def npm_version(root: Path) -> str:
         )
     )
     return data["version"]
+
+
+def citation_version(root: Path) -> str:
+    """The ``version`` value from ``CITATION.cff`` (never ``cff-version``).
+
+    CFF is YAML; rather than take a YAML dependency, match the column-0
+    ``version:`` key (the schema key ``cff-version:`` is prefixed, so ``^version:``
+    cannot match it) and strip optional quotes. Kept deliberately narrow so a
+    nested/indented ``version`` elsewhere in the document can never be picked up.
+    """
+    text = (root / "CITATION.cff").read_text(encoding="utf-8")
+    match = re.search(r'^version:\s*"?([^"\n]+?)"?\s*$', text, flags=re.MULTILINE)
+    if match is None:
+        raise ValueError("CITATION.cff: no top-level version: field")
+    return match.group(1)
 
 
 def workspace_metadata(root: Path) -> dict:
@@ -182,6 +200,7 @@ def main() -> int:
         "Cargo.toml [workspace.package].version": workspace_version(root),
         "bindings/python/pyproject.toml [project].version": pyproject_version(root),
         "crates/rdf-wasm/js/package.json .version": npm_version(root),
+        "CITATION.cff version": citation_version(root),
     }
     distinct = set(versions.values())
     if len(distinct) != 1:

--- a/scripts/set-version.py
+++ b/scripts/set-version.py
@@ -28,6 +28,8 @@ a dependency line carrying BOTH ``path = "…"`` and ``version = "…"``):
 Other version locations:
 * ``crates/rdf-capi/Cargo.toml``         — ``[package.metadata.capi.library] version``
 * ``bindings/python/uv.lock``            — the editable ``purrdf`` package pin
+* ``CITATION.cff``                       — ``version`` (and ``date-released``,
+                                           stamped to today's release date)
 
 Edits are line-scoped so file formatting and comments are preserved (only the
 version value changes). Deps that inherit via ``version.workspace = true`` and
@@ -43,6 +45,7 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
+from datetime import date
 from pathlib import Path
 
 _SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$")
@@ -158,6 +161,41 @@ def set_uv_lock(root: Path, version: str) -> None:
     lock.write_text("[[package]]".join(blocks), encoding="utf-8")
 
 
+def set_citation_cff(root: Path, version: str) -> None:
+    """Sync ``CITATION.cff`` ``version`` and ``date-released`` to the release.
+
+    The citation metadata carries its own ``version`` string that ``git`` /
+    Zenodo / CFF consumers cite. It is not a build input, so it silently drifted
+    out of the version lane between 0.2.1 and 0.5.0; the coherence gate now pins
+    it (``scripts/check-versions.py``), and this rewrite keeps it in lockstep so
+    the gate never trips at release time. The top-level ``version:`` key is
+    rewritten (never ``cff-version:``, which names the CFF schema), and
+    ``date-released`` is stamped to today so the citation date matches the day the
+    release is cut. Edits are line-scoped; the value is normalized to the quoted
+    form CFF uses.
+    """
+    path = root / "CITATION.cff"
+    today = date.today().isoformat()
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    set_version = set_date = False
+    for i, line in enumerate(lines):
+        # Anchor to a column-0 ``version:`` so ``cff-version:`` and any nested
+        # (indented) version keys are never matched.
+        if re.match(r"version:\s", line):
+            lines[i] = re.sub(r'(version:\s*)"?[^"\n]*"?', rf'\g<1>"{version}"', line)
+            set_version = True
+        elif re.match(r"date-released:\s", line):
+            lines[i] = re.sub(
+                r'(date-released:\s*)"?[^"\n]*"?', rf'\g<1>"{today}"', line
+            )
+            set_date = True
+    if not set_version:
+        raise SystemExit(f"FAIL: no top-level version: key found in {path}")
+    if not set_date:
+        raise SystemExit(f"FAIL: no date-released: key found in {path}")
+    path.write_text("".join(lines), encoding="utf-8")
+
+
 def main(argv: list[str]) -> int:
     if len(argv) != 2:
         print("usage: python3 scripts/set-version.py <x.y.z>", file=sys.stderr)
@@ -189,6 +227,9 @@ def main(argv: list[str]) -> int:
         version,
     )
     set_uv_lock(root, version)
+
+    # 4. Citation metadata (cited version + release date; pinned by the gate).
+    set_citation_cff(root, version)
 
     print(
         f"set version {version} across crates.io/PyPI/npm "


### PR DESCRIPTION
## What

Two commits:

1. **`docs(citation)`** — bumps `CITATION.cff` `version` `0.2.1` → `0.5.0` and `date-released` → `2026-07-12`.
2. **`build(release)`** — wires `CITATION.cff` into the automated version lane so it can never drift again.

## Why it drifted

`CITATION.cff` carries its own cited version but is **not a build input**, so nothing rewrote it and nothing gated it. It silently fell behind at 0.3.0 and stayed at `0.2.1` through 0.3.x, 0.4.x, and 0.5.0.

## The fix (commit 2)

- `scripts/set-version.py` now rewrites `CITATION.cff` `version` in lockstep with the crates.io/PyPI/npm sources and stamps `date-released` to today, so `make bump` keeps the citation honest.
- `scripts/check-versions.py` adds `CITATION.cff` `version` as a **fourth coherence source**, so `make check` / `make release-tags` hard-fail if it ever drifts again. The `version:` key is matched with a column-0 regex so `cff-version:` (the CFF schema key) is never picked up — no YAML dependency added.

## Verification

- `python3 scripts/check-versions.py` → `OK: version 0.5.0 coherent across crates.io/PyPI/npm` (now including CITATION.cff).
- Re-running `make bump VERSION=0.5.0` is a **no-op** on the tree (idempotent).
- `ruff check` passes on both scripts.

Note: 0.5.0 is already tagged and publishing; this PR only prevents future drift and corrects the current citation metadata.