### PR TITLE
feat(sparql-eval): native Rust-closure user-function registry

### DIFF
--- a/crates/gts/src/compact.rs
+++ b/crates/gts/src/compact.rs
@@ -250,8 +250,8 @@ fn base64url_unpadded(data: &[u8]) -> String {
 }
 
 /// Decode a base64url WITHOUT padding (RFC 4648 §5) string — the inverse of
-/// [`base64url_unpadded`], used to recover a `stream:cose` literal's raw
-/// COSE_Sign1 bytes (Task 5 signature verification).
+/// `base64url_unpadded`, used to recover a `stream:cose` literal's raw
+/// COSE_Sign1 bytes for signature verification.
 ///
 /// # Errors
 /// HARD-ERRORS on a padding character (`=`) or any byte outside the unpadded

--- a/crates/rdf/src/gts_certify.rs
+++ b/crates/rdf/src/gts_certify.rs
@@ -777,7 +777,7 @@ fn suppressions_ok(pre: &Graph, post: &Graph) -> Result<bool, CertifyError> {
 /// `pre_bytes`/`post_bytes` are UNTRUSTED (an independent verifier's whole
 /// point is to not trust the claimant), so every digest this function
 /// computes over them goes through the fallible RDFC-1.0 canonicalizer
-/// ([`try_refold_digest`]/[`try_effective_digest`], backing
+/// (`try_refold_digest`/`try_effective_digest`, backing
 /// [`try_canonicalize_with`]) rather than the panicking
 /// [`canonicalize_with`]: a pathologically symmetric blank graph that stays
 /// under [`POISON_BLANK_LIMIT`]'s cheap blank-COUNT pre-reject yet exhausts

--- a/crates/sparql-eval/src/binop.rs
+++ b/crates/sparql-eval/src/binop.rs
@@ -148,8 +148,8 @@ pub(crate) fn eval_union<D: DatasetView + Sync>(
     right: &GraphPattern,
     ctx: &mut EvalCtx<'_, D>,
 ) -> Result<SolutionSeq<D::Id>, EvalError> {
-    if !crate::parallel::is_parallel_safe_pattern(left)
-        || !crate::parallel::is_parallel_safe_pattern(right)
+    if !crate::parallel::is_parallel_safe_pattern(left, ctx.user_functions)
+        || !crate::parallel::is_parallel_safe_pattern(right, ctx.user_functions)
     {
         let l = eval(left, ctx)?;
         let r = eval(right, ctx)?;
@@ -473,7 +473,7 @@ fn left_outer_join_filtered<D: DatasetView + Sync>(
     let shared = l.schema.shared_columns(&r.schema);
 
     // A left outer join emits at least one row per left row.
-    let rows = if crate::parallel::is_parallel_safe(expr) {
+    let rows = if crate::parallel::is_parallel_safe(expr, ctx.user_functions) {
         crate::parallel::par_chunk_try_map_init(
             &l.rows,
             || ctx.fork_for_worker(),

--- a/crates/sparql-eval/src/error.rs
+++ b/crates/sparql-eval/src/error.rs
@@ -49,11 +49,13 @@ pub enum EvalError {
     /// looping forever or guessing an answer.
     Data(String),
 
-    /// A SHACL-AF SPARQL-based function (`sh:SPARQLFunction`) call was invalid: an
-    /// arity mismatch, a `sh:datatype`/`sh:nodeKind`/`sh:returnType` violation, or
-    /// exceeding the user-function recursion bound. Per the hard-fail doctrine a
-    /// mis-invoked function aborts the query rather than yielding a wrong or unbound
-    /// value.
+    /// A user function call was invalid — either a SHACL-AF SPARQL-based function
+    /// (`sh:SPARQLFunction`: an arity mismatch, a
+    /// `sh:datatype`/`sh:nodeKind`/`sh:returnType` violation, or exceeding the
+    /// user-function recursion bound) or a native (host-Rust closure) function
+    /// (an arity mismatch, the closure's own returned `Err`, or a caught panic
+    /// inside the closure). Per the hard-fail doctrine a mis-invoked function
+    /// aborts the query rather than yielding a wrong or unbound value.
     Function(String),
 }
 
@@ -94,7 +96,7 @@ impl core::fmt::Display for EvalError {
             Self::Internal(msg) => write!(f, "internal evaluator error: {msg}"),
             Self::Remote(msg) => write!(f, "SERVICE federation error: {msg}"),
             Self::Data(msg) => write!(f, "malformed RDF input: {msg}"),
-            Self::Function(msg) => write!(f, "SHACL-AF function error: {msg}"),
+            Self::Function(msg) => write!(f, "user function error: {msg}"),
         }
     }
 }

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -186,7 +186,7 @@ pub(crate) fn eval_filter<D: DatasetView + Sync>(
 ) -> Result<SolutionSeq<D::Id>, EvalError> {
     let seq = eval(inner, ctx)?;
     let schema = seq.schema.clone();
-    let rows = if crate::parallel::is_parallel_safe(expr) {
+    let rows = if crate::parallel::is_parallel_safe(expr, ctx.user_functions) {
         crate::parallel::par_chunk_try_map_init(
             &seq.rows,
             || ctx.fork_for_worker(),
@@ -231,7 +231,7 @@ pub(crate) fn eval_extend<D: DatasetView + Sync>(
     let width = schema.len();
     let schema = Arc::new(schema);
 
-    let rows = if crate::parallel::is_parallel_safe(expr) {
+    let rows = if crate::parallel::is_parallel_safe(expr, ctx.user_functions) {
         // Parallel path: `is_parallel_safe` excludes `BNODE` (every arity), so the
         // per-solution `BNODE(strExpr)` memo (`ctx.current_row`/`ctx.bnode_memo`) is
         // never observed here — no per-row `current_row` bookkeeping is needed.

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -1651,6 +1651,18 @@ fn eval_function<D: DatasetView + Sync>(
                 let result = crate::user_fn::eval_user_function(func, iri.as_str(), &vals, ctx)?;
                 return Ok(result.map(|value| intern(ctx, value)));
             }
+            // A caller-injected native (host-Rust closure) function, resolved from
+            // the same registry's second table. Checked after the SPARQL-bodied
+            // path (so a same-registry cross-kind collision can never arise — the
+            // registry's collision guard already makes that unrepresentable) and
+            // before the XSD-cast fallback, so a function IRI never collides with a
+            // datatype IRI.
+            if let Some(registry) = ctx.user_functions
+                && let Some(native) = registry.resolve_native(iri.as_str())
+            {
+                let result = crate::user_fn::eval_native_function(native, iri.as_str(), &vals)?;
+                return Ok(result.map(|value| intern(ctx, value)));
+            }
             if let Some(target) = XsdDatatype::from_iri(iri.as_str()) {
                 return Ok(eval_xsd_cast(ctx, target, arg(&vals, 0)));
             }

--- a/crates/sparql-eval/src/lib.rs
+++ b/crates/sparql-eval/src/lib.rs
@@ -89,7 +89,8 @@ pub use scratch::{ScratchId, ScratchInterner, SolutionTerm};
 pub use solution::{Solution, SolutionSeq, VarSchema, compatible};
 pub use update::GraphResolver;
 pub use user_fn::{
-    NodeKind, TypeConstraint, UserFnBody, UserFnParam, UserFunction, UserFunctionRegistry,
+    Arity, NativeFnBody, NativeFunction, NodeKind, TypeConstraint, UserFnBody, UserFnParam,
+    UserFunction, UserFunctionRegistry, Volatility,
 };
 
 /// A deterministic, seed-free hasher builder (`AHasher` with fixed keys).

--- a/crates/sparql-eval/src/modifier.rs
+++ b/crates/sparql-eval/src/modifier.rs
@@ -526,7 +526,7 @@ pub(crate) fn eval_group<D: DatasetView + Sync>(
     let safe = aggregates.iter().all(|(_, agg)| match agg {
         AggregateExpression::CountStar { .. } => true,
         AggregateExpression::FunctionCall { expression, .. } => {
-            crate::parallel::is_parallel_safe(expression)
+            crate::parallel::is_parallel_safe(expression, ctx.user_functions)
         }
     });
 

--- a/crates/sparql-eval/src/parallel.rs
+++ b/crates/sparql-eval/src/parallel.rs
@@ -44,7 +44,12 @@
 //! is excluded, because the fork model gives every worker an *independent* copy of
 //! that state rather than a shared, ordered one — running such a builtin under
 //! fork-join would make its result depend on worker scheduling, not just row
-//! content.
+//! content. [`Function::Custom`] — a caller-injected user function resolved
+//! against a [`UserFunctionRegistry`] — is likewise excluded unless the registry
+//! attests the callee is safe: a native function is safe only when registered
+//! [`Volatility::Stable`], and a SPARQL-bodied function is conservatively always
+//! unsafe (its body can itself reach `RAND`/`UUID`/`BNODE`/the list constructors,
+//! and that per-call state would merge into a forked child instead of `ctx`).
 
 use purrdf_core::{DatasetView, TermId, TermValue, ViewTermId};
 use purrdf_sparql_algebra::{
@@ -54,6 +59,7 @@ use purrdf_sparql_algebra::{
 use crate::error::EvalError;
 use crate::scratch::{ScratchInterner, SolutionTerm};
 use crate::solution::Solution;
+use crate::user_fn::{UserFunctionRegistry, Volatility};
 
 /// Rows/groups at or below this stay sequential (thread spin-up would dominate
 /// the work for small inputs). Initial value; Task 7's bench tunes it.
@@ -193,22 +199,32 @@ pub(crate) fn should_parallelize(work_items: usize) -> bool {
 /// `listIndexOf`/`listContains`) and `heldIn` touch neither counter, so they are
 /// left safe. When in doubt this walk flags UNSAFE — a sequential fallback is
 /// always a correct (if slower) answer.
-pub(crate) fn is_parallel_safe(expr: &Expression) -> bool {
-    !expr_reaches_unsafe_builtin(expr)
+///
+/// `registry` is the caller's [`UserFunctionRegistry`] (`ctx.user_functions`), if
+/// any: it is consulted only when the walk reaches a [`Function::Custom`] call —
+/// see [`function_is_unsafe`] for exactly how a native-vs-SPARQL-bodied callee is
+/// classified. `None` (no registry configured) makes every `Custom` IRI resolve
+/// to the deterministic XSD-cast/hard-error fallback, hence safe.
+pub(crate) fn is_parallel_safe(expr: &Expression, registry: Option<&UserFunctionRegistry>) -> bool {
+    !expr_reaches_unsafe_builtin(expr, registry)
 }
 
 /// Whether `pattern` (recursively) is safe to evaluate under the fork-join
 /// parallel model — the pattern-level twin of [`is_parallel_safe`], for callers
 /// (e.g. `UNION`) that must gate a whole sub-pattern rather than a single
 /// expression. Exposes the same walk [`is_parallel_safe`] already runs
-/// internally for `EXISTS`.
-pub(crate) fn is_parallel_safe_pattern(pattern: &GraphPattern) -> bool {
-    !pattern_reaches_unsafe_builtin(pattern)
+/// internally for `EXISTS`. `registry` is threaded through exactly as in
+/// [`is_parallel_safe`].
+pub(crate) fn is_parallel_safe_pattern(
+    pattern: &GraphPattern,
+    registry: Option<&UserFunctionRegistry>,
+) -> bool {
+    !pattern_reaches_unsafe_builtin(pattern, registry)
 }
 
 /// `true` iff `expr` (recursively) reaches an unsafe builtin — see
 /// [`is_parallel_safe`].
-fn expr_reaches_unsafe_builtin(expr: &Expression) -> bool {
+fn expr_reaches_unsafe_builtin(expr: &Expression, registry: Option<&UserFunctionRegistry>) -> bool {
     match expr {
         Expression::NamedNode(_)
         | Expression::Literal(_)
@@ -226,30 +242,55 @@ fn expr_reaches_unsafe_builtin(expr: &Expression) -> bool {
         | Expression::Subtract(a, b)
         | Expression::Multiply(a, b)
         | Expression::Divide(a, b) => {
-            expr_reaches_unsafe_builtin(a) || expr_reaches_unsafe_builtin(b)
+            expr_reaches_unsafe_builtin(a, registry) || expr_reaches_unsafe_builtin(b, registry)
         }
         Expression::UnaryPlus(a) | Expression::UnaryMinus(a) | Expression::Not(a) => {
-            expr_reaches_unsafe_builtin(a)
+            expr_reaches_unsafe_builtin(a, registry)
         }
         Expression::In(head, list) => {
-            expr_reaches_unsafe_builtin(head) || list.iter().any(expr_reaches_unsafe_builtin)
+            expr_reaches_unsafe_builtin(head, registry)
+                || list
+                    .iter()
+                    .any(|e| expr_reaches_unsafe_builtin(e, registry))
         }
         Expression::If(a, b, c) => {
-            expr_reaches_unsafe_builtin(a)
-                || expr_reaches_unsafe_builtin(b)
-                || expr_reaches_unsafe_builtin(c)
+            expr_reaches_unsafe_builtin(a, registry)
+                || expr_reaches_unsafe_builtin(b, registry)
+                || expr_reaches_unsafe_builtin(c, registry)
         }
-        Expression::Coalesce(list) => list.iter().any(expr_reaches_unsafe_builtin),
+        Expression::Coalesce(list) => list
+            .iter()
+            .any(|e| expr_reaches_unsafe_builtin(e, registry)),
         Expression::FunctionCall(f, args) => {
-            function_is_unsafe(f) || args.iter().any(expr_reaches_unsafe_builtin)
+            function_is_unsafe(f, registry)
+                || args
+                    .iter()
+                    .any(|e| expr_reaches_unsafe_builtin(e, registry))
         }
-        Expression::Exists(pattern) => pattern_reaches_unsafe_builtin(pattern),
+        Expression::Exists(pattern) => pattern_reaches_unsafe_builtin(pattern, registry),
     }
 }
 
 /// Whether `f` is itself one of the stateful-mint builtins (see
-/// [`is_parallel_safe`]'s doc comment for the full rationale).
-fn function_is_unsafe(f: &Function) -> bool {
+/// [`is_parallel_safe`]'s doc comment for the full rationale), or an unsafe
+/// [`Function::Custom`] user-function call.
+///
+/// A `Custom(iri)` call is resolved against `registry` (`ctx.user_functions`):
+///
+/// - No registry, or the IRI resolves to neither custom kind (an XSD cast, or an
+///   undefined-function hard error) — deterministic, so safe.
+/// - Resolves to a **native** function — safe iff its declared
+///   [`Volatility`] is NOT [`Volatile`](Volatility::Volatile): `Stable` is
+///   deterministic for the lifetime of the query, so it may run across
+///   fork-join workers exactly like a pure builtin.
+/// - Resolves to a **SPARQL-bodied** [`crate::user_fn::UserFunction`] —
+///   ALWAYS unsafe, conservatively: its body is itself an arbitrary SPARQL
+///   query that can mint `RAND`/`UUID`/`BNODE`/list cells, and that per-call
+///   state would merge into a forked child (see
+///   `crate::user_fn::eval_user_function`'s state merge-back) rather than the
+///   real `ctx` — silently diverging from the sequential stream exactly like
+///   the builtins above. A sequential fallback is always correct.
+fn function_is_unsafe(f: &Function, registry: Option<&UserFunctionRegistry>) -> bool {
     match f {
         Function::Rand | Function::Uuid | Function::StrUuid | Function::BNode => true,
         Function::Purrdf(call) => matches!(
@@ -257,58 +298,84 @@ fn function_is_unsafe(f: &Function) -> bool {
             purrdf_sparql_algebra::PurrdfFn::ListSlice
                 | purrdf_sparql_algebra::PurrdfFn::ListConcat
         ),
+        Function::Custom(iri) => {
+            let Some(reg) = registry else { return false };
+            if let Some(native) = reg.resolve_native(iri.as_str()) {
+                // Native fn: unsafe iff declared Volatile; Stable is
+                // deterministic-within-query, hence fork-join safe. (Wildcard
+                // arm — Volatility is `#[non_exhaustive]`.)
+                return matches!(native.volatility, Volatility::Volatile);
+            }
+            // A SPARQL-bodied user function's body may mint RAND/UUID/BNODE/list
+            // cells whose per-query state merges into a *forked* child and is
+            // then discarded — silently diverging from the sequential stream.
+            // Classify it UNSAFE (conservative + correct; sequential is always
+            // right). An IRI resolving to neither custom kind is an XSD cast or
+            // a hard error — both deterministic — so it stays safe.
+            reg.resolve(iri.as_str()).is_some()
+        }
         _ => false,
     }
 }
 
 /// `true` iff `pattern` (recursively) reaches an unsafe builtin through any
 /// expression-bearing variant — see [`is_parallel_safe`].
-fn pattern_reaches_unsafe_builtin(pattern: &GraphPattern) -> bool {
+fn pattern_reaches_unsafe_builtin(
+    pattern: &GraphPattern,
+    registry: Option<&UserFunctionRegistry>,
+) -> bool {
     match pattern {
         GraphPattern::Bgp { .. } | GraphPattern::Path { .. } | GraphPattern::Values { .. } => false,
         GraphPattern::Join { left, right }
         | GraphPattern::Lateral { left, right }
         | GraphPattern::Union { left, right }
         | GraphPattern::Minus { left, right } => {
-            pattern_reaches_unsafe_builtin(left) || pattern_reaches_unsafe_builtin(right)
+            pattern_reaches_unsafe_builtin(left, registry)
+                || pattern_reaches_unsafe_builtin(right, registry)
         }
         GraphPattern::Graph { inner, .. }
         | GraphPattern::Service { inner, .. }
         | GraphPattern::Distinct { inner }
         | GraphPattern::Reduced { inner }
         | GraphPattern::Slice { inner, .. }
-        | GraphPattern::Project { inner, .. } => pattern_reaches_unsafe_builtin(inner),
+        | GraphPattern::Project { inner, .. } => pattern_reaches_unsafe_builtin(inner, registry),
         GraphPattern::Filter { expr, inner } => {
-            expr_reaches_unsafe_builtin(expr) || pattern_reaches_unsafe_builtin(inner)
+            expr_reaches_unsafe_builtin(expr, registry)
+                || pattern_reaches_unsafe_builtin(inner, registry)
         }
         GraphPattern::Extend {
             inner, expression, ..
-        } => expr_reaches_unsafe_builtin(expression) || pattern_reaches_unsafe_builtin(inner),
+        } => {
+            expr_reaches_unsafe_builtin(expression, registry)
+                || pattern_reaches_unsafe_builtin(inner, registry)
+        }
         GraphPattern::LeftJoin {
             left,
             right,
             expression,
         } => {
-            pattern_reaches_unsafe_builtin(left)
-                || pattern_reaches_unsafe_builtin(right)
-                || expression.as_ref().is_some_and(expr_reaches_unsafe_builtin)
+            pattern_reaches_unsafe_builtin(left, registry)
+                || pattern_reaches_unsafe_builtin(right, registry)
+                || expression
+                    .as_ref()
+                    .is_some_and(|e| expr_reaches_unsafe_builtin(e, registry))
         }
         GraphPattern::OrderBy { inner, expression } => {
-            pattern_reaches_unsafe_builtin(inner)
+            pattern_reaches_unsafe_builtin(inner, registry)
                 || expression.iter().any(|oe| match oe {
                     OrderExpression::Asc(e) | OrderExpression::Desc(e) => {
-                        expr_reaches_unsafe_builtin(e)
+                        expr_reaches_unsafe_builtin(e, registry)
                     }
                 })
         }
         GraphPattern::Group {
             inner, aggregates, ..
         } => {
-            pattern_reaches_unsafe_builtin(inner)
+            pattern_reaches_unsafe_builtin(inner, registry)
                 || aggregates.iter().any(|(_, agg)| match agg {
                     AggregateExpression::CountStar { .. } => false,
                     AggregateExpression::FunctionCall { expression, .. } => {
-                        expr_reaches_unsafe_builtin(expression)
+                        expr_reaches_unsafe_builtin(expression, registry)
                     }
                 })
         }
@@ -633,7 +700,7 @@ mod tests {
             Box::new(Expression::Literal(Literal::new_simple("1"))),
             Box::new(Expression::Literal(Literal::new_simple("2"))),
         );
-        assert!(is_parallel_safe(&arith));
+        assert!(is_parallel_safe(&arith, None));
 
         let regex = call(
             Function::Regex,
@@ -642,21 +709,24 @@ mod tests {
                 Expression::Literal(Literal::new_simple("^a")),
             ],
         );
-        assert!(is_parallel_safe(&regex));
+        assert!(is_parallel_safe(&regex, None));
     }
 
     #[test]
     fn rand_uuid_struuid_bnode_are_unsafe() {
-        assert!(!is_parallel_safe(&call(Function::Rand, vec![])));
-        assert!(!is_parallel_safe(&call(Function::Uuid, vec![])));
-        assert!(!is_parallel_safe(&call(Function::StrUuid, vec![])));
-        assert!(!is_parallel_safe(&call(Function::BNode, vec![])));
-        assert!(!is_parallel_safe(&call(
-            Function::BNode,
-            vec![Expression::Variable(purrdf_sparql_algebra::Variable::new(
-                "x"
-            ))]
-        )));
+        assert!(!is_parallel_safe(&call(Function::Rand, vec![]), None));
+        assert!(!is_parallel_safe(&call(Function::Uuid, vec![]), None));
+        assert!(!is_parallel_safe(&call(Function::StrUuid, vec![]), None));
+        assert!(!is_parallel_safe(&call(Function::BNode, vec![]), None));
+        assert!(!is_parallel_safe(
+            &call(
+                Function::BNode,
+                vec![Expression::Variable(purrdf_sparql_algebra::Variable::new(
+                    "x"
+                ))]
+            ),
+            None
+        ));
     }
 
     #[test]
@@ -670,19 +740,22 @@ mod tests {
                 vec![],
             )
         };
-        assert!(!is_parallel_safe(&mk(
-            PurrdfFn::ListSlice,
-            "http://ex/listSlice"
-        )));
-        assert!(!is_parallel_safe(&mk(
-            PurrdfFn::ListConcat,
-            "http://ex/listConcat"
-        )));
-        assert!(is_parallel_safe(&mk(
-            PurrdfFn::ListLength,
-            "http://ex/listLength"
-        )));
-        assert!(is_parallel_safe(&mk(PurrdfFn::HeldIn, "http://ex/heldIn")));
+        assert!(!is_parallel_safe(
+            &mk(PurrdfFn::ListSlice, "http://ex/listSlice"),
+            None
+        ));
+        assert!(!is_parallel_safe(
+            &mk(PurrdfFn::ListConcat, "http://ex/listConcat"),
+            None
+        ));
+        assert!(is_parallel_safe(
+            &mk(PurrdfFn::ListLength, "http://ex/listLength"),
+            None
+        ));
+        assert!(is_parallel_safe(
+            &mk(PurrdfFn::HeldIn, "http://ex/heldIn"),
+            None
+        ));
     }
 
     #[test]
@@ -696,13 +769,13 @@ mod tests {
             Box::new(safe.clone()),
             Box::new(rand.clone()),
         );
-        assert!(!is_parallel_safe(&in_if));
+        assert!(!is_parallel_safe(&in_if, None));
 
         let in_coalesce = Expression::Coalesce(vec![safe.clone(), rand.clone()]);
-        assert!(!is_parallel_safe(&in_coalesce));
+        assert!(!is_parallel_safe(&in_coalesce, None));
 
         let in_fn_args = call(Function::Concat, vec![safe, rand]);
-        assert!(!is_parallel_safe(&in_fn_args));
+        assert!(!is_parallel_safe(&in_fn_args, None));
     }
 
     #[test]
@@ -725,7 +798,7 @@ mod tests {
             inner: Box::new(inner_bgp),
         };
         let exists = Expression::Exists(Box::new(filtered_inner));
-        assert!(!is_parallel_safe(&exists));
+        assert!(!is_parallel_safe(&exists, None));
 
         // Sanity: the same shape without RAND() is safe.
         let inner_bgp2 = GraphPattern::Bgp {
@@ -736,7 +809,91 @@ mod tests {
             }],
         };
         let safe_exists = Expression::Exists(Box::new(inner_bgp2));
-        assert!(is_parallel_safe(&safe_exists));
+        assert!(is_parallel_safe(&safe_exists, None));
+    }
+
+    // ---- is_parallel_safe: Function::Custom / UserFunctionRegistry ----------
+
+    const CUSTOM_NATIVE_IRI: &str = "http://example.org/ns#customNative";
+    const CUSTOM_SPARQL_IRI: &str = "http://example.org/ns#customSparql";
+    const CUSTOM_UNKNOWN_IRI: &str = "http://example.org/ns#customUnknown";
+
+    fn custom_call(iri: &str) -> Expression {
+        call(Function::Custom(NamedNode::new_unchecked(iri)), Vec::new())
+    }
+
+    fn trivial_native_body() -> crate::user_fn::NativeFnBody {
+        std::sync::Arc::new(|_args: &[TermValue]| {
+            Ok(TermValue::typed_literal(
+                "1",
+                "http://www.w3.org/2001/XMLSchema#integer",
+            ))
+        })
+    }
+
+    fn trivial_sparql_function() -> crate::user_fn::UserFunction {
+        crate::user_fn::UserFunction {
+            params: Vec::new(),
+            required: 0,
+            body: std::sync::Arc::new(
+                purrdf_sparql_algebra::SparqlParser::new()
+                    .parse_query("SELECT (1 AS ?result) WHERE {}")
+                    .expect("parse trivial function body"),
+            ),
+            kind: crate::user_fn::UserFnBody::Select,
+            return_constraint: crate::user_fn::TypeConstraint::default(),
+        }
+    }
+
+    #[test]
+    fn native_stable_custom_is_parallel_safe() {
+        let mut reg = UserFunctionRegistry::new();
+        reg.register_native(
+            CUSTOM_NATIVE_IRI,
+            crate::user_fn::Arity::Exact(0),
+            Volatility::Stable,
+            trivial_native_body(),
+        );
+        assert!(is_parallel_safe(
+            &custom_call(CUSTOM_NATIVE_IRI),
+            Some(&reg)
+        ));
+    }
+
+    #[test]
+    fn native_volatile_custom_is_parallel_unsafe() {
+        let mut reg = UserFunctionRegistry::new();
+        reg.register_native(
+            CUSTOM_NATIVE_IRI,
+            crate::user_fn::Arity::Exact(0),
+            Volatility::Volatile,
+            trivial_native_body(),
+        );
+        assert!(!is_parallel_safe(
+            &custom_call(CUSTOM_NATIVE_IRI),
+            Some(&reg)
+        ));
+    }
+
+    #[test]
+    fn sparql_bodied_custom_is_parallel_unsafe() {
+        let mut reg = UserFunctionRegistry::new();
+        reg.insert(CUSTOM_SPARQL_IRI, trivial_sparql_function());
+        assert!(!is_parallel_safe(
+            &custom_call(CUSTOM_SPARQL_IRI),
+            Some(&reg)
+        ));
+    }
+
+    #[test]
+    fn unknown_custom_without_registry_stays_safe() {
+        assert!(is_parallel_safe(&custom_call(CUSTOM_UNKNOWN_IRI), None));
+
+        let reg = UserFunctionRegistry::new();
+        assert!(is_parallel_safe(
+            &custom_call(CUSTOM_UNKNOWN_IRI),
+            Some(&reg)
+        ));
     }
 
     // ---- par_chunk_map ----------------------------------------------------

--- a/crates/sparql-eval/src/parallel.rs
+++ b/crates/sparql-eval/src/parallel.rs
@@ -823,7 +823,7 @@ mod tests {
     }
 
     fn trivial_native_body() -> crate::user_fn::NativeFnBody {
-        std::sync::Arc::new(|_args: &[TermValue]| {
+        std::sync::Arc::new(|_args: &[&TermValue]| {
             Ok(TermValue::typed_literal(
                 "1",
                 "http://www.w3.org/2001/XMLSchema#integer",

--- a/crates/sparql-eval/src/user_fn.rs
+++ b/crates/sparql-eval/src/user_fn.rs
@@ -130,6 +130,13 @@ pub struct UserFunction {
 /// A native (host-Rust) user function body: a closure over the already-evaluated,
 /// dataset-independent argument values.
 ///
+/// The arguments arrive as a slice of **borrows** (`&[&TermValue]`): every value
+/// already lives in the evaluator's per-call argument buffer for the duration of
+/// the call, so the dispatch path lends the closure those borrows rather than deep
+/// cloning each [`TermValue`] (which owns heap strings for IRIs/literals) on the
+/// per-row scoring hot path this seam exists to serve. A closure that needs to
+/// retain a value past the call clones it itself.
+///
 /// Unlike a [`UserFunction`]'s SPARQL body, this takes **no [`EvalCtx`]** — it
 /// therefore cannot re-enter the evaluator, so there is no recursion/re-entrancy
 /// boundary to bound (the SPARQL-bodied path's `MAX_UDF_DEPTH` guard does not
@@ -138,7 +145,7 @@ pub struct UserFunction {
 /// gate relies on that declaration alone to decide whether the call may run across
 /// worker threads, so a closure that lies about its own volatility can silently
 /// diverge under parallel evaluation.
-pub type NativeFnBody = Arc<dyn Fn(&[TermValue]) -> Result<TermValue, EvalError> + Send + Sync>;
+pub type NativeFnBody = Arc<dyn Fn(&[&TermValue]) -> Result<TermValue, EvalError> + Send + Sync>;
 
 /// A native function's determinism class — the volatility axis of its descriptor
 /// (after PostgreSQL's `provolatile`).
@@ -496,9 +503,11 @@ pub(crate) fn eval_native_function(
     if args.iter().any(Option::is_none) {
         return Ok(None);
     }
-    let values: Vec<TermValue> = args
+    // Lend the closure borrows into the caller's argument buffer — no per-call
+    // deep clone of the (heap-string-owning) TermValues on the scoring hot path.
+    let values: Vec<&TermValue> = args
         .iter()
-        .map(|arg| arg.clone().expect("checked all-Some above"))
+        .map(|arg| arg.as_ref().expect("checked all-Some above"))
         .collect();
 
     // Guard the host closure with catch_unwind: a panicking closure (dim
@@ -548,8 +557,8 @@ mod tests {
 
     /// A native closure that adds one to its sole integer-literal argument.
     fn inc_native_body() -> NativeFnBody {
-        Arc::new(|args: &[TermValue]| {
-            let TermValue::Literal { lexical_form, .. } = &args[0] else {
+        Arc::new(|args: &[&TermValue]| {
+            let TermValue::Literal { lexical_form, .. } = args[0] else {
                 return Err(EvalError::function("expected a literal argument"));
             };
             let n: i64 = lexical_form
@@ -567,8 +576,8 @@ mod tests {
     /// by `divisor`, returning an `xsd:double`. Pure math over the argument
     /// value, so it is honestly `Volatility::Stable`.
     fn ratio_score_native_body(divisor: f64) -> NativeFnBody {
-        Arc::new(move |args: &[TermValue]| {
-            let TermValue::Literal { lexical_form, .. } = &args[0] else {
+        Arc::new(move |args: &[&TermValue]| {
+            let TermValue::Literal { lexical_form, .. } = args[0] else {
                 return Err(EvalError::function("expected a literal argument"));
             };
             let n: f64 = lexical_form
@@ -585,8 +594,8 @@ mod tests {
     /// and `arg / 5.0` otherwise — used to exercise `ORDER BY`'s handling of
     /// `NaN` scores (E-nan).
     fn nan_score_native_body() -> NativeFnBody {
-        Arc::new(|args: &[TermValue]| {
-            let TermValue::Literal { lexical_form, .. } = &args[0] else {
+        Arc::new(|args: &[&TermValue]| {
+            let TermValue::Literal { lexical_form, .. } = args[0] else {
                 return Err(EvalError::function("expected a literal argument"));
             };
             let n: f64 = lexical_form
@@ -1087,7 +1096,7 @@ mod tests {
             EX_NATIVE_ERR,
             Arity::Exact(1),
             Volatility::Stable,
-            Arc::new(|_args: &[TermValue]| Err(EvalError::function("boom"))),
+            Arc::new(|_args: &[&TermValue]| Err(EvalError::function("boom"))),
         );
         let ds = empty_dataset();
         let query = format!("SELECT ((<{EX_NATIVE_ERR}>(1)) AS ?v) WHERE {{}}");
@@ -1128,7 +1137,7 @@ mod tests {
             EX_NATIVE_PANIC,
             Arity::Exact(1),
             Volatility::Stable,
-            Arc::new(|_args: &[TermValue]| panic!("native closure exploded")),
+            Arc::new(|_args: &[&TermValue]| panic!("native closure exploded")),
         );
         let ds = empty_dataset();
         let query = format!("SELECT ((<{EX_NATIVE_PANIC}>(1)) AS ?v) WHERE {{}}");
@@ -1198,7 +1207,7 @@ mod tests {
             EX_NATIVE_UNBOUND,
             Arity::Exact(1),
             Volatility::Stable,
-            Arc::new(|_args: &[TermValue]| {
+            Arc::new(|_args: &[&TermValue]| {
                 panic!("must not be invoked when an argument is unbound")
             }),
         );

--- a/crates/sparql-eval/src/user_fn.rs
+++ b/crates/sparql-eval/src/user_fn.rs
@@ -602,7 +602,7 @@ mod tests {
 
     /// A native closure returning `xsd:double` `NaN` for a non-positive argument
     /// and `arg / 5.0` otherwise — used to exercise `ORDER BY`'s handling of
-    /// `NaN` scores (E-nan).
+    /// `NaN` scores.
     fn nan_score_native_body() -> NativeFnBody {
         Arc::new(|args: &[&TermValue]| {
             let TermValue::Literal { lexical_form, .. } = args[0] else {
@@ -1351,7 +1351,7 @@ mod tests {
         }
     }
 
-    // ── R7: engine-level push-down determinism (Task 4) ─────────────────────
+    // ── engine-level push-down determinism ──────────────────────────────────
 
     /// `FILTER(<score>(?v) > 0.5)` over a `Stable` native scorer returns exactly
     /// the subjects whose score exceeds the threshold — the native call is
@@ -1416,7 +1416,7 @@ mod tests {
         );
     }
 
-    /// (E-nan) A scorer returning `xsd:double` `NaN` for some rows still yields a
+    /// A scorer returning `xsd:double` `NaN` for some rows still yields a
     /// stable *total* order under `ORDER BY`: every input row is present (no row
     /// is dropped for having an incomparable/NaN key) and the row order is
     /// identical across two runs. SPARQL's ORDER BY total order over the

--- a/crates/sparql-eval/src/user_fn.rs
+++ b/crates/sparql-eval/src/user_fn.rs
@@ -19,6 +19,7 @@
 //! body in a recursion-bounded child context. This keeps SPARQL execution inside
 //! the evaluator and the registry free of any engine coupling.
 
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 
 use purrdf_core::{DatasetView, TermValue};
@@ -126,12 +127,134 @@ pub struct UserFunction {
     pub return_constraint: TypeConstraint,
 }
 
-/// A caller-injected table of SHACL-AF functions, keyed by function IRI. Built once
-/// per shapes graph by the shapes crate and borrowed into evaluation via
+/// A native (host-Rust) user function body: a closure over the already-evaluated,
+/// dataset-independent argument values.
+///
+/// Unlike a [`UserFunction`]'s SPARQL body, this takes **no [`EvalCtx`]** — it
+/// therefore cannot re-enter the evaluator, so there is no recursion/re-entrancy
+/// boundary to bound (the SPARQL-bodied path's `MAX_UDF_DEPTH` guard does not
+/// apply here). When a function is declared non-[`Volatile`](Volatility::Volatile)
+/// it **must** be deterministic within a query: the fork-join parallel-evaluation
+/// gate relies on that declaration alone to decide whether the call may run across
+/// worker threads, so a closure that lies about its own volatility can silently
+/// diverge under parallel evaluation.
+pub type NativeFnBody = Arc<dyn Fn(&[TermValue]) -> Result<TermValue, EvalError> + Send + Sync>;
+
+/// A native function's determinism class — the volatility axis of its descriptor
+/// (after PostgreSQL's `provolatile`).
+///
+/// The fork-join parallel-evaluation gate is this enum's sole consumer:
+/// [`Volatile`](Self::Volatile) pins the call to sequential evaluation;
+/// [`Stable`](Self::Stable) (deterministic *within one query* — e.g. a frozen
+/// external-index read, or pure math over its arguments) may run across workers.
+/// There is deliberately no bool-typed "purity" flag: the three-way Postgres
+/// vocabulary (`IMMUTABLE`/`STABLE`/`VOLATILE`) is honest about the difference
+/// between "never changes" and "fixed for the lifetime of one query", and a
+/// frozen-index read is the latter, not the former.
+///
+/// `#[non_exhaustive]`: a finer class (e.g. `Immutable`, for a future
+/// const-folding pass) is addable without a breaking change — no dead variant is
+/// carried now.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[non_exhaustive]
+pub enum Volatility {
+    /// Deterministic for the lifetime of one query (a frozen external-index read,
+    /// or pure math over its arguments). Safe to run across fork-join workers.
+    Stable,
+    /// May observe or mutate state that changes between calls within the same
+    /// query (a mutable external resource, wall-clock time, RNG). Pinned to
+    /// sequential evaluation.
+    Volatile,
+}
+
+/// A native function's declared argument arity, checked before the closure is
+/// ever invoked (fail-fast: a wrong-count call never hands the host closure a
+/// short or long slice).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Arity {
+    /// Exactly `n` arguments.
+    Exact(usize),
+    /// Between `min` and `max` arguments, inclusive.
+    Range {
+        /// The minimum accepted argument count, inclusive.
+        min: usize,
+        /// The maximum accepted argument count, inclusive.
+        max: usize,
+    },
+    /// At least `n` arguments (no upper bound).
+    AtLeast(usize),
+}
+
+impl Arity {
+    /// Whether `count` arguments satisfies this declared arity.
+    fn accepts(self, count: usize) -> bool {
+        match self {
+            Self::Exact(n) => count == n,
+            Self::Range { min, max } => (min..=max).contains(&count),
+            Self::AtLeast(n) => count >= n,
+        }
+    }
+}
+
+impl core::fmt::Display for Arity {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Exact(n) => write!(f, "exactly {n}"),
+            Self::Range { min, max } => write!(f, "{min}..={max}"),
+            Self::AtLeast(n) => write!(f, "at least {n}"),
+        }
+    }
+}
+
+/// A registered native function: its closure body plus its declared arity and
+/// volatility. See [`NativeFnBody`] for the determinism contract the closure
+/// itself must uphold.
+#[derive(Clone)]
+pub struct NativeFunction {
+    pub(crate) body: NativeFnBody,
+    pub(crate) arity: Arity,
+    pub(crate) volatility: Volatility,
+}
+
+impl core::fmt::Debug for NativeFunction {
+    /// The closure body has no `Debug` impl, so only the declared arity and
+    /// volatility are shown (the same two fields the fork-join parallel gate and
+    /// [`eval_native_function`] consult).
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NativeFunction")
+            .field("arity", &self.arity)
+            .field("volatility", &self.volatility)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A caller-injected table of user functions, keyed by function IRI. Holds two
+/// independent kinds under two separate tables — SHACL-AF SPARQL-bodied
+/// ([`UserFunction`]) and native Rust-closure ([`NativeFunction`]) — sharing one
+/// IRI namespace: [`Self::insert`]/[`Self::register_native`] hard-fail on a
+/// cross-kind collision (see their docs) so an IRI is unambiguously one kind or
+/// the other, never silently shadowed. Built once per shapes graph / host
+/// configuration and borrowed into evaluation via
 /// [`NativeSparqlEngine::query_with_user_functions`](crate::NativeSparqlEngine::query_with_user_functions).
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
 pub struct UserFunctionRegistry {
     fns: DetHashMap<String, UserFunction>,
+    native: DetHashMap<String, NativeFunction>,
+}
+
+impl core::fmt::Debug for UserFunctionRegistry {
+    /// A [`NativeFunction`]'s closure has no `Debug` impl, so this lists both
+    /// tables' key sets (sorted for deterministic output) rather than deriving.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut sparql_bodied: Vec<&str> = self.fns.keys().map(String::as_str).collect();
+        sparql_bodied.sort_unstable();
+        let mut native: Vec<&str> = self.native.keys().map(String::as_str).collect();
+        native.sort_unstable();
+        f.debug_struct("UserFunctionRegistry")
+            .field("fns", &sparql_bodied)
+            .field("native", &native)
+            .finish()
+    }
 }
 
 impl UserFunctionRegistry {
@@ -143,27 +266,78 @@ impl UserFunctionRegistry {
 
     /// Register `func` under its `iri`. A later registration of the same IRI
     /// replaces the earlier one.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `iri` is already registered as a [`NativeFunction`] — one IRI
+    /// cannot be both SPARQL-bodied and native (a host misconfiguration, caught
+    /// at registration time rather than silently shadowing one kind with the
+    /// other). Re-registering the same IRI with another SPARQL-bodied function is
+    /// unaffected ("last write wins").
     pub fn insert(&mut self, iri: impl Into<String>, func: UserFunction) {
-        self.fns.insert(iri.into(), func);
+        let iri = iri.into();
+        assert!(
+            !self.native.contains_key(&iri),
+            "IRI <{iri}> is already registered as a native function; cannot also register it as a SPARQL-bodied function"
+        );
+        self.fns.insert(iri, func);
     }
 
-    /// Resolve a call-position IRI to its declared function, if any.
+    /// Register a native (host-Rust closure) function under `iri`, with its
+    /// declared calling `arity` and determinism `volatility`. A later
+    /// registration of the same IRI as another native function replaces the
+    /// earlier one ("last write wins").
+    ///
+    /// # Panics
+    ///
+    /// Panics if `iri` is already registered as a SPARQL-bodied [`UserFunction`]
+    /// — see [`Self::insert`]'s panic doc for the rationale (symmetric guard).
+    pub fn register_native(
+        &mut self,
+        iri: impl Into<String>,
+        arity: Arity,
+        volatility: Volatility,
+        body: NativeFnBody,
+    ) {
+        let iri = iri.into();
+        assert!(
+            !self.fns.contains_key(&iri),
+            "IRI <{iri}> is already registered as a SPARQL-bodied function; cannot also register it as native"
+        );
+        self.native.insert(
+            iri,
+            NativeFunction {
+                body,
+                arity,
+                volatility,
+            },
+        );
+    }
+
+    /// Resolve a call-position IRI to its declared SPARQL-bodied function, if any.
     #[must_use]
     pub fn resolve(&self, iri: &str) -> Option<&UserFunction> {
         self.fns.get(iri)
     }
 
-    /// Whether the registry holds no functions (the common case: no
-    /// `sh:SPARQLFunction` declared, so evaluation carries no registry at all).
+    /// Resolve a call-position IRI to its declared native function, if any.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.fns.is_empty()
+    pub fn resolve_native(&self, iri: &str) -> Option<&NativeFunction> {
+        self.native.get(iri)
     }
 
-    /// The number of declared functions.
+    /// Whether the registry holds no functions of either kind (the common case:
+    /// no `sh:SPARQLFunction` declared and no native functions registered, so
+    /// evaluation carries no registry at all).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.fns.is_empty() && self.native.is_empty()
+    }
+
+    /// The number of declared functions across both kinds.
     #[must_use]
     pub fn len(&self) -> usize {
-        self.fns.len()
+        self.fns.len() + self.native.len()
     }
 }
 
@@ -284,6 +458,62 @@ pub(crate) fn eval_user_function<D: DatasetView + Sync>(
     Ok(result)
 }
 
+/// Execute a resolved native (host-Rust closure) function call: arity-check the
+/// arguments, then invoke the closure with the bound values.
+///
+/// `args` are the already-evaluated argument values in call order (a `None` cell
+/// is an unbound argument). A native function declares no per-parameter
+/// optionality: unlike the SPARQL-bodied path's "leading required parameters"
+/// split, **any** unbound argument yields no result node at all (`Ok(None)`),
+/// since the closure has no way to observe which parameter was left unbound. The
+/// result is a dataset-independent [`TermValue`]; the caller interns it into the
+/// parent context.
+///
+/// # Errors
+///
+/// [`EvalError::Function`] on an arity violation, on a panic inside the closure
+/// (converted to a fixed, payload-free error so the message is identical
+/// regardless of which worker thread panicked — mirrors the `native-codec-panic`
+/// guard in `purrdf_rdf::native_codecs::parse`), or propagated straight through
+/// from the closure's own `Err`.
+pub(crate) fn eval_native_function(
+    native: &NativeFunction,
+    iri: &str,
+    args: &[Option<TermValue>],
+) -> Result<Option<TermValue>, EvalError> {
+    // Fail-fast: a wrong-count call never reaches the host closure with a short
+    // or long slice.
+    if !native.arity.accepts(args.len()) {
+        return Err(EvalError::function(format!(
+            "native function <{iri}> expects {} argument(s), got {}",
+            native.arity,
+            args.len()
+        )));
+    }
+
+    // A native function declares no per-parameter optionality: any unbound
+    // argument yields no result node rather than being handed to the closure.
+    if args.iter().any(Option::is_none) {
+        return Ok(None);
+    }
+    let values: Vec<TermValue> = args
+        .iter()
+        .map(|arg| arg.clone().expect("checked all-Some above"))
+        .collect();
+
+    // Guard the host closure with catch_unwind: a panicking closure (dim
+    // mismatch, unwrap, OOB index) must not abort a rayon worker or otherwise
+    // surface nondeterministically. The error message is fixed and
+    // payload-free so it is identical no matter which worker panicked. Mirrors
+    // `purrdf_rdf::native_codecs::parse`'s `native-codec-panic` guard.
+    match catch_unwind(AssertUnwindSafe(|| (native.body)(&values))) {
+        Ok(inner_result) => inner_result.map(Some),
+        Err(_) => Err(EvalError::function(format!(
+            "native function <{iri}> panicked"
+        ))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -297,6 +527,29 @@ mod tests {
     const EX_INC: &str = "http://example.org/ns#inc";
     const EX_EVEN: &str = "http://example.org/ns#isEven";
     const EX_LOOP: &str = "http://example.org/ns#loop";
+    const EX_NATIVE_INC: &str = "http://example.org/ns#nativeInc";
+    const EX_NATIVE_ERR: &str = "http://example.org/ns#nativeErr";
+    const EX_NATIVE_PANIC: &str = "http://example.org/ns#nativePanic";
+    const EX_NATIVE_ARITY: &str = "http://example.org/ns#nativeArity";
+    const EX_NATIVE_UNBOUND: &str = "http://example.org/ns#nativeUnbound";
+    const EX_NATIVE_COLLIDE: &str = "http://example.org/ns#nativeCollide";
+    const EX_SPARQL_ONLY: &str = "http://example.org/ns#sparqlOnly";
+    const EX_NATIVE_ONLY: &str = "http://example.org/ns#nativeOnly";
+
+    const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+
+    /// A native closure that adds one to its sole integer-literal argument.
+    fn inc_native_body() -> NativeFnBody {
+        Arc::new(|args: &[TermValue]| {
+            let TermValue::Literal { lexical_form, .. } = &args[0] else {
+                return Err(EvalError::function("expected a literal argument"));
+            };
+            let n: i64 = lexical_form
+                .parse()
+                .map_err(|_| EvalError::function("argument is not an integer"))?;
+            Ok(TermValue::typed_literal((n + 1).to_string(), XSD_INTEGER))
+        })
+    }
 
     fn empty_dataset() -> Arc<RdfDataset> {
         RdfDatasetBuilder::new().freeze().expect("freeze")
@@ -688,6 +941,296 @@ mod tests {
                     rows[0][0].is_some(),
                     "class-typed IRI return must be accepted and returned, got {:?}",
                     rows[0][0]
+                );
+            }
+            other => panic!("expected solutions, got {other:?}"),
+        }
+    }
+
+    /// A registered native `Stable` closure is invoked from a SELECT projection
+    /// and its return value is interned and reported like any other.
+    #[test]
+    fn native_function_returns_value() {
+        let mut registry = UserFunctionRegistry::new();
+        registry.register_native(
+            EX_NATIVE_INC,
+            Arity::Exact(1),
+            Volatility::Stable,
+            inc_native_body(),
+        );
+        let ds = empty_dataset();
+        let query = format!("SELECT ((<{EX_NATIVE_INC}>(41)) AS ?v) WHERE {{}}");
+        let result = NativeSparqlEngine::new()
+            .query_with_user_functions(
+                &ds,
+                SparqlRequest {
+                    query: &query,
+                    base_iri: None,
+                    substitutions: &[],
+                },
+                &registry,
+            )
+            .expect("query");
+        match result {
+            SparqlResult::Solutions { rows, .. } => {
+                let cell = rows[0][0].as_ref().expect("bound result");
+                assert!(
+                    matches!(cell, TermValue::Literal { lexical_form, .. } if lexical_form == "42"),
+                    "expected 42, got {cell:?}"
+                );
+            }
+            other => panic!("expected solutions, got {other:?}"),
+        }
+    }
+
+    /// A native closure's own `Err` return is a hard query failure, rendered
+    /// through the generalized (no-longer-SHACL-AF-only) `Function` error text.
+    #[test]
+    fn native_function_error_is_a_hard_error() {
+        let mut registry = UserFunctionRegistry::new();
+        registry.register_native(
+            EX_NATIVE_ERR,
+            Arity::Exact(1),
+            Volatility::Stable,
+            Arc::new(|_args: &[TermValue]| Err(EvalError::function("boom"))),
+        );
+        let ds = empty_dataset();
+        let query = format!("SELECT ((<{EX_NATIVE_ERR}>(1)) AS ?v) WHERE {{}}");
+        let err = NativeSparqlEngine::new()
+            .query_with_user_functions(
+                &ds,
+                SparqlRequest {
+                    query: &query,
+                    base_iri: None,
+                    substitutions: &[],
+                },
+                &registry,
+            )
+            .expect_err("closure error must fail the query");
+        assert!(
+            err.to_string().contains("user function error"),
+            "expected generalized 'user function error' text, got {err}"
+        );
+        assert!(
+            err.to_string().contains("boom"),
+            "expected the closure's own message to propagate, got {err}"
+        );
+    }
+
+    /// A panic inside a native closure is caught and converted to a clean,
+    /// deterministic [`EvalError::Function`] — the query fails cleanly rather than
+    /// aborting the test process.
+    #[test]
+    fn native_function_panic_is_a_clean_error() {
+        // Suppress the default panic-hook stderr dump for this *expected*,
+        // caught panic so test output stays clean (mirrors
+        // crates/rdf/tests/rdfc_w3c.rs and crates/shapes/tests/w3c_conformance.rs).
+        let default_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+
+        let mut registry = UserFunctionRegistry::new();
+        registry.register_native(
+            EX_NATIVE_PANIC,
+            Arity::Exact(1),
+            Volatility::Stable,
+            Arc::new(|_args: &[TermValue]| panic!("native closure exploded")),
+        );
+        let ds = empty_dataset();
+        let query = format!("SELECT ((<{EX_NATIVE_PANIC}>(1)) AS ?v) WHERE {{}}");
+        let err = NativeSparqlEngine::new()
+            .query_with_user_functions(
+                &ds,
+                SparqlRequest {
+                    query: &query,
+                    base_iri: None,
+                    substitutions: &[],
+                },
+                &registry,
+            )
+            .expect_err("a panicking closure must fail the query, not abort it");
+
+        std::panic::set_hook(default_hook);
+
+        assert!(
+            err.to_string().contains("panicked"),
+            "expected a clean 'panicked' error, got {err}"
+        );
+        // The panic payload is deliberately NOT interpolated (deterministic across
+        // rayon workers), so the closure's own message must not leak into the error.
+        assert!(
+            !err.to_string().contains("exploded"),
+            "panic payload must not leak into the deterministic error message, got {err}"
+        );
+    }
+
+    /// A call whose argument count does not match the declared [`Arity`] is a hard
+    /// error, checked before the closure ever runs.
+    #[test]
+    fn native_function_wrong_arity_is_a_hard_error() {
+        let mut registry = UserFunctionRegistry::new();
+        registry.register_native(
+            EX_NATIVE_ARITY,
+            Arity::Exact(1),
+            Volatility::Stable,
+            inc_native_body(),
+        );
+        let ds = empty_dataset();
+        // Two arguments to a one-argument native function.
+        let query = format!("SELECT ((<{EX_NATIVE_ARITY}>(1, 2)) AS ?v) WHERE {{}}");
+        let err = NativeSparqlEngine::new()
+            .query_with_user_functions(
+                &ds,
+                SparqlRequest {
+                    query: &query,
+                    base_iri: None,
+                    substitutions: &[],
+                },
+                &registry,
+            )
+            .expect_err("arity mismatch must fail");
+        assert!(
+            err.to_string().contains("expects"),
+            "expected arity error, got {err}"
+        );
+    }
+
+    /// An unbound argument yields no result node rather than reaching the closure
+    /// (a native function declares no per-parameter optionality).
+    #[test]
+    fn native_function_unbound_argument_yields_no_value() {
+        let mut registry = UserFunctionRegistry::new();
+        registry.register_native(
+            EX_NATIVE_UNBOUND,
+            Arity::Exact(1),
+            Volatility::Stable,
+            Arc::new(|_args: &[TermValue]| {
+                panic!("must not be invoked when an argument is unbound")
+            }),
+        );
+        let ds = empty_dataset();
+        // `?missing` is never bound.
+        let query = format!("SELECT ((<{EX_NATIVE_UNBOUND}>(?missing)) AS ?v) WHERE {{}}");
+        let result = NativeSparqlEngine::new()
+            .query_with_user_functions(
+                &ds,
+                SparqlRequest {
+                    query: &query,
+                    base_iri: None,
+                    substitutions: &[],
+                },
+                &registry,
+            )
+            .expect("query");
+        match result {
+            SparqlResult::Solutions { rows, .. } => {
+                assert!(
+                    rows[0][0].is_none(),
+                    "unbound argument must yield no value, got {:?}",
+                    rows[0][0]
+                );
+            }
+            other => panic!("expected solutions, got {other:?}"),
+        }
+    }
+
+    /// Registering a native function under an IRI already held by a SPARQL-bodied
+    /// function is a hard panic (cross-kind collision guard).
+    #[test]
+    #[should_panic(expected = "already registered as a SPARQL-bodied function")]
+    fn register_native_collision_with_sparql_bodied_panics() {
+        let mut registry = UserFunctionRegistry::new();
+        registry.insert(
+            EX_NATIVE_COLLIDE,
+            UserFunction {
+                params: vec![int_param("n")],
+                required: 1,
+                body: parse("SELECT ((?n) AS ?result) WHERE {}"),
+                kind: UserFnBody::Select,
+                return_constraint: TypeConstraint::default(),
+            },
+        );
+        registry.register_native(
+            EX_NATIVE_COLLIDE,
+            Arity::Exact(1),
+            Volatility::Stable,
+            inc_native_body(),
+        );
+    }
+
+    /// The reverse collision: registering a SPARQL-bodied function under an IRI
+    /// already held by a native function is likewise a hard panic.
+    #[test]
+    #[should_panic(expected = "already registered as a native function")]
+    fn insert_collision_with_native_panics() {
+        let mut registry = UserFunctionRegistry::new();
+        registry.register_native(
+            EX_NATIVE_COLLIDE,
+            Arity::Exact(1),
+            Volatility::Stable,
+            inc_native_body(),
+        );
+        registry.insert(
+            EX_NATIVE_COLLIDE,
+            UserFunction {
+                params: vec![int_param("n")],
+                required: 1,
+                body: parse("SELECT ((?n) AS ?result) WHERE {}"),
+                kind: UserFnBody::Select,
+                return_constraint: TypeConstraint::default(),
+            },
+        );
+    }
+
+    /// A SPARQL-bodied function and a native function registered under distinct
+    /// IRIs coexist in one registry: each resolves through its own path and a
+    /// single query using both gets the correct result from each.
+    #[test]
+    fn native_and_sparql_bodied_coexist() {
+        let mut registry = UserFunctionRegistry::new();
+        registry.insert(
+            EX_SPARQL_ONLY,
+            UserFunction {
+                params: vec![int_param("n")],
+                required: 1,
+                body: parse("SELECT ((?n + 1) AS ?result) WHERE {}"),
+                kind: UserFnBody::Select,
+                return_constraint: TypeConstraint::default(),
+            },
+        );
+        registry.register_native(
+            EX_NATIVE_ONLY,
+            Arity::Exact(1),
+            Volatility::Stable,
+            inc_native_body(),
+        );
+        assert_eq!(registry.len(), 2);
+
+        let ds = empty_dataset();
+        let query = format!(
+            "SELECT ((<{EX_SPARQL_ONLY}>(1)) AS ?a) ((<{EX_NATIVE_ONLY}>(1)) AS ?b) WHERE {{}}"
+        );
+        let result = NativeSparqlEngine::new()
+            .query_with_user_functions(
+                &ds,
+                SparqlRequest {
+                    query: &query,
+                    base_iri: None,
+                    substitutions: &[],
+                },
+                &registry,
+            )
+            .expect("query");
+        match result {
+            SparqlResult::Solutions { rows, .. } => {
+                let a = rows[0][0].as_ref().expect("sparql-bodied result bound");
+                let b = rows[0][1].as_ref().expect("native result bound");
+                assert!(
+                    matches!(a, TermValue::Literal { lexical_form, .. } if lexical_form == "2"),
+                    "expected SPARQL-bodied result 2, got {a:?}"
+                );
+                assert!(
+                    matches!(b, TermValue::Literal { lexical_form, .. } if lexical_form == "2"),
+                    "expected native result 2, got {b:?}"
                 );
             }
             other => panic!("expected solutions, got {other:?}"),

--- a/crates/sparql-eval/src/user_fn.rs
+++ b/crates/sparql-eval/src/user_fn.rs
@@ -1,23 +1,33 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Dynamic, host-injected SHACL-AF SPARQL-based functions (`sh:SPARQLFunction`).
+//! Dynamic, host-injected user functions — of two kinds under one IRI namespace.
 //!
-//! A shapes graph may declare its own functions: an IRI typed `sh:SPARQLFunction`
-//! with ordered `sh:parameter`s, an optional `sh:returnType`, and a `sh:select` or
-//! `sh:ask` body. Those calls appear in constraint/target queries and in SHACL-AF
-//! node expressions as an ordinary call-position IRI, which the parser lowers to
-//! [`Function::Custom`](purrdf_sparql_algebra::Function::Custom) (it is under no
-//! configured extension-function namespace, so it is not the closed `PurrdfFn`
-//! set). The evaluator resolves that IRI against a caller-injected
-//! [`UserFunctionRegistry`] at eval time — the open counterpart to the closed,
-//! parse-time-resolved `PurrdfFn` dispatch.
+//! A call-position IRI that is under no configured extension-function namespace
+//! (so not the closed, parse-time-resolved `PurrdfFn` set) is lowered by the
+//! parser to [`Function::Custom`](purrdf_sparql_algebra::Function::Custom) and
+//! resolved at eval time against a caller-injected [`UserFunctionRegistry`] — the
+//! open counterpart to `PurrdfFn` dispatch. The registry holds two independent
+//! kinds keyed by IRI, hard-failing on a cross-kind collision so an IRI is
+//! unambiguously one kind or the other:
 //!
-//! The registry is pure data (parsed bodies + parameter metadata); executing a
-//! call binds the arguments to the parameter variables as a pre-binding rewrite
-//! (the same `crate::substitute` path `$this` injection uses) and evaluates the
-//! body in a recursion-bounded child context. This keeps SPARQL execution inside
-//! the evaluator and the registry free of any engine coupling.
+//! - **SHACL-AF SPARQL-bodied** ([`UserFunction`]) — declared by a shapes graph as
+//!   an IRI typed `sh:SPARQLFunction` with ordered `sh:parameter`s, an optional
+//!   `sh:returnType`, and a `sh:select`/`sh:ask` body. This kind is pure data
+//!   (parsed body + parameter metadata); executing a call binds the arguments to
+//!   the parameter variables as a pre-binding rewrite (the same `crate::substitute`
+//!   path `$this` injection uses) and evaluates the body in a recursion-bounded
+//!   child context, keeping SPARQL execution inside the evaluator and the registry
+//!   free of engine coupling.
+//!
+//! - **Native (host-Rust closure)** ([`NativeFunction`], registered via
+//!   [`UserFunctionRegistry::register_native`]) — a `Send + Sync` closure over the
+//!   already-evaluated argument values (see [`NativeFnBody`]) for scoring
+//!   predicates whose bodies cannot be expressed in SPARQL (e.g. an external-index
+//!   read). It carries a declared [`Arity`] (fail-fast checked before the closure
+//!   runs) and a [`Volatility`] the fork-join parallel-evaluation gate consults to
+//!   decide whether the call may run across worker threads. It takes no
+//!   [`EvalCtx`] and so cannot re-enter the evaluator.
 
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;

--- a/crates/sparql-eval/src/user_fn.rs
+++ b/crates/sparql-eval/src/user_fn.rs
@@ -219,7 +219,7 @@ pub struct NativeFunction {
 impl core::fmt::Debug for NativeFunction {
     /// The closure body has no `Debug` impl, so only the declared arity and
     /// volatility are shown (the same two fields the fork-join parallel gate and
-    /// [`eval_native_function`] consult).
+    /// the native-dispatch path `eval_native_function` consult).
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("NativeFunction")
             .field("arity", &self.arity)

--- a/crates/sparql-eval/src/user_fn.rs
+++ b/crates/sparql-eval/src/user_fn.rs
@@ -574,7 +574,10 @@ mod tests {
             let n: f64 = lexical_form
                 .parse()
                 .map_err(|_| EvalError::function("argument is not numeric"))?;
-            Ok(TermValue::typed_literal((n / divisor).to_string(), XSD_DOUBLE))
+            Ok(TermValue::typed_literal(
+                (n / divisor).to_string(),
+                XSD_DOUBLE,
+            ))
         })
     }
 

--- a/crates/sparql-eval/src/user_fn.rs
+++ b/crates/sparql-eval/src/user_fn.rs
@@ -517,9 +517,12 @@ pub(crate) fn eval_native_function(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
     use std::sync::Arc;
 
-    use purrdf_core::{RdfDataset, RdfDatasetBuilder, SparqlRequest, SparqlResult, TermValue};
+    use purrdf_core::{
+        RdfDataset, RdfDatasetBuilder, RdfLiteral, SparqlRequest, SparqlResult, TermValue,
+    };
     use purrdf_sparql_algebra::SparqlParser;
 
     use crate::NativeSparqlEngine;
@@ -535,8 +538,13 @@ mod tests {
     const EX_NATIVE_COLLIDE: &str = "http://example.org/ns#nativeCollide";
     const EX_SPARQL_ONLY: &str = "http://example.org/ns#sparqlOnly";
     const EX_NATIVE_ONLY: &str = "http://example.org/ns#nativeOnly";
+    const EX_SCORE: &str = "http://example.org/ns#score";
+    const EX_SCORE_NAN: &str = "http://example.org/ns#scoreNan";
+    const EX_VAL: &str = "http://example.org/ns#val";
+    const EX_SUBJECT_PREFIX: &str = "http://example.org/ns#s";
 
     const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+    const XSD_DOUBLE: &str = "http://www.w3.org/2001/XMLSchema#double";
 
     /// A native closure that adds one to its sole integer-literal argument.
     fn inc_native_body() -> NativeFnBody {
@@ -553,6 +561,90 @@ mod tests {
 
     fn empty_dataset() -> Arc<RdfDataset> {
         RdfDatasetBuilder::new().freeze().expect("freeze")
+    }
+
+    /// A native closure that parses its literal argument as `f64` and divides it
+    /// by `divisor`, returning an `xsd:double`. Pure math over the argument
+    /// value, so it is honestly `Volatility::Stable`.
+    fn ratio_score_native_body(divisor: f64) -> NativeFnBody {
+        Arc::new(move |args: &[TermValue]| {
+            let TermValue::Literal { lexical_form, .. } = &args[0] else {
+                return Err(EvalError::function("expected a literal argument"));
+            };
+            let n: f64 = lexical_form
+                .parse()
+                .map_err(|_| EvalError::function("argument is not numeric"))?;
+            Ok(TermValue::typed_literal((n / divisor).to_string(), XSD_DOUBLE))
+        })
+    }
+
+    /// A native closure returning `xsd:double` `NaN` for a non-positive argument
+    /// and `arg / 5.0` otherwise — used to exercise `ORDER BY`'s handling of
+    /// `NaN` scores (E-nan).
+    fn nan_score_native_body() -> NativeFnBody {
+        Arc::new(|args: &[TermValue]| {
+            let TermValue::Literal { lexical_form, .. } = &args[0] else {
+                return Err(EvalError::function("expected a literal argument"));
+            };
+            let n: f64 = lexical_form
+                .parse()
+                .map_err(|_| EvalError::function("argument is not numeric"))?;
+            let score = if n <= 0.0 { f64::NAN } else { n / 5.0 };
+            Ok(TermValue::typed_literal(score.to_string(), XSD_DOUBLE))
+        })
+    }
+
+    /// A dataset of `n` subjects `ex:s1..ex:sN`, each with an integer `ex:val`
+    /// property `1..=n`.
+    fn scored_dataset(n: usize) -> Arc<RdfDataset> {
+        let mut b = RdfDatasetBuilder::new();
+        let val_pred = b.intern_iri(EX_VAL);
+        for i in 1..=n {
+            let s = b.intern_iri(&format!("{EX_SUBJECT_PREFIX}{i}"));
+            let v = b.intern_literal(RdfLiteral::typed(i.to_string(), XSD_INTEGER.to_owned()));
+            b.push_quad(s, val_pred, v, None);
+        }
+        b.freeze().expect("freeze")
+    }
+
+    /// Run `query` and collect the bound `?s` (sole projected column) IRIs of
+    /// every solution row as an unordered set.
+    fn run_subject_set(
+        ds: &Arc<RdfDataset>,
+        query: &str,
+        registry: &UserFunctionRegistry,
+    ) -> BTreeSet<String> {
+        run_subject_rows(ds, query, registry).into_iter().collect()
+    }
+
+    /// Run `query` and collect the bound `?s` (sole projected column) IRIs of
+    /// every solution row in result order.
+    fn run_subject_rows(
+        ds: &Arc<RdfDataset>,
+        query: &str,
+        registry: &UserFunctionRegistry,
+    ) -> Vec<String> {
+        let result = NativeSparqlEngine::new()
+            .query_with_user_functions(
+                ds,
+                SparqlRequest {
+                    query,
+                    base_iri: None,
+                    substitutions: &[],
+                },
+                registry,
+            )
+            .expect("query");
+        match result {
+            SparqlResult::Solutions { rows, .. } => rows
+                .into_iter()
+                .map(|row| match row[0].as_ref().expect("bound subject") {
+                    TermValue::Iri(iri) => iri.clone(),
+                    other => panic!("expected an IRI subject, got {other:?}"),
+                })
+                .collect(),
+            other => panic!("expected solutions, got {other:?}"),
+        }
     }
 
     fn parse(body: &str) -> Arc<Query> {
@@ -1235,5 +1327,160 @@ mod tests {
             }
             other => panic!("expected solutions, got {other:?}"),
         }
+    }
+
+    // ── R7: engine-level push-down determinism (Task 4) ─────────────────────
+
+    /// `FILTER(<score>(?v) > 0.5)` over a `Stable` native scorer returns exactly
+    /// the subjects whose score exceeds the threshold — the native call is
+    /// correctly pushed down into the FILTER predicate.
+    #[test]
+    fn native_score_in_filter_pushes_down() {
+        const N: usize = 20;
+        let mut registry = UserFunctionRegistry::new();
+        registry.register_native(
+            EX_SCORE,
+            Arity::Exact(1),
+            Volatility::Stable,
+            ratio_score_native_body(N as f64),
+        );
+        let ds = scored_dataset(N);
+        let query =
+            format!("SELECT ?s WHERE {{ ?s <{EX_VAL}> ?v . FILTER(<{EX_SCORE}>(?v) > 0.5) }}");
+
+        let got = run_subject_set(&ds, &query, &registry);
+        // score(v) = v / 20 > 0.5  <=>  v > 10.
+        let expected: BTreeSet<String> = (11..=N)
+            .map(|i| format!("{EX_SUBJECT_PREFIX}{i}"))
+            .collect();
+        assert_eq!(
+            got, expected,
+            "FILTER over the native scorer must keep exactly the subjects above threshold"
+        );
+    }
+
+    /// `ORDER BY DESC(<score>(?v))` yields the correct score-descending order and
+    /// is reproducible across two runs — the `Stable` native fn is deterministic
+    /// under the evaluator's ordering path.
+    #[test]
+    fn native_score_in_order_by_is_deterministic() {
+        const N: usize = 20;
+        let mut registry = UserFunctionRegistry::new();
+        registry.register_native(
+            EX_SCORE,
+            Arity::Exact(1),
+            Volatility::Stable,
+            ratio_score_native_body(N as f64),
+        );
+        let ds = scored_dataset(N);
+        let query =
+            format!("SELECT ?s WHERE {{ ?s <{EX_VAL}> ?v }} ORDER BY DESC(<{EX_SCORE}>(?v))");
+
+        let first = run_subject_rows(&ds, &query, &registry);
+        // score is strictly increasing in v, so DESC(score) == DESC(v).
+        let expected: Vec<String> = (1..=N)
+            .rev()
+            .map(|i| format!("{EX_SUBJECT_PREFIX}{i}"))
+            .collect();
+        assert_eq!(
+            first, expected,
+            "expected score-descending (val-descending) order"
+        );
+
+        let second = run_subject_rows(&ds, &query, &registry);
+        assert_eq!(
+            first, second,
+            "ORDER BY over a Stable native fn must be deterministic across runs"
+        );
+    }
+
+    /// (E-nan) A scorer returning `xsd:double` `NaN` for some rows still yields a
+    /// stable *total* order under `ORDER BY`: every input row is present (no row
+    /// is dropped for having an incomparable/NaN key) and the row order is
+    /// identical across two runs. SPARQL's ORDER BY total order over the
+    /// `xsd:double` value space already gives `NaN` a fixed (deterministic,
+    /// lexical-fallback) slot — see `compare_sort_keys` in `modifier.rs` — so
+    /// this test documents that guarantee for a native-fn-derived score rather
+    /// than surfacing a latent bug.
+    #[test]
+    fn native_score_order_by_is_total_over_nan() {
+        let mut b = RdfDatasetBuilder::new();
+        let val_pred = b.intern_iri(EX_VAL);
+        let vals: Vec<i64> = (-5..=5).collect();
+        for v in &vals {
+            let s = b.intern_iri(&format!("{EX_SUBJECT_PREFIX}{v}"));
+            let lit = b.intern_literal(RdfLiteral::typed(v.to_string(), XSD_INTEGER.to_owned()));
+            b.push_quad(s, val_pred, lit, None);
+        }
+        let ds = b.freeze().expect("freeze");
+
+        let mut registry = UserFunctionRegistry::new();
+        registry.register_native(
+            EX_SCORE_NAN,
+            Arity::Exact(1),
+            Volatility::Stable,
+            nan_score_native_body(),
+        );
+        let query =
+            format!("SELECT ?s WHERE {{ ?s <{EX_VAL}> ?v }} ORDER BY ASC(<{EX_SCORE_NAN}>(?v))");
+
+        let first = run_subject_rows(&ds, &query, &registry);
+        let expected_set: BTreeSet<String> = vals
+            .iter()
+            .map(|v| format!("{EX_SUBJECT_PREFIX}{v}"))
+            .collect();
+        assert_eq!(
+            first.len(),
+            vals.len(),
+            "every input row (including NaN-scored ones) must survive ORDER BY"
+        );
+        assert_eq!(
+            first.iter().cloned().collect::<BTreeSet<String>>(),
+            expected_set,
+            "no row may be dropped or duplicated by a NaN-valued sort key"
+        );
+
+        let second = run_subject_rows(&ds, &query, &registry);
+        assert_eq!(
+            first, second,
+            "ORDER BY must be a stable, deterministic total order even with NaN keys present"
+        );
+    }
+
+    /// FILTER over a `Stable` native scorer, over a dataset large enough to
+    /// cross [`crate::parallel::PARALLEL_MIN_ROWS`], returns exactly the
+    /// expected rows — proving the native fn is safely usable on the fork-join
+    /// parallel path at scale (same answer as the sequential semantics).
+    #[test]
+    fn native_score_filter_over_parallel_threshold() {
+        // Comfortably above PARALLEL_MIN_ROWS (1024) so the FILTER's row count
+        // actually crosses the fork-join threshold.
+        const N: usize = 1500;
+        let mut registry = UserFunctionRegistry::new();
+        registry.register_native(
+            EX_SCORE,
+            Arity::Exact(1),
+            Volatility::Stable,
+            ratio_score_native_body(N as f64),
+        );
+        let ds = scored_dataset(N);
+        let query =
+            format!("SELECT ?s WHERE {{ ?s <{EX_VAL}> ?v . FILTER(<{EX_SCORE}>(?v) > 0.5) }}");
+
+        let first = run_subject_set(&ds, &query, &registry);
+        // score(v) = v / 1500 > 0.5  <=>  v > 750.
+        let expected: BTreeSet<String> = (751..=N)
+            .map(|i| format!("{EX_SUBJECT_PREFIX}{i}"))
+            .collect();
+        assert_eq!(
+            first, expected,
+            "parallel-path FILTER over the native scorer must match the sequential answer"
+        );
+
+        let second = run_subject_set(&ds, &query, &registry);
+        assert_eq!(
+            first, second,
+            "the parallel-path result must be deterministic across runs"
+        );
     }
 }


### PR DESCRIPTION
Closes #91

## Summary
Adds a native (Rust-closure) registration seam to `UserFunctionRegistry`, dispatched from the same `Function::Custom` eval site as SPARQL-bodied SHACL-AF functions, with a determinism (`Volatility`) declaration wired into the fork-join parallel-safety gate so native scores participate in `FILTER`/`ORDER BY` and get engine push-down (the motivating need for the consumer's deductive-recall scorers: BM25, vector-similarity, phonetic).

## Changes
- **user_fn.rs** — `NativeFnBody = Arc<dyn Fn(&[TermValue]) -> Result<TermValue, EvalError> + Send + Sync>`; `Volatility {Stable, Volatile}` (`#[non_exhaustive]`); `Arity {Exact, Range, AtLeast}`; `NativeFunction`. `UserFunctionRegistry` gains a native table + `register_native`/`resolve_native` with a **cross-kind IRI collision guard** (an IRI can't be both native and SPARQL-bodied). `eval_native_function`: fail-fast arity check → unbound arg yields no value → closure invoked under `catch_unwind` (panic → deterministic `EvalError`, no nondeterministic rayon abort).
- **expr.rs** — native-resolution branch in the `Function::Custom` arm.
- **parallel.rs** — `is_parallel_safe`/`is_parallel_safe_pattern` are now registry-aware; a `Volatile` native fn, and **any** SPARQL-bodied user fn, are parallel-unsafe; a `Stable` native fn stays safe. This also **fixes a pre-existing latent nondeterminism**: SPARQL-bodied UDFs with `RAND`/`UUID`/`BNODE`/list-constructor bodies were previously run under fork-join, merging per-query mint/RNG state into a discarded forked child.
- **error.rs** — `EvalError::Function` Display generalized from 'SHACL-AF function error' to 'user function error'.
- **lib.rs** — re-export `Arity`, `NativeFnBody`, `NativeFunction`, `Volatility`.
- **tests** — FILTER/ORDER BY push-down, ORDER BY determinism, NaN stable-total-order (no rows dropped), a >1024-row fork-join FILTER (parallel-safety at scale), plus arity/panic/collision/coexistence unit tests and 4 parallel-gate classification tests.

## Verification
- `make check` (fmt + clippy pedantic/nursery + build + tests + hygiene): **green**
- `make wasm` (wasm32 cleanliness): **green**
- No new Cargo features, no dependency pins, deterministic, `example.org` fixtures only.