### PR TITLE
feat(core): id-agnostic DatasetView seam + paged u64 backend served by the evaluator

### DIFF
--- a/crates/rdf-core/src/dataset_view.rs
+++ b/crates/rdf-core/src/dataset_view.rs
@@ -16,6 +16,7 @@
 //! object-safety obligation.
 
 use std::collections::BTreeSet;
+use std::sync::Arc;
 
 use crate::RdfStoreCapabilities;
 use crate::collections::{RDF_ALT, RDF_BAG, RDF_FIRST, RDF_NIL, RDF_REST, RDF_SEQ, RDF_TYPE};
@@ -109,7 +110,11 @@ pub trait DatasetView {
     /// index-nested-loop join slot (see [`Self::probe_plan`] /
     /// [`Self::quads_for_pattern_with_plan`]). A backend with no access-pattern index
     /// uses the unit plan `()`.
-    type ProbePlan: Copy;
+    ///
+    /// `Send + Sync` because the plan is computed once per join slot and then
+    /// captured by value into every parallel probe worker (see the BGP join loop):
+    /// the loop-invariant plan crosses the fork boundary, so it must be shareable.
+    type ProbePlan: Copy + Send + Sync;
 
     /// Iterate every quad as `Copy` [`QuadIds`] (dataset-local term ids).
     fn quads(&self) -> impl Iterator<Item = QuadIds<Self::Id>> + '_;
@@ -232,6 +237,17 @@ pub trait DatasetView {
     ) -> impl Iterator<Item = (Self::Id, Self::Id, Option<Self::Id>)> + '_ {
         let _ = reifier;
         std::iter::empty()
+    }
+
+    /// Every named graph this view addresses, in ascending id order (sorted,
+    /// deduplicated). Drives `GRAPH ?g` enumeration, so the order is
+    /// result-observable and must be deterministic. The default derives the set
+    /// from the quads the view can see; a backend that also tracks explicitly
+    /// declared *empty* named graphs (e.g. [`RdfDataset`]) overrides this to
+    /// include them.
+    fn named_graphs(&self) -> impl Iterator<Item = Self::Id> + '_ {
+        let set: BTreeSet<Self::Id> = self.quads().filter_map(|q| q.g).collect();
+        set.into_iter()
     }
 
     /// Materialize an `rdf:first`/`rdf:rest`/`rdf:nil` Collection whose head is
@@ -570,6 +586,132 @@ impl DatasetView for RdfDataset {
         reifier: TermId,
     ) -> impl Iterator<Item = (TermId, TermId, Option<TermId>)> + '_ {
         Self::annotations_of_with_graph(self, reifier)
+    }
+
+    #[inline]
+    fn named_graphs(&self) -> impl Iterator<Item = TermId> + '_ {
+        // The inherent set includes explicitly-declared empty named graphs, which
+        // the quads-derived default would miss, so delegate to it verbatim.
+        Self::named_graphs(self)
+    }
+}
+
+/// A shared [`Arc`]-wrapped read view is itself a read view: every method delegates
+/// to the inner `T`, so `Arc<RdfDataset>` (the engine's `Dataset` handle) plugs into
+/// the generic evaluator directly, byte-for-byte identical to the bare `RdfDataset`.
+/// Every method — including the ones `RdfDataset` overrides for its indexed read path
+/// and RDF 1.2 side-tables — is forwarded, so no default (e.g. an empty reifier layer)
+/// can silently diverge from the inner view.
+impl<T: DatasetView> DatasetView for Arc<T> {
+    type Id = T::Id;
+    type ProbePlan = T::ProbePlan;
+
+    #[inline]
+    fn quads(&self) -> impl Iterator<Item = QuadIds<Self::Id>> + '_ {
+        (**self).quads()
+    }
+
+    #[inline]
+    fn quad_refs(&self) -> impl Iterator<Item = QuadRef<'_, Self::Id>> + '_ {
+        (**self).quad_refs()
+    }
+
+    #[inline]
+    fn resolve(&self, id: Self::Id) -> TermRef<'_, Self::Id> {
+        (**self).resolve(id)
+    }
+
+    #[inline]
+    fn quads_for_pattern(
+        &self,
+        s: Option<Self::Id>,
+        p: Option<Self::Id>,
+        o: Option<Self::Id>,
+        g: GraphMatch<Self::Id>,
+    ) -> impl Iterator<Item = QuadIds<Self::Id>> + '_ {
+        (**self).quads_for_pattern(s, p, o, g)
+    }
+
+    #[inline]
+    fn term_id_by_value(&self, value: &TermValue) -> Option<Self::Id> {
+        (**self).term_id_by_value(value)
+    }
+
+    #[inline]
+    fn capabilities(&self) -> RdfStoreCapabilities {
+        (**self).capabilities()
+    }
+
+    #[inline]
+    fn len_hint(&self) -> Option<usize> {
+        (**self).len_hint()
+    }
+
+    #[inline]
+    fn probe_plan(
+        &self,
+        s_bound: bool,
+        p_bound: bool,
+        o_bound: bool,
+        g: GraphMatch<Self::Id>,
+    ) -> Self::ProbePlan {
+        (**self).probe_plan(s_bound, p_bound, o_bound, g)
+    }
+
+    #[inline]
+    fn quads_for_pattern_with_plan(
+        &self,
+        plan: &Self::ProbePlan,
+        s: Option<Self::Id>,
+        p: Option<Self::Id>,
+        o: Option<Self::Id>,
+        g: GraphMatch<Self::Id>,
+    ) -> impl Iterator<Item = QuadIds<Self::Id>> + '_ {
+        (**self).quads_for_pattern_with_plan(plan, s, p, o, g)
+    }
+
+    #[inline]
+    fn cardinality_estimate(
+        &self,
+        s: Option<Self::Id>,
+        p: Option<Self::Id>,
+        o: Option<Self::Id>,
+        g: GraphMatch<Self::Id>,
+    ) -> usize {
+        (**self).cardinality_estimate(s, p, o, g)
+    }
+
+    #[inline]
+    fn term_count(&self) -> usize {
+        (**self).term_count()
+    }
+
+    #[inline]
+    fn stats_fingerprint(&self) -> u64 {
+        (**self).stats_fingerprint()
+    }
+
+    #[inline]
+    fn reifier_quads(&self) -> impl Iterator<Item = QuadIds<Self::Id>> + '_ {
+        (**self).reifier_quads()
+    }
+
+    #[inline]
+    fn annotation_quads(&self) -> impl Iterator<Item = QuadIds<Self::Id>> + '_ {
+        (**self).annotation_quads()
+    }
+
+    #[inline]
+    fn annotations_of_with_graph(
+        &self,
+        reifier: Self::Id,
+    ) -> impl Iterator<Item = (Self::Id, Self::Id, Option<Self::Id>)> + '_ {
+        (**self).annotations_of_with_graph(reifier)
+    }
+
+    #[inline]
+    fn named_graphs(&self) -> impl Iterator<Item = Self::Id> + '_ {
+        (**self).named_graphs()
     }
 }
 

--- a/crates/rdf-core/src/dataset_view.rs
+++ b/crates/rdf-core/src/dataset_view.rs
@@ -34,9 +34,55 @@ mod sealed {
 /// join/index machinery needs of an id (`Copy` to pass by value, `Eq`/`Ord`/`Hash`
 /// to key joins and index probes, `Send`/`Sync`/`'static` to cross the query
 /// boundary). The production id is [`TermId`]; a paged/global backend mints its own.
-pub trait ViewTermId: Copy + Eq + Ord + core::hash::Hash + Send + Sync + 'static {}
+///
+/// # Join-key encoding
+///
+/// The evaluator hash-joins on a single [`JoinKeyAtom`](Self::JoinKeyAtom): a `Copy`,
+/// totally-ordered atom that packs *either* a dataset id (via [`encode`](Self::encode))
+/// *or* an evaluator-minted computed-term id (via
+/// [`encode_computed`](Self::encode_computed)) into ONE key space, with the two
+/// disjoint by construction so an id never collides with a computed key (which would
+/// be a wrong join result, not a slowdown). For [`TermId`] the atom is the historical
+/// packed `u64` — dataset ids in `[0, 2^32)`, computed ids in `[2^32, 2^33)` — so the
+/// production hash-join is bit-identical to before the id-generic seam. A wider id
+/// (e.g. `GlobalTermId`) uses a wider atom (`u128`) so the same disjointness holds at
+/// its width.
+pub trait ViewTermId:
+    Copy + Eq + Ord + core::hash::Hash + core::fmt::Debug + Send + Sync + 'static
+{
+    /// A `Copy`, totally-ordered atom that encodes a dataset id OR a computed-term
+    /// id into one hash-join key space (see the trait docs). For [`TermId`] this is
+    /// `u64`; for a wider id it is `u128`.
+    type JoinKeyAtom: Copy + Eq + Ord + core::hash::Hash + Send + Sync + 'static;
 
-impl ViewTermId for TermId {}
+    /// Encode this dataset id into the join-key space. The image of `encode` over all
+    /// ids MUST be disjoint from the image of [`encode_computed`](Self::encode_computed)
+    /// over all scratch indices, so an `Existing` binding never shares a key with a
+    /// `Computed` one.
+    fn encode(self) -> Self::JoinKeyAtom;
+
+    /// Encode an evaluator-minted computed-term scratch index (a `u32`) into the join-key
+    /// space, disjoint from every [`encode`](Self::encode) image (see the trait docs).
+    fn encode_computed(scratch_index: u32) -> Self::JoinKeyAtom;
+}
+
+impl ViewTermId for TermId {
+    type JoinKeyAtom = u64;
+
+    #[inline]
+    fn encode(self) -> u64 {
+        let ix = self.index() as u64;
+        debug_assert!(ix < (1 << 32), "TermId index must fit u32");
+        ix
+    }
+
+    #[inline]
+    fn encode_computed(scratch_index: u32) -> u64 {
+        // Dataset ids occupy `[0, 2^32)`; computed ids occupy `[2^32, 2^33)`. Bit 32
+        // is the disjointness tag — byte-identical to the historical `join_key_u64`.
+        (1 << 32) | u64::from(scratch_index)
+    }
+}
 
 /// How a pattern query matches the graph slot of a quad.
 ///

--- a/crates/rdf-core/src/dataset_view.rs
+++ b/crates/rdf-core/src/dataset_view.rs
@@ -20,14 +20,22 @@ use std::collections::BTreeSet;
 use crate::RdfStoreCapabilities;
 use crate::collections::{RDF_ALT, RDF_BAG, RDF_FIRST, RDF_NIL, RDF_REST, RDF_SEQ, RDF_TYPE};
 use crate::collections::{RdfListError, container_member_index};
-use crate::ir::{QuadIds, QuadRef, RdfDataset, TermId, TermRef, TermValue};
+use crate::ir::{QuadIds, QuadProbePlan, QuadRef, RdfDataset, TermId, TermRef, TermValue};
 
 mod sealed {
     pub trait Sealed {}
 
-    impl Sealed for crate::ir::RdfDataset {}
     impl Sealed for crate::ir::MutableDataset {}
 }
+
+/// The associated id type of a [`DatasetView`]. An id is meaningful only within the
+/// view that minted it (C0.8); these bounds are exactly what the evaluator's
+/// join/index machinery needs of an id (`Copy` to pass by value, `Eq`/`Ord`/`Hash`
+/// to key joins and index probes, `Send`/`Sync`/`'static` to cross the query
+/// boundary). The production id is [`TermId`]; a paged/global backend mints its own.
+pub trait ViewTermId: Copy + Eq + Ord + core::hash::Hash + Send + Sync + 'static {}
+
+impl ViewTermId for TermId {}
 
 /// How a pattern query matches the graph slot of a quad.
 ///
@@ -36,21 +44,25 @@ mod sealed {
 /// hence this dedicated three-way match. Deliberately exhaustive (NOT
 /// `#[non_exhaustive]`): a quad's graph is either the default or exactly one named
 /// graph, so the three cases are closed.
+///
+/// Generic over the id type `Id` (defaulting to [`TermId`]) so it names a graph in
+/// any [`DatasetView`]'s id space; the bare spelling `GraphMatch` continues to name
+/// the `RdfDataset` (`TermId`) instantiation everywhere.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GraphMatch {
+pub enum GraphMatch<Id = TermId> {
     /// Match quads in any graph (default or named).
     Any,
     /// Match only quads in the default graph (`g == None`).
     Default,
     /// Match only quads in the named graph identified by this id.
-    Named(TermId),
+    Named(Id),
 }
 
-impl GraphMatch {
+impl<Id: Copy + PartialEq> GraphMatch<Id> {
     /// Whether a quad's stored graph slot (`None` = default graph) matches.
     #[inline]
     #[must_use]
-    pub fn matches(self, graph: Option<TermId>) -> bool {
+    pub fn matches(self, graph: Option<Id>) -> bool {
         match self {
             Self::Any => true,
             Self::Default => graph.is_none(),
@@ -86,15 +98,27 @@ pub enum GraphMatchValue<'a> {
 
 /// A static, allocation-free read view over an RDF dataset (purrdf backend
 /// contract, C2/C3/C6). All methods are infallible for a frozen, validated dataset.
-pub trait DatasetView: sealed::Sealed {
+pub trait DatasetView {
+    /// The dataset-local id type this view mints and reads in (C0.8). For the
+    /// production [`RdfDataset`] this is [`TermId`]; a paged/global backend supplies
+    /// its own id, which is meaningful only within this view.
+    type Id: ViewTermId;
+
+    /// The opaque, loop-invariant probe plan a pattern query precomputes once (from
+    /// which axes a pattern binds) and reuses across the probe rows of one
+    /// index-nested-loop join slot (see [`Self::probe_plan`] /
+    /// [`Self::quads_for_pattern_with_plan`]). A backend with no access-pattern index
+    /// uses the unit plan `()`.
+    type ProbePlan: Copy;
+
     /// Iterate every quad as `Copy` [`QuadIds`] (dataset-local term ids).
-    fn quads(&self) -> impl Iterator<Item = QuadIds> + '_;
+    fn quads(&self) -> impl Iterator<Item = QuadIds<Self::Id>> + '_;
 
     /// Iterate every quad as a borrowed, resolved [`QuadRef`] (no allocation).
-    fn quad_refs(&self) -> impl Iterator<Item = QuadRef<'_>> + '_;
+    fn quad_refs(&self) -> impl Iterator<Item = QuadRef<'_, Self::Id>> + '_;
 
-    /// Resolve a dataset-local [`TermId`] to its borrowed [`TermRef`].
-    fn resolve(&self, id: TermId) -> TermRef<'_>;
+    /// Resolve a dataset-local id to its borrowed [`TermRef`].
+    fn resolve(&self, id: Self::Id) -> TermRef<'_, Self::Id>;
 
     /// Quads matching an optional `(s, p, o)` id pattern and a [`GraphMatch`].
     ///
@@ -103,14 +127,14 @@ pub trait DatasetView: sealed::Sealed {
     /// Callers resolve term *values* to ids first (`term_id_by_value`, P4).
     fn quads_for_pattern(
         &self,
-        s: Option<TermId>,
-        p: Option<TermId>,
-        o: Option<TermId>,
-        g: GraphMatch,
-    ) -> impl Iterator<Item = QuadIds> + '_ {
+        s: Option<Self::Id>,
+        p: Option<Self::Id>,
+        o: Option<Self::Id>,
+        g: GraphMatch<Self::Id>,
+    ) -> impl Iterator<Item = QuadIds<Self::Id>> + '_ {
         self.quads().filter(move |q| {
             // Closure params named `id` (not s/p/o) to avoid shadowing the outer
-            // `Option<TermId>` filters with the unwrapped `TermId`.
+            // `Option<Self::Id>` filters with the unwrapped id.
             s.is_none_or(|id| q.s == id)
                 && p.is_none_or(|id| q.p == id)
                 && o.is_none_or(|id| q.o == id)
@@ -118,13 +142,13 @@ pub trait DatasetView: sealed::Sealed {
         })
     }
 
-    /// Resolve a term **value** to its dataset-local [`TermId`], without minting.
+    /// Resolve a term **value** to its dataset-local id, without minting.
     ///
     /// A value interned nowhere in this view yields `None` (it names no term), so a
     /// structural walk keyed on a not-present IRI simply finds nothing — absence is
     /// an empty match, never an error. Backends with a reverse value index (P4) use
     /// it; others may scan.
-    fn term_id_by_value(&self, value: &TermValue) -> Option<TermId>;
+    fn term_id_by_value(&self, value: &TermValue) -> Option<Self::Id>;
 
     /// The capabilities this view's backing data exposes (C7).
     fn capabilities(&self) -> RdfStoreCapabilities;
@@ -132,6 +156,82 @@ pub trait DatasetView: sealed::Sealed {
     /// A size hint for the number of quads, if known.
     fn len_hint(&self) -> Option<usize> {
         None
+    }
+
+    /// Precompute the loop-invariant [`ProbePlan`](Self::ProbePlan) for a pattern of
+    /// the given bound-axis shape and graph constraint, to be reused across the probe
+    /// rows of an index-nested-loop join slot via
+    /// [`Self::quads_for_pattern_with_plan`]. An index-free backend returns the unit
+    /// plan; [`RdfDataset`] returns its permutation-and-prefix plan.
+    fn probe_plan(
+        &self,
+        s_bound: bool,
+        p_bound: bool,
+        o_bound: bool,
+        g: GraphMatch<Self::Id>,
+    ) -> Self::ProbePlan;
+
+    /// Quads matching `(s, p, o, g)` under a caller-precomputed
+    /// [`ProbePlan`](Self::ProbePlan). Behaviourally identical to
+    /// [`Self::quads_for_pattern`] — the plan only skips the per-row permutation
+    /// selection; the yielded quads and their order are unchanged. An index-free
+    /// backend ignores the (unit) plan and forwards to `quads_for_pattern`.
+    fn quads_for_pattern_with_plan(
+        &self,
+        plan: &Self::ProbePlan,
+        s: Option<Self::Id>,
+        p: Option<Self::Id>,
+        o: Option<Self::Id>,
+        g: GraphMatch<Self::Id>,
+    ) -> impl Iterator<Item = QuadIds<Self::Id>> + '_;
+
+    /// An upper-bound cardinality estimate for `(s, p, o, g)`, FOR COST RANKING ONLY
+    /// (never an exact `COUNT`). The default materializes the pattern and counts it;
+    /// a backend with index bounds (P4) overrides this with an `O(log n)` estimate.
+    fn cardinality_estimate(
+        &self,
+        s: Option<Self::Id>,
+        p: Option<Self::Id>,
+        o: Option<Self::Id>,
+        g: GraphMatch<Self::Id>,
+    ) -> usize {
+        self.quads_for_pattern(s, p, o, g).count()
+    }
+
+    /// The number of distinct interned terms this view addresses.
+    fn term_count(&self) -> usize;
+
+    /// A cheap, deterministic size fingerprint for a dataset-aware cache key (e.g. a
+    /// join-order cache). A *cache discriminator*, not a content digest. The default
+    /// is `0` (no discrimination); [`RdfDataset`] hashes its quad and term counts.
+    fn stats_fingerprint(&self) -> u64 {
+        0
+    }
+
+    /// The RDF 1.2 reifier side-table AS resolved virtual triples: each
+    /// `(reifier, triple-term)` binding becomes a `(reifier, rdf:reifies, triple-term)`
+    /// quad carrying the declaration's own graph slot. Capability-gated: a backend
+    /// with no reifier layer yields nothing (the default).
+    fn reifier_quads(&self) -> impl Iterator<Item = QuadIds<Self::Id>> + '_ {
+        std::iter::empty()
+    }
+
+    /// The RDF 1.2 annotation side-table AS resolved virtual triples: each
+    /// `(reifier, predicate, object)` annotation becomes a quad carrying its own graph
+    /// slot. Capability-gated: a backend with no annotation layer yields nothing.
+    fn annotation_quads(&self) -> impl Iterator<Item = QuadIds<Self::Id>> + '_ {
+        std::iter::empty()
+    }
+
+    /// The `(predicate, object, graph)` annotations declared for `reifier` (`graph`
+    /// `None` ⇒ default graph). Capability-gated: a backend with no annotation layer
+    /// yields nothing (the default ignores `reifier`).
+    fn annotations_of_with_graph(
+        &self,
+        reifier: Self::Id,
+    ) -> impl Iterator<Item = (Self::Id, Self::Id, Option<Self::Id>)> + '_ {
+        let _ = reifier;
+        std::iter::empty()
     }
 
     /// Materialize an `rdf:first`/`rdf:rest`/`rdf:nil` Collection whose head is
@@ -147,7 +247,11 @@ pub trait DatasetView: sealed::Sealed {
     ///
     /// If the `rdf:first` IRI is not interned in this view at all, no Collection can
     /// exist, so the result is an empty `Vec` (`Ok`), not an error.
-    fn rdf_list(&self, head: TermId, graph: GraphMatch) -> Result<Vec<TermId>, RdfListError> {
+    fn rdf_list(
+        &self,
+        head: Self::Id,
+        graph: GraphMatch<Self::Id>,
+    ) -> Result<Vec<Self::Id>, RdfListError> {
         // No `rdf:first` in the term table ⇒ no cons cell can exist here.
         let Some(first_p) = self.term_id_by_value(&TermValue::iri(RDF_FIRST)) else {
             return Ok(Vec::new());
@@ -161,7 +265,7 @@ pub trait DatasetView: sealed::Sealed {
         let mut out = Vec::new();
         // Cycle guard: revisited cell terminates the walk (mirrors the reference
         // GTS `rdf_list` seen-set).
-        let mut seen: BTreeSet<TermId> = BTreeSet::new();
+        let mut seen: BTreeSet<Self::Id> = BTreeSet::new();
         let mut current = head;
         loop {
             if Some(current) == nil {
@@ -219,8 +323,8 @@ pub trait DatasetView: sealed::Sealed {
     /// RDF Container members `rdf:_1`..`rdf:_n` of `head` in numeric order, scoped
     /// to `graph`. Gaps are skipped; ordering is by the numeric suffix, NOT dataset
     /// order.
-    fn rdf_container_members(&self, head: TermId, graph: GraphMatch) -> Vec<TermId> {
-        let mut indexed: Vec<(u64, TermId)> = Vec::new();
+    fn rdf_container_members(&self, head: Self::Id, graph: GraphMatch<Self::Id>) -> Vec<Self::Id> {
+        let mut indexed: Vec<(u64, Self::Id)> = Vec::new();
         for q in self.quads_for_pattern(Some(head), None, None, graph) {
             if let TermRef::Iri(iri) = self.resolve(q.p)
                 && let Some(n) = container_member_index(iri)
@@ -238,7 +342,11 @@ pub trait DatasetView: sealed::Sealed {
     /// or carrying any `rdf:_n` property is walked as a Container
     /// ([`rdf_container_members`](Self::rdf_container_members)). A head matching
     /// neither yields an empty `Vec`.
-    fn members(&self, head: TermId, graph: GraphMatch) -> Result<Vec<TermId>, RdfListError> {
+    fn members(
+        &self,
+        head: Self::Id,
+        graph: GraphMatch<Self::Id>,
+    ) -> Result<Vec<Self::Id>, RdfListError> {
         // Collection shape wins: an `rdf:first` edge marks a cons cell.
         if let Some(first_p) = self.term_id_by_value(&TermValue::iri(RDF_FIRST))
             && self
@@ -267,10 +375,10 @@ pub trait DatasetView: sealed::Sealed {
     #[doc(hidden)]
     fn is_cons_cell(
         &self,
-        id: TermId,
-        first_p: TermId,
-        rest_p: Option<TermId>,
-        graph: GraphMatch,
+        id: Self::Id,
+        first_p: Self::Id,
+        rest_p: Option<Self::Id>,
+        graph: GraphMatch<Self::Id>,
     ) -> bool {
         if self
             .quads_for_pattern(Some(id), Some(first_p), None, graph)
@@ -289,7 +397,7 @@ pub trait DatasetView: sealed::Sealed {
     /// Whether `head` is typed `rdf:Seq`/`rdf:Bag`/`rdf:Alt` in `graph`. Internal
     /// helper for [`members`](Self::members) container dispatch.
     #[doc(hidden)]
-    fn is_typed_container(&self, head: TermId, graph: GraphMatch) -> bool {
+    fn is_typed_container(&self, head: Self::Id, graph: GraphMatch<Self::Id>) -> bool {
         let Some(type_p) = self.term_id_by_value(&TermValue::iri(RDF_TYPE)) else {
             return false;
         };
@@ -351,6 +459,9 @@ pub trait DatasetMut: sealed::Sealed {
 
 /// The production read view: the immutable value-interned [`RdfDataset`] (C1).
 impl DatasetView for RdfDataset {
+    type Id = TermId;
+    type ProbePlan = QuadProbePlan;
+
     #[inline]
     fn quads(&self) -> impl Iterator<Item = QuadIds> + '_ {
         // Inherent methods take method-resolution priority over trait methods, so
@@ -397,6 +508,69 @@ impl DatasetView for RdfDataset {
     fn len_hint(&self) -> Option<usize> {
         Some(Self::quad_count(self))
     }
+
+    #[inline]
+    fn probe_plan(
+        &self,
+        s_bound: bool,
+        p_bound: bool,
+        o_bound: bool,
+        g: GraphMatch,
+    ) -> QuadProbePlan {
+        // Inherent `probe_plan` is a value-independent associated fn (no `&self`).
+        Self::probe_plan(s_bound, p_bound, o_bound, g)
+    }
+
+    #[inline]
+    fn quads_for_pattern_with_plan(
+        &self,
+        plan: &QuadProbePlan,
+        s: Option<TermId>,
+        p: Option<TermId>,
+        o: Option<TermId>,
+        g: GraphMatch,
+    ) -> impl Iterator<Item = QuadIds> + '_ {
+        Self::quads_for_pattern_with_plan(self, plan, s, p, o, g)
+    }
+
+    #[inline]
+    fn cardinality_estimate(
+        &self,
+        s: Option<TermId>,
+        p: Option<TermId>,
+        o: Option<TermId>,
+        g: GraphMatch,
+    ) -> usize {
+        Self::cardinality_estimate(self, s, p, o, g)
+    }
+
+    #[inline]
+    fn term_count(&self) -> usize {
+        Self::term_count(self)
+    }
+
+    #[inline]
+    fn stats_fingerprint(&self) -> u64 {
+        Self::stats_fingerprint(self)
+    }
+
+    #[inline]
+    fn reifier_quads(&self) -> impl Iterator<Item = QuadIds> + '_ {
+        Self::reifier_quads(self)
+    }
+
+    #[inline]
+    fn annotation_quads(&self) -> impl Iterator<Item = QuadIds> + '_ {
+        Self::annotation_quads(self)
+    }
+
+    #[inline]
+    fn annotations_of_with_graph(
+        &self,
+        reifier: TermId,
+    ) -> impl Iterator<Item = (TermId, TermId, Option<TermId>)> + '_ {
+        Self::annotations_of_with_graph(self, reifier)
+    }
 }
 
 #[cfg(test)]
@@ -412,8 +586,10 @@ mod tests {
     fn graph_match_three_way() {
         let mut b = RdfDatasetBuilder::new();
         let g = iri(&mut b, "g");
-        assert!(GraphMatch::Any.matches(None) && GraphMatch::Any.matches(Some(g)));
-        assert!(GraphMatch::Default.matches(None) && !GraphMatch::Default.matches(Some(g)));
+        assert!(GraphMatch::<TermId>::Any.matches(None) && GraphMatch::Any.matches(Some(g)));
+        assert!(
+            GraphMatch::<TermId>::Default.matches(None) && !GraphMatch::Default.matches(Some(g))
+        );
         assert!(GraphMatch::Named(g).matches(Some(g)) && !GraphMatch::Named(g).matches(None));
     }
 

--- a/crates/rdf-core/src/describe.rs
+++ b/crates/rdf-core/src/describe.rs
@@ -38,7 +38,7 @@ use crate::{
 /// path (recursively for triple terms) — the id-agnostic twin of
 /// `RdfDataset::to_owned_term`, so the extractor rebuilds a describing subgraph over
 /// any backend whose id type is [`TermId`].
-fn owned_term<D: DatasetView<Id = TermId>>(dataset: &D, id: TermId) -> RdfTerm {
+fn owned_term<D: DatasetView>(dataset: &D, id: D::Id) -> RdfTerm {
     match dataset.resolve(id) {
         TermRef::Iri(iri) => RdfTerm::iri(iri),
         TermRef::Blank { label, scope } => RdfTerm::blank_node(scope.qualify_label(label)),
@@ -71,31 +71,37 @@ fn owned_term<D: DatasetView<Id = TermId>>(dataset: &D, id: TermId) -> RdfTerm {
     }
 }
 
+/// A view id → the quads touching it as subject/object (the endpoint adjacency).
+type EndpointQuads<I> = BTreeMap<I, Vec<QuadIds<I>>>;
+
+/// A view id → a list of `(id, id)` bindings (reifier/triple or annotation `(p, o)`).
+type EndpointPairs<I> = BTreeMap<I, Vec<(I, I)>>;
+
 /// A reusable extractor: it builds the subject/object adjacency and the reifier
 /// endpoint index **once**, so extracting the SCBD of many subjects (one per exported
 /// term/slice) is cheap — each extraction is a bounded graph walk over the index, not
 /// a full re-scan of the dataset.
 ///
-/// Generic over the read view `D` (any [`DatasetView`] whose id type is [`TermId`]),
-/// so the SCBD walk runs over the concrete [`RdfDataset`] or any other backend
-/// unchanged; the extracted subgraph is always a fresh [`RdfDataset`].
+/// Generic over the read view `D` (any [`DatasetView`]), so the SCBD walk runs over the
+/// concrete [`RdfDataset`] or any other backend id width unchanged; the extracted
+/// subgraph is always a fresh [`RdfDataset`].
 #[derive(Debug)]
-pub struct Describer<'a, D: DatasetView<Id = TermId> = RdfDataset> {
+pub struct Describer<'a, D: DatasetView = RdfDataset> {
     dataset: &'a D,
     /// term id → the quads that touch it as subject or object.
-    by_endpoint: BTreeMap<TermId, Vec<QuadIds>>,
+    by_endpoint: EndpointQuads<D::Id>,
     /// term id → the `(reifier, triple-term)` bindings whose reified triple has this
     /// id as its subject or object.
-    reifiers_by_endpoint: BTreeMap<TermId, Vec<(TermId, TermId)>>,
+    reifiers_by_endpoint: EndpointPairs<D::Id>,
     /// reifier id → the `(p, o)` annotation bindings hung off that reifier.
-    annotations_by_reifier: BTreeMap<TermId, Vec<(TermId, TermId)>>,
+    annotations_by_reifier: EndpointPairs<D::Id>,
 }
 
-impl<'a, D: DatasetView<Id = TermId>> Describer<'a, D> {
+impl<'a, D: DatasetView> Describer<'a, D> {
     /// Build the adjacency indices over `dataset`.
     #[must_use]
     pub fn new(dataset: &'a D) -> Self {
-        let mut by_endpoint: BTreeMap<TermId, Vec<QuadIds>> = BTreeMap::new();
+        let mut by_endpoint: EndpointQuads<D::Id> = BTreeMap::new();
         for q in dataset.quads() {
             by_endpoint.entry(q.s).or_default().push(q);
             // Avoid double-listing a reflexive `s p s` quad under the same key.
@@ -104,7 +110,7 @@ impl<'a, D: DatasetView<Id = TermId>> Describer<'a, D> {
             }
         }
 
-        let mut reifiers_by_endpoint: BTreeMap<TermId, Vec<(TermId, TermId)>> = BTreeMap::new();
+        let mut reifiers_by_endpoint: EndpointPairs<D::Id> = BTreeMap::new();
         for (reifier, triple) in dataset.reifier_quads().map(|q| (q.s, q.o)) {
             if let TermRef::Triple { s, p: _, o } = dataset.resolve(triple) {
                 reifiers_by_endpoint
@@ -120,7 +126,7 @@ impl<'a, D: DatasetView<Id = TermId>> Describer<'a, D> {
             }
         }
 
-        let mut annotations_by_reifier: BTreeMap<TermId, Vec<(TermId, TermId)>> = BTreeMap::new();
+        let mut annotations_by_reifier: EndpointPairs<D::Id> = BTreeMap::new();
         for (reifier, p, o) in dataset.annotation_quads().map(|q| (q.s, q.p, q.o)) {
             annotations_by_reifier
                 .entry(reifier)
@@ -157,7 +163,7 @@ impl<'a, D: DatasetView<Id = TermId>> Describer<'a, D> {
         &self,
         subjects: impl IntoIterator<Item = &'s str>,
     ) -> Result<Arc<RdfDataset>, RdfDiagnostic> {
-        let seeds: Vec<TermId> = subjects
+        let seeds: Vec<D::Id> = subjects
             .into_iter()
             .filter_map(|s| self.dataset.term_id_by_value(&TermValue::iri(s)))
             .collect();
@@ -176,19 +182,19 @@ impl<'a, D: DatasetView<Id = TermId>> Describer<'a, D> {
     /// `by_endpoint`), and a blank annotation object's triples ride along because it is
     /// pushed to the frontier when the annotation is harvested. Otherwise those blanks
     /// dangle — emitted in the subgraph with nothing describing them.
-    fn describe_seeds(&self, seeds: Vec<TermId>) -> Result<Arc<RdfDataset>, RdfDiagnostic> {
-        let mut anchors: BTreeSet<TermId> = BTreeSet::new();
-        let mut frontier: Vec<TermId> = Vec::new();
+    fn describe_seeds(&self, seeds: Vec<D::Id>) -> Result<Arc<RdfDataset>, RdfDiagnostic> {
+        let mut anchors: BTreeSet<D::Id> = BTreeSet::new();
+        let mut frontier: Vec<D::Id> = Vec::new();
         for s in seeds {
             if anchors.insert(s) {
                 frontier.push(s);
             }
         }
 
-        let mut quads: HashSet<QuadIds> = HashSet::new();
-        let mut reifiers: BTreeSet<(TermId, TermId)> = BTreeSet::new();
-        let mut annotations: Vec<(TermId, TermId, TermId)> = Vec::new();
-        let mut visited_reifiers: HashSet<TermId> = HashSet::new();
+        let mut quads: HashSet<QuadIds<D::Id>> = HashSet::new();
+        let mut reifiers: BTreeSet<(D::Id, D::Id)> = BTreeSet::new();
+        let mut annotations: Vec<(D::Id, D::Id, D::Id)> = Vec::new();
+        let mut visited_reifiers: HashSet<D::Id> = HashSet::new();
 
         // Expand a blank endpoint into the frontier; named nodes never expand (that
         // would drag in the entire neighbourhood of the graph).
@@ -247,10 +253,10 @@ impl<'a, D: DatasetView<Id = TermId>> Describer<'a, D> {
         // randomized — re-interning in that order would make the extracted subgraph's
         // bytes unstable across runs. Sort by the source `(g, s, p, o)` ids first so the
         // output is deterministic (byte-reproducibility).
-        let mut ordered: Vec<QuadIds> = quads.into_iter().collect();
+        let mut ordered: Vec<QuadIds<D::Id>> = quads.into_iter().collect();
         ordered.sort_unstable_by_key(|q| (q.g, q.s, q.p, q.o));
         let mut builder = RdfDatasetBuilder::new();
-        let mut remap: BTreeMap<TermId, TermId> = BTreeMap::new();
+        let mut remap: BTreeMap<D::Id, TermId> = BTreeMap::new();
         for q in &ordered {
             let s = self.map_id(&mut builder, &mut remap, q.s);
             let p = self.map_id(&mut builder, &mut remap, q.p);
@@ -274,7 +280,7 @@ impl<'a, D: DatasetView<Id = TermId>> Describer<'a, D> {
     }
 
     /// Whether a term id is a blank node in the source dataset.
-    fn is_blank(&self, id: TermId) -> bool {
+    fn is_blank(&self, id: D::Id) -> bool {
         matches!(self.dataset.resolve(id), TermRef::Blank { .. })
     }
 
@@ -284,8 +290,8 @@ impl<'a, D: DatasetView<Id = TermId>> Describer<'a, D> {
     fn map_id(
         &self,
         builder: &mut RdfDatasetBuilder,
-        remap: &mut BTreeMap<TermId, TermId>,
-        old: TermId,
+        remap: &mut BTreeMap<D::Id, TermId>,
+        old: D::Id,
     ) -> TermId {
         if let Some(&new) = remap.get(&old) {
             return new;

--- a/crates/rdf-core/src/describe.rs
+++ b/crates/rdf-core/src/describe.rs
@@ -29,15 +29,59 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
 
-use crate::{QuadIds, RdfDataset, RdfDatasetBuilder, RdfDiagnostic, TermId, TermRef};
+use crate::{
+    DatasetView, QuadIds, RdfDataset, RdfDatasetBuilder, RdfDiagnostic, RdfLiteral, RdfTerm,
+    RdfTriple, TermId, TermRef, TermValue,
+};
+
+/// Resolve a term id to the owned [`RdfTerm`] model through the [`DatasetView`] read
+/// path (recursively for triple terms) — the id-agnostic twin of
+/// `RdfDataset::to_owned_term`, so the extractor rebuilds a describing subgraph over
+/// any backend whose id type is [`TermId`].
+fn owned_term<D: DatasetView<Id = TermId>>(dataset: &D, id: TermId) -> RdfTerm {
+    match dataset.resolve(id) {
+        TermRef::Iri(iri) => RdfTerm::iri(iri),
+        TermRef::Blank { label, scope } => RdfTerm::blank_node(scope.qualify_label(label)),
+        TermRef::Literal {
+            lexical,
+            datatype,
+            language,
+            direction,
+        } => {
+            let datatype_iri = match dataset.resolve(datatype) {
+                TermRef::Iri(iri) => iri.to_owned(),
+                other => unreachable!("literal datatype must resolve to an IRI, got {other:?}"),
+            };
+            RdfTerm::literal(RdfLiteral {
+                lexical_form: lexical.to_owned(),
+                datatype: Some(datatype_iri),
+                language: language.map(str::to_owned),
+                direction,
+            })
+        }
+        TermRef::Triple { s, p, o } => {
+            let subject = owned_term(dataset, s);
+            let predicate = match dataset.resolve(p) {
+                TermRef::Iri(iri) => iri.to_owned(),
+                other => unreachable!("triple predicate must resolve to an IRI, got {other:?}"),
+            };
+            let object = owned_term(dataset, o);
+            RdfTerm::triple(RdfTriple::new(subject, predicate, object))
+        }
+    }
+}
 
 /// A reusable extractor: it builds the subject/object adjacency and the reifier
 /// endpoint index **once**, so extracting the SCBD of many subjects (one per exported
 /// term/slice) is cheap — each extraction is a bounded graph walk over the index, not
 /// a full re-scan of the dataset.
+///
+/// Generic over the read view `D` (any [`DatasetView`] whose id type is [`TermId`]),
+/// so the SCBD walk runs over the concrete [`RdfDataset`] or any other backend
+/// unchanged; the extracted subgraph is always a fresh [`RdfDataset`].
 #[derive(Debug)]
-pub struct Describer<'a> {
-    dataset: &'a RdfDataset,
+pub struct Describer<'a, D: DatasetView<Id = TermId> = RdfDataset> {
+    dataset: &'a D,
     /// term id → the quads that touch it as subject or object.
     by_endpoint: BTreeMap<TermId, Vec<QuadIds>>,
     /// term id → the `(reifier, triple-term)` bindings whose reified triple has this
@@ -47,10 +91,10 @@ pub struct Describer<'a> {
     annotations_by_reifier: BTreeMap<TermId, Vec<(TermId, TermId)>>,
 }
 
-impl<'a> Describer<'a> {
+impl<'a, D: DatasetView<Id = TermId>> Describer<'a, D> {
     /// Build the adjacency indices over `dataset`.
     #[must_use]
-    pub fn new(dataset: &'a RdfDataset) -> Self {
+    pub fn new(dataset: &'a D) -> Self {
         let mut by_endpoint: BTreeMap<TermId, Vec<QuadIds>> = BTreeMap::new();
         for q in dataset.quads() {
             by_endpoint.entry(q.s).or_default().push(q);
@@ -61,7 +105,7 @@ impl<'a> Describer<'a> {
         }
 
         let mut reifiers_by_endpoint: BTreeMap<TermId, Vec<(TermId, TermId)>> = BTreeMap::new();
-        for (reifier, triple) in dataset.reifiers() {
+        for (reifier, triple) in dataset.reifier_quads().map(|q| (q.s, q.o)) {
             if let TermRef::Triple { s, p: _, o } = dataset.resolve(triple) {
                 reifiers_by_endpoint
                     .entry(s)
@@ -77,7 +121,7 @@ impl<'a> Describer<'a> {
         }
 
         let mut annotations_by_reifier: BTreeMap<TermId, Vec<(TermId, TermId)>> = BTreeMap::new();
-        for (reifier, p, o) in dataset.annotations() {
+        for (reifier, p, o) in dataset.annotation_quads().map(|q| (q.s, q.p, q.o)) {
             annotations_by_reifier
                 .entry(reifier)
                 .or_default()
@@ -100,7 +144,7 @@ impl<'a> Describer<'a> {
     /// Propagates a freeze diagnostic if the extracted subgraph is somehow invalid
     /// (it never should be, being a subset of an already-valid dataset).
     pub fn describe_iri(&self, subject: &str) -> Result<Arc<RdfDataset>, RdfDiagnostic> {
-        let seed = self.dataset.term_id_by_iri(subject);
+        let seed = self.dataset.term_id_by_value(&TermValue::iri(subject));
         self.describe_seeds(seed.into_iter().collect())
     }
 
@@ -115,7 +159,7 @@ impl<'a> Describer<'a> {
     ) -> Result<Arc<RdfDataset>, RdfDiagnostic> {
         let seeds: Vec<TermId> = subjects
             .into_iter()
-            .filter_map(|s| self.dataset.term_id_by_iri(s))
+            .filter_map(|s| self.dataset.term_id_by_value(&TermValue::iri(s)))
             .collect();
         self.describe_seeds(seeds)
     }
@@ -246,7 +290,7 @@ impl<'a> Describer<'a> {
         if let Some(&new) = remap.get(&old) {
             return new;
         }
-        let owned = self.dataset.to_owned_term(old);
+        let owned = owned_term(self.dataset, old);
         let new = builder.intern_owned_term(&owned);
         remap.insert(old, new);
         new

--- a/crates/rdf-core/src/ir/dataset.rs
+++ b/crates/rdf-core/src/ir/dataset.rs
@@ -102,16 +102,20 @@ const _: () = assert!(size_of::<QuadRow>() == 16);
 
 /// A small `Copy` quad row in term ids, for ID-native consumers. `g == None` is the
 /// default graph.
+///
+/// Generic over the id type `Id` (the [`DatasetView::Id`](crate::DatasetView::Id) of
+/// the view that minted it) with a default of [`TermId`], so the bare spelling
+/// `QuadIds` continues to name the `RdfDataset` instantiation everywhere.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub struct QuadIds {
+pub struct QuadIds<Id = TermId> {
     /// The subject term id.
-    pub s: TermId,
+    pub s: Id,
     /// The predicate term id.
-    pub p: TermId,
+    pub p: Id,
     /// The object term id.
-    pub o: TermId,
+    pub o: Id,
     /// The graph-name term id (`None` = default graph).
-    pub g: Option<TermId>,
+    pub g: Option<Id>,
 }
 
 impl From<QuadRow> for QuadIds {
@@ -130,8 +134,12 @@ impl From<QuadRow> for QuadIds {
 /// `&str` slices borrowed from the dataset, so resolving a term performs **no
 /// allocation and no clone**. Triple components are returned as ids; resolve them
 /// recursively with [`RdfDataset::resolve`] if their values are needed.
+///
+/// Generic over the id type `Id` (defaulting to [`TermId`]) for the id-carrying
+/// variants (a literal's `datatype`, a triple term's `s`/`p`/`o`), so the bare
+/// spelling `TermRef<'a>` continues to name the `RdfDataset` instantiation.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub enum TermRef<'a> {
+pub enum TermRef<'a, Id = TermId> {
     /// An IRI, by its borrowed full string.
     Iri(&'a str),
     /// A blank node, identified by `(label, scope)` (C0.2).
@@ -148,7 +156,7 @@ pub enum TermRef<'a> {
         lexical: &'a str,
         /// The datatype IRI's interned term id (always present; the default is
         /// expanded at intern time).
-        datatype: TermId,
+        datatype: Id,
         /// The borrowed (lowercased) language tag, for language-tagged strings.
         language: Option<&'a str>,
         /// The RDF 1.2 base direction, for directional language-tagged strings.
@@ -157,26 +165,29 @@ pub enum TermRef<'a> {
     /// A triple term (RDF 1.2 quoted triple), by its resolved component ids (C0.3).
     Triple {
         /// The quoted triple's subject term id.
-        s: TermId,
+        s: Id,
         /// The quoted triple's predicate term id.
-        p: TermId,
+        p: Id,
         /// The quoted triple's object term id.
-        o: TermId,
+        o: Id,
     },
 }
 
 /// A borrowed, resolved quad view: each position is a [`TermRef`] borrowing into the
 /// dataset's term table. No allocation, no clone per quad.
+///
+/// Generic over the id type `Id` (defaulting to [`TermId`]), so the bare spelling
+/// `QuadRef<'a>` continues to name the `RdfDataset` instantiation.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub struct QuadRef<'a> {
+pub struct QuadRef<'a, Id = TermId> {
     /// The resolved subject term.
-    pub s: TermRef<'a>,
+    pub s: TermRef<'a, Id>,
     /// The resolved predicate term.
-    pub p: TermRef<'a>,
+    pub p: TermRef<'a, Id>,
     /// The resolved object term.
-    pub o: TermRef<'a>,
+    pub o: TermRef<'a, Id>,
     /// The resolved graph-name term (`None` = default graph).
-    pub g: Option<TermRef<'a>>,
+    pub g: Option<TermRef<'a, Id>>,
 }
 
 /// The immutable, frozen RDF 1.2 dataset. Constructed only via

--- a/crates/rdf-core/src/ir/global.rs
+++ b/crates/rdf-core/src/ir/global.rs
@@ -99,7 +99,26 @@ impl GlobalTermId {
 
 /// A `GlobalTermId` is a valid [`DatasetView`](crate::DatasetView) id, so a paged /
 /// global backend (Task 4) can use it as its `DatasetView::Id`.
-impl ViewTermId for GlobalTermId {}
+///
+/// Its [`JoinKeyAtom`](ViewTermId::JoinKeyAtom) is `u128`: a dataset id occupies the
+/// low 64 bits (`[0, 2^64)`, since a `GlobalTermId` dense index is `u64`-bounded) and
+/// a computed-term id sets bit 64 (`[2^64, 2^64 + 2^32)`), so the two spaces are
+/// disjoint by construction — an id can never collide with a computed key.
+impl ViewTermId for GlobalTermId {
+    type JoinKeyAtom = u128;
+
+    #[inline]
+    fn encode(self) -> u128 {
+        // The dense index is `u64`-bounded, so it fits the low 64 bits with bit 64
+        // clear — disjoint from every `encode_computed` image (which sets bit 64).
+        self.index() as u128
+    }
+
+    #[inline]
+    fn encode_computed(scratch_index: u32) -> u128 {
+        (1u128 << 64) | u128::from(scratch_index)
+    }
+}
 
 // The `NonZeroU64` niche is the global layer's `Option`-packing invariant, exactly
 // as `TermId`'s `NonZeroU32` niche is for the frozen dataset. The THIRD assertion is

--- a/crates/rdf-core/src/ir/global.rs
+++ b/crates/rdf-core/src/ir/global.rs
@@ -318,7 +318,12 @@ type GlobalValueIndex = HashMap<u64, Vec<GlobalTermId>, FastHasher>;
 /// ahash, hash/eq resolving into the arena BY VALUE), and a lazily-built reverse
 /// value index. `Send + Sync` (the lazy index rides an [`OnceLock`], like
 /// [`RdfDataset`](super::RdfDataset)).
-#[derive(Debug)]
+///
+/// `Clone` is a genuine deep copy of the arena, term table, and value index —
+/// `PagedDataset::with_pages` clones the oversized dictionary when it drops pages
+/// (the dictionary keeps its now-dead ids until `PagedDataset::compact` reclaims
+/// them).
+#[derive(Debug, Clone)]
 pub struct GlobalDictionary {
     /// The byte arena owning every interned string ONCE; terms hold ranges.
     arena: Vec<u8>,
@@ -521,6 +526,42 @@ impl GlobalDictionary {
                 s: *s,
                 p: *p,
                 o: *o,
+            },
+        }
+    }
+
+    /// Resolve a global id to its **dataset-independent** [`TermValue`], recursing
+    /// through a literal's datatype IRI and a triple term's components (the inverse
+    /// of [`intern`](Self::intern)). Unlike [`resolve`](Self::resolve) — which hands
+    /// back component ids local to THIS dictionary — the returned value is
+    /// self-contained, so it survives being re-interned into a different dictionary.
+    /// This is what [`PagedDataset::compact`](super::paged::PagedDataset::compact)
+    /// re-interns into its fresh, dead-id-free dictionary.
+    #[must_use]
+    pub fn term_value(&self, id: GlobalTermId) -> TermValue {
+        match &self.terms[id.index()] {
+            GlobalInternedTerm::Iri(iri) => TermValue::Iri(arena_str(&self.arena, *iri).to_owned()),
+            GlobalInternedTerm::Blank { label, scope } => TermValue::Blank {
+                label: arena_str(&self.arena, *label).to_owned(),
+                scope: *scope,
+            },
+            GlobalInternedTerm::Literal(lit) => {
+                // A literal's datatype is always an interned IRI (C0.1).
+                let datatype = match &self.terms[lit.datatype.index()] {
+                    GlobalInternedTerm::Iri(iri) => arena_str(&self.arena, *iri).to_owned(),
+                    _ => unreachable!("a literal datatype is always an interned IRI"),
+                };
+                TermValue::Literal {
+                    lexical_form: arena_str(&self.arena, lit.lexical_form).to_owned(),
+                    datatype,
+                    language: lit.language.map(|r| arena_str(&self.arena, r).to_owned()),
+                    direction: lit.direction,
+                }
+            }
+            GlobalInternedTerm::Triple { s, p, o } => TermValue::Triple {
+                s: Box::new(self.term_value(*s)),
+                p: Box::new(self.term_value(*p)),
+                o: Box::new(self.term_value(*o)),
             },
         }
     }

--- a/crates/rdf-core/src/ir/global.rs
+++ b/crates/rdf-core/src/ir/global.rs
@@ -15,7 +15,7 @@
 //!
 //! The dictionary mirrors the immutable IR's interning discipline exactly, one
 //! width up: a store-once byte arena (each interned string owned ONCE), a dense
-//! [`GlobalInternedTerm`] table, a value→dense-index [`HashTable`] using fixed-key
+//! `GlobalInternedTerm` table, a value→dense-index [`HashTable`] using fixed-key
 //! ahash, and a lazily-built reverse value index. Ids are minted in insertion order,
 //! so a fixed push sequence is reproducible; no observable output depends on hash
 //! iteration order (buckets are populated in ascending-id order and reads return the
@@ -314,7 +314,7 @@ type GlobalValueIndex = HashMap<u64, Vec<GlobalTermId>, FastHasher>;
 
 /// A `u64`-scaled value-interner keyed on the dataset-independent [`TermValue`] — the
 /// global-identity twin of the frozen IR's `Interner`. Owns a store-once byte arena,
-/// a dense [`GlobalInternedTerm`] table, a value→dense-index [`HashTable`] (fixed-key
+/// a dense `GlobalInternedTerm` table, a value→dense-index [`HashTable`] (fixed-key
 /// ahash, hash/eq resolving into the arena BY VALUE), and a lazily-built reverse
 /// value index. `Send + Sync` (the lazy index rides an [`OnceLock`], like
 /// [`RdfDataset`](super::RdfDataset)).

--- a/crates/rdf-core/src/ir/global.rs
+++ b/crates/rdf-core/src/ir/global.rs
@@ -1,0 +1,854 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The **global** `u64`-scaled term-identity layer: [`GlobalTermId`] and the
+//! [`GlobalDictionary`] value-interner (backend seam, purrdf P4/paged backends).
+//!
+//! This is a SEPARATE id space from the frozen [`RdfDataset`](super::RdfDataset)'s
+//! [`TermId`]. A paged / cross-segment backend needs a term identity that can span
+//! more than a single frozen dataset's `u32`-bounded table, so it mints
+//! [`GlobalTermId`]s from a [`GlobalDictionary`] keyed on the dataset-INDEPENDENT
+//! [`TermValue`]. Nothing here widens [`TermId`]: the load-bearing `NonZeroU32`
+//! niche of `TermId` (why `Option<TermId>` — and every quad row's graph slot — costs
+//! no extra word) is untouched, and a `const` assertion below fails the build if it
+//! ever regresses.
+//!
+//! The dictionary mirrors the immutable IR's interning discipline exactly, one
+//! width up: a store-once byte arena (each interned string owned ONCE), a dense
+//! [`GlobalInternedTerm`] table, a value→dense-index [`HashTable`] using fixed-key
+//! ahash, and a lazily-built reverse value index. Ids are minted in insertion order,
+//! so a fixed push sequence is reproducible; no observable output depends on hash
+//! iteration order (buckets are populated in ascending-id order and reads return the
+//! first match).
+
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::num::NonZeroU64;
+use std::sync::OnceLock;
+
+use hashbrown::HashTable;
+
+use crate::RdfTextDirection;
+use crate::dataset_view::ViewTermId;
+use crate::hash::FastHasher;
+
+use super::dataset::TermRef;
+use super::term::{BlankScope, StrRange, TermId, TermValue, arena_str};
+
+/// Opaque **global** term identity — the id space a paged / cross-segment backend
+/// mints, one width up from [`TermId`]. Like `TermId` it is opaque, is NOT
+/// `Serialize`/`Deserialize`, and is meaningful only within the
+/// [`GlobalDictionary`] that minted it (C0.8): a durable identifier must resolve the
+/// term to its RDF value rather than retain a `GlobalTermId`.
+///
+/// # Layout
+///
+/// The inner value is a [`NonZeroU64`] holding `dense_index + 1`, so the all-zero
+/// bit pattern is free for the [`Option`] niche: `Option<GlobalTermId>` is **8
+/// bytes**, not 16. `#[repr(transparent)]` keeps the FFI layout a plain `u64`. Id
+/// `0` is reserved as the niche sentinel and never minted. The `+1` offset is
+/// confined entirely to [`index`](GlobalTermId::index) /
+/// [`from_index`](GlobalTermId::from_index) — every other site is offset-agnostic,
+/// so insertion (allocation) order, and therefore the `Ord` sort, is preserved
+/// exactly. This mirrors [`TermId`]'s `NonZeroU32` discipline at `u64` width.
+///
+/// [`Hash`] is implemented by hand to hash the **0-based dense index as a `u64`**, so
+/// the `+1` storage offset never leaks into the hash and cannot perturb any
+/// hash-iteration order of a `HashMap<GlobalTermId, _>` / `HashSet<GlobalTermId>`.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[repr(transparent)]
+pub struct GlobalTermId(NonZeroU64);
+
+impl Hash for GlobalTermId {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // `self.0.get() - 1` is the 0-based dense index; hashing it (not the stored
+        // `+1`) keeps the niche a pure memory optimization with no ordering effect.
+        (self.0.get() - 1).hash(state);
+    }
+}
+
+impl GlobalTermId {
+    /// The dense index this id addresses in the dictionary's term table.
+    ///
+    /// The stored value is `index + 1` (id 0 is the niche sentinel), so the dense
+    /// index is one less. Never underflows (the inner is `>= 1`). Uses `try_from`
+    /// rather than an `as` cast so it stays truncation-clean on a 32-bit `usize`
+    /// target (wasm32): a `u64` index that could not fit `usize` cannot address a
+    /// real `Vec`-backed term on that platform, so a hard-fail is correct.
+    #[inline]
+    #[must_use]
+    pub fn index(self) -> usize {
+        usize::try_from(self.0.get() - 1)
+            .expect("global term id index exceeds usize on this platform")
+    }
+
+    /// Construct a `GlobalTermId` from a dense table index. Hard-fails (rather than
+    /// wrapping) if `index` is `u64::MAX`, since `index + 1` would overflow the id
+    /// space — the largest dense index is `u64::MAX - 1`.
+    #[inline]
+    #[must_use]
+    pub fn from_index(index: u64) -> Self {
+        let raw = index
+            .checked_add(1)
+            .expect("global dictionary cannot exceed u64::MAX-1 entries");
+        // `raw = index + 1 >= 1`, so the `NonZeroU64` invariant always holds.
+        Self(NonZeroU64::new(raw).expect("index + 1 is always >= 1"))
+    }
+}
+
+/// A `GlobalTermId` is a valid [`DatasetView`](crate::DatasetView) id, so a paged /
+/// global backend (Task 4) can use it as its `DatasetView::Id`.
+impl ViewTermId for GlobalTermId {}
+
+// The `NonZeroU64` niche is the global layer's `Option`-packing invariant, exactly
+// as `TermId`'s `NonZeroU32` niche is for the frozen dataset. The THIRD assertion is
+// the ring-fence: it proves the new `u64` layer did NOT perturb the load-bearing
+// `u32` `TermId` niche (the reason `Option<TermId>` costs no extra word).
+const _: () = assert!(size_of::<GlobalTermId>() == 8);
+const _: () = assert!(size_of::<Option<GlobalTermId>>() == 8);
+const _: () = assert!(size_of::<TermId>() == 4);
+
+/// An interned literal in the global dictionary — the `u64`-scaled twin of
+/// [`InternedLiteral`](super::term). The datatype is always an interned IRI, stored
+/// as a [`GlobalTermId`] (never a `TermId`); string components are [`StrRange`]s into
+/// the dictionary's byte arena.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+struct GlobalInternedLiteral {
+    /// The lexical form, byte-for-byte as authored (C0.1).
+    lexical_form: StrRange,
+    /// The expanded datatype IRI's interned id (always present).
+    datatype: GlobalTermId,
+    /// The language tag, lowercased for the identity key (C0.1).
+    language: Option<StrRange>,
+    /// The RDF 1.2 base direction; distinct directions are distinct literals.
+    direction: Option<RdfTextDirection>,
+}
+
+/// An interned term in the global dictionary — the storage form behind a
+/// [`GlobalTermId`]. Mirrors [`InternedTerm`](super::term), but every id-carrying
+/// component (a literal's datatype, a triple term's `s`/`p`/`o`) holds a
+/// [`GlobalTermId`]. Strings are [`StrRange`]s into the dictionary's arena.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+enum GlobalInternedTerm {
+    /// An IRI, by its arena range.
+    Iri(StrRange),
+    /// A blank node, identified by `(label, scope)` (C0.2).
+    Blank { label: StrRange, scope: BlankScope },
+    /// A literal, identified per C0.1.
+    Literal(GlobalInternedLiteral),
+    /// A triple term (RDF 1.2 quoted triple), identified structurally by its
+    /// resolved `(s, p, o)` (C0.3).
+    Triple {
+        s: GlobalTermId,
+        p: GlobalTermId,
+        o: GlobalTermId,
+    },
+}
+
+/// A borrowed term lookup key: carries string components by reference so the
+/// dictionary can dedup BY VALUE *before* anything is pushed to the arena. Mirrors
+/// [`GlobalInternedTerm`] but with `&str` where the stored form holds a [`StrRange`].
+/// The id-carrying components (datatype, triple `s`/`p`/`o`) are already-interned
+/// [`GlobalTermId`]s, so dedup on them is id-based, exactly like the frozen IR's
+/// interner.
+#[derive(Clone, Copy)]
+enum GlobalTermLookup<'a> {
+    Iri(&'a str),
+    Blank {
+        label: &'a str,
+        scope: BlankScope,
+    },
+    Literal {
+        lexical: &'a str,
+        datatype: GlobalTermId,
+        language: Option<&'a str>,
+        direction: Option<RdfTextDirection>,
+    },
+    Triple {
+        s: GlobalTermId,
+        p: GlobalTermId,
+        o: GlobalTermId,
+    },
+}
+
+/// Fixed-key ahash of a lookup (id-based dedup path). MUST hash byte-identically to
+/// [`hash_stored`] for equal values — explicit discriminant tags + `str::hash`.
+fn hash_lookup<H: Hasher>(lookup: &GlobalTermLookup<'_>, state: &mut H) {
+    match lookup {
+        GlobalTermLookup::Iri(iri) => {
+            0u8.hash(state);
+            iri.hash(state);
+        }
+        GlobalTermLookup::Blank { label, scope } => {
+            1u8.hash(state);
+            label.hash(state);
+            scope.hash(state);
+        }
+        GlobalTermLookup::Literal {
+            lexical,
+            datatype,
+            language,
+            direction,
+        } => {
+            2u8.hash(state);
+            lexical.hash(state);
+            datatype.hash(state);
+            language.hash(state);
+            direction.hash(state);
+        }
+        GlobalTermLookup::Triple { s, p, o } => {
+            3u8.hash(state);
+            s.hash(state);
+            p.hash(state);
+            o.hash(state);
+        }
+    }
+}
+
+/// Fixed-key ahash of a stored term, resolving its `StrRange`s through `arena`
+/// (id-based dedup path). MUST match [`hash_lookup`] for equal values.
+fn hash_stored<H: Hasher>(arena: &[u8], term: &GlobalInternedTerm, state: &mut H) {
+    match term {
+        GlobalInternedTerm::Iri(r) => {
+            0u8.hash(state);
+            arena_str(arena, *r).hash(state);
+        }
+        GlobalInternedTerm::Blank { label, scope } => {
+            1u8.hash(state);
+            arena_str(arena, *label).hash(state);
+            scope.hash(state);
+        }
+        GlobalInternedTerm::Literal(lit) => {
+            2u8.hash(state);
+            arena_str(arena, lit.lexical_form).hash(state);
+            lit.datatype.hash(state);
+            lit.language.map(|r| arena_str(arena, r)).hash(state);
+            lit.direction.hash(state);
+        }
+        GlobalInternedTerm::Triple { s, p, o } => {
+            3u8.hash(state);
+            s.hash(state);
+            p.hash(state);
+            o.hash(state);
+        }
+    }
+}
+
+fn hash_lookup_value(lookup: &GlobalTermLookup<'_>) -> u64 {
+    let mut hasher = ahash::AHasher::default();
+    hash_lookup(lookup, &mut hasher);
+    hasher.finish()
+}
+
+fn hash_stored_value(arena: &[u8], term: &GlobalInternedTerm) -> u64 {
+    let mut hasher = ahash::AHasher::default();
+    hash_stored(arena, term, &mut hasher);
+    hasher.finish()
+}
+
+/// Whether a stored term equals a lookup, resolving the stored ranges through
+/// `arena` (id-based dedup path).
+fn term_eq(arena: &[u8], term: &GlobalInternedTerm, lookup: &GlobalTermLookup<'_>) -> bool {
+    match (term, lookup) {
+        (GlobalInternedTerm::Iri(r), GlobalTermLookup::Iri(s)) => arena_str(arena, *r) == *s,
+        (
+            GlobalInternedTerm::Blank { label, scope },
+            GlobalTermLookup::Blank {
+                label: ls,
+                scope: ss,
+            },
+        ) => arena_str(arena, *label) == *ls && scope == ss,
+        (
+            GlobalInternedTerm::Literal(lit),
+            GlobalTermLookup::Literal {
+                lexical,
+                datatype,
+                language,
+                direction,
+            },
+        ) => {
+            arena_str(arena, lit.lexical_form) == *lexical
+                && lit.datatype == *datatype
+                && lit.direction == *direction
+                && lit.language.map(|r| arena_str(arena, r)) == *language
+        }
+        (
+            GlobalInternedTerm::Triple { s, p, o },
+            GlobalTermLookup::Triple {
+                s: ls,
+                p: lp,
+                o: lo,
+            },
+        ) => s == ls && p == lp && o == lo,
+        _ => false,
+    }
+}
+
+/// The lazily-built reverse value index: a canonical **value hash** → dense-index
+/// bucket map. The buckets store [`GlobalTermId`]s (NOT strings), so building it
+/// duplicates no term strings; the rare hash collision is resolved by comparing BY
+/// VALUE through the arena. `GlobalTermId`s are pushed in ascending (0..n) order, so
+/// a single-answer read (`term_id_by_value`) is deterministic without an explicit
+/// sort.
+type GlobalValueIndex = HashMap<u64, Vec<GlobalTermId>, FastHasher>;
+
+/// A `u64`-scaled value-interner keyed on the dataset-independent [`TermValue`] — the
+/// global-identity twin of the frozen IR's `Interner`. Owns a store-once byte arena,
+/// a dense [`GlobalInternedTerm`] table, a value→dense-index [`HashTable`] (fixed-key
+/// ahash, hash/eq resolving into the arena BY VALUE), and a lazily-built reverse
+/// value index. `Send + Sync` (the lazy index rides an [`OnceLock`], like
+/// [`RdfDataset`](super::RdfDataset)).
+#[derive(Debug)]
+pub struct GlobalDictionary {
+    /// The byte arena owning every interned string ONCE; terms hold ranges.
+    arena: Vec<u8>,
+    /// Dense table of interned terms (range-backed); the sole structural owner.
+    terms: Vec<GlobalInternedTerm>,
+    /// Store-once value→id index: `u64` dense indices into `terms`, with hash/eq
+    /// resolving ranges through the arena and comparing BY VALUE.
+    index: HashTable<u64>,
+    /// Lazy value-hash → id reverse index for [`term_id_by_value`](Self::term_id_by_value).
+    /// Built on first query and cached; `OnceLock` keeps the dictionary `Send + Sync`.
+    /// Because the dictionary is MUTABLE (unlike the frozen `RdfDataset`), this cache
+    /// is invalidated (`take`n) on every structural growth in
+    /// [`intern_lookup`](Self::intern_lookup) and rebuilt on the next query.
+    value_index: OnceLock<GlobalValueIndex>,
+}
+
+impl Default for GlobalDictionary {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GlobalDictionary {
+    /// A fresh, empty dictionary.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            arena: Vec::new(),
+            terms: Vec::new(),
+            index: HashTable::new(),
+            value_index: OnceLock::new(),
+        }
+    }
+
+    /// The number of distinct interned terms.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.terms.len()
+    }
+
+    /// Whether the dictionary has interned no terms yet.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.terms.is_empty()
+    }
+
+    /// Append a string to the arena, returning its range. Validates the range fits
+    /// `u32` BEFORE mutating the arena, so a checked overflow fails fast and leaves
+    /// the dictionary consistent.
+    fn push_str(&mut self, s: &str) -> StrRange {
+        let offset = u32::try_from(self.arena.len()).expect("term arena exceeds u32::MAX bytes");
+        let len = u32::try_from(s.len()).expect("term string exceeds u32::MAX bytes");
+        offset
+            .checked_add(len)
+            .expect("term arena exceeds u32::MAX bytes");
+        self.arena.extend_from_slice(s.as_bytes());
+        StrRange { offset, len }
+    }
+
+    /// Intern a borrowed lookup BY VALUE: dedups against existing terms (resolving
+    /// their ranges through the arena) and pushes strings to the arena only on a
+    /// MISS. Idempotent: equal values map to one id, minted in insertion order.
+    fn intern_lookup(&mut self, lookup: GlobalTermLookup<'_>) -> GlobalTermId {
+        let hash = hash_lookup_value(&lookup);
+        {
+            let (arena, terms) = (&self.arena, &self.terms);
+            if let Some(&i) = self
+                .index
+                .find(hash, |&i| term_eq(arena, &terms[i as usize], &lookup))
+            {
+                return GlobalTermId::from_index(i);
+            }
+        }
+        let i = u64::try_from(self.terms.len())
+            .expect("global dictionary table exceeds u64::MAX entries");
+        // Miss: now (and only now) push the strings to the arena and build the term.
+        let term = match lookup {
+            GlobalTermLookup::Iri(iri) => GlobalInternedTerm::Iri(self.push_str(iri)),
+            GlobalTermLookup::Blank { label, scope } => GlobalInternedTerm::Blank {
+                label: self.push_str(label),
+                scope,
+            },
+            GlobalTermLookup::Literal {
+                lexical,
+                datatype,
+                language,
+                direction,
+            } => {
+                let lexical_form = self.push_str(lexical);
+                let language = language.map(|l| self.push_str(l));
+                GlobalInternedTerm::Literal(GlobalInternedLiteral {
+                    lexical_form,
+                    datatype,
+                    language,
+                    direction,
+                })
+            }
+            GlobalTermLookup::Triple { s, p, o } => GlobalInternedTerm::Triple { s, p, o },
+        };
+        self.terms.push(term);
+        // A new term makes any previously-cached reverse value index stale. Unlike
+        // the FROZEN `RdfDataset` (whose `OnceLock` value index is built once and
+        // never invalidated), a `GlobalDictionary` keeps growing, so the lazy cache
+        // must be dropped on every structural growth and rebuilt on the next query.
+        // Only the MISS branch reaches here, so an idempotent re-intern (a hit,
+        // above) leaves an already-built index intact.
+        self.value_index.take();
+        let (arena, terms) = (&self.arena, &self.terms);
+        self.index
+            .insert_unique(hash, i, |&i| hash_stored_value(arena, &terms[i as usize]));
+        GlobalTermId::from_index(i)
+    }
+
+    /// Intern an IRI term. Idempotent: the same IRI string yields the same id.
+    pub fn intern_iri(&mut self, iri: &str) -> GlobalTermId {
+        self.intern_lookup(GlobalTermLookup::Iri(iri))
+    }
+
+    /// Intern a blank node. Identity is `(label, scope)` (C0.2).
+    pub fn intern_blank(&mut self, label: &str, scope: BlankScope) -> GlobalTermId {
+        self.intern_lookup(GlobalTermLookup::Blank { label, scope })
+    }
+
+    /// Intern a literal from its already-expanded components (C0.1): the datatype is
+    /// an already-interned IRI [`GlobalTermId`], and the language, if present, is
+    /// expected already-lowercased by the caller (as the frozen IR's builder does at
+    /// intern time). The lexical form is preserved byte-for-byte.
+    pub fn intern_literal(
+        &mut self,
+        lexical: &str,
+        datatype: GlobalTermId,
+        language: Option<&str>,
+        direction: Option<RdfTextDirection>,
+    ) -> GlobalTermId {
+        self.intern_lookup(GlobalTermLookup::Literal {
+            lexical,
+            datatype,
+            language,
+            direction,
+        })
+    }
+
+    /// Intern a triple term (RDF 1.2 quoted triple) from already-resolved component
+    /// ids. Identified structurally by the resolved `(s, p, o)` (C0.3).
+    pub fn intern_triple(
+        &mut self,
+        s: GlobalTermId,
+        p: GlobalTermId,
+        o: GlobalTermId,
+    ) -> GlobalTermId {
+        self.intern_lookup(GlobalTermLookup::Triple { s, p, o })
+    }
+
+    /// Intern a dataset-independent [`TermValue`], recursively for triple terms and
+    /// literal datatypes. Idempotent, store-once, insertion order.
+    ///
+    /// The datatype of a [`TermValue::Literal`] is interned as its own IRI term
+    /// first, so a literal's datatype is itself a [`GlobalTermId`] in this space; a
+    /// [`TermValue::Triple`]'s components are interned before the enclosing triple.
+    pub fn intern(&mut self, value: &TermValue) -> GlobalTermId {
+        match value {
+            TermValue::Iri(iri) => self.intern_iri(iri),
+            TermValue::Blank { label, scope } => self.intern_blank(label, *scope),
+            TermValue::Literal {
+                lexical_form,
+                datatype,
+                language,
+                direction,
+            } => {
+                let datatype_id = self.intern_iri(datatype);
+                self.intern_literal(lexical_form, datatype_id, language.as_deref(), *direction)
+            }
+            TermValue::Triple { s, p, o } => {
+                let s = self.intern(s);
+                let p = self.intern(p);
+                let o = self.intern(o);
+                self.intern_triple(s, p, o)
+            }
+        }
+    }
+
+    /// Resolve a global id to a borrowed [`TermRef`] (arena-borrow; no allocation).
+    /// Triple components and a literal's datatype are returned as [`GlobalTermId`]s;
+    /// resolve them recursively if their values are needed.
+    #[must_use]
+    pub fn resolve(&self, id: GlobalTermId) -> TermRef<'_, GlobalTermId> {
+        match &self.terms[id.index()] {
+            GlobalInternedTerm::Iri(iri) => TermRef::Iri(arena_str(&self.arena, *iri)),
+            GlobalInternedTerm::Blank { label, scope } => TermRef::Blank {
+                label: arena_str(&self.arena, *label),
+                scope: *scope,
+            },
+            GlobalInternedTerm::Literal(lit) => TermRef::Literal {
+                lexical: arena_str(&self.arena, lit.lexical_form),
+                datatype: lit.datatype,
+                language: lit.language.map(|r| arena_str(&self.arena, r)),
+                direction: lit.direction,
+            },
+            GlobalInternedTerm::Triple { s, p, o } => TermRef::Triple {
+                s: *s,
+                p: *p,
+                o: *o,
+            },
+        }
+    }
+
+    /// Hash the IRI string of a term known to be an interned IRI (a literal
+    /// datatype), for the value-based reverse index. Mirrors the frozen dataset's
+    /// `hash_iri_string`.
+    fn hash_datatype_iri<H: Hasher>(&self, id: GlobalTermId, state: &mut H) {
+        match &self.terms[id.index()] {
+            GlobalInternedTerm::Iri(iri) => arena_str(&self.arena, *iri).hash(state),
+            // Unreachable for a well-formed literal (a datatype is always an IRI);
+            // hash the Debug form rather than panic.
+            other => format!("{other:?}").hash(state),
+        }
+    }
+
+    /// Canonical **value** hash of a stored term, resolving the literal datatype id
+    /// to its IRI string and recursing triple components to their values. MUST match
+    /// [`hash_value`] (i.e. [`TermValue`]'s `Hash`) for equal values.
+    fn hash_term_value<H: Hasher>(&self, id: GlobalTermId, state: &mut H) {
+        match &self.terms[id.index()] {
+            GlobalInternedTerm::Iri(iri) => {
+                0u8.hash(state);
+                arena_str(&self.arena, *iri).hash(state);
+            }
+            GlobalInternedTerm::Blank { label, scope } => {
+                1u8.hash(state);
+                arena_str(&self.arena, *label).hash(state);
+                scope.hash(state);
+            }
+            GlobalInternedTerm::Literal(lit) => {
+                2u8.hash(state);
+                arena_str(&self.arena, lit.lexical_form).hash(state);
+                self.hash_datatype_iri(lit.datatype, state);
+                lit.language.map(|r| arena_str(&self.arena, r)).hash(state);
+                lit.direction.hash(state);
+            }
+            GlobalInternedTerm::Triple { s, p, o } => {
+                3u8.hash(state);
+                self.hash_term_value(*s, state);
+                self.hash_term_value(*p, state);
+                self.hash_term_value(*o, state);
+            }
+        }
+    }
+
+    /// Whether a stored term equals a dataset-independent [`TermValue`], compared BY
+    /// VALUE directly against the interned representation (zero allocations).
+    fn term_matches_value(&self, id: GlobalTermId, value: &TermValue) -> bool {
+        match (&self.terms[id.index()], value) {
+            (GlobalInternedTerm::Iri(iri), TermValue::Iri(v)) => arena_str(&self.arena, *iri) == v,
+            (
+                GlobalInternedTerm::Blank { label, scope },
+                TermValue::Blank {
+                    label: vl,
+                    scope: vs,
+                },
+            ) => arena_str(&self.arena, *label) == vl && scope == vs,
+            (
+                GlobalInternedTerm::Literal(lit),
+                TermValue::Literal {
+                    lexical_form,
+                    datatype,
+                    language,
+                    direction,
+                },
+            ) => {
+                arena_str(&self.arena, lit.lexical_form) == lexical_form
+                    && lit.direction == *direction
+                    && lit.language.map(|r| arena_str(&self.arena, r)) == language.as_deref()
+                    && self.iri_matches(lit.datatype, datatype)
+            }
+            (
+                GlobalInternedTerm::Triple { s, p, o },
+                TermValue::Triple {
+                    s: vs,
+                    p: vp,
+                    o: vo,
+                },
+            ) => {
+                self.term_matches_value(*s, vs)
+                    && self.term_matches_value(*p, vp)
+                    && self.term_matches_value(*o, vo)
+            }
+            _ => false,
+        }
+    }
+
+    /// Whether a term known to be an interned IRI equals `expected` (zero-alloc).
+    fn iri_matches(&self, id: GlobalTermId, expected: &str) -> bool {
+        matches!(&self.terms[id.index()], GlobalInternedTerm::Iri(iri) if arena_str(&self.arena, *iri) == expected)
+    }
+
+    /// The lazily-built reverse value index (built once, cached).
+    fn value_index(&self) -> &GlobalValueIndex {
+        self.value_index.get_or_init(|| {
+            let mut map: GlobalValueIndex =
+                HashMap::with_capacity_and_hasher(self.terms.len(), FastHasher::default());
+            for i in 0..self.terms.len() {
+                let id = GlobalTermId::from_index(
+                    u64::try_from(i).expect("dense index fits u64 for a Vec-bounded table"),
+                );
+                let mut hasher = ahash::AHasher::default();
+                self.hash_term_value(id, &mut hasher);
+                map.entry(hasher.finish()).or_default().push(id);
+            }
+            map
+        })
+    }
+
+    /// The id of an interned term given its **dataset-independent** value, or `None`
+    /// if the dictionary contains no such term. Backed by the lazy reverse value
+    /// index; keying on [`TermValue`] (not [`TermRef`]) is the correctness rule — a
+    /// `TermRef`'s ids are local to whichever dictionary/dataset minted them.
+    #[must_use]
+    pub fn term_id_by_value(&self, value: &TermValue) -> Option<GlobalTermId> {
+        let hash = hash_value(value);
+        self.value_index()
+            .get(&hash)?
+            .iter()
+            .copied()
+            .find(|&id| self.term_matches_value(id, value))
+    }
+}
+
+/// Fixed-key ahash of a dataset-independent [`TermValue`] (value-based path). Uses
+/// [`TermValue`]'s hand-written `Hash`, so it matches
+/// [`GlobalDictionary::hash_term_value`] for equal values.
+fn hash_value(value: &TermValue) -> u64 {
+    let mut hasher = ahash::AHasher::default();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intern_is_idempotent_and_insertion_ordered() {
+        let mut dict = GlobalDictionary::new();
+        let a = dict.intern(&TermValue::iri("http://example.org/x"));
+        let a_again = dict.intern(&TermValue::iri("http://example.org/x"));
+        let b = dict.intern(&TermValue::iri("http://example.org/y"));
+        assert_eq!(a, a_again, "same value → same id");
+        assert_ne!(a, b, "different values → different ids");
+        // Ids are minted in insertion order: N then N+1.
+        assert_eq!(b.index(), a.index() + 1);
+        assert_eq!(dict.len(), 2);
+        assert!(!dict.is_empty());
+    }
+
+    #[test]
+    fn new_dictionary_is_empty() {
+        let dict = GlobalDictionary::new();
+        assert!(dict.is_empty());
+        assert_eq!(dict.len(), 0);
+    }
+
+    #[test]
+    fn resolve_round_trips_iri() {
+        let mut dict = GlobalDictionary::new();
+        let id = dict.intern(&TermValue::iri("http://example.org/thing"));
+        assert_eq!(dict.resolve(id), TermRef::Iri("http://example.org/thing"));
+    }
+
+    #[test]
+    fn resolve_round_trips_blank() {
+        let mut dict = GlobalDictionary::new();
+        let value = TermValue::Blank {
+            label: "b0".to_string(),
+            scope: BlankScope(3),
+        };
+        let id = dict.intern(&value);
+        assert_eq!(
+            dict.resolve(id),
+            TermRef::Blank {
+                label: "b0",
+                scope: BlankScope(3),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_round_trips_typed_literal_with_interned_datatype() {
+        let mut dict = GlobalDictionary::new();
+        let value = TermValue::typed_literal("42", "http://www.w3.org/2001/XMLSchema#integer");
+        let id = dict.intern(&value);
+        let TermRef::Literal {
+            lexical,
+            datatype,
+            language,
+            direction,
+        } = dict.resolve(id)
+        else {
+            panic!("expected a literal");
+        };
+        assert_eq!(lexical, "42");
+        assert_eq!(language, None);
+        assert_eq!(direction, None);
+        // The datatype is itself an interned GlobalTermId that resolves to its IRI.
+        assert_eq!(
+            dict.resolve(datatype),
+            TermRef::Iri("http://www.w3.org/2001/XMLSchema#integer")
+        );
+    }
+
+    #[test]
+    fn resolve_round_trips_language_literal() {
+        let mut dict = GlobalDictionary::new();
+        // `lang_literal` lowercases the tag and expands to rdf:langString.
+        let value = TermValue::lang_literal("Bonjour", "FR");
+        let id = dict.intern(&value);
+        let TermRef::Literal {
+            lexical,
+            datatype,
+            language,
+            direction,
+        } = dict.resolve(id)
+        else {
+            panic!("expected a literal");
+        };
+        assert_eq!(lexical, "Bonjour");
+        assert_eq!(language, Some("fr"));
+        assert_eq!(direction, None);
+        assert_eq!(
+            dict.resolve(datatype),
+            TermRef::Iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#langString")
+        );
+    }
+
+    #[test]
+    fn resolve_round_trips_triple_with_interned_components() {
+        let mut dict = GlobalDictionary::new();
+        let s = TermValue::iri("http://example.org/s");
+        let p = TermValue::iri("http://example.org/p");
+        let o = TermValue::simple_literal("obj");
+        let value = TermValue::Triple {
+            s: Box::new(s.clone()),
+            p: Box::new(p.clone()),
+            o: Box::new(o.clone()),
+        };
+        let id = dict.intern(&value);
+        let TermRef::Triple {
+            s: sid,
+            p: pid,
+            o: oid,
+        } = dict.resolve(id)
+        else {
+            panic!("expected a triple term");
+        };
+        // Each component was interned and resolves back to its value.
+        assert_eq!(dict.resolve(sid), TermRef::Iri("http://example.org/s"));
+        assert_eq!(dict.resolve(pid), TermRef::Iri("http://example.org/p"));
+        // And the components share identity with a direct intern of the same value.
+        assert_eq!(dict.term_id_by_value(&s), Some(sid));
+        assert_eq!(dict.term_id_by_value(&p), Some(pid));
+        assert_eq!(dict.term_id_by_value(&o), Some(oid));
+    }
+
+    #[test]
+    fn term_id_by_value_hits_and_misses() {
+        let mut dict = GlobalDictionary::new();
+        let present = TermValue::iri("http://example.org/present");
+        let id = dict.intern(&present);
+        assert_eq!(dict.term_id_by_value(&present), Some(id));
+        // A value never interned yields None (absence is an empty match, not error).
+        let absent = TermValue::iri("http://example.org/absent");
+        assert_eq!(dict.term_id_by_value(&absent), None);
+    }
+
+    #[test]
+    fn term_id_by_value_matches_intern_for_all_shapes() {
+        let mut dict = GlobalDictionary::new();
+        let values = [
+            TermValue::iri("http://example.org/i"),
+            TermValue::blank("b1"),
+            TermValue::simple_literal("plain"),
+            TermValue::typed_literal("3.14", "http://www.w3.org/2001/XMLSchema#double"),
+            TermValue::lang_literal("hello", "en"),
+        ];
+        for v in &values {
+            let id = dict.intern(v);
+            assert_eq!(dict.term_id_by_value(v), Some(id), "value {v:?}");
+        }
+    }
+
+    #[test]
+    fn intern_is_deterministic_across_runs() {
+        let sequence = [
+            TermValue::iri("http://example.org/a"),
+            TermValue::blank("b"),
+            TermValue::typed_literal("1", "http://www.w3.org/2001/XMLSchema#integer"),
+            TermValue::iri("http://example.org/a"), // repeat → same id
+            TermValue::lang_literal("x", "en"),
+            TermValue::Triple {
+                s: Box::new(TermValue::iri("http://example.org/a")),
+                p: Box::new(TermValue::iri("http://example.org/p")),
+                o: Box::new(TermValue::simple_literal("o")),
+            },
+        ];
+
+        let mut first = GlobalDictionary::new();
+        let ids_first: Vec<usize> = sequence.iter().map(|v| first.intern(v).index()).collect();
+
+        let mut second = GlobalDictionary::new();
+        let ids_second: Vec<usize> = sequence.iter().map(|v| second.intern(v).index()).collect();
+
+        assert_eq!(ids_first, ids_second, "id assignments must be reproducible");
+        assert_eq!(first.len(), second.len());
+    }
+
+    #[test]
+    fn ring_fence_term_id_stays_four_bytes() {
+        // The new u64 global layer must NOT perturb the load-bearing u32 TermId
+        // niche (mirrors the const asserts near GlobalTermId).
+        assert_eq!(size_of::<TermId>(), 4);
+        assert_eq!(size_of::<Option<TermId>>(), 4);
+        assert_eq!(size_of::<GlobalTermId>(), 8);
+        assert_eq!(size_of::<Option<GlobalTermId>>(), 8);
+    }
+
+    #[test]
+    fn blank_scope_participates_in_identity() {
+        let mut dict = GlobalDictionary::new();
+        let s1 = dict.intern(&TermValue::Blank {
+            label: "b".to_string(),
+            scope: BlankScope(1),
+        });
+        let s2 = dict.intern(&TermValue::Blank {
+            label: "b".to_string(),
+            scope: BlankScope(2),
+        });
+        assert_ne!(s1, s2, "same label, different scope → different id (C0.2)");
+    }
+
+    #[test]
+    fn global_term_id_index_round_trips() {
+        for raw in [0u64, 1, 42, u64::MAX - 1] {
+            let id = GlobalTermId::from_index(raw);
+            assert_eq!(u64::try_from(id.index()).expect("index fits u64"), raw);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot exceed u64::MAX-1 entries")]
+    fn global_term_id_from_index_rejects_u64_max() {
+        let _ = GlobalTermId::from_index(u64::MAX);
+    }
+}

--- a/crates/rdf-core/src/ir/mod.rs
+++ b/crates/rdf-core/src/ir/mod.rs
@@ -58,8 +58,9 @@ pub use global::{GlobalDictionary, GlobalTermId};
 pub use ingest::{DatasetSink, FrozenDatasetSource};
 pub use mutable::{MutableDataset, QuadValues};
 pub use paged::{
-    CountingDemandProvider, InMemoryPageProvider, PageFault, PageId, PageProvider, PageTranslation,
-    PagedDataset, PagedFreezeError, PagedQuadOverlap, PagedQuadTable, SubsetPageProvider,
+    CountingDemandProvider, InMemoryPageProvider, PageFault, PageId, PagePart, PageProvider,
+    PageTranslation, PagedDataset, PagedFreezeError, PagedQuadOverlap, PagedQuadTable,
+    SubsetPageProvider,
 };
 pub use pipeline_bundle::{HandleEntry, HandleKey, PipelineBundle, PipelineBundleError};
 pub use term::{BlankScope, TermId, TermValue};

--- a/crates/rdf-core/src/ir/mod.rs
+++ b/crates/rdf-core/src/ir/mod.rs
@@ -37,6 +37,11 @@ pub mod global;
 // `purrdf-events` protocol) that buffers forward references and freezes a dataset
 // at `finish()`, plus the frozen-IR-replay `RdfEventSource` that drives it.
 pub mod ingest;
+// A reference, in-memory, demand-paged dataset (backend seam): `PagedDataset`
+// composes many frozen `RdfDataset` pages into one logical `DatasetView` keyed on
+// `GlobalTermId`, plus the `PageProvider` demand-paging hook and per-page
+// `PageTranslation` local↔global id map.
+pub mod paged;
 pub mod term;
 pub mod validate;
 
@@ -52,5 +57,9 @@ pub use event_sink::RdfDatasetVisitor;
 pub use global::{GlobalDictionary, GlobalTermId};
 pub use ingest::{DatasetSink, FrozenDatasetSource};
 pub use mutable::{MutableDataset, QuadValues};
+pub use paged::{
+    CountingDemandProvider, InMemoryPageProvider, PageFault, PageId, PageProvider, PageTranslation,
+    PagedDataset,
+};
 pub use pipeline_bundle::{HandleEntry, HandleKey, PipelineBundle, PipelineBundleError};
 pub use term::{BlankScope, TermId, TermValue};

--- a/crates/rdf-core/src/ir/mod.rs
+++ b/crates/rdf-core/src/ir/mod.rs
@@ -59,7 +59,7 @@ pub use ingest::{DatasetSink, FrozenDatasetSource};
 pub use mutable::{MutableDataset, QuadValues};
 pub use paged::{
     CountingDemandProvider, InMemoryPageProvider, PageFault, PageId, PageProvider, PageTranslation,
-    PagedDataset, PagedFreezeError, PagedQuadOverlap, SubsetPageProvider,
+    PagedDataset, PagedFreezeError, PagedQuadOverlap, PagedQuadTable, SubsetPageProvider,
 };
 pub use pipeline_bundle::{HandleEntry, HandleKey, PipelineBundle, PipelineBundleError};
 pub use term::{BlankScope, TermId, TermValue};

--- a/crates/rdf-core/src/ir/mod.rs
+++ b/crates/rdf-core/src/ir/mod.rs
@@ -59,7 +59,7 @@ pub use ingest::{DatasetSink, FrozenDatasetSource};
 pub use mutable::{MutableDataset, QuadValues};
 pub use paged::{
     CountingDemandProvider, InMemoryPageProvider, PageFault, PageId, PageProvider, PageTranslation,
-    PagedDataset,
+    PagedDataset, PagedFreezeError, PagedQuadOverlap, SubsetPageProvider,
 };
 pub use pipeline_bundle::{HandleEntry, HandleKey, PipelineBundle, PipelineBundleError};
 pub use term::{BlankScope, TermId, TermValue};

--- a/crates/rdf-core/src/ir/mod.rs
+++ b/crates/rdf-core/src/ir/mod.rs
@@ -29,6 +29,10 @@ pub mod mutable;
 // Evented, ID-addressed OUTPUT of a frozen dataset (C6): the dual of the
 // permissive ingestion protocol, for chase / SHACL-result / projection consumers.
 pub mod event_sink;
+// The u64-scaled GLOBAL term-identity layer (backend seam): a separate id space
+// (`GlobalTermId`) and its value-interner (`GlobalDictionary`), for paged /
+// cross-segment backends. NEVER widens the frozen dataset's u32 `TermId` niche.
+pub mod global;
 // The permissive-ingestion adapter (purrdf P6): an `RdfEventSink` (the
 // `purrdf-events` protocol) that buffers forward references and freezes a dataset
 // at `finish()`, plus the frozen-IR-replay `RdfEventSource` that drives it.
@@ -45,6 +49,7 @@ pub use dataset::{
     TermRef,
 };
 pub use event_sink::RdfDatasetVisitor;
+pub use global::{GlobalDictionary, GlobalTermId};
 pub use ingest::{DatasetSink, FrozenDatasetSource};
 pub use mutable::{MutableDataset, QuadValues};
 pub use pipeline_bundle::{HandleEntry, HandleKey, PipelineBundle, PipelineBundleError};

--- a/crates/rdf-core/src/ir/paged/mod.rs
+++ b/crates/rdf-core/src/ir/paged/mod.rs
@@ -93,14 +93,43 @@ pub enum PagedFreezeError {
     QuadOverlap(Box<PagedQuadOverlap>),
 }
 
+/// Which composed quad stream a [`PagedFreezeError::QuadOverlap`] refusal came from.
+/// The paged view exposes three cross-page streams that each assume disjoint pages and
+/// do NO cross-page dedup — the primary quads and the two RDF 1.2 side tables — so the
+/// seal enforces disjointness on all three, not just the primary quads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PagedQuadTable {
+    /// The base (asserted) quads, surfaced by [`DatasetView::quads`].
+    Primary,
+    /// The reifier bindings, surfaced by [`DatasetView::reifier_quads`] as
+    /// `(reifier, rdf:reifies, triple-term)` virtual quads.
+    Reifier,
+    /// The annotation triples, surfaced by [`DatasetView::annotation_quads`].
+    Annotation,
+}
+
+impl PagedQuadTable {
+    /// A short human label for the refusal message.
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Primary => "primary",
+            Self::Reifier => "reifier side-table",
+            Self::Annotation => "annotation side-table",
+        }
+    }
+}
+
 /// The offending quad of a [`PagedFreezeError::QuadOverlap`] refusal: the two pages
-/// that share it and the quad resolved to dataset-independent [`TermValue`]s.
+/// that share it, which composed stream it belongs to, and the quad resolved to
+/// dataset-independent [`TermValue`]s.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PagedQuadOverlap {
     /// The lower-numbered page that first carried the quad.
     pub first_page: PageId,
     /// The higher-numbered page that repeats it.
     pub second_page: PageId,
+    /// Which cross-page quad stream (primary or a side table) the duplicate is in.
+    pub table: PagedQuadTable,
     /// The shared quad's subject value.
     pub subject: TermValue,
     /// The shared quad's predicate value.
@@ -123,10 +152,16 @@ impl std::fmt::Display for PagedFreezeError {
             Self::Page(fault) => write!(f, "{fault}"),
             Self::QuadOverlap(o) => write!(
                 f,
-                "pages {} and {} are not quad-disjoint: the global quad \
+                "pages {} and {} are not quad-disjoint in the {} stream: the global quad \
                  (s={:?}, p={:?}, o={:?}, g={:?}) occurs on both; PagedDataset refuses \
                  to silently dedup (G3)",
-                o.first_page.0, o.second_page.0, o.subject, o.predicate, o.object, o.graph
+                o.first_page.0,
+                o.second_page.0,
+                o.table.label(),
+                o.subject,
+                o.predicate,
+                o.object,
+                o.graph
             ),
         }
     }
@@ -206,17 +241,25 @@ impl PagedDataset {
         let mut caps = RdfStoreCapabilities::plain_rdf();
         let mut total_quads = 0usize;
         let mut pages: Vec<PageSlot> = Vec::with_capacity(page_count);
-        // G3 refusal ledger: the first page on which each global quad was seen. A
-        // second sighting on a LATER page is a non-disjoint overlap. Insertion order
-        // is deterministic (pages ascending, each page's quads in frozen order), so
-        // the refusal is reproducible.
+        // G3 refusal ledgers: the first page on which each global quad was seen, kept
+        // PER composed stream. A second sighting on a LATER page is a non-disjoint
+        // overlap in that stream. The paged read path concatenates each stream across
+        // pages and does NO cross-page dedup, so the seal enforces disjointness on all
+        // three — the primary quads AND both RDF 1.2 side tables (reifier bindings,
+        // annotation triples). Insertion order is deterministic (pages ascending, each
+        // page's quads in frozen order), so the refusal is reproducible. The ledgers
+        // are SEPARATE: a base quad and a reifier virtual quad may legitimately share
+        // the same `(s, p, o, g)` values without being a duplicate emission, because
+        // they surface through different trait methods.
         type GlobalQuad = (
             GlobalTermId,
             GlobalTermId,
             GlobalTermId,
             Option<GlobalTermId>,
         );
-        let mut seen: HashMap<GlobalQuad, PageId> = HashMap::new();
+        let mut seen_primary: HashMap<GlobalQuad, PageId> = HashMap::new();
+        let mut seen_reifier: HashMap<GlobalQuad, PageId> = HashMap::new();
+        let mut seen_annotation: HashMap<GlobalQuad, PageId> = HashMap::new();
         for i in 0..page_count {
             let id = PageId(u32::try_from(i).expect("page count fits u32"));
             let page = provider.materialize(id)?;
@@ -227,29 +270,41 @@ impl PagedDataset {
             let translation = PageTranslation::build(&page, &mut dictionary);
             let page_caps = page.capabilities();
             let page_quads = page.quad_count();
-            // G3: map each of this page's quads to the shared id space and refuse on a
-            // cross-page collision. A page's own quads are distinct and its terms map
-            // injectively to global ids, so any collision here is with an EARLIER page.
+            // G3: map each of this page's quads (primary + side tables) to the shared id
+            // space and refuse on a cross-page collision. A page's own quads within a
+            // stream are distinct and its terms map injectively to global ids, so any
+            // collision here is with an EARLIER page. `key` is `Copy`, so it survives
+            // the move into the ledger for the error report.
+            let overlap = |key: GlobalQuad, first_page: PageId, table: PagedQuadTable| {
+                PagedFreezeError::QuadOverlap(Box::new(PagedQuadOverlap {
+                    first_page,
+                    second_page: id,
+                    table,
+                    subject: dictionary.term_value(key.0),
+                    predicate: dictionary.term_value(key.1),
+                    object: dictionary.term_value(key.2),
+                    graph: key.3.map(|g| dictionary.term_value(g)),
+                }))
+            };
             for q in page.quads() {
-                let key: GlobalQuad = (
-                    translation.to_global(q.s),
-                    translation.to_global(q.p),
-                    translation.to_global(q.o),
-                    q.g.map(|g| translation.to_global(g)),
-                );
-                // Single hash+probe: `insert` returns the prior page id iff this global
-                // quad was already seen (an EARLIER page — see the injectivity argument
-                // above), which is exactly the cross-page overlap we refuse. `key` is
-                // `Copy`, so it survives the move into the map for the error report.
-                if let Some(first_page) = seen.insert(key, id) {
-                    return Err(PagedFreezeError::QuadOverlap(Box::new(PagedQuadOverlap {
-                        first_page,
-                        second_page: id,
-                        subject: dictionary.term_value(key.0),
-                        predicate: dictionary.term_value(key.1),
-                        object: dictionary.term_value(key.2),
-                        graph: key.3.map(|g| dictionary.term_value(g)),
-                    })));
+                let g = map_quad_to_global(&translation, q);
+                let key: GlobalQuad = (g.s, g.p, g.o, g.g);
+                if let Some(first_page) = seen_primary.insert(key, id) {
+                    return Err(overlap(key, first_page, PagedQuadTable::Primary));
+                }
+            }
+            for q in page.reifier_quads() {
+                let g = map_quad_to_global(&translation, q);
+                let key: GlobalQuad = (g.s, g.p, g.o, g.g);
+                if let Some(first_page) = seen_reifier.insert(key, id) {
+                    return Err(overlap(key, first_page, PagedQuadTable::Reifier));
+                }
+            }
+            for q in page.annotation_quads() {
+                let g = map_quad_to_global(&translation, q);
+                let key: GlobalQuad = (g.s, g.p, g.o, g.g);
+                if let Some(first_page) = seen_annotation.insert(key, id) {
+                    return Err(overlap(key, first_page, PagedQuadTable::Annotation));
                 }
             }
             caps = caps.union(page_caps);

--- a/crates/rdf-core/src/ir/paged/mod.rs
+++ b/crates/rdf-core/src/ir/paged/mod.rs
@@ -669,21 +669,22 @@ impl DatasetView for PagedDataset {
     type ProbePlan = ();
 
     fn quads(&self) -> impl Iterator<Item = QuadIds<GlobalTermId>> + '_ {
-        let mut out: Vec<QuadIds<GlobalTermId>> = Vec::with_capacity(self.total_quads);
-        for slot in &self.pages {
+        // Stream page-by-page: each page is materialized lazily on first touch (cached
+        // in its `OnceLock`) and its quads are translated to the shared id space on the
+        // fly. Peak extra memory is one page's translated rows, never the whole dataset.
+        self.pages.iter().flat_map(move |slot| {
             let page = self
                 .page(slot.id)
                 .expect("sealed page must re-materialize deterministically");
-            for q in page.quads() {
-                out.push(map_quad_to_global(&slot.translation, q));
-            }
-        }
-        out.into_iter()
+            page.quads()
+                .map(move |q| map_quad_to_global(&slot.translation, q))
+        })
     }
 
     fn quad_refs(&self) -> impl Iterator<Item = QuadRef<'_, GlobalTermId>> + '_ {
-        // `quads()` owns its rows (the pages are materialized transiently inside it),
-        // so resolving each through the shared dictionary borrows only `self`.
+        // `quads()` yields OWNED id rows (each page is materialized behind `self`'s
+        // per-page cache, not by the caller), so resolving each through the shared
+        // dictionary borrows only `self`.
         self.quads().map(move |q| QuadRef {
             s: self.dictionary.resolve(q.s),
             p: self.dictionary.resolve(q.p),
@@ -704,20 +705,21 @@ impl DatasetView for PagedDataset {
         o: Option<GlobalTermId>,
         g: GraphMatch<GlobalTermId>,
     ) -> impl Iterator<Item = QuadIds<GlobalTermId>> + '_ {
-        let mut out: Vec<QuadIds<GlobalTermId>> = Vec::new();
-        for slot in &self.pages {
-            // Skip a page that cannot possibly match a bound id (incl. a Named graph).
-            let Some((ls, lp, lo, lg)) = translate_pattern(&slot.translation, s, p, o, g) else {
-                continue;
-            };
-            let page = self
-                .page(slot.id)
-                .expect("sealed page must re-materialize deterministically");
-            for q in page.quads_for_pattern_indexed(ls, lp, lo, lg) {
-                out.push(map_quad_to_global(&slot.translation, q));
-            }
-        }
-        out.into_iter()
+        // Stream across pages, skipping any page that cannot match a bound id (incl. a
+        // Named graph) BEFORE it is materialized: `translate_pattern` returning `None`
+        // yields an empty inner iterator, so `self.page` — the only materialization —
+        // never runs for a skipped page (the lazy hook is preserved by construction).
+        self.pages.iter().flat_map(move |slot| {
+            translate_pattern(&slot.translation, s, p, o, g)
+                .into_iter()
+                .flat_map(move |(ls, lp, lo, lg)| {
+                    let page = self
+                        .page(slot.id)
+                        .expect("sealed page must re-materialize deterministically");
+                    page.quads_for_pattern_indexed(ls, lp, lo, lg)
+                        .map(move |q| map_quad_to_global(&slot.translation, q))
+                })
+        })
     }
 
     fn term_id_by_value(&self, value: &TermValue) -> Option<GlobalTermId> {
@@ -789,53 +791,50 @@ impl DatasetView for PagedDataset {
     }
 
     fn reifier_quads(&self) -> impl Iterator<Item = QuadIds<GlobalTermId>> + '_ {
-        let mut out: Vec<QuadIds<GlobalTermId>> = Vec::new();
-        for slot in &self.pages {
+        // Stream the reifier side table page-by-page (same lazy composition as `quads`).
+        self.pages.iter().flat_map(move |slot| {
             let page = self
                 .page(slot.id)
                 .expect("sealed page must re-materialize deterministically");
-            for q in page.reifier_quads() {
-                out.push(map_quad_to_global(&slot.translation, q));
-            }
-        }
-        out.into_iter()
+            page.reifier_quads()
+                .map(move |q| map_quad_to_global(&slot.translation, q))
+        })
     }
 
     fn annotation_quads(&self) -> impl Iterator<Item = QuadIds<GlobalTermId>> + '_ {
-        let mut out: Vec<QuadIds<GlobalTermId>> = Vec::new();
-        for slot in &self.pages {
+        // Stream the annotation side table page-by-page.
+        self.pages.iter().flat_map(move |slot| {
             let page = self
                 .page(slot.id)
                 .expect("sealed page must re-materialize deterministically");
-            for q in page.annotation_quads() {
-                out.push(map_quad_to_global(&slot.translation, q));
-            }
-        }
-        out.into_iter()
+            page.annotation_quads()
+                .map(move |q| map_quad_to_global(&slot.translation, q))
+        })
     }
 
     fn annotations_of_with_graph(
         &self,
         reifier: GlobalTermId,
     ) -> impl Iterator<Item = (GlobalTermId, GlobalTermId, Option<GlobalTermId>)> + '_ {
-        let mut out: Vec<(GlobalTermId, GlobalTermId, Option<GlobalTermId>)> = Vec::new();
-        for slot in &self.pages {
-            // Translate the reifier to each page's local id; a page that lacks it
-            // contributes nothing.
-            let Some(local_reifier) = slot.translation.to_local(reifier) else {
-                continue;
-            };
-            let page = self
-                .page(slot.id)
-                .expect("sealed page must re-materialize deterministically");
-            for (p, o, g) in page.annotations_of_with_graph(local_reifier) {
-                out.push((
-                    slot.translation.to_global(p),
-                    slot.translation.to_global(o),
-                    g.map(|g| slot.translation.to_global(g)),
-                ));
-            }
-        }
-        out.into_iter()
+        // A page whose translation lacks the reifier is skipped BEFORE materialization
+        // (empty inner iterator), exactly as in `quads_for_pattern`.
+        self.pages.iter().flat_map(move |slot| {
+            slot.translation
+                .to_local(reifier)
+                .into_iter()
+                .flat_map(move |local_reifier| {
+                    let page = self
+                        .page(slot.id)
+                        .expect("sealed page must re-materialize deterministically");
+                    page.annotations_of_with_graph(local_reifier)
+                        .map(move |(p, o, g)| {
+                            (
+                                slot.translation.to_global(p),
+                                slot.translation.to_global(o),
+                                g.map(|g| slot.translation.to_global(g)),
+                            )
+                        })
+                })
+        })
     }
 }

--- a/crates/rdf-core/src/ir/paged/mod.rs
+++ b/crates/rdf-core/src/ir/paged/mod.rs
@@ -237,7 +237,11 @@ impl PagedDataset {
                     translation.to_global(q.o),
                     q.g.map(|g| translation.to_global(g)),
                 );
-                if let Some(&first_page) = seen.get(&key) {
+                // Single hash+probe: `insert` returns the prior page id iff this global
+                // quad was already seen (an EARLIER page — see the injectivity argument
+                // above), which is exactly the cross-page overlap we refuse. `key` is
+                // `Copy`, so it survives the move into the map for the error report.
+                if let Some(first_page) = seen.insert(key, id) {
                     return Err(PagedFreezeError::QuadOverlap(Box::new(PagedQuadOverlap {
                         first_page,
                         second_page: id,
@@ -247,7 +251,6 @@ impl PagedDataset {
                         graph: key.3.map(|g| dictionary.term_value(g)),
                     })));
                 }
-                seen.insert(key, id);
             }
             caps = caps.union(page_caps);
             total_quads += page_quads;

--- a/crates/rdf-core/src/ir/paged/mod.rs
+++ b/crates/rdf-core/src/ir/paged/mod.rs
@@ -1,0 +1,413 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! A reference, in-memory, demand-paged dataset — [`PagedDataset`] — that composes
+//! many frozen [`RdfDataset`] pages into ONE logical dataset queried through the
+//! id-agnostic [`DatasetView`] trait, with `type Id = GlobalTermId`.
+//!
+//! # What a page is, and how ids compose
+//!
+//! Each page is a frozen [`RdfDataset`] with its own dense, dataset-local
+//! [`TermId`](crate::ir::TermId) space. The paged view addresses terms in the shared
+//! [`GlobalTermId`](crate::ir::GlobalTermId) space of a single
+//! [`GlobalDictionary`](crate::ir::GlobalDictionary): every page term is re-interned
+//! BY VALUE into that dictionary (boundary G1, in
+//! [`PageTranslation::build`](translation::PageTranslation::build)), so equal RDF
+//! values across pages collapse onto one `GlobalTermId` and cross-page joins unify
+//! automatically. A per-page [`PageTranslation`] maps local↔global.
+//!
+//! # Seal-then-lazy contract
+//!
+//! [`PagedDataset::from_provider`] runs an EAGER seal pass: it materializes every
+//! page exactly once, folds its terms into the shared dictionary, ORs its
+//! capabilities, and tracks the total quad count — the dictionary MUST be complete
+//! before any query, so [`term_id_by_value`](DatasetView::term_id_by_value) is
+//! correct for terms on pages that have not been re-queried. The seal pass then DROPS
+//! the materialized page (it is not kept resident); query-time access re-materializes
+//! it through the [`PageProvider`] and caches the result in the slot's
+//! [`OnceLock`]. For an [`InMemoryPageProvider`](provider::InMemoryPageProvider) the
+//! re-materialize is a cheap `Arc::clone`; for a
+//! [`CountingDemandProvider`](provider::CountingDemandProvider) it is a counted
+//! rebuild — which is exactly what makes the lazy hook observable at query time.
+//!
+//! # Determinism
+//!
+//! Pages iterate in ascending [`PageId`] order and each page yields in its frozen
+//! in-page order, so every egress (`quads`, `quads_for_pattern`, the reifier/
+//! annotation views) is deterministic. Pages are quad-disjoint (G3, enforced at
+//! freeze in a later task), so no cross-page dedup is needed.
+
+pub mod provider;
+pub mod translation;
+
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, OnceLock};
+
+use crate::RdfStoreCapabilities;
+use crate::dataset_view::{DatasetView, GraphMatch};
+use crate::ir::{GlobalDictionary, GlobalTermId, QuadIds, QuadRef, RdfDataset, TermId, TermValue};
+
+pub use provider::{CountingDemandProvider, InMemoryPageProvider, PageFault, PageId, PageProvider};
+pub use translation::PageTranslation;
+
+/// One page of a [`PagedDataset`]: its [`PageId`], the local↔global
+/// [`PageTranslation`] built at seal time, and a lazily-cached resident
+/// [`RdfDataset`] (empty after the seal pass; filled on first query-time access).
+#[derive(Debug)]
+struct PageSlot {
+    /// The page's dense ordinal (equals its index in `PagedDataset::pages`).
+    id: PageId,
+    /// The seal-time local↔global term-id map for this page.
+    translation: PageTranslation,
+    /// The query-time re-materialization cache. Empty after the seal pass; filled by
+    /// [`PagedDataset::page`] on first access (deterministic per the provider
+    /// contract).
+    resident: OnceLock<Arc<RdfDataset>>,
+}
+
+/// A reference, in-memory, demand-paged dataset composing many frozen
+/// [`RdfDataset`] pages into one logical [`DatasetView`] keyed on
+/// [`GlobalTermId`]. See the [module docs](self) for the id-composition and
+/// seal-then-lazy contracts.
+pub struct PagedDataset {
+    /// The shared value-interner: the single global id space over all pages. Its own
+    /// reverse value index answers [`term_id_by_value`](DatasetView::term_id_by_value)
+    /// and [`resolve`](DatasetView::resolve) WITHOUT materializing any page.
+    dictionary: GlobalDictionary,
+    /// The pages in ascending [`PageId`] order (`pages[i].id == PageId(i)`).
+    pages: Box<[PageSlot]>,
+    /// The demand-paging hook. Shared (`Arc`) so the dataset stays `Send + Sync`.
+    provider: Arc<dyn PageProvider>,
+    /// The OR of every page's capabilities (an honest composite: a flag is on iff
+    /// some page surfaces it).
+    caps: RdfStoreCapabilities,
+    /// The total quad count, summed at seal time so [`len_hint`](DatasetView::len_hint)
+    /// never materializes a page.
+    total_quads: usize,
+}
+
+impl std::fmt::Debug for PagedDataset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `dyn PageProvider` is not `Debug`; summarize by page count instead.
+        f.debug_struct("PagedDataset")
+            .field("page_count", &self.pages.len())
+            .field("term_count", &self.dictionary.len())
+            .field("total_quads", &self.total_quads)
+            .field("caps", &self.caps)
+            // `dictionary`, `pages`, and the `dyn` `provider` are intentionally
+            // summarized above rather than dumped.
+            .finish_non_exhaustive()
+    }
+}
+
+impl PagedDataset {
+    /// Seal a provider's pages into a queryable paged dataset (the eager
+    /// correctness-required pass; see the [module docs](self)).
+    ///
+    /// For each `PageId` in `0..page_count` this materializes the page ONCE, folds
+    /// its terms into the shared [`GlobalDictionary`] by value, ORs its capabilities,
+    /// and adds its quad count to the running total — then drops the materialized
+    /// page (query-time access re-materializes it, cached). Returns the first
+    /// [`PageFault`] if any page fails to materialize.
+    ///
+    /// # Errors
+    ///
+    /// Propagates a [`PageFault`] from the provider if a page cannot be materialized.
+    pub fn from_provider(provider: Arc<dyn PageProvider>) -> Result<Self, PageFault> {
+        let page_count = provider.page_count();
+        let mut dictionary = GlobalDictionary::new();
+        let mut caps = RdfStoreCapabilities::plain_rdf();
+        let mut total_quads = 0usize;
+        let mut pages: Vec<PageSlot> = Vec::with_capacity(page_count);
+        for i in 0..page_count {
+            let id = PageId(u32::try_from(i).expect("page count fits u32"));
+            let page = provider.materialize(id)?;
+            // Boundary G1: fold this page's terms into the shared dictionary BY VALUE.
+            // This must happen for every page before any query so the dictionary is
+            // complete (value lookups are correct for terms on not-yet-requeried
+            // pages).
+            let translation = PageTranslation::build(&page, &mut dictionary);
+            caps = caps.union(page.capabilities());
+            total_quads += page.quad_count();
+            pages.push(PageSlot {
+                id,
+                translation,
+                // Sealed page is intentionally NOT kept resident: query-time access
+                // re-materializes via the provider (cheap Arc::clone for the in-memory
+                // provider; a counted rebuild for the demand provider — the observable
+                // lazy hook).
+                resident: OnceLock::new(),
+            });
+        }
+        Ok(Self {
+            dictionary,
+            pages: pages.into_boxed_slice(),
+            provider,
+            caps,
+            total_quads,
+        })
+    }
+
+    /// The number of pages composing this dataset.
+    #[must_use]
+    pub fn page_count(&self) -> usize {
+        self.pages.len()
+    }
+
+    /// The shared global dictionary over all pages (read-only).
+    #[must_use]
+    pub fn dictionary(&self) -> &GlobalDictionary {
+        &self.dictionary
+    }
+
+    /// The [`PageTranslation`] of a page, by ordinal. `None` if `id` is out of range.
+    /// Exposed so a test can prove one [`GlobalTermId`] maps to DISTINCT local
+    /// [`TermId`]s on different pages.
+    #[must_use]
+    pub fn translation(&self, id: PageId) -> Option<&PageTranslation> {
+        let index = usize::try_from(id.0).ok()?;
+        self.pages.get(index).map(|slot| &slot.translation)
+    }
+
+    /// The cached, fallible per-page getter: fast-path the resident [`OnceLock`],
+    /// otherwise re-materialize through the provider and cache it. Deterministic per
+    /// the [`PageProvider`] contract.
+    fn page(&self, id: PageId) -> Result<&Arc<RdfDataset>, PageFault> {
+        let index = usize::try_from(id.0).expect("page id fits usize");
+        let slot = &self.pages[index];
+        if let Some(ds) = slot.resident.get() {
+            return Ok(ds);
+        }
+        let ds = self.provider.materialize(id)?;
+        let _ = slot.resident.set(ds);
+        Ok(slot
+            .resident
+            .get()
+            .expect("resident cell set immediately above"))
+    }
+}
+
+/// Translate a whole `(s, p, o, g)` global pattern to this page's local id space, or
+/// `None` if ANY bound id (including a `Named` graph) is absent on the page — in which
+/// case the page cannot match and is skipped. An unbound axis (`None`) stays unbound;
+/// a bound axis present on the page becomes its local `TermId`.
+#[allow(clippy::type_complexity)]
+fn translate_pattern(
+    translation: &PageTranslation,
+    s: Option<GlobalTermId>,
+    p: Option<GlobalTermId>,
+    o: Option<GlobalTermId>,
+    g: GraphMatch<GlobalTermId>,
+) -> Option<(
+    Option<TermId>,
+    Option<TermId>,
+    Option<TermId>,
+    GraphMatch<TermId>,
+)> {
+    // For each bound axis, `?` short-circuits to `None` (skip the page) when the term
+    // is absent; an unbound axis passes through as `None`.
+    let s = match s {
+        None => None,
+        Some(global) => Some(translation.to_local(global)?),
+    };
+    let p = match p {
+        None => None,
+        Some(global) => Some(translation.to_local(global)?),
+    };
+    let o = match o {
+        None => None,
+        Some(global) => Some(translation.to_local(global)?),
+    };
+    let g = match g {
+        GraphMatch::Any => GraphMatch::Any,
+        GraphMatch::Default => GraphMatch::Default,
+        GraphMatch::Named(gid) => GraphMatch::Named(translation.to_local(gid)?),
+    };
+    Some((s, p, o, g))
+}
+
+/// Map a page-local [`QuadIds`] back to the shared global id space.
+fn map_quad_to_global(translation: &PageTranslation, q: QuadIds<TermId>) -> QuadIds<GlobalTermId> {
+    QuadIds {
+        s: translation.to_global(q.s),
+        p: translation.to_global(q.p),
+        o: translation.to_global(q.o),
+        g: q.g.map(|g| translation.to_global(g)),
+    }
+}
+
+impl DatasetView for PagedDataset {
+    type Id = GlobalTermId;
+    type ProbePlan = ();
+
+    fn quads(&self) -> impl Iterator<Item = QuadIds<GlobalTermId>> + '_ {
+        let mut out: Vec<QuadIds<GlobalTermId>> = Vec::with_capacity(self.total_quads);
+        for slot in &self.pages {
+            let page = self
+                .page(slot.id)
+                .expect("sealed page must re-materialize deterministically");
+            for q in page.quads() {
+                out.push(map_quad_to_global(&slot.translation, q));
+            }
+        }
+        out.into_iter()
+    }
+
+    fn quad_refs(&self) -> impl Iterator<Item = QuadRef<'_, GlobalTermId>> + '_ {
+        // `quads()` owns its rows (the pages are materialized transiently inside it),
+        // so resolving each through the shared dictionary borrows only `self`.
+        self.quads().map(move |q| QuadRef {
+            s: self.dictionary.resolve(q.s),
+            p: self.dictionary.resolve(q.p),
+            o: self.dictionary.resolve(q.o),
+            g: q.g.map(|g| self.dictionary.resolve(g)),
+        })
+    }
+
+    fn resolve(&self, id: GlobalTermId) -> crate::ir::TermRef<'_, GlobalTermId> {
+        // O(1); never materializes a page.
+        self.dictionary.resolve(id)
+    }
+
+    fn quads_for_pattern(
+        &self,
+        s: Option<GlobalTermId>,
+        p: Option<GlobalTermId>,
+        o: Option<GlobalTermId>,
+        g: GraphMatch<GlobalTermId>,
+    ) -> impl Iterator<Item = QuadIds<GlobalTermId>> + '_ {
+        let mut out: Vec<QuadIds<GlobalTermId>> = Vec::new();
+        for slot in &self.pages {
+            // Skip a page that cannot possibly match a bound id (incl. a Named graph).
+            let Some((ls, lp, lo, lg)) = translate_pattern(&slot.translation, s, p, o, g) else {
+                continue;
+            };
+            let page = self
+                .page(slot.id)
+                .expect("sealed page must re-materialize deterministically");
+            for q in page.quads_for_pattern_indexed(ls, lp, lo, lg) {
+                out.push(map_quad_to_global(&slot.translation, q));
+            }
+        }
+        out.into_iter()
+    }
+
+    fn term_id_by_value(&self, value: &TermValue) -> Option<GlobalTermId> {
+        // The dictionary is complete after the seal pass; never materializes a page.
+        self.dictionary.term_id_by_value(value)
+    }
+
+    fn capabilities(&self) -> RdfStoreCapabilities {
+        self.caps
+    }
+
+    fn len_hint(&self) -> Option<usize> {
+        Some(self.total_quads)
+    }
+
+    fn probe_plan(
+        &self,
+        _s_bound: bool,
+        _p_bound: bool,
+        _o_bound: bool,
+        _g: GraphMatch<GlobalTermId>,
+    ) {
+    }
+
+    fn quads_for_pattern_with_plan(
+        &self,
+        _plan: &(),
+        s: Option<GlobalTermId>,
+        p: Option<GlobalTermId>,
+        o: Option<GlobalTermId>,
+        g: GraphMatch<GlobalTermId>,
+    ) -> impl Iterator<Item = QuadIds<GlobalTermId>> + '_ {
+        // The unit plan carries nothing; forward to the pattern query.
+        self.quads_for_pattern(s, p, o, g)
+    }
+
+    fn cardinality_estimate(
+        &self,
+        s: Option<GlobalTermId>,
+        p: Option<GlobalTermId>,
+        o: Option<GlobalTermId>,
+        g: GraphMatch<GlobalTermId>,
+    ) -> usize {
+        // The Merge-scope summation: Σ over non-skipped pages of each page's own
+        // O(log n) estimate on the translated pattern.
+        let mut total = 0usize;
+        for slot in &self.pages {
+            let Some((ls, lp, lo, lg)) = translate_pattern(&slot.translation, s, p, o, g) else {
+                continue;
+            };
+            let page = self
+                .page(slot.id)
+                .expect("sealed page must re-materialize deterministically");
+            total += page.cardinality_estimate(ls, lp, lo, lg);
+        }
+        total
+    }
+
+    fn term_count(&self) -> usize {
+        self.dictionary.len()
+    }
+
+    fn stats_fingerprint(&self) -> u64 {
+        // Mirror RdfDataset's coarse fingerprint: hash (total quads, distinct terms).
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        self.total_quads.hash(&mut h);
+        self.dictionary.len().hash(&mut h);
+        h.finish()
+    }
+
+    fn reifier_quads(&self) -> impl Iterator<Item = QuadIds<GlobalTermId>> + '_ {
+        let mut out: Vec<QuadIds<GlobalTermId>> = Vec::new();
+        for slot in &self.pages {
+            let page = self
+                .page(slot.id)
+                .expect("sealed page must re-materialize deterministically");
+            for q in page.reifier_quads() {
+                out.push(map_quad_to_global(&slot.translation, q));
+            }
+        }
+        out.into_iter()
+    }
+
+    fn annotation_quads(&self) -> impl Iterator<Item = QuadIds<GlobalTermId>> + '_ {
+        let mut out: Vec<QuadIds<GlobalTermId>> = Vec::new();
+        for slot in &self.pages {
+            let page = self
+                .page(slot.id)
+                .expect("sealed page must re-materialize deterministically");
+            for q in page.annotation_quads() {
+                out.push(map_quad_to_global(&slot.translation, q));
+            }
+        }
+        out.into_iter()
+    }
+
+    fn annotations_of_with_graph(
+        &self,
+        reifier: GlobalTermId,
+    ) -> impl Iterator<Item = (GlobalTermId, GlobalTermId, Option<GlobalTermId>)> + '_ {
+        let mut out: Vec<(GlobalTermId, GlobalTermId, Option<GlobalTermId>)> = Vec::new();
+        for slot in &self.pages {
+            // Translate the reifier to each page's local id; a page that lacks it
+            // contributes nothing.
+            let Some(local_reifier) = slot.translation.to_local(reifier) else {
+                continue;
+            };
+            let page = self
+                .page(slot.id)
+                .expect("sealed page must re-materialize deterministically");
+            for (p, o, g) in page.annotations_of_with_graph(local_reifier) {
+                out.push((
+                    slot.translation.to_global(p),
+                    slot.translation.to_global(o),
+                    g.map(|g| slot.translation.to_global(g)),
+                ));
+            }
+        }
+        out.into_iter()
+    }
+}

--- a/crates/rdf-core/src/ir/paged/mod.rs
+++ b/crates/rdf-core/src/ir/paged/mod.rs
@@ -176,6 +176,28 @@ impl std::error::Error for PagedFreezeError {
     }
 }
 
+/// One page's pre-built seal metadata, the unit of
+/// [`PagedDataset::from_parts`]/[`to_parts`](PagedDataset::to_parts).
+///
+/// A [`PageTranslation`] can only be produced by walking a page (its by-value
+/// re-intern boundary), so this is NOT how a fresh corpus is ingested — it is how an
+/// ALREADY-INDEXED store is reconstituted. A backend that persists its
+/// [`GlobalDictionary`] and per-page translations reloads a [`PagedDataset`] from these
+/// parts WITHOUT re-scanning every page (the warm-restart path), where
+/// [`from_provider`](PagedDataset::from_provider) would eagerly re-materialize all of
+/// them. `capabilities` and `quad_count` are the page's seal-time metadata, kept so the
+/// reconstituted dataset answers [`capabilities`](DatasetView::capabilities) and
+/// [`len_hint`](DatasetView::len_hint) without a materialization.
+#[derive(Debug, Clone)]
+pub struct PagePart {
+    /// The page's local↔global term-id map (as built at its original seal).
+    pub translation: PageTranslation,
+    /// The page's capabilities, captured at seal time.
+    pub capabilities: RdfStoreCapabilities,
+    /// The page's quad count, captured at seal time.
+    pub quad_count: usize,
+}
+
 /// A reference, in-memory, demand-paged dataset composing many frozen
 /// [`RdfDataset`] pages into one logical [`DatasetView`] keyed on
 /// [`GlobalTermId`]. See the [module docs](self) for the id-composition and
@@ -328,6 +350,92 @@ impl PagedDataset {
             caps,
             total_quads,
         })
+    }
+
+    /// Reconstitute a paged dataset from PRE-BUILT parts WITHOUT materializing any page
+    /// — the warm-restart / already-indexed constructor.
+    ///
+    /// [`from_provider`](Self::from_provider) is the eager path: it materializes every
+    /// page once to fold its terms into the shared dictionary and to check G3
+    /// quad-disjointness. A store that has ALREADY done that and persisted the resulting
+    /// [`GlobalDictionary`] and per-page [`PagePart`]s does not need to re-scan — this
+    /// constructor rebuilds the dataset from those parts and defers every page load to
+    /// query time (each page's [`OnceLock`] starts empty). For a large store that is the
+    /// difference between an O(all pages) reload and an O(1) one.
+    ///
+    /// `caps` and `total_quads` are DERIVED from the parts (the OR of the per-page
+    /// capabilities and the sum of the per-page quad counts), so the reconstituted
+    /// dataset answers [`capabilities`](DatasetView::capabilities) and
+    /// [`len_hint`](DatasetView::len_hint) without a materialization.
+    ///
+    /// # Disjointness
+    ///
+    /// Unlike [`from_provider`](Self::from_provider), this path does NOT re-verify G3
+    /// quad-disjointness — it cannot without reading the pages, which is the cost it
+    /// exists to avoid. The caller warrants that `parts` came from a previously-sealed
+    /// dataset (e.g. [`to_parts`](Self::to_parts)) whose pages were disjoint; the read
+    /// path relies on that invariant exactly as `from_provider`'s output does.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `parts.len()` disagrees with `provider.page_count()` — the parts and
+    /// the provider must describe the SAME pages `0..page_count`.
+    #[must_use]
+    pub fn from_parts(
+        dictionary: GlobalDictionary,
+        provider: Arc<dyn PageProvider>,
+        parts: Vec<PagePart>,
+    ) -> Self {
+        assert_eq!(
+            parts.len(),
+            provider.page_count(),
+            "from_parts: {} parts but the provider has {} pages",
+            parts.len(),
+            provider.page_count()
+        );
+        let mut caps = RdfStoreCapabilities::plain_rdf();
+        let mut total_quads = 0usize;
+        let mut pages: Vec<PageSlot> = Vec::with_capacity(parts.len());
+        for (i, part) in parts.into_iter().enumerate() {
+            caps = caps.union(part.capabilities);
+            total_quads += part.quad_count;
+            pages.push(PageSlot {
+                id: PageId(u32::try_from(i).expect("page count fits u32")),
+                translation: part.translation,
+                // Lazy: query-time access materializes through the provider (the whole
+                // point — construction touches no page).
+                resident: OnceLock::new(),
+                caps: part.capabilities,
+                quad_count: part.quad_count,
+            });
+        }
+        Self {
+            dictionary,
+            pages: pages.into_boxed_slice(),
+            provider,
+            caps,
+            total_quads,
+        }
+    }
+
+    /// Decompose this dataset into its shared [`GlobalDictionary`] and per-page
+    /// [`PagePart`]s — the inverse of [`from_parts`](Self::from_parts).
+    ///
+    /// A pure clone of the seal-time metadata (no page is materialized): a store can
+    /// persist these parts and later reload via [`from_parts`](Self::from_parts) without
+    /// the eager re-scan. Pages are returned in ascending [`PageId`] order.
+    #[must_use]
+    pub fn to_parts(&self) -> (GlobalDictionary, Vec<PagePart>) {
+        let parts = self
+            .pages
+            .iter()
+            .map(|slot| PagePart {
+                translation: slot.translation.clone(),
+                capabilities: slot.caps,
+                quad_count: slot.quad_count,
+            })
+            .collect();
+        (self.dictionary.clone(), parts)
     }
 
     /// Produce a variant retaining `keep` (each an existing [`PageId`]) as fresh dense

--- a/crates/rdf-core/src/ir/paged/mod.rs
+++ b/crates/rdf-core/src/ir/paged/mod.rs
@@ -40,6 +40,7 @@
 pub mod provider;
 pub mod translation;
 
+use std::collections::{BTreeSet, HashMap};
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, OnceLock};
 
@@ -47,7 +48,10 @@ use crate::RdfStoreCapabilities;
 use crate::dataset_view::{DatasetView, GraphMatch};
 use crate::ir::{GlobalDictionary, GlobalTermId, QuadIds, QuadRef, RdfDataset, TermId, TermValue};
 
-pub use provider::{CountingDemandProvider, InMemoryPageProvider, PageFault, PageId, PageProvider};
+pub use provider::{
+    CountingDemandProvider, InMemoryPageProvider, PageFault, PageId, PageProvider,
+    SubsetPageProvider,
+};
 pub use translation::PageTranslation;
 
 /// One page of a [`PagedDataset`]: its [`PageId`], the local↔global
@@ -63,6 +67,78 @@ struct PageSlot {
     /// [`PagedDataset::page`] on first access (deterministic per the provider
     /// contract).
     resident: OnceLock<Arc<RdfDataset>>,
+    /// This page's capabilities, captured at seal time so
+    /// [`with_pages`](PagedDataset::with_pages) can recompute the honest composite of
+    /// a page SUBSET without re-materializing.
+    caps: RdfStoreCapabilities,
+    /// This page's quad count, captured at seal time so a page-subset dataset can sum
+    /// its own `total_quads` without re-materializing.
+    quad_count: usize,
+}
+
+/// Why sealing a provider into a [`PagedDataset`] failed.
+///
+/// The seal pass is the checked construction path: besides a provider
+/// [`PageFault`], it REFUSES (never silently dedups) when the pages are not
+/// quad-disjoint in [`GlobalTermId`] space — i.e. the same global quad `(s, p, o, g)`
+/// occurs on more than one page (G3). Naming both offending pages and the quad makes
+/// the refusal actionable.
+#[derive(Debug)]
+pub enum PagedFreezeError {
+    /// A page could not be materialized by the provider.
+    Page(PageFault),
+    /// Two pages carry the SAME global quad — the pages are not quad-disjoint, so the
+    /// seal refuses rather than collapse the duplicate. Boxed to keep the enum (and
+    /// therefore the seal `Result`) small.
+    QuadOverlap(Box<PagedQuadOverlap>),
+}
+
+/// The offending quad of a [`PagedFreezeError::QuadOverlap`] refusal: the two pages
+/// that share it and the quad resolved to dataset-independent [`TermValue`]s.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PagedQuadOverlap {
+    /// The lower-numbered page that first carried the quad.
+    pub first_page: PageId,
+    /// The higher-numbered page that repeats it.
+    pub second_page: PageId,
+    /// The shared quad's subject value.
+    pub subject: TermValue,
+    /// The shared quad's predicate value.
+    pub predicate: TermValue,
+    /// The shared quad's object value.
+    pub object: TermValue,
+    /// The shared quad's graph value (`None` = the default graph).
+    pub graph: Option<TermValue>,
+}
+
+impl From<PageFault> for PagedFreezeError {
+    fn from(fault: PageFault) -> Self {
+        Self::Page(fault)
+    }
+}
+
+impl std::fmt::Display for PagedFreezeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Page(fault) => write!(f, "{fault}"),
+            Self::QuadOverlap(o) => write!(
+                f,
+                "pages {} and {} are not quad-disjoint: the global quad \
+                 (s={:?}, p={:?}, o={:?}, g={:?}) occurs on both; PagedDataset refuses \
+                 to silently dedup (G3)",
+                o.first_page.0, o.second_page.0, o.subject, o.predicate, o.object, o.graph
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PagedFreezeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Page(fault) => Some(fault),
+            Self::QuadOverlap(_) => None,
+        }
+    }
 }
 
 /// A reference, in-memory, demand-paged dataset composing many frozen
@@ -102,23 +178,45 @@ impl std::fmt::Debug for PagedDataset {
 
 impl PagedDataset {
     /// Seal a provider's pages into a queryable paged dataset (the eager
-    /// correctness-required pass; see the [module docs](self)).
+    /// correctness-required pass; see the [module docs](self)). This is the CHECKED
+    /// construction path — the only public constructor — so the quad-disjointness
+    /// refusal below is always on the production path, never a test-only helper.
     ///
     /// For each `PageId` in `0..page_count` this materializes the page ONCE, folds
     /// its terms into the shared [`GlobalDictionary`] by value, ORs its capabilities,
     /// and adds its quad count to the running total — then drops the materialized
-    /// page (query-time access re-materializes it, cached). Returns the first
-    /// [`PageFault`] if any page fails to materialize.
+    /// page (query-time access re-materializes it, cached).
+    ///
+    /// # Quad-disjointness (G3)
+    ///
+    /// Pages MUST be quad-disjoint in [`GlobalTermId`] space. After mapping each
+    /// page's quads to the shared id space, if the SAME global quad `(s, p, o, g)`
+    /// appears on more than one page the seal REFUSES with
+    /// [`PagedFreezeError::QuadOverlap`] — it never silently dedups (the paged read
+    /// path assumes disjoint pages and does no cross-page dedup). The disjoint success
+    /// path is behavior-identical to before.
     ///
     /// # Errors
     ///
-    /// Propagates a [`PageFault`] from the provider if a page cannot be materialized.
-    pub fn from_provider(provider: Arc<dyn PageProvider>) -> Result<Self, PageFault> {
+    /// [`PagedFreezeError::Page`] if a page cannot be materialized;
+    /// [`PagedFreezeError::QuadOverlap`] if two pages share a global quad.
+    pub fn from_provider(provider: Arc<dyn PageProvider>) -> Result<Self, PagedFreezeError> {
         let page_count = provider.page_count();
         let mut dictionary = GlobalDictionary::new();
         let mut caps = RdfStoreCapabilities::plain_rdf();
         let mut total_quads = 0usize;
         let mut pages: Vec<PageSlot> = Vec::with_capacity(page_count);
+        // G3 refusal ledger: the first page on which each global quad was seen. A
+        // second sighting on a LATER page is a non-disjoint overlap. Insertion order
+        // is deterministic (pages ascending, each page's quads in frozen order), so
+        // the refusal is reproducible.
+        type GlobalQuad = (
+            GlobalTermId,
+            GlobalTermId,
+            GlobalTermId,
+            Option<GlobalTermId>,
+        );
+        let mut seen: HashMap<GlobalQuad, PageId> = HashMap::new();
         for i in 0..page_count {
             let id = PageId(u32::try_from(i).expect("page count fits u32"));
             let page = provider.materialize(id)?;
@@ -127,8 +225,32 @@ impl PagedDataset {
             // complete (value lookups are correct for terms on not-yet-requeried
             // pages).
             let translation = PageTranslation::build(&page, &mut dictionary);
-            caps = caps.union(page.capabilities());
-            total_quads += page.quad_count();
+            let page_caps = page.capabilities();
+            let page_quads = page.quad_count();
+            // G3: map each of this page's quads to the shared id space and refuse on a
+            // cross-page collision. A page's own quads are distinct and its terms map
+            // injectively to global ids, so any collision here is with an EARLIER page.
+            for q in page.quads() {
+                let key: GlobalQuad = (
+                    translation.to_global(q.s),
+                    translation.to_global(q.p),
+                    translation.to_global(q.o),
+                    q.g.map(|g| translation.to_global(g)),
+                );
+                if let Some(&first_page) = seen.get(&key) {
+                    return Err(PagedFreezeError::QuadOverlap(Box::new(PagedQuadOverlap {
+                        first_page,
+                        second_page: id,
+                        subject: dictionary.term_value(key.0),
+                        predicate: dictionary.term_value(key.1),
+                        object: dictionary.term_value(key.2),
+                        graph: key.3.map(|g| dictionary.term_value(g)),
+                    })));
+                }
+                seen.insert(key, id);
+            }
+            caps = caps.union(page_caps);
+            total_quads += page_quads;
             pages.push(PageSlot {
                 id,
                 translation,
@@ -137,6 +259,8 @@ impl PagedDataset {
                 // provider; a counted rebuild for the demand provider — the observable
                 // lazy hook).
                 resident: OnceLock::new(),
+                caps: page_caps,
+                quad_count: page_quads,
             });
         }
         Ok(Self {
@@ -146,6 +270,144 @@ impl PagedDataset {
             caps,
             total_quads,
         })
+    }
+
+    /// Produce a variant retaining `keep` (each an existing [`PageId`]) as fresh dense
+    /// pages `0..keep.len()`, in the given order — the page-eviction primitive.
+    ///
+    /// The returned dataset keeps the ORIGINAL (now possibly oversized) dictionary: a
+    /// dropped page's ids are NOT reclaimed here — that is exactly what
+    /// [`compact`](Self::compact) later does. This models lillith's real use case:
+    /// pages are evicted over time, the shared dictionary accumulates dead ids, and a
+    /// periodic compaction reclaims them. The retained per-page translations are
+    /// carried over verbatim (their local id spaces and the global ids they point at
+    /// are untouched by dropping OTHER pages), and `caps` / `total_quads` are the
+    /// honest recomputation over ONLY the retained pages.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any id in `keep` is out of range (`>= page_count`).
+    #[must_use]
+    pub fn with_pages(&self, keep: &[PageId]) -> Self {
+        // The retained pages keep the oversized dictionary; its dead ids survive until
+        // `compact`. The clone is a deep copy over an identical term table, so its lazy
+        // value index stays valid.
+        let dictionary = self.dictionary.clone();
+        let mut caps = RdfStoreCapabilities::plain_rdf();
+        let mut total_quads = 0usize;
+        let mut pages: Vec<PageSlot> = Vec::with_capacity(keep.len());
+        for (new_index, &original) in keep.iter().enumerate() {
+            let src = usize::try_from(original.0).expect("page id fits usize");
+            let slot = &self.pages[src];
+            caps = caps.union(slot.caps);
+            total_quads += slot.quad_count;
+            pages.push(PageSlot {
+                id: PageId(u32::try_from(new_index).expect("page count fits u32")),
+                translation: slot.translation.clone(),
+                resident: OnceLock::new(),
+                caps: slot.caps,
+                quad_count: slot.quad_count,
+            });
+        }
+        let indices: Vec<PageId> = keep.to_vec();
+        Self {
+            dictionary,
+            pages: pages.into_boxed_slice(),
+            provider: Arc::new(SubsetPageProvider::new(self.provider.clone(), indices)),
+            caps,
+            total_quads,
+        }
+    }
+
+    /// Drop one page, returning a variant over the remaining pages (a thin wrapper
+    /// over [`with_pages`](Self::with_pages)). The surviving pages keep the oversized
+    /// dictionary until [`compact`](Self::compact) reclaims the dropped page's dead
+    /// ids.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `drop` is out of range (`>= page_count`).
+    #[must_use]
+    pub fn drop_page(&self, drop: PageId) -> Self {
+        assert!(
+            (usize::try_from(drop.0).expect("page id fits usize")) < self.pages.len(),
+            "drop_page: page {} out of range 0..{}",
+            drop.0,
+            self.pages.len()
+        );
+        let keep: Vec<PageId> = self
+            .pages
+            .iter()
+            .map(|s| s.id)
+            .filter(|&p| p != drop)
+            .collect();
+        self.with_pages(&keep)
+    }
+
+    /// Reclaim dead global ids and renumber the survivors DETERMINISTICALLY.
+    ///
+    /// Compaction is a pure function of the LIVE term-VALUE set:
+    ///
+    /// 1. **Mark-live** — union the retained pages' term tables into a
+    ///    `BTreeSet<GlobalTermId>` (sorted, deterministic). A frozen page's term table
+    ///    is closed over triple components and literal datatypes, so this union IS the
+    ///    transitive set of ids the pages' quads and side tables reference.
+    /// 2. **Renumber canonically** — resolve each live id to its dataset-independent
+    ///    [`TermValue`], sort those VALUES in canonical order (see
+    ///    [`TermValue`]'s `Ord`, which mirrors the serializer), and re-intern them in
+    ///    that order into a fresh [`GlobalDictionary`]. The new id assignment therefore
+    ///    depends only on the live value set — not the old numbering, ingest order, or
+    ///    page order — so compacting the same live set twice yields identical ids.
+    /// 3. **Rebuild translations** — pass each retained page's global side through the
+    ///    old→new remap ([`PageTranslation::remap`]); local id spaces and quad tables
+    ///    are unchanged. The lazy `value_index` resets with the fresh dictionary.
+    ///
+    /// The result has no dead ids and a canonical global numbering, and preserves
+    /// every quad's meaning (each survivor resolves to the identical `TermValue`).
+    #[must_use]
+    pub fn compact(&self) -> Self {
+        // 1. Mark-live: the sorted union of every retained page's global ids.
+        let mut live: BTreeSet<GlobalTermId> = BTreeSet::new();
+        for slot in &self.pages {
+            live.extend(slot.translation.global_ids().iter().copied());
+        }
+        // 2. Resolve to dataset-independent values and sort them CANONICALLY, so the
+        // fresh id assignment is a pure function of the live value set.
+        let mut live_values: Vec<(GlobalTermId, TermValue)> = live
+            .iter()
+            .map(|&old| (old, self.dictionary.term_value(old)))
+            .collect();
+        live_values.sort_by(|(_, a), (_, b)| a.cmp(b));
+        // Re-intern in canonical order into a fresh dictionary; record old→new.
+        let mut dictionary = GlobalDictionary::new();
+        let mut remap: HashMap<GlobalTermId, GlobalTermId> =
+            HashMap::with_capacity(live_values.len());
+        for (old, value) in &live_values {
+            remap.insert(*old, dictionary.intern(value));
+        }
+        // 3. Rebuild each page's translation through the remap; local spaces unchanged.
+        let pages: Vec<PageSlot> = self
+            .pages
+            .iter()
+            .map(|slot| PageSlot {
+                id: slot.id,
+                translation: slot.translation.remap(|g| {
+                    *remap
+                        .get(&g)
+                        .expect("every retained page global id is live and remapped")
+                }),
+                resident: OnceLock::new(),
+                caps: slot.caps,
+                quad_count: slot.quad_count,
+            })
+            .collect();
+        Self {
+            dictionary,
+            pages: pages.into_boxed_slice(),
+            provider: self.provider.clone(),
+            caps: self.caps,
+            total_quads: self.total_quads,
+        }
     }
 
     /// The number of pages composing this dataset.

--- a/crates/rdf-core/src/ir/paged/mod.rs
+++ b/crates/rdf-core/src/ir/paged/mod.rs
@@ -8,9 +8,9 @@
 //! # What a page is, and how ids compose
 //!
 //! Each page is a frozen [`RdfDataset`] with its own dense, dataset-local
-//! [`TermId`](crate::ir::TermId) space. The paged view addresses terms in the shared
-//! [`GlobalTermId`](crate::ir::GlobalTermId) space of a single
-//! [`GlobalDictionary`](crate::ir::GlobalDictionary): every page term is re-interned
+//! [`TermId`] space. The paged view addresses terms in the shared
+//! [`GlobalTermId`] space of a single
+//! [`GlobalDictionary`]: every page term is re-interned
 //! BY VALUE into that dictionary (boundary G1, in
 //! [`PageTranslation::build`](translation::PageTranslation::build)), so equal RDF
 //! values across pages collapse onto one `GlobalTermId` and cross-page joins unify
@@ -25,9 +25,9 @@
 //! correct for terms on pages that have not been re-queried. The seal pass then DROPS
 //! the materialized page (it is not kept resident); query-time access re-materializes
 //! it through the [`PageProvider`] and caches the result in the slot's
-//! [`OnceLock`]. For an [`InMemoryPageProvider`](provider::InMemoryPageProvider) the
+//! [`OnceLock`]. For an [`InMemoryPageProvider`] the
 //! re-materialize is a cheap `Arc::clone`; for a
-//! [`CountingDemandProvider`](provider::CountingDemandProvider) it is a counted
+//! [`CountingDemandProvider`] it is a counted
 //! rebuild — which is exactly what makes the lazy hook observable at query time.
 //!
 //! # Determinism
@@ -525,7 +525,7 @@ impl PagedDataset {
     ///    depends only on the live value set — not the old numbering, ingest order, or
     ///    page order — so compacting the same live set twice yields identical ids.
     /// 3. **Rebuild translations** — pass each retained page's global side through the
-    ///    old→new remap ([`PageTranslation::remap`]); local id spaces and quad tables
+    ///    old→new remap (a private [`PageTranslation`] pass); local id spaces and quad tables
     ///    are unchanged. The lazy `value_index` resets with the fresh dictionary.
     ///
     /// The result has no dead ids and a canonical global numbering, and preserves

--- a/crates/rdf-core/src/ir/paged/provider.rs
+++ b/crates/rdf-core/src/ir/paged/provider.rs
@@ -107,6 +107,65 @@ impl PageProvider for InMemoryPageProvider {
     }
 }
 
+/// A provider that exposes a SUBSET of another provider's pages under fresh, dense
+/// [`PageId`]s — the page-eviction primitive behind
+/// [`PagedDataset::with_pages`](super::PagedDataset::with_pages) /
+/// [`drop_page`](super::PagedDataset::drop_page).
+///
+/// `indices[new_id]` is the ORIGINAL page id in `inner` that new dense page `new_id`
+/// re-materializes, so the pruned dataset keeps dense `0..kept` page ordinals (the
+/// [`PagedDataset`](super::PagedDataset) invariant) while its retained per-page
+/// translations still address the ORIGINAL — now oversized — dictionary. Holds only
+/// an `Arc` and a boxed slice, so it stays `Send + Sync` and `wasm32`-clean.
+pub struct SubsetPageProvider {
+    /// The backing provider whose pages are being subset.
+    inner: Arc<dyn PageProvider>,
+    /// `indices[new_id] = original PageId`; its length is the pruned page count.
+    indices: Box<[PageId]>,
+}
+
+impl std::fmt::Debug for SubsetPageProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `dyn PageProvider` is not `Debug`; summarize by the retained id map.
+        f.debug_struct("SubsetPageProvider")
+            .field("indices", &self.indices)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SubsetPageProvider {
+    /// Expose exactly `indices` (each an original page id in `inner`) as dense pages
+    /// `0..indices.len()`. Order is preserved: new page `i` materializes
+    /// `inner`'s `indices[i]`.
+    #[must_use]
+    pub fn new(inner: Arc<dyn PageProvider>, indices: Vec<PageId>) -> Self {
+        Self {
+            inner,
+            indices: indices.into_boxed_slice(),
+        }
+    }
+}
+
+impl PageProvider for SubsetPageProvider {
+    fn page_count(&self) -> usize {
+        self.indices.len()
+    }
+
+    fn materialize(&self, page: PageId) -> Result<Arc<RdfDataset>, PageFault> {
+        let index = usize::try_from(page.0).expect("page id fits usize");
+        let Some(&original) = self.indices.get(index) else {
+            return Err(PageFault {
+                page,
+                message: format!(
+                    "subset page index {index} out of range 0..{}",
+                    self.indices.len()
+                ),
+            });
+        };
+        self.inner.materialize(original)
+    }
+}
+
 /// A reference provider that OBSERVES demand: each [`materialize`](PageProvider::materialize)
 /// call increments an atomic hit counter, so a test can assert exactly which pages
 /// were pulled and when.

--- a/crates/rdf-core/src/ir/paged/provider.rs
+++ b/crates/rdf-core/src/ir/paged/provider.rs
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The demand-paging hook for the reference [`PagedDataset`](super::PagedDataset):
+//! [`PageProvider`], the page identity [`PageId`], the materialization error
+//! [`PageFault`], and two reference providers ([`InMemoryPageProvider`],
+//! [`CountingDemandProvider`]).
+//!
+//! A [`PageProvider`] is the sole source of a page's frozen [`RdfDataset`]. It MUST
+//! be **deterministic** — the same [`PageId`] materializes byte-identical quads on
+//! every call — and `Send + Sync`, so a [`PagedDataset`](super::PagedDataset) can be
+//! queried from any thread and its per-page id translation stays stable across
+//! re-materialization. Nothing here touches `std::fs`/`thread`/`time`/rng: the two
+//! reference providers keep their pages (or page thunks) in memory, so the layer is
+//! `wasm32-unknown-unknown`-clean.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::ir::RdfDataset;
+
+/// A dense page ordinal. Pages of a [`PagedDataset`](super::PagedDataset) are
+/// numbered `0..page_count` and iterated in ascending `PageId` order, which is the
+/// backbone of the paged view's determinism (page order, then in-page frozen order).
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct PageId(pub u32);
+
+/// A page could not be materialized: the [`PageProvider`] failed to produce the
+/// frozen [`RdfDataset`] for [`page`](PageFault::page). Carries a human-readable
+/// [`message`](PageFault::message) for diagnostics.
+#[derive(Debug)]
+pub struct PageFault {
+    /// The page whose materialization failed.
+    pub page: PageId,
+    /// A human-readable description of the failure.
+    pub message: String,
+}
+
+impl std::fmt::Display for PageFault {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "page fault materializing page {}: {}",
+            self.page.0, self.message
+        )
+    }
+}
+
+impl std::error::Error for PageFault {}
+
+/// The demand-paging hook: the lazy materialization boundary between a
+/// [`PagedDataset`](super::PagedDataset) and the frozen [`RdfDataset`] pages that
+/// compose it.
+///
+/// # Contract
+///
+/// - **Deterministic.** [`materialize`](PageProvider::materialize) called twice with
+///   the same [`PageId`] MUST yield a dataset with byte-identical quads (and term
+///   table), so the per-page [`PageTranslation`](super::PageTranslation) built once at
+///   seal time stays valid across every later re-materialization.
+/// - **`Send + Sync`.** The provider is shared behind an `Arc` and read from the query
+///   path; it must be thread-safe.
+pub trait PageProvider: Send + Sync {
+    /// The number of pages this provider can materialize. `PageId(0..page_count)` are
+    /// exactly the valid page ordinals.
+    fn page_count(&self) -> usize;
+
+    /// Materialize one page into its frozen [`RdfDataset`], or report a
+    /// [`PageFault`] (e.g. an out-of-range `page`). Must be deterministic per the
+    /// trait contract.
+    fn materialize(&self, page: PageId) -> Result<Arc<RdfDataset>, PageFault>;
+}
+
+/// The trivial reference provider: every page is already resident in memory, so
+/// [`materialize`](PageProvider::materialize) is an infallible `Arc::clone` (an
+/// out-of-range `PageId` is the only failure).
+#[derive(Debug)]
+pub struct InMemoryPageProvider {
+    pages: Box<[Arc<RdfDataset>]>,
+}
+
+impl InMemoryPageProvider {
+    /// Wrap an ordered collection of frozen pages. Page `i` is materialized by
+    /// `PageId(i)`.
+    #[must_use]
+    pub fn new(pages: Vec<Arc<RdfDataset>>) -> Self {
+        Self {
+            pages: pages.into_boxed_slice(),
+        }
+    }
+}
+
+impl PageProvider for InMemoryPageProvider {
+    fn page_count(&self) -> usize {
+        self.pages.len()
+    }
+
+    fn materialize(&self, page: PageId) -> Result<Arc<RdfDataset>, PageFault> {
+        let index = usize::try_from(page.0).expect("page id fits usize");
+        self.pages
+            .get(index)
+            .map(Arc::clone)
+            .ok_or_else(|| PageFault {
+                page,
+                message: format!("page index {index} out of range 0..{}", self.pages.len()),
+            })
+    }
+}
+
+/// A reference provider that OBSERVES demand: each [`materialize`](PageProvider::materialize)
+/// call increments an atomic hit counter, so a test can assert exactly which pages
+/// were pulled and when.
+///
+/// It holds a rebuild thunk per page (`Fn() -> Arc<RdfDataset>`), so a re-materialize
+/// is a genuine counted rebuild rather than a cached `Arc::clone` — this is what lets
+/// a test watch the lazy hook fire AT QUERY TIME (a
+/// [`PagedDataset`](super::PagedDataset) drops the sealed page and re-materializes on
+/// first query). The counter is an [`AtomicUsize`], which is `wasm32`-clean.
+pub struct CountingDemandProvider {
+    #[allow(clippy::type_complexity)]
+    thunks: Box<[Box<dyn Fn() -> Arc<RdfDataset> + Send + Sync>]>,
+    hits: AtomicUsize,
+}
+
+impl std::fmt::Debug for CountingDemandProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CountingDemandProvider")
+            .field("page_count", &self.thunks.len())
+            .field("hits", &self.hits.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
+impl CountingDemandProvider {
+    /// Wrap one rebuild thunk per page. Thunk `i` is invoked (and the hit counter
+    /// bumped) each time `PageId(i)` is materialized. Each thunk MUST be deterministic
+    /// per the [`PageProvider`] contract.
+    #[must_use]
+    pub fn new(thunks: Vec<Box<dyn Fn() -> Arc<RdfDataset> + Send + Sync>>) -> Self {
+        Self {
+            thunks: thunks.into_boxed_slice(),
+            hits: AtomicUsize::new(0),
+        }
+    }
+
+    /// The number of [`materialize`](PageProvider::materialize) calls served so far.
+    #[must_use]
+    pub fn hits(&self) -> usize {
+        self.hits.load(Ordering::Relaxed)
+    }
+}
+
+impl PageProvider for CountingDemandProvider {
+    fn page_count(&self) -> usize {
+        self.thunks.len()
+    }
+
+    fn materialize(&self, page: PageId) -> Result<Arc<RdfDataset>, PageFault> {
+        let index = usize::try_from(page.0).expect("page id fits usize");
+        let thunk = self.thunks.get(index).ok_or_else(|| PageFault {
+            page,
+            message: format!("page index {index} out of range 0..{}", self.thunks.len()),
+        })?;
+        // Count the demand BEFORE rebuilding so a test observing `hits()` sees the
+        // pull even if the rebuild itself is trivial.
+        self.hits.fetch_add(1, Ordering::Relaxed);
+        Ok(thunk())
+    }
+}

--- a/crates/rdf-core/src/ir/paged/translation.rs
+++ b/crates/rdf-core/src/ir/paged/translation.rs
@@ -4,9 +4,9 @@
 //! The per-page local↔global term-id map, [`PageTranslation`].
 //!
 //! A page is a frozen [`RdfDataset`] with its own dense, `u32`-scoped
-//! [`TermId`](crate::ir::TermId) space; a [`PagedDataset`](super::PagedDataset)
+//! [`TermId`] space; a [`PagedDataset`](super::PagedDataset)
 //! addresses terms in the shared, `u64`-scoped
-//! [`GlobalTermId`](crate::ir::GlobalTermId) space. `PageTranslation` bridges the two
+//! [`GlobalTermId`] space. `PageTranslation` bridges the two
 //! for ONE page:
 //!
 //! - `local -> global` is an `O(1)` table lookup indexed by the page's dense
@@ -15,7 +15,7 @@
 //!   side table (absent ⇒ the term does not occur on this page).
 //!
 //! The translation is built by **re-interning every page term BY VALUE** into the
-//! shared [`GlobalDictionary`](crate::ir::GlobalDictionary) (boundary G1): equal RDF
+//! shared [`GlobalDictionary`] (boundary G1): equal RDF
 //! values across pages fold onto one `GlobalTermId`, so cross-page joins unify
 //! automatically. It is NEVER a numeric offset remap — a page's local id space is
 //! meaningless outside that page (C0.8).

--- a/crates/rdf-core/src/ir/paged/translation.rs
+++ b/crates/rdf-core/src/ir/paged/translation.rs
@@ -27,7 +27,12 @@ use crate::ir::{GlobalDictionary, GlobalTermId, RdfDataset, TermId};
 ///
 /// See the [module docs](self) for the two directions and the by-value re-intern
 /// boundary.
-#[derive(Debug)]
+///
+/// `Clone` copies both id tables — [`PagedDataset::with_pages`](super::PagedDataset::with_pages)
+/// carries a retained page's translation into the pruned dataset unchanged (its
+/// local id space and the global ids it points at are untouched by dropping OTHER
+/// pages).
+#[derive(Debug, Clone)]
 pub struct PageTranslation {
     /// `local_to_global[TermId::index()]` is the page-local term's shared
     /// [`GlobalTermId`]. Dense, indexed by the page's `0..term_count` term table.
@@ -96,5 +101,44 @@ impl PageTranslation {
     #[inline]
     pub fn term_count(&self) -> usize {
         self.local_to_global.len()
+    }
+
+    /// The shared [`GlobalTermId`] of every page-local term, in local index order.
+    /// Because a frozen page's term table is closed over triple components and
+    /// literal datatypes, this slice IS the set of global ids the page keeps live —
+    /// which [`PagedDataset::compact`](super::PagedDataset::compact) unions across the
+    /// retained pages to mark-live before reclaiming dead ids.
+    #[must_use]
+    #[inline]
+    pub fn global_ids(&self) -> &[GlobalTermId] {
+        &self.local_to_global
+    }
+
+    /// Rebuild this translation with every global id passed through `remap`. The
+    /// page's LOCAL id space and its quad table are unchanged — only the global side
+    /// moves — so the reverse `(global, local)` table is re-sorted for the fresh
+    /// global ids. Used by [`PagedDataset::compact`](super::PagedDataset::compact) to
+    /// point a retained page at the compacted dictionary.
+    #[must_use]
+    pub(crate) fn remap(&self, remap: impl Fn(GlobalTermId) -> GlobalTermId) -> Self {
+        let local_to_global: Vec<GlobalTermId> =
+            self.local_to_global.iter().map(|&g| remap(g)).collect();
+        let mut global_to_local: Vec<(GlobalTermId, TermId)> = local_to_global
+            .iter()
+            .enumerate()
+            .map(|(i, &g)| {
+                (
+                    g,
+                    TermId::from_index(u32::try_from(i).expect("page term index fits u32")),
+                )
+            })
+            .collect();
+        // Re-sort the reverse table by the NEW global ids for the binary search. The
+        // remap is a bijection over live ids, so keys stay unique.
+        global_to_local.sort_unstable_by_key(|&(g, _)| g);
+        Self {
+            local_to_global: local_to_global.into_boxed_slice(),
+            global_to_local: global_to_local.into_boxed_slice(),
+        }
     }
 }

--- a/crates/rdf-core/src/ir/paged/translation.rs
+++ b/crates/rdf-core/src/ir/paged/translation.rs
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The per-page local↔global term-id map, [`PageTranslation`].
+//!
+//! A page is a frozen [`RdfDataset`] with its own dense, `u32`-scoped
+//! [`TermId`](crate::ir::TermId) space; a [`PagedDataset`](super::PagedDataset)
+//! addresses terms in the shared, `u64`-scoped
+//! [`GlobalTermId`](crate::ir::GlobalTermId) space. `PageTranslation` bridges the two
+//! for ONE page:
+//!
+//! - `local -> global` is an `O(1)` table lookup indexed by the page's dense
+//!   [`TermId::index`](crate::ir::TermId::index).
+//! - `global -> local` is an `O(log n)` binary search of a `GlobalTermId`-sorted
+//!   side table (absent ⇒ the term does not occur on this page).
+//!
+//! The translation is built by **re-interning every page term BY VALUE** into the
+//! shared [`GlobalDictionary`](crate::ir::GlobalDictionary) (boundary G1): equal RDF
+//! values across pages fold onto one `GlobalTermId`, so cross-page joins unify
+//! automatically. It is NEVER a numeric offset remap — a page's local id space is
+//! meaningless outside that page (C0.8).
+
+use crate::ir::{GlobalDictionary, GlobalTermId, RdfDataset, TermId};
+
+/// The local↔global term-id map for a single page of a
+/// [`PagedDataset`](super::PagedDataset).
+///
+/// See the [module docs](self) for the two directions and the by-value re-intern
+/// boundary.
+#[derive(Debug)]
+pub struct PageTranslation {
+    /// `local_to_global[TermId::index()]` is the page-local term's shared
+    /// [`GlobalTermId`]. Dense, indexed by the page's `0..term_count` term table.
+    local_to_global: Box<[GlobalTermId]>,
+    /// `(global, local)` pairs SORTED by `GlobalTermId`, binary-searched by
+    /// [`to_local`](Self::to_local). A `GlobalTermId` absent here does not occur on
+    /// this page.
+    global_to_local: Box<[(GlobalTermId, TermId)]>,
+}
+
+impl PageTranslation {
+    /// Build the translation for `page`, folding EVERY page term into the shared
+    /// `dict` by value (boundary G1).
+    ///
+    /// Walks the page's dense term table (`0..term_count`), resolves each local
+    /// [`TermId`] to its dataset-independent
+    /// [`TermValue`](crate::ir::TermValue), interns that value into `dict` to obtain
+    /// the shared [`GlobalTermId`], and records both directions. After this returns,
+    /// `dict` contains a global id for every term on the page — the invariant that
+    /// makes the paged view's value lookups correct for terms on not-yet-requeried
+    /// pages.
+    #[must_use]
+    pub fn build(page: &RdfDataset, dict: &mut GlobalDictionary) -> Self {
+        let term_count = page.term_count();
+        let mut local_to_global: Vec<GlobalTermId> = Vec::with_capacity(term_count);
+        let mut global_to_local: Vec<(GlobalTermId, TermId)> = Vec::with_capacity(term_count);
+        for i in 0..term_count {
+            let local = TermId::from_index(u32::try_from(i).expect("page term index fits u32"));
+            // The by-value re-intern boundary: resolve to a dataset-INDEPENDENT value,
+            // then intern that value into the shared dictionary. Equal values across
+            // pages collapse to one GlobalTermId.
+            let value = page.term_value(local);
+            let global = dict.intern(&value);
+            local_to_global.push(global);
+            global_to_local.push((global, local));
+        }
+        // Sort the reverse table by GlobalTermId for the binary search. A page's term
+        // table has distinct terms, so the keys are unique.
+        global_to_local.sort_unstable_by_key(|&(g, _)| g);
+        Self {
+            local_to_global: local_to_global.into_boxed_slice(),
+            global_to_local: global_to_local.into_boxed_slice(),
+        }
+    }
+
+    /// The shared [`GlobalTermId`] for a page-local [`TermId`] (`O(1)`).
+    #[must_use]
+    #[inline]
+    pub fn to_global(&self, local: TermId) -> GlobalTermId {
+        self.local_to_global[local.index()]
+    }
+
+    /// The page-local [`TermId`] for a shared [`GlobalTermId`], or `None` if the term
+    /// does not occur on this page (`O(log n)` binary search).
+    #[must_use]
+    #[inline]
+    pub fn to_local(&self, global: GlobalTermId) -> Option<TermId> {
+        self.global_to_local
+            .binary_search_by_key(&global, |&(g, _)| g)
+            .ok()
+            .map(|pos| self.global_to_local[pos].1)
+    }
+
+    /// The number of terms on this page (the length of the local id space).
+    #[must_use]
+    #[inline]
+    pub fn term_count(&self) -> usize {
+        self.local_to_global.len()
+    }
+}

--- a/crates/rdf-core/src/ir/term.rs
+++ b/crates/rdf-core/src/ir/term.rs
@@ -329,6 +329,91 @@ impl TermValue {
     pub fn is_blank(&self) -> bool {
         matches!(self, Self::Blank { .. })
     }
+
+    /// The canonical kind tag used to order terms of DIFFERENT kinds. It mirrors the
+    /// canonical Turtle renderer's `ObjKey` kind ordering (IRI < Literal < Blank <
+    /// Triple, see `turtle_render`), so the total order below AGREES with the
+    /// serializer's notion of canonical term order rather than inventing a second,
+    /// conflicting one. (Note this is NOT the derive order, which would put Blank
+    /// before Literal — hence the hand-written `Ord`.)
+    #[inline]
+    fn canonical_tag(&self) -> u8 {
+        match self {
+            Self::Iri(_) => 0,
+            Self::Literal { .. } => 1,
+            Self::Blank { .. } => 2,
+            Self::Triple { .. } => 3,
+        }
+    }
+}
+
+// A TOTAL, dataset-independent order over `TermValue` — the canonical order in which
+// `PagedDataset::compact` re-interns the live terms, so the renumbered
+// `GlobalTermId` assignment is a pure function of the live term-VALUE set (never of
+// ingest order, page order, or the old numbering). Cross-kind order follows
+// [`canonical_tag`](TermValue::canonical_tag) (the serializer's IRI < Literal < Blank
+// < Triple); within a kind the components compare in the same (datatype, language,
+// lexical) precedence the renderer's `ObjKey` uses, with `direction` as a final
+// tiebreak so two literals differing ONLY in base direction (distinct values) still
+// order deterministically.
+impl Ord for TermValue {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.canonical_tag()
+            .cmp(&other.canonical_tag())
+            .then_with(|| match (self, other) {
+                (Self::Iri(a), Self::Iri(b)) => a.cmp(b),
+                (
+                    Self::Literal {
+                        lexical_form: la,
+                        datatype: da,
+                        language: ga,
+                        direction: dira,
+                    },
+                    Self::Literal {
+                        lexical_form: lb,
+                        datatype: db,
+                        language: gb,
+                        direction: dirb,
+                    },
+                ) => da
+                    .cmp(db)
+                    .then_with(|| ga.cmp(gb))
+                    .then_with(|| la.cmp(lb))
+                    .then_with(|| dira.cmp(dirb)),
+                (
+                    Self::Blank {
+                        label: la,
+                        scope: sa,
+                    },
+                    Self::Blank {
+                        label: lb,
+                        scope: sb,
+                    },
+                ) => la.cmp(lb).then_with(|| sa.cmp(sb)),
+                (
+                    Self::Triple {
+                        s: sa,
+                        p: pa,
+                        o: oa,
+                    },
+                    Self::Triple {
+                        s: sb,
+                        p: pb,
+                        o: ob,
+                    },
+                ) => sa.cmp(sb).then_with(|| pa.cmp(pb)).then_with(|| oa.cmp(ob)),
+                // Equal tags guarantee the same variant, so every reachable pair is
+                // matched above; a mixed-variant pair is unreachable here.
+                _ => core::cmp::Ordering::Equal,
+            })
+    }
+}
+
+impl PartialOrd for TermValue {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 // `Hash` is hand-written (not derived) with **explicit** discriminant tags so it is

--- a/crates/rdf-core/src/lib.rs
+++ b/crates/rdf-core/src/lib.rs
@@ -96,7 +96,7 @@ pub use bundle::{
 pub use collections::RdfListError;
 pub use content_id::{Blake3ContentId, ContentIdScheme};
 pub use content_store::{Bytes, ContentDigest, ContentStore, ContentStoreError};
-pub use dataset_view::{DatasetMut, DatasetView, GraphMatch, GraphMatchValue};
+pub use dataset_view::{DatasetMut, DatasetView, GraphMatch, GraphMatchValue, ViewTermId};
 pub use describe::{Describer, describe};
 pub use diagnostic::{RdfDiagnostic, RdfLocation, RdfLoss, RdfSeverity};
 pub use fno::{

--- a/crates/rdf-core/src/lib.rs
+++ b/crates/rdf-core/src/lib.rs
@@ -105,11 +105,12 @@ pub use fno::{
 };
 pub use hash::{FastHasher, FastMap, FastSet, IdSet};
 pub use ir::{
-    BlankScope, CanonHash, Canonicalized, DatasetDiff, DatasetSink, FrozenDatasetSource, GtsBundle,
-    HandleEntry, HandleKey, MutableDataset, PipelineBundle, PipelineBundleError, QuadHandle,
-    QuadIds, QuadPatternCursor, QuadProbePlan, QuadRef, QuadValues, RdfDataset, RdfDatasetBuilder,
-    RdfDatasetVisitor, RdfEnvelope, TermId, TermRef, TermValue, ValidatedRdfDatasetBuilder,
-    canonicalize, canonicalize_with, dataset_diff, datasets_isomorphic,
+    BlankScope, CanonHash, Canonicalized, DatasetDiff, DatasetSink, FrozenDatasetSource,
+    GlobalDictionary, GlobalTermId, GtsBundle, HandleEntry, HandleKey, MutableDataset,
+    PipelineBundle, PipelineBundleError, QuadHandle, QuadIds, QuadPatternCursor, QuadProbePlan,
+    QuadRef, QuadValues, RdfDataset, RdfDatasetBuilder, RdfDatasetVisitor, RdfEnvelope, TermId,
+    TermRef, TermValue, ValidatedRdfDatasetBuilder, canonicalize, canonicalize_with, dataset_diff,
+    datasets_isomorphic,
 };
 pub use lookaside::{
     RdfBlobOrigin, RdfBlobRecord, RdfLookaside, RdfLookasideKind, RdfLookasideResource,

--- a/crates/rdf-core/src/lib.rs
+++ b/crates/rdf-core/src/lib.rs
@@ -107,12 +107,12 @@ pub use hash::{FastHasher, FastMap, FastSet, IdSet};
 pub use ir::{
     BlankScope, CanonHash, Canonicalized, CountingDemandProvider, DatasetDiff, DatasetSink,
     FrozenDatasetSource, GlobalDictionary, GlobalTermId, GtsBundle, HandleEntry, HandleKey,
-    InMemoryPageProvider, MutableDataset, PageFault, PageId, PageProvider, PageTranslation,
-    PagedDataset, PagedFreezeError, PagedQuadOverlap, PagedQuadTable, PipelineBundle,
-    PipelineBundleError, QuadHandle, QuadIds, QuadPatternCursor, QuadProbePlan, QuadRef,
-    QuadValues, RdfDataset, RdfDatasetBuilder, RdfDatasetVisitor, RdfEnvelope, SubsetPageProvider,
-    TermId, TermRef, TermValue, ValidatedRdfDatasetBuilder, canonicalize, canonicalize_with,
-    dataset_diff, datasets_isomorphic,
+    InMemoryPageProvider, MutableDataset, PageFault, PageId, PagePart, PageProvider,
+    PageTranslation, PagedDataset, PagedFreezeError, PagedQuadOverlap, PagedQuadTable,
+    PipelineBundle, PipelineBundleError, QuadHandle, QuadIds, QuadPatternCursor, QuadProbePlan,
+    QuadRef, QuadValues, RdfDataset, RdfDatasetBuilder, RdfDatasetVisitor, RdfEnvelope,
+    SubsetPageProvider, TermId, TermRef, TermValue, ValidatedRdfDatasetBuilder, canonicalize,
+    canonicalize_with, dataset_diff, datasets_isomorphic,
 };
 pub use lookaside::{
     RdfBlobOrigin, RdfBlobRecord, RdfLookaside, RdfLookasideKind, RdfLookasideResource,

--- a/crates/rdf-core/src/lib.rs
+++ b/crates/rdf-core/src/lib.rs
@@ -108,11 +108,11 @@ pub use ir::{
     BlankScope, CanonHash, Canonicalized, CountingDemandProvider, DatasetDiff, DatasetSink,
     FrozenDatasetSource, GlobalDictionary, GlobalTermId, GtsBundle, HandleEntry, HandleKey,
     InMemoryPageProvider, MutableDataset, PageFault, PageId, PageProvider, PageTranslation,
-    PagedDataset, PagedFreezeError, PagedQuadOverlap, PipelineBundle, PipelineBundleError,
-    QuadHandle, QuadIds, QuadPatternCursor, QuadProbePlan, QuadRef, QuadValues, RdfDataset,
-    RdfDatasetBuilder, RdfDatasetVisitor, RdfEnvelope, SubsetPageProvider, TermId, TermRef,
-    TermValue, ValidatedRdfDatasetBuilder, canonicalize, canonicalize_with, dataset_diff,
-    datasets_isomorphic,
+    PagedDataset, PagedFreezeError, PagedQuadOverlap, PagedQuadTable, PipelineBundle,
+    PipelineBundleError, QuadHandle, QuadIds, QuadPatternCursor, QuadProbePlan, QuadRef,
+    QuadValues, RdfDataset, RdfDatasetBuilder, RdfDatasetVisitor, RdfEnvelope, SubsetPageProvider,
+    TermId, TermRef, TermValue, ValidatedRdfDatasetBuilder, canonicalize, canonicalize_with,
+    dataset_diff, datasets_isomorphic,
 };
 pub use lookaside::{
     RdfBlobOrigin, RdfBlobRecord, RdfLookaside, RdfLookasideKind, RdfLookasideResource,

--- a/crates/rdf-core/src/lib.rs
+++ b/crates/rdf-core/src/lib.rs
@@ -105,12 +105,13 @@ pub use fno::{
 };
 pub use hash::{FastHasher, FastMap, FastSet, IdSet};
 pub use ir::{
-    BlankScope, CanonHash, Canonicalized, DatasetDiff, DatasetSink, FrozenDatasetSource,
-    GlobalDictionary, GlobalTermId, GtsBundle, HandleEntry, HandleKey, MutableDataset,
-    PipelineBundle, PipelineBundleError, QuadHandle, QuadIds, QuadPatternCursor, QuadProbePlan,
-    QuadRef, QuadValues, RdfDataset, RdfDatasetBuilder, RdfDatasetVisitor, RdfEnvelope, TermId,
-    TermRef, TermValue, ValidatedRdfDatasetBuilder, canonicalize, canonicalize_with, dataset_diff,
-    datasets_isomorphic,
+    BlankScope, CanonHash, Canonicalized, CountingDemandProvider, DatasetDiff, DatasetSink,
+    FrozenDatasetSource, GlobalDictionary, GlobalTermId, GtsBundle, HandleEntry, HandleKey,
+    InMemoryPageProvider, MutableDataset, PageFault, PageId, PageProvider, PageTranslation,
+    PagedDataset, PipelineBundle, PipelineBundleError, QuadHandle, QuadIds, QuadPatternCursor,
+    QuadProbePlan, QuadRef, QuadValues, RdfDataset, RdfDatasetBuilder, RdfDatasetVisitor,
+    RdfEnvelope, TermId, TermRef, TermValue, ValidatedRdfDatasetBuilder, canonicalize,
+    canonicalize_with, dataset_diff, datasets_isomorphic,
 };
 pub use lookaside::{
     RdfBlobOrigin, RdfBlobRecord, RdfLookaside, RdfLookasideKind, RdfLookasideResource,

--- a/crates/rdf-core/src/lib.rs
+++ b/crates/rdf-core/src/lib.rs
@@ -108,10 +108,11 @@ pub use ir::{
     BlankScope, CanonHash, Canonicalized, CountingDemandProvider, DatasetDiff, DatasetSink,
     FrozenDatasetSource, GlobalDictionary, GlobalTermId, GtsBundle, HandleEntry, HandleKey,
     InMemoryPageProvider, MutableDataset, PageFault, PageId, PageProvider, PageTranslation,
-    PagedDataset, PipelineBundle, PipelineBundleError, QuadHandle, QuadIds, QuadPatternCursor,
-    QuadProbePlan, QuadRef, QuadValues, RdfDataset, RdfDatasetBuilder, RdfDatasetVisitor,
-    RdfEnvelope, TermId, TermRef, TermValue, ValidatedRdfDatasetBuilder, canonicalize,
-    canonicalize_with, dataset_diff, datasets_isomorphic,
+    PagedDataset, PagedFreezeError, PagedQuadOverlap, PipelineBundle, PipelineBundleError,
+    QuadHandle, QuadIds, QuadPatternCursor, QuadProbePlan, QuadRef, QuadValues, RdfDataset,
+    RdfDatasetBuilder, RdfDatasetVisitor, RdfEnvelope, SubsetPageProvider, TermId, TermRef,
+    TermValue, ValidatedRdfDatasetBuilder, canonicalize, canonicalize_with, dataset_diff,
+    datasets_isomorphic,
 };
 pub use lookaside::{
     RdfBlobOrigin, RdfBlobRecord, RdfLookaside, RdfLookasideKind, RdfLookasideResource,

--- a/crates/rdf-core/src/model.rs
+++ b/crates/rdf-core/src/model.rs
@@ -17,7 +17,7 @@ pub enum RdfTermKind {
 }
 
 /// RDF 1.2 base direction for directional language-tagged literals.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum RdfTextDirection {
     /// Left-to-right base direction (`ltr`).
     Ltr,

--- a/crates/rdf-core/src/store.rs
+++ b/crates/rdf-core/src/store.rs
@@ -36,6 +36,23 @@ impl RdfStoreCapabilities {
             lookaside: false,
         }
     }
+
+    /// The field-wise logical OR of two capability sets: a flag is on in the result
+    /// iff it is on in EITHER input. A composite view over several backing stores
+    /// (e.g. a paged dataset folding many pages) reports a capability if any page
+    /// surfaces it, so the union is the honest aggregate capability.
+    #[must_use]
+    pub const fn union(self, other: Self) -> Self {
+        Self {
+            named_graphs: self.named_graphs || other.named_graphs,
+            quoted_triples: self.quoted_triples || other.quoted_triples,
+            reifiers: self.reifiers || other.reifiers,
+            annotations: self.annotations || other.annotations,
+            source_locations: self.source_locations || other.source_locations,
+            loss_records: self.loss_records || other.loss_records,
+            lookaside: self.lookaside || other.lookaside,
+        }
+    }
 }
 
 impl Default for RdfStoreCapabilities {

--- a/crates/rdf-core/tests/paged_backend.rs
+++ b/crates/rdf-core/tests/paged_backend.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 
 use purrdf_core::{
     CountingDemandProvider, DatasetView, GraphMatch, InMemoryPageProvider, PageId, PagedDataset,
-    PagedFreezeError, RdfDataset, RdfDatasetBuilder, RdfLiteral, TermId, TermRef, TermValue,
-    render_canonical_turtle,
+    PagedFreezeError, PagedQuadTable, RdfDataset, RdfDatasetBuilder, RdfLiteral, TermId, TermRef,
+    TermValue, render_canonical_turtle,
 };
 
 // The standard RDF Collection vocabulary (crate-internal constants are not public;
@@ -486,6 +486,7 @@ fn freeze_refuses_non_quad_disjoint_pages() {
         PagedFreezeError::QuadOverlap(o) => {
             assert_eq!(o.first_page, PageId(0), "the earlier page is named");
             assert_eq!(o.second_page, PageId(1), "the later page is named");
+            assert_eq!(o.table, PagedQuadTable::Primary, "a base-quad overlap");
             assert_eq!(o.subject, iri("s"));
             assert_eq!(o.predicate, iri("p"));
             assert_eq!(o.object, iri("o"));
@@ -503,6 +504,93 @@ fn freeze_refuses_non_quad_disjoint_pages() {
     let paged = PagedDataset::from_provider(ok_provider).expect("disjoint pages seal");
     assert_eq!(paged.page_count(), 2);
     assert_eq!(paged.quads().count(), 2, "both disjoint quads survive");
+}
+
+#[test]
+fn freeze_refuses_non_disjoint_side_tables() {
+    // The reifier and annotation side tables are composed across pages the SAME way as
+    // primary quads — concatenated with no cross-page dedup — so the seal must enforce
+    // disjointness on them too, not just the primary quads. Both pages below carry
+    // DISJOINT primary quads (so the primary ledger stays clean) but a DUPLICATE
+    // side-table entry, which must be refused and attributed to the right stream.
+
+    // (1) Annotation overlap: the shared `(r, confidence, high)` annotation appears on
+    // both pages; the composed annotation stream would emit it twice.
+    let anno_page = |s: &str, o: &str| {
+        let mut b = RdfDatasetBuilder::new();
+        let subj = b.intern_iri(&format!("http://example.org/{s}"));
+        let p = b.intern_iri("http://example.org/p");
+        let obj = b.intern_iri(&format!("http://example.org/{o}"));
+        b.push_quad(subj, p, obj, None); // a page-unique primary quad
+        let r = b.intern_iri("http://example.org/r");
+        let conf = b.intern_iri("http://example.org/confidence");
+        let high = b.intern_iri("http://example.org/high");
+        b.push_annotation(r, conf, high); // the SHARED annotation
+        b.freeze().expect("annotation page")
+    };
+    let provider = Arc::new(InMemoryPageProvider::new(vec![
+        anno_page("s0", "o0"),
+        anno_page("s1", "o1"),
+    ]));
+    match PagedDataset::from_provider(provider)
+        .expect_err("duplicate annotation across pages must refuse")
+    {
+        PagedFreezeError::QuadOverlap(o) => {
+            assert_eq!(
+                o.table,
+                PagedQuadTable::Annotation,
+                "annotation-table overlap"
+            );
+            assert_eq!(o.first_page, PageId(0));
+            assert_eq!(o.second_page, PageId(1));
+            assert_eq!(o.subject, iri("r"));
+            assert_eq!(o.predicate, iri("confidence"));
+            assert_eq!(o.object, iri("high"));
+        }
+        PagedFreezeError::Page(fault) => panic!("expected QuadOverlap, got page fault: {fault}"),
+    }
+
+    // (2) Reifier overlap: the shared reifier binding `r rdf:reifies <<(a b c)>>` (over
+    // an unasserted triple term) appears on both pages; the composed reifier stream
+    // would emit it twice.
+    let reifier_page = |s: &str, o: &str| {
+        let mut b = RdfDatasetBuilder::new();
+        let subj = b.intern_iri(&format!("http://example.org/{s}"));
+        let p = b.intern_iri("http://example.org/p");
+        let obj = b.intern_iri(&format!("http://example.org/{o}"));
+        b.push_quad(subj, p, obj, None); // a page-unique primary quad
+        let a = b.intern_iri("http://example.org/a");
+        let bb = b.intern_iri("http://example.org/b");
+        let c = b.intern_iri("http://example.org/c");
+        let triple = b.intern_triple(a, bb, c);
+        let r = b.intern_iri("http://example.org/r");
+        b.push_reifier(r, triple); // the SHARED reifier binding
+        b.freeze().expect("reifier page")
+    };
+    let provider = Arc::new(InMemoryPageProvider::new(vec![
+        reifier_page("s0", "o0"),
+        reifier_page("s1", "o1"),
+    ]));
+    match PagedDataset::from_provider(provider)
+        .expect_err("duplicate reifier binding across pages must refuse")
+    {
+        PagedFreezeError::QuadOverlap(o) => {
+            assert_eq!(o.table, PagedQuadTable::Reifier, "reifier-table overlap");
+            assert_eq!(o.first_page, PageId(0));
+            assert_eq!(o.second_page, PageId(1));
+            assert_eq!(o.subject, iri("r"));
+            assert_eq!(
+                o.object,
+                TermValue::Triple {
+                    s: Box::new(iri("a")),
+                    p: Box::new(iri("b")),
+                    o: Box::new(iri("c")),
+                },
+                "the reified triple term is the shared object"
+            );
+        }
+        PagedFreezeError::Page(fault) => panic!("expected QuadOverlap, got page fault: {fault}"),
+    }
 }
 
 // ── Compaction: dead-id reclaim + determinism ──────────────────────────────────

--- a/crates/rdf-core/tests/paged_backend.rs
+++ b/crates/rdf-core/tests/paged_backend.rs
@@ -20,7 +20,8 @@ use std::sync::Arc;
 
 use purrdf_core::{
     CountingDemandProvider, DatasetView, GraphMatch, InMemoryPageProvider, PageId, PagedDataset,
-    RdfDataset, RdfDatasetBuilder, RdfLiteral, TermId, TermRef, TermValue,
+    PagedFreezeError, RdfDataset, RdfDatasetBuilder, RdfLiteral, TermId, TermRef, TermValue,
+    render_canonical_turtle,
 };
 
 // The standard RDF Collection vocabulary (crate-internal constants are not public;
@@ -467,6 +468,179 @@ fn reifier_and_annotation_views_compose_across_pages() {
     );
     // `annotation_quads` sees the same two annotations as virtual quads.
     assert_eq!(paged.annotation_quads().count(), 2);
+}
+
+// ── Freeze / disjointness refusal (G3) ─────────────────────────────────────────
+
+#[test]
+fn freeze_refuses_non_quad_disjoint_pages() {
+    // Two pages that carry the SAME triple via the SAME term values → after mapping
+    // to the shared GlobalTermId space they are the SAME global quad, so the seal MUST
+    // refuse (never silently dedup).
+    let shared = (iri("s"), iri("p"), iri("o"));
+    let page0 = build_page(std::slice::from_ref(&shared));
+    let page1 = build_page(std::slice::from_ref(&shared));
+    let provider = Arc::new(InMemoryPageProvider::new(vec![page0, page1]));
+    let err = PagedDataset::from_provider(provider).expect_err("overlapping pages must refuse");
+    match err {
+        PagedFreezeError::QuadOverlap(o) => {
+            assert_eq!(o.first_page, PageId(0), "the earlier page is named");
+            assert_eq!(o.second_page, PageId(1), "the later page is named");
+            assert_eq!(o.subject, iri("s"));
+            assert_eq!(o.predicate, iri("p"));
+            assert_eq!(o.object, iri("o"));
+            assert_eq!(o.graph, None, "default-graph quad");
+        }
+        PagedFreezeError::Page(fault) => panic!("expected QuadOverlap, got page fault: {fault}"),
+    }
+
+    // The disjoint construction (distinct global quads) is the normal path and Oks.
+    let ok_pages = vec![
+        build_page(&[(iri("s"), iri("p"), iri("o"))]),
+        build_page(&[(iri("s2"), iri("p"), iri("o"))]),
+    ];
+    let ok_provider = Arc::new(InMemoryPageProvider::new(ok_pages));
+    let paged = PagedDataset::from_provider(ok_provider).expect("disjoint pages seal");
+    assert_eq!(paged.page_count(), 2);
+    assert_eq!(paged.quads().count(), 2, "both disjoint quads survive");
+}
+
+// ── Compaction: dead-id reclaim + determinism ──────────────────────────────────
+
+/// A three-page corpus where page 2's terms (`dave`, `likes`, `eve`) are UNIQUE to it,
+/// so dropping page 2 makes exactly those three ids dead.
+fn reclaim_pages() -> Vec<Arc<RdfDataset>> {
+    vec![
+        build_page(&[(iri("alice"), iri("knows"), iri("bob"))]),
+        build_page(&[(iri("bob"), iri("knows"), iri("carol"))]),
+        build_page(&[(iri("dave"), iri("likes"), iri("eve"))]),
+    ]
+}
+
+#[test]
+fn compact_reclaims_dead_ids_deterministically() {
+    let provider = Arc::new(InMemoryPageProvider::new(reclaim_pages()));
+    let full = PagedDataset::from_provider(provider).expect("seal pages");
+
+    // Seven distinct IRIs across the three pages.
+    let full_len = full.dictionary().len();
+    assert_eq!(full_len, 7, "alice knows bob carol dave likes eve");
+
+    // Evict page 2. Its three unique terms are now DEAD but the dictionary still
+    // carries them (len unchanged) — reclaim only happens at compaction.
+    let dropped = full.drop_page(PageId(2));
+    assert_eq!(dropped.page_count(), 2);
+    assert_eq!(
+        dropped.dictionary().len(),
+        full_len,
+        "dropping a page does NOT reclaim ids"
+    );
+    // The dead terms are still resolvable by value in the oversized dictionary.
+    for dead in [iri("dave"), iri("likes"), iri("eve")] {
+        assert!(
+            dropped.term_id_by_value(&dead).is_some(),
+            "dead term {dead:?} is retained before compaction"
+        );
+    }
+
+    // Compact: the three dead ids are reclaimed, so len shrinks by EXACTLY three.
+    let compacted = dropped.compact();
+    assert_eq!(
+        compacted.dictionary().len(),
+        full_len - 3,
+        "compaction reclaims exactly the 3 terms unique to the dropped page"
+    );
+    for reclaimed in [iri("dave"), iri("likes"), iri("eve")] {
+        assert!(
+            compacted.term_id_by_value(&reclaimed).is_none(),
+            "reclaimed term {reclaimed:?} is gone after compaction"
+        );
+    }
+
+    // Meaning is preserved: every surviving quad resolves to identical TermValues.
+    assert_eq!(
+        collect_rows(&compacted),
+        vec![
+            vec![
+                iri("alice"),
+                iri("knows"),
+                iri("bob"),
+                TermValue::iri("urn:default-graph")
+            ],
+            vec![
+                iri("bob"),
+                iri("knows"),
+                iri("carol"),
+                TermValue::iri("urn:default-graph")
+            ],
+        ],
+        "compaction preserves the surviving quads by value"
+    );
+
+    // Determinism: compacting the SAME live set twice assigns IDENTICAL GlobalTermIds
+    // to every survivor (a pure function of the live term-value set). Compare the id
+    // of every live value under two independent compactions.
+    let compacted_again = dropped.compact();
+    assert_eq!(
+        compacted.dictionary().len(),
+        compacted_again.dictionary().len()
+    );
+    for value in [iri("alice"), iri("knows"), iri("bob"), iri("carol")] {
+        assert_eq!(
+            compacted.term_id_by_value(&value),
+            compacted_again.term_id_by_value(&value),
+            "value {value:?} must get the same GlobalTermId across compactions"
+        );
+    }
+    // And the whole id→value mapping is identical index-for-index.
+    for i in 0..compacted.dictionary().len() {
+        let id = purrdf_core::GlobalTermId::from_index(u64::try_from(i).expect("fits u64"));
+        assert_eq!(
+            to_value(&compacted, id),
+            to_value(&compacted_again, id),
+            "id {i} resolves to the same value across compactions"
+        );
+    }
+}
+
+// ── Serialization equivalence (determinism vs a single dataset) ─────────────────
+
+/// Materialize a paged dataset's quads (by value) into a fresh single `RdfDataset`.
+fn materialize_to_dataset(paged: &PagedDataset) -> Arc<RdfDataset> {
+    let mut b = RdfDatasetBuilder::new();
+    for q in paged.quads() {
+        let s = intern_value(&mut b, &to_value(paged, q.s));
+        let p = intern_value(&mut b, &to_value(paged, q.p));
+        let o = intern_value(&mut b, &to_value(paged, q.o));
+        let g = q.g.map(|g| intern_value(&mut b, &to_value(paged, g)));
+        b.push_quad(s, p, o, g);
+    }
+    b.freeze().expect("materialized freeze")
+}
+
+#[test]
+fn compacted_paged_serializes_byte_identical_to_single() {
+    let corpus = parity_corpus();
+
+    // The single-dataset reference and its canonical Turtle.
+    let single = build_page(&corpus);
+    let single_ttl = render_canonical_turtle(&single, &[]);
+
+    // The paged view over the SAME triples, split across 3 pages, then COMPACTED
+    // (a canonical renumber). Materialize its quads back into one RdfDataset and
+    // serialize — the honest determinism check (there is no standalone paged
+    // serializer; proving the materialized-equivalent is byte-identical is the point).
+    let pages = split_pages(&corpus, 3);
+    let provider = Arc::new(InMemoryPageProvider::new(pages));
+    let paged = PagedDataset::from_provider(provider).expect("seal pages");
+    let compacted = paged.compact();
+    let materialized = materialize_to_dataset(&compacted);
+    let paged_ttl = render_canonical_turtle(&materialized, &[]);
+
+    assert_eq!(
+        single_ttl, paged_ttl,
+        "compacted-then-materialized paged dataset must serialize byte-identically"
+    );
 }
 
 /// The paged dataset and its provider must be thread-shareable.

--- a/crates/rdf-core/tests/paged_backend.rs
+++ b/crates/rdf-core/tests/paged_backend.rs
@@ -1,0 +1,480 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Falsifiable tests for the reference demand-paged dataset (`PagedDataset`): the
+//! id-agnostic `DatasetView` read path over many frozen `RdfDataset` pages composed
+//! through the shared `GlobalTermId` space.
+//!
+//! Three guards:
+//! 1. **Cross-page parity** — the trait surface over a multi-page `PagedDataset`
+//!    yields exactly the rows of a single `RdfDataset` of the same triples (whole-
+//!    dataset scan, a two-pattern join whose `?x` unifies across a page boundary, and
+//!    `DatasetView::members` walking an `rdf:List` whose cons cells straddle pages).
+//! 2. **Lazy hook fires on demand** — a `CountingDemandProvider` shows the seal pass
+//!    pulling each page once, value lookups pulling nothing, and a bound-id query
+//!    re-materializing exactly the one page that can match (cached by the `OnceLock`).
+//! 3. **Cross-page cost model (F1)** — `cardinality_estimate` on a skewed page
+//!    distribution equals the independently-computed per-page sum.
+
+use std::sync::Arc;
+
+use purrdf_core::{
+    CountingDemandProvider, DatasetView, GraphMatch, InMemoryPageProvider, PageId, PagedDataset,
+    RdfDataset, RdfDatasetBuilder, RdfLiteral, TermId, TermRef, TermValue,
+};
+
+// The standard RDF Collection vocabulary (crate-internal constants are not public;
+// these are the well-known IRIs).
+const RDF_FIRST: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#first";
+const RDF_REST: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest";
+const RDF_NIL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
+
+/// An `example.org` IRI value.
+fn iri(name: &str) -> TermValue {
+    TermValue::iri(format!("http://example.org/{name}"))
+}
+
+/// Intern one dataset-independent value into a builder, recursing for triple terms
+/// (this is the by-value inverse the fixtures need).
+fn intern_value(b: &mut RdfDatasetBuilder, v: &TermValue) -> TermId {
+    match v {
+        TermValue::Iri(s) => b.intern_iri(s),
+        TermValue::Blank { label, scope } => b.intern_blank(label, *scope),
+        TermValue::Literal {
+            lexical_form,
+            datatype,
+            language,
+            direction,
+        } => b.intern_literal(RdfLiteral {
+            lexical_form: lexical_form.clone(),
+            datatype: Some(datatype.clone()),
+            language: language.clone(),
+            direction: *direction,
+        }),
+        TermValue::Triple { s, p, o } => {
+            let s = intern_value(b, s);
+            let p = intern_value(b, p);
+            let o = intern_value(b, o);
+            b.intern_triple(s, p, o)
+        }
+    }
+}
+
+type Triple = (TermValue, TermValue, TermValue);
+
+/// Freeze one page from a list of `(s, p, o)` triples in the default graph.
+fn build_page(triples: &[Triple]) -> Arc<RdfDataset> {
+    let mut b = RdfDatasetBuilder::new();
+    for (s, p, o) in triples {
+        let s = intern_value(&mut b, s);
+        let p = intern_value(&mut b, p);
+        let o = intern_value(&mut b, o);
+        b.push_quad(s, p, o, None);
+    }
+    b.freeze().expect("page freeze")
+}
+
+/// Resolve a view id to its dataset-INDEPENDENT `TermValue`, recursing through the
+/// literal datatype and triple components. Generic over any `DatasetView`, so the
+/// same routine reads a single `RdfDataset` and a multi-page `PagedDataset` and lets
+/// their rows be compared by value.
+fn to_value<V: DatasetView>(v: &V, id: V::Id) -> TermValue {
+    match v.resolve(id) {
+        TermRef::Iri(s) => TermValue::iri(s),
+        TermRef::Blank { label, scope } => TermValue::Blank {
+            label: label.to_owned(),
+            scope,
+        },
+        TermRef::Literal {
+            lexical,
+            datatype,
+            language,
+            direction,
+        } => {
+            let datatype = match v.resolve(datatype) {
+                TermRef::Iri(s) => s.to_owned(),
+                _ => panic!("literal datatype must resolve to an IRI"),
+            };
+            TermValue::Literal {
+                lexical_form: lexical.to_owned(),
+                datatype,
+                language: language.map(str::to_owned),
+                direction,
+            }
+        }
+        TermRef::Triple { s, p, o } => TermValue::Triple {
+            s: Box::new(to_value(v, s)),
+            p: Box::new(to_value(v, p)),
+            o: Box::new(to_value(v, o)),
+        },
+    }
+}
+
+/// A deterministic sort key for a value row (`TermValue` is not `Ord`; its `Debug`
+/// form is total and dataset-independent).
+fn row_key(row: &[TermValue]) -> String {
+    format!("{row:?}")
+}
+
+/// Collect every quad of the view as sorted `[s, p, o, g?]` value rows, via the
+/// generic trait surface only. `g` is rendered as an extra element (a sentinel for
+/// the default graph) so named-graph quads stay distinguishable.
+fn collect_rows<V: DatasetView>(v: &V) -> Vec<Vec<TermValue>> {
+    let mut rows: Vec<Vec<TermValue>> = v
+        .quads_for_pattern(None, None, None, GraphMatch::Any)
+        .map(|q| {
+            let mut row = vec![to_value(v, q.s), to_value(v, q.p), to_value(v, q.o)];
+            row.push(q.g.map_or_else(|| TermValue::iri("urn:default-graph"), |g| to_value(v, g)));
+            row
+        })
+        .collect();
+    rows.sort_by_key(|r| row_key(r));
+    rows
+}
+
+/// A generic two-pattern join `(a_s a_p ?x)(?x b_p ?y)` returning the sorted
+/// `(?x, ?y)` value pairs. `?x` is threaded as a NATIVE view id from the first
+/// pattern into the second — the id-space unification a `PagedDataset` must provide
+/// across a page boundary.
+fn join_rows<V: DatasetView>(
+    v: &V,
+    a_s: &TermValue,
+    a_p: &TermValue,
+    b_p: &TermValue,
+) -> Vec<(TermValue, TermValue)> {
+    let a_s_id = v.term_id_by_value(a_s);
+    let a_p_id = v.term_id_by_value(a_p);
+    let b_p_id = v.term_id_by_value(b_p);
+    let mut out: Vec<(TermValue, TermValue)> = Vec::new();
+    for q1 in v.quads_for_pattern(a_s_id, a_p_id, None, GraphMatch::Any) {
+        let x = q1.o;
+        for q2 in v.quads_for_pattern(Some(x), b_p_id, None, GraphMatch::Any) {
+            out.push((to_value(v, x), to_value(v, q2.o)));
+        }
+    }
+    out.sort_by_key(|(x, y)| format!("{x:?}{y:?}"));
+    out
+}
+
+/// Generic list walk: resolve `head` by value, then `DatasetView::members`, mapping
+/// each member id back to its value.
+fn walk_members<V: DatasetView>(v: &V, head: &TermValue) -> Vec<TermValue> {
+    let head_id = v.term_id_by_value(head).expect("head interned");
+    v.members(head_id, GraphMatch::Any)
+        .expect("well-formed list")
+        .into_iter()
+        .map(|id| to_value(v, id))
+        .collect()
+}
+
+/// The full triple corpus used by the parity test. Cons cells `c1 -> c2 -> c3 -> nil`
+/// form an `rdf:List`; the `knows` edges form the join chain.
+fn parity_corpus() -> Vec<Triple> {
+    vec![
+        // A join chain: alice knows bob; bob knows carol (unifies on ?x = bob).
+        (iri("alice"), iri("knows"), iri("bob")),
+        (iri("bob"), iri("knows"), iri("carol")),
+        // A typed literal object, to exercise datatype interning across pages.
+        (
+            iri("alice"),
+            iri("age"),
+            TermValue::typed_literal("42", "http://www.w3.org/2001/XMLSchema#integer"),
+        ),
+        // An rdf:List (item1, item2, item3) whose cons cells straddle pages.
+        (iri("c1"), TermValue::iri(RDF_FIRST), iri("item1")),
+        (iri("c1"), TermValue::iri(RDF_REST), iri("c2")),
+        (iri("c2"), TermValue::iri(RDF_FIRST), iri("item2")),
+        (iri("c2"), TermValue::iri(RDF_REST), iri("c3")),
+        (iri("c3"), TermValue::iri(RDF_FIRST), iri("item3")),
+        (iri("c3"), TermValue::iri(RDF_REST), TermValue::iri(RDF_NIL)),
+    ]
+}
+
+/// Split a corpus round-robin across `page_count` quad-disjoint pages.
+fn split_pages(triples: &[Triple], page_count: usize) -> Vec<Arc<RdfDataset>> {
+    let mut buckets: Vec<Vec<Triple>> = vec![Vec::new(); page_count];
+    for (i, t) in triples.iter().enumerate() {
+        buckets[i % page_count].push(t.clone());
+    }
+    buckets.iter().map(|b| build_page(b)).collect()
+}
+
+#[test]
+fn cross_page_parity_via_trait_surface() {
+    let corpus = parity_corpus();
+
+    // The single-dataset reference.
+    let single = build_page(&corpus);
+
+    // The multi-page paged view over the SAME triples, split across 3 pages so the
+    // join chain and the list cons cells straddle page boundaries.
+    let pages = split_pages(&corpus, 3);
+    let provider = Arc::new(InMemoryPageProvider::new(pages));
+    let paged = PagedDataset::from_provider(provider).expect("seal pages");
+
+    assert_eq!(paged.page_count(), 3);
+
+    // (1) Whole-dataset scan parity.
+    assert_eq!(
+        collect_rows(&*single),
+        collect_rows(&paged),
+        "multi-page scan must equal the single-dataset scan"
+    );
+
+    // (2) Two-pattern join parity: ?x unifies bob across pages.
+    let single_join = join_rows(&*single, &iri("alice"), &iri("knows"), &iri("knows"));
+    let paged_join = join_rows(&paged, &iri("alice"), &iri("knows"), &iri("knows"));
+    assert_eq!(
+        single_join,
+        vec![(iri("bob"), iri("carol"))],
+        "join must find alice->bob->carol"
+    );
+    assert_eq!(single_join, paged_join, "join parity across pages");
+
+    // (3) rdf:List membership parity with cons cells on different pages.
+    let single_members = walk_members(&*single, &iri("c1"));
+    let paged_members = walk_members(&paged, &iri("c1"));
+    assert_eq!(
+        single_members,
+        vec![iri("item1"), iri("item2"), iri("item3")],
+        "list members in order"
+    );
+    assert_eq!(single_members, paged_members, "member parity across pages");
+}
+
+/// Page 0: `o_shared` interned FIRST (local index 0). `s0` present only here.
+fn lazy_page0() -> Arc<RdfDataset> {
+    let mut b = RdfDatasetBuilder::new();
+    let o = b.intern_iri("http://example.org/o_shared");
+    let s = b.intern_iri("http://example.org/s0");
+    let p = b.intern_iri("http://example.org/p");
+    b.push_quad(s, p, o, None);
+    b.freeze().expect("page0")
+}
+
+/// Page 1: `o_shared` interned LAST (local index 2). `s1` present only here — so its
+/// distinct local index vs page 0 proves the id spaces are independent.
+fn lazy_page1() -> Arc<RdfDataset> {
+    let mut b = RdfDatasetBuilder::new();
+    let s = b.intern_iri("http://example.org/s1");
+    let p = b.intern_iri("http://example.org/p");
+    let o = b.intern_iri("http://example.org/o_shared");
+    b.push_quad(s, p, o, None);
+    b.freeze().expect("page1")
+}
+
+/// Page 2: `s2` present only here.
+fn lazy_page2() -> Arc<RdfDataset> {
+    let mut b = RdfDatasetBuilder::new();
+    let s = b.intern_iri("http://example.org/s2");
+    let p = b.intern_iri("http://example.org/p");
+    let o = b.intern_iri("http://example.org/o_shared");
+    b.push_quad(s, p, o, None);
+    b.freeze().expect("page2")
+}
+
+#[test]
+fn lazy_hook_fires_on_demand() {
+    let provider = Arc::new(CountingDemandProvider::new(vec![
+        Box::new(lazy_page0),
+        Box::new(lazy_page1),
+        Box::new(lazy_page2),
+    ]));
+    let paged = PagedDataset::from_provider(provider.clone() as Arc<dyn purrdf_core::PageProvider>)
+        .expect("seal pages");
+
+    // The seal pass materializes each page exactly once.
+    let hits_after_construction = provider.hits();
+    assert_eq!(hits_after_construction, 3, "seal pass pulls each page once");
+
+    // A value lookup is answered by the shared dictionary — no page is pulled.
+    let s1 = paged
+        .term_id_by_value(&iri("s1"))
+        .expect("s1 interned at seal");
+    assert_eq!(
+        provider.hits(),
+        hits_after_construction,
+        "term_id_by_value must not materialize a page"
+    );
+
+    // A query bound to a subject present only on page 1 re-materializes exactly that
+    // one page (pages 0 and 2 are skipped before any materialization).
+    let row_count = paged
+        .quads_for_pattern(Some(s1), None, None, GraphMatch::Any)
+        .count();
+    assert_eq!(row_count, 1, "s1 has exactly one quad");
+    assert_eq!(
+        provider.hits(),
+        hits_after_construction + 1,
+        "only page 1 re-materialized"
+    );
+
+    // Re-running the same query hits the OnceLock cache — no further pull.
+    let _ = paged
+        .quads_for_pattern(Some(s1), None, None, GraphMatch::Any)
+        .count();
+    assert_eq!(
+        provider.hits(),
+        hits_after_construction + 1,
+        "cached page is not re-materialized"
+    );
+
+    // The shared object lives on all three pages: ONE GlobalTermId, but DISTINCT
+    // local TermIds via the per-page translations.
+    let o_global = paged
+        .term_id_by_value(&iri("o_shared"))
+        .expect("o_shared interned");
+    let local0 = paged
+        .translation(PageId(0))
+        .expect("page 0")
+        .to_local(o_global)
+        .expect("o_shared on page 0");
+    let local1 = paged
+        .translation(PageId(1))
+        .expect("page 1")
+        .to_local(o_global)
+        .expect("o_shared on page 1");
+    assert_ne!(
+        local0, local1,
+        "same global id maps to distinct local ids on different pages"
+    );
+    assert_eq!(
+        local0,
+        TermId::from_index(0),
+        "o_shared is index 0 on page 0"
+    );
+    assert_eq!(
+        local1,
+        TermId::from_index(2),
+        "o_shared is index 2 on page 1"
+    );
+}
+
+#[test]
+fn cross_page_cost_model_is_per_page_sum() {
+    // A skewed distribution: predicate `dense` is heavy on page 0 and sparse
+    // elsewhere. Every page also carries `dense`, so no page is skipped and the sum
+    // spans all pages.
+    let dense = iri("dense");
+    let page0 = build_page(&[
+        (iri("a0"), dense.clone(), iri("x0")),
+        (iri("a1"), dense.clone(), iri("x1")),
+        (iri("a2"), dense.clone(), iri("x2")),
+        (iri("a3"), dense.clone(), iri("x3")),
+        (iri("a4"), dense.clone(), iri("x4")),
+    ]);
+    let page1 = build_page(&[(iri("b0"), dense.clone(), iri("y0"))]);
+    let page2 = build_page(&[(iri("c0"), dense.clone(), iri("z0"))]);
+
+    let raw_pages = vec![page0, page1, page2];
+    let provider = Arc::new(InMemoryPageProvider::new(raw_pages.clone()));
+    let paged = PagedDataset::from_provider(provider).expect("seal pages");
+
+    let dense_g = paged
+        .term_id_by_value(&dense)
+        .expect("dense predicate interned");
+
+    // The paged estimate for (?, dense, ?, Any).
+    let paged_estimate = paged.cardinality_estimate(None, Some(dense_g), None, GraphMatch::Any);
+
+    // Independently: translate the pattern per page and sum each page's own estimate.
+    let expected: usize = raw_pages
+        .iter()
+        .map(|page| {
+            page.term_id_by_value(&dense).map_or(0, |local_p| {
+                page.cardinality_estimate(None, Some(local_p), None, GraphMatch::Any)
+            })
+        })
+        .sum();
+
+    assert_eq!(
+        paged_estimate, expected,
+        "paged cardinality must equal the per-page sum (Merge-scope summation)"
+    );
+    // Falsifiability: the sum spans multiple pages (not a single-page constant).
+    assert!(expected >= 7, "skewed corpus totals at least 5 + 1 + 1");
+}
+
+#[test]
+fn reifier_and_annotation_views_compose_across_pages() {
+    // Page A: a base triple, its reifier binding `r rdf:reifies <<(s p o)>>`, and one
+    // annotation on `r`. This page surfaces quoted_triples + reifiers + annotations.
+    let page_a = {
+        let mut b = RdfDatasetBuilder::new();
+        let s = b.intern_iri("http://example.org/s");
+        let p = b.intern_iri("http://example.org/p");
+        let o = b.intern_iri("http://example.org/o");
+        b.push_quad(s, p, o, None);
+        let triple = b.intern_triple(s, p, o);
+        let r = b.intern_iri("http://example.org/r");
+        b.push_reifier(r, triple);
+        let conf = b.intern_iri("http://example.org/confidence");
+        let high = b.intern_iri("http://example.org/high");
+        b.push_annotation(r, conf, high);
+        b.freeze().expect("page a")
+    };
+    // Page B: a SECOND annotation on the same reifier resource `r` (by value). The
+    // reifier need not bind a triple here — an annotation only requires an asserted
+    // subject — so this exercises cross-page annotation aggregation.
+    let page_b = {
+        let mut b = RdfDatasetBuilder::new();
+        let r = b.intern_iri("http://example.org/r");
+        let source = b.intern_iri("http://example.org/source");
+        let doc = b.intern_iri("http://example.org/doc");
+        b.push_annotation(r, source, doc);
+        b.freeze().expect("page b")
+    };
+
+    let provider = Arc::new(InMemoryPageProvider::new(vec![page_a, page_b]));
+    let paged = PagedDataset::from_provider(provider).expect("seal pages");
+
+    // Capabilities are the honest OR of the pages, and the reifier/annotation methods
+    // actually surface what those capabilities advertise.
+    let caps = paged.capabilities();
+    assert!(caps.reifiers, "page A has a reifier binding");
+    assert!(caps.annotations, "both pages carry annotations");
+    assert!(caps.quoted_triples, "the reifier binds a triple term");
+
+    // The single reifier binding surfaces as one virtual `rdf:reifies` quad.
+    let reifier_quads: Vec<_> = paged.reifier_quads().collect();
+    assert_eq!(reifier_quads.len(), 1, "exactly one reifier binding");
+    // Its object is the triple term <<(s p o)>>.
+    assert_eq!(
+        to_value(&paged, reifier_quads[0].o),
+        TermValue::Triple {
+            s: Box::new(iri("s")),
+            p: Box::new(iri("p")),
+            o: Box::new(iri("o")),
+        },
+    );
+
+    // Both annotations aggregate across the two pages for the shared reifier `r`.
+    let r_global = paged
+        .term_id_by_value(&iri("r"))
+        .expect("reifier r interned");
+    let mut annos: Vec<(TermValue, TermValue)> = paged
+        .annotations_of_with_graph(r_global)
+        .map(|(p, o, _g)| (to_value(&paged, p), to_value(&paged, o)))
+        .collect();
+    annos.sort_by_key(|(p, o)| format!("{p:?}{o:?}"));
+    assert_eq!(
+        annos,
+        vec![
+            (iri("confidence"), iri("high")),
+            (iri("source"), iri("doc")),
+        ],
+        "annotations from both pages compose for the one reifier"
+    );
+    // `annotation_quads` sees the same two annotations as virtual quads.
+    assert_eq!(paged.annotation_quads().count(), 2);
+}
+
+/// The paged dataset and its provider must be thread-shareable.
+#[test]
+fn paged_dataset_is_send_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<PagedDataset>();
+    assert_send_sync::<Arc<dyn purrdf_core::PageProvider>>();
+    assert_send_sync::<CountingDemandProvider>();
+    assert_send_sync::<InMemoryPageProvider>();
+}

--- a/crates/rdf-core/tests/paged_backend.rs
+++ b/crates/rdf-core/tests/paged_backend.rs
@@ -731,6 +731,55 @@ fn compacted_paged_serializes_byte_identical_to_single() {
     );
 }
 
+// ── from_parts: warm restart without the eager re-scan ──────────────────────────
+
+#[test]
+fn from_parts_reconstitutes_without_materializing_pages() {
+    // Seal a 3-page dataset the EAGER way (from_provider materializes every page once),
+    // then decompose it into its persisted parts.
+    let corpus = parity_corpus();
+    let raw = split_pages(&corpus, 3);
+    let eager = PagedDataset::from_provider(Arc::new(InMemoryPageProvider::new(raw.clone())))
+        .expect("seal pages");
+    let (dictionary, parts) = eager.to_parts();
+    assert_eq!(parts.len(), 3, "one part per page");
+
+    // Rebuild from those parts over a COUNTING provider serving the SAME page contents.
+    // The warm-restart path must materialize NO page at construction — that is the whole
+    // point (an already-indexed store reloads without re-scanning).
+    let p0 = raw[0].clone();
+    let p1 = raw[1].clone();
+    let p2 = raw[2].clone();
+    let counting = Arc::new(CountingDemandProvider::new(vec![
+        Box::new(move || p0.clone()),
+        Box::new(move || p1.clone()),
+        Box::new(move || p2.clone()),
+    ]));
+    let warm = PagedDataset::from_parts(
+        dictionary,
+        counting.clone() as Arc<dyn purrdf_core::PageProvider>,
+        parts,
+    );
+    assert_eq!(
+        counting.hits(),
+        0,
+        "from_parts must not materialize any page (unlike the eager from_provider seal)"
+    );
+    assert_eq!(warm.page_count(), 3);
+
+    // The reconstituted dataset is byte-identical to the eagerly-sealed one, and it
+    // genuinely serves reads — which DO now pull pages lazily through the provider.
+    assert_eq!(
+        collect_rows(&eager),
+        collect_rows(&warm),
+        "from_parts yields the same rows as from_provider"
+    );
+    assert!(
+        counting.hits() > 0,
+        "reads materialize pages lazily after construction"
+    );
+}
+
 /// The paged dataset and its provider must be thread-shareable.
 #[test]
 fn paged_dataset_is_send_sync() {

--- a/crates/sparql-eval/Cargo.toml
+++ b/crates/sparql-eval/Cargo.toml
@@ -129,3 +129,12 @@ harness = false
 # — excluded from `make check`.
 name = "solution_row"
 harness = false
+
+[[bench]]
+# Cross-page BGP evaluation: the same 3-pattern join + FILTER query over
+# a single frozen RdfDataset vs a multi-page PagedDataset whose knows/name/age
+# triples are split across pages, so the join unifies across page boundaries.
+# Report-only, no single-vs-paged speedup assertion; `make bench` lane only —
+# excluded from `make check`.
+name = "paged_cross_page_bgp"
+harness = false

--- a/crates/sparql-eval/benches/paged_cross_page_bgp.rs
+++ b/crates/sparql-eval/benches/paged_cross_page_bgp.rs
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Bench targets are not public API: `criterion_group!` expands to a `pub fn`,
+// which would otherwise trip the workspace `missing_docs` lint.
+#![allow(missing_docs)]
+
+//! Cross-page BGP evaluation latency: the SAME 3-pattern join + `FILTER` query
+//! evaluated (a) over a single frozen [`RdfDataset`] and (b) over a multi-page
+//! [`PagedDataset`] whose `knows`/`name`/`age` triples for any given entity are
+//! deliberately spread across DIFFERENT pages, so the join variable `?x` must be
+//! unified across page boundaries via the external paged backend.
+//!
+//! This gives the new cross-page BGP path (`NativeSparqlEngine::query_prepared_view`
+//! over `PagedDataset`) bench coverage alongside the single-dataset baseline
+//! (`NativeSparqlEngine::query_prepared`) so a reader can compare the two — this bench
+//! draws NO conclusion and asserts NO speedup or absolute timing threshold: the
+//! machine running `cargo bench` is not quiet, and paged evaluation does strictly
+//! more work per pattern (per-page translation + demand materialization) than a
+//! single frozen dataset by construction, so a naive "paged should be faster/slower"
+//! assertion would be meaningless.
+//!
+//! Report-only, `cargo bench -p purrdf-sparql-eval --bench paged_cross_page_bgp` (the
+//! `make bench` lane) — excluded from `make check`.
+
+use std::sync::Arc;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+use purrdf_core::{
+    InMemoryPageProvider, PagedDataset, RdfDataset, RdfDatasetBuilder, RdfLiteral, TermId,
+    TermValue,
+};
+use purrdf_sparql_eval::NativeSparqlEngine;
+
+/// Entity count. Each entity contributes 3 quads (`knows`/`name`/`age`), so 200
+/// entities is 600 triples — a "few hundred" moderate corpus.
+const ENTITIES: usize = 200;
+
+/// Number of pages the corpus is round-robin split across, so a join binding for
+/// `?x` (an entity's `knows` target) has its `name`/`age` triples land on different
+/// pages from its `knows` triple more often than not.
+const PAGE_COUNT: usize = 6;
+
+const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+const EX: &str = "http://example.org/";
+
+type Triple = (TermValue, TermValue, TermValue);
+
+/// An `example.org` IRI value.
+fn iri(name: &str) -> TermValue {
+    TermValue::iri(format!("{EX}{name}"))
+}
+
+/// Intern one dataset-independent value into a builder (no triple terms needed here,
+/// so this is the non-recursive subset of the sibling paged-backend test helper).
+fn intern_value(b: &mut RdfDatasetBuilder, v: &TermValue) -> TermId {
+    match v {
+        TermValue::Iri(s) => b.intern_iri(s),
+        TermValue::Literal {
+            lexical_form,
+            datatype,
+            language,
+            direction,
+        } => b.intern_literal(RdfLiteral {
+            lexical_form: lexical_form.clone(),
+            datatype: Some(datatype.clone()),
+            language: language.clone(),
+            direction: *direction,
+        }),
+        TermValue::Blank { .. } | TermValue::Triple { .. } => {
+            unreachable!("bench corpus contains only IRIs and literals")
+        }
+    }
+}
+
+/// Build the corpus: for each entity `i`, `personI knows person(i+1)`, `personI name
+/// "NameI"`, `personI age xsd:integer(18 + i % 60)` — a ring of `knows` edges plus a
+/// name/age pair per entity, so `?x ex:knows ?y . ?y ex:name ?n . ?y ex:age ?a` joins
+/// on `?y` across all three predicates.
+fn corpus() -> Vec<Triple> {
+    let mut triples = Vec::with_capacity(ENTITIES * 3);
+    for i in 0..ENTITIES {
+        let s = iri(&format!("person{i}"));
+        let next = iri(&format!("person{}", (i + 1) % ENTITIES));
+        triples.push((s.clone(), iri("knows"), next));
+        triples.push((
+            s.clone(),
+            iri("name"),
+            TermValue::simple_literal(format!("Name{i}")),
+        ));
+        let age = TermValue::typed_literal((18 + i % 60).to_string(), XSD_INTEGER);
+        triples.push((s, iri("age"), age));
+    }
+    triples
+}
+
+/// Freeze one page (or the single reference dataset) from `(s, p, o)` triples in the
+/// default graph.
+fn build_page(triples: &[Triple]) -> Arc<RdfDataset> {
+    let mut b = RdfDatasetBuilder::new();
+    for (s, p, o) in triples {
+        let s = intern_value(&mut b, s);
+        let p = intern_value(&mut b, p);
+        let o = intern_value(&mut b, o);
+        b.push_quad(s, p, o, None);
+    }
+    b.freeze().expect("page freeze")
+}
+
+/// Round-robin split `triples` across `page_count` quad-disjoint pages, so a single
+/// entity's three triples (pushed consecutively by [`corpus`]) land on DIFFERENT
+/// pages — the cross-page join condition this bench exists to measure.
+fn split_pages(triples: &[Triple], page_count: usize) -> Vec<Arc<RdfDataset>> {
+    let mut buckets: Vec<Vec<Triple>> = vec![Vec::new(); page_count];
+    for (i, t) in triples.iter().enumerate() {
+        buckets[i % page_count].push(t.clone());
+    }
+    buckets.iter().map(|b| build_page(b)).collect()
+}
+
+/// The representative 3-pattern BGP join + numeric `FILTER`: entities known by some
+/// other entity, whose name and age (age > 30) are pulled across the join.
+const QUERY: &str = "\
+PREFIX ex: <http://example.org/>
+SELECT ?x ?n ?a WHERE {
+  ?p ex:knows ?x .
+  ?x ex:name ?n .
+  ?x ex:age ?a .
+  FILTER(?a > 30)
+}";
+
+fn bench_cross_page_bgp(c: &mut Criterion) {
+    let corpus = corpus();
+
+    // (1) The single-dataset baseline: every triple in one frozen `RdfDataset`.
+    let single = build_page(&corpus);
+
+    // (2) The paged view over the SAME triples, split across several pages so the
+    // join crosses page boundaries.
+    let pages = split_pages(&corpus, PAGE_COUNT);
+    let provider = Arc::new(InMemoryPageProvider::new(pages));
+    let paged = PagedDataset::from_provider(provider).expect("seal pages");
+    assert_eq!(
+        paged.page_count(),
+        PAGE_COUNT,
+        "the corpus spans every page"
+    );
+
+    let engine = NativeSparqlEngine::new();
+    let prepared = engine.prepare_query(QUERY, None).expect("prepare");
+
+    // Sanity pass: both backends must do real join work (a broken fixture would
+    // silently benchmark a no-op). `age > 30` keeps roughly (60 - 13) / 60 of the
+    // ring, so this is comfortably non-empty for `ENTITIES = 200`.
+    let single_rows = engine
+        .query_prepared(&single, &prepared, &[])
+        .expect("single query");
+    let paged_rows = engine
+        .query_prepared_view(&paged, &prepared, &[])
+        .expect("paged query");
+    let row_count = |r: &purrdf_core::SparqlResult| match r {
+        purrdf_core::SparqlResult::Solutions { rows, .. } => rows.len(),
+        purrdf_core::SparqlResult::Boolean(_) | purrdf_core::SparqlResult::Graph(_) => 0,
+    };
+    assert!(
+        row_count(&single_rows) > 0,
+        "single-dataset query must return rows"
+    );
+    assert_eq!(
+        row_count(&single_rows),
+        row_count(&paged_rows),
+        "single and paged backends must agree on row count"
+    );
+
+    let mut group = c.benchmark_group("cross_page_bgp");
+    group.bench_function("single", |bencher| {
+        bencher.iter(|| {
+            let result = engine
+                .query_prepared(
+                    criterion::black_box(&single),
+                    criterion::black_box(&prepared),
+                    &[],
+                )
+                .expect("single query");
+            criterion::black_box(result);
+        });
+    });
+    group.bench_function("paged", |bencher| {
+        bencher.iter(|| {
+            let result = engine
+                .query_prepared_view(
+                    criterion::black_box(&paged),
+                    criterion::black_box(&prepared),
+                    &[],
+                )
+                .expect("paged query");
+            criterion::black_box(result);
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_cross_page_bgp);
+criterion_main!(benches);

--- a/crates/sparql-eval/benches/paged_cross_page_bgp.rs
+++ b/crates/sparql-eval/benches/paged_cross_page_bgp.rs
@@ -28,8 +28,8 @@ use std::sync::Arc;
 use criterion::{Criterion, criterion_group, criterion_main};
 
 use purrdf_core::{
-    InMemoryPageProvider, PagedDataset, RdfDataset, RdfDatasetBuilder, RdfLiteral, TermId,
-    TermValue,
+    DatasetView, InMemoryPageProvider, PagedDataset, RdfDataset, RdfDatasetBuilder, RdfLiteral,
+    TermId, TermValue,
 };
 use purrdf_sparql_eval::NativeSparqlEngine;
 
@@ -201,5 +201,42 @@ fn bench_cross_page_bgp(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_cross_page_bgp);
+/// Whole-dataset scan latency through the read path: the BGP bench above drives
+/// `quads_for_pattern`; this drives the streaming `DatasetView::quads` full scan over
+/// the multi-page paged backend (which materializes each page lazily and translates its
+/// quads on the fly) against the single-dataset inherent scan. Same report-only caveats:
+/// a noisy machine and strictly-more per-quad work on the paged side make any
+/// "faster/slower" assertion meaningless — this exists for comparison, not a threshold.
+fn bench_paged_full_scan(c: &mut Criterion) {
+    let corpus = corpus();
+    let single = build_page(&corpus);
+    let pages = split_pages(&corpus, PAGE_COUNT);
+    let paged = PagedDataset::from_provider(Arc::new(InMemoryPageProvider::new(pages)))
+        .expect("seal pages");
+
+    // Sanity: both scans see every triple (a broken fixture would benchmark a no-op).
+    assert_eq!(single.quads().count(), corpus.len());
+    assert_eq!(
+        DatasetView::quads(&paged).count(),
+        corpus.len(),
+        "the paged scan streams every quad across all pages"
+    );
+
+    let mut group = c.benchmark_group("paged_full_scan");
+    group.bench_function("single", |bencher| {
+        bencher.iter(|| {
+            let n = criterion::black_box(&single).quads().count();
+            criterion::black_box(n);
+        });
+    });
+    group.bench_function("paged", |bencher| {
+        bencher.iter(|| {
+            let n = DatasetView::quads(criterion::black_box(&paged)).count();
+            criterion::black_box(n);
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_cross_page_bgp, bench_paged_full_scan);
 criterion_main!(benches);

--- a/crates/sparql-eval/src/bgp.rs
+++ b/crates/sparql-eval/src/bgp.rs
@@ -31,7 +31,7 @@
 //! **projected away**, so two independent BGPs that happen to reuse the label `_:b`
 //! never accidentally share a join variable.
 
-use purrdf_core::{DatasetView, GraphMatch, QuadIds, QuadProbePlan, RdfDataset, TermId, TermRef};
+use purrdf_core::{DatasetView, GraphMatch, QuadIds, TermId, TermRef};
 use purrdf_sparql_algebra::{
     GraphPattern, Literal, NamedNodePattern, TermPattern, TriplePattern, Variable,
 };
@@ -86,9 +86,9 @@ struct CompiledPattern {
 
 /// Evaluate a basic graph pattern to a multiset of solutions over its real
 /// (non-blank) variables.
-pub(crate) fn eval_bgp(
+pub(crate) fn eval_bgp<D: DatasetView<Id = TermId> + Sync>(
     patterns: &[TriplePattern],
-    ctx: &EvalCtx<'_>,
+    ctx: &EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     // The empty BGP is the identity table Z: one solution binding nothing.
     if patterns.is_empty() {
@@ -151,8 +151,8 @@ pub(crate) fn eval_bgp(
         // `QuadProbePlan` once from the first row (non-empty — the loop `break`s above
         // the moment `rows` empties) and capture the `Copy` plan in every worker,
         // instead of re-selecting it per row.
-        let plan: Option<QuadProbePlan> = match &scope {
-            GraphScope::One(gm) => Some(RdfDataset::probe_plan(
+        let plan: Option<D::ProbePlan> = match &scope {
+            GraphScope::One(gm) => Some(ctx.dataset.probe_plan(
                 query_id(&cp.s, &rows[0]).is_some(),
                 query_id(&cp.p, &rows[0]).is_some(),
                 query_id(&cp.o, &rows[0]).is_some(),
@@ -283,9 +283,9 @@ const COST_DP_MAX_PATTERNS: usize = 8;
 /// just not memoised. The cache key is `(dataset stats fingerprint, BGP shape key)`; on
 /// a hit the cached order's length is asserted against `compiled` so a (vanishingly
 /// unlikely) shape-key collision re-plans rather than indexing out of bounds.
-fn plan_or_cached_order(
+fn plan_or_cached_order<D: DatasetView<Id = TermId>>(
     compiled: &[CompiledPattern],
-    dataset: &RdfDataset,
+    dataset: &D,
     scope: &GraphScope,
     cache: Option<&BgpOrderCache>,
 ) -> Arc<[usize]> {
@@ -395,9 +395,9 @@ fn hash_pos<H: std::hash::Hasher>(pos: &Pos, h: &mut H) {
 /// identical run to run, no hash-iteration leak.
 ///
 /// Returns a permutation of `0..compiled.len()`.
-fn cost_based_order(
+fn cost_based_order<D: DatasetView<Id = TermId>>(
     compiled: &[CompiledPattern],
-    dataset: &RdfDataset,
+    dataset: &D,
     scope: &GraphScope,
 ) -> Vec<usize> {
     let n = compiled.len();
@@ -435,7 +435,11 @@ fn cost_based_order(
 /// ground position through, leave slots and quoted-triple positions free. A
 /// quoted-triple position is treated as unconstrained — a conservative over-estimate,
 /// safe by the multiset invariant. For a FROM/USING merge, sum the per-graph estimates.
-fn base_cardinality(dataset: &RdfDataset, cp: &CompiledPattern, scope: &GraphScope) -> usize {
+fn base_cardinality<D: DatasetView<Id = TermId>>(
+    dataset: &D,
+    cp: &CompiledPattern,
+    scope: &GraphScope,
+) -> usize {
     let s = constant_of(&cp.s);
     let p = constant_of(&cp.p);
     let o = constant_of(&cp.o);
@@ -750,10 +754,10 @@ fn is_blank_var(var: &Variable) -> bool {
 
 /// Compile a triple pattern's positions. Returns `Ok(None)` if a ground constant is
 /// absent from the dataset (the pattern — and hence the BGP — cannot match).
-fn compile_pattern(
+fn compile_pattern<D: DatasetView<Id = TermId>>(
     pattern: &TriplePattern,
     schema: &VarSchema,
-    dataset: &RdfDataset,
+    dataset: &D,
 ) -> Result<Option<CompiledPattern>, EvalError> {
     let Some(s) = compile_term(&pattern.subject, schema, dataset)? else {
         return Ok(None);
@@ -769,10 +773,10 @@ fn compile_pattern(
 
 /// Compile a subject/object term position. `Ok(None)` = an absent ground constant
 /// (the pattern — and hence the BGP — cannot match).
-fn compile_term(
+fn compile_term<D: DatasetView<Id = TermId>>(
     term: &TermPattern,
     schema: &VarSchema,
-    dataset: &RdfDataset,
+    dataset: &D,
 ) -> Result<Option<Pos>, EvalError> {
     match term {
         TermPattern::Variable(v) => Ok(Some(Pos::Slot(slot_col(schema, v)))),
@@ -800,10 +804,10 @@ fn compile_term(
 
 /// Compile a nested quoted-triple pattern's three positions. `Ok(None)` if any
 /// ground component is absent from the dataset (so the whole pattern cannot match).
-fn compile_triple_pos(
+fn compile_triple_pos<D: DatasetView<Id = TermId>>(
     triple: &TriplePattern,
     schema: &VarSchema,
-    dataset: &RdfDataset,
+    dataset: &D,
 ) -> Result<Option<TriplePos>, EvalError> {
     let Some(s) = compile_term(&triple.subject, schema, dataset)? else {
         return Ok(None);
@@ -843,10 +847,10 @@ fn term_has_variable(term: &TermPattern) -> bool {
 }
 
 /// Compile a predicate position (IRI or variable). `None` = an absent ground IRI.
-fn compile_predicate(
+fn compile_predicate<D: DatasetView<Id = TermId>>(
     predicate: &NamedNodePattern,
     schema: &VarSchema,
-    dataset: &RdfDataset,
+    dataset: &D,
 ) -> Option<Pos> {
     match predicate {
         NamedNodePattern::Variable(v) => Some(Pos::Slot(
@@ -883,11 +887,11 @@ fn query_id(pos: &Pos, row: &Solution) -> Option<TermId> {
 /// quoted-triple position fails to unify, or if a ground constant disagrees (the
 /// virtual reification candidates are NOT pre-filtered by `quads_for_pattern`, so a
 /// `Pos::Bound` mismatch must be rejected here).
-fn bind_row(
+fn bind_row<D: DatasetView<Id = TermId>>(
     row: &Solution,
     cp: &CompiledPattern,
     quad: &QuadIds,
-    dataset: &RdfDataset,
+    dataset: &D,
 ) -> Option<Solution> {
     let mut out = row.clone();
     for (pos, id) in [(&cp.s, quad.s), (&cp.p, quad.p), (&cp.o, quad.o)] {
@@ -904,7 +908,12 @@ fn bind_row(
 /// - a `Pos::Slot` repeated/previously-bound variable that disagrees;
 /// - a `Pos::Triple` whose candidate id is not a triple term, or whose components fail
 ///   to unify recursively.
-fn bind_pos(out: &mut Solution, pos: &Pos, id: TermId, dataset: &RdfDataset) -> bool {
+fn bind_pos<D: DatasetView<Id = TermId>>(
+    out: &mut Solution,
+    pos: &Pos,
+    id: TermId,
+    dataset: &D,
+) -> bool {
     match pos {
         Pos::Bound(want) => *want == id,
         Pos::Slot(col) => {
@@ -950,8 +959,8 @@ fn bind_pos(out: &mut Solution, pos: &Pos, id: TermId, dataset: &RdfDataset) -> 
 /// side-table walks are not pre-narrowed by the probe. A callback keeps this hot path
 /// lazy without boxing or allocating an intermediate candidate buffer.
 #[allow(clippy::too_many_arguments)]
-fn emit_virtual_candidates(
-    dataset: &RdfDataset,
+fn emit_virtual_candidates<D: DatasetView<Id = TermId>>(
+    dataset: &D,
     cp: &CompiledPattern,
     s: Option<TermId>,
     p: Option<TermId>,
@@ -1018,7 +1027,7 @@ fn emit_virtual_candidates(
 /// Whether an object position could resolve to a quoted-triple term (so the reifier
 /// layer — whose object is always a triple term — is worth scanning for it). An IRI or
 /// literal constant never is.
-fn object_can_be_triple_term(pos: &Pos, dataset: &RdfDataset) -> bool {
+fn object_can_be_triple_term<D: DatasetView<Id = TermId>>(pos: &Pos, dataset: &D) -> bool {
     match pos {
         // A free variable or a structural quoted-triple pattern can match a triple term.
         Pos::Slot(_) | Pos::Triple(_) => true,
@@ -1086,8 +1095,8 @@ fn literal_to_string(l: &Literal) -> String {
 /// This is a pure-introspection path: it does not evaluate the query, and it
 /// falls back to source order for BGPs whose constants are absent from the dataset
 /// (those BGPs are empty regardless of order).
-pub(crate) fn explain_pattern_orders(
-    dataset: &RdfDataset,
+pub(crate) fn explain_pattern_orders<D: DatasetView<Id = TermId>>(
+    dataset: &D,
     active_dataset: &ActiveDataset,
     active_graph: GraphMatch,
     pattern: &GraphPattern,
@@ -1203,7 +1212,7 @@ mod tests {
     use super::*;
     use crate::scratch::ScratchInterner;
     use pretty_assertions::assert_eq;
-    use purrdf_core::{RdfDatasetBuilder, RdfLiteral, TermValue};
+    use purrdf_core::{RdfDataset, RdfDatasetBuilder, RdfLiteral, TermValue};
     use purrdf_sparql_algebra::{Literal, NamedNode};
 
     /// A small graph:

--- a/crates/sparql-eval/src/bgp.rs
+++ b/crates/sparql-eval/src/bgp.rs
@@ -31,7 +31,7 @@
 //! **projected away**, so two independent BGPs that happen to reuse the label `_:b`
 //! never accidentally share a join variable.
 
-use purrdf_core::{DatasetView, GraphMatch, QuadIds, TermId, TermRef};
+use purrdf_core::{DatasetView, GraphMatch, QuadIds, TermId, TermRef, ViewTermId};
 use purrdf_sparql_algebra::{
     GraphPattern, Literal, NamedNodePattern, TermPattern, TriplePattern, Variable,
 };
@@ -56,40 +56,40 @@ const RDF_REIFIES: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies";
 const BLANK_VAR_PREFIX: char = '\u{0}';
 
 /// A compiled triple-pattern position.
-enum Pos {
+enum Pos<I: ViewTermId = TermId> {
     /// A variable (or blank-node) column index into the working schema.
     Slot(usize),
     /// A ground constant resolved to its dataset id.
-    Bound(TermId),
+    Bound(I),
     /// A nested RDF 1.2 quoted-triple pattern `<<( s p o )>>` that contains at least
     /// one variable (a fully-ground quoted triple resolves to a single [`Pos::Bound`]
     /// id instead). Binding descends into the candidate row's triple-term value,
     /// unifying the inner positions and enforcing repeated-variable consistency.
-    Triple(Box<TriplePos>),
+    Triple(Box<TriplePos<I>>),
 }
 
 /// A compiled nested quoted-triple position: its three component positions, each
 /// itself a [`Pos`] (so quoted triples may nest, and any component may be a variable,
 /// a ground constant, or a further nested triple).
-struct TriplePos {
-    s: Pos,
-    p: Pos,
-    o: Pos,
+struct TriplePos<I: ViewTermId = TermId> {
+    s: Pos<I>,
+    p: Pos<I>,
+    o: Pos<I>,
 }
 
 /// One compiled triple pattern: its three positions in `(s, p, o)` order.
-struct CompiledPattern {
-    s: Pos,
-    p: Pos,
-    o: Pos,
+struct CompiledPattern<I: ViewTermId = TermId> {
+    s: Pos<I>,
+    p: Pos<I>,
+    o: Pos<I>,
 }
 
 /// Evaluate a basic graph pattern to a multiset of solutions over its real
 /// (non-blank) variables.
-pub(crate) fn eval_bgp<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_bgp<D: DatasetView + Sync>(
     patterns: &[TriplePattern],
     ctx: &EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     // The empty BGP is the identity table Z: one solution binding nothing.
     if patterns.is_empty() {
         return Ok(SolutionSeq::unit());
@@ -142,7 +142,7 @@ pub(crate) fn eval_bgp<D: DatasetView<Id = TermId> + Sync>(
         .term_id_by_value(&purrdf_core::TermValue::Iri(RDF_REIFIES.to_owned()));
 
     // Index-nested-loop evaluation. Rows start as a single all-unbound solution.
-    let mut rows: Vec<Solution> = vec![smallvec::smallvec![None; working.len()]];
+    let mut rows: Vec<Solution<D::Id>> = vec![smallvec::smallvec![None; working.len()]];
     for &i in order.iter() {
         let cp = &compiled[i];
         // The probe's bound-axis shape is fixed across this slot's rows (a variable is
@@ -194,7 +194,7 @@ pub(crate) fn eval_bgp<D: DatasetView<Id = TermId> + Sync>(
                 // local to this row's worker (each row gets its own), identical to the
                 // sequential path.
                 GraphScope::Merge(gs) => {
-                    let mut seen: DetHashSet<(TermId, TermId, TermId)> = DetHashSet::default();
+                    let mut seen: DetHashSet<(D::Id, D::Id, D::Id)> = DetHashSet::default();
                     for &g in gs {
                         for quad in ctx.dataset.quads_for_pattern(s, p, o, GraphMatch::Named(g)) {
                             if !seen.insert((quad.s, quad.p, quad.o)) {
@@ -224,8 +224,8 @@ pub(crate) fn eval_bgp<D: DatasetView<Id = TermId> + Sync>(
 ///
 /// This is the S7 behaviour `cost_based_order` replaced; it is intentionally
 /// deterministic and never materialises a plan as triples.
-fn structural_order(compiled: &[CompiledPattern]) -> Vec<usize> {
-    fn constrained(pos: &Pos, bound: &[bool]) -> bool {
+fn structural_order<I: ViewTermId>(compiled: &[CompiledPattern<I>]) -> Vec<usize> {
+    fn constrained<I: ViewTermId>(pos: &Pos<I>, bound: &[bool]) -> bool {
         match pos {
             Pos::Bound(_) => true,
             Pos::Slot(c) => bound[*c],
@@ -283,10 +283,10 @@ const COST_DP_MAX_PATTERNS: usize = 8;
 /// just not memoised. The cache key is `(dataset stats fingerprint, BGP shape key)`; on
 /// a hit the cached order's length is asserted against `compiled` so a (vanishingly
 /// unlikely) shape-key collision re-plans rather than indexing out of bounds.
-fn plan_or_cached_order<D: DatasetView<Id = TermId>>(
-    compiled: &[CompiledPattern],
+fn plan_or_cached_order<D: DatasetView>(
+    compiled: &[CompiledPattern<D::Id>],
     dataset: &D,
-    scope: &GraphScope,
+    scope: &GraphScope<D::Id>,
     cache: Option<&BgpOrderCache>,
 ) -> Arc<[usize]> {
     let Some(cache) = cache else {
@@ -314,7 +314,7 @@ fn plan_or_cached_order<D: DatasetView<Id = TermId>>(
 /// the order cache key. Encodes `compiled.len()` and the full positional structure so two
 /// structurally distinct BGPs cannot collide to one cached order, and folds in the scope
 /// because a pattern's cardinality (hence its best order) is scope-dependent.
-fn bgp_shape_key(compiled: &[CompiledPattern], scope: &GraphScope) -> u64 {
+fn bgp_shape_key<I: ViewTermId>(compiled: &[CompiledPattern<I>], scope: &GraphScope<I>) -> u64 {
     use std::hash::{Hash, Hasher};
     let mut h = std::collections::hash_map::DefaultHasher::new();
     compiled.len().hash(&mut h);
@@ -331,7 +331,7 @@ fn bgp_shape_key(compiled: &[CompiledPattern], scope: &GraphScope) -> u64 {
                 GraphMatch::Default => 1u8.hash(&mut h),
                 GraphMatch::Named(id) => {
                     2u8.hash(&mut h);
-                    id.index().hash(&mut h);
+                    id.encode().hash(&mut h);
                 }
             }
         }
@@ -339,7 +339,7 @@ fn bgp_shape_key(compiled: &[CompiledPattern], scope: &GraphScope) -> u64 {
             1u8.hash(&mut h);
             gs.len().hash(&mut h);
             for g in gs {
-                g.index().hash(&mut h);
+                g.encode().hash(&mut h);
             }
         }
     }
@@ -348,7 +348,7 @@ fn bgp_shape_key(compiled: &[CompiledPattern], scope: &GraphScope) -> u64 {
 
 /// Hash one compiled position structurally (tag + payload), descending into nested
 /// quoted triples — a helper for [`bgp_shape_key`].
-fn hash_pos<H: std::hash::Hasher>(pos: &Pos, h: &mut H) {
+fn hash_pos<I: ViewTermId, H: std::hash::Hasher>(pos: &Pos<I>, h: &mut H) {
     use std::hash::Hash;
     match pos {
         Pos::Slot(c) => {
@@ -357,7 +357,12 @@ fn hash_pos<H: std::hash::Hasher>(pos: &Pos, h: &mut H) {
         }
         Pos::Bound(id) => {
             1u8.hash(h);
-            id.index().hash(h);
+            // Hash the id via its join-key encoding: for `TermId` this is the 0-based
+            // index as `u64` (byte-identical to the historical `id.index().hash(h)` on a
+            // 64-bit target), and it is available for any `ViewTermId` id width. Only a
+            // join-order-cache discriminator (a collision is at worst a suboptimal order,
+            // never a wrong result), so the exact bytes need only be deterministic.
+            id.encode().hash(h);
         }
         Pos::Triple(t) => {
             2u8.hash(h);
@@ -395,10 +400,10 @@ fn hash_pos<H: std::hash::Hasher>(pos: &Pos, h: &mut H) {
 /// identical run to run, no hash-iteration leak.
 ///
 /// Returns a permutation of `0..compiled.len()`.
-fn cost_based_order<D: DatasetView<Id = TermId>>(
-    compiled: &[CompiledPattern],
+fn cost_based_order<D: DatasetView>(
+    compiled: &[CompiledPattern<D::Id>],
     dataset: &D,
-    scope: &GraphScope,
+    scope: &GraphScope<D::Id>,
 ) -> Vec<usize> {
     let n = compiled.len();
     if n <= 1 {
@@ -435,10 +440,10 @@ fn cost_based_order<D: DatasetView<Id = TermId>>(
 /// ground position through, leave slots and quoted-triple positions free. A
 /// quoted-triple position is treated as unconstrained — a conservative over-estimate,
 /// safe by the multiset invariant. For a FROM/USING merge, sum the per-graph estimates.
-fn base_cardinality<D: DatasetView<Id = TermId>>(
+fn base_cardinality<D: DatasetView>(
     dataset: &D,
-    cp: &CompiledPattern,
-    scope: &GraphScope,
+    cp: &CompiledPattern<D::Id>,
+    scope: &GraphScope<D::Id>,
 ) -> usize {
     let s = constant_of(&cp.s);
     let p = constant_of(&cp.p);
@@ -454,7 +459,7 @@ fn base_cardinality<D: DatasetView<Id = TermId>>(
 
 /// The ground id of a position, or `None` for a slot or (conservatively) a nested
 /// quoted-triple position.
-fn constant_of(pos: &Pos) -> Option<TermId> {
+fn constant_of<I: ViewTermId>(pos: &Pos<I>) -> Option<I> {
     match pos {
         Pos::Bound(id) => Some(*id),
         Pos::Slot(_) | Pos::Triple(_) => None,
@@ -465,7 +470,7 @@ fn constant_of(pos: &Pos) -> Option<TermId> {
 /// earlier-scheduled pattern — each is an equality-join axis (selectivity ~`1/T`).
 /// Ground constants are excluded: their selectivity is already folded into the
 /// pattern's base cardinality.
-fn join_positions(cp: &CompiledPattern, bound: &[bool]) -> usize {
+fn join_positions<I: ViewTermId>(cp: &CompiledPattern<I>, bound: &[bool]) -> usize {
     [&cp.s, &cp.p, &cp.o]
         .into_iter()
         .filter(|pos| pos_has_bound_slot(pos, bound))
@@ -481,8 +486,8 @@ fn step_size(running: f64, base_p: f64, joins: usize, t: f64) -> f64 {
 /// Greedy minimum-cardinality join order for a large BGP (`n > COST_DP_MAX_PATTERNS`):
 /// repeatedly schedule the connected pattern whose appended intermediate-size estimate
 /// is smallest, lowest-index on ties. Connectivity is enforced exactly as in the DP.
-fn cost_order_greedy(
-    compiled: &[CompiledPattern],
+fn cost_order_greedy<I: ViewTermId>(
+    compiled: &[CompiledPattern<I>],
     base: &[f64],
     t: f64,
     n_cols: usize,
@@ -572,7 +577,12 @@ struct DpPlan {
 /// The order is carried as a nibble-packed `u64` (see [`DpPlan`]): each DP transition
 /// copies the `Copy` struct and shifts in one nibble — no heap allocation per step.
 /// The final order is decoded MSB→LSB into a `Vec<usize>` for the caller.
-fn cost_order_dp(compiled: &[CompiledPattern], base: &[f64], t: f64, n_cols: usize) -> Vec<usize> {
+fn cost_order_dp<I: ViewTermId>(
+    compiled: &[CompiledPattern<I>],
+    base: &[f64],
+    t: f64,
+    n_cols: usize,
+) -> Vec<usize> {
     let n = compiled.len();
     // Safety invariant: each pattern index must fit in a 4-bit nibble (values 1–15
     // after the 1-based offset). COST_DP_MAX_PATTERNS == 8 satisfies this with margin.
@@ -671,14 +681,14 @@ fn cost_order_dp(compiled: &[CompiledPattern], base: &[f64], t: f64, n_cols: usi
 /// Whether a pattern shares at least one already-bound variable with the bindings
 /// produced so far (so joining it cannot be a Cartesian product). Descends into nested
 /// quoted triples: a triple position is connected if any of its inner slots is bound.
-fn pattern_connected(cp: &CompiledPattern, bound: &[bool]) -> bool {
+fn pattern_connected<I: ViewTermId>(cp: &CompiledPattern<I>, bound: &[bool]) -> bool {
     [&cp.s, &cp.p, &cp.o]
         .into_iter()
         .any(|pos| pos_has_bound_slot(pos, bound))
 }
 
 /// Whether a position contains an already-bound slot anywhere (recursively).
-fn pos_has_bound_slot(pos: &Pos, bound: &[bool]) -> bool {
+fn pos_has_bound_slot<I: ViewTermId>(pos: &Pos<I>, bound: &[bool]) -> bool {
     match pos {
         Pos::Bound(_) => false,
         Pos::Slot(c) => bound[*c],
@@ -690,7 +700,7 @@ fn pos_has_bound_slot(pos: &Pos, bound: &[bool]) -> bool {
 
 /// Record a scheduled pattern's slot columns as now-bound (descending into nested
 /// quoted triples).
-fn mark_bound(cp: &CompiledPattern, bound: &mut [bool]) {
+fn mark_bound<I: ViewTermId>(cp: &CompiledPattern<I>, bound: &mut [bool]) {
     for pos in [&cp.s, &cp.p, &cp.o] {
         for_each_slot(pos, &mut |c| bound[c] = true);
     }
@@ -698,7 +708,7 @@ fn mark_bound(cp: &CompiledPattern, bound: &mut [bool]) {
 
 /// Visit every slot column reachable from a position (itself, or the inner positions
 /// of a nested quoted triple).
-fn for_each_slot(pos: &Pos, f: &mut impl FnMut(usize)) {
+fn for_each_slot<I: ViewTermId>(pos: &Pos<I>, f: &mut impl FnMut(usize)) {
     match pos {
         Pos::Bound(_) => {}
         Pos::Slot(c) => f(*c),
@@ -754,11 +764,11 @@ fn is_blank_var(var: &Variable) -> bool {
 
 /// Compile a triple pattern's positions. Returns `Ok(None)` if a ground constant is
 /// absent from the dataset (the pattern — and hence the BGP — cannot match).
-fn compile_pattern<D: DatasetView<Id = TermId>>(
+fn compile_pattern<D: DatasetView>(
     pattern: &TriplePattern,
     schema: &VarSchema,
     dataset: &D,
-) -> Result<Option<CompiledPattern>, EvalError> {
+) -> Result<Option<CompiledPattern<D::Id>>, EvalError> {
     let Some(s) = compile_term(&pattern.subject, schema, dataset)? else {
         return Ok(None);
     };
@@ -773,11 +783,11 @@ fn compile_pattern<D: DatasetView<Id = TermId>>(
 
 /// Compile a subject/object term position. `Ok(None)` = an absent ground constant
 /// (the pattern — and hence the BGP — cannot match).
-fn compile_term<D: DatasetView<Id = TermId>>(
+fn compile_term<D: DatasetView>(
     term: &TermPattern,
     schema: &VarSchema,
     dataset: &D,
-) -> Result<Option<Pos>, EvalError> {
+) -> Result<Option<Pos<D::Id>>, EvalError> {
     match term {
         TermPattern::Variable(v) => Ok(Some(Pos::Slot(slot_col(schema, v)))),
         TermPattern::BlankNode(b) => Ok(Some(Pos::Slot(slot_col(schema, &blank_var(b.as_str()))))),
@@ -804,11 +814,11 @@ fn compile_term<D: DatasetView<Id = TermId>>(
 
 /// Compile a nested quoted-triple pattern's three positions. `Ok(None)` if any
 /// ground component is absent from the dataset (so the whole pattern cannot match).
-fn compile_triple_pos<D: DatasetView<Id = TermId>>(
+fn compile_triple_pos<D: DatasetView>(
     triple: &TriplePattern,
     schema: &VarSchema,
     dataset: &D,
-) -> Result<Option<TriplePos>, EvalError> {
+) -> Result<Option<TriplePos<D::Id>>, EvalError> {
     let Some(s) = compile_term(&triple.subject, schema, dataset)? else {
         return Ok(None);
     };
@@ -847,11 +857,11 @@ fn term_has_variable(term: &TermPattern) -> bool {
 }
 
 /// Compile a predicate position (IRI or variable). `None` = an absent ground IRI.
-fn compile_predicate<D: DatasetView<Id = TermId>>(
+fn compile_predicate<D: DatasetView>(
     predicate: &NamedNodePattern,
     schema: &VarSchema,
     dataset: &D,
-) -> Option<Pos> {
+) -> Option<Pos<D::Id>> {
     match predicate {
         NamedNodePattern::Variable(v) => Some(Pos::Slot(
             schema
@@ -868,7 +878,7 @@ fn compile_predicate<D: DatasetView<Id = TermId>>(
 /// constant, an already-bound variable's id, or `None` (a wildcard / a variable not
 /// yet bound). A `Computed` binding (never produced inside a BGP) degrades to a
 /// wildcard and is rejected by [`bind_row`].
-fn query_id(pos: &Pos, row: &Solution) -> Option<TermId> {
+fn query_id<I: ViewTermId>(pos: &Pos<I>, row: &Solution<I>) -> Option<I> {
     match pos {
         Pos::Bound(id) => Some(*id),
         Pos::Slot(col) => match row[*col] {
@@ -887,12 +897,12 @@ fn query_id(pos: &Pos, row: &Solution) -> Option<TermId> {
 /// quoted-triple position fails to unify, or if a ground constant disagrees (the
 /// virtual reification candidates are NOT pre-filtered by `quads_for_pattern`, so a
 /// `Pos::Bound` mismatch must be rejected here).
-fn bind_row<D: DatasetView<Id = TermId>>(
-    row: &Solution,
-    cp: &CompiledPattern,
-    quad: &QuadIds,
+fn bind_row<D: DatasetView>(
+    row: &Solution<D::Id>,
+    cp: &CompiledPattern<D::Id>,
+    quad: &QuadIds<D::Id>,
     dataset: &D,
-) -> Option<Solution> {
+) -> Option<Solution<D::Id>> {
     let mut out = row.clone();
     for (pos, id) in [(&cp.s, quad.s), (&cp.p, quad.p), (&cp.o, quad.o)] {
         if !bind_pos(&mut out, pos, id, dataset) {
@@ -908,10 +918,10 @@ fn bind_row<D: DatasetView<Id = TermId>>(
 /// - a `Pos::Slot` repeated/previously-bound variable that disagrees;
 /// - a `Pos::Triple` whose candidate id is not a triple term, or whose components fail
 ///   to unify recursively.
-fn bind_pos<D: DatasetView<Id = TermId>>(
-    out: &mut Solution,
-    pos: &Pos,
-    id: TermId,
+fn bind_pos<D: DatasetView>(
+    out: &mut Solution<D::Id>,
+    pos: &Pos<D::Id>,
+    id: D::Id,
     dataset: &D,
 ) -> bool {
     match pos {
@@ -959,15 +969,15 @@ fn bind_pos<D: DatasetView<Id = TermId>>(
 /// side-table walks are not pre-narrowed by the probe. A callback keeps this hot path
 /// lazy without boxing or allocating an intermediate candidate buffer.
 #[allow(clippy::too_many_arguments)]
-fn emit_virtual_candidates<D: DatasetView<Id = TermId>>(
+fn emit_virtual_candidates<D: DatasetView>(
     dataset: &D,
-    cp: &CompiledPattern,
-    s: Option<TermId>,
-    p: Option<TermId>,
-    o: Option<TermId>,
-    reifies_id: Option<TermId>,
-    gm: GraphMatch,
-    mut emit: impl FnMut(QuadIds),
+    cp: &CompiledPattern<D::Id>,
+    s: Option<D::Id>,
+    p: Option<D::Id>,
+    o: Option<D::Id>,
+    reifies_id: Option<D::Id>,
+    gm: GraphMatch<D::Id>,
+    mut emit: impl FnMut(QuadIds<D::Id>),
 ) {
     // Reifier layer: only when the predicate can be `rdf:reifies`. The object must also
     // be triple-term-shaped to be worth scanning — a quoted-triple pattern position
@@ -1027,7 +1037,7 @@ fn emit_virtual_candidates<D: DatasetView<Id = TermId>>(
 /// Whether an object position could resolve to a quoted-triple term (so the reifier
 /// layer — whose object is always a triple term — is worth scanning for it). An IRI or
 /// literal constant never is.
-fn object_can_be_triple_term<D: DatasetView<Id = TermId>>(pos: &Pos, dataset: &D) -> bool {
+fn object_can_be_triple_term<D: DatasetView>(pos: &Pos<D::Id>, dataset: &D) -> bool {
     match pos {
         // A free variable or a structural quoted-triple pattern can match a triple term.
         Pos::Slot(_) | Pos::Triple(_) => true,
@@ -1095,10 +1105,10 @@ fn literal_to_string(l: &Literal) -> String {
 /// This is a pure-introspection path: it does not evaluate the query, and it
 /// falls back to source order for BGPs whose constants are absent from the dataset
 /// (those BGPs are empty regardless of order).
-pub(crate) fn explain_pattern_orders<D: DatasetView<Id = TermId>>(
+pub(crate) fn explain_pattern_orders<D: DatasetView>(
     dataset: &D,
-    active_dataset: &ActiveDataset,
-    active_graph: GraphMatch,
+    active_dataset: &ActiveDataset<D::Id>,
+    active_graph: GraphMatch<D::Id>,
     pattern: &GraphPattern,
     out: &mut Vec<String>,
 ) -> Result<(), EvalError> {
@@ -1166,7 +1176,7 @@ pub(crate) fn explain_pattern_orders<D: DatasetView<Id = TermId>>(
 }
 
 /// An empty solution sequence over only the real (non-blank) variables of `working`.
-fn empty_over_real_vars(working: &VarSchema) -> SolutionSeq {
+fn empty_over_real_vars<I: ViewTermId>(working: &VarSchema) -> SolutionSeq<I> {
     let real = real_var_schema(working);
     SolutionSeq::empty(Arc::new(real))
 }
@@ -1179,7 +1189,10 @@ fn real_var_schema(working: &VarSchema) -> VarSchema {
 /// Project the working rows onto only the real variables, dropping the synthetic
 /// blank-node columns (which are scoped to this BGP and must not leak into joins).
 /// Multiset cardinality is preserved (no dedup).
-fn project_out_blanks(working: &VarSchema, rows: Vec<Solution>) -> SolutionSeq {
+fn project_out_blanks<I: ViewTermId>(
+    working: &VarSchema,
+    rows: Vec<Solution<I>>,
+) -> SolutionSeq<I> {
     // The working columns that survive, in order.
     let keep: Vec<usize> = working
         .vars()

--- a/crates/sparql-eval/src/binop.rs
+++ b/crates/sparql-eval/src/binop.rs
@@ -18,7 +18,7 @@
 
 use std::sync::Arc;
 
-use purrdf_core::{DatasetView, TermId};
+use purrdf_core::{DatasetView, TermId, ViewTermId};
 use purrdf_sparql_algebra::{Expression, GraphPattern};
 
 use crate::error::EvalError;
@@ -30,25 +30,26 @@ use crate::{DetHashMap, DetHasher};
 /// A hash-join key over the shared columns of two solutions.
 ///
 /// The overwhelmingly common case is a **single** shared variable (a star join on
-/// `?p`), so that case is specialized to a `Copy` `u64` ([`SolutionTerm::join_key_u64`])
+/// `?p`), so that case is specialized to a `Copy` join-key atom ([`SolutionTerm::join_key`])
 /// — no per-row heap allocation on either the build or probe side. Joins on zero or
 /// ≥2 shared columns keep the general owned-vector key. Within one join the shared
 /// column count is fixed, so every key is the same variant and the two never compare
 /// across variants.
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub(crate) enum JoinKey {
-    /// Exactly one shared column: the term encoded as a collision-free `u64`.
-    Single(u64),
+pub(crate) enum JoinKey<I: ViewTermId = TermId> {
+    /// Exactly one shared column: the term encoded as a collision-free join-key atom
+    /// ([`SolutionTerm::join_key`]). For `I = TermId` this is the historical `u64`.
+    Single(I::JoinKeyAtom),
     /// Zero or ≥2 shared columns: the bound terms in shared-column order.
-    Multi(Vec<SolutionTerm>),
+    Multi(Vec<SolutionTerm<I>>),
 }
 
 /// Evaluate `left . right` (algebra `Join`) as a hash join on shared variables.
-pub(crate) fn eval_join<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_join<D: DatasetView + Sync>(
     left: &GraphPattern,
     right: &GraphPattern,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     let l = eval(left, ctx)?;
     let r = eval(right, ctx)?;
     Ok(hash_join(&l, &r))
@@ -63,11 +64,11 @@ pub(crate) fn eval_join<D: DatasetView<Id = TermId> + Sync>(
 /// μ, the sole case being a variable-endpoint `SERVICE ?g` whose endpoint IRI is
 /// bound by μ. Reuses the correlated-EXISTS substitution machinery, including the
 /// address-keyed-cache ABA guard (`in_substituted_exists`) around the inner eval.
-pub(crate) fn eval_lateral<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_lateral<D: DatasetView + Sync>(
     left: &GraphPattern,
     right: &GraphPattern,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     let l = eval(left, ctx)?;
     let left_schema = Arc::clone(&l.schema);
     let left_len = left_schema.len();
@@ -76,7 +77,9 @@ pub(crate) fn eval_lateral<D: DatasetView<Id = TermId> + Sync>(
     // per-row results and the union of their schemas (stable across rows for the
     // SERVICE ?var use, but computed generally).
     let mut right_schema = VarSchema::new();
-    let mut per_row: Vec<(Solution, SolutionSeq)> = Vec::with_capacity(l.rows.len());
+    // Each left row μ paired with the per-row `right` result it drives.
+    type LateralPerRow<I> = Vec<(Solution<I>, SolutionSeq<I>)>;
+    let mut per_row: LateralPerRow<D::Id> = Vec::with_capacity(l.rows.len());
     for mu in &l.rows {
         let bindings = crate::expr::outer_bindings_for_substitution(mu, &left_schema, ctx);
         let substituted = crate::expr::substitute_pattern(right, &bindings);
@@ -96,7 +99,7 @@ pub(crate) fn eval_lateral<D: DatasetView<Id = TermId> + Sync>(
 
     let out = Arc::new(left_schema.union(&right_schema));
     let out_len = out.len();
-    let mut rows: Vec<Solution> = Vec::new();
+    let mut rows: Vec<Solution<D::Id>> = Vec::new();
     for (mu, r) in &per_row {
         let right_to_out = right_to_out_map(&r.schema, &out);
         for nu in &r.rows {
@@ -140,11 +143,11 @@ pub(crate) fn eval_lateral<D: DatasetView<Id = TermId> + Sync>(
 /// re-intern them back into `ctx.scratch`, left branch first then right, via
 /// [`crate::parallel::reintern_portable_row`] — reproducing the sequential
 /// concat's exact row order (left rows, then right rows) and column layout.
-pub(crate) fn eval_union<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_union<D: DatasetView + Sync>(
     left: &GraphPattern,
     right: &GraphPattern,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     if !crate::parallel::is_parallel_safe_pattern(left)
         || !crate::parallel::is_parallel_safe_pattern(right)
     {
@@ -165,7 +168,7 @@ pub(crate) fn eval_union<D: DatasetView<Id = TermId> + Sync>(
     // branch) is kept as-is with zero extra allocation, and only a row
     // carrying a genuinely fresh cell pays for the portable-materialize round
     // trip. The child (and its scratch) does not survive past this closure.
-    let eval_branch = |pattern: &GraphPattern| -> Result<PortableBranch, EvalError> {
+    let eval_branch = |pattern: &GraphPattern| -> Result<PortableBranch<D::Id>, EvalError> {
         let mut child = ctx_ref.fork_for_worker();
         let seq = eval(pattern, &mut child)?;
         let minted: Vec<_> = seq
@@ -213,7 +216,7 @@ pub(crate) fn eval_union<D: DatasetView<Id = TermId> + Sync>(
 /// union schema (left columns first). Shared by both the sequential fallback
 /// and (conceptually) documents the exact row shape the parallel path in
 /// [`eval_union`] must reproduce.
-fn concat_union(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
+fn concat_union<I: ViewTermId>(l: &SolutionSeq<I>, r: &SolutionSeq<I>) -> SolutionSeq<I> {
     let out = l.schema.union(&r.schema);
     let out_len = out.len();
     let left_len = l.schema.len();
@@ -244,7 +247,7 @@ fn concat_union(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
 /// result row classified via [`crate::parallel::minted_row`] — `Direct` (no
 /// remap needed) or `Portable` (materialized while the branch's forked child
 /// is still alive) — so it survives that child being dropped.
-type PortableBranch = (Arc<VarSchema>, Vec<crate::parallel::MintedRow>);
+type PortableBranch<I> = (Arc<VarSchema>, Vec<crate::parallel::MintedRow<I>>);
 
 /// The mapping from a right operand's column ordinal to its ordinal in `out`.
 fn right_to_out_map(right: &VarSchema, out: &VarSchema) -> Vec<usize> {
@@ -265,13 +268,13 @@ fn right_to_out_map(right: &VarSchema, out: &VarSchema) -> Vec<usize> {
 /// Exposed `pub(crate)` so an `EXISTS` site can build the index over its inner
 /// result **once** and reuse it across every outer row (see [`probe_has_match`]),
 /// rather than rebuilding it per probe.
-pub(crate) fn build_index(
-    r: &SolutionSeq,
+pub(crate) fn build_index<I: ViewTermId>(
+    r: &SolutionSeq<I>,
     shared: &[(usize, usize)],
-) -> (DetHashMap<JoinKey, Vec<usize>>, Vec<usize>) {
+) -> (DetHashMap<JoinKey<I>, Vec<usize>>, Vec<usize>) {
     // Pre-size to the build-row count: the exact upper bound on distinct keys, so a
     // large build side is filled without incremental rehash-and-reallocate churn.
-    let mut keyed: DetHashMap<JoinKey, Vec<usize>> =
+    let mut keyed: DetHashMap<JoinKey<I>, Vec<usize>> =
         DetHashMap::with_capacity_and_hasher(r.rows.len(), DetHasher::default());
     let mut wild: Vec<usize> = Vec::new();
     for (idx, rrow) in r.rows.iter().enumerate() {
@@ -295,12 +298,12 @@ pub(crate) fn build_index(
 /// this falls back to a per-row compatibility scan over the full inner result — that
 /// case is O(|inner|) per probe. A probe fully bound on its shared columns (the common
 /// anti-join shape) hits the keyed bucket in O(1).
-pub(crate) fn probe_has_match(
-    probe: &[Option<SolutionTerm>],
+pub(crate) fn probe_has_match<I: ViewTermId>(
+    probe: &[Option<SolutionTerm<I>>],
     shared: &[(usize, usize)],
-    keyed: &DetHashMap<JoinKey, Vec<usize>>,
+    keyed: &DetHashMap<JoinKey<I>, Vec<usize>>,
     wild: &[usize],
-    r_rows: &[Solution],
+    r_rows: &[Solution<I>],
 ) -> bool {
     match bound_key(probe, shared, KeySide::Left) {
         // Fully bound on shared columns: a present exact-key bucket is a match
@@ -315,7 +318,7 @@ pub(crate) fn probe_has_match(
 }
 
 /// Hash-join two solution sequences on their shared variables.
-fn hash_join(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
+fn hash_join<I: ViewTermId>(l: &SolutionSeq<I>, r: &SolutionSeq<I>) -> SolutionSeq<I> {
     let out = l.schema.union(&r.schema);
     let out_len = out.len();
     let left_len = l.schema.len();
@@ -381,18 +384,18 @@ enum KeySide {
 /// right key iff the two rows agree on every (bound) shared column. A single shared
 /// column — the common star-join shape — produces an allocation-free
 /// [`JoinKey::Single`]; zero or ≥2 columns fall back to an owned [`JoinKey::Multi`].
-fn bound_key(
-    row: &[Option<SolutionTerm>],
+fn bound_key<I: ViewTermId>(
+    row: &[Option<SolutionTerm<I>>],
     shared: &[(usize, usize)],
     side: KeySide,
-) -> Option<JoinKey> {
+) -> Option<JoinKey<I>> {
     let col_of = |ia: usize, ib: usize| match side {
         KeySide::Left => ia,
         KeySide::Right => ib,
     };
     if let [(ia, ib)] = *shared {
         // Single shared column: no heap allocation for the key.
-        return Some(JoinKey::Single(row[col_of(ia, ib)]?.join_key_u64()));
+        return Some(JoinKey::Single(row[col_of(ia, ib)]?.join_key()));
     }
     let mut key = Vec::with_capacity(shared.len());
     for &(ia, ib) in shared {
@@ -406,13 +409,13 @@ fn bound_key(
 /// output slot only if still unbound, so a shared column unbound on the left is
 /// filled from the right (and an already-bound shared column — equal by
 /// compatibility — is left intact).
-fn merge(
-    left_row: &Solution,
-    right_row: &Solution,
+fn merge<I: ViewTermId>(
+    left_row: &Solution<I>,
+    right_row: &Solution<I>,
     left_len: usize,
     right_to_out: &[usize],
     out_len: usize,
-) -> Solution {
+) -> Solution<I> {
     debug_assert_eq!(left_row.len(), left_len);
     // One exact-size allocation, initialized from the left row directly (no
     // write-None-then-overwrite pass over the left prefix).
@@ -430,12 +433,12 @@ fn merge(
 
 /// Evaluate `left OPTIONAL { right }` (algebra `LeftJoin`) as a left outer join,
 /// with an optional inline `FILTER` condition evaluated on the merged solution.
-pub(crate) fn eval_left_join<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_left_join<D: DatasetView + Sync>(
     left: &GraphPattern,
     right: &GraphPattern,
     expression: Option<&Expression>,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     let l = eval(left, ctx)?;
     let r = eval(right, ctx)?;
     match expression {
@@ -457,12 +460,12 @@ pub(crate) fn eval_left_join<D: DatasetView<Id = TermId> + Sync>(
 /// nothing — see its doc comment), so nothing new escapes a forked child's
 /// scratch and it is discarded after use — no re-interning via
 /// [`crate::parallel::reintern_minted_row`] is needed.
-fn left_outer_join_filtered<D: DatasetView<Id = TermId> + Sync>(
-    l: &SolutionSeq,
-    r: &SolutionSeq,
+fn left_outer_join_filtered<D: DatasetView + Sync>(
+    l: &SolutionSeq<D::Id>,
+    r: &SolutionSeq<D::Id>,
     expr: &Expression,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     let out = Arc::new(l.schema.union(&r.schema));
     let out_len = out.len();
     let left_len = l.schema.len();
@@ -520,7 +523,7 @@ fn left_outer_join_filtered<D: DatasetView<Id = TermId> + Sync>(
 
 /// Left outer join: every left solution merged with each compatible right
 /// solution, or emitted alone (right columns unbound) when none is compatible.
-fn left_outer_join(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
+fn left_outer_join<I: ViewTermId>(l: &SolutionSeq<I>, r: &SolutionSeq<I>) -> SolutionSeq<I> {
     let out = l.schema.union(&r.schema);
     let out_len = out.len();
     let left_len = l.schema.len();
@@ -579,11 +582,11 @@ fn left_outer_join(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
 /// SPARQL §18.5): solutions with disjoint domains never remove, so `MINUS` over
 /// patterns with no common variable is a no-op. The result schema is the left
 /// schema (MINUS introduces no right columns) and left multiplicity is preserved.
-pub(crate) fn eval_minus<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_minus<D: DatasetView + Sync>(
     left: &GraphPattern,
     right: &GraphPattern,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     let l = eval(left, ctx)?;
     let r = eval(right, ctx)?;
     let shared = l.schema.shared_columns(&r.schema);

--- a/crates/sparql-eval/src/binop.rs
+++ b/crates/sparql-eval/src/binop.rs
@@ -18,6 +18,7 @@
 
 use std::sync::Arc;
 
+use purrdf_core::{DatasetView, TermId};
 use purrdf_sparql_algebra::{Expression, GraphPattern};
 
 use crate::error::EvalError;
@@ -43,10 +44,10 @@ pub(crate) enum JoinKey {
 }
 
 /// Evaluate `left . right` (algebra `Join`) as a hash join on shared variables.
-pub(crate) fn eval_join(
+pub(crate) fn eval_join<D: DatasetView<Id = TermId> + Sync>(
     left: &GraphPattern,
     right: &GraphPattern,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     let l = eval(left, ctx)?;
     let r = eval(right, ctx)?;
@@ -62,10 +63,10 @@ pub(crate) fn eval_join(
 /// μ, the sole case being a variable-endpoint `SERVICE ?g` whose endpoint IRI is
 /// bound by μ. Reuses the correlated-EXISTS substitution machinery, including the
 /// address-keyed-cache ABA guard (`in_substituted_exists`) around the inner eval.
-pub(crate) fn eval_lateral(
+pub(crate) fn eval_lateral<D: DatasetView<Id = TermId> + Sync>(
     left: &GraphPattern,
     right: &GraphPattern,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     let l = eval(left, ctx)?;
     let left_schema = Arc::clone(&l.schema);
@@ -139,10 +140,10 @@ pub(crate) fn eval_lateral(
 /// re-intern them back into `ctx.scratch`, left branch first then right, via
 /// [`crate::parallel::reintern_portable_row`] — reproducing the sequential
 /// concat's exact row order (left rows, then right rows) and column layout.
-pub(crate) fn eval_union(
+pub(crate) fn eval_union<D: DatasetView<Id = TermId> + Sync>(
     left: &GraphPattern,
     right: &GraphPattern,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     if !crate::parallel::is_parallel_safe_pattern(left)
         || !crate::parallel::is_parallel_safe_pattern(right)
@@ -156,7 +157,7 @@ pub(crate) fn eval_union(
     // A shared (immutable) borrow of `ctx`: both closures below only need
     // `fork_for_worker`'s `&self` access, so they run concurrently over the same
     // `&EvalCtx` — `EvalCtx: Sync` (see its definition) makes this sound.
-    let ctx_ref: &EvalCtx<'_> = ctx;
+    let ctx_ref: &EvalCtx<'_, D> = ctx;
 
     // Each closure forks its own child, evaluates its branch on it, and
     // classifies every result row (see [`crate::parallel::minted_row`]): a row
@@ -429,11 +430,11 @@ fn merge(
 
 /// Evaluate `left OPTIONAL { right }` (algebra `LeftJoin`) as a left outer join,
 /// with an optional inline `FILTER` condition evaluated on the merged solution.
-pub(crate) fn eval_left_join(
+pub(crate) fn eval_left_join<D: DatasetView<Id = TermId> + Sync>(
     left: &GraphPattern,
     right: &GraphPattern,
     expression: Option<&Expression>,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     let l = eval(left, ctx)?;
     let r = eval(right, ctx)?;
@@ -456,11 +457,11 @@ pub(crate) fn eval_left_join(
 /// nothing — see its doc comment), so nothing new escapes a forked child's
 /// scratch and it is discarded after use — no re-interning via
 /// [`crate::parallel::reintern_minted_row`] is needed.
-fn left_outer_join_filtered(
+fn left_outer_join_filtered<D: DatasetView<Id = TermId> + Sync>(
     l: &SolutionSeq,
     r: &SolutionSeq,
     expr: &Expression,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     let out = Arc::new(l.schema.union(&r.schema));
     let out_len = out.len();
@@ -578,10 +579,10 @@ fn left_outer_join(l: &SolutionSeq, r: &SolutionSeq) -> SolutionSeq {
 /// SPARQL §18.5): solutions with disjoint domains never remove, so `MINUS` over
 /// patterns with no common variable is a no-op. The result schema is the left
 /// schema (MINUS introduces no right columns) and left multiplicity is preserved.
-pub(crate) fn eval_minus(
+pub(crate) fn eval_minus<D: DatasetView<Id = TermId> + Sync>(
     left: &GraphPattern,
     right: &GraphPattern,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     let l = eval(left, ctx)?;
     let r = eval(right, ctx)?;

--- a/crates/sparql-eval/src/construct.rs
+++ b/crates/sparql-eval/src/construct.rs
@@ -27,7 +27,7 @@ use purrdf_core::loss::{
     LOSS_ANNOTATION_LAYER_DROPPED, LOSS_REIFIER_LAYER_DROPPED, LOSS_STANDPOINT_SCOPE_DROPPED,
 };
 use purrdf_core::{
-    RdfDataset, RdfDatasetBuilder, RdfLiteral, TermFactory, TermId, TermRef, TermValue,
+    DatasetView, RdfDataset, RdfDatasetBuilder, RdfLiteral, TermFactory, TermId, TermRef, TermValue,
 };
 use purrdf_sparql_algebra::{GraphPattern, NamedNodePattern, TermPattern, TriplePattern};
 
@@ -56,10 +56,10 @@ const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
 /// behaves like a plain `CONSTRUCT`. When the `WHERE` has no `rdf:reifies`
 /// pattern at all the detection does zero extra work and the output is
 /// byte-identical to a plain `CONSTRUCT`.
-pub(crate) fn eval_construct(
+pub(crate) fn eval_construct<D: DatasetView<Id = TermId> + Sync>(
     template: &[TriplePattern],
     pattern: &GraphPattern,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Arc<RdfDataset>, EvalError> {
     let seq = eval(pattern, ctx)?;
     let schema = seq.schema.clone();
@@ -383,12 +383,12 @@ fn collect_term_pattern_vars(term: &TermPattern, out: &mut BTreeSet<String>) {
 /// `<lossNode>` is a DETERMINISTIC blank node whose label is derived purely from the
 /// resolved triple-term content, so identical drops across rows collapse to one node
 /// via the builder's dedup.
-fn emit_dropped_losses(
+fn emit_dropped_losses<D: DatasetView<Id = TermId> + Sync>(
     dropped: &[DroppedReifier],
     row: &Solution,
     schema: &VarSchema,
     builder: &mut RdfDatasetBuilder,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
     (proj_loss_id, loss_code_id, lost_reifies_id): (TermId, TermId, TermId),
 ) {
     for d in dropped {
@@ -465,13 +465,13 @@ fn loss_node_label(code: &str, inner: &TermValue) -> String {
 
 /// Instantiate one template triple for `row`, interning into `builder`. Returns
 /// `None` if the triple is skipped (an unbound variable or an ill-formed position).
-fn instantiate(
+fn instantiate<D: DatasetView<Id = TermId> + Sync>(
     tp: &TriplePattern,
     row: &Solution,
     schema: &VarSchema,
     builder: &mut RdfDatasetBuilder,
     blanks: &mut DetHashMap<String, String>,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Option<(TermId, TermId, TermId)> {
     let s = instantiate_term(&tp.subject, row, schema, blanks, ctx)?;
     let p = instantiate_predicate(&tp.predicate, row, schema, ctx)?;

--- a/crates/sparql-eval/src/construct.rs
+++ b/crates/sparql-eval/src/construct.rs
@@ -56,7 +56,7 @@ const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
 /// behaves like a plain `CONSTRUCT`. When the `WHERE` has no `rdf:reifies`
 /// pattern at all the detection does zero extra work and the output is
 /// byte-identical to a plain `CONSTRUCT`.
-pub(crate) fn eval_construct<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_construct<D: DatasetView + Sync>(
     template: &[TriplePattern],
     pattern: &GraphPattern,
     ctx: &mut EvalCtx<'_, D>,
@@ -383,9 +383,9 @@ fn collect_term_pattern_vars(term: &TermPattern, out: &mut BTreeSet<String>) {
 /// `<lossNode>` is a DETERMINISTIC blank node whose label is derived purely from the
 /// resolved triple-term content, so identical drops across rows collapse to one node
 /// via the builder's dedup.
-fn emit_dropped_losses<D: DatasetView<Id = TermId> + Sync>(
+fn emit_dropped_losses<D: DatasetView + Sync>(
     dropped: &[DroppedReifier],
-    row: &Solution,
+    row: &Solution<D::Id>,
     schema: &VarSchema,
     builder: &mut RdfDatasetBuilder,
     ctx: &mut EvalCtx<'_, D>,
@@ -465,9 +465,9 @@ fn loss_node_label(code: &str, inner: &TermValue) -> String {
 
 /// Instantiate one template triple for `row`, interning into `builder`. Returns
 /// `None` if the triple is skipped (an unbound variable or an ill-formed position).
-fn instantiate<D: DatasetView<Id = TermId> + Sync>(
+fn instantiate<D: DatasetView + Sync>(
     tp: &TriplePattern,
-    row: &Solution,
+    row: &Solution<D::Id>,
     schema: &VarSchema,
     builder: &mut RdfDatasetBuilder,
     blanks: &mut DetHashMap<String, String>,

--- a/crates/sparql-eval/src/dataset_spec.rs
+++ b/crates/sparql-eval/src/dataset_spec.rs
@@ -24,52 +24,52 @@
 
 use std::collections::BTreeSet;
 
-use purrdf_core::{DatasetView, GraphMatch, QuadIds, TermId, TermValue};
+use purrdf_core::{DatasetView, GraphMatch, QuadIds, TermId, TermValue, ViewTermId};
 use purrdf_sparql_algebra::{QueryDataset, UsingClause};
 
 use crate::convert::named_node_to_value;
 
 /// How the active **default graph** is sourced.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum DefaultSpec {
+pub(crate) enum DefaultSpec<I: ViewTermId = TermId> {
     /// No `FROM`/`USING`: the store's own default graph.
     StoreDefault,
     /// `FROM`/`USING` graphs: the RDF-merge of these named graphs (sorted, deduped).
     /// An empty vector is legal — every named IRI was absent, or only `FROM NAMED`
     /// was given — and matches nothing.
-    Merged(Vec<TermId>),
+    Merged(Vec<I>),
 }
 
-/// The SPARQL active dataset (§13), resolved to dataset-local ids once per query/op.
+/// The SPARQL active dataset (§13), resolved to view-local ids once per query/op.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ActiveDataset {
+pub(crate) struct ActiveDataset<I: ViewTermId = TermId> {
     /// The active default-graph specification.
-    default: DefaultSpec,
+    default: DefaultSpec<I>,
     /// The graphs addressable by `GRAPH`. `None` = every store named graph (the
     /// no-clause default); `Some(set)` = exactly these (an explicit `FROM NAMED` /
     /// `USING NAMED`; possibly empty).
-    named: Option<BTreeSet<TermId>>,
+    named: Option<BTreeSet<I>>,
 }
 
 /// The resolved graph filter(s) for the *current* evaluation scope — almost always a
 /// single [`GraphMatch`]; a `FROM`/`USING`-merged default graph expands to one filter
 /// per merged graph (the union of which IS the RDF-merge).
-pub(crate) enum GraphScope {
+pub(crate) enum GraphScope<I: ViewTermId = TermId> {
     /// A single filter (store default, a named graph, or `Any`). No de-dup needed.
-    One(GraphMatch),
+    One(GraphMatch<I>),
     /// The merge of these named graphs. A consumer producing *rows* (BGP) must de-dupe
     /// triples; a consumer collecting *endpoints* into a set (paths) gets it for free.
-    Merge(Vec<TermId>),
+    Merge(Vec<I>),
 }
 
-/// Resolve a list of graph IRIs to their dataset-local ids, dropping any that name no
+/// Resolve a list of graph IRIs to their view-local ids, dropping any that name no
 /// term (an absent graph contributes nothing — never an error), then sort+dedupe for
 /// a deterministic, duplicate-free merge set.
-fn resolve_graphs<D: DatasetView<Id = TermId>>(
+fn resolve_graphs<D: DatasetView>(
     graphs: &[purrdf_sparql_algebra::NamedNode],
     dataset: &D,
-) -> Vec<TermId> {
-    let mut ids: Vec<TermId> = graphs
+) -> Vec<D::Id> {
+    let mut ids: Vec<D::Id> = graphs
         .iter()
         .filter_map(|n| dataset.term_id_by_value(&named_node_to_value(n)))
         .collect();
@@ -78,7 +78,7 @@ fn resolve_graphs<D: DatasetView<Id = TermId>>(
     ids
 }
 
-impl ActiveDataset {
+impl<I: ViewTermId> ActiveDataset<I> {
     /// The store's own default dataset: the store default graph plus every named graph.
     pub(crate) fn store_default() -> Self {
         Self {
@@ -89,7 +89,7 @@ impl ActiveDataset {
 
     /// Build the active dataset from a query's `FROM` / `FROM NAMED` clause. An empty
     /// clause means "use the store's default dataset" (§13.2).
-    pub(crate) fn from_query_dataset<D: DatasetView<Id = TermId>>(
+    pub(crate) fn from_query_dataset<D: DatasetView<Id = I>>(
         qd: &QueryDataset,
         dataset: &D,
     ) -> Self {
@@ -106,10 +106,7 @@ impl ActiveDataset {
     /// clauses (the write-path twin of [`from_query_dataset`]). The caller only invokes
     /// this when `using` is non-empty (§3.1.3: `USING` replaces `WITH`'s effect on the
     /// WHERE dataset).
-    pub(crate) fn from_using<D: DatasetView<Id = TermId>>(
-        using: &[UsingClause],
-        dataset: &D,
-    ) -> Self {
+    pub(crate) fn from_using<D: DatasetView<Id = I>>(using: &[UsingClause], dataset: &D) -> Self {
         let mut default = Vec::new();
         let mut named = Vec::new();
         for u in using {
@@ -137,10 +134,7 @@ impl ActiveDataset {
     /// Scope the WHERE default graph to a single `WITH <g>` graph (named graphs stay
     /// unrestricted). An absent `g` yields an empty default graph (the WHERE matches
     /// nothing), matching the implicit-existence doctrine.
-    pub(crate) fn with_default_graph<D: DatasetView<Id = TermId>>(
-        dataset: &D,
-        g: &TermValue,
-    ) -> Self {
+    pub(crate) fn with_default_graph<D: DatasetView<Id = I>>(dataset: &D, g: &TermValue) -> Self {
         let ids = dataset
             .term_id_by_value(g)
             .map(|id| vec![id])
@@ -155,7 +149,7 @@ impl ActiveDataset {
     /// (`GraphMatch::Default`) expands through the default spec (store default or a
     /// merge); an in-`GRAPH` scope (`Named`) is always a single filter — the default
     /// merge never applies inside a `GRAPH` block.
-    pub(crate) fn scope_for(&self, active_graph: GraphMatch) -> GraphScope {
+    pub(crate) fn scope_for(&self, active_graph: GraphMatch<I>) -> GraphScope<I> {
         match active_graph {
             GraphMatch::Default => match &self.default {
                 DefaultSpec::StoreDefault => GraphScope::One(GraphMatch::Default),
@@ -166,7 +160,7 @@ impl ActiveDataset {
     }
 
     /// Whether the named graph `id` is addressable by `GRAPH` under this dataset.
-    pub(crate) fn named_allows(&self, id: TermId) -> bool {
+    pub(crate) fn named_allows(&self, id: I) -> bool {
         match &self.named {
             None => true,
             Some(set) => set.contains(&id),
@@ -174,18 +168,18 @@ impl ActiveDataset {
     }
 }
 
-impl GraphScope {
+impl<I: ViewTermId> GraphScope<I> {
     /// Visit every quad matching `(s, p, o)` in this scope. For a merged scope the
     /// per-graph indexed reads are unioned in order; **no triple de-dup is applied
     /// here** (the BGP caller de-dupes by `(s,p,o)`; endpoint-collecting callers do
     /// not need it).
-    pub(crate) fn for_each_quad<D: DatasetView<Id = TermId>>(
+    pub(crate) fn for_each_quad<D: DatasetView<Id = I>>(
         &self,
         dataset: &D,
-        s: Option<TermId>,
-        p: Option<TermId>,
-        o: Option<TermId>,
-        mut f: impl FnMut(QuadIds),
+        s: Option<I>,
+        p: Option<I>,
+        o: Option<I>,
+        mut f: impl FnMut(QuadIds<I>),
     ) {
         match self {
             Self::One(gm) => {

--- a/crates/sparql-eval/src/dataset_spec.rs
+++ b/crates/sparql-eval/src/dataset_spec.rs
@@ -24,7 +24,7 @@
 
 use std::collections::BTreeSet;
 
-use purrdf_core::{DatasetView, GraphMatch, QuadIds, RdfDataset, TermId, TermValue};
+use purrdf_core::{DatasetView, GraphMatch, QuadIds, TermId, TermValue};
 use purrdf_sparql_algebra::{QueryDataset, UsingClause};
 
 use crate::convert::named_node_to_value;
@@ -65,9 +65,9 @@ pub(crate) enum GraphScope {
 /// Resolve a list of graph IRIs to their dataset-local ids, dropping any that name no
 /// term (an absent graph contributes nothing — never an error), then sort+dedupe for
 /// a deterministic, duplicate-free merge set.
-fn resolve_graphs(
+fn resolve_graphs<D: DatasetView<Id = TermId>>(
     graphs: &[purrdf_sparql_algebra::NamedNode],
-    dataset: &RdfDataset,
+    dataset: &D,
 ) -> Vec<TermId> {
     let mut ids: Vec<TermId> = graphs
         .iter()
@@ -89,7 +89,10 @@ impl ActiveDataset {
 
     /// Build the active dataset from a query's `FROM` / `FROM NAMED` clause. An empty
     /// clause means "use the store's default dataset" (§13.2).
-    pub(crate) fn from_query_dataset(qd: &QueryDataset, dataset: &RdfDataset) -> Self {
+    pub(crate) fn from_query_dataset<D: DatasetView<Id = TermId>>(
+        qd: &QueryDataset,
+        dataset: &D,
+    ) -> Self {
         if qd.default.is_empty() && qd.named.is_empty() {
             return Self::store_default();
         }
@@ -103,7 +106,10 @@ impl ActiveDataset {
     /// clauses (the write-path twin of [`from_query_dataset`]). The caller only invokes
     /// this when `using` is non-empty (§3.1.3: `USING` replaces `WITH`'s effect on the
     /// WHERE dataset).
-    pub(crate) fn from_using(using: &[UsingClause], dataset: &RdfDataset) -> Self {
+    pub(crate) fn from_using<D: DatasetView<Id = TermId>>(
+        using: &[UsingClause],
+        dataset: &D,
+    ) -> Self {
         let mut default = Vec::new();
         let mut named = Vec::new();
         for u in using {
@@ -131,7 +137,10 @@ impl ActiveDataset {
     /// Scope the WHERE default graph to a single `WITH <g>` graph (named graphs stay
     /// unrestricted). An absent `g` yields an empty default graph (the WHERE matches
     /// nothing), matching the implicit-existence doctrine.
-    pub(crate) fn with_default_graph(dataset: &RdfDataset, g: &TermValue) -> Self {
+    pub(crate) fn with_default_graph<D: DatasetView<Id = TermId>>(
+        dataset: &D,
+        g: &TermValue,
+    ) -> Self {
         let ids = dataset
             .term_id_by_value(g)
             .map(|id| vec![id])
@@ -170,9 +179,9 @@ impl GraphScope {
     /// per-graph indexed reads are unioned in order; **no triple de-dup is applied
     /// here** (the BGP caller de-dupes by `(s,p,o)`; endpoint-collecting callers do
     /// not need it).
-    pub(crate) fn for_each_quad(
+    pub(crate) fn for_each_quad<D: DatasetView<Id = TermId>>(
         &self,
-        dataset: &RdfDataset,
+        dataset: &D,
         s: Option<TermId>,
         p: Option<TermId>,
         o: Option<TermId>,

--- a/crates/sparql-eval/src/describe_query.rs
+++ b/crates/sparql-eval/src/describe_query.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use purrdf_core::describe::Describer;
-use purrdf_core::{DatasetView, RdfDataset, TermId, TermValue};
+use purrdf_core::{DatasetView, RdfDataset, TermValue};
 use purrdf_sparql_algebra::{GraphPattern, NamedNodePattern};
 
 use crate::error::EvalError;
@@ -29,7 +29,7 @@ use crate::eval::{EvalCtx, eval, materialize_solutions};
 
 /// Evaluate a `DESCRIBE` query to a frozen IR dataset: the union Symmetric CBD of its
 /// resolved subject IRIs.
-pub(crate) fn eval_describe<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_describe<D: DatasetView + Sync>(
     pattern: &GraphPattern,
     targets: &[NamedNodePattern],
     ctx: &mut EvalCtx<'_, D>,

--- a/crates/sparql-eval/src/describe_query.rs
+++ b/crates/sparql-eval/src/describe_query.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use purrdf_core::describe::Describer;
-use purrdf_core::{RdfDataset, TermValue};
+use purrdf_core::{DatasetView, RdfDataset, TermId, TermValue};
 use purrdf_sparql_algebra::{GraphPattern, NamedNodePattern};
 
 use crate::error::EvalError;
@@ -29,10 +29,10 @@ use crate::eval::{EvalCtx, eval, materialize_solutions};
 
 /// Evaluate a `DESCRIBE` query to a frozen IR dataset: the union Symmetric CBD of its
 /// resolved subject IRIs.
-pub(crate) fn eval_describe(
+pub(crate) fn eval_describe<D: DatasetView<Id = TermId> + Sync>(
     pattern: &GraphPattern,
     targets: &[NamedNodePattern],
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Arc<RdfDataset>, EvalError> {
     // A `BTreeSet` gives a deterministic, deduplicated subject order.
     let mut subjects: BTreeSet<String> = BTreeSet::new();

--- a/crates/sparql-eval/src/engine.rs
+++ b/crates/sparql-eval/src/engine.rs
@@ -17,8 +17,8 @@ use std::cell::RefCell;
 use std::sync::Arc;
 
 use purrdf_core::{
-    GraphMatch, MutableDataset, RdfDataset, RdfDiagnostic, SparqlEngine, SparqlRequest,
-    SparqlResult, TermValue,
+    DatasetView, GraphMatch, MutableDataset, RdfDataset, RdfDiagnostic, SparqlEngine,
+    SparqlRequest, SparqlResult, TermId, TermValue,
 };
 use purrdf_sparql_algebra::{ParserOptions, Query, SparqlParser};
 
@@ -187,6 +187,22 @@ impl NativeSparqlEngine {
         prepared: &PreparedQuery,
         substitutions: &[(String, TermValue)],
     ) -> Result<SparqlResult, RdfDiagnostic> {
+        self.query_prepared_view(&**dataset, prepared, substitutions)
+    }
+
+    /// [`Self::query_prepared`] over any [`DatasetView`] backend whose id type is the
+    /// production [`TermId`]. The concrete [`Self::query_prepared`] is a thin wrapper
+    /// that derefs its `Arc<RdfDataset>` and calls this.
+    ///
+    /// # Errors
+    ///
+    /// Propagates evaluation errors as an [`RdfDiagnostic`].
+    pub fn query_prepared_view<D: DatasetView<Id = TermId> + Sync>(
+        &self,
+        dataset: &D,
+        prepared: &PreparedQuery,
+        substitutions: &[(String, TermValue)],
+    ) -> Result<SparqlResult, RdfDiagnostic> {
         let mut ctx = self.eval_ctx(dataset);
         let outcome = evaluate_with_substitutions(prepared, substitutions, &mut ctx)?;
         Ok(materialize(outcome, &ctx))
@@ -253,7 +269,10 @@ impl NativeSparqlEngine {
     /// eval options) into it. `NOW()`/`RAND()`/`UUID()`/`STRUUID()` are already
     /// correct by construction: [`EvalCtx::new`] samples the real host wall clock
     /// and OS entropy itself.
-    fn eval_ctx<'d>(&'d self, dataset: &'d RdfDataset) -> EvalCtx<'d> {
+    fn eval_ctx<'d, D: DatasetView<Id = TermId> + Sync>(
+        &'d self,
+        dataset: &'d D,
+    ) -> EvalCtx<'d, D> {
         let mut ctx = EvalCtx::new(dataset)
             .with_order_cache(&self.order_cache)
             .with_eval_options(self.eval_options);
@@ -282,6 +301,22 @@ impl NativeSparqlEngine {
     pub fn explain_query(
         &self,
         dataset: &Arc<RdfDataset>,
+        query_text: &str,
+        base_iri: Option<&str>,
+    ) -> Result<Vec<String>, RdfDiagnostic> {
+        self.explain_query_view(&**dataset, query_text, base_iri)
+    }
+
+    /// [`Self::explain_query`] over any [`DatasetView`] backend whose id type is the
+    /// production [`TermId`]. The cost-based join order is computed against the given
+    /// view's cardinalities exactly as the concrete path does.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`RdfDiagnostic`] if the query text does not parse.
+    pub fn explain_query_view<D: DatasetView<Id = TermId> + Sync>(
+        &self,
+        dataset: &D,
         query_text: &str,
         base_iri: Option<&str>,
     ) -> Result<Vec<String>, RdfDiagnostic> {
@@ -324,6 +359,22 @@ impl NativeSparqlEngine {
         base_iri: Option<&str>,
         substitutions: &[(String, TermValue)],
     ) -> Result<SparqlResult, RdfDiagnostic> {
+        self.query_with_shacl_prebinding_view(&**dataset, query, base_iri, substitutions)
+    }
+
+    /// [`Self::query_with_shacl_prebinding`] over any [`DatasetView`] backend whose id
+    /// type is the production [`TermId`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates parse/evaluation errors as an [`RdfDiagnostic`].
+    pub fn query_with_shacl_prebinding_view<D: DatasetView<Id = TermId> + Sync>(
+        &self,
+        dataset: &D,
+        query: &str,
+        base_iri: Option<&str>,
+        substitutions: &[(String, TermValue)],
+    ) -> Result<SparqlResult, RdfDiagnostic> {
         let prepared =
             self.cache
                 .borrow_mut()
@@ -342,6 +393,29 @@ impl NativeSparqlEngine {
     pub fn query_with_shacl_prebinding_and_functions(
         &self,
         dataset: &Arc<RdfDataset>,
+        query: &str,
+        base_iri: Option<&str>,
+        substitutions: &[(String, TermValue)],
+        registry: &crate::user_fn::UserFunctionRegistry,
+    ) -> Result<SparqlResult, RdfDiagnostic> {
+        self.query_with_shacl_prebinding_and_functions_view(
+            &**dataset,
+            query,
+            base_iri,
+            substitutions,
+            registry,
+        )
+    }
+
+    /// [`Self::query_with_shacl_prebinding_and_functions`] over any [`DatasetView`]
+    /// backend whose id type is the production [`TermId`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates parse/evaluation errors as an [`RdfDiagnostic`].
+    pub fn query_with_shacl_prebinding_and_functions_view<D: DatasetView<Id = TermId> + Sync>(
+        &self,
+        dataset: &D,
         query: &str,
         base_iri: Option<&str>,
         substitutions: &[(String, TermValue)],
@@ -372,6 +446,21 @@ impl NativeSparqlEngine {
         request: SparqlRequest<'_>,
         source: &(dyn crate::remote::RemoteQuerySource + Sync),
     ) -> Result<SparqlResult, RdfDiagnostic> {
+        self.query_with_source_view(&**dataset, request, source)
+    }
+
+    /// [`Self::query_with_source`] over any [`DatasetView`] backend whose id type is
+    /// the production [`TermId`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates parse and evaluation errors as an [`RdfDiagnostic`].
+    pub fn query_with_source_view<D: DatasetView<Id = TermId> + Sync>(
+        &self,
+        dataset: &D,
+        request: SparqlRequest<'_>,
+        source: &(dyn crate::remote::RemoteQuerySource + Sync),
+    ) -> Result<SparqlResult, RdfDiagnostic> {
         let prepared = self.cache.borrow_mut().prepare_with(
             request.query,
             request.base_iri,
@@ -397,6 +486,21 @@ impl NativeSparqlEngine {
         request: SparqlRequest<'_>,
         registry: &crate::user_fn::UserFunctionRegistry,
     ) -> Result<SparqlResult, RdfDiagnostic> {
+        self.query_with_user_functions_view(&**dataset, request, registry)
+    }
+
+    /// [`Self::query_with_user_functions`] over any [`DatasetView`] backend whose id
+    /// type is the production [`TermId`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates parse and evaluation errors as an [`RdfDiagnostic`].
+    pub fn query_with_user_functions_view<D: DatasetView<Id = TermId> + Sync>(
+        &self,
+        dataset: &D,
+        request: SparqlRequest<'_>,
+        registry: &crate::user_fn::UserFunctionRegistry,
+    ) -> Result<SparqlResult, RdfDiagnostic> {
         let prepared = self.cache.borrow_mut().prepare_with(
             request.query,
             request.base_iri,
@@ -413,10 +517,10 @@ impl NativeSparqlEngine {
 /// When there are no substitutions the cached parse is evaluated directly (the hot
 /// path). Otherwise the cached parse is **cloned** and rewritten — the substitution
 /// must never poison the shared, un-substituted plan-cache entry.
-fn evaluate_with_substitutions(
+fn evaluate_with_substitutions<D: DatasetView<Id = TermId> + Sync>(
     prepared: &PreparedQuery,
     substitutions: &[(String, TermValue)],
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Outcome, RdfDiagnostic> {
     let eval_err = |e: crate::error::EvalError| {
         RdfDiagnostic::error("native-sparql-query-eval", e.to_string())
@@ -429,10 +533,10 @@ fn evaluate_with_substitutions(
     evaluate_query(&substituted, ctx).map_err(eval_err)
 }
 
-fn evaluate_with_shacl_prebinding(
+fn evaluate_with_shacl_prebinding<D: DatasetView<Id = TermId> + Sync>(
     prepared: &PreparedQuery,
     substitutions: &[(String, TermValue)],
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Outcome, RdfDiagnostic> {
     let substituted =
         crate::substitute::apply_shacl_prebinding(prepared.query.clone(), substitutions)?;
@@ -484,7 +588,10 @@ impl SparqlEngine for NativeSparqlEngine {
 /// Materialize an evaluation [`Outcome`] into the dataset-independent
 /// `SparqlResult` egress model (the interned-id space ends here: every solution
 /// cell becomes an owned [`TermValue`](purrdf_core::TermValue)).
-fn materialize(outcome: Outcome, ctx: &EvalCtx<'_>) -> SparqlResult {
+fn materialize<D: DatasetView<Id = TermId> + Sync>(
+    outcome: Outcome,
+    ctx: &EvalCtx<'_, D>,
+) -> SparqlResult {
     match outcome {
         Outcome::Solutions(seq) => {
             let (variables, rows) = crate::eval::materialize_solutions(&seq, ctx);

--- a/crates/sparql-eval/src/engine.rs
+++ b/crates/sparql-eval/src/engine.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use purrdf_core::{
     DatasetView, GraphMatch, MutableDataset, RdfDataset, RdfDiagnostic, SparqlEngine,
-    SparqlRequest, SparqlResult, TermId, TermValue,
+    SparqlRequest, SparqlResult, TermValue,
 };
 use purrdf_sparql_algebra::{ParserOptions, Query, SparqlParser};
 
@@ -191,13 +191,13 @@ impl NativeSparqlEngine {
     }
 
     /// [`Self::query_prepared`] over any [`DatasetView`] backend whose id type is the
-    /// production [`TermId`]. The concrete [`Self::query_prepared`] is a thin wrapper
+    /// production [`TermId`](purrdf_core::TermId). The concrete [`Self::query_prepared`] is a thin wrapper
     /// that derefs its `Arc<RdfDataset>` and calls this.
     ///
     /// # Errors
     ///
     /// Propagates evaluation errors as an [`RdfDiagnostic`].
-    pub fn query_prepared_view<D: DatasetView<Id = TermId> + Sync>(
+    pub fn query_prepared_view<D: DatasetView + Sync>(
         &self,
         dataset: &D,
         prepared: &PreparedQuery,
@@ -269,10 +269,7 @@ impl NativeSparqlEngine {
     /// eval options) into it. `NOW()`/`RAND()`/`UUID()`/`STRUUID()` are already
     /// correct by construction: [`EvalCtx::new`] samples the real host wall clock
     /// and OS entropy itself.
-    fn eval_ctx<'d, D: DatasetView<Id = TermId> + Sync>(
-        &'d self,
-        dataset: &'d D,
-    ) -> EvalCtx<'d, D> {
+    fn eval_ctx<'d, D: DatasetView + Sync>(&'d self, dataset: &'d D) -> EvalCtx<'d, D> {
         let mut ctx = EvalCtx::new(dataset)
             .with_order_cache(&self.order_cache)
             .with_eval_options(self.eval_options);
@@ -308,13 +305,13 @@ impl NativeSparqlEngine {
     }
 
     /// [`Self::explain_query`] over any [`DatasetView`] backend whose id type is the
-    /// production [`TermId`]. The cost-based join order is computed against the given
+    /// production [`TermId`](purrdf_core::TermId). The cost-based join order is computed against the given
     /// view's cardinalities exactly as the concrete path does.
     ///
     /// # Errors
     ///
     /// Returns an [`RdfDiagnostic`] if the query text does not parse.
-    pub fn explain_query_view<D: DatasetView<Id = TermId> + Sync>(
+    pub fn explain_query_view<D: DatasetView + Sync>(
         &self,
         dataset: &D,
         query_text: &str,
@@ -363,12 +360,12 @@ impl NativeSparqlEngine {
     }
 
     /// [`Self::query_with_shacl_prebinding`] over any [`DatasetView`] backend whose id
-    /// type is the production [`TermId`].
+    /// type is the production [`TermId`](purrdf_core::TermId).
     ///
     /// # Errors
     ///
     /// Propagates parse/evaluation errors as an [`RdfDiagnostic`].
-    pub fn query_with_shacl_prebinding_view<D: DatasetView<Id = TermId> + Sync>(
+    pub fn query_with_shacl_prebinding_view<D: DatasetView + Sync>(
         &self,
         dataset: &D,
         query: &str,
@@ -408,12 +405,12 @@ impl NativeSparqlEngine {
     }
 
     /// [`Self::query_with_shacl_prebinding_and_functions`] over any [`DatasetView`]
-    /// backend whose id type is the production [`TermId`].
+    /// backend whose id type is the production [`TermId`](purrdf_core::TermId).
     ///
     /// # Errors
     ///
     /// Propagates parse/evaluation errors as an [`RdfDiagnostic`].
-    pub fn query_with_shacl_prebinding_and_functions_view<D: DatasetView<Id = TermId> + Sync>(
+    pub fn query_with_shacl_prebinding_and_functions_view<D: DatasetView + Sync>(
         &self,
         dataset: &D,
         query: &str,
@@ -450,12 +447,12 @@ impl NativeSparqlEngine {
     }
 
     /// [`Self::query_with_source`] over any [`DatasetView`] backend whose id type is
-    /// the production [`TermId`].
+    /// the production [`TermId`](purrdf_core::TermId).
     ///
     /// # Errors
     ///
     /// Propagates parse and evaluation errors as an [`RdfDiagnostic`].
-    pub fn query_with_source_view<D: DatasetView<Id = TermId> + Sync>(
+    pub fn query_with_source_view<D: DatasetView + Sync>(
         &self,
         dataset: &D,
         request: SparqlRequest<'_>,
@@ -490,12 +487,12 @@ impl NativeSparqlEngine {
     }
 
     /// [`Self::query_with_user_functions`] over any [`DatasetView`] backend whose id
-    /// type is the production [`TermId`].
+    /// type is the production [`TermId`](purrdf_core::TermId).
     ///
     /// # Errors
     ///
     /// Propagates parse and evaluation errors as an [`RdfDiagnostic`].
-    pub fn query_with_user_functions_view<D: DatasetView<Id = TermId> + Sync>(
+    pub fn query_with_user_functions_view<D: DatasetView + Sync>(
         &self,
         dataset: &D,
         request: SparqlRequest<'_>,
@@ -517,11 +514,11 @@ impl NativeSparqlEngine {
 /// When there are no substitutions the cached parse is evaluated directly (the hot
 /// path). Otherwise the cached parse is **cloned** and rewritten — the substitution
 /// must never poison the shared, un-substituted plan-cache entry.
-fn evaluate_with_substitutions<D: DatasetView<Id = TermId> + Sync>(
+fn evaluate_with_substitutions<D: DatasetView + Sync>(
     prepared: &PreparedQuery,
     substitutions: &[(String, TermValue)],
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<Outcome, RdfDiagnostic> {
+) -> Result<Outcome<D::Id>, RdfDiagnostic> {
     let eval_err = |e: crate::error::EvalError| {
         RdfDiagnostic::error("native-sparql-query-eval", e.to_string())
     };
@@ -533,11 +530,11 @@ fn evaluate_with_substitutions<D: DatasetView<Id = TermId> + Sync>(
     evaluate_query(&substituted, ctx).map_err(eval_err)
 }
 
-fn evaluate_with_shacl_prebinding<D: DatasetView<Id = TermId> + Sync>(
+fn evaluate_with_shacl_prebinding<D: DatasetView + Sync>(
     prepared: &PreparedQuery,
     substitutions: &[(String, TermValue)],
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<Outcome, RdfDiagnostic> {
+) -> Result<Outcome<D::Id>, RdfDiagnostic> {
     let substituted =
         crate::substitute::apply_shacl_prebinding(prepared.query.clone(), substitutions)?;
     evaluate_query(&substituted, ctx)
@@ -588,8 +585,8 @@ impl SparqlEngine for NativeSparqlEngine {
 /// Materialize an evaluation [`Outcome`] into the dataset-independent
 /// `SparqlResult` egress model (the interned-id space ends here: every solution
 /// cell becomes an owned [`TermValue`](purrdf_core::TermValue)).
-fn materialize<D: DatasetView<Id = TermId> + Sync>(
-    outcome: Outcome,
+fn materialize<D: DatasetView + Sync>(
+    outcome: Outcome<D::Id>,
     ctx: &EvalCtx<'_, D>,
 ) -> SparqlResult {
     match outcome {

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -17,7 +17,9 @@
 
 use std::sync::Arc;
 
-use purrdf_core::{DatasetView, GraphMatch, RdfDataset, TermFactory, TermId, TermValue};
+use purrdf_core::{
+    DatasetView, GraphMatch, RdfDataset, TermFactory, TermId, TermValue, ViewTermId,
+};
 use purrdf_sparql_algebra::{GraphPattern, Query, Variable};
 
 use crate::DetHashMap;
@@ -129,21 +131,21 @@ impl LossVocabulary {
 /// pairing and the keyed/wild split derived from it — depends on the outer schema, not
 /// just the inner pattern and graph. Keying on it makes a cached index correct *by
 /// construction* even if the same `EXISTS` AST node is reached under two outer schemas.
-pub(crate) type ExistsCacheKey = (usize, (u8, u32), u64);
+pub(crate) type ExistsCacheKey<I> = (usize, (u8, Option<I>), u64);
 
 /// A memoized `EXISTS`/`NOT EXISTS` inner pattern together with the probe index built
 /// over it. The inner pattern is evaluated unconstrained **once** per [`ExistsCacheKey`];
 /// the `(shared, keyed, wild)` index is built once and reused to existence-probe every
 /// outer row (see [`crate::binop::probe_has_match`]). This is what turns a `FILTER (NOT)
 /// EXISTS` anti-join from N per-row index rebuilds into N O(1)/scan probes.
-pub(crate) struct ExistsInner {
+pub(crate) struct ExistsInner<I: ViewTermId = TermId> {
     /// The inner pattern's unconstrained result (outer-row-independent).
-    pub inner: Arc<SolutionSeq>,
+    pub inner: Arc<SolutionSeq<I>>,
     /// Shared columns between the outer schema and `inner.schema`, as
     /// `(outer_ordinal, inner_ordinal)` pairs (the probe's join key).
     pub shared: Vec<(usize, usize)>,
     /// Inner rows fully bound on the shared columns, grouped by their key.
-    pub keyed: DetHashMap<crate::binop::JoinKey, Vec<usize>>,
+    pub keyed: DetHashMap<crate::binop::JoinKey<I>, Vec<usize>>,
     /// Inner rows with an unbound shared column (compatible with any probe value).
     pub wild: Vec<usize>,
 }
@@ -183,7 +185,7 @@ pub type BgpOrderCache = std::sync::RwLock<DetHashMap<(u64, u64), Arc<[usize]>>>
 /// its own id space bridges to `TermId` before this boundary. `D` defaults to
 /// [`RdfDataset`], so the bare spelling `EvalCtx<'d>` names the production
 /// instantiation everywhere it did before.
-pub struct EvalCtx<'d, D: DatasetView<Id = TermId> + Sync = RdfDataset> {
+pub struct EvalCtx<'d, D: DatasetView + Sync = RdfDataset> {
     /// The frozen read view being queried, driven through the [`DatasetView`] trait.
     pub dataset: &'d D,
     /// The per-query interner for terms computed during evaluation (BIND, VALUES,
@@ -192,11 +194,11 @@ pub struct EvalCtx<'d, D: DatasetView<Id = TermId> + Sync = RdfDataset> {
     /// The graph currently in scope (set by `GRAPH`; the default graph at the root).
     /// At the root this is `GraphMatch::Default`, which `active_dataset` resolves to
     /// either the store default graph or a `FROM`/`USING`-merged default graph.
-    pub active_graph: GraphMatch,
+    pub active_graph: GraphMatch<D::Id>,
     /// The SPARQL active dataset (§13): how `active_graph == Default` is sourced and
     /// which named graphs `GRAPH` may address. Set from a query's `FROM` clause (the
     /// query path) or an UPDATE op's `USING` / `WITH` (the update path).
-    pub(crate) active_dataset: ActiveDataset,
+    pub(crate) active_dataset: ActiveDataset<D::Id>,
     /// A monotonic counter for minting fresh blank nodes (`BNODE()` and CONSTRUCT
     /// template blanks).
     pub bnode_counter: u64,
@@ -215,7 +217,7 @@ pub struct EvalCtx<'d, D: DatasetView<Id = TermId> + Sync = RdfDataset> {
     /// form bypasses this entirely and always mints fresh. Query-scoped like the
     /// other caches on this context — never cleared mid-query, since a later row
     /// never revisits an earlier row's ordinal within the same `Extend` chain.
-    pub(crate) bnode_memo: DetHashMap<(u64, String), SolutionTerm>,
+    pub(crate) bnode_memo: DetHashMap<(u64, String), SolutionTerm<D::Id>>,
     /// The evaluation-time value of NOW() — an xsd:dateTime, captured once at
     /// context construction from the host platform's real wall clock so all NOW()
     /// calls in a query return the same instant (SPARQL 1.1 §17.4.5.1).
@@ -242,7 +244,7 @@ pub struct EvalCtx<'d, D: DatasetView<Id = TermId> + Sync = RdfDataset> {
     /// over it are outer-row-independent, so this turns `expr::exists`'s per-row
     /// re-evaluation *and* per-row index rebuild into a single build per site.
     /// Naturally per-query: a fresh [`EvalCtx`] is built for each `query()` call.
-    pub(crate) exists_inner_cache: DetHashMap<ExistsCacheKey, Arc<ExistsInner>>,
+    pub(crate) exists_inner_cache: DetHashMap<ExistsCacheKey<D::Id>, Arc<ExistsInner<D::Id>>>,
     /// Per-query syntactic variable cache for expression positions inside an
     /// `EXISTS` inner pattern, keyed by the immutable inner-pattern AST address.
     /// Correlation detection runs for every outer row; caching this pure walk keeps
@@ -263,7 +265,7 @@ pub struct EvalCtx<'d, D: DatasetView<Id = TermId> + Sync = RdfDataset> {
     /// `(dataset, scratch)` — the dataset is pinned for the context's lifetime and
     /// the scratch interner dedups by value — so the cached term is bit-identical
     /// to what a fresh intern would return.
-    pub(crate) cached_bool_terms: [Option<SolutionTerm>; 2],
+    pub(crate) cached_bool_terms: [Option<SolutionTerm<D::Id>>; 2],
     /// Per-query memo of interned constant expression atoms (`NamedNode` /
     /// `Literal`), keyed by the atom node's immutable AST address. A constant atom
     /// inside a `FILTER`/`BIND` is otherwise re-`to_owned()`'d into an owned
@@ -281,7 +283,7 @@ pub struct EvalCtx<'d, D: DatasetView<Id = TermId> + Sync = RdfDataset> {
     /// otherwise return a stale, wrong-row value from this cache.
     /// [`Self::in_substituted_exists`] flags exactly that window so `const_atom`
     /// bypasses this cache while it is set.
-    pub(crate) const_atom_cache: DetHashMap<usize, SolutionTerm>,
+    pub(crate) const_atom_cache: DetHashMap<usize, SolutionTerm<D::Id>>,
     /// Per-query memo of the parsed XSD value of a dataset literal, keyed by its
     /// `TermId`. `FILTER`/comparison hot paths (`compare`/`equal`/`ebv_term`) parse
     /// the same `Existing(TermId)` literal's lexical form via `parse_by_iri` on
@@ -291,7 +293,7 @@ pub struct EvalCtx<'d, D: DatasetView<Id = TermId> + Sync = RdfDataset> {
     /// value" outcome) collapses per-row re-parsing to one parse per distinct id.
     /// Naturally per-query. Only dataset (`Existing`) ids are cached; computed
     /// scratch values are ephemeral and stay on the borrowed-view path.
-    pub(crate) xsd_parse_cache: DetHashMap<TermId, Option<purrdf_xsd::XsdValue>>,
+    pub(crate) xsd_parse_cache: DetHashMap<D::Id, Option<purrdf_xsd::XsdValue>>,
     /// The `SERVICE` federation source, if one is injected. `None` in
     /// the default engine path: a non-silent `SERVICE` then hard-fails. Tests and
     /// the conformance harness inject an in-memory source via [`EvalCtx::with_remote`].
@@ -360,7 +362,7 @@ const _: fn() = || {
     assert_send_sync::<EvalCtx<'static>>();
 };
 
-impl<D: DatasetView<Id = TermId> + Sync> core::fmt::Debug for EvalCtx<'_, D> {
+impl<D: DatasetView + Sync> core::fmt::Debug for EvalCtx<'_, D> {
     /// Summarized: the injected `SERVICE` source (`remote`) is a plain `dyn`
     /// trait object and the per-query caches are noise, so only the scalar
     /// evaluation state is shown.
@@ -377,7 +379,7 @@ impl<D: DatasetView<Id = TermId> + Sync> core::fmt::Debug for EvalCtx<'_, D> {
     }
 }
 
-impl<'d, D: DatasetView<Id = TermId> + Sync> EvalCtx<'d, D> {
+impl<'d, D: DatasetView + Sync> EvalCtx<'d, D> {
     /// A fresh context over `dataset`, scoped to the default graph.
     pub fn new(dataset: &'d D) -> Self {
         let now_val = purrdf_xsd::XsdValue::DateTime(crate::clock::wall_clock_now());
@@ -693,11 +695,13 @@ impl<'d, D: DatasetView<Id = TermId> + Sync> EvalCtx<'d, D> {
     }
 
     /// A compact hashable encoding of the active graph, for [`ExistsCacheKey`].
-    pub(crate) fn graph_key(&self) -> (u8, u32) {
+    /// The named-graph id rides as `Option<D::Id>` (not a truncated integer) so the
+    /// key is collision-free for any id width (e.g. a `u64` `GlobalTermId`).
+    pub(crate) fn graph_key(&self) -> (u8, Option<D::Id>) {
         match self.active_graph {
-            GraphMatch::Any => (0, 0),
-            GraphMatch::Default => (1, 0),
-            GraphMatch::Named(id) => (2, id.index() as u32),
+            GraphMatch::Any => (0, None),
+            GraphMatch::Default => (1, None),
+            GraphMatch::Named(id) => (2, Some(id)),
         }
     }
 }
@@ -708,10 +712,10 @@ impl<'d, D: DatasetView<Id = TermId> + Sync> EvalCtx<'d, D> {
 /// returns [`EvalError::Unsupported`] naming the construct. Property paths are
 /// evaluated in-engine (S8, the `path` module); the remaining out-of-scope
 /// nodes (`Service`, `Lateral`) stay permanent hard errors (SERVICE is S6b).
-pub fn eval<D: DatasetView<Id = TermId> + Sync>(
+pub fn eval<D: DatasetView + Sync>(
     pattern: &GraphPattern,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     match pattern {
         GraphPattern::Bgp { patterns } => crate::bgp::eval_bgp(patterns, ctx),
         GraphPattern::Path {
@@ -768,9 +772,9 @@ pub fn eval<D: DatasetView<Id = TermId> + Sync>(
 /// The result of evaluating a top-level query form — the internal counterpart of
 /// the `SparqlResult` egress model (materialized by the engine, S6 Task 9).
 #[derive(Debug)]
-pub enum Outcome {
+pub enum Outcome<I: ViewTermId = TermId> {
     /// `SELECT` solutions (a multiset over the projected schema).
-    Solutions(SolutionSeq),
+    Solutions(SolutionSeq<I>),
     /// `CONSTRUCT`/`DESCRIBE` graph result.
     Graph(Arc<RdfDataset>),
     /// `ASK` boolean.
@@ -781,10 +785,10 @@ pub enum Outcome {
 ///
 /// `SELECT`/`ASK` walk the modifier-wrapped pattern; `CONSTRUCT` and `DESCRIBE` emit
 /// the IR dataset directly (`DESCRIBE` via the canonical Symmetric CBD).
-pub fn evaluate_query<D: DatasetView<Id = TermId> + Sync>(
+pub fn evaluate_query<D: DatasetView + Sync>(
     query: &Query,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<Outcome, EvalError> {
+) -> Result<Outcome<D::Id>, EvalError> {
     // Install the query's FROM / FROM NAMED active dataset (§13) before evaluating.
     ctx.active_dataset = ActiveDataset::from_query_dataset(query.dataset(), ctx.dataset);
     // Install the query's effective base IRI so IRI()/URI() can resolve a relative
@@ -813,8 +817,8 @@ pub fn evaluate_query<D: DatasetView<Id = TermId> + Sync>(
 /// Shared by the engine's `SparqlResult` materializer and the SERVICE result
 /// path, both of which turn an interned solution sequence into owned
 /// term values via the per-query [`ScratchInterner`](crate::scratch::ScratchInterner).
-pub(crate) fn materialize_solutions<D: DatasetView<Id = TermId> + Sync>(
-    seq: &SolutionSeq,
+pub(crate) fn materialize_solutions<D: DatasetView + Sync>(
+    seq: &SolutionSeq<D::Id>,
     ctx: &EvalCtx<'_, D>,
 ) -> (Vec<String>, Vec<Vec<Option<TermValue>>>) {
     let variables = seq
@@ -824,9 +828,9 @@ pub(crate) fn materialize_solutions<D: DatasetView<Id = TermId> + Sync>(
         .map(|v| v.as_str().to_owned())
         .collect();
     // Literal datatype IRIs repeat massively across a result (a handful of XSD
-    // types over tens of thousands of cells), so each datatype TermId is resolved
+    // types over tens of thousands of cells), so each datatype id is resolved
     // once per call and cloned from a small memo instead of re-resolved per cell.
-    let mut datatype_memo: DetHashMap<TermId, String> = DetHashMap::default();
+    let mut datatype_memo: DetHashMap<D::Id, String> = DetHashMap::default();
     let mut rows = Vec::with_capacity(seq.rows.len());
     for row in &seq.rows {
         let mut out = Vec::with_capacity(row.len());
@@ -840,10 +844,10 @@ pub(crate) fn materialize_solutions<D: DatasetView<Id = TermId> + Sync>(
 
 /// [`ScratchInterner::value_of`], with repeated literal datatype-IRI resolutions
 /// served from `datatype_memo` (egress-only; identical output values).
-fn memoized_value_of<D: DatasetView<Id = TermId> + Sync>(
+fn memoized_value_of<D: DatasetView + Sync>(
     ctx: &EvalCtx<'_, D>,
-    term: SolutionTerm,
-    datatype_memo: &mut DetHashMap<TermId, String>,
+    term: SolutionTerm<D::Id>,
+    datatype_memo: &mut DetHashMap<D::Id, String>,
 ) -> TermValue {
     match term {
         SolutionTerm::Existing(id) => memoized_term_value(ctx.dataset, id, datatype_memo),
@@ -853,10 +857,10 @@ fn memoized_value_of<D: DatasetView<Id = TermId> + Sync>(
 
 /// `scratch::term_id_to_value`, with the literal datatype id → IRI string
 /// resolution memoized across cells (recursing through RDF-1.2 triple terms).
-fn memoized_term_value<D: DatasetView<Id = TermId>>(
+fn memoized_term_value<D: DatasetView>(
     dataset: &D,
-    id: TermId,
-    datatype_memo: &mut DetHashMap<TermId, String>,
+    id: D::Id,
+    datatype_memo: &mut DetHashMap<D::Id, String>,
 ) -> TermValue {
     match dataset.resolve(id) {
         purrdf_core::TermRef::Iri(iri) => TermValue::Iri(iri.to_owned()),

--- a/crates/sparql-eval/src/eval.rs
+++ b/crates/sparql-eval/src/eval.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use purrdf_core::{GraphMatch, RdfDataset, TermFactory, TermValue};
+use purrdf_core::{DatasetView, GraphMatch, RdfDataset, TermFactory, TermId, TermValue};
 use purrdf_sparql_algebra::{GraphPattern, Query, Variable};
 
 use crate::DetHashMap;
@@ -175,10 +175,17 @@ pub(crate) fn schema_fingerprint(schema: &crate::solution::VarSchema) -> u64 {
 pub type BgpOrderCache = std::sync::RwLock<DetHashMap<(u64, u64), Arc<[usize]>>>;
 
 /// The mutable evaluation context threaded through [`eval`].
-pub struct EvalCtx<'d> {
-    /// The frozen dataset being queried (the concrete IR — see the module docs for
-    /// why this is not a generic `DatasetView`).
-    pub dataset: &'d RdfDataset,
+///
+/// Generic over the read view `D` (the storage-backend seam): the evaluator drives
+/// the dataset entirely through the [`DatasetView`] trait, so any backend whose id
+/// type is the production [`TermId`] (`D::Id = TermId`) plugs in unchanged. The
+/// binding/solution id space is still concrete `TermId` in this layer; a backend with
+/// its own id space bridges to `TermId` before this boundary. `D` defaults to
+/// [`RdfDataset`], so the bare spelling `EvalCtx<'d>` names the production
+/// instantiation everywhere it did before.
+pub struct EvalCtx<'d, D: DatasetView<Id = TermId> + Sync = RdfDataset> {
+    /// The frozen read view being queried, driven through the [`DatasetView`] trait.
+    pub dataset: &'d D,
     /// The per-query interner for terms computed during evaluation (BIND, VALUES,
     /// aggregate output, arithmetic/string-function results).
     pub scratch: ScratchInterner,
@@ -284,7 +291,7 @@ pub struct EvalCtx<'d> {
     /// value" outcome) collapses per-row re-parsing to one parse per distinct id.
     /// Naturally per-query. Only dataset (`Existing`) ids are cached; computed
     /// scratch values are ephemeral and stay on the borrowed-view path.
-    pub(crate) xsd_parse_cache: DetHashMap<purrdf_core::TermId, Option<purrdf_xsd::XsdValue>>,
+    pub(crate) xsd_parse_cache: DetHashMap<TermId, Option<purrdf_xsd::XsdValue>>,
     /// The `SERVICE` federation source, if one is injected. `None` in
     /// the default engine path: a non-silent `SERVICE` then hard-fails. Tests and
     /// the conformance harness inject an in-memory source via [`EvalCtx::with_remote`].
@@ -353,7 +360,7 @@ const _: fn() = || {
     assert_send_sync::<EvalCtx<'static>>();
 };
 
-impl core::fmt::Debug for EvalCtx<'_> {
+impl<D: DatasetView<Id = TermId> + Sync> core::fmt::Debug for EvalCtx<'_, D> {
     /// Summarized: the injected `SERVICE` source (`remote`) is a plain `dyn`
     /// trait object and the per-query caches are noise, so only the scalar
     /// evaluation state is shown.
@@ -370,9 +377,9 @@ impl core::fmt::Debug for EvalCtx<'_> {
     }
 }
 
-impl<'d> EvalCtx<'d> {
+impl<'d, D: DatasetView<Id = TermId> + Sync> EvalCtx<'d, D> {
     /// A fresh context over `dataset`, scoped to the default graph.
-    pub fn new(dataset: &'d RdfDataset) -> Self {
+    pub fn new(dataset: &'d D) -> Self {
         let now_val = purrdf_xsd::XsdValue::DateTime(crate::clock::wall_clock_now());
         let rng_seed: u64 = crate::clock::entropy_seed();
 
@@ -701,7 +708,10 @@ impl<'d> EvalCtx<'d> {
 /// returns [`EvalError::Unsupported`] naming the construct. Property paths are
 /// evaluated in-engine (S8, the `path` module); the remaining out-of-scope
 /// nodes (`Service`, `Lateral`) stay permanent hard errors (SERVICE is S6b).
-pub fn eval(pattern: &GraphPattern, ctx: &mut EvalCtx<'_>) -> Result<SolutionSeq, EvalError> {
+pub fn eval<D: DatasetView<Id = TermId> + Sync>(
+    pattern: &GraphPattern,
+    ctx: &mut EvalCtx<'_, D>,
+) -> Result<SolutionSeq, EvalError> {
     match pattern {
         GraphPattern::Bgp { patterns } => crate::bgp::eval_bgp(patterns, ctx),
         GraphPattern::Path {
@@ -771,7 +781,10 @@ pub enum Outcome {
 ///
 /// `SELECT`/`ASK` walk the modifier-wrapped pattern; `CONSTRUCT` and `DESCRIBE` emit
 /// the IR dataset directly (`DESCRIBE` via the canonical Symmetric CBD).
-pub fn evaluate_query(query: &Query, ctx: &mut EvalCtx<'_>) -> Result<Outcome, EvalError> {
+pub fn evaluate_query<D: DatasetView<Id = TermId> + Sync>(
+    query: &Query,
+    ctx: &mut EvalCtx<'_, D>,
+) -> Result<Outcome, EvalError> {
     // Install the query's FROM / FROM NAMED active dataset (§13) before evaluating.
     ctx.active_dataset = ActiveDataset::from_query_dataset(query.dataset(), ctx.dataset);
     // Install the query's effective base IRI so IRI()/URI() can resolve a relative
@@ -800,9 +813,9 @@ pub fn evaluate_query(query: &Query, ctx: &mut EvalCtx<'_>) -> Result<Outcome, E
 /// Shared by the engine's `SparqlResult` materializer and the SERVICE result
 /// path, both of which turn an interned solution sequence into owned
 /// term values via the per-query [`ScratchInterner`](crate::scratch::ScratchInterner).
-pub(crate) fn materialize_solutions(
+pub(crate) fn materialize_solutions<D: DatasetView<Id = TermId> + Sync>(
     seq: &SolutionSeq,
-    ctx: &EvalCtx<'_>,
+    ctx: &EvalCtx<'_, D>,
 ) -> (Vec<String>, Vec<Vec<Option<TermValue>>>) {
     let variables = seq
         .schema
@@ -813,7 +826,7 @@ pub(crate) fn materialize_solutions(
     // Literal datatype IRIs repeat massively across a result (a handful of XSD
     // types over tens of thousands of cells), so each datatype TermId is resolved
     // once per call and cloned from a small memo instead of re-resolved per cell.
-    let mut datatype_memo: DetHashMap<purrdf_core::TermId, String> = DetHashMap::default();
+    let mut datatype_memo: DetHashMap<TermId, String> = DetHashMap::default();
     let mut rows = Vec::with_capacity(seq.rows.len());
     for row in &seq.rows {
         let mut out = Vec::with_capacity(row.len());
@@ -827,10 +840,10 @@ pub(crate) fn materialize_solutions(
 
 /// [`ScratchInterner::value_of`], with repeated literal datatype-IRI resolutions
 /// served from `datatype_memo` (egress-only; identical output values).
-fn memoized_value_of(
-    ctx: &EvalCtx<'_>,
+fn memoized_value_of<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &EvalCtx<'_, D>,
     term: SolutionTerm,
-    datatype_memo: &mut DetHashMap<purrdf_core::TermId, String>,
+    datatype_memo: &mut DetHashMap<TermId, String>,
 ) -> TermValue {
     match term {
         SolutionTerm::Existing(id) => memoized_term_value(ctx.dataset, id, datatype_memo),
@@ -840,10 +853,10 @@ fn memoized_value_of(
 
 /// `scratch::term_id_to_value`, with the literal datatype id → IRI string
 /// resolution memoized across cells (recursing through RDF-1.2 triple terms).
-fn memoized_term_value(
-    dataset: &RdfDataset,
-    id: purrdf_core::TermId,
-    datatype_memo: &mut DetHashMap<purrdf_core::TermId, String>,
+fn memoized_term_value<D: DatasetView<Id = TermId>>(
+    dataset: &D,
+    id: TermId,
+    datatype_memo: &mut DetHashMap<TermId, String>,
 ) -> TermValue {
     match dataset.resolve(id) {
         purrdf_core::TermRef::Iri(iri) => TermValue::Iri(iri.to_owned()),

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -26,7 +26,7 @@ use std::cmp::Ordering;
 use std::sync::Arc;
 
 use purrdf_core::{
-    BlankScope, DatasetView, GraphMatch, RdfTextDirection, TermId, TermRef, TermValue,
+    BlankScope, DatasetView, GraphMatch, RdfTextDirection, TermRef, TermValue, ViewTermId,
 };
 use purrdf_sparql_algebra::{Expression, Function, GraphPattern, PurrdfFn, Variable};
 use purrdf_xsd::{
@@ -50,12 +50,12 @@ const RDF_DIR_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#di
 
 /// Evaluate an expression over a solution. See the [module docs](self) for the
 /// `Ok(Some)` / `Ok(None)` / `Err` contract.
-pub(crate) fn eval_expr<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_expr<D: DatasetView + Sync>(
     expr: &Expression,
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     match expr {
         // ---- atoms ---------------------------------------------------------
         Expression::NamedNode(n) => Ok(Some(const_atom(ctx, expr, || {
@@ -158,9 +158,9 @@ pub(crate) fn eval_expr<D: DatasetView<Id = TermId> + Sync>(
 
 /// Evaluate `expr` and reduce it to an effective boolean value (`Ok(None)` =
 /// error/unbound).
-pub(crate) fn eval_ebv<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_ebv<D: DatasetView + Sync>(
     expr: &Expression,
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<bool>, EvalError> {
@@ -179,11 +179,11 @@ pub(crate) fn eval_ebv<D: DatasetView<Id = TermId> + Sync>(
 /// surviving rows are the ORIGINAL rows (never a value derived from the child's
 /// scratch), so each forked child's scratch is discarded after use — nothing to
 /// re-intern via [`crate::parallel::reintern_minted_row`].
-pub(crate) fn eval_filter<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_filter<D: DatasetView + Sync>(
     expr: &Expression,
     inner: &GraphPattern,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     let seq = eval(inner, ctx)?;
     let schema = seq.schema.clone();
     let rows = if crate::parallel::is_parallel_safe(expr) {
@@ -219,12 +219,12 @@ pub(crate) fn eval_filter<D: DatasetView<Id = TermId> + Sync>(
 /// [`crate::parallel::portable_row`] while its scratch is still alive, and this
 /// function re-interns each portable row against `ctx.scratch` afterwards, in
 /// source-index order, via [`crate::parallel::reintern_portable_row`].
-pub(crate) fn eval_extend<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_extend<D: DatasetView + Sync>(
     inner: &GraphPattern,
     var: &Variable,
     expr: &Expression,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     let seq = eval(inner, ctx)?;
     let mut schema = (*seq.schema).clone();
     let col = schema.push(var.clone());
@@ -275,19 +275,19 @@ pub(crate) fn eval_extend<D: DatasetView<Id = TermId> + Sync>(
 // ---------------------------------------------------------------------------
 
 /// Look up a variable's binding in a solution.
-fn lookup(
+fn lookup<I: ViewTermId>(
     var: &Variable,
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<I>>],
     schema: &VarSchema,
-) -> Option<SolutionTerm> {
+) -> Option<SolutionTerm<I>> {
     schema.index_of(var).and_then(|c| row[c])
 }
 
 /// Intern a value to a solution term (promoting to an existing dataset id).
-fn intern<D: DatasetView<Id = TermId> + Sync>(
+fn intern<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     value: TermValue,
-) -> SolutionTerm {
+) -> SolutionTerm<D::Id> {
     ctx.scratch.intern(ctx.dataset, value)
 }
 
@@ -295,11 +295,11 @@ fn intern<D: DatasetView<Id = TermId> + Sync>(
 /// node's AST address (see [`EvalCtx::const_atom_cache`]). `build` — which owns
 /// the `TermValue` allocation — runs only on a cache miss, so a FILTER/BIND over
 /// N rows pays the `to_owned()` + intern probe once, not N times.
-fn const_atom<D: DatasetView<Id = TermId> + Sync>(
+fn const_atom<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     expr: &Expression,
     build: impl FnOnce() -> TermValue,
-) -> SolutionTerm {
+) -> SolutionTerm<D::Id> {
     // Address-keyed memoization is unsound over a per-row substituted-EXISTS
     // temporary (see `EvalCtx::in_substituted_exists`): the node's address can
     // be a dropped-and-reused allocation from an earlier outer row, so a hit
@@ -318,10 +318,7 @@ fn const_atom<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// Materialize a solution term to an owned value.
-fn value_of<D: DatasetView<Id = TermId> + Sync>(
-    ctx: &EvalCtx<'_, D>,
-    term: SolutionTerm,
-) -> TermValue {
+fn value_of<D: DatasetView + Sync>(ctx: &EvalCtx<'_, D>, term: SolutionTerm<D::Id>) -> TermValue {
     ctx.scratch.value_of(ctx.dataset, term)
 }
 
@@ -332,10 +329,7 @@ fn value_of<D: DatasetView<Id = TermId> + Sync>(
 /// intern probe once, not N times. The cache is exact — interning is
 /// deterministic for the context's pinned dataset and dedup-by-value scratch, so
 /// the cached term is the same `SolutionTerm` a fresh intern would produce.
-fn bool_term<D: DatasetView<Id = TermId> + Sync>(
-    ctx: &mut EvalCtx<'_, D>,
-    b: bool,
-) -> SolutionTerm {
+fn bool_term<D: DatasetView + Sync>(ctx: &mut EvalCtx<'_, D>, b: bool) -> SolutionTerm<D::Id> {
     let slot = usize::from(b);
     if let Some(term) = ctx.cached_bool_terms[slot] {
         return term;
@@ -346,18 +340,18 @@ fn bool_term<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// Intern an `xsd:string` literal.
-fn string_term<D: DatasetView<Id = TermId> + Sync>(
+fn string_term<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     lexical: &str,
-) -> SolutionTerm {
+) -> SolutionTerm<D::Id> {
     intern(ctx, typed(lexical, XSD_STRING))
 }
 
 /// Intern an `xsd:integer` literal.
-fn integer_term<D: DatasetView<Id = TermId> + Sync>(
+fn integer_term<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     value: i64,
-) -> SolutionTerm {
+) -> SolutionTerm<D::Id> {
     intern(ctx, typed(&value.to_string(), XSD_INTEGER))
 }
 
@@ -387,9 +381,9 @@ pub(crate) fn xsd_of(value: &TermValue) -> Option<XsdValue> {
 }
 
 /// The effective boolean value of an evaluated expression (`Ok(None)` = error).
-fn ebv_of<D: DatasetView<Id = TermId> + Sync>(
+fn ebv_of<D: DatasetView + Sync>(
     expr: &Expression,
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<bool>, EvalError> {
@@ -400,9 +394,9 @@ fn ebv_of<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// The effective boolean value of a concrete term (`None` = type error).
-fn ebv_term<D: DatasetView<Id = TermId> + Sync>(
+fn ebv_term<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
-    term: SolutionTerm,
+    term: SolutionTerm<D::Id>,
 ) -> Option<bool> {
     // A language-tagged string (rdf:langString / rdf:dirLangString) has no effective
     // boolean value — EBV covers only xsd:string, xsd:boolean, and the numeric types.
@@ -443,9 +437,9 @@ fn ebv_term<D: DatasetView<Id = TermId> + Sync>(
 /// fixed id, so a comparison/`FILTER` over N rows parses each distinct literal once
 /// instead of once per row. Computed scratch values are ephemeral and stay on the
 /// direct borrowed-view path.
-fn xsd_of_term<D: DatasetView<Id = TermId> + Sync>(
+fn xsd_of_term<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
-    term: SolutionTerm,
+    term: SolutionTerm<D::Id>,
 ) -> Option<XsdValue> {
     match term {
         SolutionTerm::Existing(id) => {
@@ -458,7 +452,7 @@ fn xsd_of_term<D: DatasetView<Id = TermId> + Sync>(
                 } => match ctx.dataset.resolve(datatype) {
                     TermRef::Iri(iri) => parse_by_iri(lexical, iri).ok().flatten(),
                     // A literal's datatype is always an interned IRI (C0.1).
-                    other => unreachable!("literal datatype must be an IRI, got {other:?}"),
+                    _ => unreachable!("literal datatype must be an IRI"),
                 },
                 _ => None,
             };
@@ -471,10 +465,7 @@ fn xsd_of_term<D: DatasetView<Id = TermId> + Sync>(
 
 /// Whether a solution term is a literal, checked on the borrowed view (no
 /// materialization).
-fn term_is_literal<D: DatasetView<Id = TermId> + Sync>(
-    ctx: &EvalCtx<'_, D>,
-    term: SolutionTerm,
-) -> bool {
+fn term_is_literal<D: DatasetView + Sync>(ctx: &EvalCtx<'_, D>, term: SolutionTerm<D::Id>) -> bool {
     match term {
         SolutionTerm::Existing(id) => {
             matches!(ctx.dataset.resolve(id), TermRef::Literal { .. })
@@ -487,10 +478,7 @@ fn term_is_literal<D: DatasetView<Id = TermId> + Sync>(
 
 /// Whether a solution term is a triple term, checked on the borrowed view (no
 /// materialization) — mirrors [`term_is_literal`].
-fn term_is_triple<D: DatasetView<Id = TermId> + Sync>(
-    ctx: &EvalCtx<'_, D>,
-    term: SolutionTerm,
-) -> bool {
+fn term_is_triple<D: DatasetView + Sync>(ctx: &EvalCtx<'_, D>, term: SolutionTerm<D::Id>) -> bool {
     match term {
         SolutionTerm::Existing(id) => {
             matches!(ctx.dataset.resolve(id), TermRef::Triple { .. })
@@ -504,14 +492,14 @@ fn term_is_triple<D: DatasetView<Id = TermId> + Sync>(
 /// Evaluate a comparison: both operands to values, compare in the XSD value space,
 /// and test the resulting [`Ordering`] with `keep`. `None` (error/unbound operand
 /// or incomparable values) propagates.
-fn compare<D: DatasetView<Id = TermId> + Sync>(
+fn compare<D: DatasetView + Sync>(
     a: &Expression,
     b: &Expression,
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
     keep: impl Fn(Ordering) -> bool,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let ta = eval_expr(a, row, schema, ctx)?;
     let tb = eval_expr(b, row, schema, ctx)?;
     let (Some(ta), Some(tb)) = (ta, tb) else {
@@ -542,13 +530,13 @@ fn compare<D: DatasetView<Id = TermId> + Sync>(
 /// incomparable literals are a type error (`None`). This is the equality companion to
 /// the ordering [`compare`]; using `compare` for `=` would wrongly turn a distinct
 /// IRI pair into an error.
-fn equal<D: DatasetView<Id = TermId> + Sync>(
+fn equal<D: DatasetView + Sync>(
     a: &Expression,
     b: &Expression,
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let ta = eval_expr(a, row, schema, ctx)?;
     let tb = eval_expr(b, row, schema, ctx)?;
     let (Some(ta), Some(tb)) = (ta, tb) else {
@@ -592,13 +580,13 @@ fn equal<D: DatasetView<Id = TermId> + Sync>(
 
 /// `expr IN (list)`: true if equal (value semantics) to any list entry; an error in
 /// the list propagates only if no `true` is found (SPARQL §17.4.1.9).
-fn eval_in<D: DatasetView<Id = TermId> + Sync>(
+fn eval_in<D: DatasetView + Sync>(
     needle: &Expression,
     haystack: &[Expression],
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let Some(target) = eval_expr(needle, row, schema, ctx)? else {
         return Ok(None);
     };
@@ -859,9 +847,9 @@ fn pattern_expr_vars(pattern: &GraphPattern, out: &mut DetHashSet<Variable>) {
 /// row's bound variables pre-seeded as a VALUES-like leading input, so they are
 /// visible as bound during expression evaluation. This result is NOT memoized
 /// because it depends on the specific outer row.
-fn exists<D: DatasetView<Id = TermId> + Sync>(
+fn exists<D: DatasetView + Sync>(
     pattern: &GraphPattern,
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
 ) -> Result<bool, EvalError> {
@@ -1279,8 +1267,8 @@ fn substitute_expr(expr: &Expression, bindings: &[(Variable, Expression)]) -> Ex
 
 /// Build the binding list for substitution from the outer row's bound variables,
 /// materializing each `SolutionTerm` to a constant `Expression`.
-pub(crate) fn outer_bindings_for_substitution<D: DatasetView<Id = TermId> + Sync>(
-    row: &[Option<SolutionTerm>],
+pub(crate) fn outer_bindings_for_substitution<D: DatasetView + Sync>(
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &EvalCtx<'_, D>,
 ) -> Vec<(Variable, Expression)> {
@@ -1320,13 +1308,13 @@ pub(crate) fn outer_bindings_for_substitution<D: DatasetView<Id = TermId> + Sync
 }
 
 /// Dispatch a built-in (or custom) function call.
-fn eval_function<D: DatasetView<Id = TermId> + Sync>(
+fn eval_function<D: DatasetView + Sync>(
     function: &Function,
     args: &[Expression],
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     match function {
         Function::Contains => {
             return eval_string_pred_expr(args, row, schema, ctx, |h, n| h.contains(n));
@@ -1694,11 +1682,11 @@ fn eval_function<D: DatasetView<Id = TermId> + Sync>(
 /// `"false"`, not `"0"`) — only a source with no numeric/boolean value (a plain
 /// string, an already-`xsd:string` literal, an unrecognized datatype, …) falls back to
 /// copying its lexical form verbatim.
-fn eval_xsd_cast<D: DatasetView<Id = TermId> + Sync>(
+fn eval_xsd_cast<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     target: XsdDatatype,
     source: Option<&TermValue>,
-) -> Option<SolutionTerm> {
+) -> Option<SolutionTerm<D::Id>> {
     let source = source?;
     if target == XsdDatatype::String {
         if let TermValue::Iri(iri) = source {
@@ -1887,10 +1875,10 @@ fn format_plain_decimal(value: f64) -> String {
 /// absent from the dataset is a well-formed negative answer — `Ok(Some(false))`, not
 /// `None`. Missing `accordingTo`/`sharpens` interning simply yields no
 /// matches (→ false), which is correct.
-fn eval_held_in<D: DatasetView<Id = TermId> + Sync>(
+fn eval_held_in<D: DatasetView + Sync>(
     vals: &[Option<TermValue>],
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     // The predicate table is mandatory configuration — fail loudly BEFORE looking at
     // the arguments, so a misconfigured deployment cannot get a quietly-wrong answer.
     let Some(predicates) = ctx.standpoint_predicates.clone() else {
@@ -1956,13 +1944,13 @@ fn arg(vals: &[Option<TermValue>], i: usize) -> Option<&TermValue> {
     vals.get(i).and_then(|v| v.as_ref())
 }
 
-fn eval_string_pred_expr<D: DatasetView<Id = TermId> + Sync>(
+fn eval_string_pred_expr<D: DatasetView + Sync>(
     args: &[Expression],
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
     f: impl Fn(&str, &str) -> bool,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let result = {
         let (Some((h, _)), Some((n, _))) = (
             eval_string_arg_expr(args.first(), row, schema, ctx)?,
@@ -1975,12 +1963,12 @@ fn eval_string_pred_expr<D: DatasetView<Id = TermId> + Sync>(
     Ok(Some(bool_term(ctx, result)))
 }
 
-fn eval_regex_expr<D: DatasetView<Id = TermId> + Sync>(
+fn eval_regex_expr<D: DatasetView + Sync>(
     args: &[Expression],
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let text = eval_string_arg_expr(args.first(), row, schema, ctx)?;
     let pattern = eval_string_arg_expr(args.get(1), row, schema, ctx)?;
     let flags = eval_string_arg_expr(args.get(2), row, schema, ctx)?;
@@ -1994,12 +1982,12 @@ fn eval_regex_expr<D: DatasetView<Id = TermId> + Sync>(
     }
 }
 
-fn eval_lang_matches_expr<D: DatasetView<Id = TermId> + Sync>(
+fn eval_lang_matches_expr<D: DatasetView + Sync>(
     args: &[Expression],
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let result = {
         let (Some((tag, _)), Some((range, _))) = (
             eval_string_arg_expr(args.first(), row, schema, ctx)?,
@@ -2014,9 +2002,9 @@ fn eval_lang_matches_expr<D: DatasetView<Id = TermId> + Sync>(
     Ok(Some(bool_term(ctx, result)))
 }
 
-fn eval_string_arg_expr<D: DatasetView<Id = TermId> + Sync>(
+fn eval_string_arg_expr<D: DatasetView + Sync>(
     expr: Option<&Expression>,
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<(String, Option<String>)>, EvalError> {
@@ -2049,9 +2037,9 @@ fn eval_string_arg_expr<D: DatasetView<Id = TermId> + Sync>(
     }
 }
 
-fn eval_str_lexical_expr<D: DatasetView<Id = TermId> + Sync>(
+fn eval_str_lexical_expr<D: DatasetView + Sync>(
     expr: &Expression,
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<String>, EvalError> {
@@ -2067,9 +2055,9 @@ fn eval_str_lexical_expr<D: DatasetView<Id = TermId> + Sync>(
     }
 }
 
-fn eval_lang_lexical_expr<D: DatasetView<Id = TermId> + Sync>(
+fn eval_lang_lexical_expr<D: DatasetView + Sync>(
     expr: &Expression,
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<String>, EvalError> {
@@ -2088,9 +2076,9 @@ fn eval_lang_lexical_expr<D: DatasetView<Id = TermId> + Sync>(
     }
 }
 
-fn str_lexical_term<D: DatasetView<Id = TermId> + Sync>(
+fn str_lexical_term<D: DatasetView + Sync>(
     ctx: &EvalCtx<'_, D>,
-    term: SolutionTerm,
+    term: SolutionTerm<D::Id>,
 ) -> Option<String> {
     match term {
         SolutionTerm::Existing(id) => match ctx.dataset.resolve(id) {
@@ -2106,9 +2094,9 @@ fn str_lexical_term<D: DatasetView<Id = TermId> + Sync>(
     }
 }
 
-fn lang_lexical_term<D: DatasetView<Id = TermId> + Sync>(
+fn lang_lexical_term<D: DatasetView + Sync>(
     ctx: &EvalCtx<'_, D>,
-    term: SolutionTerm,
+    term: SolutionTerm<D::Id>,
 ) -> Option<String> {
     match term {
         SolutionTerm::Existing(id) => match ctx.dataset.resolve(id) {
@@ -2183,11 +2171,11 @@ fn string_arg_value(
 
 /// Apply a pure string transform to a single string argument, preserving its
 /// language tag.
-fn map_string<D: DatasetView<Id = TermId> + Sync>(
+fn map_string<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
     f: impl Fn(&str) -> String,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     match string_arg(vals, 0) {
         Some((s, lang)) => Ok(Some(make_string(ctx, f(&s), lang))),
         None => Ok(None),
@@ -2195,11 +2183,11 @@ fn map_string<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// A two-string boolean predicate (CONTAINS/STRSTARTS/STRENDS).
-fn string_pred<D: DatasetView<Id = TermId> + Sync>(
+fn string_pred<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
     f: impl Fn(&str, &str) -> bool,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     match (string_arg(vals, 0), string_arg(vals, 1)) {
         (Some((h, _)), Some((n, _))) => Ok(Some(bool_term(ctx, f(&h, &n)))),
         _ => Ok(None),
@@ -2208,11 +2196,11 @@ fn string_pred<D: DatasetView<Id = TermId> + Sync>(
 
 /// Intern a string literal, as `rdf:langString@lang` if a language is present, else
 /// `xsd:string`.
-fn make_string<D: DatasetView<Id = TermId> + Sync>(
+fn make_string<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     lexical: String,
     lang: Option<String>,
-) -> SolutionTerm {
+) -> SolutionTerm<D::Id> {
     match lang {
         Some(l) => intern(
             ctx,
@@ -2230,12 +2218,12 @@ fn make_string<D: DatasetView<Id = TermId> + Sync>(
 /// Intern a string literal keeping a language tag and (RDF 1.2) base direction:
 /// `rdf:dirLangString` when both are present, `rdf:langString` when only a
 /// language is, else `xsd:string`. A direction without a language is dropped.
-fn make_string_dir<D: DatasetView<Id = TermId> + Sync>(
+fn make_string_dir<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     lexical: String,
     lang: Option<String>,
     dir: Option<RdfTextDirection>,
-) -> SolutionTerm {
+) -> SolutionTerm<D::Id> {
     match (lang, dir) {
         (Some(l), Some(d)) => intern(
             ctx,
@@ -2254,10 +2242,10 @@ fn make_string_dir<D: DatasetView<Id = TermId> + Sync>(
 /// `CONCAT(...)`: concatenate string arguments. The result keeps the language tag
 /// **and** base direction iff *every* argument shares the same `(lang, dir)` pair;
 /// if either facet differs across arguments the result is a plain `xsd:string`.
-fn eval_concat<D: DatasetView<Id = TermId> + Sync>(
+fn eval_concat<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let mut out = String::new();
     let mut common: Option<(Option<String>, Option<RdfTextDirection>)> = None;
     let mut consistent = true;
@@ -2279,10 +2267,10 @@ fn eval_concat<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// `SUBSTR(str, start[, length])` with 1-based indexing over Unicode scalars.
-fn eval_substr<D: DatasetView<Id = TermId> + Sync>(
+fn eval_substr<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let Some((s, lang)) = string_arg(vals, 0) else {
         return Ok(None);
     };
@@ -2326,11 +2314,11 @@ fn args_compatible(arg1_lang: Option<&str>, arg2_lang: Option<&str>) -> bool {
 }
 
 /// `STRBEFORE`/`STRAFTER(haystack, needle)`.
-fn eval_str_before_after<D: DatasetView<Id = TermId> + Sync>(
+fn eval_str_before_after<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
     before: bool,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let (Some((h, lang)), Some((n, needle_lang))) = (string_arg(vals, 0), string_arg(vals, 1))
     else {
         return Ok(None);
@@ -2357,10 +2345,10 @@ fn eval_str_before_after<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// `REPLACE(str, pattern, replacement[, flags])` via the regex engine.
-fn eval_replace<D: DatasetView<Id = TermId> + Sync>(
+fn eval_replace<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let Some((s, lang)) = string_arg(vals, 0) else {
         return Ok(None);
     };
@@ -2378,10 +2366,10 @@ fn eval_replace<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// `REGEX(text, pattern[, flags])`.
-fn eval_regex<D: DatasetView<Id = TermId> + Sync>(
+fn eval_regex<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let Some((text, _)) = string_arg(vals, 0) else {
         return Ok(None);
     };
@@ -2402,7 +2390,7 @@ fn eval_regex<D: DatasetView<Id = TermId> + Sync>(
 /// rows of one filter share a single compiled regex and therefore its lazy-DFA
 /// cache pool, instead of each row cloning a fresh one. Compile failures are
 /// cached as `None` (same errors, compiled once).
-fn cached_regex<D: DatasetView<Id = TermId> + Sync>(
+fn cached_regex<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     pattern: &str,
     flags: &str,
@@ -2438,10 +2426,10 @@ fn build_regex(pattern: &str, flags: &str) -> Option<regex::Regex> {
 }
 
 /// `langMatches(tag, range)` — RFC 4647 basic filtering (`*` matches any tag).
-fn eval_lang_matches<D: DatasetView<Id = TermId> + Sync>(
+fn eval_lang_matches<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let (Some((tag, _)), Some((range, _))) = (string_arg(vals, 0), string_arg(vals, 1)) else {
         return Ok(None);
     };
@@ -2456,10 +2444,10 @@ fn eval_lang_matches<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// `STRLANG(lexical, lang)`.
-fn eval_str_lang<D: DatasetView<Id = TermId> + Sync>(
+fn eval_str_lang<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     // §17.4.2.5: the lexical-form argument must be a simple/`xsd:string` literal
     // — one that ALREADY carries a language tag (or RDF 1.2 base direction) is a
     // type error, not silently re-tagged.
@@ -2475,10 +2463,10 @@ fn eval_str_lang<D: DatasetView<Id = TermId> + Sync>(
 /// `STRLANGDIR(lexical, lang, dir)` — RDF 1.2 directional-language-string
 /// constructor. An empty `dir` yields a plain `rdf:langString`; `ltr`/`rtl`
 /// (case-insensitive) yield an `rdf:dirLangString`; any other direction errors.
-fn eval_str_lang_dir<D: DatasetView<Id = TermId> + Sync>(
+fn eval_str_lang_dir<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let (Some((lex, _)), Some((lang, _)), Some((dir, _))) = (
         string_arg(vals, 0),
         string_arg(vals, 1),
@@ -2508,10 +2496,10 @@ fn eval_str_lang_dir<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// `STRDT(lexical, datatypeIri)`.
-fn eval_str_dt<D: DatasetView<Id = TermId> + Sync>(
+fn eval_str_dt<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     // §17.4.2.4: the lexical-form argument must be a simple/`xsd:string` literal
     // — a language-tagged (or RDF 1.2 direction-tagged) argument is a type error.
     let Some(lex) = plain_string_arg(vals, 0) else {
@@ -2524,10 +2512,10 @@ fn eval_str_dt<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// `TRIPLE(s, p, o)` — RDF 1.2 triple-term constructor.
-fn eval_triple_ctor<D: DatasetView<Id = TermId> + Sync>(
+fn eval_triple_ctor<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let (Some(s), Some(p), Some(o)) = (arg(vals, 0), arg(vals, 1), arg(vals, 2)) else {
         return Ok(None);
     };
@@ -2548,11 +2536,11 @@ fn eval_triple_ctor<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// Extract a component of a triple term (`SUBJECT`/`PREDICATE`/`OBJECT`).
-fn triple_part<D: DatasetView<Id = TermId> + Sync>(
+fn triple_part<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
     pick: impl Fn(TermValue, TermValue, TermValue) -> TermValue,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     match arg(vals, 0) {
         Some(TermValue::Triple { s, p, o }) => {
             let part = pick((**s).clone(), (**p).clone(), (**o).clone());
@@ -2572,24 +2560,24 @@ fn xsd_int_of(v: &TermValue) -> Option<i64> {
 
 /// Convert a computed [`XsdValue`] back into an interned [`SolutionTerm`] using the
 /// canonical typed-literal form. The datatype IRI comes from `v.datatype().iri()`.
-pub(crate) fn xsd_to_term<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn xsd_to_term<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     v: &XsdValue,
-) -> SolutionTerm {
+) -> SolutionTerm<D::Id> {
     intern(ctx, typed(&v.canonical_lexical(), v.datatype().iri()))
 }
 
 /// Evaluate a binary numeric expression: resolve both operands to [`XsdValue`], call
 /// `op`, and return `Ok(Some(term))` on success or `Ok(None)` on any error (type
 /// error, overflow, divide-by-zero — all SPARQL expression errors).
-fn binary_numeric<D: DatasetView<Id = TermId> + Sync>(
+fn binary_numeric<D: DatasetView + Sync>(
     a: &Expression,
     b: &Expression,
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
     op: impl Fn(&XsdValue, &XsdValue) -> Result<XsdValue, purrdf_xsd::XsdError>,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let (Some(ta), Some(tb)) = (
         eval_expr(a, row, schema, ctx)?,
         eval_expr(b, row, schema, ctx)?,
@@ -2608,13 +2596,13 @@ fn binary_numeric<D: DatasetView<Id = TermId> + Sync>(
 
 /// Evaluate a unary numeric expression (`+` / `-`): resolve the operand, call `op`,
 /// return `Ok(None)` on any error.
-fn unary_numeric<D: DatasetView<Id = TermId> + Sync>(
+fn unary_numeric<D: DatasetView + Sync>(
     a: &Expression,
-    row: &[Option<SolutionTerm>],
+    row: &[Option<SolutionTerm<D::Id>>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
     op: impl Fn(&XsdValue) -> Result<XsdValue, purrdf_xsd::XsdError>,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let Some(ta) = eval_expr(a, row, schema, ctx)? else {
         return Ok(None);
     };
@@ -2630,11 +2618,11 @@ fn unary_numeric<D: DatasetView<Id = TermId> + Sync>(
 
 /// Apply a unary numeric function from the `vals` pre-evaluated argument list.
 /// Argument 0 must be a numeric literal; type errors → `Ok(None)`.
-fn unary_numeric_fn<D: DatasetView<Id = TermId> + Sync>(
+fn unary_numeric_fn<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
     op: impl Fn(&XsdValue) -> Result<XsdValue, purrdf_xsd::XsdError>,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let Some(xa) = arg(vals, 0).and_then(xsd_of) else {
         return Ok(None);
     };
@@ -2650,7 +2638,7 @@ fn unary_numeric_fn<D: DatasetView<Id = TermId> + Sync>(
 
 /// Splitmix64 step: advance the PRNG state and return the next pseudo-random u64.
 /// Algorithm: <https://prng.di.unimi.it/splitmix64.c>
-fn next_u64<D: DatasetView<Id = TermId> + Sync>(ctx: &mut EvalCtx<'_, D>) -> u64 {
+fn next_u64<D: DatasetView + Sync>(ctx: &mut EvalCtx<'_, D>) -> u64 {
     ctx.rng_state = ctx.rng_state.wrapping_add(0x9e37_79b9_7f4a_7c15);
     let mut z = ctx.rng_state;
     z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
@@ -2659,7 +2647,7 @@ fn next_u64<D: DatasetView<Id = TermId> + Sync>(ctx: &mut EvalCtx<'_, D>) -> u64
 }
 
 /// Mint a fresh blank node (`BNODE()`/`BNODE(strExpr)`'s cache-miss path).
-fn mint_bnode<D: DatasetView<Id = TermId> + Sync>(ctx: &mut EvalCtx<'_, D>) -> SolutionTerm {
+fn mint_bnode<D: DatasetView + Sync>(ctx: &mut EvalCtx<'_, D>) -> SolutionTerm<D::Id> {
     ctx.bnode_counter += 1;
     let label = format!("bnode{}", ctx.bnode_counter);
     intern(
@@ -2767,7 +2755,7 @@ fn format_tz_string(offset_minutes: Option<i64>) -> String {
 
 /// Mint a version-4 UUID from the PRNG state and return it as a
 /// lowercase-hyphenated `8-4-4-4-12` string (without any `urn:uuid:` prefix).
-fn make_uuid<D: DatasetView<Id = TermId> + Sync>(ctx: &mut EvalCtx<'_, D>) -> (String, [u8; 16]) {
+fn make_uuid<D: DatasetView + Sync>(ctx: &mut EvalCtx<'_, D>) -> (String, [u8; 16]) {
     let hi = next_u64(ctx);
     let lo = next_u64(ctx);
     let mut bytes = [0u8; 16];

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -25,7 +25,9 @@
 use std::cmp::Ordering;
 use std::sync::Arc;
 
-use purrdf_core::{BlankScope, DatasetView, GraphMatch, RdfTextDirection, TermRef, TermValue};
+use purrdf_core::{
+    BlankScope, DatasetView, GraphMatch, RdfTextDirection, TermId, TermRef, TermValue,
+};
 use purrdf_sparql_algebra::{Expression, Function, GraphPattern, PurrdfFn, Variable};
 use purrdf_xsd::{
     XsdDatatype, XsdValue, effective_boolean_value, numeric_abs, numeric_add, numeric_ceil,
@@ -48,11 +50,11 @@ const RDF_DIR_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#di
 
 /// Evaluate an expression over a solution. See the [module docs](self) for the
 /// `Ok(Some)` / `Ok(None)` / `Err` contract.
-pub(crate) fn eval_expr(
+pub(crate) fn eval_expr<D: DatasetView<Id = TermId> + Sync>(
     expr: &Expression,
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<SolutionTerm>, EvalError> {
     match expr {
         // ---- atoms ---------------------------------------------------------
@@ -156,11 +158,11 @@ pub(crate) fn eval_expr(
 
 /// Evaluate `expr` and reduce it to an effective boolean value (`Ok(None)` =
 /// error/unbound).
-pub(crate) fn eval_ebv(
+pub(crate) fn eval_ebv<D: DatasetView<Id = TermId> + Sync>(
     expr: &Expression,
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<bool>, EvalError> {
     ebv_of(expr, row, schema, ctx)
 }
@@ -177,10 +179,10 @@ pub(crate) fn eval_ebv(
 /// surviving rows are the ORIGINAL rows (never a value derived from the child's
 /// scratch), so each forked child's scratch is discarded after use — nothing to
 /// re-intern via [`crate::parallel::reintern_minted_row`].
-pub(crate) fn eval_filter(
+pub(crate) fn eval_filter<D: DatasetView<Id = TermId> + Sync>(
     expr: &Expression,
     inner: &GraphPattern,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     let seq = eval(inner, ctx)?;
     let schema = seq.schema.clone();
@@ -217,11 +219,11 @@ pub(crate) fn eval_filter(
 /// [`crate::parallel::portable_row`] while its scratch is still alive, and this
 /// function re-interns each portable row against `ctx.scratch` afterwards, in
 /// source-index order, via [`crate::parallel::reintern_portable_row`].
-pub(crate) fn eval_extend(
+pub(crate) fn eval_extend<D: DatasetView<Id = TermId> + Sync>(
     inner: &GraphPattern,
     var: &Variable,
     expr: &Expression,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     let seq = eval(inner, ctx)?;
     let mut schema = (*seq.schema).clone();
@@ -282,7 +284,10 @@ fn lookup(
 }
 
 /// Intern a value to a solution term (promoting to an existing dataset id).
-fn intern(ctx: &mut EvalCtx<'_>, value: TermValue) -> SolutionTerm {
+fn intern<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
+    value: TermValue,
+) -> SolutionTerm {
     ctx.scratch.intern(ctx.dataset, value)
 }
 
@@ -290,8 +295,8 @@ fn intern(ctx: &mut EvalCtx<'_>, value: TermValue) -> SolutionTerm {
 /// node's AST address (see [`EvalCtx::const_atom_cache`]). `build` — which owns
 /// the `TermValue` allocation — runs only on a cache miss, so a FILTER/BIND over
 /// N rows pays the `to_owned()` + intern probe once, not N times.
-fn const_atom(
-    ctx: &mut EvalCtx<'_>,
+fn const_atom<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     expr: &Expression,
     build: impl FnOnce() -> TermValue,
 ) -> SolutionTerm {
@@ -313,7 +318,10 @@ fn const_atom(
 }
 
 /// Materialize a solution term to an owned value.
-fn value_of(ctx: &EvalCtx<'_>, term: SolutionTerm) -> TermValue {
+fn value_of<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &EvalCtx<'_, D>,
+    term: SolutionTerm,
+) -> TermValue {
     ctx.scratch.value_of(ctx.dataset, term)
 }
 
@@ -324,7 +332,10 @@ fn value_of(ctx: &EvalCtx<'_>, term: SolutionTerm) -> TermValue {
 /// intern probe once, not N times. The cache is exact — interning is
 /// deterministic for the context's pinned dataset and dedup-by-value scratch, so
 /// the cached term is the same `SolutionTerm` a fresh intern would produce.
-fn bool_term(ctx: &mut EvalCtx<'_>, b: bool) -> SolutionTerm {
+fn bool_term<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
+    b: bool,
+) -> SolutionTerm {
     let slot = usize::from(b);
     if let Some(term) = ctx.cached_bool_terms[slot] {
         return term;
@@ -335,12 +346,18 @@ fn bool_term(ctx: &mut EvalCtx<'_>, b: bool) -> SolutionTerm {
 }
 
 /// Intern an `xsd:string` literal.
-fn string_term(ctx: &mut EvalCtx<'_>, lexical: &str) -> SolutionTerm {
+fn string_term<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
+    lexical: &str,
+) -> SolutionTerm {
     intern(ctx, typed(lexical, XSD_STRING))
 }
 
 /// Intern an `xsd:integer` literal.
-fn integer_term(ctx: &mut EvalCtx<'_>, value: i64) -> SolutionTerm {
+fn integer_term<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
+    value: i64,
+) -> SolutionTerm {
     intern(ctx, typed(&value.to_string(), XSD_INTEGER))
 }
 
@@ -370,11 +387,11 @@ pub(crate) fn xsd_of(value: &TermValue) -> Option<XsdValue> {
 }
 
 /// The effective boolean value of an evaluated expression (`Ok(None)` = error).
-fn ebv_of(
+fn ebv_of<D: DatasetView<Id = TermId> + Sync>(
     expr: &Expression,
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<bool>, EvalError> {
     match eval_expr(expr, row, schema, ctx)? {
         Some(term) => Ok(ebv_term(ctx, term)),
@@ -383,7 +400,10 @@ fn ebv_of(
 }
 
 /// The effective boolean value of a concrete term (`None` = type error).
-fn ebv_term(ctx: &mut EvalCtx<'_>, term: SolutionTerm) -> Option<bool> {
+fn ebv_term<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
+    term: SolutionTerm,
+) -> Option<bool> {
     // A language-tagged string (rdf:langString / rdf:dirLangString) has no effective
     // boolean value — EBV covers only xsd:string, xsd:boolean, and the numeric types.
     let is_lang_tagged = match term {
@@ -423,7 +443,10 @@ fn ebv_term(ctx: &mut EvalCtx<'_>, term: SolutionTerm) -> Option<bool> {
 /// fixed id, so a comparison/`FILTER` over N rows parses each distinct literal once
 /// instead of once per row. Computed scratch values are ephemeral and stay on the
 /// direct borrowed-view path.
-fn xsd_of_term(ctx: &mut EvalCtx<'_>, term: SolutionTerm) -> Option<XsdValue> {
+fn xsd_of_term<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
+    term: SolutionTerm,
+) -> Option<XsdValue> {
     match term {
         SolutionTerm::Existing(id) => {
             if let Some(cached) = ctx.xsd_parse_cache.get(&id) {
@@ -448,7 +471,10 @@ fn xsd_of_term(ctx: &mut EvalCtx<'_>, term: SolutionTerm) -> Option<XsdValue> {
 
 /// Whether a solution term is a literal, checked on the borrowed view (no
 /// materialization).
-fn term_is_literal(ctx: &EvalCtx<'_>, term: SolutionTerm) -> bool {
+fn term_is_literal<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &EvalCtx<'_, D>,
+    term: SolutionTerm,
+) -> bool {
     match term {
         SolutionTerm::Existing(id) => {
             matches!(ctx.dataset.resolve(id), TermRef::Literal { .. })
@@ -461,7 +487,10 @@ fn term_is_literal(ctx: &EvalCtx<'_>, term: SolutionTerm) -> bool {
 
 /// Whether a solution term is a triple term, checked on the borrowed view (no
 /// materialization) — mirrors [`term_is_literal`].
-fn term_is_triple(ctx: &EvalCtx<'_>, term: SolutionTerm) -> bool {
+fn term_is_triple<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &EvalCtx<'_, D>,
+    term: SolutionTerm,
+) -> bool {
     match term {
         SolutionTerm::Existing(id) => {
             matches!(ctx.dataset.resolve(id), TermRef::Triple { .. })
@@ -475,12 +504,12 @@ fn term_is_triple(ctx: &EvalCtx<'_>, term: SolutionTerm) -> bool {
 /// Evaluate a comparison: both operands to values, compare in the XSD value space,
 /// and test the resulting [`Ordering`] with `keep`. `None` (error/unbound operand
 /// or incomparable values) propagates.
-fn compare(
+fn compare<D: DatasetView<Id = TermId> + Sync>(
     a: &Expression,
     b: &Expression,
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
     keep: impl Fn(Ordering) -> bool,
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let ta = eval_expr(a, row, schema, ctx)?;
@@ -513,12 +542,12 @@ fn compare(
 /// incomparable literals are a type error (`None`). This is the equality companion to
 /// the ordering [`compare`]; using `compare` for `=` would wrongly turn a distinct
 /// IRI pair into an error.
-fn equal(
+fn equal<D: DatasetView<Id = TermId> + Sync>(
     a: &Expression,
     b: &Expression,
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let ta = eval_expr(a, row, schema, ctx)?;
     let tb = eval_expr(b, row, schema, ctx)?;
@@ -563,12 +592,12 @@ fn equal(
 
 /// `expr IN (list)`: true if equal (value semantics) to any list entry; an error in
 /// the list propagates only if no `true` is found (SPARQL §17.4.1.9).
-fn eval_in(
+fn eval_in<D: DatasetView<Id = TermId> + Sync>(
     needle: &Expression,
     haystack: &[Expression],
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let Some(target) = eval_expr(needle, row, schema, ctx)? else {
         return Ok(None);
@@ -830,11 +859,11 @@ fn pattern_expr_vars(pattern: &GraphPattern, out: &mut DetHashSet<Variable>) {
 /// row's bound variables pre-seeded as a VALUES-like leading input, so they are
 /// visible as bound during expression evaluation. This result is NOT memoized
 /// because it depends on the specific outer row.
-fn exists(
+fn exists<D: DatasetView<Id = TermId> + Sync>(
     pattern: &GraphPattern,
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<bool, EvalError> {
     // Build the set of outer-bound variables (those with a concrete binding in
     // the current row), then check if any of them are referenced in expression
@@ -1250,10 +1279,10 @@ fn substitute_expr(expr: &Expression, bindings: &[(Variable, Expression)]) -> Ex
 
 /// Build the binding list for substitution from the outer row's bound variables,
 /// materializing each `SolutionTerm` to a constant `Expression`.
-pub(crate) fn outer_bindings_for_substitution(
+pub(crate) fn outer_bindings_for_substitution<D: DatasetView<Id = TermId> + Sync>(
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &EvalCtx<'_>,
+    ctx: &EvalCtx<'_, D>,
 ) -> Vec<(Variable, Expression)> {
     use purrdf_core::TermValue;
     use purrdf_sparql_algebra::{Literal, NamedNode};
@@ -1291,12 +1320,12 @@ pub(crate) fn outer_bindings_for_substitution(
 }
 
 /// Dispatch a built-in (or custom) function call.
-fn eval_function(
+fn eval_function<D: DatasetView<Id = TermId> + Sync>(
     function: &Function,
     args: &[Expression],
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<SolutionTerm>, EvalError> {
     match function {
         Function::Contains => {
@@ -1665,8 +1694,8 @@ fn eval_function(
 /// `"false"`, not `"0"`) — only a source with no numeric/boolean value (a plain
 /// string, an already-`xsd:string` literal, an unrecognized datatype, …) falls back to
 /// copying its lexical form verbatim.
-fn eval_xsd_cast(
-    ctx: &mut EvalCtx<'_>,
+fn eval_xsd_cast<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     target: XsdDatatype,
     source: Option<&TermValue>,
 ) -> Option<SolutionTerm> {
@@ -1858,9 +1887,9 @@ fn format_plain_decimal(value: f64) -> String {
 /// absent from the dataset is a well-formed negative answer — `Ok(Some(false))`, not
 /// `None`. Missing `accordingTo`/`sharpens` interning simply yields no
 /// matches (→ false), which is correct.
-fn eval_held_in(
+fn eval_held_in<D: DatasetView<Id = TermId> + Sync>(
     vals: &[Option<TermValue>],
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<SolutionTerm>, EvalError> {
     // The predicate table is mandatory configuration — fail loudly BEFORE looking at
     // the arguments, so a misconfigured deployment cannot get a quietly-wrong answer.
@@ -1898,9 +1927,9 @@ fn eval_held_in(
     // `accordingTo`. If it was never interned, there are no vantage standpoints.
     let held = according_to_id.is_some_and(|atid| {
         ctx.dataset
-            .annotations_of(reifier_id)
-            .filter(|(pred, _)| *pred == atid)
-            .map(|(_, vantage)| vantage)
+            .annotations_of_with_graph(reifier_id)
+            .filter(|(pred, _, _)| *pred == atid)
+            .map(|(_, vantage, _)| vantage)
             .any(|vantage| {
                 // Held directly in the queried standpoint, …
                 vantage == standpoint_id
@@ -1927,11 +1956,11 @@ fn arg(vals: &[Option<TermValue>], i: usize) -> Option<&TermValue> {
     vals.get(i).and_then(|v| v.as_ref())
 }
 
-fn eval_string_pred_expr(
+fn eval_string_pred_expr<D: DatasetView<Id = TermId> + Sync>(
     args: &[Expression],
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
     f: impl Fn(&str, &str) -> bool,
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let result = {
@@ -1946,11 +1975,11 @@ fn eval_string_pred_expr(
     Ok(Some(bool_term(ctx, result)))
 }
 
-fn eval_regex_expr(
+fn eval_regex_expr<D: DatasetView<Id = TermId> + Sync>(
     args: &[Expression],
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let text = eval_string_arg_expr(args.first(), row, schema, ctx)?;
     let pattern = eval_string_arg_expr(args.get(1), row, schema, ctx)?;
@@ -1965,11 +1994,11 @@ fn eval_regex_expr(
     }
 }
 
-fn eval_lang_matches_expr(
+fn eval_lang_matches_expr<D: DatasetView<Id = TermId> + Sync>(
     args: &[Expression],
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let result = {
         let (Some((tag, _)), Some((range, _))) = (
@@ -1985,11 +2014,11 @@ fn eval_lang_matches_expr(
     Ok(Some(bool_term(ctx, result)))
 }
 
-fn eval_string_arg_expr(
+fn eval_string_arg_expr<D: DatasetView<Id = TermId> + Sync>(
     expr: Option<&Expression>,
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<(String, Option<String>)>, EvalError> {
     let Some(expr) = expr else {
         return Ok(None);
@@ -2020,11 +2049,11 @@ fn eval_string_arg_expr(
     }
 }
 
-fn eval_str_lexical_expr(
+fn eval_str_lexical_expr<D: DatasetView<Id = TermId> + Sync>(
     expr: &Expression,
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<String>, EvalError> {
     match expr {
         Expression::NamedNode(node) => Ok(Some(node.as_str().to_owned())),
@@ -2038,11 +2067,11 @@ fn eval_str_lexical_expr(
     }
 }
 
-fn eval_lang_lexical_expr(
+fn eval_lang_lexical_expr<D: DatasetView<Id = TermId> + Sync>(
     expr: &Expression,
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<String>, EvalError> {
     match expr {
         Expression::Literal(lit) => Ok(Some(
@@ -2059,7 +2088,10 @@ fn eval_lang_lexical_expr(
     }
 }
 
-fn str_lexical_term(ctx: &EvalCtx<'_>, term: SolutionTerm) -> Option<String> {
+fn str_lexical_term<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &EvalCtx<'_, D>,
+    term: SolutionTerm,
+) -> Option<String> {
     match term {
         SolutionTerm::Existing(id) => match ctx.dataset.resolve(id) {
             TermRef::Iri(iri) => Some(iri.to_owned()),
@@ -2074,7 +2106,10 @@ fn str_lexical_term(ctx: &EvalCtx<'_>, term: SolutionTerm) -> Option<String> {
     }
 }
 
-fn lang_lexical_term(ctx: &EvalCtx<'_>, term: SolutionTerm) -> Option<String> {
+fn lang_lexical_term<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &EvalCtx<'_, D>,
+    term: SolutionTerm,
+) -> Option<String> {
     match term {
         SolutionTerm::Existing(id) => match ctx.dataset.resolve(id) {
             TermRef::Literal { language, .. } => Some(language.unwrap_or_default().to_owned()),
@@ -2148,8 +2183,8 @@ fn string_arg_value(
 
 /// Apply a pure string transform to a single string argument, preserving its
 /// language tag.
-fn map_string(
-    ctx: &mut EvalCtx<'_>,
+fn map_string<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
     f: impl Fn(&str) -> String,
 ) -> Result<Option<SolutionTerm>, EvalError> {
@@ -2160,8 +2195,8 @@ fn map_string(
 }
 
 /// A two-string boolean predicate (CONTAINS/STRSTARTS/STRENDS).
-fn string_pred(
-    ctx: &mut EvalCtx<'_>,
+fn string_pred<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
     f: impl Fn(&str, &str) -> bool,
 ) -> Result<Option<SolutionTerm>, EvalError> {
@@ -2173,7 +2208,11 @@ fn string_pred(
 
 /// Intern a string literal, as `rdf:langString@lang` if a language is present, else
 /// `xsd:string`.
-fn make_string(ctx: &mut EvalCtx<'_>, lexical: String, lang: Option<String>) -> SolutionTerm {
+fn make_string<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
+    lexical: String,
+    lang: Option<String>,
+) -> SolutionTerm {
     match lang {
         Some(l) => intern(
             ctx,
@@ -2191,8 +2230,8 @@ fn make_string(ctx: &mut EvalCtx<'_>, lexical: String, lang: Option<String>) -> 
 /// Intern a string literal keeping a language tag and (RDF 1.2) base direction:
 /// `rdf:dirLangString` when both are present, `rdf:langString` when only a
 /// language is, else `xsd:string`. A direction without a language is dropped.
-fn make_string_dir(
-    ctx: &mut EvalCtx<'_>,
+fn make_string_dir<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     lexical: String,
     lang: Option<String>,
     dir: Option<RdfTextDirection>,
@@ -2215,8 +2254,8 @@ fn make_string_dir(
 /// `CONCAT(...)`: concatenate string arguments. The result keeps the language tag
 /// **and** base direction iff *every* argument shares the same `(lang, dir)` pair;
 /// if either facet differs across arguments the result is a plain `xsd:string`.
-fn eval_concat(
-    ctx: &mut EvalCtx<'_>,
+fn eval_concat<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let mut out = String::new();
@@ -2240,8 +2279,8 @@ fn eval_concat(
 }
 
 /// `SUBSTR(str, start[, length])` with 1-based indexing over Unicode scalars.
-fn eval_substr(
-    ctx: &mut EvalCtx<'_>,
+fn eval_substr<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let Some((s, lang)) = string_arg(vals, 0) else {
@@ -2287,8 +2326,8 @@ fn args_compatible(arg1_lang: Option<&str>, arg2_lang: Option<&str>) -> bool {
 }
 
 /// `STRBEFORE`/`STRAFTER(haystack, needle)`.
-fn eval_str_before_after(
-    ctx: &mut EvalCtx<'_>,
+fn eval_str_before_after<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
     before: bool,
 ) -> Result<Option<SolutionTerm>, EvalError> {
@@ -2318,8 +2357,8 @@ fn eval_str_before_after(
 }
 
 /// `REPLACE(str, pattern, replacement[, flags])` via the regex engine.
-fn eval_replace(
-    ctx: &mut EvalCtx<'_>,
+fn eval_replace<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let Some((s, lang)) = string_arg(vals, 0) else {
@@ -2339,8 +2378,8 @@ fn eval_replace(
 }
 
 /// `REGEX(text, pattern[, flags])`.
-fn eval_regex(
-    ctx: &mut EvalCtx<'_>,
+fn eval_regex<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let Some((text, _)) = string_arg(vals, 0) else {
@@ -2363,7 +2402,11 @@ fn eval_regex(
 /// rows of one filter share a single compiled regex and therefore its lazy-DFA
 /// cache pool, instead of each row cloning a fresh one. Compile failures are
 /// cached as `None` (same errors, compiled once).
-fn cached_regex(ctx: &mut EvalCtx<'_>, pattern: &str, flags: &str) -> Option<Arc<regex::Regex>> {
+fn cached_regex<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
+    pattern: &str,
+    flags: &str,
+) -> Option<Arc<regex::Regex>> {
     if let Some(cached) = ctx
         .regex_cache
         .get(pattern)
@@ -2395,8 +2438,8 @@ fn build_regex(pattern: &str, flags: &str) -> Option<regex::Regex> {
 }
 
 /// `langMatches(tag, range)` — RFC 4647 basic filtering (`*` matches any tag).
-fn eval_lang_matches(
-    ctx: &mut EvalCtx<'_>,
+fn eval_lang_matches<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let (Some((tag, _)), Some((range, _))) = (string_arg(vals, 0), string_arg(vals, 1)) else {
@@ -2413,8 +2456,8 @@ fn eval_lang_matches(
 }
 
 /// `STRLANG(lexical, lang)`.
-fn eval_str_lang(
-    ctx: &mut EvalCtx<'_>,
+fn eval_str_lang<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
 ) -> Result<Option<SolutionTerm>, EvalError> {
     // §17.4.2.5: the lexical-form argument must be a simple/`xsd:string` literal
@@ -2432,8 +2475,8 @@ fn eval_str_lang(
 /// `STRLANGDIR(lexical, lang, dir)` — RDF 1.2 directional-language-string
 /// constructor. An empty `dir` yields a plain `rdf:langString`; `ltr`/`rtl`
 /// (case-insensitive) yield an `rdf:dirLangString`; any other direction errors.
-fn eval_str_lang_dir(
-    ctx: &mut EvalCtx<'_>,
+fn eval_str_lang_dir<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let (Some((lex, _)), Some((lang, _)), Some((dir, _))) = (
@@ -2465,8 +2508,8 @@ fn eval_str_lang_dir(
 }
 
 /// `STRDT(lexical, datatypeIri)`.
-fn eval_str_dt(
-    ctx: &mut EvalCtx<'_>,
+fn eval_str_dt<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
 ) -> Result<Option<SolutionTerm>, EvalError> {
     // §17.4.2.4: the lexical-form argument must be a simple/`xsd:string` literal
@@ -2481,8 +2524,8 @@ fn eval_str_dt(
 }
 
 /// `TRIPLE(s, p, o)` — RDF 1.2 triple-term constructor.
-fn eval_triple_ctor(
-    ctx: &mut EvalCtx<'_>,
+fn eval_triple_ctor<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let (Some(s), Some(p), Some(o)) = (arg(vals, 0), arg(vals, 1), arg(vals, 2)) else {
@@ -2505,8 +2548,8 @@ fn eval_triple_ctor(
 }
 
 /// Extract a component of a triple term (`SUBJECT`/`PREDICATE`/`OBJECT`).
-fn triple_part(
-    ctx: &mut EvalCtx<'_>,
+fn triple_part<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
     pick: impl Fn(TermValue, TermValue, TermValue) -> TermValue,
 ) -> Result<Option<SolutionTerm>, EvalError> {
@@ -2529,19 +2572,22 @@ fn xsd_int_of(v: &TermValue) -> Option<i64> {
 
 /// Convert a computed [`XsdValue`] back into an interned [`SolutionTerm`] using the
 /// canonical typed-literal form. The datatype IRI comes from `v.datatype().iri()`.
-pub(crate) fn xsd_to_term(ctx: &mut EvalCtx<'_>, v: &XsdValue) -> SolutionTerm {
+pub(crate) fn xsd_to_term<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
+    v: &XsdValue,
+) -> SolutionTerm {
     intern(ctx, typed(&v.canonical_lexical(), v.datatype().iri()))
 }
 
 /// Evaluate a binary numeric expression: resolve both operands to [`XsdValue`], call
 /// `op`, and return `Ok(Some(term))` on success or `Ok(None)` on any error (type
 /// error, overflow, divide-by-zero — all SPARQL expression errors).
-fn binary_numeric(
+fn binary_numeric<D: DatasetView<Id = TermId> + Sync>(
     a: &Expression,
     b: &Expression,
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
     op: impl Fn(&XsdValue, &XsdValue) -> Result<XsdValue, purrdf_xsd::XsdError>,
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let (Some(ta), Some(tb)) = (
@@ -2562,11 +2608,11 @@ fn binary_numeric(
 
 /// Evaluate a unary numeric expression (`+` / `-`): resolve the operand, call `op`,
 /// return `Ok(None)` on any error.
-fn unary_numeric(
+fn unary_numeric<D: DatasetView<Id = TermId> + Sync>(
     a: &Expression,
     row: &[Option<SolutionTerm>],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
     op: impl Fn(&XsdValue) -> Result<XsdValue, purrdf_xsd::XsdError>,
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let Some(ta) = eval_expr(a, row, schema, ctx)? else {
@@ -2584,8 +2630,8 @@ fn unary_numeric(
 
 /// Apply a unary numeric function from the `vals` pre-evaluated argument list.
 /// Argument 0 must be a numeric literal; type errors → `Ok(None)`.
-fn unary_numeric_fn(
-    ctx: &mut EvalCtx<'_>,
+fn unary_numeric_fn<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
     op: impl Fn(&XsdValue) -> Result<XsdValue, purrdf_xsd::XsdError>,
 ) -> Result<Option<SolutionTerm>, EvalError> {
@@ -2604,7 +2650,7 @@ fn unary_numeric_fn(
 
 /// Splitmix64 step: advance the PRNG state and return the next pseudo-random u64.
 /// Algorithm: <https://prng.di.unimi.it/splitmix64.c>
-fn next_u64(ctx: &mut EvalCtx<'_>) -> u64 {
+fn next_u64<D: DatasetView<Id = TermId> + Sync>(ctx: &mut EvalCtx<'_, D>) -> u64 {
     ctx.rng_state = ctx.rng_state.wrapping_add(0x9e37_79b9_7f4a_7c15);
     let mut z = ctx.rng_state;
     z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
@@ -2613,7 +2659,7 @@ fn next_u64(ctx: &mut EvalCtx<'_>) -> u64 {
 }
 
 /// Mint a fresh blank node (`BNODE()`/`BNODE(strExpr)`'s cache-miss path).
-fn mint_bnode(ctx: &mut EvalCtx<'_>) -> SolutionTerm {
+fn mint_bnode<D: DatasetView<Id = TermId> + Sync>(ctx: &mut EvalCtx<'_, D>) -> SolutionTerm {
     ctx.bnode_counter += 1;
     let label = format!("bnode{}", ctx.bnode_counter);
     intern(
@@ -2721,7 +2767,7 @@ fn format_tz_string(offset_minutes: Option<i64>) -> String {
 
 /// Mint a version-4 UUID from the PRNG state and return it as a
 /// lowercase-hyphenated `8-4-4-4-12` string (without any `urn:uuid:` prefix).
-fn make_uuid(ctx: &mut EvalCtx<'_>) -> (String, [u8; 16]) {
+fn make_uuid<D: DatasetView<Id = TermId> + Sync>(ctx: &mut EvalCtx<'_, D>) -> (String, [u8; 16]) {
     let hi = next_u64(ctx);
     let lo = next_u64(ctx);
     let mut bytes = [0u8; 16];
@@ -2897,7 +2943,7 @@ mod tests {
         let bad =
             Expression::FunctionCall(Function::Regex, vec![lit("Hello"), lit("^h"), lit("z")]);
         // Total `(pattern, flags)` entries across the pattern-keyed two-level map.
-        let entries = |ctx: &EvalCtx<'_>| {
+        let entries = |ctx: &EvalCtx<'_, Arc<RdfDataset>>| {
             ctx.regex_cache
                 .values()
                 .map(crate::DetHashMap::len)

--- a/crates/sparql-eval/src/list_fn.rs
+++ b/crates/sparql-eval/src/list_fn.rs
@@ -26,7 +26,7 @@
 //! The walk is cycle-guarded: a cyclic or torn `rdf:List` is malformed input and
 //! hard-fails ([`EvalError::Data`]) rather than looping forever.
 
-use purrdf_core::{BlankScope, DatasetView, TermId, TermValue};
+use purrdf_core::{BlankScope, DatasetView, TermValue};
 use purrdf_sparql_algebra::PurrdfFn;
 use purrdf_xsd::XsdValue;
 
@@ -47,11 +47,11 @@ const RDF_NIL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
 /// expression contract: `Ok(Some)` is a value, `Ok(None)` is a SPARQL error/unbound,
 /// and `Err` is a hard failure. The non-list [`PurrdfFn::HeldIn`] is handled by its
 /// own arm in [`crate::expr`] and never reaches here (defensively an internal error).
-pub(crate) fn dispatch<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn dispatch<D: DatasetView + Sync>(
     func: PurrdfFn,
     vals: &[Option<TermValue>],
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     match func {
         PurrdfFn::ListLength => list_length(ctx, vals),
         PurrdfFn::ListGet => list_get(ctx, vals),
@@ -65,10 +65,10 @@ pub(crate) fn dispatch<D: DatasetView<Id = TermId> + Sync>(
 
 /// `listLength(list)` → the number of members, as `xsd:integer`. A non-list
 /// argument yields a SPARQL error (`Ok(None)`).
-fn list_length<D: DatasetView<Id = TermId> + Sync>(
+fn list_length<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let Some(head) = arg(vals, 0) else {
         return Ok(None);
     };
@@ -80,10 +80,10 @@ fn list_length<D: DatasetView<Id = TermId> + Sync>(
 
 /// `listGet(list, index)` → the zero-based member, or a SPARQL error when the
 /// index is out of range / not an integer.
-fn list_get<D: DatasetView<Id = TermId> + Sync>(
+fn list_get<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let (Some(head), Some(index)) = (arg(vals, 0), arg(vals, 1)) else {
         return Ok(None);
     };
@@ -104,10 +104,10 @@ fn list_get<D: DatasetView<Id = TermId> + Sync>(
 
 /// `listIndexOf(list, value)` → the zero-based index of the first occurrence,
 /// or a SPARQL error when the value is absent.
-fn list_index_of<D: DatasetView<Id = TermId> + Sync>(
+fn list_index_of<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let (Some(head), Some(value)) = (arg(vals, 0), arg(vals, 1)) else {
         return Ok(None);
     };
@@ -122,10 +122,10 @@ fn list_index_of<D: DatasetView<Id = TermId> + Sync>(
 
 /// `listContains(list, value)` → `xsd:boolean`. A non-list argument yields a
 /// SPARQL error (`Ok(None)`); membership over a valid (possibly empty) list is total.
-fn list_contains<D: DatasetView<Id = TermId> + Sync>(
+fn list_contains<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let (Some(head), Some(value)) = (arg(vals, 0), arg(vals, 1)) else {
         return Ok(None);
     };
@@ -140,10 +140,10 @@ fn list_contains<D: DatasetView<Id = TermId> + Sync>(
 /// (negatives to 0), so an out-of-range or inverted range yields `rdf:nil`. The new
 /// cells are buffered on [`EvalCtx`] and surface at the result boundary (see
 /// [`materialize_list`]). A non-list / non-integer argument yields a SPARQL error.
-fn list_slice<D: DatasetView<Id = TermId> + Sync>(
+fn list_slice<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let (Some(head), Some(start), Some(end)) = (arg(vals, 0), arg(vals, 1), arg(vals, 2)) else {
         return Ok(None);
     };
@@ -164,10 +164,10 @@ fn list_slice<D: DatasetView<Id = TermId> + Sync>(
 /// `listConcat(listA, listB)` → a fresh `rdf:List` of A's members followed by
 /// B's. The new cells are buffered on [`EvalCtx`] and surface at the result boundary
 /// (see [`materialize_list`]). A non-list argument yields a SPARQL error.
-fn list_concat<D: DatasetView<Id = TermId> + Sync>(
+fn list_concat<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     let (Some(a), Some(b)) = (arg(vals, 0), arg(vals, 1)) else {
         return Ok(None);
     };
@@ -186,7 +186,7 @@ fn list_concat<D: DatasetView<Id = TermId> + Sync>(
 /// `cell rdf:first member` / `cell rdf:rest next` are pushed onto
 /// [`EvalCtx::constructed`] to surface at the result boundary; the empty list is
 /// simply `rdf:nil` (no cells).
-fn materialize_list<D: DatasetView<Id = TermId> + Sync>(
+fn materialize_list<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     members: Vec<TermValue>,
 ) -> TermValue {
@@ -235,26 +235,23 @@ fn as_index(value: &TermValue) -> Option<i64> {
 }
 
 /// Intern a value to a solution term (promoting to an existing dataset id).
-fn intern<D: DatasetView<Id = TermId> + Sync>(
+fn intern<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     value: TermValue,
-) -> SolutionTerm {
+) -> SolutionTerm<D::Id> {
     ctx.scratch.intern(ctx.dataset, value)
 }
 
 /// Intern an `xsd:integer` literal.
-fn integer_term<D: DatasetView<Id = TermId> + Sync>(
+fn integer_term<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     value: i64,
-) -> SolutionTerm {
+) -> SolutionTerm<D::Id> {
     intern(ctx, typed(&value.to_string(), XSD_INTEGER))
 }
 
 /// Intern an `xsd:boolean` literal.
-fn bool_term<D: DatasetView<Id = TermId> + Sync>(
-    ctx: &mut EvalCtx<'_, D>,
-    b: bool,
-) -> SolutionTerm {
+fn bool_term<D: DatasetView + Sync>(ctx: &mut EvalCtx<'_, D>, b: bool) -> SolutionTerm<D::Id> {
     intern(ctx, typed(if b { "true" } else { "false" }, XSD_BOOLEAN))
 }
 
@@ -285,7 +282,7 @@ fn typed(lexical: &str, datatype: &str) -> TermValue {
 /// * `Err(EvalError::Data)` — a cyclic, torn, or multi-edge list (a cell revisited,
 ///   an interior cell missing `rdf:first`/`rdf:rest`, or a cell carrying two of
 ///   either edge): malformed input, a hard fail.
-fn walk<D: DatasetView<Id = TermId> + Sync>(
+fn walk<D: DatasetView + Sync>(
     ctx: &EvalCtx<'_, D>,
     head: &TermValue,
 ) -> Result<Option<Vec<TermValue>>, EvalError> {
@@ -306,7 +303,7 @@ fn walk<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// Walk a list interned in the active dataset (the common case).
-fn walk_dataset<D: DatasetView<Id = TermId> + Sync>(
+fn walk_dataset<D: DatasetView + Sync>(
     ctx: &EvalCtx<'_, D>,
     head: &TermValue,
 ) -> Result<Option<Vec<TermValue>>, EvalError> {
@@ -325,7 +322,7 @@ fn walk_dataset<D: DatasetView<Id = TermId> + Sync>(
 
     let scope = ctx.active_dataset.scope_for(ctx.active_graph);
     let mut members: Vec<TermValue> = Vec::new();
-    let mut seen: DetHashSet<TermId> = DetHashSet::default();
+    let mut seen: DetHashSet<D::Id> = DetHashSet::default();
     let mut cur = head_id;
     loop {
         if cur == nil_id {
@@ -340,7 +337,7 @@ fn walk_dataset<D: DatasetView<Id = TermId> + Sync>(
         // A well-formed cell has exactly one `rdf:first` and one `rdf:rest`. Two of
         // either makes the cell ambiguous: take no arbitrary, iteration-order-dependent
         // branch — hard-fail (the malformed-input contract).
-        let mut first_obj: Option<TermId> = None;
+        let mut first_obj: Option<D::Id> = None;
         let mut first_count = 0usize;
         scope.for_each_quad(ctx.dataset, Some(cur), Some(first_id), None, |q| {
             first_obj = Some(q.o);
@@ -361,7 +358,7 @@ fn walk_dataset<D: DatasetView<Id = TermId> + Sync>(
         };
         members.push(term_id_to_value(ctx.dataset, fo));
 
-        let mut rest_obj: Option<TermId> = None;
+        let mut rest_obj: Option<D::Id> = None;
         let mut rest_count = 0usize;
         scope.for_each_quad(ctx.dataset, Some(cur), Some(rest_id), None, |q| {
             rest_obj = Some(q.o);
@@ -384,7 +381,7 @@ fn walk_dataset<D: DatasetView<Id = TermId> + Sync>(
 /// within the same query. Returns `None` when `head` is not a constructed-list head
 /// (the caller then treats it as a non-list / unbound); otherwise the same
 /// well-formed / malformed contract as [`walk_dataset`].
-fn walk_constructed<D: DatasetView<Id = TermId> + Sync>(
+fn walk_constructed<D: DatasetView + Sync>(
     ctx: &EvalCtx<'_, D>,
     head: &TermValue,
 ) -> Option<Result<Vec<TermValue>, EvalError>> {
@@ -430,7 +427,7 @@ fn walk_constructed<D: DatasetView<Id = TermId> + Sync>(
 /// The unique object of `(subject, predicate, ?)` in the per-query constructed
 /// buffer: `Ok(None)` if absent, `Ok(Some)` if exactly one, `Err` if more than one
 /// (a multi-edge malformed cell — same hard-fail as the dataset walk).
-fn single_constructed_edge<D: DatasetView<Id = TermId> + Sync>(
+fn single_constructed_edge<D: DatasetView + Sync>(
     ctx: &EvalCtx<'_, D>,
     subject: &TermValue,
     predicate: &TermValue,

--- a/crates/sparql-eval/src/list_fn.rs
+++ b/crates/sparql-eval/src/list_fn.rs
@@ -26,7 +26,7 @@
 //! The walk is cycle-guarded: a cyclic or torn `rdf:List` is malformed input and
 //! hard-fails ([`EvalError::Data`]) rather than looping forever.
 
-use purrdf_core::{BlankScope, TermId, TermValue};
+use purrdf_core::{BlankScope, DatasetView, TermId, TermValue};
 use purrdf_sparql_algebra::PurrdfFn;
 use purrdf_xsd::XsdValue;
 
@@ -47,10 +47,10 @@ const RDF_NIL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
 /// expression contract: `Ok(Some)` is a value, `Ok(None)` is a SPARQL error/unbound,
 /// and `Err` is a hard failure. The non-list [`PurrdfFn::HeldIn`] is handled by its
 /// own arm in [`crate::expr`] and never reaches here (defensively an internal error).
-pub(crate) fn dispatch(
+pub(crate) fn dispatch<D: DatasetView<Id = TermId> + Sync>(
     func: PurrdfFn,
     vals: &[Option<TermValue>],
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<SolutionTerm>, EvalError> {
     match func {
         PurrdfFn::ListLength => list_length(ctx, vals),
@@ -65,8 +65,8 @@ pub(crate) fn dispatch(
 
 /// `listLength(list)` → the number of members, as `xsd:integer`. A non-list
 /// argument yields a SPARQL error (`Ok(None)`).
-fn list_length(
-    ctx: &mut EvalCtx<'_>,
+fn list_length<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let Some(head) = arg(vals, 0) else {
@@ -80,8 +80,8 @@ fn list_length(
 
 /// `listGet(list, index)` → the zero-based member, or a SPARQL error when the
 /// index is out of range / not an integer.
-fn list_get(
-    ctx: &mut EvalCtx<'_>,
+fn list_get<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let (Some(head), Some(index)) = (arg(vals, 0), arg(vals, 1)) else {
@@ -104,8 +104,8 @@ fn list_get(
 
 /// `listIndexOf(list, value)` → the zero-based index of the first occurrence,
 /// or a SPARQL error when the value is absent.
-fn list_index_of(
-    ctx: &mut EvalCtx<'_>,
+fn list_index_of<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let (Some(head), Some(value)) = (arg(vals, 0), arg(vals, 1)) else {
@@ -122,8 +122,8 @@ fn list_index_of(
 
 /// `listContains(list, value)` → `xsd:boolean`. A non-list argument yields a
 /// SPARQL error (`Ok(None)`); membership over a valid (possibly empty) list is total.
-fn list_contains(
-    ctx: &mut EvalCtx<'_>,
+fn list_contains<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let (Some(head), Some(value)) = (arg(vals, 0), arg(vals, 1)) else {
@@ -140,8 +140,8 @@ fn list_contains(
 /// (negatives to 0), so an out-of-range or inverted range yields `rdf:nil`. The new
 /// cells are buffered on [`EvalCtx`] and surface at the result boundary (see
 /// [`materialize_list`]). A non-list / non-integer argument yields a SPARQL error.
-fn list_slice(
-    ctx: &mut EvalCtx<'_>,
+fn list_slice<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let (Some(head), Some(start), Some(end)) = (arg(vals, 0), arg(vals, 1), arg(vals, 2)) else {
@@ -164,8 +164,8 @@ fn list_slice(
 /// `listConcat(listA, listB)` → a fresh `rdf:List` of A's members followed by
 /// B's. The new cells are buffered on [`EvalCtx`] and surface at the result boundary
 /// (see [`materialize_list`]). A non-list argument yields a SPARQL error.
-fn list_concat(
-    ctx: &mut EvalCtx<'_>,
+fn list_concat<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
     vals: &[Option<TermValue>],
 ) -> Result<Option<SolutionTerm>, EvalError> {
     let (Some(a), Some(b)) = (arg(vals, 0), arg(vals, 1)) else {
@@ -186,7 +186,10 @@ fn list_concat(
 /// `cell rdf:first member` / `cell rdf:rest next` are pushed onto
 /// [`EvalCtx::constructed`] to surface at the result boundary; the empty list is
 /// simply `rdf:nil` (no cells).
-fn materialize_list(ctx: &mut EvalCtx<'_>, members: Vec<TermValue>) -> TermValue {
+fn materialize_list<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
+    members: Vec<TermValue>,
+) -> TermValue {
     if members.is_empty() {
         return iri(RDF_NIL);
     }
@@ -232,17 +235,26 @@ fn as_index(value: &TermValue) -> Option<i64> {
 }
 
 /// Intern a value to a solution term (promoting to an existing dataset id).
-fn intern(ctx: &mut EvalCtx<'_>, value: TermValue) -> SolutionTerm {
+fn intern<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
+    value: TermValue,
+) -> SolutionTerm {
     ctx.scratch.intern(ctx.dataset, value)
 }
 
 /// Intern an `xsd:integer` literal.
-fn integer_term(ctx: &mut EvalCtx<'_>, value: i64) -> SolutionTerm {
+fn integer_term<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
+    value: i64,
+) -> SolutionTerm {
     intern(ctx, typed(&value.to_string(), XSD_INTEGER))
 }
 
 /// Intern an `xsd:boolean` literal.
-fn bool_term(ctx: &mut EvalCtx<'_>, b: bool) -> SolutionTerm {
+fn bool_term<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
+    b: bool,
+) -> SolutionTerm {
     intern(ctx, typed(if b { "true" } else { "false" }, XSD_BOOLEAN))
 }
 
@@ -273,7 +285,10 @@ fn typed(lexical: &str, datatype: &str) -> TermValue {
 /// * `Err(EvalError::Data)` — a cyclic, torn, or multi-edge list (a cell revisited,
 ///   an interior cell missing `rdf:first`/`rdf:rest`, or a cell carrying two of
 ///   either edge): malformed input, a hard fail.
-fn walk(ctx: &EvalCtx<'_>, head: &TermValue) -> Result<Option<Vec<TermValue>>, EvalError> {
+fn walk<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &EvalCtx<'_, D>,
+    head: &TermValue,
+) -> Result<Option<Vec<TermValue>>, EvalError> {
     // The empty list is `rdf:nil`, whether or not it happens to be interned.
     if is_nil(head) {
         return Ok(Some(Vec::new()));
@@ -291,7 +306,10 @@ fn walk(ctx: &EvalCtx<'_>, head: &TermValue) -> Result<Option<Vec<TermValue>>, E
 }
 
 /// Walk a list interned in the active dataset (the common case).
-fn walk_dataset(ctx: &EvalCtx<'_>, head: &TermValue) -> Result<Option<Vec<TermValue>>, EvalError> {
+fn walk_dataset<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &EvalCtx<'_, D>,
+    head: &TermValue,
+) -> Result<Option<Vec<TermValue>>, EvalError> {
     // The list nodes and edges must exist in the active dataset to be walkable.
     let (Some(first_id), Some(rest_id), Some(nil_id)) = (
         ctx.dataset.term_id_by_value(&iri(RDF_FIRST)),
@@ -366,8 +384,8 @@ fn walk_dataset(ctx: &EvalCtx<'_>, head: &TermValue) -> Result<Option<Vec<TermVa
 /// within the same query. Returns `None` when `head` is not a constructed-list head
 /// (the caller then treats it as a non-list / unbound); otherwise the same
 /// well-formed / malformed contract as [`walk_dataset`].
-fn walk_constructed(
-    ctx: &EvalCtx<'_>,
+fn walk_constructed<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &EvalCtx<'_, D>,
     head: &TermValue,
 ) -> Option<Result<Vec<TermValue>, EvalError>> {
     let first = iri(RDF_FIRST);
@@ -412,8 +430,8 @@ fn walk_constructed(
 /// The unique object of `(subject, predicate, ?)` in the per-query constructed
 /// buffer: `Ok(None)` if absent, `Ok(Some)` if exactly one, `Err` if more than one
 /// (a multi-edge malformed cell — same hard-fail as the dataset walk).
-fn single_constructed_edge(
-    ctx: &EvalCtx<'_>,
+fn single_constructed_edge<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &EvalCtx<'_, D>,
     subject: &TermValue,
     predicate: &TermValue,
 ) -> Result<Option<TermValue>, EvalError> {

--- a/crates/sparql-eval/src/modifier.rs
+++ b/crates/sparql-eval/src/modifier.rs
@@ -9,7 +9,7 @@ use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
-use purrdf_core::{GraphMatch, TermId, TermValue};
+use purrdf_core::{DatasetView, GraphMatch, TermId, TermValue};
 use purrdf_sparql_algebra::{
     AggregateExpression, AggregateFunction, Expression, GraphPattern, NamedNodePattern,
     OrderExpression, Variable,
@@ -29,10 +29,10 @@ use crate::{DetHashMap, DetHashSet, DetHasher};
 
 /// Inline `VALUES`: one solution per binding row, each cell an interned ground term
 /// (or unbound for `UNDEF`).
-pub(crate) fn eval_values(
+pub(crate) fn eval_values<D: DatasetView<Id = TermId> + Sync>(
     variables: &[Variable],
     bindings: &[Vec<Option<purrdf_sparql_algebra::GroundTerm>>],
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     let schema = Arc::new(VarSchema::from_vars(variables.iter().cloned()));
     let width = schema.len();
@@ -54,10 +54,10 @@ pub(crate) fn eval_values(
 
 /// `SELECT`-list projection: restrict to `variables` in order. A projected variable
 /// absent from the inner solution yields an all-unbound column.
-pub(crate) fn eval_project(
+pub(crate) fn eval_project<D: DatasetView<Id = TermId> + Sync>(
     inner: &GraphPattern,
     variables: &[Variable],
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     let seq = eval(inner, ctx)?;
     let out = Arc::new(VarSchema::from_vars(variables.iter().cloned()));
@@ -72,18 +72,18 @@ pub(crate) fn eval_project(
 }
 
 /// `DISTINCT`: drop duplicate whole-solution rows, preserving first-seen order.
-pub(crate) fn eval_distinct(
+pub(crate) fn eval_distinct<D: DatasetView<Id = TermId> + Sync>(
     inner: &GraphPattern,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     Ok(dedup(eval(inner, ctx)?))
 }
 
 /// `REDUCED`: permitted to drop duplicates; we apply the same dedup as `DISTINCT`
 /// (a stronger-but-permitted reduction than the spec's minimum).
-pub(crate) fn eval_reduced(
+pub(crate) fn eval_reduced<D: DatasetView<Id = TermId> + Sync>(
     inner: &GraphPattern,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     Ok(dedup(eval(inner, ctx)?))
 }
@@ -109,11 +109,11 @@ fn dedup(seq: SolutionSeq) -> SolutionSeq {
 }
 
 /// `LIMIT`/`OFFSET`: skip `start` solutions then keep at most `length`.
-pub(crate) fn eval_slice(
+pub(crate) fn eval_slice<D: DatasetView<Id = TermId> + Sync>(
     inner: &GraphPattern,
     start: usize,
     length: Option<usize>,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     let seq = eval(inner, ctx)?;
     let rows = seq
@@ -129,10 +129,10 @@ pub(crate) fn eval_slice(
 }
 
 /// `ORDER BY`: stable-sort by the sort keys under SPARQL ordering (§15.1).
-pub(crate) fn eval_order_by(
+pub(crate) fn eval_order_by<D: DatasetView<Id = TermId> + Sync>(
     inner: &GraphPattern,
     exprs: &[OrderExpression],
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     let seq = eval(inner, ctx)?;
     let schema = seq.schema.clone();
@@ -158,10 +158,10 @@ pub(crate) fn eval_order_by(
 
 /// `GRAPH name { ... }`: scope the inner pattern to a named graph (or, for a
 /// variable, every named graph in turn, binding the variable to each).
-pub(crate) fn eval_graph(
+pub(crate) fn eval_graph<D: DatasetView<Id = TermId> + Sync>(
     name: &NamedNodePattern,
     inner: &GraphPattern,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     match name {
         NamedNodePattern::NamedNode(n) => {
@@ -196,10 +196,10 @@ pub(crate) fn eval_graph(
 /// (e.g. an outer `VALUES (?g ?t) { ... }` nested inside the `GRAPH ?g { }` block,
 /// or any other pre-binding), each candidate graph must be JOINED against that
 /// existing binding — kept only when compatible — rather than blindly overwritten.
-fn eval_graph_var(
+fn eval_graph_var<D: DatasetView<Id = TermId> + Sync>(
     var: &Variable,
     inner: &GraphPattern,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     // Enumerate every named graph the dataset knows about, restricted to those the
     // active dataset admits (a `FROM NAMED` / `USING NAMED` may limit which graphs
@@ -479,11 +479,11 @@ fn literal_order(a: (&str, &str, &Option<String>), b: (&str, &str, &Option<Strin
 ///
 /// With **no** grouping variables but aggregates present, the whole input is a
 /// single group — even when empty (so `COUNT(*)` yields one row binding `0`).
-pub(crate) fn eval_group(
+pub(crate) fn eval_group<D: DatasetView<Id = TermId> + Sync>(
     inner: &GraphPattern,
     variables: &[Variable],
     aggregates: &[(Variable, AggregateExpression)],
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     let seq = eval(inner, ctx)?;
     let in_schema = seq.schema.clone();
@@ -573,12 +573,12 @@ pub(crate) fn eval_group(
 }
 
 /// Compute one aggregate over a group's rows.
-fn eval_aggregate(
+fn eval_aggregate<D: DatasetView<Id = TermId> + Sync>(
     agg: &AggregateExpression,
     idxs: &[usize],
     rows: &[Solution],
     schema: &VarSchema,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<SolutionTerm>, EvalError> {
     match agg {
         AggregateExpression::CountStar { distinct } => {
@@ -613,10 +613,10 @@ fn eval_aggregate(
 }
 
 /// Apply a named aggregate to the collected group values.
-fn apply_aggregate(
+fn apply_aggregate<D: DatasetView<Id = TermId> + Sync>(
     function: &AggregateFunction,
     values: &[(SolutionTerm, TermValue)],
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<SolutionTerm>, EvalError> {
     match function {
         AggregateFunction::Count => Ok(Some(integer_term(ctx, values.len() as i64))),
@@ -728,7 +728,10 @@ fn lexical_of(value: &TermValue) -> Option<String> {
 }
 
 /// Intern an `xsd:integer` literal.
-fn integer_term(ctx: &mut EvalCtx<'_>, value: i64) -> SolutionTerm {
+fn integer_term<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
+    value: i64,
+) -> SolutionTerm {
     ctx.scratch.intern(
         ctx.dataset,
         TermValue::Literal {
@@ -741,7 +744,10 @@ fn integer_term(ctx: &mut EvalCtx<'_>, value: i64) -> SolutionTerm {
 }
 
 /// Intern an `xsd:string` literal.
-fn string_term(ctx: &mut EvalCtx<'_>, lexical: String) -> SolutionTerm {
+fn string_term<D: DatasetView<Id = TermId> + Sync>(
+    ctx: &mut EvalCtx<'_, D>,
+    lexical: String,
+) -> SolutionTerm {
     ctx.scratch.intern(
         ctx.dataset,
         TermValue::Literal {
@@ -1069,7 +1075,12 @@ mod tests {
     }
 
     /// Helper: resolve an aggregate column via the eval scratch.
-    fn agg_lex(ds: &Arc<RdfDataset>, ctx: &EvalCtx<'_>, seq: &SolutionSeq, var: &str) -> String {
+    fn agg_lex(
+        ds: &Arc<RdfDataset>,
+        ctx: &EvalCtx<'_, Arc<RdfDataset>>,
+        seq: &SolutionSeq,
+        var: &str,
+    ) -> String {
         let col = seq.schema.index_of(&Variable::new(var)).unwrap();
         match ctx.scratch.value_of(ds, seq.rows[0][col].unwrap()) {
             TermValue::Literal { lexical_form, .. } => lexical_form,

--- a/crates/sparql-eval/src/modifier.rs
+++ b/crates/sparql-eval/src/modifier.rs
@@ -9,7 +9,7 @@ use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
-use purrdf_core::{DatasetView, GraphMatch, TermId, TermValue};
+use purrdf_core::{DatasetView, GraphMatch, TermValue, ViewTermId};
 use purrdf_sparql_algebra::{
     AggregateExpression, AggregateFunction, Expression, GraphPattern, NamedNodePattern,
     OrderExpression, Variable,
@@ -29,11 +29,11 @@ use crate::{DetHashMap, DetHashSet, DetHasher};
 
 /// Inline `VALUES`: one solution per binding row, each cell an interned ground term
 /// (or unbound for `UNDEF`).
-pub(crate) fn eval_values<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_values<D: DatasetView + Sync>(
     variables: &[Variable],
     bindings: &[Vec<Option<purrdf_sparql_algebra::GroundTerm>>],
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     let schema = Arc::new(VarSchema::from_vars(variables.iter().cloned()));
     let width = schema.len();
     let mut rows = Vec::with_capacity(bindings.len());
@@ -54,11 +54,11 @@ pub(crate) fn eval_values<D: DatasetView<Id = TermId> + Sync>(
 
 /// `SELECT`-list projection: restrict to `variables` in order. A projected variable
 /// absent from the inner solution yields an all-unbound column.
-pub(crate) fn eval_project<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_project<D: DatasetView + Sync>(
     inner: &GraphPattern,
     variables: &[Variable],
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     let seq = eval(inner, ctx)?;
     let out = Arc::new(VarSchema::from_vars(variables.iter().cloned()));
     // For each projected column, the source column in the inner schema (if any).
@@ -72,25 +72,25 @@ pub(crate) fn eval_project<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// `DISTINCT`: drop duplicate whole-solution rows, preserving first-seen order.
-pub(crate) fn eval_distinct<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_distinct<D: DatasetView + Sync>(
     inner: &GraphPattern,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     Ok(dedup(eval(inner, ctx)?))
 }
 
 /// `REDUCED`: permitted to drop duplicates; we apply the same dedup as `DISTINCT`
 /// (a stronger-but-permitted reduction than the spec's minimum).
-pub(crate) fn eval_reduced<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_reduced<D: DatasetView + Sync>(
     inner: &GraphPattern,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     Ok(dedup(eval(inner, ctx)?))
 }
 
 /// Drop duplicate rows, preserving first-seen order (SolutionTerm equality is exact
 /// RDF-term identity — see the scratch-interner promotion rule).
-fn dedup(seq: SolutionSeq) -> SolutionSeq {
+fn dedup<I: ViewTermId>(seq: SolutionSeq<I>) -> SolutionSeq<I> {
     let mut unique = DetHashMap::with_capacity_and_hasher(seq.rows.len(), DetHasher::default());
     for (ordinal, row) in seq.rows.into_iter().enumerate() {
         if let Entry::Vacant(entry) = unique.entry(row) {
@@ -109,12 +109,12 @@ fn dedup(seq: SolutionSeq) -> SolutionSeq {
 }
 
 /// `LIMIT`/`OFFSET`: skip `start` solutions then keep at most `length`.
-pub(crate) fn eval_slice<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_slice<D: DatasetView + Sync>(
     inner: &GraphPattern,
     start: usize,
     length: Option<usize>,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     let seq = eval(inner, ctx)?;
     let rows = seq
         .rows
@@ -129,11 +129,11 @@ pub(crate) fn eval_slice<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// `ORDER BY`: stable-sort by the sort keys under SPARQL ordering (§15.1).
-pub(crate) fn eval_order_by<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_order_by<D: DatasetView + Sync>(
     inner: &GraphPattern,
     exprs: &[OrderExpression],
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     let seq = eval(inner, ctx)?;
     let schema = seq.schema.clone();
 
@@ -141,7 +141,7 @@ pub(crate) fn eval_order_by<D: DatasetView<Id = TermId> + Sync>(
     // that `term_value_order` would otherwise re-run inside the O(n log n)
     // comparator — so the sort comparator is a cheap pure function (no `ctx`
     // borrow, no re-parsing during the sort).
-    let mut keyed: Vec<(Vec<SortKey>, Solution)> = Vec::with_capacity(seq.rows.len());
+    let mut keyed: Vec<(Vec<SortKey>, Solution<D::Id>)> = Vec::with_capacity(seq.rows.len());
     for row in seq.rows {
         let mut keys = Vec::with_capacity(exprs.len());
         for oe in exprs {
@@ -158,11 +158,11 @@ pub(crate) fn eval_order_by<D: DatasetView<Id = TermId> + Sync>(
 
 /// `GRAPH name { ... }`: scope the inner pattern to a named graph (or, for a
 /// variable, every named graph in turn, binding the variable to each).
-pub(crate) fn eval_graph<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_graph<D: DatasetView + Sync>(
     name: &NamedNodePattern,
     inner: &GraphPattern,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     match name {
         NamedNodePattern::NamedNode(n) => {
             match ctx.dataset.term_id_by_value(&named_node_to_value(n)) {
@@ -196,15 +196,15 @@ pub(crate) fn eval_graph<D: DatasetView<Id = TermId> + Sync>(
 /// (e.g. an outer `VALUES (?g ?t) { ... }` nested inside the `GRAPH ?g { }` block,
 /// or any other pre-binding), each candidate graph must be JOINED against that
 /// existing binding — kept only when compatible — rather than blindly overwritten.
-fn eval_graph_var<D: DatasetView<Id = TermId> + Sync>(
+fn eval_graph_var<D: DatasetView + Sync>(
     var: &Variable,
     inner: &GraphPattern,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     // Enumerate every named graph the dataset knows about, restricted to those the
     // active dataset admits (a `FROM NAMED` / `USING NAMED` may limit which graphs
     // `GRAPH ?g` binds to).
-    let graphs: Vec<TermId> = ctx
+    let graphs: Vec<D::Id> = ctx
         .dataset
         .named_graphs()
         .filter(|g| ctx.active_dataset.named_allows(*g))
@@ -479,20 +479,20 @@ fn literal_order(a: (&str, &str, &Option<String>), b: (&str, &str, &Option<Strin
 ///
 /// With **no** grouping variables but aggregates present, the whole input is a
 /// single group — even when empty (so `COUNT(*)` yields one row binding `0`).
-pub(crate) fn eval_group<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_group<D: DatasetView + Sync>(
     inner: &GraphPattern,
     variables: &[Variable],
     aggregates: &[(Variable, AggregateExpression)],
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     let seq = eval(inner, ctx)?;
     let in_schema = seq.schema.clone();
     let key_cols: Vec<Option<usize>> = variables.iter().map(|v| in_schema.index_of(v)).collect();
 
     // Partition rows into groups, keeping groups in first-seen order.
-    let mut groups: DetHashMap<Solution, (usize, Vec<usize>)> = DetHashMap::default();
+    let mut groups: DetHashMap<Solution<D::Id>, (usize, Vec<usize>)> = DetHashMap::default();
     for (idx, row) in seq.rows.iter().enumerate() {
-        let key: Solution = key_cols.iter().map(|c| c.and_then(|c| row[c])).collect();
+        let key: Solution<D::Id> = key_cols.iter().map(|c| c.and_then(|c| row[c])).collect();
         let next_ordinal = groups.len();
         match groups.entry(key) {
             Entry::Occupied(mut entry) => entry.get_mut().1.push(idx),
@@ -573,17 +573,17 @@ pub(crate) fn eval_group<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// Compute one aggregate over a group's rows.
-fn eval_aggregate<D: DatasetView<Id = TermId> + Sync>(
+fn eval_aggregate<D: DatasetView + Sync>(
     agg: &AggregateExpression,
     idxs: &[usize],
-    rows: &[Solution],
+    rows: &[Solution<D::Id>],
     schema: &VarSchema,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     match agg {
         AggregateExpression::CountStar { distinct } => {
             let count = if *distinct {
-                let mut seen: DetHashSet<&Solution> = DetHashSet::default();
+                let mut seen: DetHashSet<&Solution<D::Id>> = DetHashSet::default();
                 idxs.iter().filter(|&&i| seen.insert(&rows[i])).count()
             } else {
                 idxs.len()
@@ -596,7 +596,7 @@ fn eval_aggregate<D: DatasetView<Id = TermId> + Sync>(
             distinct,
         } => {
             // Collect the bound values of the expression over the group.
-            let mut values: Vec<(SolutionTerm, TermValue)> = Vec::new();
+            let mut values: Vec<(SolutionTerm<D::Id>, TermValue)> = Vec::new();
             for &i in idxs {
                 if let Some(term) = eval_expr(expression, &rows[i], schema, ctx)? {
                     let value = ctx.scratch.value_of(ctx.dataset, term);
@@ -604,7 +604,7 @@ fn eval_aggregate<D: DatasetView<Id = TermId> + Sync>(
                 }
             }
             if *distinct {
-                let mut seen: DetHashSet<SolutionTerm> = DetHashSet::default();
+                let mut seen: DetHashSet<SolutionTerm<D::Id>> = DetHashSet::default();
                 values.retain(|(t, _)| seen.insert(*t));
             }
             apply_aggregate(function, &values, ctx)
@@ -613,11 +613,11 @@ fn eval_aggregate<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// Apply a named aggregate to the collected group values.
-fn apply_aggregate<D: DatasetView<Id = TermId> + Sync>(
+fn apply_aggregate<D: DatasetView + Sync>(
     function: &AggregateFunction,
-    values: &[(SolutionTerm, TermValue)],
+    values: &[(SolutionTerm<D::Id>, TermValue)],
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<Option<SolutionTerm>, EvalError> {
+) -> Result<Option<SolutionTerm<D::Id>>, EvalError> {
     match function {
         AggregateFunction::Count => Ok(Some(integer_term(ctx, values.len() as i64))),
         AggregateFunction::Sample => Ok(values.first().map(|(t, _)| *t)),
@@ -705,7 +705,10 @@ fn is_numeric_xsd(v: &XsdValue) -> bool {
 
 /// The group's extreme value (`Ordering::Less` = MIN, `Greater` = MAX) under SPARQL
 /// term ordering, returning its solution term; `None` for an empty group.
-fn extreme(values: &[(SolutionTerm, TermValue)], want: Ordering) -> Option<SolutionTerm> {
+fn extreme<I: ViewTermId>(
+    values: &[(SolutionTerm<I>, TermValue)],
+    want: Ordering,
+) -> Option<SolutionTerm<I>> {
     values
         .iter()
         .reduce(|acc, cur| {
@@ -728,10 +731,10 @@ fn lexical_of(value: &TermValue) -> Option<String> {
 }
 
 /// Intern an `xsd:integer` literal.
-fn integer_term<D: DatasetView<Id = TermId> + Sync>(
+fn integer_term<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     value: i64,
-) -> SolutionTerm {
+) -> SolutionTerm<D::Id> {
     ctx.scratch.intern(
         ctx.dataset,
         TermValue::Literal {
@@ -744,10 +747,10 @@ fn integer_term<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// Intern an `xsd:string` literal.
-fn string_term<D: DatasetView<Id = TermId> + Sync>(
+fn string_term<D: DatasetView + Sync>(
     ctx: &mut EvalCtx<'_, D>,
     lexical: String,
-) -> SolutionTerm {
+) -> SolutionTerm<D::Id> {
     ctx.scratch.intern(
         ctx.dataset,
         TermValue::Literal {

--- a/crates/sparql-eval/src/parallel.rs
+++ b/crates/sparql-eval/src/parallel.rs
@@ -46,7 +46,7 @@
 //! fork-join would make its result depend on worker scheduling, not just row
 //! content.
 
-use purrdf_core::{DatasetView, TermId, TermValue};
+use purrdf_core::{DatasetView, TermId, TermValue, ViewTermId};
 use purrdf_sparql_algebra::{
     AggregateExpression, Expression, Function, GraphPattern, OrderExpression,
 };
@@ -479,10 +479,10 @@ where
 ///   [`TermValue`] ([`PortableTerm::Fresh`]) while the child (and its scratch)
 ///   is still alive, for the caller to re-intern against the parent later.
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum PortableTerm {
+pub(crate) enum PortableTerm<I = TermId> {
     /// A term already valid in the parent's id space: an `Existing` dataset
     /// term, or a `Computed` id minted before the fork.
-    Parent(SolutionTerm),
+    Parent(SolutionTerm<I>),
     /// A value the child minted after the fork; not yet interned anywhere but
     /// the child's own (about-to-be-dropped) scratch.
     Fresh(TermValue),
@@ -492,11 +492,11 @@ pub(crate) enum PortableTerm {
 /// scratch into a portable form, while `local` is still alive. `base` is the
 /// parent's [`ScratchInterner::computed_count`] captured **at fork time** —
 /// see [`PortableTerm`] for the id rule this relies on.
-pub(crate) fn portable_row(
+pub(crate) fn portable_row<I: ViewTermId>(
     local: &ScratchInterner,
     base: usize,
-    row: &Solution,
-) -> Vec<Option<PortableTerm>> {
+    row: &Solution<I>,
+) -> Vec<Option<PortableTerm<I>>> {
     row.iter()
         .map(|cell| match cell {
             None => None,
@@ -520,11 +520,11 @@ pub(crate) fn portable_row(
 /// workers minting the same fresh value converge on the same parent id
 /// deterministically (whichever reinterns first wins the id; the same value
 /// reinterned again is deduplicated against it, not re-minted).
-pub(crate) fn reintern_portable_row<D: DatasetView<Id = TermId>>(
+pub(crate) fn reintern_portable_row<D: DatasetView>(
     main: &mut ScratchInterner,
     dataset: &D,
-    prow: Vec<Option<PortableTerm>>,
-) -> Solution {
+    prow: Vec<Option<PortableTerm<D::Id>>>,
+) -> Solution<D::Id> {
     prow.into_iter()
         .map(|cell| match cell {
             None => None,
@@ -549,19 +549,23 @@ pub(crate) fn reintern_portable_row<D: DatasetView<Id = TermId>>(
 /// nothing) or a `MIN`/`MAX`/`SAMPLE` group (whose result is an existing bound
 /// value passed through) — `BIND`/most aggregates mint a genuinely new value
 /// and always take the `Portable` arm, exactly as before this fast path.
-pub(crate) enum MintedRow {
+pub(crate) enum MintedRow<I = TermId> {
     /// No cell of this row is a post-fork mint — pass it through untouched.
-    Direct(Solution),
+    Direct(Solution<I>),
     /// At least one cell was freshly minted by the child after the fork;
     /// captured in portable form for [`reintern_minted_row`] to re-intern.
-    Portable(Vec<Option<PortableTerm>>),
+    Portable(Vec<Option<PortableTerm<I>>>),
 }
 
 /// Classify one worker-produced `row` into a [`MintedRow`]: `Direct` iff no
 /// cell is a `Computed(sid)` with `sid >= base` (a post-fork mint), else
 /// `Portable` (materialized against `local` — the minting child's scratch —
 /// while it is still alive). See [`MintedRow`] for the reasoning.
-pub(crate) fn minted_row(local: &ScratchInterner, base: usize, row: Solution) -> MintedRow {
+pub(crate) fn minted_row<I: ViewTermId>(
+    local: &ScratchInterner,
+    base: usize,
+    row: Solution<I>,
+) -> MintedRow<I> {
     let has_fresh_mint = row
         .iter()
         .any(|cell| matches!(cell, Some(SolutionTerm::Computed(sid)) if sid.index() >= base));
@@ -578,11 +582,11 @@ pub(crate) fn minted_row(local: &ScratchInterner, base: usize, row: Solution) ->
 /// source-index order across all workers — see [`reintern_portable_row`]'s doc
 /// comment for why that ordering (not anything in this function) is what makes
 /// the result deterministic.
-pub(crate) fn reintern_minted_row<D: DatasetView<Id = TermId>>(
+pub(crate) fn reintern_minted_row<D: DatasetView>(
     main: &mut ScratchInterner,
     dataset: &D,
-    row: MintedRow,
-) -> Solution {
+    row: MintedRow<D::Id>,
+) -> Solution<D::Id> {
     match row {
         MintedRow::Direct(solution) => solution,
         MintedRow::Portable(prow) => reintern_portable_row(main, dataset, prow),

--- a/crates/sparql-eval/src/parallel.rs
+++ b/crates/sparql-eval/src/parallel.rs
@@ -46,7 +46,7 @@
 //! fork-join would make its result depend on worker scheduling, not just row
 //! content.
 
-use purrdf_core::{RdfDataset, TermValue};
+use purrdf_core::{DatasetView, TermId, TermValue};
 use purrdf_sparql_algebra::{
     AggregateExpression, Expression, Function, GraphPattern, OrderExpression,
 };
@@ -520,9 +520,9 @@ pub(crate) fn portable_row(
 /// workers minting the same fresh value converge on the same parent id
 /// deterministically (whichever reinterns first wins the id; the same value
 /// reinterned again is deduplicated against it, not re-minted).
-pub(crate) fn reintern_portable_row(
+pub(crate) fn reintern_portable_row<D: DatasetView<Id = TermId>>(
     main: &mut ScratchInterner,
-    dataset: &RdfDataset,
+    dataset: &D,
     prow: Vec<Option<PortableTerm>>,
 ) -> Solution {
     prow.into_iter()
@@ -578,9 +578,9 @@ pub(crate) fn minted_row(local: &ScratchInterner, base: usize, row: Solution) ->
 /// source-index order across all workers — see [`reintern_portable_row`]'s doc
 /// comment for why that ordering (not anything in this function) is what makes
 /// the result deterministic.
-pub(crate) fn reintern_minted_row(
+pub(crate) fn reintern_minted_row<D: DatasetView<Id = TermId>>(
     main: &mut ScratchInterner,
-    dataset: &RdfDataset,
+    dataset: &D,
     row: MintedRow,
 ) -> Solution {
     match row {
@@ -806,9 +806,9 @@ mod tests {
                 if item % 7 != 0 {
                     std::thread::yield_now();
                 }
-                acc.push(vec![Some(SolutionTerm::Existing(
-                    purrdf_core::TermId::from_index(item as u32),
-                ))]);
+                acc.push(vec![Some(SolutionTerm::Existing(TermId::from_index(
+                    item as u32,
+                )))]);
                 Ok(())
             },
         )
@@ -842,9 +842,9 @@ mod tests {
                 if item % 3 == 0 {
                     std::thread::yield_now();
                 }
-                acc.push(vec![Some(SolutionTerm::Existing(
-                    purrdf_core::TermId::from_index(item as u32),
-                ))]);
+                acc.push(vec![Some(SolutionTerm::Existing(TermId::from_index(
+                    item as u32,
+                )))]);
                 Ok(())
             },
         )
@@ -876,9 +876,9 @@ mod tests {
                 0_u64
             },
             |_state, acc, &item| {
-                acc.push(vec![Some(SolutionTerm::Existing(
-                    purrdf_core::TermId::from_index(item as u32),
-                ))]);
+                acc.push(vec![Some(SolutionTerm::Existing(TermId::from_index(
+                    item as u32,
+                )))]);
                 Ok(())
             },
         )

--- a/crates/sparql-eval/src/path.rs
+++ b/crates/sparql-eval/src/path.rs
@@ -43,7 +43,7 @@ use std::collections::BTreeSet;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use purrdf_core::{DatasetView, TermId, TermRef, TermValue};
+use purrdf_core::{DatasetView, TermId, TermRef, TermValue, ViewTermId};
 use purrdf_sparql_algebra::{NamedNode, PropertyPathExpression, TermPattern, Variable};
 
 use crate::convert::{ground_term_pattern_to_value, named_node_to_value};
@@ -64,51 +64,51 @@ use crate::{DetHashMap, DetHashSet};
 /// because an empty `TermId` set would only arise from a non-empty element
 /// list whose IRIs are simply absent from the dataset, which still
 /// legitimately participates (excluding nothing that occurs).
-struct NegatedSets {
+struct NegatedSets<I: ViewTermId = TermId> {
     /// Predicates excluded from a **forward** hop (the plain, non-`^` elements),
     /// or `None` if the set has no plain elements.
-    forward: Option<BTreeSet<TermId>>,
+    forward: Option<BTreeSet<I>>,
     /// Predicates excluded from a **reverse** hop (the `^`-prefixed elements),
     /// or `None` if the set has no inverted elements.
-    inverse: Option<BTreeSet<TermId>>,
+    inverse: Option<BTreeSet<I>>,
 }
 
-/// Per-`NegatedPropertySet` exclusion sets, resolved to dataset ids ONCE per
+/// Per-`NegatedPropertySet` exclusion sets, resolved to view ids ONCE per
 /// `eval_path` call and keyed by the element slice's data pointer (stable for
 /// the immutable path AST).
-type NegatedCache = BTreeMap<usize, NegatedSets>;
-type ReachKey = (usize, TermId, bool);
-type ReachCache = RefCell<DetHashMap<ReachKey, Rc<BTreeSet<TermId>>>>;
+type NegatedCache<I = TermId> = BTreeMap<usize, NegatedSets<I>>;
+type ReachKey<I = TermId> = (usize, I, bool);
+type ReachCache<I = TermId> = RefCell<DetHashMap<ReachKey<I>, Rc<BTreeSet<I>>>>;
 
 /// The immutable, traversal-wide context shared by every `reach` recursion: the
 /// frozen dataset, the active dataset graph scope (§13: a single graph, or a
 /// `FROM`/`USING`-merged default graph), the once-resolved negated-set cache, and
 /// a per-evaluation reachability memo. Bundling these keeps the recursive
 /// path-evaluation signatures small.
-struct PathCtx<'a, D: DatasetView<Id = TermId> + Sync> {
+struct PathCtx<'a, D: DatasetView + Sync> {
     dataset: &'a D,
-    scope: GraphScope,
-    cache: NegatedCache,
-    reach_cache: ReachCache,
+    scope: GraphScope<D::Id>,
+    cache: NegatedCache<D::Id>,
+    reach_cache: ReachCache<D::Id>,
 }
 
 /// Build a `NegatedCache` by walking `path` once and pre-resolving every
 /// `NegatedPropertySet`'s excluded predicates to `TermId`s. The result is
 /// threaded through all `reach`/`closure`/`step_negated` calls so that IRI
 /// resolution is not repeated on every traversal step.
-fn build_negated_cache<D: DatasetView<Id = TermId> + Sync>(
+fn build_negated_cache<D: DatasetView + Sync>(
     path: &PropertyPathExpression,
     dataset: &D,
-) -> NegatedCache {
+) -> NegatedCache<D::Id> {
     let mut cache = NegatedCache::new();
     collect_negated(path, dataset, &mut cache);
     cache
 }
 
-fn collect_negated<D: DatasetView<Id = TermId> + Sync>(
+fn collect_negated<D: DatasetView + Sync>(
     path: &PropertyPathExpression,
     dataset: &D,
-    cache: &mut NegatedCache,
+    cache: &mut NegatedCache<D::Id>,
 ) {
     use PropertyPathExpression as P;
     match path {
@@ -157,12 +157,12 @@ fn collect_negated<D: DatasetView<Id = TermId> + Sync>(
 /// self-pairing (W3C `property-path/zero_or_more_set_start` /
 /// `zero_or_more_set_end`). A non-reflexive path cannot connect an absent node
 /// to anything else (it has no edges to traverse), so it correctly stays empty.
-pub(crate) fn eval_path<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_path<D: DatasetView + Sync>(
     subject: &TermPattern,
     path: &PropertyPathExpression,
     object: &TermPattern,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     let dataset = ctx.dataset;
     let scope = ctx.active_dataset.scope_for(ctx.active_graph);
 
@@ -196,7 +196,7 @@ pub(crate) fn eval_path<D: DatasetView<Id = TermId> + Sync>(
     // shapes are unified behind `node_reach`, which returns a `Vec` either way
     // (with genuine duplicates in the bag case, and none in the set case).
     let bag = !path_has_repetition(path);
-    let node_reach = |node: TermId, forward: bool| -> Vec<TermId> {
+    let node_reach = |node: D::Id, forward: bool| -> Vec<D::Id> {
         if bag {
             simple_reach_multiset(path, node, forward, &pctx)
         } else {
@@ -207,18 +207,19 @@ pub(crate) fn eval_path<D: DatasetView<Id = TermId> + Sync>(
         }
     };
 
-    let mut rows: Vec<Solution> = Vec::new();
-    let push_pair =
-        |rows: &mut Vec<Solution>, s_id: Option<SolutionTerm>, o_id: Option<SolutionTerm>| {
-            let mut row = smallvec::smallvec![None; width];
-            if let (Some(c), Some(id)) = (s_col, s_id) {
-                row[c] = Some(id);
-            }
-            if let (Some(c), Some(id)) = (o_col, o_id) {
-                row[c] = Some(id);
-            }
-            rows.push(row);
-        };
+    let mut rows: Vec<Solution<D::Id>> = Vec::new();
+    let push_pair = |rows: &mut Vec<Solution<D::Id>>,
+                     s_id: Option<SolutionTerm<D::Id>>,
+                     o_id: Option<SolutionTerm<D::Id>>| {
+        let mut row = smallvec::smallvec![None; width];
+        if let (Some(c), Some(id)) = (s_col, s_id) {
+            row[c] = Some(id);
+        }
+        if let (Some(c), Some(id)) = (o_col, o_id) {
+            row[c] = Some(id);
+        }
+        rows.push(row);
+    };
 
     match (s_end, o_end) {
         // Both ground: an ASK-shaped membership test. The schema is empty, so
@@ -335,9 +336,9 @@ pub(crate) fn eval_path<D: DatasetView<Id = TermId> + Sync>(
 
 /// A resolved path endpoint: a ground dataset id, a ground term absent from the
 /// dataset, or a free (variable / blank) position.
-enum Endpoint {
+enum Endpoint<I: ViewTermId = TermId> {
     /// A ground constant resolved to its dataset id.
-    Bound(TermId),
+    Bound(I),
     /// A ground constant that is not the subject or object of any quad in the
     /// dataset. Still a valid RDF term for the zero-length reflexive identity
     /// (see [`eval_path`]'s doc comment) — just not reachable by any real hop.
@@ -349,10 +350,10 @@ enum Endpoint {
 }
 
 /// Resolve an endpoint term to a [`Endpoint`].
-fn resolve_end<D: DatasetView<Id = TermId> + Sync>(
+fn resolve_end<D: DatasetView + Sync>(
     term: &TermPattern,
     dataset: &D,
-) -> Result<Endpoint, EvalError> {
+) -> Result<Endpoint<D::Id>, EvalError> {
     match term {
         TermPattern::Variable(v) => Ok(Endpoint::Free { var: v.clone() }),
         // A blank node in a path endpoint is an anonymous variable (SPARQL §4.1.4):
@@ -397,10 +398,7 @@ fn visible_var(term: &TermPattern) -> Option<Variable> {
 /// All terms that appear as a subject or object of a quad in the active-dataset scope
 /// — the node universe for a both-endpoints-variable path (SPARQL §18.1.7). The
 /// `BTreeSet` de-dupes endpoints, so a `FROM`-merged scope needs no extra triple dedup.
-fn node_universe<D: DatasetView<Id = TermId> + Sync>(
-    dataset: &D,
-    scope: &GraphScope,
-) -> BTreeSet<TermId> {
+fn node_universe<D: DatasetView + Sync>(dataset: &D, scope: &GraphScope<D::Id>) -> BTreeSet<D::Id> {
     let mut out = BTreeSet::new();
     scope.for_each_quad(dataset, None, None, None, |q| {
         out.insert(q.s);
@@ -409,12 +407,12 @@ fn node_universe<D: DatasetView<Id = TermId> + Sync>(
     out
 }
 
-fn reach_cached<D: DatasetView<Id = TermId> + Sync>(
+fn reach_cached<D: DatasetView + Sync>(
     path: &PropertyPathExpression,
-    node: TermId,
+    node: D::Id,
     forward: bool,
     ctx: &PathCtx<'_, D>,
-) -> Rc<BTreeSet<TermId>> {
+) -> Rc<BTreeSet<D::Id>> {
     let key = (
         std::ptr::from_ref::<PropertyPathExpression>(path) as usize,
         node,
@@ -429,12 +427,12 @@ fn reach_cached<D: DatasetView<Id = TermId> + Sync>(
     result
 }
 
-fn reach_uncached<D: DatasetView<Id = TermId> + Sync>(
+fn reach_uncached<D: DatasetView + Sync>(
     path: &PropertyPathExpression,
-    node: TermId,
+    node: D::Id,
     forward: bool,
     ctx: &PathCtx<'_, D>,
-) -> BTreeSet<TermId> {
+) -> BTreeSet<D::Id> {
     use PropertyPathExpression as P;
     match path {
         P::NamedNode(p) => step_predicate(p, node, forward, ctx),
@@ -532,12 +530,12 @@ fn path_has_repetition(path: &PropertyPathExpression) -> bool {
 /// and `Sequence`/`Alternative` compose that order structurally, so row order
 /// is stable run-to-run. Must never be called on a path containing repetition
 /// (`path_has_repetition(path)` is checked once by the caller, `eval_path`).
-fn simple_reach_multiset<D: DatasetView<Id = TermId> + Sync>(
+fn simple_reach_multiset<D: DatasetView + Sync>(
     path: &PropertyPathExpression,
-    node: TermId,
+    node: D::Id,
     forward: bool,
     ctx: &PathCtx<'_, D>,
-) -> Vec<TermId> {
+) -> Vec<D::Id> {
     use PropertyPathExpression as P;
     match path {
         P::NamedNode(p) => step_predicate(p, node, forward, ctx).into_iter().collect(),
@@ -574,12 +572,12 @@ fn simple_reach_multiset<D: DatasetView<Id = TermId> + Sync>(
 
 /// One predicate hop. Forward: objects of `(node, p, ?)`; backward: subjects of
 /// `(?, p, node)`. A predicate absent from the dataset yields nothing.
-fn step_predicate<D: DatasetView<Id = TermId> + Sync>(
+fn step_predicate<D: DatasetView + Sync>(
     p: &NamedNode,
-    node: TermId,
+    node: D::Id,
     forward: bool,
     ctx: &PathCtx<'_, D>,
-) -> BTreeSet<TermId> {
+) -> BTreeSet<D::Id> {
     let Some(pid) = ctx.dataset.term_id_by_value(&named_node_to_value(p)) else {
         return BTreeSet::new();
     };
@@ -604,12 +602,12 @@ fn step_predicate<D: DatasetView<Id = TermId> + Sync>(
 /// unioned, and a direction with no listed elements is omitted entirely (see
 /// [`NegatedSets`]). Uses the pre-resolved `cache` to avoid re-resolving
 /// excluded IRIs on every call.
-fn step_negated<D: DatasetView<Id = TermId> + Sync>(
+fn step_negated<D: DatasetView + Sync>(
     elems: &[purrdf_sparql_algebra::NegatedPathElement],
-    node: TermId,
+    node: D::Id,
     forward: bool,
     ctx: &PathCtx<'_, D>,
-) -> BTreeSet<TermId> {
+) -> BTreeSet<D::Id> {
     let sets = &ctx.cache[&(elems.as_ptr() as usize)];
     let mut out = BTreeSet::new();
     if let Some(excluded) = &sets.forward {
@@ -624,12 +622,12 @@ fn step_negated<D: DatasetView<Id = TermId> + Sync>(
 /// One hop along any predicate NOT in `excluded`, in the given direction —
 /// the direction-parameterised primitive `step_negated` composes twice (once
 /// per element kind) to get the full negated-set relation.
-fn step_excluding<D: DatasetView<Id = TermId> + Sync>(
-    excluded: &BTreeSet<TermId>,
-    node: TermId,
+fn step_excluding<D: DatasetView + Sync>(
+    excluded: &BTreeSet<D::Id>,
+    node: D::Id,
     forward: bool,
     ctx: &PathCtx<'_, D>,
-) -> BTreeSet<TermId> {
+) -> BTreeSet<D::Id> {
     let mut out = BTreeSet::new();
     if forward {
         ctx.scope
@@ -651,14 +649,14 @@ fn step_excluding<D: DatasetView<Id = TermId> + Sync>(
 
 /// `<any>` / `<any:ns>`: one hop along any predicate, optionally restricted to
 /// predicates whose IRI begins with the namespace prefix.
-fn step_wildcard<D: DatasetView<Id = TermId> + Sync>(
+fn step_wildcard<D: DatasetView + Sync>(
     namespace: Option<&NamedNode>,
-    node: TermId,
+    node: D::Id,
     forward: bool,
     ctx: &PathCtx<'_, D>,
-) -> BTreeSet<TermId> {
+) -> BTreeSet<D::Id> {
     let prefix = namespace.map(NamedNode::as_str);
-    let pred_ok = |pid: TermId| -> bool {
+    let pred_ok = |pid: D::Id| -> bool {
         match prefix {
             None => true,
             Some(pfx) => {
@@ -689,19 +687,19 @@ fn step_wildcard<D: DatasetView<Id = TermId> + Sync>(
 /// by applying `inner` at least once. The visited-set guards the endpoint frontier
 /// so cyclic graphs terminate; `node` itself appears iff it is reachable from
 /// itself via a cycle (the correct SPARQL `+` behaviour).
-fn closure<D: DatasetView<Id = TermId> + Sync>(
+fn closure<D: DatasetView + Sync>(
     inner: &PropertyPathExpression,
-    node: TermId,
+    node: D::Id,
     forward: bool,
     ctx: &PathCtx<'_, D>,
-) -> BTreeSet<TermId> {
+) -> BTreeSet<D::Id> {
     // `result` stays an ordered `BTreeSet` — it is the returned/egress set, and its
     // iteration order determines solution-row order (byte-identity). `visited` is a
     // membership-only guard, never iterated into output, so it uses an O(1)
     // `DetHashSet` instead of the O(log n) `BTreeSet` on the closure's hot loop.
     let mut result = BTreeSet::new();
-    let mut visited: DetHashSet<TermId> = DetHashSet::default();
-    let mut frontier: Vec<TermId> = reach_cached(inner, node, forward, ctx)
+    let mut visited: DetHashSet<D::Id> = DetHashSet::default();
+    let mut frontier: Vec<D::Id> = reach_cached(inner, node, forward, ctx)
         .iter()
         .copied()
         .collect();
@@ -723,17 +721,17 @@ fn closure<D: DatasetView<Id = TermId> + Sync>(
 /// single joint traversal: every node reachable by applying `inner` at least once
 /// from any seed. Equivalent to unioning `closure` over each seed, but visits each
 /// node at most once (O(V+E), not O(|seeds|·(V+E))).
-fn closure_multi<D: DatasetView<Id = TermId> + Sync>(
+fn closure_multi<D: DatasetView + Sync>(
     inner: &PropertyPathExpression,
-    seeds: &BTreeSet<TermId>,
+    seeds: &BTreeSet<D::Id>,
     forward: bool,
     ctx: &PathCtx<'_, D>,
-) -> BTreeSet<TermId> {
+) -> BTreeSet<D::Id> {
     // As in `closure`: ordered `result` for egress, O(1) `DetHashSet` for the
     // membership-only `visited` guard.
     let mut result = BTreeSet::new();
-    let mut visited: DetHashSet<TermId> = DetHashSet::default();
-    let mut frontier: Vec<TermId> = Vec::new();
+    let mut visited: DetHashSet<D::Id> = DetHashSet::default();
+    let mut frontier: Vec<D::Id> = Vec::new();
     for &s in seeds {
         frontier.extend(reach_cached(inner, s, forward, ctx).iter().copied());
     }
@@ -756,17 +754,17 @@ fn closure_multi<D: DatasetView<Id = TermId> + Sync>(
 /// (re-entrant per `k`), so a node reachable at multiple repetition counts is
 /// reported. `max == None` (`{n,}`) applies `inner` exactly `min` times then takes
 /// the `*`-closure of that frontier.
-fn range_reach<D: DatasetView<Id = TermId> + Sync>(
+fn range_reach<D: DatasetView + Sync>(
     inner: &PropertyPathExpression,
-    node: TermId,
+    node: D::Id,
     forward: bool,
     min: u32,
     max: Option<u32>,
     ctx: &PathCtx<'_, D>,
-) -> BTreeSet<TermId> {
+) -> BTreeSet<D::Id> {
     let mut out = BTreeSet::new();
     // `current` = nodes reachable in exactly `k` applications; k starts at 0.
-    let mut current: BTreeSet<TermId> = BTreeSet::from([node]);
+    let mut current: BTreeSet<D::Id> = BTreeSet::from([node]);
     for k in 0u32.. {
         if k >= min {
             out.extend(current.iter().copied());

--- a/crates/sparql-eval/src/path.rs
+++ b/crates/sparql-eval/src/path.rs
@@ -43,7 +43,7 @@ use std::collections::BTreeSet;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use purrdf_core::{RdfDataset, TermId, TermRef, TermValue};
+use purrdf_core::{DatasetView, TermId, TermRef, TermValue};
 use purrdf_sparql_algebra::{NamedNode, PropertyPathExpression, TermPattern, Variable};
 
 use crate::convert::{ground_term_pattern_to_value, named_node_to_value};
@@ -85,8 +85,8 @@ type ReachCache = RefCell<DetHashMap<ReachKey, Rc<BTreeSet<TermId>>>>;
 /// `FROM`/`USING`-merged default graph), the once-resolved negated-set cache, and
 /// a per-evaluation reachability memo. Bundling these keeps the recursive
 /// path-evaluation signatures small.
-struct PathCtx<'a> {
-    dataset: &'a RdfDataset,
+struct PathCtx<'a, D: DatasetView<Id = TermId> + Sync> {
+    dataset: &'a D,
     scope: GraphScope,
     cache: NegatedCache,
     reach_cache: ReachCache,
@@ -96,13 +96,20 @@ struct PathCtx<'a> {
 /// `NegatedPropertySet`'s excluded predicates to `TermId`s. The result is
 /// threaded through all `reach`/`closure`/`step_negated` calls so that IRI
 /// resolution is not repeated on every traversal step.
-fn build_negated_cache(path: &PropertyPathExpression, dataset: &RdfDataset) -> NegatedCache {
+fn build_negated_cache<D: DatasetView<Id = TermId> + Sync>(
+    path: &PropertyPathExpression,
+    dataset: &D,
+) -> NegatedCache {
     let mut cache = NegatedCache::new();
     collect_negated(path, dataset, &mut cache);
     cache
 }
 
-fn collect_negated(path: &PropertyPathExpression, dataset: &RdfDataset, cache: &mut NegatedCache) {
+fn collect_negated<D: DatasetView<Id = TermId> + Sync>(
+    path: &PropertyPathExpression,
+    dataset: &D,
+    cache: &mut NegatedCache,
+) {
     use PropertyPathExpression as P;
     match path {
         P::NegatedPropertySet(elems) => {
@@ -150,11 +157,11 @@ fn collect_negated(path: &PropertyPathExpression, dataset: &RdfDataset, cache: &
 /// self-pairing (W3C `property-path/zero_or_more_set_start` /
 /// `zero_or_more_set_end`). A non-reflexive path cannot connect an absent node
 /// to anything else (it has no edges to traverse), so it correctly stays empty.
-pub(crate) fn eval_path(
+pub(crate) fn eval_path<D: DatasetView<Id = TermId> + Sync>(
     subject: &TermPattern,
     path: &PropertyPathExpression,
     object: &TermPattern,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     let dataset = ctx.dataset;
     let scope = ctx.active_dataset.scope_for(ctx.active_graph);
@@ -342,7 +349,10 @@ enum Endpoint {
 }
 
 /// Resolve an endpoint term to a [`Endpoint`].
-fn resolve_end(term: &TermPattern, dataset: &RdfDataset) -> Result<Endpoint, EvalError> {
+fn resolve_end<D: DatasetView<Id = TermId> + Sync>(
+    term: &TermPattern,
+    dataset: &D,
+) -> Result<Endpoint, EvalError> {
     match term {
         TermPattern::Variable(v) => Ok(Endpoint::Free { var: v.clone() }),
         // A blank node in a path endpoint is an anonymous variable (SPARQL §4.1.4):
@@ -387,7 +397,10 @@ fn visible_var(term: &TermPattern) -> Option<Variable> {
 /// All terms that appear as a subject or object of a quad in the active-dataset scope
 /// — the node universe for a both-endpoints-variable path (SPARQL §18.1.7). The
 /// `BTreeSet` de-dupes endpoints, so a `FROM`-merged scope needs no extra triple dedup.
-fn node_universe(dataset: &RdfDataset, scope: &GraphScope) -> BTreeSet<TermId> {
+fn node_universe<D: DatasetView<Id = TermId> + Sync>(
+    dataset: &D,
+    scope: &GraphScope,
+) -> BTreeSet<TermId> {
     let mut out = BTreeSet::new();
     scope.for_each_quad(dataset, None, None, None, |q| {
         out.insert(q.s);
@@ -396,11 +409,11 @@ fn node_universe(dataset: &RdfDataset, scope: &GraphScope) -> BTreeSet<TermId> {
     out
 }
 
-fn reach_cached(
+fn reach_cached<D: DatasetView<Id = TermId> + Sync>(
     path: &PropertyPathExpression,
     node: TermId,
     forward: bool,
-    ctx: &PathCtx<'_>,
+    ctx: &PathCtx<'_, D>,
 ) -> Rc<BTreeSet<TermId>> {
     let key = (
         std::ptr::from_ref::<PropertyPathExpression>(path) as usize,
@@ -416,11 +429,11 @@ fn reach_cached(
     result
 }
 
-fn reach_uncached(
+fn reach_uncached<D: DatasetView<Id = TermId> + Sync>(
     path: &PropertyPathExpression,
     node: TermId,
     forward: bool,
-    ctx: &PathCtx<'_>,
+    ctx: &PathCtx<'_, D>,
 ) -> BTreeSet<TermId> {
     use PropertyPathExpression as P;
     match path {
@@ -519,11 +532,11 @@ fn path_has_repetition(path: &PropertyPathExpression) -> bool {
 /// and `Sequence`/`Alternative` compose that order structurally, so row order
 /// is stable run-to-run. Must never be called on a path containing repetition
 /// (`path_has_repetition(path)` is checked once by the caller, `eval_path`).
-fn simple_reach_multiset(
+fn simple_reach_multiset<D: DatasetView<Id = TermId> + Sync>(
     path: &PropertyPathExpression,
     node: TermId,
     forward: bool,
-    ctx: &PathCtx<'_>,
+    ctx: &PathCtx<'_, D>,
 ) -> Vec<TermId> {
     use PropertyPathExpression as P;
     match path {
@@ -561,11 +574,11 @@ fn simple_reach_multiset(
 
 /// One predicate hop. Forward: objects of `(node, p, ?)`; backward: subjects of
 /// `(?, p, node)`. A predicate absent from the dataset yields nothing.
-fn step_predicate(
+fn step_predicate<D: DatasetView<Id = TermId> + Sync>(
     p: &NamedNode,
     node: TermId,
     forward: bool,
-    ctx: &PathCtx<'_>,
+    ctx: &PathCtx<'_, D>,
 ) -> BTreeSet<TermId> {
     let Some(pid) = ctx.dataset.term_id_by_value(&named_node_to_value(p)) else {
         return BTreeSet::new();
@@ -591,11 +604,11 @@ fn step_predicate(
 /// unioned, and a direction with no listed elements is omitted entirely (see
 /// [`NegatedSets`]). Uses the pre-resolved `cache` to avoid re-resolving
 /// excluded IRIs on every call.
-fn step_negated(
+fn step_negated<D: DatasetView<Id = TermId> + Sync>(
     elems: &[purrdf_sparql_algebra::NegatedPathElement],
     node: TermId,
     forward: bool,
-    ctx: &PathCtx<'_>,
+    ctx: &PathCtx<'_, D>,
 ) -> BTreeSet<TermId> {
     let sets = &ctx.cache[&(elems.as_ptr() as usize)];
     let mut out = BTreeSet::new();
@@ -611,11 +624,11 @@ fn step_negated(
 /// One hop along any predicate NOT in `excluded`, in the given direction —
 /// the direction-parameterised primitive `step_negated` composes twice (once
 /// per element kind) to get the full negated-set relation.
-fn step_excluding(
+fn step_excluding<D: DatasetView<Id = TermId> + Sync>(
     excluded: &BTreeSet<TermId>,
     node: TermId,
     forward: bool,
-    ctx: &PathCtx<'_>,
+    ctx: &PathCtx<'_, D>,
 ) -> BTreeSet<TermId> {
     let mut out = BTreeSet::new();
     if forward {
@@ -638,11 +651,11 @@ fn step_excluding(
 
 /// `<any>` / `<any:ns>`: one hop along any predicate, optionally restricted to
 /// predicates whose IRI begins with the namespace prefix.
-fn step_wildcard(
+fn step_wildcard<D: DatasetView<Id = TermId> + Sync>(
     namespace: Option<&NamedNode>,
     node: TermId,
     forward: bool,
-    ctx: &PathCtx<'_>,
+    ctx: &PathCtx<'_, D>,
 ) -> BTreeSet<TermId> {
     let prefix = namespace.map(NamedNode::as_str);
     let pred_ok = |pid: TermId| -> bool {
@@ -676,11 +689,11 @@ fn step_wildcard(
 /// by applying `inner` at least once. The visited-set guards the endpoint frontier
 /// so cyclic graphs terminate; `node` itself appears iff it is reachable from
 /// itself via a cycle (the correct SPARQL `+` behaviour).
-fn closure(
+fn closure<D: DatasetView<Id = TermId> + Sync>(
     inner: &PropertyPathExpression,
     node: TermId,
     forward: bool,
-    ctx: &PathCtx<'_>,
+    ctx: &PathCtx<'_, D>,
 ) -> BTreeSet<TermId> {
     // `result` stays an ordered `BTreeSet` — it is the returned/egress set, and its
     // iteration order determines solution-row order (byte-identity). `visited` is a
@@ -710,11 +723,11 @@ fn closure(
 /// single joint traversal: every node reachable by applying `inner` at least once
 /// from any seed. Equivalent to unioning `closure` over each seed, but visits each
 /// node at most once (O(V+E), not O(|seeds|·(V+E))).
-fn closure_multi(
+fn closure_multi<D: DatasetView<Id = TermId> + Sync>(
     inner: &PropertyPathExpression,
     seeds: &BTreeSet<TermId>,
     forward: bool,
-    ctx: &PathCtx<'_>,
+    ctx: &PathCtx<'_, D>,
 ) -> BTreeSet<TermId> {
     // As in `closure`: ordered `result` for egress, O(1) `DetHashSet` for the
     // membership-only `visited` guard.
@@ -743,13 +756,13 @@ fn closure_multi(
 /// (re-entrant per `k`), so a node reachable at multiple repetition counts is
 /// reported. `max == None` (`{n,}`) applies `inner` exactly `min` times then takes
 /// the `*`-closure of that frontier.
-fn range_reach(
+fn range_reach<D: DatasetView<Id = TermId> + Sync>(
     inner: &PropertyPathExpression,
     node: TermId,
     forward: bool,
     min: u32,
     max: Option<u32>,
-    ctx: &PathCtx<'_>,
+    ctx: &PathCtx<'_, D>,
 ) -> BTreeSet<TermId> {
     let mut out = BTreeSet::new();
     // `current` = nodes reachable in exactly `k` applications; k starts at 0.
@@ -784,7 +797,7 @@ fn range_reach(
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
-    use purrdf_core::RdfDatasetBuilder;
+    use purrdf_core::{RdfDataset, RdfDatasetBuilder};
     use purrdf_sparql_algebra::NamedNode;
 
     const EX: &str = "http://ex/";

--- a/crates/sparql-eval/src/remote.rs
+++ b/crates/sparql-eval/src/remote.rs
@@ -31,7 +31,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use purrdf_core::{DatasetView, RdfDataset, TermId, TermValue};
+use purrdf_core::{DatasetView, RdfDataset, TermValue, ViewTermId};
 use purrdf_sparql_algebra::{GraphPattern, NamedNodePattern, Variable};
 
 use crate::error::EvalError;
@@ -94,12 +94,12 @@ pub trait RemoteQuerySource {
 ///
 /// Returns [`EvalError::Remote`] for a non-silent failure (no source, variable
 /// endpoint, transport/decode error).
-pub(crate) fn eval_service<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_service<D: DatasetView + Sync>(
     name: &NamedNodePattern,
     inner: &GraphPattern,
     silent: bool,
     ctx: &mut EvalCtx<'_, D>,
-) -> Result<SolutionSeq, EvalError> {
+) -> Result<SolutionSeq<D::Id>, EvalError> {
     // Resolve the endpoint IRI. A variable endpoint needs per-row (lateral)
     // resolution, which the engine defers — so it is a hard error unless SILENT.
     let endpoint = match name {
@@ -133,7 +133,10 @@ pub(crate) fn eval_service<D: DatasetView<Id = TermId> + Sync>(
 
 /// On `SILENT`, return the join identity (one empty row, a no-op for the
 /// surrounding join); otherwise raise [`EvalError::Remote`] with `msg()`.
-fn silent_or_err(silent: bool, msg: impl FnOnce() -> String) -> Result<SolutionSeq, EvalError> {
+fn silent_or_err<I: ViewTermId>(
+    silent: bool,
+    msg: impl FnOnce() -> String,
+) -> Result<SolutionSeq<I>, EvalError> {
     if silent {
         Ok(identity_seq())
     } else {
@@ -143,7 +146,7 @@ fn silent_or_err(silent: bool, msg: impl FnOnce() -> String) -> Result<SolutionS
 
 /// The join identity: a single empty-binding row. `Join(left, identity) == left`,
 /// so a swallowed `SERVICE SILENT` leaves the surrounding query unchanged.
-fn identity_seq() -> SolutionSeq {
+fn identity_seq<I: ViewTermId>() -> SolutionSeq<I> {
     SolutionSeq {
         schema: Arc::new(VarSchema::new()),
         rows: vec![smallvec::smallvec![]],
@@ -154,10 +157,10 @@ fn identity_seq() -> SolutionSeq {
 /// yielding a [`SolutionSeq`] over the result schema. (Mirrors `modifier::eval_values`
 /// but carries `TermValue` directly, so remote blank nodes survive — `GroundTerm`
 /// has no blank-node variant.)
-fn ingest<D: DatasetView<Id = TermId> + Sync>(
+fn ingest<D: DatasetView + Sync>(
     resolved: ResolvedBindings,
     ctx: &mut EvalCtx<'_, D>,
-) -> SolutionSeq {
+) -> SolutionSeq<D::Id> {
     let schema = Arc::new(VarSchema::from_vars(resolved.variables));
     let width = schema.len();
     let mut rows = Vec::with_capacity(resolved.rows.len());

--- a/crates/sparql-eval/src/remote.rs
+++ b/crates/sparql-eval/src/remote.rs
@@ -31,7 +31,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use purrdf_core::{RdfDataset, TermValue};
+use purrdf_core::{DatasetView, RdfDataset, TermId, TermValue};
 use purrdf_sparql_algebra::{GraphPattern, NamedNodePattern, Variable};
 
 use crate::error::EvalError;
@@ -94,11 +94,11 @@ pub trait RemoteQuerySource {
 ///
 /// Returns [`EvalError::Remote`] for a non-silent failure (no source, variable
 /// endpoint, transport/decode error).
-pub(crate) fn eval_service(
+pub(crate) fn eval_service<D: DatasetView<Id = TermId> + Sync>(
     name: &NamedNodePattern,
     inner: &GraphPattern,
     silent: bool,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq, EvalError> {
     // Resolve the endpoint IRI. A variable endpoint needs per-row (lateral)
     // resolution, which the engine defers — so it is a hard error unless SILENT.
@@ -154,7 +154,10 @@ fn identity_seq() -> SolutionSeq {
 /// yielding a [`SolutionSeq`] over the result schema. (Mirrors `modifier::eval_values`
 /// but carries `TermValue` directly, so remote blank nodes survive — `GroundTerm`
 /// has no blank-node variant.)
-fn ingest(resolved: ResolvedBindings, ctx: &mut EvalCtx<'_>) -> SolutionSeq {
+fn ingest<D: DatasetView<Id = TermId> + Sync>(
+    resolved: ResolvedBindings,
+    ctx: &mut EvalCtx<'_, D>,
+) -> SolutionSeq {
     let schema = Arc::new(VarSchema::from_vars(resolved.variables));
     let width = schema.len();
     let mut rows = Vec::with_capacity(resolved.rows.len());
@@ -207,7 +210,7 @@ impl RemoteQuerySource for LocalRemoteQuerySource {
         // Thread this source into the forwarded evaluation so a nested SERVICE
         // inside the forwarded query resolves against the same in-memory sources
         // rather than hard-failing on a missing remote.
-        let mut ctx = EvalCtx::new(dataset).with_remote(self);
+        let mut ctx = EvalCtx::new(&**dataset).with_remote(self);
         match crate::eval::evaluate_query(&parsed, &mut ctx)
             .map_err(|e| RemoteError::Decode(e.to_string()))?
         {

--- a/crates/sparql-eval/src/scratch.rs
+++ b/crates/sparql-eval/src/scratch.rs
@@ -29,7 +29,7 @@
 //! single integer compare. The one lookup cost (`term_id_by_value`) is paid only
 //! when a term is *minted* (BIND/VALUES/aggregate output), never in BGP matching.
 
-use purrdf_core::{RdfDataset, TermId, TermRef, TermValue};
+use purrdf_core::{DatasetView, TermId, TermRef, TermValue};
 
 use std::hash::{Hash, Hasher};
 
@@ -131,7 +131,11 @@ impl ScratchInterner {
     ///
     /// This is the unification rule: a value already in the data never becomes a
     /// `Computed` id, so cross-case join keys are unequal by construction.
-    pub fn intern(&mut self, dataset: &RdfDataset, value: TermValue) -> SolutionTerm {
+    pub fn intern<D: DatasetView<Id = TermId>>(
+        &mut self,
+        dataset: &D,
+        value: TermValue,
+    ) -> SolutionTerm {
         if let Some(id) = dataset.term_id_by_value(&value) {
             return SolutionTerm::Existing(id);
         }
@@ -155,7 +159,11 @@ impl ScratchInterner {
     /// terms, expanding the literal datatype id to its IRI string); `Computed` ids
     /// are read from the scratch table. This is the egress boundary used to build
     /// `SparqlResult` rows.
-    pub fn value_of(&self, dataset: &RdfDataset, term: SolutionTerm) -> TermValue {
+    pub fn value_of<D: DatasetView<Id = TermId>>(
+        &self,
+        dataset: &D,
+        term: SolutionTerm,
+    ) -> TermValue {
         match term {
             SolutionTerm::Existing(id) => term_id_to_value(dataset, id),
             SolutionTerm::Computed(sid) => self.values[sid.index()].clone(),
@@ -182,7 +190,7 @@ impl ScratchInterner {
 ///
 /// Recurses through RDF-1.2 triple terms and expands a literal's datatype id to its
 /// IRI string, so the result carries no dataset-local ids (the C0.8 boundary).
-pub(crate) fn term_id_to_value(dataset: &RdfDataset, id: TermId) -> TermValue {
+pub(crate) fn term_id_to_value<D: DatasetView<Id = TermId>>(dataset: &D, id: TermId) -> TermValue {
     match dataset.resolve(id) {
         TermRef::Iri(iri) => TermValue::Iri(iri.to_owned()),
         TermRef::Blank { label, scope } => TermValue::Blank {
@@ -219,7 +227,7 @@ pub(crate) fn term_id_to_value(dataset: &RdfDataset, id: TermId) -> TermValue {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
-    use purrdf_core::{RdfDatasetBuilder, RdfLiteral};
+    use purrdf_core::{RdfDataset, RdfDatasetBuilder, RdfLiteral};
 
     fn dataset_with_one_iri() -> std::sync::Arc<RdfDataset> {
         let mut b = RdfDatasetBuilder::new();

--- a/crates/sparql-eval/src/scratch.rs
+++ b/crates/sparql-eval/src/scratch.rs
@@ -29,7 +29,7 @@
 //! single integer compare. The one lookup cost (`term_id_by_value`) is paid only
 //! when a term is *minted* (BIND/VALUES/aggregate output), never in BGP matching.
 
-use purrdf_core::{DatasetView, TermId, TermRef, TermValue};
+use purrdf_core::{DatasetView, TermId, TermRef, TermValue, ViewTermId};
 
 use std::hash::{Hash, Hasher};
 
@@ -57,6 +57,13 @@ impl ScratchId {
     pub(crate) fn index(self) -> usize {
         self.0 as usize
     }
+
+    /// The raw `u32` table index, for encoding a `Computed` id into a
+    /// [`ViewTermId::JoinKeyAtom`] join key (see [`SolutionTerm::join_key`]).
+    #[inline]
+    pub(crate) fn raw(self) -> u32 {
+        self.0
+    }
 }
 
 /// One bound value in a solution row.
@@ -64,41 +71,44 @@ impl ScratchId {
 /// See the [module docs](self) for the `Existing`/`Computed` unification rule that
 /// keeps this `Copy` and join-comparable by a single integer compare.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub enum SolutionTerm {
-    /// A term that exists in the queried dataset (dataset-local [`TermId`]).
-    Existing(TermId),
+pub enum SolutionTerm<I = TermId> {
+    /// A term that exists in the queried dataset (the view's local id `I`).
+    Existing(I),
     /// A term minted during evaluation, held in the [`ScratchInterner`].
     Computed(ScratchId),
 }
 
-impl SolutionTerm {
-    /// A total, collision-free `u64` encoding used as a single-column hash-join key,
-    /// so a one-variable join key is a `Copy` `u64` with **no per-row `Vec`
-    /// allocation**.
+impl<I: ViewTermId> SolutionTerm<I> {
+    /// A total, collision-free encoding used as a single-column hash-join key, so a
+    /// one-variable join key is a `Copy` [`ViewTermId::JoinKeyAtom`] with **no per-row
+    /// `Vec` allocation**.
     ///
-    /// `Existing` ids map into `[0, 2^32)` and `Computed` ids into `[2^32, 2^33)`, so
-    /// two terms encode to the same `u64` **iff** they are equal — the same invariant
-    /// the `Existing`/`Computed` unification rule already guarantees for join
-    /// correctness (a value present in the dataset is never also a `Computed` id).
-    /// A collision here would be a *wrong join result*, not a slowdown, so the width
-    /// assumption (both ids fit `u32` — `TermId` is a `NonZeroU32`, `ScratchId` a
-    /// `u32`) is asserted in debug builds.
+    /// `Existing` ids encode into the id space and `Computed` ids into a disjoint
+    /// space (see [`ViewTermId`]'s join-key contract), so two terms encode to the same
+    /// atom **iff** they are equal — the same invariant the `Existing`/`Computed`
+    /// unification rule already guarantees for join correctness (a value present in the
+    /// dataset is never also a `Computed` id). A collision here would be a *wrong join
+    /// result*, not a slowdown. For `I = TermId` the atom is the historical packed
+    /// `u64` (`Existing` in `[0, 2^32)`, `Computed` in `[2^32, 2^33)`), so the
+    /// production hash-join is byte-identical.
     #[inline]
-    pub(crate) fn join_key_u64(self) -> u64 {
+    pub(crate) fn join_key(self) -> I::JoinKeyAtom {
         match self {
-            Self::Existing(id) => {
-                let ix = id.index() as u64;
-                debug_assert!(ix < (1 << 32), "TermId index must fit u32");
-                ix
-            }
-            Self::Computed(sid) => {
-                let s = sid.index() as u64;
-                debug_assert!(s < (1 << 32), "ScratchId must fit u32");
-                (1 << 32) | s
-            }
+            Self::Existing(id) => id.encode(),
+            Self::Computed(sid) => I::encode_computed(sid.raw()),
         }
     }
 }
+
+/// The `I = TermId` monomorphization must keep its historical layout: `TermId` is a
+/// `NonZeroU32`, so the two-variant enum has a spare discriminant value and
+/// `Option<SolutionTerm<TermId>>` is niche-packed to the SAME size as
+/// `SolutionTerm<TermId>` (no extra word). Genericizing over `I` must not grow the
+/// production row cell.
+const _: () = assert!(
+    size_of::<Option<SolutionTerm<TermId>>>() == size_of::<SolutionTerm<TermId>>(),
+    "Option<SolutionTerm<TermId>> must stay niche-packed to SolutionTerm<TermId>'s size"
+);
 
 /// A per-query interner for terms computed during evaluation.
 ///
@@ -131,11 +141,7 @@ impl ScratchInterner {
     ///
     /// This is the unification rule: a value already in the data never becomes a
     /// `Computed` id, so cross-case join keys are unequal by construction.
-    pub fn intern<D: DatasetView<Id = TermId>>(
-        &mut self,
-        dataset: &D,
-        value: TermValue,
-    ) -> SolutionTerm {
+    pub fn intern<D: DatasetView>(&mut self, dataset: &D, value: TermValue) -> SolutionTerm<D::Id> {
         if let Some(id) = dataset.term_id_by_value(&value) {
             return SolutionTerm::Existing(id);
         }
@@ -159,11 +165,7 @@ impl ScratchInterner {
     /// terms, expanding the literal datatype id to its IRI string); `Computed` ids
     /// are read from the scratch table. This is the egress boundary used to build
     /// `SparqlResult` rows.
-    pub fn value_of<D: DatasetView<Id = TermId>>(
-        &self,
-        dataset: &D,
-        term: SolutionTerm,
-    ) -> TermValue {
+    pub fn value_of<D: DatasetView>(&self, dataset: &D, term: SolutionTerm<D::Id>) -> TermValue {
         match term {
             SolutionTerm::Existing(id) => term_id_to_value(dataset, id),
             SolutionTerm::Computed(sid) => self.values[sid.index()].clone(),
@@ -190,7 +192,7 @@ impl ScratchInterner {
 ///
 /// Recurses through RDF-1.2 triple terms and expands a literal's datatype id to its
 /// IRI string, so the result carries no dataset-local ids (the C0.8 boundary).
-pub(crate) fn term_id_to_value<D: DatasetView<Id = TermId>>(dataset: &D, id: TermId) -> TermValue {
+pub(crate) fn term_id_to_value<D: DatasetView>(dataset: &D, id: D::Id) -> TermValue {
     match dataset.resolve(id) {
         TermRef::Iri(iri) => TermValue::Iri(iri.to_owned()),
         TermRef::Blank { label, scope } => TermValue::Blank {

--- a/crates/sparql-eval/src/solution.rs
+++ b/crates/sparql-eval/src/solution.rs
@@ -16,6 +16,7 @@
 
 use std::sync::Arc;
 
+use purrdf_core::{TermId, ViewTermId};
 use purrdf_sparql_algebra::Variable;
 
 use crate::DetHashMap;
@@ -124,21 +125,21 @@ impl VarSchema {
 /// the common row lives inline with no heap allocation and spills to the heap
 /// only for wider schemas. Derefs to `&[Option<SolutionTerm>]`, so indexing,
 /// iteration, slicing, and `&[Option<SolutionTerm>]` parameters are unchanged.
-pub type Solution = smallvec::SmallVec<[Option<SolutionTerm>; 4]>;
+pub type Solution<I = TermId> = smallvec::SmallVec<[Option<SolutionTerm<I>>; 4]>;
 
 /// A multiset (bag) of [`Solution`]s over a shared [`VarSchema`].
 ///
 /// `rows.len()` is the solution cardinality; duplicate rows are preserved
 /// (multiset semantics) until an explicit `DISTINCT`/`REDUCED`.
 #[derive(Clone, Debug)]
-pub struct SolutionSeq {
+pub struct SolutionSeq<I: ViewTermId = TermId> {
     /// The shared variable schema (so a row is just a `Vec<Option<SolutionTerm>>`).
     pub schema: Arc<VarSchema>,
     /// The solution rows (a bag — duplicates significant).
-    pub rows: Vec<Solution>,
+    pub rows: Vec<Solution<I>>,
 }
 
-impl SolutionSeq {
+impl<I: ViewTermId> SolutionSeq<I> {
     /// An empty sequence over `schema` (zero solutions).
     pub fn empty(schema: Arc<VarSchema>) -> Self {
         Self {
@@ -178,9 +179,9 @@ impl SolutionSeq {
 /// [`VarSchema::shared_columns`]). This is the predicate underlying `Join`,
 /// `LeftJoin`, and `Minus`.
 #[must_use]
-pub fn compatible(
-    a: &[Option<SolutionTerm>],
-    b: &[Option<SolutionTerm>],
+pub fn compatible<I: ViewTermId>(
+    a: &[Option<SolutionTerm<I>>],
+    b: &[Option<SolutionTerm<I>>],
     shared: &[(usize, usize)],
 ) -> bool {
     shared.iter().all(|&(ia, ib)| match (a[ia], b[ib]) {
@@ -238,12 +239,12 @@ mod tests {
         // None is compatible with anything.
         assert!(compatible(&[None], &[term(2)], &shared));
         assert!(compatible(&[term(1)], &[None], &shared));
-        assert!(compatible(&[None], &[None], &shared));
+        assert!(compatible::<TermId>(&[None], &[None], &shared));
     }
 
     #[test]
     fn unit_sequence_has_one_empty_solution() {
-        let z = SolutionSeq::unit();
+        let z = SolutionSeq::<TermId>::unit();
         assert_eq!(z.len(), 1);
         assert!(z.schema.is_empty());
         assert!(z.rows[0].is_empty());

--- a/crates/sparql-eval/src/template.rs
+++ b/crates/sparql-eval/src/template.rs
@@ -21,7 +21,7 @@
 //! resolved via `ctx.scratch.value_of(ctx.dataset, term)`, so the value is valid
 //! across a snapshot→mutable boundary (the UPDATE round-trip).
 
-use purrdf_core::{BlankScope, DatasetView, TermId, TermValue};
+use purrdf_core::{BlankScope, DatasetView, TermValue};
 use purrdf_sparql_algebra::{NamedNodePattern, TermPattern};
 
 use crate::DetHashMap;
@@ -69,9 +69,9 @@ pub(crate) fn instantiate_ground_term(
 }
 
 /// Instantiate a subject/object template term. `None` = an unbound variable.
-pub(crate) fn instantiate_term<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn instantiate_term<D: DatasetView + Sync>(
     term: &TermPattern,
-    row: &Solution,
+    row: &Solution<D::Id>,
     schema: &VarSchema,
     blanks: &mut DetHashMap<String, String>,
     ctx: &mut EvalCtx<'_, D>,
@@ -99,9 +99,9 @@ pub(crate) fn instantiate_term<D: DatasetView<Id = TermId> + Sync>(
 }
 
 /// Instantiate a predicate template position. `None` = an unbound variable.
-pub(crate) fn instantiate_predicate<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn instantiate_predicate<D: DatasetView + Sync>(
     predicate: &NamedNodePattern,
-    row: &Solution,
+    row: &Solution<D::Id>,
     schema: &VarSchema,
     ctx: &EvalCtx<'_, D>,
 ) -> Option<TermValue> {
@@ -119,7 +119,7 @@ pub(crate) fn instantiate_predicate<D: DatasetView<Id = TermId> + Sync>(
 /// `bnode_counter`, later occurrences in the same row reuse it (the `blanks` map
 /// resets per row, so the counter — not the map — is what makes two rows' blanks
 /// distinct).
-pub(crate) fn fresh_blank<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn fresh_blank<D: DatasetView + Sync>(
     template_label: &str,
     blanks: &mut DetHashMap<String, String>,
     ctx: &mut EvalCtx<'_, D>,

--- a/crates/sparql-eval/src/template.rs
+++ b/crates/sparql-eval/src/template.rs
@@ -21,7 +21,7 @@
 //! resolved via `ctx.scratch.value_of(ctx.dataset, term)`, so the value is valid
 //! across a snapshot→mutable boundary (the UPDATE round-trip).
 
-use purrdf_core::{BlankScope, TermValue};
+use purrdf_core::{BlankScope, DatasetView, TermId, TermValue};
 use purrdf_sparql_algebra::{NamedNodePattern, TermPattern};
 
 use crate::DetHashMap;
@@ -69,12 +69,12 @@ pub(crate) fn instantiate_ground_term(
 }
 
 /// Instantiate a subject/object template term. `None` = an unbound variable.
-pub(crate) fn instantiate_term(
+pub(crate) fn instantiate_term<D: DatasetView<Id = TermId> + Sync>(
     term: &TermPattern,
     row: &Solution,
     schema: &VarSchema,
     blanks: &mut DetHashMap<String, String>,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Option<TermValue> {
     match term {
         TermPattern::NamedNode(n) => Some(named_node_to_value(n)),
@@ -99,11 +99,11 @@ pub(crate) fn instantiate_term(
 }
 
 /// Instantiate a predicate template position. `None` = an unbound variable.
-pub(crate) fn instantiate_predicate(
+pub(crate) fn instantiate_predicate<D: DatasetView<Id = TermId> + Sync>(
     predicate: &NamedNodePattern,
     row: &Solution,
     schema: &VarSchema,
-    ctx: &EvalCtx<'_>,
+    ctx: &EvalCtx<'_, D>,
 ) -> Option<TermValue> {
     match predicate {
         NamedNodePattern::NamedNode(n) => Some(named_node_to_value(n)),
@@ -119,10 +119,10 @@ pub(crate) fn instantiate_predicate(
 /// `bnode_counter`, later occurrences in the same row reuse it (the `blanks` map
 /// resets per row, so the counter — not the map — is what makes two rows' blanks
 /// distinct).
-pub(crate) fn fresh_blank(
+pub(crate) fn fresh_blank<D: DatasetView<Id = TermId> + Sync>(
     template_label: &str,
     blanks: &mut DetHashMap<String, String>,
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> TermValue {
     mint_blank(template_label, blanks, &mut ctx.bnode_counter)
 }

--- a/crates/sparql-eval/src/update.rs
+++ b/crates/sparql-eval/src/update.rs
@@ -236,7 +236,7 @@ fn delete_insert(
     let with_value = with.map(named_node_to_value);
 
     let snap = m.freeze()?;
-    let mut ctx = EvalCtx::new(&snap);
+    let mut ctx = EvalCtx::new(&*snap);
     ctx = ctx.with_order_cache(cfg.order_cache);
     if let Some(preds) = cfg.standpoint_predicates {
         ctx = ctx.with_standpoint_predicates(preds.clone());

--- a/crates/sparql-eval/src/user_fn.rs
+++ b/crates/sparql-eval/src/user_fn.rs
@@ -21,7 +21,7 @@
 
 use std::sync::Arc;
 
-use purrdf_core::{DatasetView, TermId, TermValue};
+use purrdf_core::{DatasetView, TermValue};
 use purrdf_sparql_algebra::Query;
 
 use crate::DetHashMap;
@@ -199,7 +199,7 @@ fn matches_node_kind(value: &TermValue, nk: NodeKind) -> bool {
 ///
 /// [`EvalError::Function`] on an arity or type-constraint violation or on exceeding
 /// the user-function recursion bound; propagates body evaluation errors.
-pub(crate) fn eval_user_function<D: DatasetView<Id = TermId> + Sync>(
+pub(crate) fn eval_user_function<D: DatasetView + Sync>(
     func: &UserFunction,
     iri: &str,
     args: &[Option<TermValue>],

--- a/crates/sparql-eval/src/user_fn.rs
+++ b/crates/sparql-eval/src/user_fn.rs
@@ -21,7 +21,7 @@
 
 use std::sync::Arc;
 
-use purrdf_core::TermValue;
+use purrdf_core::{DatasetView, TermId, TermValue};
 use purrdf_sparql_algebra::Query;
 
 use crate::DetHashMap;
@@ -199,11 +199,11 @@ fn matches_node_kind(value: &TermValue, nk: NodeKind) -> bool {
 ///
 /// [`EvalError::Function`] on an arity or type-constraint violation or on exceeding
 /// the user-function recursion bound; propagates body evaluation errors.
-pub(crate) fn eval_user_function(
+pub(crate) fn eval_user_function<D: DatasetView<Id = TermId> + Sync>(
     func: &UserFunction,
     iri: &str,
     args: &[Option<TermValue>],
-    ctx: &mut EvalCtx<'_>,
+    ctx: &mut EvalCtx<'_, D>,
 ) -> Result<Option<TermValue>, EvalError> {
     if args.len() < func.required || args.len() > func.params.len() {
         return Err(EvalError::function(format!(

--- a/crates/sparql-eval/tests/paged_query_e2e.rs
+++ b/crates/sparql-eval/tests/paged_query_e2e.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Headline acceptance for issue #90: a SPARQL query served DIRECTLY by the native
+//! Headline acceptance: a SPARQL query served DIRECTLY by the native
 //! evaluator over a multi-page [`PagedDataset`] (the external paged backend), through
 //! the engine's public generic entry points ([`NativeSparqlEngine::query_prepared_view`]
 //! / [`NativeSparqlEngine::explain_query_view`]).
@@ -29,8 +29,8 @@
 use std::sync::Arc;
 
 use purrdf_core::{
-    CountingDemandProvider, DatasetView, GraphMatch, InMemoryPageProvider, PagedDataset, RdfDataset,
-    RdfDatasetBuilder, RdfLiteral, SparqlResult, TermId, TermValue,
+    CountingDemandProvider, DatasetView, GraphMatch, InMemoryPageProvider, PagedDataset,
+    RdfDataset, RdfDatasetBuilder, RdfLiteral, SparqlResult, TermId, TermValue,
 };
 use purrdf_sparql_eval::NativeSparqlEngine;
 
@@ -133,9 +133,21 @@ fn parity_page_age() -> Vec<Triple> {
 fn parity_page_name() -> Vec<Triple> {
     vec![
         (iri("bob"), iri("name"), TermValue::simple_literal("Bob")),
-        (iri("carol"), iri("name"), TermValue::simple_literal("Carol")),
-        (iri("frank"), iri("name"), TermValue::simple_literal("Frank")),
-        (iri("heidi"), iri("name"), TermValue::simple_literal("Heidi")),
+        (
+            iri("carol"),
+            iri("name"),
+            TermValue::simple_literal("Carol"),
+        ),
+        (
+            iri("frank"),
+            iri("name"),
+            TermValue::simple_literal("Frank"),
+        ),
+        (
+            iri("heidi"),
+            iri("name"),
+            TermValue::simple_literal("Heidi"),
+        ),
         (iri("dave"), iri("name"), TermValue::simple_literal("Dave")),
     ]
 }
@@ -175,8 +187,11 @@ fn paged_query_parity_is_byte_identical_to_single_dataset() {
     let engine = NativeSparqlEngine::new();
     let prepared = engine.prepare_query(PARITY_QUERY, None).expect("prepare");
 
-    let (single_vars, single_rows) =
-        solutions(engine.query_prepared(&single, &prepared, &[]).expect("single query"));
+    let (single_vars, single_rows) = solutions(
+        engine
+            .query_prepared(&single, &prepared, &[])
+            .expect("single query"),
+    );
     let (paged_vars, paged_rows) = solutions(
         engine
             .query_prepared_view(&paged, &prepared, &[])
@@ -187,7 +202,11 @@ fn paged_query_parity_is_byte_identical_to_single_dataset() {
     // FILTER, carol(17) is dropped, judy(no name/age) and dave(no knows edge) never bind.
     // ORDER BY ?name makes the row order total and deterministic.
     assert_eq!(single_vars, vec!["x", "name", "age"], "projected variables");
-    assert_eq!(single_rows.len(), 3, "Bob, Frank, Heidi survive the join+filter");
+    assert_eq!(
+        single_rows.len(),
+        3,
+        "Bob, Frank, Heidi survive the join+filter"
+    );
     let subjects: Vec<&TermValue> = single_rows.iter().map(|r| r[0].as_ref().unwrap()).collect();
     assert_eq!(subjects, vec![&iri("bob"), &iri("frank"), &iri("heidi")]);
 
@@ -196,7 +215,10 @@ fn paged_query_parity_is_byte_identical_to_single_dataset() {
     // the proof a SPARQL query is served directly over the paged backend, unifying `?x`
     // across pages, with a byte-identical result to the single-dataset evaluation.
     assert_eq!(single_vars, paged_vars, "same projected variables");
-    assert_eq!(single_rows, paged_rows, "byte-identical rows: single == paged");
+    assert_eq!(
+        single_rows, paged_rows,
+        "byte-identical rows: single == paged"
+    );
 }
 
 // ── Test B — cross-page join order is cost-driven (F1 guard) ─────────────────────
@@ -266,7 +288,11 @@ fn cross_page_join_order_is_cost_driven_and_flips_with_skew() {
     let order1 = engine
         .explain_query_view(&fixture1, SKEW_QUERY, None)
         .expect("explain fixture 1");
-    assert_eq!(order1, vec![PATTERN_A, PATTERN_B], "selective pa probed first");
+    assert_eq!(
+        order1,
+        vec![PATTERN_A, PATTERN_B],
+        "selective pa probed first"
+    );
 
     let order2 = engine
         .explain_query_view(&fixture2, SKEW_QUERY, None)
@@ -274,7 +300,11 @@ fn cross_page_join_order_is_cost_driven_and_flips_with_skew() {
     // The FLIP: inverting the cross-page skew inverts the probe order. This can only
     // happen if the Σ-per-page cost model is actually consulted — an estimator that
     // ignored the paged cardinalities would return the same (source) order both times.
-    assert_eq!(order2, vec![PATTERN_B, PATTERN_A], "selective pb probed first");
+    assert_eq!(
+        order2,
+        vec![PATTERN_B, PATTERN_A],
+        "selective pb probed first"
+    );
     assert_ne!(order1, order2, "the probe order flips with the skew");
 }
 
@@ -304,7 +334,9 @@ fn query_materializes_only_the_pages_the_plan_needs() {
     );
 
     let engine = NativeSparqlEngine::new();
-    let prepared = engine.prepare_query(BOUND_SUBJECT_QUERY, None).expect("prepare");
+    let prepared = engine
+        .prepare_query(BOUND_SUBJECT_QUERY, None)
+        .expect("prepare");
 
     // Run the bound-subject query through the PUBLIC generic entry point.
     let (_vars, rows) = solutions(
@@ -319,7 +351,10 @@ fn query_materializes_only_the_pages_the_plan_needs() {
     // The lazy hook fired for EXACTLY the one page that could match (page 0); pages 1
     // and 2 — whose translations lack `:alice` — were never re-materialized.
     let delta = provider.hits() - hits_after_seal;
-    assert_eq!(delta, 1, "only page 0 (the page containing :alice) materialized");
+    assert_eq!(
+        delta, 1,
+        "only page 0 (the page containing :alice) materialized"
+    );
 
     // A second identical run hits the per-page OnceLock cache — no further pulls.
     let _ = engine

--- a/crates/sparql-eval/tests/paged_query_e2e.rs
+++ b/crates/sparql-eval/tests/paged_query_e2e.rs
@@ -1,0 +1,333 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Headline acceptance for issue #90: a SPARQL query served DIRECTLY by the native
+//! evaluator over a multi-page [`PagedDataset`] (the external paged backend), through
+//! the engine's public generic entry points ([`NativeSparqlEngine::query_prepared_view`]
+//! / [`NativeSparqlEngine::explain_query_view`]).
+//!
+//! Three falsifiable guards, each exercising the production query surface:
+//!
+//! * **Test A — result parity (byte-identical).** The SAME prepared query (a
+//!   three-pattern BGP + `FILTER` + `ORDER BY`) evaluated over a single frozen
+//!   `RdfDataset` and over a `PagedDataset` split across three pages — where the
+//!   shared join variable `?x` binds a term (`:bob`, `:frank`, `:heidi`) whose
+//!   `knows`/`name`/`age` triples live on DIFFERENT pages — yields the exact same
+//!   materialized `SparqlResult::Solutions` (`variables` and `rows` equal). This is
+//!   the proof the paged backend is served directly and unifies terms across pages.
+//! * **Test B — cross-page join order is cost-driven.** Two paged fixtures with
+//!   DELIBERATELY INVERTED cross-page cardinality skew for a two-pattern BGP. The
+//!   planner's explained probe order (via `explain_query_view`) puts the low-Σ-per-page
+//!   pattern FIRST, and the order FLIPS when the skew inverts. Result-equality alone is
+//!   invariant under `ORDER BY`, so it cannot detect a broken cross-page estimator; only
+//!   the order FLIP can, and it can only happen if the Σ-per-page cost model is consulted.
+//! * **Test C — lazy hook fires only for needed pages.** Over a
+//!   `CountingDemandProvider`, a query whose BGP is bound to a subject present on exactly
+//!   one page re-materializes exactly that one page (not all pages), and a second
+//!   identical run adds no hits (the per-page `OnceLock` cache).
+
+use std::sync::Arc;
+
+use purrdf_core::{
+    CountingDemandProvider, DatasetView, GraphMatch, InMemoryPageProvider, PagedDataset, RdfDataset,
+    RdfDatasetBuilder, RdfLiteral, SparqlResult, TermId, TermValue,
+};
+use purrdf_sparql_eval::NativeSparqlEngine;
+
+// ── shared fixture helpers ─────────────────────────────────────────────────────
+
+/// An `example.org` IRI value.
+fn iri(name: &str) -> TermValue {
+    TermValue::iri(format!("http://example.org/{name}"))
+}
+
+/// An `xsd:integer` typed literal (numeric so `FILTER(?age >= 18)` compares by value).
+fn xsd_int(n: &str) -> TermValue {
+    TermValue::typed_literal(n, "http://www.w3.org/2001/XMLSchema#integer")
+}
+
+/// Intern one dataset-independent value into a builder, recursing for triple terms.
+fn intern_value(b: &mut RdfDatasetBuilder, v: &TermValue) -> TermId {
+    match v {
+        TermValue::Iri(s) => b.intern_iri(s),
+        TermValue::Blank { label, scope } => b.intern_blank(label, *scope),
+        TermValue::Literal {
+            lexical_form,
+            datatype,
+            language,
+            direction,
+        } => b.intern_literal(RdfLiteral {
+            lexical_form: lexical_form.clone(),
+            datatype: Some(datatype.clone()),
+            language: language.clone(),
+            direction: *direction,
+        }),
+        TermValue::Triple { s, p, o } => {
+            let s = intern_value(b, s);
+            let p = intern_value(b, p);
+            let o = intern_value(b, o);
+            b.intern_triple(s, p, o)
+        }
+    }
+}
+
+type Triple = (TermValue, TermValue, TermValue);
+
+/// Freeze one page (or the single reference dataset) from `(s, p, o)` triples in the
+/// default graph.
+fn build_page(triples: &[Triple]) -> Arc<RdfDataset> {
+    let mut b = RdfDatasetBuilder::new();
+    for (s, p, o) in triples {
+        let s = intern_value(&mut b, s);
+        let p = intern_value(&mut b, p);
+        let o = intern_value(&mut b, o);
+        b.push_quad(s, p, o, None);
+    }
+    b.freeze().expect("page freeze")
+}
+
+/// Wrap eagerly-built pages in an in-memory provider and seal them into a
+/// `PagedDataset`.
+fn paged_over(pages: Vec<Arc<RdfDataset>>) -> PagedDataset {
+    let provider = Arc::new(InMemoryPageProvider::new(pages));
+    PagedDataset::from_provider(provider).expect("seal pages")
+}
+
+/// Destructure a `SparqlResult` into `(variables, rows)`, panicking on any other shape.
+fn solutions(result: SparqlResult) -> (Vec<String>, Vec<Vec<Option<TermValue>>>) {
+    match result {
+        SparqlResult::Solutions {
+            variables, rows, ..
+        } => (variables, rows),
+        other => panic!("expected solutions, got {other:?}"),
+    }
+}
+
+// ── Test A — direct evaluation, byte-identical result parity ────────────────────
+
+/// Page 0 — the `knows` edges. `:judy` is known but has no `name`/`age`; `:dave` has
+/// `name`/`age` but no `knows` edge — both must be excluded by the join.
+fn parity_page_knows() -> Vec<Triple> {
+    vec![
+        (iri("alice"), iri("knows"), iri("bob")),
+        (iri("eve"), iri("knows"), iri("frank")),
+        (iri("grace"), iri("knows"), iri("heidi")),
+        (iri("ivan"), iri("knows"), iri("judy")),
+        (iri("alice"), iri("knows"), iri("carol")),
+    ]
+}
+
+/// Page 1 — the `age` edges (a DIFFERENT page from `knows` and `name`, so a single
+/// join binding for `?x` must be assembled across three pages).
+fn parity_page_age() -> Vec<Triple> {
+    vec![
+        (iri("bob"), iri("age"), xsd_int("30")),
+        (iri("carol"), iri("age"), xsd_int("17")),
+        (iri("frank"), iri("age"), xsd_int("40")),
+        (iri("heidi"), iri("age"), xsd_int("19")),
+        (iri("dave"), iri("age"), xsd_int("22")),
+    ]
+}
+
+/// Page 2 — the `name` edges.
+fn parity_page_name() -> Vec<Triple> {
+    vec![
+        (iri("bob"), iri("name"), TermValue::simple_literal("Bob")),
+        (iri("carol"), iri("name"), TermValue::simple_literal("Carol")),
+        (iri("frank"), iri("name"), TermValue::simple_literal("Frank")),
+        (iri("heidi"), iri("name"), TermValue::simple_literal("Heidi")),
+        (iri("dave"), iri("name"), TermValue::simple_literal("Dave")),
+    ]
+}
+
+const PARITY_QUERY: &str = "\
+PREFIX ex: <http://example.org/>
+SELECT ?x ?name ?age WHERE {
+  ?p ex:knows ?x .
+  ?x ex:name ?name .
+  ?x ex:age ?age .
+  FILTER(?age >= 18)
+} ORDER BY ?name";
+
+#[test]
+fn paged_query_parity_is_byte_identical_to_single_dataset() {
+    let corpus: Vec<Triple> = parity_page_knows()
+        .into_iter()
+        .chain(parity_page_age())
+        .chain(parity_page_name())
+        .collect();
+    assert_eq!(corpus.len(), 15, "the fixture corpus is 15 triples");
+
+    // (1) the single-dataset reference: all 15 triples in one frozen dataset.
+    let single = build_page(&corpus);
+
+    // (2) the paged view over the SAME triples, split so each of `knows`/`name`/`age`
+    // lives on its OWN page — a join binding for `?x` therefore straddles all three.
+    let paged = paged_over(vec![
+        build_page(&parity_page_knows()),
+        build_page(&parity_page_age()),
+        build_page(&parity_page_name()),
+    ]);
+    assert_eq!(paged.page_count(), 3);
+
+    // ONE prepared query, evaluated via the concrete `query_prepared` (single) and the
+    // generic `query_prepared_view` (paged) public engine entry points.
+    let engine = NativeSparqlEngine::new();
+    let prepared = engine.prepare_query(PARITY_QUERY, None).expect("prepare");
+
+    let (single_vars, single_rows) =
+        solutions(engine.query_prepared(&single, &prepared, &[]).expect("single query"));
+    let (paged_vars, paged_rows) = solutions(
+        engine
+            .query_prepared_view(&paged, &prepared, &[])
+            .expect("paged query"),
+    );
+
+    // The join actually crossed page boundaries: bob(30)/frank(40)/heidi(19) survive the
+    // FILTER, carol(17) is dropped, judy(no name/age) and dave(no knows edge) never bind.
+    // ORDER BY ?name makes the row order total and deterministic.
+    assert_eq!(single_vars, vec!["x", "name", "age"], "projected variables");
+    assert_eq!(single_rows.len(), 3, "Bob, Frank, Heidi survive the join+filter");
+    let subjects: Vec<&TermValue> = single_rows.iter().map(|r| r[0].as_ref().unwrap()).collect();
+    assert_eq!(subjects, vec![&iri("bob"), &iri("frank"), &iri("heidi")]);
+
+    // The headline assertion: the paged and single result sequences are IDENTICAL —
+    // same variables AND same ordered rows of dataset-independent `TermValue`s. This is
+    // the proof a SPARQL query is served directly over the paged backend, unifying `?x`
+    // across pages, with a byte-identical result to the single-dataset evaluation.
+    assert_eq!(single_vars, paged_vars, "same projected variables");
+    assert_eq!(single_rows, paged_rows, "byte-identical rows: single == paged");
+}
+
+// ── Test B — cross-page join order is cost-driven (F1 guard) ─────────────────────
+
+/// A two-pattern BGP joined on `?x`. Full IRIs so the explained pattern strings are
+/// stable and directly assertable.
+const SKEW_QUERY: &str = "\
+SELECT ?x ?y ?z WHERE {
+  ?x <http://example.org/pa> ?y .
+  ?x <http://example.org/pb> ?z .
+}";
+
+/// `triple_pattern_to_string` renders `?x <predicate> ?var .` — the exact form the
+/// explain API emits, so probe order can be asserted position-by-position.
+const PATTERN_A: &str = "?x <http://example.org/pa> ?y .";
+const PATTERN_B: &str = "?x <http://example.org/pb> ?z .";
+
+/// Build a paged fixture over three pages where predicate `heavy` outnumbers `light`.
+/// The heavy/light triples are spread across the pages so the estimator's Σ-per-page
+/// summation (not a single page) is what makes the two patterns' cardinalities differ.
+fn skew_fixture(light: &str, heavy: &str) -> PagedDataset {
+    let light = iri(light);
+    let heavy = iri(heavy);
+    // light: exactly ONE triple, on page 0. heavy: SIX triples, spread 2/2/2.
+    let page0 = build_page(&[
+        (iri("s_light"), light, iri("o_light")),
+        (iri("h0"), heavy.clone(), iri("v0")),
+        (iri("h1"), heavy.clone(), iri("v1")),
+    ]);
+    let page1 = build_page(&[
+        (iri("h2"), heavy.clone(), iri("v2")),
+        (iri("h3"), heavy.clone(), iri("v3")),
+    ]);
+    let page2 = build_page(&[
+        (iri("h4"), heavy.clone(), iri("v4")),
+        (iri("h5"), heavy, iri("v5")),
+    ]);
+    paged_over(vec![page0, page1, page2])
+}
+
+#[test]
+fn cross_page_join_order_is_cost_driven_and_flips_with_skew() {
+    let engine = NativeSparqlEngine::new();
+
+    // Fixture 1: `pa` selective (Σ = 1), `pb` broad (Σ = 6). The planner must probe the
+    // low-cardinality pattern A first.
+    let fixture1 = skew_fixture("pa", "pb");
+    // Fixture 2: the skew INVERTED — `pb` selective, `pa` broad — so the order flips.
+    let fixture2 = skew_fixture("pb", "pa");
+
+    // The estimator's Σ-per-page cross-page cardinality is what drives the order. These
+    // direct estimates (using the same GraphMatch::Default scope the planner uses) show
+    // the skew is real and inverted between the two fixtures.
+    let card = |ds: &PagedDataset, pred: &str| -> usize {
+        let p = ds.term_id_by_value(&iri(pred)).expect("predicate interned");
+        ds.cardinality_estimate(None, Some(p), None, GraphMatch::Default)
+    };
+    assert_eq!(card(&fixture1, "pa"), 1, "pa is selective in fixture 1");
+    assert_eq!(card(&fixture1, "pb"), 6, "pb is broad in fixture 1");
+    assert!(card(&fixture1, "pa") < card(&fixture1, "pb"));
+    assert_eq!(card(&fixture2, "pa"), 6, "pa is broad in fixture 2");
+    assert_eq!(card(&fixture2, "pb"), 1, "pb is selective in fixture 2");
+    assert!(card(&fixture2, "pb") < card(&fixture2, "pa"));
+
+    // The real planner path: `explain_query_view` returns the cost-based probe order as
+    // triple-pattern strings. The low-Σ-per-page pattern is probed FIRST.
+    let order1 = engine
+        .explain_query_view(&fixture1, SKEW_QUERY, None)
+        .expect("explain fixture 1");
+    assert_eq!(order1, vec![PATTERN_A, PATTERN_B], "selective pa probed first");
+
+    let order2 = engine
+        .explain_query_view(&fixture2, SKEW_QUERY, None)
+        .expect("explain fixture 2");
+    // The FLIP: inverting the cross-page skew inverts the probe order. This can only
+    // happen if the Σ-per-page cost model is actually consulted — an estimator that
+    // ignored the paged cardinalities would return the same (source) order both times.
+    assert_eq!(order2, vec![PATTERN_B, PATTERN_A], "selective pb probed first");
+    assert_ne!(order1, order2, "the probe order flips with the skew");
+}
+
+// ── Test C — lazy hook fires only for needed pages (query-time) ─────────────────
+
+const BOUND_SUBJECT_QUERY: &str =
+    "SELECT ?o WHERE { <http://example.org/alice> <http://example.org/knows> ?o }";
+
+#[test]
+fn query_materializes_only_the_pages_the_plan_needs() {
+    // `:alice` lives on page 0 ONLY; pages 1 and 2 carry unrelated `knows` edges. A
+    // query bound to `:alice` can only match page 0.
+    let provider = Arc::new(CountingDemandProvider::new(vec![
+        Box::new(|| build_page(&[(iri("alice"), iri("knows"), iri("bob"))])),
+        Box::new(|| build_page(&[(iri("carol"), iri("knows"), iri("dave"))])),
+        Box::new(|| build_page(&[(iri("eve"), iri("knows"), iri("frank"))])),
+    ]));
+    let paged = PagedDataset::from_provider(provider.clone() as Arc<dyn purrdf_core::PageProvider>)
+        .expect("seal pages");
+
+    // The seal pass materialized each page exactly once.
+    let hits_after_seal = provider.hits();
+    assert_eq!(
+        hits_after_seal,
+        paged.page_count(),
+        "seal pass pulls each of the 3 pages once"
+    );
+
+    let engine = NativeSparqlEngine::new();
+    let prepared = engine.prepare_query(BOUND_SUBJECT_QUERY, None).expect("prepare");
+
+    // Run the bound-subject query through the PUBLIC generic entry point.
+    let (_vars, rows) = solutions(
+        engine
+            .query_prepared_view(&paged, &prepared, &[])
+            .expect("paged query"),
+    );
+    // Correctness: the query is genuinely served — `:alice :knows :bob`.
+    assert_eq!(rows.len(), 1, "alice knows exactly one thing");
+    assert_eq!(rows[0][0].as_ref().unwrap(), &iri("bob"));
+
+    // The lazy hook fired for EXACTLY the one page that could match (page 0); pages 1
+    // and 2 — whose translations lack `:alice` — were never re-materialized.
+    let delta = provider.hits() - hits_after_seal;
+    assert_eq!(delta, 1, "only page 0 (the page containing :alice) materialized");
+
+    // A second identical run hits the per-page OnceLock cache — no further pulls.
+    let _ = engine
+        .query_prepared_view(&paged, &prepared, &[])
+        .expect("paged query (rerun)");
+    assert_eq!(
+        provider.hits() - hits_after_seal,
+        1,
+        "the cached page is not re-materialized on a repeat query"
+    );
+}

--- a/crates/sparql-eval/tests/paged_query_e2e.rs
+++ b/crates/sparql-eval/tests/paged_query_e2e.rs
@@ -366,3 +366,128 @@ fn query_materializes_only_the_pages_the_plan_needs() {
         "the cached page is not re-materialized on a repeat query"
     );
 }
+
+// ── Test D — harder SPARQL feature classes: paged == single (byte-identical) ─────
+//
+// The BGP parity above proves basic joins cross pages. These guards extend that proof
+// to the SPARQL feature classes whose evaluation is NOT a plain triple scan — property
+// paths, aggregates, and subqueries — over a multi-page `PagedDataset`. Each fixture is
+// built so the feature genuinely spans page boundaries, and each asserts the paged
+// result is byte-identical (same `variables`, same ordered `rows`) to the single-dataset
+// evaluation of the SAME prepared query through the public engine entry points.
+
+/// Evaluate `query` over a single frozen dataset of `corpus` AND over `pages` sealed
+/// into a `PagedDataset`, and assert the two `Solutions` are identical. `min_rows`
+/// guards against a vacuous pass (empty == empty). The pages MUST be exactly the corpus
+/// re-partitioned, so any divergence is the paged evaluation, not a different dataset.
+fn assert_paged_matches_single(
+    corpus: &[Triple],
+    pages: Vec<Arc<RdfDataset>>,
+    query: &str,
+    min_rows: usize,
+) {
+    let single = build_page(corpus);
+    let paged = paged_over(pages);
+    let engine = NativeSparqlEngine::new();
+    let prepared = engine.prepare_query(query, None).expect("prepare");
+
+    let (single_vars, single_rows) = solutions(
+        engine
+            .query_prepared(&single, &prepared, &[])
+            .expect("single query"),
+    );
+    let (paged_vars, paged_rows) = solutions(
+        engine
+            .query_prepared_view(&paged, &prepared, &[])
+            .expect("paged query"),
+    );
+
+    assert!(
+        single_rows.len() >= min_rows,
+        "non-vacuous: expected at least {min_rows} rows, got {}",
+        single_rows.len()
+    );
+    assert_eq!(single_vars, paged_vars, "same projected variables");
+    assert_eq!(
+        single_rows, paged_rows,
+        "byte-identical rows: single == paged"
+    );
+}
+
+const PATH_QUERY: &str = "\
+PREFIX ex: <http://example.org/>
+SELECT ?y WHERE { ex:alice ex:knows+ ?y } ORDER BY ?y";
+
+#[test]
+fn paged_property_path_parity_across_pages() {
+    // A knows-chain alice→bob→carol→dave→erin with EACH edge on its own page, so the
+    // transitive `ex:knows+` closure can only be computed by walking across all pages.
+    let p0 = vec![(iri("alice"), iri("knows"), iri("bob"))];
+    let p1 = vec![(iri("bob"), iri("knows"), iri("carol"))];
+    let p2 = vec![(iri("carol"), iri("knows"), iri("dave"))];
+    let p3 = vec![(iri("dave"), iri("knows"), iri("erin"))];
+    let corpus: Vec<Triple> = p0
+        .iter()
+        .chain(&p1)
+        .chain(&p2)
+        .chain(&p3)
+        .cloned()
+        .collect();
+    let pages = vec![
+        build_page(&p0),
+        build_page(&p1),
+        build_page(&p2),
+        build_page(&p3),
+    ];
+    // The closure of alice under knows+ is {bob, carol, dave, erin} — 4 rows spanning
+    // all four pages.
+    assert_paged_matches_single(&corpus, pages, PATH_QUERY, 4);
+}
+
+const AGGREGATE_QUERY: &str = "\
+PREFIX ex: <http://example.org/>
+SELECT ?g (COUNT(?p) AS ?c) WHERE { ?p ex:inGroup ?g } GROUP BY ?g ORDER BY ?g";
+
+#[test]
+fn paged_aggregate_group_by_parity_across_pages() {
+    // Members of two groups spread across three pages, so each group's COUNT must sum
+    // contributions materialized from multiple pages.
+    let p0 = vec![
+        (iri("p1"), iri("inGroup"), iri("g_a")),
+        (iri("p2"), iri("inGroup"), iri("g_b")),
+    ];
+    let p1 = vec![
+        (iri("p3"), iri("inGroup"), iri("g_a")),
+        (iri("p4"), iri("inGroup"), iri("g_a")),
+    ];
+    let p2 = vec![(iri("p5"), iri("inGroup"), iri("g_b"))];
+    let corpus: Vec<Triple> = p0.iter().chain(&p1).chain(&p2).cloned().collect();
+    let pages = vec![build_page(&p0), build_page(&p1), build_page(&p2)];
+    // Two groups (g_a with 3 members, g_b with 2), each counted across pages → 2 rows.
+    assert_paged_matches_single(&corpus, pages, AGGREGATE_QUERY, 2);
+}
+
+const SUBQUERY_QUERY: &str = "\
+PREFIX ex: <http://example.org/>
+SELECT ?x ?c WHERE {
+  { SELECT ?x (COUNT(?y) AS ?c) WHERE { ?x ex:knows ?y } GROUP BY ?x }
+} ORDER BY ?x ?c";
+
+#[test]
+fn paged_subquery_parity_across_pages() {
+    // Each subject's knows-edges are spread across pages, so the inner aggregating
+    // subquery must count them cross-page before the outer query projects the result.
+    let p0 = vec![
+        (iri("alice"), iri("knows"), iri("bob")),
+        (iri("alice"), iri("knows"), iri("carol")),
+    ];
+    let p1 = vec![
+        (iri("alice"), iri("knows"), iri("dave")), // alice's third edge, on another page
+        (iri("bob"), iri("knows"), iri("carol")),
+    ];
+    let corpus: Vec<Triple> = p0.iter().chain(&p1).cloned().collect();
+    let pages = vec![build_page(&p0), build_page(&p1)];
+    // alice (3 edges) and bob (1 edge) → 2 rows; alice's count only equals 3 if the
+    // subquery aggregated across both pages.
+    assert_paged_matches_single(&corpus, pages, SUBQUERY_QUERY, 2);
+}

--- a/docs/design/purrdf-backend-contract.md
+++ b/docs/design/purrdf-backend-contract.md
@@ -221,6 +221,12 @@ overlapping quad — silent dedup would hide a construction error and make the
 composed dataset depend on page ordering, so overlap is a rejected input, not a
 condition the layer papers over.
 
+Disjointness is enforced on **all three composed streams**, not only the base quads:
+the primary quads and both RDF 1.2 side tables — the reifier bindings and the
+annotation triples — are each concatenated across pages with no cross-page dedup, so
+two pages that share a reifier binding or an annotation triple are refused exactly as
+two that share a base quad. The refusal names which stream the duplicate is in.
+
 ### G4 — a `PageProvider` is deterministic and thread-safe
 
 A `PageProvider` supplies page contents to the paged layer on demand. It must be
@@ -238,6 +244,29 @@ published crate, because every published crate must stay
 The in-memory provider satisfies the G4 contract on every target, including
 wasm32; a consumer that needs persistence implements the same deterministic,
 `Send + Sync` `PageProvider` seam against its own storage tier.
+
+### G6 — two construction paths: eager seal vs warm restart
+
+`PagedDataset` offers two constructors with different cost and different guarantees:
+
+- **`from_provider` (eager).** Materializes every page ONCE to fold its terms into the
+  shared dictionary by value (G1) and to verify quad-disjointness (G3). This is the
+  checked path and the reference way to build a paged dataset from raw pages — but its
+  construction cost is `O(all pages)`, which for a very large store is exactly the scan
+  the paged design exists to defer.
+- **`from_parts` (warm restart).** Reconstitutes a dataset from a pre-built
+  `GlobalDictionary` and per-page `PagePart`s (`to_parts` is the inverse) WITHOUT
+  materializing any page — construction is `O(page count)`, not `O(all content)`. A
+  store that has already sealed once and persisted its dictionary and translations
+  reloads through this path. It does NOT re-verify G3 (it cannot without reading the
+  pages); the caller warrants the parts came from a previously-disjoint seal.
+
+The reference `PagedDataset` is a **demonstrator** backend: `from_provider`'s eager
+seal means it does not itself build a dictionary incrementally at ingest. A consumer
+whose working set exceeds what a single eager scan can afford builds its index
+incrementally at ingest and reaches the evaluator either through `from_parts` (a warm
+restart from that persisted index) or by implementing `DatasetView` directly (C1) —
+the id-agnostic read seam serves the evaluator over any backend, not only this one.
 
 ---
 

--- a/docs/design/purrdf-backend-contract.md
+++ b/docs/design/purrdf-backend-contract.md
@@ -1,0 +1,259 @@
+<!-- SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca> -->
+<!-- SPDX-License-Identifier: MIT OR Apache-2.0 -->
+
+# PurRDF Backend Contract
+
+This document is the authoritative statement of the invariants that any PurRDF
+dataset backend — and the pluggable read seam layered over it — must honor. It
+consolidates the normative contract that previously lived only as scattered
+doc-comments in `purrdf-core`, and it adds the **G-clauses** governing the paged
+storage layer.
+
+The contract has two families of clauses:
+
+- **C-clauses** describe the term-identity model and the read/write traits over a
+  single dataset (`DatasetView`, `DatasetMut`, `RdfStoreCapabilities`).
+- **G-clauses** describe the paged storage layer: a global, durable dictionary
+  generation and the deterministic, value-boundary rules by which quad-disjoint
+  pages compose into one logical dataset.
+
+All example IRIs use `example.org`. PurRDF mints no vocabulary IRIs; every
+vocabulary term is caller-supplied configuration.
+
+---
+
+## C-clauses — term identity and the single-dataset seam
+
+### C0 — Term identity is defined by the IR
+
+Literal identity is defined by the IR, not by any backend (C0.1): the datatype is
+always expanded (`xsd:string` for a plain literal, `rdf:langString` for a
+language-tagged literal), the language tag is lowercased for the interning key,
+base direction participates in identity, and the lexical spelling is preserved
+verbatim. Blank-node scope participates in the interning key (C0.2): two blank
+nodes from different scopes are distinct even with the same label, and two blank
+nodes in the same scope with the same label are the same node. Triple terms are
+identified structurally by their resolved `(s, p, o)` (C0.3).
+
+#### C0.8 — `TermId` is dataset-local (the ring-fence the whole design honors)
+
+`TermId` is an opaque term identity that is **local to exactly one frozen
+`RdfDataset`**. It is deliberately:
+
+- **not** `Serialize` / `Deserialize`,
+- **not** merge-stable,
+- **not** meaningful across datasets.
+
+Any consumer that needs a durable identifier MUST resolve the `TermId` to its RDF
+term value and retain the value — never the id. This is the ring-fence that the
+entire backend design is built to honor: an id names a position in one dataset's
+term table and nothing more. Even the low-level `TermId::index` /
+`TermId::from_index` kernel API, which exposes the dense table index so the
+sibling `purrdf` adapters (the canonical Turtle serializer in particular) can
+address terms by position, is only meaningful against the single dataset whose
+table holds that index.
+
+#### The `Option<TermId>` niche (load-bearing P3a invariant)
+
+`TermId` wraps a `NonZeroU32` holding `dense_index + 1`, so the all-zero bit
+pattern is free for the `Option` niche. This makes `Option<TermId>` **4 bytes**,
+not 8, which shrinks the quad row from 20 to 16 bytes — roughly 20% off the quad
+table — because the absent-graph slot (`g: Option<TermId>`) needs no extra
+discriminant word. Two compile-time assertions enforce it and fail the build if
+the niche ever regresses:
+
+```text
+size_of::<TermId>()         == 4
+size_of::<Option<TermId>>() == 4
+```
+
+The `+1` storage offset is confined to `index` / `from_index`; it never leaks
+into `Hash` (which hashes the 0-based dense index, byte-identical to a plain
+`TermId(u32)` derive) and never into `Ord`. The niche is therefore a pure memory
+optimization with no observable effect on iteration order or sort order — a perf
+change must not silently reorder any hash-iteration-dependent output.
+
+### C1 — Frozen, validated dataset; single compile-time backend via static generics
+
+The production read view is the immutable, value-interned `RdfDataset`: a frozen,
+validated dataset over which every read method is infallible. Backend selection is
+**compile-time and static**. This is realized as **static generics**
+(`impl DatasetView`, monomorphized), NOT dynamic dispatch: the `DatasetView`
+methods return position-independent RPITIT iterators and are therefore
+non-object-safe **by design**. Because a backend is resolved at compile time at
+each query site, the trait carries no object-safety obligation and there is no
+erased `&mut dyn` layer.
+
+`DatasetView` is **open**: any crate may implement it, so an external
+demand-paged or store-backed dataset can serve the query evaluator directly rather
+than being materialized into a scratch `RdfDataset` first. Openness does not weaken
+C0.8 — each implementer carries its **own** associated id type, and an id is only
+ever meaningful within the view that minted it. `RdfDataset`'s id type is the
+dataset-local `TermId`; the paged layer's is `GlobalTermId` (G0). The evaluator is
+generic over the view's associated id, so the `RdfDataset` case monomorphizes to
+exactly the concrete `TermId` code path.
+
+### C2 / C3 / C6 — the `DatasetView` read contract
+
+`DatasetView` is the static, allocation-free, id-based read view over an RDF
+dataset. It yields `Copy` quad-id rows and borrowed, resolved quad references with
+no per-quad allocation and no term-string clones. Its surface:
+
+- `quads` — iterate every quad as `Copy` quad-id rows in dataset-local `TermId`s.
+- `quad_refs` — iterate every quad as a borrowed, resolved quad reference (no
+  allocation).
+- `resolve(id)` — resolve a dataset-local `TermId` to its borrowed term reference.
+- `quads_for_pattern(s, p, o, g)` — quads matching an optional `(s, p, o)` id
+  pattern plus a three-way `GraphMatch` (any graph / the default graph / one named
+  graph). The default implementation is an id-equality **linear scan** with no
+  string resolution; a backend carrying access-pattern indexes overrides it with
+  an indexed lookup that is byte-identical to the scan. Callers resolve term
+  *values* to ids first via `term_id_by_value`.
+- `term_id_by_value(value)` — resolve a term **value** to its dataset-local
+  `TermId` **without minting**. A value interned nowhere in the view yields `None`:
+  it names no term, so a structural walk keyed on a not-present IRI simply finds
+  nothing. Absence is an empty match, never an error.
+- `capabilities()` — the capability probe for this view's backing data (see C7).
+- `len_hint()` — an optional quad-count hint.
+
+The graph slot is stored as `g: Option<TermId>` where `None` is the default
+graph. Because `Option<TermId>` alone cannot distinguish *any graph* from *the
+default graph*, the read view uses the dedicated three-way `GraphMatch` enum, which
+is deliberately exhaustive (a quad's graph is either the default or exactly one
+named graph). All `DatasetView` methods are infallible for a frozen, validated
+dataset.
+
+### C4 — `DatasetMut` mutates by value, not by id
+
+`DatasetMut` is the write companion to `DatasetView` — the mutation surface a
+copy-on-write or store-backed dataset exposes. Where `DatasetView` reads in
+dataset-local `TermId`s, `DatasetMut` mutates by **value**: its `Quad` associated
+type is an owned, dataset-independent quad, each component a term value.
+
+The reason is C0.8. A mutable dataset that straddles a frozen base and an
+in-memory delta has **no single id space** in which a caller could name a
+brand-new term, so a term value is the only well-defined mutation identity. The
+implementer resolves each value to its internal handle — a base hit, or a freshly
+minted delta id. This is the precedent the paged layer's G-clauses follow: the
+mutable dataset never widens `TermId`; it works in an internal tagged `MutTermId`
+enum of `Base(TermId)` (an id into the frozen base) and `Delta(...)` (an index
+into the delta's own small interner). A quad's term is bound to `Base` when the
+base's `term_id_by_value` hits and to `Delta` when it misses. These tagged handles
+are strictly internal; the outside world only ever sees frozen base `TermId`s
+(pre-mutation) or post-freeze dense `TermId`s. A plain two-tier **numeric**
+`TermId` — a single integer whose high range meant "delta" — would violate C0.8 by
+implying one id space spanning two datasets, which is exactly why the segregation
+is a tagged enum and never a numeric threshold.
+
+`DatasetMut` operates on the **effective** set:
+
+- `insert(quad)` / `remove(&quad)` return whether the effective set actually
+  changed (a no-op returns `false`).
+- `contains(&quad)` reflects the effective set after any sequence of mutations.
+- `quads_for_pattern(s, p, o, g)` returns owned value-quads (the mutable view has
+  no stable id space to borrow into across the base/delta boundary). Its graph
+  filter is **value-based** (`GraphMatchValue`, not the read side's `TermId`-based
+  `GraphMatch`), so a delta-only named graph — one introduced after branching, with
+  no base `TermId` — is still expressible, consistent with the value-based
+  `s`/`p`/`o` slots. The implementer resolves a filter value to its internal handle
+  without minting; a value interned in neither base nor delta matches nothing.
+
+### C7 — capabilities
+
+`RdfStoreCapabilities` is the capability probe a view exposes for its backing
+data. Each field is an independent yes/no feature probe, not an encoded state
+machine:
+
+- `named_graphs` — quads outside the default graph are representable.
+- `quoted_triples` — RDF 1.2 triple terms (quoted triples) are representable.
+- `reifiers` — RDF 1.2 reifier bindings are representable.
+- `annotations` — RDF 1.2 statement annotations are representable.
+- `source_locations` — source/location context is preserved.
+- `loss_records` — conversion-loss records are preserved.
+- `lookaside` — structured non-triple lookaside material is preserved.
+
+The plain-RDF baseline has every flag off.
+
+---
+
+## G-clauses — the paged storage layer
+
+The paged layer composes many independently frozen **pages** into one logical
+dataset. Each page is itself a frozen dataset with its own dataset-local `TermId`
+space (C0.8 still holds inside a page). The G-clauses define the global identity
+generation and the deterministic value-boundary rules by which pages compose.
+
+### G0 — `GlobalTermId` is global and durable within one dictionary generation
+
+`GlobalTermId` is a **global, durable** term identity within one dictionary
+generation. It is distinct from `TermId`: where a `TermId` names a position in one
+frozen dataset's local term table (C0.8), a `GlobalTermId` names a term in the
+paged layer's shared dictionary and is stable across every page that participates
+in the same generation. A `GlobalTermId` is only meaningful within the generation
+that minted it; a compaction (G2) begins a new generation.
+
+### G1 — no numeric cross-space translation; the map is built by value
+
+There is **no numeric translation** between a page's local `TermId` space and the
+`GlobalTermId` space. A page's local `TermId` maps to a `GlobalTermId` only through
+a `PageTranslation` built by re-interning each of the page's term **values** into
+the shared dictionary — the same by-value boundary that union, `push_dataset`, and
+ingest remaps already use when they re-intern a foreign dataset's terms into a
+fresh interner. `GlobalTermId` **never widens `TermId`**: it is a separate space,
+not a superset id, so nothing is ever reinterpreted by bit-pattern or by numeric
+range across the two spaces. The value is the only bridge, exactly as in C4.
+
+### G2 — compaction renumbers survivors deterministically in canonical value order
+
+Compaction renumbers surviving terms **deterministically in canonical `TermValue`
+sort order**. The new `GlobalTermId` assignment is a **pure function of the set of
+live term values** — it depends only on which term values survive and their
+canonical order, and is independent of ingest history, page arrival order, or the
+prior generation's numbering. Two compactions of the same live term-value set
+produce byte-identical renumberings.
+
+### G3 — pages are quad-disjoint in `GlobalTermId` space; freeze refuses overlap
+
+Pages must be **quad-disjoint** in `GlobalTermId` space: no quad may appear in more
+than one page once terms are mapped to their global ids. Freeze **refuses** with a
+hard error if the pages are not disjoint. It **never silently dedups** an
+overlapping quad — silent dedup would hide a construction error and make the
+composed dataset depend on page ordering, so overlap is a rejected input, not a
+condition the layer papers over.
+
+### G4 — a `PageProvider` is deterministic and thread-safe
+
+A `PageProvider` supplies page contents to the paged layer on demand. It must be
+**deterministic**: the same `PageId` always yields byte-identical quads. It must
+also be `Send + Sync`, so the paged layer can be shared and read concurrently.
+Determinism at this seam is what lets the composed dataset's egress order and
+serialization be reproducible.
+
+### G5 — the shipped `PageProvider` is in-memory; durable tiers are external
+
+The reference `PageProvider` shipped in `purrdf-core` is **in-memory**. A durable
+disk-backed or memory-mapped tier belongs to the **external consumer**, not to any
+published crate, because every published crate must stay
+`wasm32-unknown-unknown`-clean: no filesystem, no threads, no wall-clock, no RNG.
+The in-memory provider satisfies the G4 contract on every target, including
+wasm32; a consumer that needs persistence implements the same deterministic,
+`Send + Sync` `PageProvider` seam against its own storage tier.
+
+---
+
+## Determinism & wasm
+
+Determinism in PurRDF comes from **id-sorting and BTree egress** and from applying
+**canonical ordering before serialization** — never from hash iteration order. The
+interners use fixed-key ahash rather than a randomized hasher (getrandom is absent
+on wasm32, and ids are insertion-ordered), so hash-map iteration order is never a
+source of observable order: every serializer and the GTS writer sort or fold
+through ordered structures first. The `TermId` niche, `GraphMatch`, the by-value
+mutation boundary (C4), and the by-value page translation (G1) all preserve this:
+none of them lets a hasher's iteration order leak into output. Compaction's
+canonical `TermValue` ordering (G2) is the paged-layer instance of the same rule.
+
+Everything in `purrdf-core` — including the reference in-memory `PageProvider`
+(G5) — stays `wasm32-unknown-unknown`-clean: no filesystem, threads, wall-clock, or
+RNG. Storage tiers that need any of those live in the external consumer, behind the
+same deterministic `PageProvider` seam.


### PR DESCRIPTION
Closes #90

## Summary

Delivers the storage-backend seam PurRDF owns: an **id-agnostic, pluggable read path** and a
**reference in-memory demand-paged backend** that exercises every seam capability, served
**directly** by the SPARQL evaluator. Subsumes both paths the issue offered (unseal `DatasetView`
∪ first-class paged dataset with a `u64` global dictionary), with the three required "stories"
(cross-page BGP planning, value index, freeze/compaction) **implemented and tested**, not just
described. The durable disk/mmap tier stays with the external consumer behind a `PageProvider`
trait — it cannot live in a published, `wasm32`-clean crate.

The transformational core: `DatasetView` gains an associated `type Id`, and the SPARQL evaluator
is generic over it. `RdfDataset` (`Id = TermId`, u32) monomorphizes back to today's **exact** code
— the SPARQL conformance suite stays byte-green — while `PagedDataset` (`Id = GlobalTermId`, u64)
scales past the per-dataset u32 ceiling.

## Changes

- **docs**: authored `docs/design/purrdf-backend-contract.md` (C0–C7 + new paged-layer G0–G5),
  resolving the previously-dangling doc link at `dataset_view.rs`.
- **core (seam)**: unsealed `DatasetView`; added `ViewTermId` + associated `type Id` / `type ProbePlan`;
  parametrized `QuadIds`/`GraphMatch`/`TermRef`/`QuadRef` with a defaulted `<Id = TermId>`; promoted the
  evaluator hot-path methods (probe plan, cardinality, term_count, stats_fingerprint, RDF-1.2 reifier
  side-tables) onto the trait with capability-gated defaults; genericized the `rdf_list`/`members`/…
  walkers over `Self::Id`. `RdfDataset` delegates to its inherent methods (byte-identical).
- **core (u64 identity)**: `GlobalTermId(NonZeroU64)` — a **separate** id space that never widens the
  load-bearing `Option<TermId>` niche (ring-fence asserted) — and `GlobalDictionary`, a u64-scaled
  value-interned dictionary with an `OnceLock` reverse value index.
- **core (paged backend)**: `PagedDataset` composing frozen `RdfDataset` pages via `DatasetView`
  (`Id = GlobalTermId`); `PageProvider` (the lazy materialization hook: in-memory + counting-demand
  reference providers); `PageTranslation` mapping local u32 ↔ global u64 **by value**; cross-page
  `quads_for_pattern` with page-skipping; Σ-per-page `cardinality_estimate`; freeze that **refuses**
  non-disjoint pages and deterministic canonical-order `compact()` reclaiming dead ids.
- **sparql-eval (generify)**: `EvalCtx<'d, D: DatasetView + Sync>`; the whole read path + the binding
  layer (`SolutionTerm<I>`/`Solution`/`JoinKey`/hash-join, property-path frontiers, the parallel
  determinism gate) are generic over `I = D::Id`. `ViewTermId::encode` reproduces today's packed-`u64`
  join key for `TermId` (bit-identical hash-join) and a disjoint `u128` for `GlobalTermId`.
  `NativeSparqlEngine` keeps its concrete `Arc<RdfDataset>` entry points as thin wrappers and gains
  `query_*_view` + `explain_query_view` generic twins; the `update` path stays concrete.
- **tests/bench**: `crates/rdf-core/tests/paged_backend.rs` (cross-page parity, lazy-hook deltas,
  Σ-cardinality guard, freeze-refuse, dead-id reclaim + determinism, byte-identical serialization);
  `crates/sparql-eval/tests/paged_query_e2e.rs` (byte-identical single-vs-paged query, cross-page
  order-flip under inverted skew, demand-only materialization); a report-only paged cross-page BGP
  criterion bench.

## Verification

- SPARQL **conformance suite byte-green** (the `D = RdfDataset` monomorphization is behavior-identical).
- `make check` (fmt + clippy pedantic/nursery + build + tests + hygiene) and `make wasm` both pass;
  `check-no-features` clean; `purrdf-core` gained no oxigraph/PyO3 dep; `TermId` niche asserts intact.
- The paged backend is verified `wasm32-unknown-unknown`-clean (forced rebuild).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added demand-paged RDF datasets that combine multiple pages into one queryable dataset.
  * Added lazy page loading, page selection, warm restart, and deterministic compaction support.
  * Added SPARQL query support across paged data, including joins, paths, aggregates, subqueries, annotations, and reifiers.
  * Added global term identity and translation utilities for consistent cross-page results.
  * Added generic dataset-view APIs for custom RDF backends.
* **Documentation**
  * Added the backend contract and storage invariants documentation.
* **Tests**
  * Added extensive coverage for paging, query parity, lazy loading, compaction, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->