### PR TITLE
feat(gts): two-inventory diff/splice fetch-list + streaming RdfEventSink bridge on a shared decode core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,6 +1314,7 @@ dependencies = [
  "fastrand",
  "filetime",
  "flate2",
+ "purrdf-events",
  "rayon",
  "serde",
  "sha1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,6 +1307,7 @@ name = "purrdf-gts"
 version = "0.5.0"
 dependencies = [
  "aes-gcm",
+ "ahash",
  "blake3",
  "ciborium",
  "criterion",

--- a/crates/gts/Cargo.toml
+++ b/crates/gts/Cargo.toml
@@ -27,6 +27,10 @@ workspace = true
 # This edge is acyclic — `purrdf-events` depends on nothing — so it never risks
 # a cycle and keeps `make wasm` green.
 purrdf-events = { workspace = true }
+# Fixed-key (no runtime RNG seeding) hasher for the segment-decode / event-bridge
+# dedup maps — mirrors the workspace's `FastHasher` policy (`crates/rdf-core/src/hash.rs`);
+# wasm-clean since `getrandom` is absent on wasm32 and `default-features = false` here.
+ahash = { workspace = true }
 # emojihash + randomart visual fingerprints, published from
 # Blackcat-Informatics/visual-hashing.
 visual-hashing = { workspace = true }

--- a/crates/gts/Cargo.toml
+++ b/crates/gts/Cargo.toml
@@ -22,6 +22,11 @@ all-features = true
 workspace = true
 
 [dependencies]
+# The zero-dependency, wasm-clean RDF 1.2 ingestion protocol (purrdf P6): the
+# neutral `RdfEventSink` seam the GTS event bridge (`event_stream`) folds into.
+# This edge is acyclic — `purrdf-events` depends on nothing — so it never risks
+# a cycle and keeps `make wasm` green.
+purrdf-events = { workspace = true }
 # emojihash + randomart visual fingerprints, published from
 # Blackcat-Informatics/visual-hashing.
 visual-hashing = { workspace = true }

--- a/crates/gts/examples/streaming_sink_bench.rs
+++ b/crates/gts/examples/streaming_sink_bench.rs
@@ -4,16 +4,21 @@
 //! Report-only streaming-sink throughput probe for the GTS writer; not a
 //! criterion gate — see `docs/BENCHMARKS.md` for the benchmarking policy.
 
+use core::ops::ControlFlow;
 use std::env;
 use std::fs;
 use std::fs::File;
 use std::process::ExitCode;
 
+use purrdf_events::{
+    EventError, EventQuad, EventTerm, EventTermId, EventTriple, RdfEventSink, ScopeId,
+};
+use purrdf_gts::event_stream::{GtsEventSink, stream_events};
 use purrdf_gts::model::{
     AnnotationRow, Diagnostic, OpaqueNode, Quad, ReifierRow, Signature, StreamableInfo,
     Suppression, Term,
 };
-use purrdf_gts::reader::{ReadOptions, StreamingSink, read_to_sink_from_reader};
+use purrdf_gts::reader::{FrameContext, ReadOptions, StreamingSink, read_to_sink_from_reader};
 
 #[derive(Default)]
 struct CountingSink {
@@ -81,6 +86,82 @@ impl StreamingSink for CountingSink {
     }
 }
 
+/// A counting `GtsEventSink` driven through the `event_stream` bridge, so the
+/// event path shares the streaming-sink probe. Report-only, like `CountingSink`.
+#[derive(Default)]
+struct CountingEventSink {
+    terms: usize,
+    quads: usize,
+    reifiers: usize,
+    annotations: usize,
+    frames: usize,
+    blobs: usize,
+}
+
+impl RdfEventSink for CountingEventSink {
+    fn term(
+        &mut self,
+        _id: EventTermId,
+        _term: EventTerm<'_>,
+    ) -> Result<ControlFlow<()>, EventError> {
+        self.terms += 1;
+        Ok(ControlFlow::Continue(()))
+    }
+
+    fn quad(&mut self, _q: EventQuad) -> Result<ControlFlow<()>, EventError> {
+        self.quads += 1;
+        Ok(ControlFlow::Continue(()))
+    }
+
+    fn reifier(
+        &mut self,
+        _reifier: EventTermId,
+        _triple: EventTriple,
+    ) -> Result<ControlFlow<()>, EventError> {
+        self.reifiers += 1;
+        Ok(ControlFlow::Continue(()))
+    }
+
+    fn annotation(
+        &mut self,
+        _reifier: EventTermId,
+        _p: EventTermId,
+        _o: EventTermId,
+    ) -> Result<ControlFlow<()>, EventError> {
+        self.annotations += 1;
+        Ok(ControlFlow::Continue(()))
+    }
+
+    fn open_scope(&mut self) -> Result<ScopeId, EventError> {
+        Ok(ScopeId::DEFAULT)
+    }
+
+    fn close_scope(&mut self, _scope: ScopeId) -> Result<ControlFlow<()>, EventError> {
+        Ok(ControlFlow::Continue(()))
+    }
+
+    fn finish(&mut self) -> Result<(), EventError> {
+        Ok(())
+    }
+}
+
+impl GtsEventSink for CountingEventSink {
+    fn frame(&mut self, _ctx: FrameContext<'_>) -> Result<ControlFlow<()>, EventError> {
+        self.frames += 1;
+        Ok(ControlFlow::Continue(()))
+    }
+
+    fn blob(
+        &mut self,
+        _ctx: Option<FrameContext<'_>>,
+        _digest: &str,
+        _meta: Option<&ciborium::value::Value>,
+    ) -> Result<ControlFlow<()>, EventError> {
+        self.blobs += 1;
+        Ok(ControlFlow::Continue(()))
+    }
+}
+
 fn linux_peak_kib() -> Option<usize> {
     let status = fs::read_to_string("/proc/self/status").ok()?;
     for line in status.lines() {
@@ -106,6 +187,31 @@ fn main() -> ExitCode {
     };
     let mut sink = CountingSink::default();
     let result = read_to_sink_from_reader(file, ReadOptions::new(true, None), &mut sink);
+
+    // Drive the event-bridge path over the same fixture so the `stream_events`
+    // seam shares this probe. Report-only; the counts are descriptive.
+    let (event_terms, event_quads, event_frames, event_blobs) = match fs::read(&path) {
+        Ok(bytes) => {
+            let mut event_sink = CountingEventSink::default();
+            match stream_events(&bytes, ReadOptions::new(true, None), &mut event_sink) {
+                Ok(_) => (
+                    event_sink.terms,
+                    event_sink.quads,
+                    event_sink.frames,
+                    event_sink.blobs,
+                ),
+                Err(err) => {
+                    eprintln!("streaming_sink_bench: event bridge: {err}");
+                    (0, 0, 0, 0)
+                }
+            }
+        }
+        Err(err) => {
+            eprintln!("streaming_sink_bench: re-read for event bridge: {err}");
+            (0, 0, 0, 0)
+        }
+    };
+
     let peak = linux_peak_kib().map_or_else(|| "null".to_string(), |value| value.to_string());
     println!(
         concat!(
@@ -123,6 +229,10 @@ fn main() -> ExitCode {
             "\"diagnostics\":{},",
             "\"segment_heads\":{},",
             "\"streamable_layouts\":{},",
+            "\"event_terms\":{},",
+            "\"event_quads\":{},",
+            "\"event_frames\":{},",
+            "\"event_blobs\":{},",
             "\"peak_kib\":{}",
             "}}"
         ),
@@ -137,6 +247,10 @@ fn main() -> ExitCode {
         result.diagnostics.len(),
         result.segment_heads.len(),
         result.segment_streamable.len(),
+        event_terms,
+        event_quads,
+        event_frames,
+        event_blobs,
         peak
     );
     ExitCode::SUCCESS

--- a/crates/gts/src/compact.rs
+++ b/crates/gts/src/compact.rs
@@ -250,8 +250,8 @@ fn base64url_unpadded(data: &[u8]) -> String {
 }
 
 /// Decode a base64url WITHOUT padding (RFC 4648 §5) string — the inverse of
-/// [`base64url_unpadded`], used to recover a `stream:cose` literal's raw
-/// COSE_Sign1 bytes (Task 5 signature verification).
+/// the private `base64url_unpadded` encoder, used to recover a `stream:cose`
+/// literal's raw COSE_Sign1 bytes for signature verification.
 ///
 /// # Errors
 /// HARD-ERRORS on a padding character (`=`) or any byte outside the unpadded

--- a/crates/gts/src/event_stream.rs
+++ b/crates/gts/src/event_stream.rs
@@ -212,6 +212,17 @@ impl<'s> EventEmitter<'s> {
         id
     }
 
+    /// Count of resolved IRI strings currently retained in `iri_map` (see the
+    /// field doc). `iri_map` is cleared on every genuine segment transition
+    /// ([`Self::ensure_scope`]), so reading this right after a segment has
+    /// been fully resolved reflects only THAT segment's own interned-IRI
+    /// count, never the cumulative total across every segment seen so far.
+    /// Exposed for tests asserting the bounded-memory contract (GTS-SPEC
+    /// §7.7) from outside the crate.
+    pub fn interned_iri_count(&self) -> usize {
+        self.iri_map.len()
+    }
+
     /// Ensure the scope for `segment_index` is the open one, closing the previous
     /// segment's scope and opening a fresh one on a segment change. A no-op once
     /// cancelled (beyond recording the segment).

--- a/crates/gts/src/event_stream.rs
+++ b/crates/gts/src/event_stream.rs
@@ -58,7 +58,6 @@
 //! `tests/event_bridge.rs`).
 
 use core::ops::ControlFlow;
-use std::collections::HashMap;
 
 use ciborium::value::Value;
 use purrdf_events::{
@@ -69,6 +68,13 @@ use purrdf_events::{
 use crate::model::{ByteRange, Diagnostic, OpaqueNode, Signature, StreamableInfo, Suppression};
 use crate::reader::{FrameContext, ReadOptions, StreamingReadResult, read_to_sink_with_options};
 use crate::segment_decode::{ResolvedSink, SegmentResolver};
+
+/// A [`std::collections::HashMap`] keyed by the workspace's fixed-key `ahash`
+/// policy (`crates/rdf-core/src/hash.rs`'s `FastHasher`) — no runtime RNG
+/// seeding, so it stays wasm-clean. Iteration order is unspecified; this map is
+/// only ever point-looked-up, never iterated for egress.
+type FastMap<K, V> =
+    std::collections::HashMap<K, V, core::hash::BuildHasherDefault<ahash::AHasher>>;
 
 /// Well-known `xsd:string` datatype IRI implied by a plain literal (RDF §7.1).
 ///
@@ -185,7 +191,7 @@ pub struct EventEmitter<'s> {
     next_id: u32,
     /// Resolved IRI text by minted id, retained so a literal's datatype id can be
     /// resolved back to its IRI string for [`EventTerm::Literal`].
-    iri_map: HashMap<EventTermId, String>,
+    iri_map: FastMap<EventTermId, String>,
     /// The segment whose scope is currently open, if any.
     current_segment: Option<usize>,
     /// The scope opened for [`Self::current_segment`].
@@ -215,7 +221,7 @@ impl<'s> EventEmitter<'s> {
         Self {
             sink,
             next_id: 0,
-            iri_map: HashMap::new(),
+            iri_map: FastMap::default(),
             current_segment: None,
             current_scope: ScopeId::DEFAULT,
             cached: None,

--- a/crates/gts/src/event_stream.rs
+++ b/crates/gts/src/event_stream.rs
@@ -10,6 +10,12 @@
 //! GTS-specific frames (blobs, opaque nodes, signatures, suppressions) that have
 //! no place in the neutral RDF event vocabulary.
 //!
+//! It rides the bounded-memory streaming fold (GTS-SPEC §7.7 "Streaming fold and
+//! bounded memory"): the reader delivers one frame at a time and the decode core
+//! buffers only the current segment's descriptors, so an external index builder
+//! (posting lists, a ClaimId→byte-offset map) runs in a single pass without ever
+//! materializing the union dataset.
+//!
 //! # Id and scope mapping
 //!
 //! The decode core resolves each segment's terms in a deterministic

--- a/crates/gts/src/event_stream.rs
+++ b/crates/gts/src/event_stream.rs
@@ -239,7 +239,7 @@ impl<'s> EventEmitter<'s> {
 
     /// Count of resolved IRI strings currently retained in `iri_map` (see the
     /// field doc). `iri_map` is cleared on every genuine segment transition
-    /// ([`Self::ensure_scope`]), so reading this right after a segment has
+    /// (`ensure_scope`), so reading this right after a segment has
     /// been fully resolved reflects only THAT segment's own interned-IRI
     /// count, never the cumulative total across every segment seen so far.
     /// Exposed for tests asserting the bounded-memory contract (GTS-SPEC

--- a/crates/gts/src/event_stream.rs
+++ b/crates/gts/src/event_stream.rs
@@ -92,10 +92,11 @@ const RDF_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langSt
 ///
 /// Every GTS hook defaults to a no-op `Continue`, so a consumer that only cares
 /// about RDF terms and quads implements just [`RdfEventSink`] and inherits inert
-/// GTS hooks. Each provenance-bearing hook receives the [`FrameContext`] cached
-/// from the most recently streamed frame — `None` before the first frame has
-/// been announced, since the reader fires a frame's provenance *after* that
-/// frame's rows.
+/// GTS hooks. The reader announces a frame's provenance via [`Self::frame`]
+/// *before* that frame's rows, so each provenance-bearing hook receives the
+/// [`FrameContext`] of the frame it belongs to — the cache holds the current
+/// frame by the time these hooks fire. (A hook's context is `None` only when no
+/// frame provenance is available at all.)
 pub trait GtsEventSink: RdfEventSink {
     /// Per-frame byte/identity provenance, announced once per frame.
     fn frame(&mut self, _ctx: FrameContext<'_>) -> Result<ControlFlow<()>, EventError> {

--- a/crates/gts/src/event_stream.rs
+++ b/crates/gts/src/event_stream.rs
@@ -38,6 +38,24 @@
 //! *graph-scoped* reifier or annotation therefore cannot be represented, and the
 //! bridge raises a hard [`purrdf_events::EventError`] rather than silently
 //! dropping the graph — honoring the no-swallow doctrine.
+//!
+//! The raw GTS reader ([`crate::reader`]) is a deliberately permissive
+//! Baseline Reader (GTS-SPEC §7.4/§7.5, GTS-CONFORMANCE.md §6): a row whose
+//! subject/predicate/object/graph-name/datatype/reifier names a segment-local
+//! term id no `term` event ever introduced is diagnosed (`PositionConstraint`
+//! or `ForwardReference`) and DROPPED, and folding continues so a damaged or
+//! partially-authored file still yields its recoverable content. That
+//! degrade-and-continue policy is right for the raw byte reader, but the RDF
+//! event protocol promises every id it ever declares is usable — a row that
+//! silently vanishes is indistinguishable from a fact that was never
+//! asserted. [`EventEmitter::diagnostic`] therefore escalates exactly those
+//! two diagnostic codes to a hard [`purrdf_events::EventError`] (the same
+//! "genuinely dangling term id" failure [`stream_events`] documents), while
+//! every other reader diagnostic (frame damage, chain breaks, unknown codecs,
+//! …) still passes through to [`GtsEventSink::gts_diagnostic`] unharmed —
+//! that class of degradation is not a dangling reference and stays governed
+//! by the permissive-read contract (see `claimid_offset_index_single_pass` in
+//! `tests/event_bridge.rs`).
 
 use core::ops::ControlFlow;
 use std::collections::HashMap;
@@ -563,6 +581,28 @@ impl ResolvedSink for EventEmitter<'_> {
     fn diagnostic(&mut self, diag: &Diagnostic) -> Result<(), Self::Error> {
         if self.cancelled {
             return Ok(());
+        }
+        // `PositionConstraint` / `ForwardReference` mean the RAW GTS reader
+        // (§7.4/§7.5) just silently DROPPED a row — a quad/reifier/annotation
+        // whose subject/predicate/object/graph-name/dt/rf named a segment-local
+        // term id no `term` event ever introduced — rather than resolving it.
+        // GTS's Baseline Reader is deliberately permissive about this (it
+        // degrades and keeps folding survivors, per GTS-CONFORMANCE.md §6), but
+        // the RDF event protocol is stricter: every id it ever declares MUST be
+        // usable, and a row silently vanishing from the stream is exactly the
+        // "genuinely dangling term id" this module's docs already promise is an
+        // `Err`, never a silent skip. Escalate here rather than passing it
+        // through as an informational `gts_diagnostic` — otherwise the drive
+        // would finish "successfully" having quietly dropped the row, which is
+        // indistinguishable from that row never having been asserted.
+        if matches!(
+            diag.code.as_str(),
+            "PositionConstraint" | "ForwardReference"
+        ) {
+            return Err(EventError::message(format!(
+                "GTS dangling term reference ({}): {}",
+                diag.code, diag.detail
+            )));
         }
         // A frame-scoped diagnostic carries the cached frame provenance; a
         // file-level diagnostic (e.g. `EmptyFile`) carries none.

--- a/crates/gts/src/event_stream.rs
+++ b/crates/gts/src/event_stream.rs
@@ -1,0 +1,599 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Bridge a GTS file onto the permissive RDF 1.2 ingestion protocol
+//! ([`purrdf_events::RdfEventSink`]).
+//!
+//! [`stream_events`] drives a GTS file through the shared two-phase decode core
+//! ([`crate::segment_decode::SegmentResolver`]) into a [`GtsEventSink`] — an
+//! [`RdfEventSink`] that also receives per-frame GTS provenance and the
+//! GTS-specific frames (blobs, opaque nodes, signatures, suppressions) that have
+//! no place in the neutral RDF event vocabulary.
+//!
+//! # Id and scope mapping
+//!
+//! The decode core resolves each segment's terms in a deterministic
+//! `(segment_index, gts_id)` order (segment-major, `gts_id`-sorted, inner-triple
+//! first), calling the sink's `intern_*` methods exactly once per term. The
+//! bridge mints a fresh, monotonically increasing [`EventTermId`] on each intern
+//! — so id assignment is a pure function of file order, reproducible across runs.
+//! Because every id is declared exactly once, the protocol never sees an
+//! [`purrdf_events::EventError::RedeclaredId`].
+//!
+//! Per-segment blank-node scope (the same `_:b0` in two segments names two
+//! different nodes) is preserved by opening a fresh [`ScopeId`] on the first
+//! intern of each segment and closing the previous one, mirroring GTS segment
+//! isolation onto the protocol's scope namespacing.
+//!
+//! # Faithful failures
+//!
+//! The RDF event protocol carries no graph slot on a reifier binding or a
+//! statement annotation ([`EventTriple`] is a bare triple). A GTS
+//! *graph-scoped* reifier or annotation therefore cannot be represented, and the
+//! bridge raises a hard [`purrdf_events::EventError`] rather than silently
+//! dropping the graph — honoring the no-swallow doctrine.
+
+use core::ops::ControlFlow;
+use std::collections::HashMap;
+
+use ciborium::value::Value;
+use purrdf_events::{
+    EventError, EventQuad, EventTerm, EventTermId, EventTriple, RdfEventSink, ScopeId,
+    TextDirection,
+};
+
+use crate::model::{ByteRange, Diagnostic, OpaqueNode, Signature, StreamableInfo, Suppression};
+use crate::reader::{FrameContext, ReadOptions, StreamingReadResult, read_to_sink_with_options};
+use crate::segment_decode::{ResolvedSink, SegmentResolver};
+
+/// Well-known `xsd:string` datatype IRI implied by a plain literal (RDF §7.1).
+///
+/// This is RDF's own datatype IRI, mirrored from
+/// `crates/rdf/src/native_codecs/hextuples.rs`; it is NOT fabricated PurRDF
+/// vocabulary.
+const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
+/// Well-known `rdf:langString` datatype IRI implied by a language tag (RDF §7.1).
+///
+/// RDF's own datatype IRI (see [`XSD_STRING`]), not fabricated vocabulary.
+const RDF_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
+
+/// A GTS-aware event sink: an [`RdfEventSink`] that also receives per-frame GTS
+/// provenance and the GTS-specific frames that have no neutral RDF event.
+///
+/// Every GTS hook defaults to a no-op `Continue`, so a consumer that only cares
+/// about RDF terms and quads implements just [`RdfEventSink`] and inherits inert
+/// GTS hooks. Each provenance-bearing hook receives the [`FrameContext`] cached
+/// from the most recently streamed frame — `None` before the first frame has
+/// been announced, since the reader fires a frame's provenance *after* that
+/// frame's rows.
+pub trait GtsEventSink: RdfEventSink {
+    /// Per-frame byte/identity provenance, announced once per frame.
+    fn frame(&mut self, _ctx: FrameContext<'_>) -> Result<ControlFlow<()>, EventError> {
+        Ok(ControlFlow::Continue(()))
+    }
+
+    /// An inline blob's content digest and declared public metadata.
+    fn blob(
+        &mut self,
+        _ctx: Option<FrameContext<'_>>,
+        _digest: &str,
+        _meta: Option<&Value>,
+    ) -> Result<ControlFlow<()>, EventError> {
+        Ok(ControlFlow::Continue(()))
+    }
+
+    /// An opaque frame (unknown codec, missing key, or damaged payload).
+    fn opaque(
+        &mut self,
+        _ctx: Option<FrameContext<'_>>,
+        _node: &OpaqueNode,
+    ) -> Result<ControlFlow<()>, EventError> {
+        Ok(ControlFlow::Continue(()))
+    }
+
+    /// A signature observation on a frame.
+    fn signature(
+        &mut self,
+        _ctx: Option<FrameContext<'_>>,
+        _sig: &Signature,
+    ) -> Result<ControlFlow<()>, EventError> {
+        Ok(ControlFlow::Continue(()))
+    }
+
+    /// A suppression directive.
+    fn suppression(
+        &mut self,
+        _ctx: Option<FrameContext<'_>>,
+        _suppression: &Suppression,
+    ) -> Result<ControlFlow<()>, EventError> {
+        Ok(ControlFlow::Continue(()))
+    }
+
+    /// A reader diagnostic. Frame-scoped diagnostics carry the cached
+    /// [`FrameContext`]; file-level diagnostics carry `None`.
+    fn gts_diagnostic(
+        &mut self,
+        _ctx: Option<FrameContext<'_>>,
+        _diagnostic: &Diagnostic,
+    ) -> Result<ControlFlow<()>, EventError> {
+        Ok(ControlFlow::Continue(()))
+    }
+}
+
+/// An owned snapshot of the most recently streamed [`FrameContext`], kept so the
+/// provenance-bearing [`GtsEventSink`] hooks can borrow it after the reader's
+/// borrowed context has expired.
+struct CachedFrame {
+    segment_index: usize,
+    frame_index: usize,
+    content_id: Vec<u8>,
+    range: ByteRange,
+    frame_type: String,
+    valid: bool,
+}
+
+impl CachedFrame {
+    /// Reconstruct a borrowed [`FrameContext`] over this cached snapshot.
+    fn as_context(&self) -> FrameContext<'_> {
+        FrameContext {
+            segment_index: self.segment_index,
+            frame_index: self.frame_index,
+            content_id: &self.content_id,
+            range: self.range.clone(),
+            frame_type: &self.frame_type,
+            valid: self.valid,
+        }
+    }
+}
+
+/// A [`ResolvedSink`] that folds resolved GTS terms and rows onto a
+/// [`GtsEventSink`], minting a fresh [`EventTermId`] per term and rotating a
+/// [`ScopeId`] per segment.
+///
+/// Constructible through [`EventEmitter::new`] so callers that cannot go through
+/// [`stream_events`] — chiefly tests exercising a decode failure the GTS
+/// [`crate::writer::Writer`] refuses to author — can drive it behind a
+/// [`SegmentResolver`] directly.
+pub struct EventEmitter<'s> {
+    /// The bridged consumer.
+    sink: &'s mut dyn GtsEventSink,
+    /// The next [`EventTermId`] to mint; incremented on every intern.
+    next_id: u32,
+    /// Resolved IRI text by minted id, retained so a literal's datatype id can be
+    /// resolved back to its IRI string for [`EventTerm::Literal`].
+    iri_map: HashMap<EventTermId, String>,
+    /// The segment whose scope is currently open, if any.
+    current_segment: Option<usize>,
+    /// The scope opened for [`Self::current_segment`].
+    current_scope: ScopeId,
+    /// The most recently streamed frame's provenance.
+    cached: Option<CachedFrame>,
+    /// Set once any sink call requests [`ControlFlow::Break`]; further sink
+    /// emission is suppressed so a cancelled drive is never finalized.
+    cancelled: bool,
+}
+
+impl std::fmt::Debug for EventEmitter<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventEmitter")
+            .field("next_id", &self.next_id)
+            .field("interned_iris", &self.iri_map.len())
+            .field("current_segment", &self.current_segment)
+            .field("current_scope", &self.current_scope)
+            .field("cancelled", &self.cancelled)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'s> EventEmitter<'s> {
+    /// Wrap a [`GtsEventSink`] in a fresh emitter.
+    pub fn new(sink: &'s mut dyn GtsEventSink) -> Self {
+        Self {
+            sink,
+            next_id: 0,
+            iri_map: HashMap::new(),
+            current_segment: None,
+            current_scope: ScopeId::DEFAULT,
+            cached: None,
+            cancelled: false,
+        }
+    }
+
+    /// Mint the next monotonically increasing [`EventTermId`].
+    fn mint(&mut self) -> EventTermId {
+        let id = EventTermId(self.next_id);
+        self.next_id += 1;
+        id
+    }
+
+    /// Ensure the scope for `segment_index` is the open one, closing the previous
+    /// segment's scope and opening a fresh one on a segment change. A no-op once
+    /// cancelled (beyond recording the segment).
+    fn ensure_scope(&mut self, segment_index: usize) -> Result<(), EventError> {
+        if self.current_segment == Some(segment_index) {
+            return Ok(());
+        }
+        if self.cancelled {
+            self.current_segment = Some(segment_index);
+            return Ok(());
+        }
+        if self.current_segment.is_some()
+            && self.sink.close_scope(self.current_scope)? == ControlFlow::Break(())
+        {
+            self.cancelled = true;
+            self.current_segment = Some(segment_index);
+            return Ok(());
+        }
+        self.current_scope = self.sink.open_scope()?;
+        self.current_segment = Some(segment_index);
+        Ok(())
+    }
+
+    /// Emit a term declaration, latching cancellation on a `Break`.
+    fn emit_term(&mut self, id: EventTermId, term: EventTerm<'_>) -> Result<(), EventError> {
+        if self.cancelled {
+            return Ok(());
+        }
+        if self.sink.term(id, term)? == ControlFlow::Break(()) {
+            self.cancelled = true;
+        }
+        Ok(())
+    }
+
+    /// Close the scope left open by the final segment, if any. Called once by
+    /// [`stream_events`] before finalizing a non-cancelled drive.
+    fn close_open_scope(&mut self) -> Result<(), EventError> {
+        if self.cancelled {
+            return Ok(());
+        }
+        if self.current_segment.is_some() {
+            if self.sink.close_scope(self.current_scope)? == ControlFlow::Break(()) {
+                self.cancelled = true;
+            }
+            self.current_segment = None;
+        }
+        Ok(())
+    }
+
+    /// Resolve a literal's datatype id (or absence) to its expanded datatype IRI.
+    ///
+    /// A `Some` datatype id that never resolved to an IRI is a hard error (a
+    /// literal cannot be typed by a non-IRI). Absence defaults per RDF §7.1:
+    /// `rdf:langString` with a language tag, else `xsd:string`.
+    fn datatype_iri(
+        &self,
+        datatype: Option<EventTermId>,
+        lang: Option<&str>,
+    ) -> Result<String, EventError> {
+        match datatype {
+            Some(dt) => {
+                self.iri_map.get(&dt).cloned().ok_or_else(|| {
+                    EventError::message("GTS literal datatype must resolve to an IRI")
+                })
+            }
+            None if lang.is_some() => Ok(RDF_LANG_STRING.to_owned()),
+            None => Ok(XSD_STRING.to_owned()),
+        }
+    }
+}
+
+/// Parse a GTS literal base-direction token into a [`TextDirection`].
+///
+/// Mirrors `crates/rdf/src/gts_resolve.rs::parse_gts_direction`: `None` is
+/// legitimate absence, an unrecognized token is a hard error, and RDF 1.2 admits
+/// a base direction only on a non-empty language-tagged string.
+fn parse_direction(
+    direction: Option<&str>,
+    lang: Option<&str>,
+) -> Result<Option<TextDirection>, EventError> {
+    let parsed = match direction {
+        None => return Ok(None),
+        Some("ltr") => TextDirection::Ltr,
+        Some("rtl") => TextDirection::Rtl,
+        Some(other) => {
+            return Err(EventError::message(format!(
+                "unrecognized GTS literal base direction {other:?}"
+            )));
+        }
+    };
+    if lang.is_none_or(str::is_empty) {
+        return Err(EventError::message(
+            "an RDF 1.2 literal base direction requires a non-empty language tag",
+        ));
+    }
+    Ok(Some(parsed))
+}
+
+impl ResolvedSink for EventEmitter<'_> {
+    type Id = EventTermId;
+    type Error = EventError;
+
+    fn intern_iri(
+        &mut self,
+        segment_index: usize,
+        _gts_id: usize,
+        iri: &str,
+    ) -> Result<Self::Id, Self::Error> {
+        self.ensure_scope(segment_index)?;
+        let id = self.mint();
+        self.iri_map.insert(id, iri.to_owned());
+        self.emit_term(id, EventTerm::Iri(iri))?;
+        Ok(id)
+    }
+
+    fn intern_blank(
+        &mut self,
+        segment_index: usize,
+        _gts_id: usize,
+        label: &str,
+    ) -> Result<Self::Id, Self::Error> {
+        self.ensure_scope(segment_index)?;
+        let id = self.mint();
+        let scope = self.current_scope;
+        self.emit_term(id, EventTerm::Blank { label, scope })?;
+        Ok(id)
+    }
+
+    fn intern_literal(
+        &mut self,
+        segment_index: usize,
+        _gts_id: usize,
+        lexical: String,
+        datatype: Option<Self::Id>,
+        lang: Option<String>,
+        direction: Option<String>,
+    ) -> Result<Self::Id, Self::Error> {
+        self.ensure_scope(segment_index)?;
+        // Clone the datatype IRI into a local so the `sink.term` call below does
+        // not hold a borrow of `self.iri_map` while it borrows `self.sink`.
+        let datatype_iri = self.datatype_iri(datatype, lang.as_deref())?;
+        let direction = parse_direction(direction.as_deref(), lang.as_deref())?;
+        let id = self.mint();
+        self.emit_term(
+            id,
+            EventTerm::Literal {
+                lexical: &lexical,
+                datatype: &datatype_iri,
+                language: lang.as_deref(),
+                direction,
+            },
+        )?;
+        Ok(id)
+    }
+
+    fn intern_triple(
+        &mut self,
+        segment_index: usize,
+        _gts_id: usize,
+        s: Self::Id,
+        p: Self::Id,
+        o: Self::Id,
+    ) -> Result<Self::Id, Self::Error> {
+        self.ensure_scope(segment_index)?;
+        let id = self.mint();
+        self.emit_term(id, EventTerm::Triple(EventTriple { s, p, o }))?;
+        Ok(id)
+    }
+
+    fn push_quad(
+        &mut self,
+        segment_index: usize,
+        s: Self::Id,
+        p: Self::Id,
+        o: Self::Id,
+        g: Option<Self::Id>,
+    ) -> Result<(), Self::Error> {
+        self.ensure_scope(segment_index)?;
+        if self.cancelled {
+            return Ok(());
+        }
+        if self.sink.quad(EventQuad { s, p, o, g })? == ControlFlow::Break(()) {
+            self.cancelled = true;
+        }
+        Ok(())
+    }
+
+    fn push_reifier(
+        &mut self,
+        segment_index: usize,
+        reifier: Self::Id,
+        s: Self::Id,
+        p: Self::Id,
+        o: Self::Id,
+        g: Option<Self::Id>,
+    ) -> Result<(), Self::Error> {
+        self.ensure_scope(segment_index)?;
+        if self.cancelled {
+            return Ok(());
+        }
+        if g.is_some() {
+            return Err(EventError::message(
+                "graph-scoped reifier cannot be represented on the RdfEventSink protocol (no graph slot)",
+            ));
+        }
+        if self.sink.reifier(reifier, EventTriple { s, p, o })? == ControlFlow::Break(()) {
+            self.cancelled = true;
+        }
+        Ok(())
+    }
+
+    fn push_annotation(
+        &mut self,
+        segment_index: usize,
+        reifier: Self::Id,
+        p: Self::Id,
+        o: Self::Id,
+        g: Option<Self::Id>,
+    ) -> Result<(), Self::Error> {
+        self.ensure_scope(segment_index)?;
+        if self.cancelled {
+            return Ok(());
+        }
+        if g.is_some() {
+            return Err(EventError::message(
+                "graph-scoped annotation cannot be represented on the RdfEventSink protocol (no graph slot)",
+            ));
+        }
+        if self.sink.annotation(reifier, p, o)? == ControlFlow::Break(()) {
+            self.cancelled = true;
+        }
+        Ok(())
+    }
+
+    fn err_dangling_term(&self, segment_index: usize, gts_id: usize, role: &str) -> Self::Error {
+        EventError::message(format!(
+            "GTS dangling term reference: segment {segment_index} {role} names undeclared term id {gts_id}"
+        ))
+    }
+
+    fn err_nesting_limit(&self, segment_index: usize, gts_id: usize) -> Self::Error {
+        EventError::message(format!(
+            "GTS quoted-triple nesting limit exceeded resolving segment {segment_index} term id {gts_id}"
+        ))
+    }
+
+    fn err_unbound_triple(&self, segment_index: usize, gts_id: usize) -> Self::Error {
+        EventError::message(format!(
+            "GTS triple term has no reifier binding: segment {segment_index} term id {gts_id}"
+        ))
+    }
+
+    fn err_missing_reifier(&self, segment_index: usize, reifier: usize) -> Self::Error {
+        EventError::message(format!(
+            "GTS triple term references missing reifier {reifier} in segment {segment_index}"
+        ))
+    }
+
+    fn frame(&mut self, ctx: FrameContext<'_>) -> Result<(), Self::Error> {
+        self.cached = Some(CachedFrame {
+            segment_index: ctx.segment_index,
+            frame_index: ctx.frame_index,
+            content_id: ctx.content_id.to_vec(),
+            range: ctx.range.clone(),
+            frame_type: ctx.frame_type.to_owned(),
+            valid: ctx.valid,
+        });
+        if self.cancelled {
+            return Ok(());
+        }
+        if self.sink.frame(ctx)? == ControlFlow::Break(()) {
+            self.cancelled = true;
+        }
+        Ok(())
+    }
+
+    fn blob(
+        &mut self,
+        _segment_index: usize,
+        digest: &str,
+        meta: Option<&Value>,
+    ) -> Result<(), Self::Error> {
+        if self.cancelled {
+            return Ok(());
+        }
+        let ctx = self.cached.as_ref().map(CachedFrame::as_context);
+        if self.sink.blob(ctx, digest, meta)? == ControlFlow::Break(()) {
+            self.cancelled = true;
+        }
+        Ok(())
+    }
+
+    fn opaque(&mut self, _segment_index: usize, node: &OpaqueNode) -> Result<(), Self::Error> {
+        if self.cancelled {
+            return Ok(());
+        }
+        let ctx = self.cached.as_ref().map(CachedFrame::as_context);
+        if self.sink.opaque(ctx, node)? == ControlFlow::Break(()) {
+            self.cancelled = true;
+        }
+        Ok(())
+    }
+
+    fn signature(&mut self, _segment_index: usize, sig: &Signature) -> Result<(), Self::Error> {
+        if self.cancelled {
+            return Ok(());
+        }
+        let ctx = self.cached.as_ref().map(CachedFrame::as_context);
+        if self.sink.signature(ctx, sig)? == ControlFlow::Break(()) {
+            self.cancelled = true;
+        }
+        Ok(())
+    }
+
+    fn suppression(
+        &mut self,
+        _segment_index: usize,
+        suppression: &Suppression,
+    ) -> Result<(), Self::Error> {
+        if self.cancelled {
+            return Ok(());
+        }
+        let ctx = self.cached.as_ref().map(CachedFrame::as_context);
+        if self.sink.suppression(ctx, suppression)? == ControlFlow::Break(()) {
+            self.cancelled = true;
+        }
+        Ok(())
+    }
+
+    fn diagnostic(&mut self, diag: &Diagnostic) -> Result<(), Self::Error> {
+        if self.cancelled {
+            return Ok(());
+        }
+        // A frame-scoped diagnostic carries the cached frame provenance; a
+        // file-level diagnostic (e.g. `EmptyFile`) carries none.
+        let ctx = diag
+            .frame_index
+            .and(self.cached.as_ref())
+            .map(CachedFrame::as_context);
+        if self.sink.gts_diagnostic(ctx, diag)? == ControlFlow::Break(()) {
+            self.cancelled = true;
+        }
+        Ok(())
+    }
+
+    fn streamable_layout(
+        &mut self,
+        _segment_index: usize,
+        _info: &StreamableInfo,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+/// Drive a GTS file through the shared decode core into a [`GtsEventSink`].
+///
+/// Terms resolve in deterministic file order (segment-major, `gts_id`-sorted,
+/// inner-triple first); each mints a fresh [`EventTermId`], and each segment
+/// opens its own blank-node [`ScopeId`]. GTS-specific frames (blobs, opaque
+/// nodes, signatures, suppressions) and per-frame provenance reach the sink's
+/// GTS hooks; diagnostics reach [`GtsEventSink::gts_diagnostic`] and are also
+/// returned in the [`StreamingReadResult`].
+///
+/// A structural decode failure (a genuinely dangling term id, a graph-scoped
+/// reifier the protocol cannot carry, …) is returned as [`Err`] rather than
+/// swallowed. When any sink call returns [`ControlFlow::Break`] the drive stops
+/// emitting and, crucially, [`RdfEventSink::finish`] is NOT called — a cancelled
+/// drive is never finalized.
+///
+/// # Errors
+///
+/// Returns the first [`EventError`] raised while resolving or emitting the
+/// stream, or by finalizing the sink.
+pub fn stream_events(
+    data: &[u8],
+    options: ReadOptions<'_>,
+    sink: &mut dyn GtsEventSink,
+) -> Result<StreamingReadResult, EventError> {
+    let mut resolver = SegmentResolver::new(EventEmitter::new(sink));
+    let read_result = read_to_sink_with_options(data, options, &mut resolver);
+    if let Some(error) = resolver.take_error() {
+        return Err(error);
+    }
+    resolver.finish()?;
+    let mut emitter = resolver.into_sink();
+    emitter.close_open_scope()?;
+    if !emitter.cancelled {
+        emitter.sink.finish()?;
+    }
+    Ok(read_result)
+}

--- a/crates/gts/src/event_stream.rs
+++ b/crates/gts/src/event_stream.rs
@@ -219,6 +219,14 @@ impl<'s> EventEmitter<'s> {
         if self.current_segment == Some(segment_index) {
             return Ok(());
         }
+        // Genuine segment change: the shared decode core resolves and flushes
+        // one segment's terms in full (inner-triple first) before opening the
+        // next, so `iri_map` can never hold an IRI a later literal in THIS new
+        // segment still needs — every datatype IRI a literal references is
+        // (re-)interned within its own segment before that literal is emitted.
+        // Dropping the map here bounds `EventEmitter`'s retained memory to one
+        // segment's worth of IRIs (R8) instead of the whole file's.
+        self.iri_map.clear();
         if self.cancelled {
             self.current_segment = Some(segment_index);
             return Ok(());

--- a/crates/gts/src/lib.rs
+++ b/crates/gts/src/lib.rs
@@ -66,6 +66,7 @@ pub mod codec;
 pub mod compact;
 pub mod cose;
 pub mod dict;
+pub mod event_stream;
 // emojihash + randomart now live in the standalone `visual-hashing` crate;
 // re-exported here so `purrdf_gts::emojihash::…` paths keep resolving.
 pub use visual_hashing as emojihash;

--- a/crates/gts/src/lib.rs
+++ b/crates/gts/src/lib.rs
@@ -85,6 +85,7 @@ mod reader_layout;
 mod reader_rows;
 mod reader_union;
 pub mod replication;
+pub mod segment_decode;
 pub mod stream;
 pub mod tar;
 pub mod ulid;

--- a/crates/gts/src/model.rs
+++ b/crates/gts/src/model.rs
@@ -191,6 +191,28 @@ pub struct StreamableInfo {
     pub head: Option<Vec<u8>>,
 }
 
+/// Half-open byte range `[start, end)` into a GTS file, shared by the
+/// replication inventory and other byte-provenance callers.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ByteRange {
+    /// Start byte offset.
+    pub start: usize,
+    /// End byte offset, exclusive.
+    pub end: usize,
+}
+
+impl ByteRange {
+    /// Number of bytes spanned by this range.
+    pub fn len(&self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+
+    /// Whether this range spans zero bytes.
+    pub fn is_empty(&self) -> bool {
+        self.start >= self.end
+    }
+}
+
 /// One content-addressed blob entry in a folded graph.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BlobEntry {

--- a/crates/gts/src/reader.rs
+++ b/crates/gts/src/reader.rs
@@ -1304,33 +1304,53 @@ impl ActiveStreamingSegment {
             described,
             blob_events,
         };
-        // Owned provenance fields for the `sink.frame()` call fired below,
-        // once `folder` has released its borrow of `sink`.
-        let ctx_id: Vec<u8>;
-        let ctx_type: String;
-        let ctx_valid: bool;
+        // `sink.frame()` is fired for THIS frame before any of its rows are
+        // folded (the `StreamingSink::frame` contract), so index builders can
+        // attribute the rows that follow to this frame's provenance.
+        let range = ByteRange {
+            start: frame_start,
+            end: frame_end,
+        };
         if let Value::Map(frame) = raw {
             let stored_id: Option<&Vec<u8>> = match map_get(frame, "id") {
                 Some(Value::Bytes(b)) => Some(b),
                 _ => None,
             };
             let computed = content_id(frame);
+            let ftype = text_or(map_get(frame, "t"), "").to_string();
             if stored_id.map(|b| &b[..]) != Some(&computed[..]) {
+                let ctx_id = stored_id.cloned().unwrap_or_else(|| computed.clone());
+                folder.with_sink(|segment_index, sink| {
+                    sink.frame(FrameContext {
+                        segment_index,
+                        frame_index,
+                        content_id: &ctx_id,
+                        range,
+                        frame_type: &ftype,
+                        valid: false,
+                    });
+                });
                 folder.diag(
                     "DamagedFrame",
                     "frame self-hash mismatch".to_string(),
                     Some(abs_index),
                 );
-                let ftype = text_or(map_get(frame, "t"), "").to_string();
                 folder.opaque(frame, &ftype, "damaged");
                 self.expected_prev = stored_id.cloned().unwrap_or(computed);
                 self.frame_ids.push(self.expected_prev.clone());
-                ctx_id = self.expected_prev.clone();
-                ctx_type = ftype;
-                ctx_valid = false;
             } else {
                 let prev_ok = matches!(map_get(frame, "prev"),
                     Some(Value::Bytes(b)) if *b == self.expected_prev);
+                folder.with_sink(|segment_index, sink| {
+                    sink.frame(FrameContext {
+                        segment_index,
+                        frame_index,
+                        content_id: &computed,
+                        range,
+                        frame_type: &ftype,
+                        valid: prev_ok,
+                    });
+                });
                 if !prev_ok {
                     folder.diag(
                         "BrokenChain",
@@ -1352,46 +1372,35 @@ impl ActiveStreamingSegment {
                         cose,
                     });
                 }
-                let ftype = text_or(map_get(frame, "t"), "").to_string();
                 folder.fold_frame(frame, abs_index);
-                ctx_id = computed;
-                ctx_type = ftype;
-                ctx_valid = prev_ok;
             }
         } else {
+            folder.with_sink(|segment_index, sink| {
+                sink.frame(FrameContext {
+                    segment_index,
+                    frame_index,
+                    content_id: &[],
+                    range,
+                    frame_type: "<non-map>",
+                    valid: false,
+                });
+            });
             folder.diag(
                 "DamagedFrame",
                 "frame is not a map".to_string(),
                 Some(abs_index),
             );
             self.frame_ids.push(Vec::new());
-            ctx_id = Vec::new();
-            ctx_type = "<non-map>".to_string();
-            ctx_valid = false;
         }
         let catalog = std::mem::take(&mut folder.catalog);
         let index_records = std::mem::take(&mut folder.index_records);
         let described = std::mem::take(&mut folder.described);
         let blob_events = std::mem::take(&mut folder.blob_events);
-        let restored_sink = folder.sink.take();
         drop(folder);
         self.catalog = catalog;
         self.index_records = index_records;
         self.described = described;
         self.blob_events = blob_events;
-        if let Some(sink) = restored_sink {
-            sink.frame(FrameContext {
-                segment_index: self.segment_index,
-                frame_index,
-                content_id: &ctx_id,
-                range: ByteRange {
-                    start: frame_start,
-                    end: frame_end,
-                },
-                frame_type: &ctx_type,
-                valid: ctx_valid,
-            });
-        }
     }
 
     fn finish_into_result(

--- a/crates/gts/src/reader.rs
+++ b/crates/gts/src/reader.rs
@@ -18,8 +18,8 @@ use ciborium::value::Value;
 
 use crate::codec::{Codec, CodecError, decode_chain, decode_chain_with_decrypt};
 use crate::model::{
-    AnnotationRow, Diagnostic, Graph, OpaqueNode, Quad, ReifierRow, Signature, StreamableInfo,
-    Suppression, Term, TermKind, Triple3,
+    AnnotationRow, ByteRange, Diagnostic, Graph, OpaqueNode, Quad, ReifierRow, Signature,
+    StreamableInfo, Suppression, Term, TermKind, Triple3,
 };
 use crate::reader_layout::{IndexRecord, check_index_mmr, layout_check};
 use crate::reader_rows::{
@@ -181,6 +181,49 @@ pub struct StreamingReadResult {
     pub torn: Option<usize>,
 }
 
+/// Physical provenance of one streamed frame: where its bytes live and what it
+/// hashes to.
+///
+/// Fired once per frame by [`read_to_sink_from_reader`] (and its callers)
+/// before that frame's rows are folded, so index builders can record byte
+/// offsets without re-parsing the source. The field semantics mirror
+/// `replication::FrameInventory`, the offline equivalent computed from a
+/// fully-buffered file.
+#[derive(Clone, Debug)]
+pub struct FrameContext<'a> {
+    /// Zero-based segment index.
+    pub segment_index: usize,
+    /// Zero-based frame index within the segment (excludes the header).
+    pub frame_index: usize,
+    /// Frame content-id: the stored `"id"` when present and self-hash-valid,
+    /// else the recomputed id; empty for a non-map placeholder frame.
+    pub content_id: &'a [u8],
+    /// `[start, end)` byte range of this frame in the source.
+    pub range: ByteRange,
+    /// Wire `"t"` value; `"<non-map>"` for a non-map placeholder frame.
+    pub frame_type: &'a str,
+    /// True when both the id self-hash and the `prev`-chain link hold.
+    pub valid: bool,
+}
+
+impl FrameContext<'_> {
+    /// Recompute the content-id over `source[range]` and compare it to
+    /// [`Self::content_id`].
+    ///
+    /// Returns `false` when the range is out of bounds, the bytes fail to
+    /// decode as CBOR, or the decoded value is not a map — a damaged frame
+    /// never verifies.
+    pub fn verify(&self, source: &[u8]) -> bool {
+        let Some(bytes) = source.get(self.range.start..self.range.end) else {
+            return false;
+        };
+        let Ok(Value::Map(map)) = ciborium::de::from_reader::<Value, _>(bytes) else {
+            return false;
+        };
+        content_id(&map) == self.content_id
+    }
+}
+
 /// Sink for [`read_to_sink`] events.
 ///
 /// Term ids in events are segment-local ids. A sink that needs a file-level
@@ -188,6 +231,8 @@ pub struct StreamingReadResult {
 /// project rows into a table can usually consume the segment-local ids directly
 /// with the segment index as the scope.
 pub trait StreamingSink {
+    /// Per-frame provenance, fired once per frame before its rows are processed.
+    fn frame(&mut self, _ctx: FrameContext<'_>) {}
     /// Accepted term row.
     fn term(&mut self, _segment_index: usize, _term_id: usize, _term: &Term) {}
     /// Accepted quad row.
@@ -1123,10 +1168,10 @@ impl<R: Read> Read for StreamingCountingReader<R> {
 
 fn next_stream_item<R: Read>(
     reader: &mut StreamingCountingReader<R>,
-) -> Result<Option<Value>, usize> {
+) -> Result<Option<(Value, usize, usize)>, usize> {
     let start = reader.pos;
     match ciborium::de::from_reader::<Value, _>(&mut *reader) {
-        Ok(item) => Ok(Some(item)),
+        Ok(item) => Ok(Some((item, start, reader.pos))),
         Err(_) if reader.pos == start => Ok(None),
         Err(_) => Err(start),
     }
@@ -1232,12 +1277,18 @@ impl ActiveStreamingSegment {
         &mut self,
         raw: &Value,
         abs_index: usize,
+        frame_start: usize,
+        frame_end: usize,
         sink: &mut dyn StreamingSink,
         content_key: Option<&'k ContentKeyResolver<'k>>,
     ) {
         if !self.valid_header {
             return;
         }
+        // Captured before any push below — the zero-based index of THIS
+        // frame within the segment (mirrors `collect_frames` in
+        // `replication.rs`).
+        let frame_index = self.frame_ids.len();
         let catalog = std::mem::take(&mut self.catalog);
         let index_records = std::mem::take(&mut self.index_records);
         let described = std::mem::take(&mut self.described);
@@ -1253,6 +1304,11 @@ impl ActiveStreamingSegment {
             described,
             blob_events,
         };
+        // Owned provenance fields for the `sink.frame()` call fired below,
+        // once `folder` has released its borrow of `sink`.
+        let ctx_id: Vec<u8>;
+        let ctx_type: String;
+        let ctx_valid: bool;
         if let Value::Map(frame) = raw {
             let stored_id: Option<&Vec<u8>> = match map_get(frame, "id") {
                 Some(Value::Bytes(b)) => Some(b),
@@ -1269,6 +1325,9 @@ impl ActiveStreamingSegment {
                 folder.opaque(frame, &ftype, "damaged");
                 self.expected_prev = stored_id.cloned().unwrap_or(computed);
                 self.frame_ids.push(self.expected_prev.clone());
+                ctx_id = self.expected_prev.clone();
+                ctx_type = ftype;
+                ctx_valid = false;
             } else {
                 let prev_ok = matches!(map_get(frame, "prev"),
                     Some(Value::Bytes(b)) if *b == self.expected_prev);
@@ -1287,13 +1346,17 @@ impl ActiveStreamingSegment {
                         _ => ("invalid", None),
                     };
                     folder.push_signature(Signature {
-                        frame_id: computed,
+                        frame_id: computed.clone(),
                         kid: None,
                         status: status.to_string(),
                         cose,
                     });
                 }
+                let ftype = text_or(map_get(frame, "t"), "").to_string();
                 folder.fold_frame(frame, abs_index);
+                ctx_id = computed;
+                ctx_type = ftype;
+                ctx_valid = prev_ok;
             }
         } else {
             folder.diag(
@@ -1302,16 +1365,33 @@ impl ActiveStreamingSegment {
                 Some(abs_index),
             );
             self.frame_ids.push(Vec::new());
+            ctx_id = Vec::new();
+            ctx_type = "<non-map>".to_string();
+            ctx_valid = false;
         }
         let catalog = std::mem::take(&mut folder.catalog);
         let index_records = std::mem::take(&mut folder.index_records);
         let described = std::mem::take(&mut folder.described);
         let blob_events = std::mem::take(&mut folder.blob_events);
+        let restored_sink = folder.sink.take();
         drop(folder);
         self.catalog = catalog;
         self.index_records = index_records;
         self.described = described;
         self.blob_events = blob_events;
+        if let Some(sink) = restored_sink {
+            sink.frame(FrameContext {
+                segment_index: self.segment_index,
+                frame_index,
+                content_id: &ctx_id,
+                range: ByteRange {
+                    start: frame_start,
+                    end: frame_end,
+                },
+                frame_type: &ctx_type,
+                valid: ctx_valid,
+            });
+        }
     }
 
     fn finish_into_result(
@@ -1377,7 +1457,7 @@ pub fn read_to_sink_from_reader<R: Read>(
     let mut item_index = 0usize;
     let mut current: Option<ActiveStreamingSegment> = None;
     loop {
-        let item = match next_stream_item(&mut reader) {
+        let (item, frame_start, frame_end) = match next_stream_item(&mut reader) {
             Ok(Some(item)) => item,
             Ok(None) => break,
             Err(torn) => {
@@ -1424,7 +1504,14 @@ pub fn read_to_sink_from_reader<R: Read>(
                 sink,
             ));
         } else if let Some(segment) = current.as_mut() {
-            segment.process_frame(&item, item_index, sink, options.content_key);
+            segment.process_frame(
+                &item,
+                item_index,
+                frame_start,
+                frame_end,
+                sink,
+                options.content_key,
+            );
         } else {
             push_result_diagnostic(
                 &mut result,

--- a/crates/gts/src/replication.rs
+++ b/crates/gts/src/replication.rs
@@ -9,8 +9,8 @@
 
 use ciborium::value::Value;
 
-use crate::model::{Diagnostic, StreamableInfo};
 pub use crate::model::ByteRange;
+use crate::model::{Diagnostic, StreamableInfo};
 use crate::reader::read_file_segments;
 use crate::wire::{
     blake3_256, canonical, content_id, header_id, hex, iter_items, map_get, unwrap_header,
@@ -120,7 +120,7 @@ impl Inventory {
                 .any(|segment| !segment.diagnostics.is_empty())
     }
 
-    fn problem_detail(&self) -> Option<String> {
+    pub(crate) fn problem_detail(&self) -> Option<String> {
         if let Some(fatal) = &self.fatal {
             return Some(format!("{}: {}", fatal.code, fatal.detail));
         }
@@ -485,6 +485,25 @@ pub fn segments_json(inventory: &Inventory) -> String {
     )
 }
 
+/// Locate the first valid frame carrying `id`, scanning segments and their
+/// frames in file order.
+///
+/// Returns the `(segment_index, frame_index)` pair, suitable for indexing
+/// back into [`Inventory::segments`] and [`SegmentInventory::frames`].
+/// Invalid frames (failed id or `prev` chain checks) are skipped, matching
+/// the trust rule used throughout this module: only a validated chain
+/// position counts as a known head.
+fn find_frame(inventory: &Inventory, id: &[u8]) -> Option<(usize, usize)> {
+    for segment in &inventory.segments {
+        for frame in &segment.frames {
+            if frame.valid && frame.id.as_slice() == id {
+                return Some((segment.index, frame.frame_index));
+            }
+        }
+    }
+    None
+}
+
 /// Compute the byte ranges a peer at `from_head` is missing from this inventory.
 ///
 /// `from_head` may name a segment head or any valid frame id; an unknown head
@@ -525,29 +544,28 @@ pub fn missing(inventory: &Inventory, from_head: &[u8]) -> MissingResult {
                 detail: None,
             };
         }
-        for frame in &segment.frames {
-            if frame.valid && frame.id.as_slice() == from_head {
-                let ranges = if frame.end < inventory.clean_end {
-                    vec![ByteRange {
-                        start: frame.end,
-                        end: inventory.clean_end,
-                    }]
-                } else {
-                    Vec::new()
-                };
-                return MissingResult {
-                    status: if ranges.is_empty() {
-                        MissingStatus::Complete
-                    } else {
-                        MissingStatus::Ranges
-                    },
-                    from_head: from_head.to_vec(),
-                    ranges,
-                    scan_required: false,
-                    detail: None,
-                };
-            }
-        }
+    }
+    if let Some((segment_index, frame_index)) = find_frame(inventory, from_head) {
+        let frame = &inventory.segments[segment_index].frames[frame_index];
+        let ranges = if frame.end < inventory.clean_end {
+            vec![ByteRange {
+                start: frame.end,
+                end: inventory.clean_end,
+            }]
+        } else {
+            Vec::new()
+        };
+        return MissingResult {
+            status: if ranges.is_empty() {
+                MissingStatus::Complete
+            } else {
+                MissingStatus::Ranges
+            },
+            from_head: from_head.to_vec(),
+            ranges,
+            scan_required: false,
+            detail: None,
+        };
     }
     MissingResult {
         status: MissingStatus::Unknown,
@@ -607,6 +625,378 @@ pub fn resume_after<'a>(data: &'a [u8], frame_id: &[u8]) -> Result<&'a [u8], Str
         }
     }
     Err(format!("frame {} not found", hex(frame_id)))
+}
+
+/// Outcome category for a two-file replication [`diff`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DiffStatus {
+    /// Local already matches remote through their common prefix; nothing to fetch.
+    Current,
+    /// Remote linearly extends local; `DiffResult::fetch` names the ranges that reconstruct it.
+    Fetch,
+    /// Local and remote disagree on content; remote is not a linear extension of local.
+    Diverged,
+    /// One or both inventories are not trustworthy enough to diff.
+    Error,
+}
+
+/// One remote byte range to retrieve in order to extend local toward remote.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SegmentFetch {
+    /// Index of the segment in the *remote* inventory that this range covers.
+    pub remote_index: usize,
+    /// Byte range within the remote file to copy.
+    pub range: ByteRange,
+    /// Remote segment head, when known.
+    pub head: Option<Vec<u8>>,
+}
+
+/// Result of comparing a local inventory against a remote inventory.
+#[derive(Clone, Debug)]
+pub struct DiffResult {
+    /// High-level outcome category.
+    pub status: DiffStatus,
+    /// Remote byte ranges to fetch, ordered by `remote_index` (file order).
+    pub fetch: Vec<SegmentFetch>,
+    /// Byte offset in the *local* file where the fetched suffix is appended.
+    ///
+    /// `None` when the result cannot be spliced (`Diverged`/`Error`).
+    pub splice_offset: Option<usize>,
+    /// True when the fetch (if any) forms an unbroken extension of local.
+    pub continuous: bool,
+    /// Human-readable explanation, set for `Diverged` and `Error`.
+    pub detail: Option<String>,
+}
+
+/// Index of the first frame at which `local_frames` stops being a prefix of
+/// `remote_frames`, comparing frame identity only.
+fn frames_id_mismatch(
+    local_frames: &[FrameInventory],
+    remote_frames: &[FrameInventory],
+) -> Option<usize> {
+    local_frames
+        .iter()
+        .zip(remote_frames.iter())
+        .position(|(local, remote)| local.id != remote.id)
+}
+
+/// Whether `inventory` is problematic enough to refuse diffing.
+///
+/// A wholly empty byte stream (`inventory(&[])`) reports a fatal `EmptyFile`
+/// diagnostic so other callers can flag "nothing decoded here" — but for a
+/// two-file diff, a genuinely empty local or remote is a valid trivial
+/// starting point (the empty-local "fetch everything" case), not a defect
+/// worth erroring out on. Any other fatal, torn, or per-segment diagnostic
+/// still refuses the diff.
+fn is_diff_problem(inventory: &Inventory) -> bool {
+    let trivially_empty =
+        inventory.segments.is_empty() && inventory.item_count == 0 && inventory.torn.is_none();
+    !trivially_empty && inventory.has_problems()
+}
+
+/// Compare `local` against `remote` and describe how to extend local to match it.
+///
+/// Continuity is judged primarily by segment-head *prefix* equality: GTS
+/// segments are independently rooted, so a whole-segment append's first
+/// frame chains onto its own segment header, not onto local's head. Frame
+/// `prev` chaining is only consulted when the trailing segment itself is
+/// being extended with more frames (a mid-segment cat-append).
+pub fn diff(local: &Inventory, remote: &Inventory) -> DiffResult {
+    let local_problem = is_diff_problem(local);
+    let remote_problem = is_diff_problem(remote);
+    if local_problem || remote_problem {
+        let mut details = Vec::new();
+        if local_problem {
+            details.push(format!(
+                "local: {}",
+                local
+                    .problem_detail()
+                    .unwrap_or_else(|| "unknown problem".to_string())
+            ));
+        }
+        if remote_problem {
+            details.push(format!(
+                "remote: {}",
+                remote
+                    .problem_detail()
+                    .unwrap_or_else(|| "unknown problem".to_string())
+            ));
+        }
+        return DiffResult {
+            status: DiffStatus::Error,
+            fetch: Vec::new(),
+            splice_offset: None,
+            continuous: false,
+            detail: Some(details.join("; ")),
+        };
+    }
+
+    // Largest k such that local.segments[..k] and remote.segments[..k] share
+    // byte-identical, byte-aligned segments (matching heads at matching offsets).
+    let limit = local.segments.len().min(remote.segments.len());
+    let mut k = 0usize;
+    for i in 0..limit {
+        let local_segment = &local.segments[i];
+        let remote_segment = &remote.segments[i];
+        match (&local_segment.head, &remote_segment.head) {
+            (Some(local_head), Some(remote_head)) if local_head == remote_head => {
+                let aligned = local_segment.start == remote_segment.start
+                    && local_segment.end - local_segment.start
+                        == remote_segment.end - remote_segment.start;
+                if aligned {
+                    k += 1;
+                } else {
+                    return DiffResult {
+                        status: DiffStatus::Diverged,
+                        fetch: Vec::new(),
+                        splice_offset: None,
+                        continuous: false,
+                        detail: Some(format!(
+                            "segment {i} heads match but byte ranges diverge (local \
+                             {ls}..{le}, remote {rs}..{re}); likely a re-encoded mirror",
+                            ls = local_segment.start,
+                            le = local_segment.end,
+                            rs = remote_segment.start,
+                            re = remote_segment.end,
+                        )),
+                    };
+                }
+            }
+            _ => break,
+        }
+    }
+
+    if k == local.segments.len() && k == remote.segments.len() {
+        return DiffResult {
+            status: DiffStatus::Current,
+            fetch: Vec::new(),
+            splice_offset: Some(local.clean_end),
+            continuous: true,
+            detail: None,
+        };
+    }
+
+    if k == local.segments.len() {
+        // remote.segments.len() > k: remote appended one or more whole segments.
+        let fetch: Vec<SegmentFetch> = remote.segments[k..]
+            .iter()
+            .map(|segment| SegmentFetch {
+                remote_index: segment.index,
+                range: ByteRange {
+                    start: segment.start,
+                    end: segment.end,
+                },
+                head: segment.head.clone(),
+            })
+            .collect();
+        return DiffResult {
+            status: DiffStatus::Fetch,
+            fetch,
+            splice_offset: Some(local.clean_end),
+            continuous: true,
+            detail: None,
+        };
+    }
+
+    if k == remote.segments.len() {
+        // remote.segments.len() < local.segments.len(): remote is behind local.
+        return DiffResult {
+            status: DiffStatus::Current,
+            fetch: Vec::new(),
+            splice_offset: Some(local.clean_end),
+            continuous: true,
+            detail: None,
+        };
+    }
+
+    // k < local.segments.len() && k < remote.segments.len(): the segments at
+    // index k disagree. The only continuous shape is a mid-segment
+    // cat-append onto local's own last (and only divergent) segment.
+    if local.segments.len() != k + 1 {
+        return DiffResult {
+            status: DiffStatus::Diverged,
+            fetch: Vec::new(),
+            splice_offset: None,
+            continuous: false,
+            detail: Some(format!(
+                "local has {extra} segment(s) beyond the common prefix at segment {k}; \
+                 only local's own last segment may be a partial extension",
+                extra = local.segments.len() - (k + 1),
+            )),
+        };
+    }
+
+    let local_segment = &local.segments[k];
+    let remote_segment = &remote.segments[k];
+    let local_frames = &local_segment.frames;
+    let remote_frames = &remote_segment.frames;
+
+    // The overlap must match by content first: if this segment's head
+    // differed at index k (that's how we got here), and the overlapping
+    // frame ids are equal length and identical, the only remaining
+    // possibility is that identical frame content sits under a differently
+    // encoded header (a re-encoded mirror) — never a genuine linear
+    // extension. Checking the id prefix before the length shortcut keeps a
+    // same-length fork (equal frame counts, different content) from being
+    // misread as "local already ahead".
+    if let Some(mismatch) = frames_id_mismatch(local_frames, remote_frames) {
+        return DiffResult {
+            status: DiffStatus::Diverged,
+            fetch: Vec::new(),
+            splice_offset: None,
+            continuous: false,
+            detail: Some(format!(
+                "segment {k} frame {mismatch} id diverges from remote's frame at the same index"
+            )),
+        };
+    }
+
+    if local_frames.len() >= remote_frames.len() {
+        // Local already has at least as many frames in this segment and the
+        // overlapping ids agree, so remote has nothing new here.
+        return DiffResult {
+            status: DiffStatus::Current,
+            fetch: Vec::new(),
+            splice_offset: Some(local.clean_end),
+            continuous: true,
+            detail: None,
+        };
+    }
+
+    let first_new = &remote_frames[local_frames.len()];
+    let chained = match local_frames.len().checked_sub(1) {
+        Some(last_local_frame) => first_new
+            .prev
+            .as_deref()
+            .is_some_and(|prev| find_frame(local, prev) == Some((k, last_local_frame))),
+        None => first_new.prev.as_deref() == local_segment.head.as_deref(),
+    };
+
+    if first_new.valid && chained {
+        DiffResult {
+            status: DiffStatus::Fetch,
+            fetch: vec![SegmentFetch {
+                remote_index: remote_segment.index,
+                range: ByteRange {
+                    start: local.clean_end,
+                    end: remote.clean_end,
+                },
+                head: remote_segment.head.clone(),
+            }],
+            splice_offset: Some(local.clean_end),
+            continuous: true,
+            detail: None,
+        }
+    } else {
+        DiffResult {
+            status: DiffStatus::Diverged,
+            fetch: Vec::new(),
+            splice_offset: None,
+            continuous: false,
+            detail: Some(format!(
+                "segment {k}'s first new remote frame does not chain onto local's head; possible fork"
+            )),
+        }
+    }
+}
+
+/// Reconstruct bytes by applying a [`diff`] result's fetch list onto `local_bytes`.
+///
+/// # Errors
+///
+/// Returns an error when `result.status` is [`DiffStatus::Diverged`] or
+/// [`DiffStatus::Error`], when a fetch range falls outside `remote_bytes`,
+/// or when the spliced (or unchanged) output is not itself a clean
+/// inventory.
+pub fn splice(
+    local_bytes: &[u8],
+    remote_bytes: &[u8],
+    result: &DiffResult,
+) -> Result<Vec<u8>, String> {
+    if matches!(result.status, DiffStatus::Diverged | DiffStatus::Error) {
+        return Err(result
+            .detail
+            .clone()
+            .unwrap_or_else(|| "diff result cannot be spliced".to_string()));
+    }
+
+    if result.fetch.is_empty() {
+        let rebuilt = inventory(local_bytes);
+        if rebuilt.has_problems() {
+            return Err(rebuilt
+                .problem_detail()
+                .unwrap_or_else(|| "local bytes are not a clean inventory".to_string()));
+        }
+        return Ok(local_bytes.to_vec());
+    }
+
+    let offset = result
+        .splice_offset
+        .ok_or_else(|| "diff result has no splice offset".to_string())?;
+    if offset > local_bytes.len() {
+        return Err(format!(
+            "splice offset {offset} exceeds local length {}",
+            local_bytes.len()
+        ));
+    }
+
+    let mut out = local_bytes[..offset].to_vec();
+    for fetch in &result.fetch {
+        let start = fetch.range.start;
+        let end = fetch.range.end;
+        if start > end || end > remote_bytes.len() {
+            return Err(format!(
+                "fetch range {start}..{end} exceeds remote length {}",
+                remote_bytes.len()
+            ));
+        }
+        out.extend_from_slice(&remote_bytes[start..end]);
+    }
+
+    let rebuilt = inventory(&out);
+    if rebuilt.has_problems() {
+        return Err(rebuilt
+            .problem_detail()
+            .unwrap_or_else(|| "spliced bytes are not a clean inventory".to_string()));
+    }
+    Ok(out)
+}
+
+/// Render a [`diff`] result as `gts-replication-diff-v1` JSON.
+pub fn diff_json(result: &DiffResult) -> String {
+    let status = match result.status {
+        DiffStatus::Current => "current",
+        DiffStatus::Fetch => "fetch",
+        DiffStatus::Diverged => "diverged",
+        DiffStatus::Error => "error",
+    };
+    let fetch = result
+        .fetch
+        .iter()
+        .map(|f| {
+            format!(
+                "{{\"remote_index\":{},\"range\":{},\"head\":{}}}",
+                f.remote_index,
+                range_json(&f.range),
+                json_optional_hex(f.head.as_deref())
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "{{\"schema\":\"gts-replication-diff-v1\",\"status\":{},\"fetch\":[{}],\
+         \"splice_offset\":{},\"continuous\":{},\"detail\":{}}}\n",
+        json_string(status),
+        fetch,
+        result
+            .splice_offset
+            .map_or_else(|| "null".to_string(), |offset| offset.to_string()),
+        result.continuous,
+        result
+            .detail
+            .as_deref()
+            .map_or_else(|| "null".to_string(), json_string)
+    )
 }
 
 #[cfg(test)]

--- a/crates/gts/src/replication.rs
+++ b/crates/gts/src/replication.rs
@@ -10,6 +10,7 @@
 use ciborium::value::Value;
 
 use crate::model::{Diagnostic, StreamableInfo};
+pub use crate::model::ByteRange;
 use crate::reader::read_file_segments;
 use crate::wire::{
     blake3_256, canonical, content_id, header_id, hex, iter_items, map_get, unwrap_header,
@@ -32,6 +33,10 @@ pub struct FrameInventory {
     pub frame_type: String,
     /// True when both self-id and `prev` chain checks passed for this frame.
     pub valid: bool,
+    /// Stored `prev` chain-link bytes the frame claims to chain onto.
+    ///
+    /// `None` for header-derived seed frames and non-map placeholder frames.
+    pub prev: Option<Vec<u8>>,
 }
 
 /// Inventory for one segment in a possibly concatenated GTS file.
@@ -74,15 +79,6 @@ pub struct Inventory {
     pub clean_end: usize,
     /// Number of complete CBOR items parsed before any torn append.
     pub item_count: usize,
-}
-
-/// Half-open byte range `[start, end)` needed to resume replication.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ByteRange {
-    /// Start byte offset.
-    pub start: usize,
-    /// End byte offset, exclusive.
-    pub end: usize,
 }
 
 /// Result category for a replication missing-range query.
@@ -212,6 +208,7 @@ fn collect_frames(
                 id: Vec::new(),
                 frame_type: "<non-map>".to_string(),
                 valid: false,
+                prev: None,
             });
             continue;
         };
@@ -226,8 +223,11 @@ fn collect_frames(
         // Replication uses the same id/prev chain invariant as the reader, but
         // keeps scanning so callers can still identify byte ranges around bad
         // frames.
-        let prev_ok =
-            matches!(map_get(frame, "prev"), Some(Value::Bytes(prev)) if prev == &expected_prev);
+        let stored_prev = match map_get(frame, "prev") {
+            Some(Value::Bytes(prev)) => Some(prev.clone()),
+            _ => None,
+        };
+        let prev_ok = stored_prev.as_deref() == Some(expected_prev.as_slice());
         let id = stored_id.clone().unwrap_or_else(|| computed.clone());
         expected_prev = stored_id.unwrap_or(computed);
         frames.push(FrameInventory {
@@ -241,6 +241,7 @@ fn collect_frames(
                 .unwrap_or("<unknown>")
                 .to_string(),
             valid: id_ok && prev_ok,
+            prev: stored_prev,
         });
     }
     frames

--- a/crates/gts/src/segment_decode.rs
+++ b/crates/gts/src/segment_decode.rs
@@ -274,6 +274,7 @@ impl<S: ResolvedSink> std::fmt::Debug for SegmentResolver<S> {
             .field("buffered_reifiers", &self.raw_reifiers.len())
             .field("buffered_annotations", &self.raw_annotations.len())
             .field("buffered_remaps", &self.remaps.len())
+            .field("buffered_reifier_bindings", &self.reifier_bindings.len())
             .field("current_segment", &self.current_segment)
             .field("has_error", &self.error.is_some())
             .finish_non_exhaustive()
@@ -314,6 +315,27 @@ impl<S: ResolvedSink> SegmentResolver<S> {
     /// Take the first latched streaming error, if any.
     pub fn take_error(&mut self) -> Option<S::Error> {
         self.error.take()
+    }
+
+    /// Count of the per-segment reifier→triple binding map currently
+    /// retained (see the `reifier_bindings` field doc). This is populated as
+    /// `reifier` events for the CURRENTLY OPEN segment stream in, and is `0`
+    /// immediately after every [`Self::resolve_buffered`] flush — so reading
+    /// it right after a segment has flushed (e.g. on the first event of the
+    /// next segment, or after [`Self::finish`]) is bounded by a single
+    /// segment's own reifier cardinality, never by the sum across every
+    /// segment already flushed. Exposed for tests asserting the
+    /// bounded-memory contract (GTS-SPEC §7.7) from outside the crate.
+    pub fn buffered_reifier_binding_count(&self) -> usize {
+        self.reifier_bindings.len()
+    }
+
+    /// Count of the per-segment gts-id → target-id remap memo currently
+    /// retained (see the `remaps` field doc). Same bound as
+    /// [`Self::buffered_reifier_binding_count`]: `0` immediately after every
+    /// segment flush.
+    pub fn buffered_remap_count(&self) -> usize {
+        self.remaps.len()
     }
 
     /// Flush the final buffered segment, resolving its terms and pushing its

--- a/crates/gts/src/segment_decode.rs
+++ b/crates/gts/src/segment_decode.rs
@@ -51,14 +51,19 @@
 //! or reifier binding — one still unresolved after ALL of a segment's events are
 //! seen — is an [`Err`], never a silent skip.
 
-use std::collections::HashMap;
-
 use ciborium::value::Value;
 
 use crate::model::{
     Diagnostic, OpaqueNode, Quad, Signature, StreamableInfo, Suppression, Term, TermKind, Triple3,
 };
 use crate::reader::{FrameContext, StreamingSink};
+
+/// A [`std::collections::HashMap`] keyed by the workspace's fixed-key `ahash`
+/// policy (`crates/rdf-core/src/hash.rs`'s `FastHasher`) — no runtime RNG
+/// seeding, so it stays wasm-clean. Iteration order is unspecified; every
+/// order-sensitive read here goes through an explicit sort, never hash order.
+type FastMap<K, V> =
+    std::collections::HashMap<K, V, core::hash::BuildHasherDefault<ahash::AHasher>>;
 
 /// Depth bound for resolving nested quoted-triple terms. A cyclic or absurdly
 /// nested triple term hard-fails rather than recursing without bound. Mirrors
@@ -241,18 +246,18 @@ pub struct SegmentResolver<S: ResolvedSink> {
     sink: S,
     /// RAW per-segment terms buffered during the streaming phase, keyed by
     /// `(segment_index, gts_id)`, resolved and drained at segment close.
-    raw_terms: HashMap<(usize, usize), Term>,
+    raw_terms: FastMap<(usize, usize), Term>,
     /// Per-segment memo from `(segment_index, gts_id)` to the target id,
     /// populated as the currently buffered segment's terms resolve (so a term
     /// referenced twice — e.g. as both a quad subject and a reifier subject —
     /// interns once) and cleared at the end of [`Self::resolve_buffered`]:
     /// segment-local ids never cross a segment boundary, so retaining this
     /// past segment close would grow it O(total terms across ALL segments).
-    remaps: HashMap<(usize, usize), S::Id>,
+    remaps: FastMap<(usize, usize), S::Id>,
     /// Per-segment reifier bindings `(segment_index, reifier) → (s, p, o)` gts
     /// ids, recorded from `reifier` events so a Triple term (any order) can
     /// recover its components.
-    reifier_bindings: HashMap<(usize, usize), Triple3>,
+    reifier_bindings: FastMap<(usize, usize), Triple3>,
     /// RAW quad rows `(segment_index, (s, p, o, g) gts ids)`.
     raw_quads: Vec<(usize, Quad)>,
     /// RAW reifier rows `(segment_index, reifier, (s, p, o), graph?)`.
@@ -286,9 +291,9 @@ impl<S: ResolvedSink> SegmentResolver<S> {
     pub fn new(sink: S) -> Self {
         Self {
             sink,
-            raw_terms: HashMap::new(),
-            remaps: HashMap::new(),
-            reifier_bindings: HashMap::new(),
+            raw_terms: FastMap::default(),
+            remaps: FastMap::default(),
+            reifier_bindings: FastMap::default(),
             raw_quads: Vec::new(),
             raw_reifiers: Vec::new(),
             raw_annotations: Vec::new(),

--- a/crates/gts/src/segment_decode.rs
+++ b/crates/gts/src/segment_decode.rs
@@ -1,0 +1,649 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Target-agnostic GTS segment decode + two-phase resolution core.
+//!
+//! Folding GTS events into an id-carrying model has two hazards that any
+//! consumer must handle identically:
+//!
+//! 1. **Per-segment scope.** `reader::read` folds every segment into one
+//!    append-order term table, which destroys per-segment blank-node scope (the
+//!    same `_:b1` label in two segments names two *different* nodes). Only the
+//!    [`StreamingSink`] callbacks preserve segment identity — each carries a
+//!    `segment_index`.
+//! 2. **Event-order independence.** `writer::Writer::deterministic` emits frames
+//!    in the order `terms → quads → reifies → annot`. A quoted-triple `Term`
+//!    therefore arrives (in the `terms` frame) carrying only its `reifier` id —
+//!    the `reifies` frame that binds that reifier to the triple's `(s, p, o)`
+//!    arrives **later**. A single-pass fold that resolves a triple term the
+//!    instant its `term` event fires cannot succeed.
+//!
+//! [`SegmentResolver`] owns that hazard-handling once, generic over an emit
+//! target ([`ResolvedSink`]). It buffers each segment's raw term / quad /
+//! reifier / annotation rows, then runs a **two-phase** resolution:
+//!
+//! 1. **Streaming phase** ([`StreamingSink`] callbacks): record RAW per-segment
+//!    descriptors keyed by `(segment_index, gts_id)`; forward every non-RDF
+//!    event straight through to the target.
+//! 2. **Resolution phase** (per-segment flush, see below): resolve each gts term
+//!    to a target id — non-triple terms intern directly; triple terms resolve
+//!    their now-complete `(s, p, o)` recursively, inner-first, depth-bounded by
+//!    [`MAX_GTS_TERM_NESTING_DEPTH`] — then push the raw quad / reifier /
+//!    annotation rows through the per-segment remap.
+//!
+//! # Memory model — resolve per-segment at close
+//!
+//! GTS term ids are segment-local and no resolution ever crosses a segment
+//! (reifier bindings, datatype ids, and triple components are all
+//! within-segment), and the streaming reader delivers every event of segment
+//! *N* before any event of segment *N+1*. [`SegmentResolver`] therefore FLUSHES
+//! a completed segment the moment an incoming event carries a `segment_index`
+//! greater than the current one: it resolves that segment's buffered terms in
+//! sorted `gts_id` order, pushes its quads / reifiers / annotations in insertion
+//! order, and drops that segment's raw buffers. [`SegmentResolver::finish`]
+//! flushes the final segment. Because `(seg, id)` keys sort segment-major, this
+//! yields the SAME interner allocation order (hence identical frozen term
+//! order) and the SAME row push order as a whole-file fold that resolved all
+//! buffered terms in one global sorted pass — while bounding buffered memory to
+//! a single segment.
+//!
+//! Per the no-optionality / hard-fail doctrine, a *genuinely* dangling term id
+//! or reifier binding — one still unresolved after ALL of a segment's events are
+//! seen — is an [`Err`], never a silent skip.
+
+use std::collections::HashMap;
+
+use ciborium::value::Value;
+
+use crate::model::{
+    Diagnostic, OpaqueNode, Quad, Signature, StreamableInfo, Suppression, Term, TermKind, Triple3,
+};
+use crate::reader::{FrameContext, StreamingSink};
+
+/// Depth bound for resolving nested quoted-triple terms. A cyclic or absurdly
+/// nested triple term hard-fails rather than recursing without bound. Mirrors
+/// the same guard on the folded (`reader::read`) path.
+pub const MAX_GTS_TERM_NESTING_DEPTH: usize = 16;
+
+/// The three resolved components `(subject, predicate, object)` a reifier binds,
+/// in the target's id space.
+type ResolvedComponents<S> = (
+    <S as ResolvedSink>::Id,
+    <S as ResolvedSink>::Id,
+    <S as ResolvedSink>::Id,
+);
+
+/// The emit target [`SegmentResolver`] drives once GTS segment-local ids have
+/// been resolved to the target's own id space.
+///
+/// The resolver owns GTS-frame decode and per-segment two-phase resolution; the
+/// target owns interning, row storage, and the mapping of the four structured
+/// decode failures onto its own error type (usually enriched with location
+/// context). Non-RDF events pass through with no-op defaults so a target that
+/// only cares about triples need not implement them.
+pub trait ResolvedSink {
+    /// The target's resolved-term identifier. `Copy` so the resolver can cache
+    /// it in its per-segment remap without cloning.
+    type Id: Copy;
+    /// The target's error type. Streaming callbacks latch the first one.
+    type Error;
+
+    /// Intern a resolved IRI term, returning its target id.
+    fn intern_iri(
+        &mut self,
+        segment_index: usize,
+        gts_id: usize,
+        iri: &str,
+    ) -> Result<Self::Id, Self::Error>;
+
+    /// Intern a resolved blank-node term (already scoped by `segment_index`),
+    /// returning its target id.
+    fn intern_blank(
+        &mut self,
+        segment_index: usize,
+        gts_id: usize,
+        label: &str,
+    ) -> Result<Self::Id, Self::Error>;
+
+    /// Intern a resolved literal term, returning its target id. The datatype (if
+    /// any) is already resolved to a target id; the target performs its own
+    /// datatype-must-be-IRI check and base-direction parsing.
+    fn intern_literal(
+        &mut self,
+        segment_index: usize,
+        gts_id: usize,
+        lexical: String,
+        datatype: Option<Self::Id>,
+        lang: Option<String>,
+        direction: Option<String>,
+    ) -> Result<Self::Id, Self::Error>;
+
+    /// Intern a resolved quoted-triple term from its resolved components.
+    fn intern_triple(
+        &mut self,
+        segment_index: usize,
+        gts_id: usize,
+        s: Self::Id,
+        p: Self::Id,
+        o: Self::Id,
+    ) -> Result<Self::Id, Self::Error>;
+
+    /// Push a resolved quad row (`g` is `None` for the default graph).
+    fn push_quad(
+        &mut self,
+        segment_index: usize,
+        s: Self::Id,
+        p: Self::Id,
+        o: Self::Id,
+        g: Option<Self::Id>,
+    ) -> Result<(), Self::Error>;
+
+    /// Push a resolved reifier row binding `reifier` to the triple `(s, p, o)`
+    /// in graph `g`.
+    fn push_reifier(
+        &mut self,
+        segment_index: usize,
+        reifier: Self::Id,
+        s: Self::Id,
+        p: Self::Id,
+        o: Self::Id,
+        g: Option<Self::Id>,
+    ) -> Result<(), Self::Error>;
+
+    /// Push a resolved annotation row `(reifier, predicate, object)` in graph
+    /// `g`.
+    fn push_annotation(
+        &mut self,
+        segment_index: usize,
+        reifier: Self::Id,
+        p: Self::Id,
+        o: Self::Id,
+        g: Option<Self::Id>,
+    ) -> Result<(), Self::Error>;
+
+    /// Build the error for a gts id that no `term` event ever introduced —
+    /// a genuinely dangling reference. `role` names the referencing position.
+    fn err_dangling_term(&self, segment_index: usize, gts_id: usize, role: &str) -> Self::Error;
+
+    /// Build the error for exceeding [`MAX_GTS_TERM_NESTING_DEPTH`] while
+    /// resolving nested quoted triples.
+    fn err_nesting_limit(&self, segment_index: usize, gts_id: usize) -> Self::Error;
+
+    /// Build the error for a quoted-triple term that carries no reifier id.
+    fn err_unbound_triple(&self, segment_index: usize, gts_id: usize) -> Self::Error;
+
+    /// Build the error for a triple term whose reifier no `reifies` event ever
+    /// bound.
+    fn err_missing_reifier(&self, segment_index: usize, reifier: usize) -> Self::Error;
+
+    /// Per-frame provenance passthrough (default no-op).
+    fn frame(&mut self, _ctx: FrameContext<'_>) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Inline blob digest + declared metadata passthrough (default no-op).
+    fn blob(
+        &mut self,
+        _segment_index: usize,
+        _digest: &str,
+        _meta: Option<&Value>,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Opaque frame passthrough (default no-op).
+    fn opaque(&mut self, _segment_index: usize, _node: &OpaqueNode) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Signature observation passthrough (default no-op).
+    fn signature(&mut self, _segment_index: usize, _sig: &Signature) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Suppression directive passthrough (default no-op).
+    fn suppression(
+        &mut self,
+        _segment_index: usize,
+        _suppression: &Suppression,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Completed segment-head passthrough (default no-op).
+    fn segment_head(&mut self, _segment_index: usize, _head: &[u8]) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Completed streamable-layout passthrough (default no-op).
+    fn streamable_layout(
+        &mut self,
+        _segment_index: usize,
+        _info: &StreamableInfo,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Reader diagnostic passthrough (default no-op).
+    fn diagnostic(&mut self, _diag: &Diagnostic) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+/// A [`StreamingSink`] that drives a [`ResolvedSink`], owning GTS-frame decode
+/// and per-segment two-phase resolution exactly once (see the module docs).
+///
+/// The `StreamingSink` callbacks return `()`; a decode or target error is
+/// therefore latched (first-wins) and surfaced through [`Self::take_error`],
+/// while [`Self::finish`] returns any error raised flushing the final segment.
+pub struct SegmentResolver<S: ResolvedSink> {
+    /// The emit target resolved rows are pushed into.
+    sink: S,
+    /// RAW per-segment terms buffered during the streaming phase, keyed by
+    /// `(segment_index, gts_id)`, resolved and drained at segment close.
+    raw_terms: HashMap<(usize, usize), Term>,
+    /// Per-segment map from `(segment_index, gts_id)` to the target id, kept
+    /// across flushes so [`Self::remap`] can inspect it after resolution.
+    remaps: HashMap<(usize, usize), S::Id>,
+    /// Per-segment reifier bindings `(segment_index, reifier) → (s, p, o)` gts
+    /// ids, recorded from `reifier` events so a Triple term (any order) can
+    /// recover its components.
+    reifier_bindings: HashMap<(usize, usize), Triple3>,
+    /// RAW quad rows `(segment_index, (s, p, o, g) gts ids)`.
+    raw_quads: Vec<(usize, Quad)>,
+    /// RAW reifier rows `(segment_index, reifier, (s, p, o), graph?)`.
+    raw_reifiers: Vec<(usize, usize, Triple3, Option<usize>)>,
+    /// RAW annotation rows `(segment_index, (r, p, v), graph?)`.
+    raw_annotations: Vec<(usize, Triple3, Option<usize>)>,
+    /// The segment currently being buffered; a higher incoming index flushes it.
+    current_segment: Option<usize>,
+    /// First latched error. Streaming callbacks are infallible, so a failure is
+    /// parked here and surfaced after the reader returns.
+    error: Option<S::Error>,
+}
+
+impl<S: ResolvedSink> std::fmt::Debug for SegmentResolver<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SegmentResolver")
+            .field("buffered_terms", &self.raw_terms.len())
+            .field("buffered_quads", &self.raw_quads.len())
+            .field("buffered_reifiers", &self.raw_reifiers.len())
+            .field("buffered_annotations", &self.raw_annotations.len())
+            .field("remaps", &self.remaps.len())
+            .field("current_segment", &self.current_segment)
+            .field("has_error", &self.error.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S: ResolvedSink> SegmentResolver<S> {
+    /// Wrap an emit target in a fresh resolver.
+    pub fn new(sink: S) -> Self {
+        Self {
+            sink,
+            raw_terms: HashMap::new(),
+            remaps: HashMap::new(),
+            reifier_bindings: HashMap::new(),
+            raw_quads: Vec::new(),
+            raw_reifiers: Vec::new(),
+            raw_annotations: Vec::new(),
+            current_segment: None,
+            error: None,
+        }
+    }
+
+    /// Borrow the emit target.
+    pub fn sink(&self) -> &S {
+        &self.sink
+    }
+
+    /// Mutably borrow the emit target.
+    pub fn sink_mut(&mut self) -> &mut S {
+        &mut self.sink
+    }
+
+    /// Consume the resolver, returning the emit target.
+    pub fn into_sink(self) -> S {
+        self.sink
+    }
+
+    /// Look up the target id a segment-local gts id resolved to, for white-box
+    /// inspection after [`Self::finish`].
+    pub fn remap(&self, segment_index: usize, gts_id: usize) -> Option<S::Id> {
+        self.remaps.get(&(segment_index, gts_id)).copied()
+    }
+
+    /// Take the first latched streaming error, if any.
+    pub fn take_error(&mut self) -> Option<S::Error> {
+        self.error.take()
+    }
+
+    /// Flush the final buffered segment, resolving its terms and pushing its
+    /// rows. Call once after [`crate::reader::read_to_sink`] returns (and after
+    /// checking [`Self::take_error`]).
+    pub fn finish(&mut self) -> Result<(), S::Error> {
+        self.resolve_buffered()
+    }
+
+    /// Record the first latched error; later errors do not overwrite it.
+    fn fail(&mut self, error: S::Error) {
+        if self.error.is_none() {
+            self.error = Some(error);
+        }
+    }
+
+    /// Note an incoming buffering event's segment. When it advances past the
+    /// segment currently buffered, flush the completed segment (latching any
+    /// error) before accepting the new one.
+    fn advance_segment(&mut self, segment_index: usize) {
+        match self.current_segment {
+            Some(current) if segment_index > current => {
+                if let Err(error) = self.resolve_buffered() {
+                    self.fail(error);
+                }
+                self.current_segment = Some(segment_index);
+            }
+            None => self.current_segment = Some(segment_index),
+            Some(_) => {}
+        }
+    }
+
+    /// Phase 2 for the currently buffered segment: resolve every buffered term
+    /// (sorted `(segment_index, gts_id)`, which is `gts_id`-sorted within the
+    /// single buffered segment) then push its quad / reifier / annotation rows
+    /// in insertion order, draining the raw buffers.
+    fn resolve_buffered(&mut self) -> Result<(), S::Error> {
+        // Resolve every introduced term (idempotent through `remaps`). Iterate
+        // in a deterministic order so the target's interner allocation order —
+        // and thus any frozen term order — is reproducible for a fixed stream.
+        let mut keys: Vec<(usize, usize)> = self.raw_terms.keys().copied().collect();
+        keys.sort_unstable();
+        for (segment_index, gts_id) in keys {
+            self.resolve_term(segment_index, gts_id, "term", 0)?;
+        }
+
+        // Quads.
+        let raw_quads = std::mem::take(&mut self.raw_quads);
+        for (segment_index, (s, p, o, g)) in raw_quads {
+            let s = self.resolve_term(segment_index, s, "quad subject", 0)?;
+            let p = self.resolve_term(segment_index, p, "quad predicate", 0)?;
+            let o = self.resolve_term(segment_index, o, "quad object", 0)?;
+            let g = match g {
+                Some(g) => Some(self.resolve_term(segment_index, g, "quad graph name", 0)?),
+                None => None,
+            };
+            self.sink.push_quad(segment_index, s, p, o, g)?;
+        }
+
+        // Reifier bindings: bind the reifier resource to the triple.
+        let raw_reifiers = std::mem::take(&mut self.raw_reifiers);
+        for (segment_index, reifier, (s, p, o), graph) in raw_reifiers {
+            let reifier_id = self.resolve_term(segment_index, reifier, "reifier", 0)?;
+            let s = self.resolve_term(segment_index, s, "reified subject", 0)?;
+            let p = self.resolve_term(segment_index, p, "reified predicate", 0)?;
+            let o = self.resolve_term(segment_index, o, "reified object", 0)?;
+            let g = match graph {
+                Some(g) => Some(self.resolve_term(segment_index, g, "reifier graph name", 0)?),
+                None => None,
+            };
+            self.sink.push_reifier(segment_index, reifier_id, s, p, o, g)?;
+        }
+
+        // Annotations `(reifier, predicate, object, graph?)`.
+        let raw_annotations = std::mem::take(&mut self.raw_annotations);
+        for (segment_index, (r, p, v), graph) in raw_annotations {
+            let r = self.resolve_term(segment_index, r, "annotation reifier", 0)?;
+            let p = self.resolve_term(segment_index, p, "annotation predicate", 0)?;
+            let v = self.resolve_term(segment_index, v, "annotation object", 0)?;
+            let g = match graph {
+                Some(g) => Some(self.resolve_term(segment_index, g, "annotation graph name", 0)?),
+                None => None,
+            };
+            self.sink.push_annotation(segment_index, r, p, v, g)?;
+        }
+
+        Ok(())
+    }
+
+    /// Resolve a GTS segment-local term id to its target id, interning it (and
+    /// any nested quoted triples) on demand. Memoized through `remaps` and
+    /// depth-bounded against cyclic quoted triples. A gts id no `term` event
+    /// introduced is a genuinely dangling reference and hence an [`Err`].
+    fn resolve_term(
+        &mut self,
+        segment_index: usize,
+        gts_id: usize,
+        role: &str,
+        depth: usize,
+    ) -> Result<S::Id, S::Error> {
+        if let Some(&id) = self.remaps.get(&(segment_index, gts_id)) {
+            return Ok(id);
+        }
+        if depth > MAX_GTS_TERM_NESTING_DEPTH {
+            return Err(self.sink.err_nesting_limit(segment_index, gts_id));
+        }
+        // MOVE the raw term out: it resolves at most once (every later reference
+        // hits the `remaps` cache above), so taking ownership lets interning
+        // borrow the target mutably without a conflict AND without cloning the
+        // term's owned strings. A (pathological) cyclic reference now surfaces as
+        // a dangling-term ref — the term is already removed — rather than the
+        // nesting-limit; both are hard failures and a GTS Writer never emits
+        // cycles.
+        let Some(term) = self.raw_terms.remove(&(segment_index, gts_id)) else {
+            return Err(self.sink.err_dangling_term(segment_index, gts_id, role));
+        };
+        let our_id = self.intern_raw_term(segment_index, gts_id, term, depth)?;
+        self.remaps.insert((segment_index, gts_id), our_id);
+        Ok(our_id)
+    }
+
+    /// Intern one already-located raw term, recursing (inner-first) for quoted
+    /// triples through their reifier binding. Takes the [`Term`] BY VALUE (it was
+    /// just removed from `raw_terms`) and MOVES its owned strings into the target.
+    fn intern_raw_term(
+        &mut self,
+        segment_index: usize,
+        gts_id: usize,
+        term: Term,
+        depth: usize,
+    ) -> Result<S::Id, S::Error> {
+        let our_id = match term.kind {
+            TermKind::Iri => {
+                // An absent or empty value is the target's `iri-missing-value`
+                // failure, raised from its own `intern_iri`.
+                let iri = term.value.as_deref().unwrap_or_default();
+                self.sink.intern_iri(segment_index, gts_id, iri)?
+            }
+            // Per-segment scope isolation: the target scopes by `segment_index`
+            // so the SAME blank label in different segments interns distinctly.
+            TermKind::Bnode => {
+                let label = term
+                    .value
+                    .unwrap_or_else(|| format!("gts_bnode_{segment_index}_{gts_id}"));
+                self.sink.intern_blank(segment_index, gts_id, &label)?
+            }
+            TermKind::Literal => {
+                let datatype = match term.datatype {
+                    Some(dt_gts_id) => Some(self.resolve_term(
+                        segment_index,
+                        dt_gts_id,
+                        "literal datatype",
+                        depth + 1,
+                    )?),
+                    None => None,
+                };
+                self.sink.intern_literal(
+                    segment_index,
+                    gts_id,
+                    term.value.unwrap_or_default(),
+                    datatype,
+                    term.lang,
+                    term.direction,
+                )?
+            }
+            TermKind::Triple => {
+                let Some(reifier_gts_id) = term.reifier else {
+                    return Err(self.sink.err_unbound_triple(segment_index, gts_id));
+                };
+                let (s, p, o) =
+                    self.resolve_triple_components(segment_index, reifier_gts_id, depth + 1)?;
+                self.sink.intern_triple(segment_index, gts_id, s, p, o)?
+            }
+        };
+        Ok(our_id)
+    }
+
+    /// Resolve the `(s, p, o)` of the triple a reifier binds, THROUGH this
+    /// segment's terms, depth-bounded against cyclic quoted triples. The reifier
+    /// binding MUST exist by phase 2; a missing one is a genuine dangling
+    /// reference and hence an [`Err`].
+    fn resolve_triple_components(
+        &mut self,
+        segment_index: usize,
+        reifier: usize,
+        depth: usize,
+    ) -> Result<ResolvedComponents<S>, S::Error> {
+        if depth > MAX_GTS_TERM_NESTING_DEPTH {
+            return Err(self.sink.err_nesting_limit(segment_index, reifier));
+        }
+        let Some(&(s, p, o)) = self.reifier_bindings.get(&(segment_index, reifier)) else {
+            return Err(self.sink.err_missing_reifier(segment_index, reifier));
+        };
+        let s = self.resolve_term(segment_index, s, "reified subject", depth)?;
+        let p = self.resolve_term(segment_index, p, "reified predicate", depth)?;
+        let o = self.resolve_term(segment_index, o, "reified object", depth)?;
+        Ok((s, p, o))
+    }
+}
+
+impl<S: ResolvedSink> StreamingSink for SegmentResolver<S> {
+    fn frame(&mut self, ctx: FrameContext<'_>) {
+        if self.error.is_some() {
+            return;
+        }
+        if let Err(error) = self.sink.frame(ctx) {
+            self.fail(error);
+        }
+    }
+
+    fn term(&mut self, segment_index: usize, term_id: usize, term: &Term) {
+        if self.error.is_some() {
+            return;
+        }
+        self.advance_segment(segment_index);
+        if self.error.is_some() {
+            return;
+        }
+        // Streaming phase: stash the raw term verbatim. A quoted-triple term
+        // cannot be resolved yet — its reifier binding may arrive in a later
+        // frame — so we defer ALL resolution to segment close.
+        self.raw_terms.insert((segment_index, term_id), term.clone());
+    }
+
+    fn quad(&mut self, segment_index: usize, quad: Quad) {
+        if self.error.is_some() {
+            return;
+        }
+        self.advance_segment(segment_index);
+        if self.error.is_some() {
+            return;
+        }
+        self.raw_quads.push((segment_index, quad));
+    }
+
+    fn reifier(&mut self, segment_index: usize, reifier: crate::model::ReifierRow) {
+        if self.error.is_some() {
+            return;
+        }
+        self.advance_segment(segment_index);
+        if self.error.is_some() {
+            return;
+        }
+        // Row-array `(reifier_id, (s, p, o), graph?)`. Record the reifier → (s,
+        // p, o) binding so a Triple term (any order) can resolve its components,
+        // and stash the row (with its named graph) so the reifier resource binds
+        // the resolved triple at segment close.
+        let (reifier_id, triple, graph) = reifier;
+        self.reifier_bindings
+            .insert((segment_index, reifier_id), triple);
+        self.raw_reifiers
+            .push((segment_index, reifier_id, triple, graph));
+    }
+
+    fn annotation(&mut self, segment_index: usize, annotation: crate::model::AnnotationRow) {
+        if self.error.is_some() {
+            return;
+        }
+        self.advance_segment(segment_index);
+        if self.error.is_some() {
+            return;
+        }
+        // Row-array `(reifier, predicate, value, graph?)`.
+        let (reifier, predicate, value, graph) = annotation;
+        self.raw_annotations
+            .push((segment_index, (reifier, predicate, value), graph));
+    }
+
+    fn suppression(&mut self, segment_index: usize, suppression: &Suppression) {
+        if self.error.is_some() {
+            return;
+        }
+        if let Err(error) = self.sink.suppression(segment_index, suppression) {
+            self.fail(error);
+        }
+    }
+
+    fn blob(&mut self, segment_index: usize, digest: &str, meta: Option<&Value>) {
+        if self.error.is_some() {
+            return;
+        }
+        if let Err(error) = self.sink.blob(segment_index, digest, meta) {
+            self.fail(error);
+        }
+    }
+
+    fn opaque(&mut self, segment_index: usize, opaque: &OpaqueNode) {
+        if self.error.is_some() {
+            return;
+        }
+        if let Err(error) = self.sink.opaque(segment_index, opaque) {
+            self.fail(error);
+        }
+    }
+
+    fn signature(&mut self, segment_index: usize, signature: &Signature) {
+        if self.error.is_some() {
+            return;
+        }
+        if let Err(error) = self.sink.signature(segment_index, signature) {
+            self.fail(error);
+        }
+    }
+
+    fn diagnostic(&mut self, diagnostic: &Diagnostic) {
+        if self.error.is_some() {
+            return;
+        }
+        if let Err(error) = self.sink.diagnostic(diagnostic) {
+            self.fail(error);
+        }
+    }
+
+    fn segment_head(&mut self, segment_index: usize, head: &[u8]) {
+        if self.error.is_some() {
+            return;
+        }
+        if let Err(error) = self.sink.segment_head(segment_index, head) {
+            self.fail(error);
+        }
+    }
+
+    fn streamable_layout(&mut self, segment_index: usize, info: &StreamableInfo) {
+        if self.error.is_some() {
+            return;
+        }
+        if let Err(error) = self.sink.streamable_layout(segment_index, info) {
+            self.fail(error);
+        }
+    }
+}

--- a/crates/gts/src/segment_decode.rs
+++ b/crates/gts/src/segment_decode.rs
@@ -325,7 +325,7 @@ impl<S: ResolvedSink> SegmentResolver<S> {
     /// Count of the per-segment reifier→triple binding map currently
     /// retained (see the `reifier_bindings` field doc). This is populated as
     /// `reifier` events for the CURRENTLY OPEN segment stream in, and is `0`
-    /// immediately after every [`Self::resolve_buffered`] flush — so reading
+    /// immediately after every `resolve_buffered` flush — so reading
     /// it right after a segment has flushed (e.g. on the first event of the
     /// next segment, or after [`Self::finish`]) is bounded by a single
     /// segment's own reifier cardinality, never by the sum across every

--- a/crates/gts/src/segment_decode.rs
+++ b/crates/gts/src/segment_decode.rs
@@ -242,8 +242,12 @@ pub struct SegmentResolver<S: ResolvedSink> {
     /// RAW per-segment terms buffered during the streaming phase, keyed by
     /// `(segment_index, gts_id)`, resolved and drained at segment close.
     raw_terms: HashMap<(usize, usize), Term>,
-    /// Per-segment map from `(segment_index, gts_id)` to the target id, kept
-    /// across flushes so [`Self::remap`] can inspect it after resolution.
+    /// Per-segment memo from `(segment_index, gts_id)` to the target id,
+    /// populated as the currently buffered segment's terms resolve (so a term
+    /// referenced twice — e.g. as both a quad subject and a reifier subject —
+    /// interns once) and cleared at the end of [`Self::resolve_buffered`]:
+    /// segment-local ids never cross a segment boundary, so retaining this
+    /// past segment close would grow it O(total terms across ALL segments).
     remaps: HashMap<(usize, usize), S::Id>,
     /// Per-segment reifier bindings `(segment_index, reifier) → (s, p, o)` gts
     /// ids, recorded from `reifier` events so a Triple term (any order) can
@@ -269,7 +273,7 @@ impl<S: ResolvedSink> std::fmt::Debug for SegmentResolver<S> {
             .field("buffered_quads", &self.raw_quads.len())
             .field("buffered_reifiers", &self.raw_reifiers.len())
             .field("buffered_annotations", &self.raw_annotations.len())
-            .field("remaps", &self.remaps.len())
+            .field("buffered_remaps", &self.remaps.len())
             .field("current_segment", &self.current_segment)
             .field("has_error", &self.error.is_some())
             .finish_non_exhaustive()
@@ -305,12 +309,6 @@ impl<S: ResolvedSink> SegmentResolver<S> {
     /// Consume the resolver, returning the emit target.
     pub fn into_sink(self) -> S {
         self.sink
-    }
-
-    /// Look up the target id a segment-local gts id resolved to, for white-box
-    /// inspection after [`Self::finish`].
-    pub fn remap(&self, segment_index: usize, gts_id: usize) -> Option<S::Id> {
-        self.remaps.get(&(segment_index, gts_id)).copied()
     }
 
     /// Take the first latched streaming error, if any.
@@ -402,6 +400,15 @@ impl<S: ResolvedSink> SegmentResolver<S> {
             };
             self.sink.push_annotation(segment_index, r, p, v, g)?;
         }
+
+        // Bounded-memory streaming fold: both maps are segment-local — no
+        // resolution ever crosses a segment boundary (reifier bindings, and
+        // the term-id remap memo, are only ever read for the segment that is
+        // currently buffered) — so drop them here rather than retaining them
+        // for the lifetime of the resolver. Without this, both grow O(total
+        // reifiers/terms across ALL segments) instead of O(one segment).
+        self.reifier_bindings.clear();
+        self.remaps.clear();
 
         Ok(())
     }

--- a/crates/gts/src/segment_decode.rs
+++ b/crates/gts/src/segment_decode.rs
@@ -386,7 +386,8 @@ impl<S: ResolvedSink> SegmentResolver<S> {
                 Some(g) => Some(self.resolve_term(segment_index, g, "reifier graph name", 0)?),
                 None => None,
             };
-            self.sink.push_reifier(segment_index, reifier_id, s, p, o, g)?;
+            self.sink
+                .push_reifier(segment_index, reifier_id, s, p, o, g)?;
         }
 
         // Annotations `(reifier, predicate, object, graph?)`.
@@ -537,7 +538,8 @@ impl<S: ResolvedSink> StreamingSink for SegmentResolver<S> {
         // Streaming phase: stash the raw term verbatim. A quoted-triple term
         // cannot be resolved yet — its reifier binding may arrive in a later
         // frame — so we defer ALL resolution to segment close.
-        self.raw_terms.insert((segment_index, term_id), term.clone());
+        self.raw_terms
+            .insert((segment_index, term_id), term.clone());
     }
 
     fn quad(&mut self, segment_index: usize, quad: Quad) {

--- a/crates/gts/tests/event_bridge.rs
+++ b/crates/gts/tests/event_bridge.rs
@@ -681,3 +681,115 @@ fn dangling_term_ref_is_err() {
     );
     assert_eq!(sink.finish_count, 0, "the failed drive was never finalized");
 }
+
+/// Feed ONLY the first term of segment `seg`. This single event is what trips
+/// `SegmentResolver::advance_segment` (the incoming `segment_index` exceeds
+/// the currently-buffered one), which synchronously flushes whichever
+/// segment was previously buffered — resolving its terms/quads/reifiers into
+/// the sink and, per the bounded-memory fix, clearing `reifier_bindings` and
+/// `remaps` — before this segment starts accumulating anything of its own.
+fn open_bounded_memory_segment(resolver: &mut SegmentResolver<EventEmitter<'_>>, seg: usize) {
+    resolver.term(seg, 0, &iri(&format!("http://example.org/seg{seg}/s")));
+}
+
+/// Feed the REST of segment `seg` (4 more IRI terms, one quad, and two
+/// reifiers binding that quad's triple) — everything [`open_bounded_memory_segment`]
+/// did not already send. Together the two functions introduce 5 distinct IRI
+/// terms and 2 reifier bindings per segment, all segment-qualified
+/// (`http://example.org/seg{seg}/...`) so no cross-segment id reuse could
+/// accidentally mask a leak as "the same entry, re-seen".
+fn fill_bounded_memory_segment(resolver: &mut SegmentResolver<EventEmitter<'_>>, seg: usize) {
+    resolver.term(seg, 1, &iri(&format!("http://example.org/seg{seg}/p")));
+    resolver.term(seg, 2, &iri(&format!("http://example.org/seg{seg}/o")));
+    resolver.term(seg, 3, &iri(&format!("http://example.org/seg{seg}/r1")));
+    resolver.term(seg, 4, &iri(&format!("http://example.org/seg{seg}/r2")));
+    resolver.quad(seg, (0, 1, 2, None));
+    resolver.reifier(seg, (3, (0, 1, 2), None));
+    resolver.reifier(seg, (4, (0, 1, 2), None));
+}
+
+/// R8-exec: bounded-memory streaming fold (GTS-SPEC §7.7). `SegmentResolver`'s
+/// per-segment `reifier_bindings` / `remaps` maps, and the bridged
+/// `EventEmitter`'s `iri_map`, must stay bounded to O(one segment) as MANY
+/// segments stream through — never grow with the cumulative segment count.
+///
+/// This drives a hand-built 12-segment fixture directly through
+/// `SegmentResolver`'s public `StreamingSink` callbacks (no GTS byte
+/// encoding needed — the same technique `dangling_term_ref_is_err` above
+/// uses) and samples the resolver's and emitter's retained sizes immediately
+/// after each segment's flush (i.e. right after the NEXT segment's first
+/// event, before that next segment has contributed anything of its own). A
+/// regression that stops clearing `reifier_bindings`/`remaps`
+/// (`resolve_buffered`) or `iri_map` (`EventEmitter::ensure_scope`) makes
+/// these counts grow with the segment index instead of staying flat, so this
+/// assertion is falsifiable: reverting either clear turns it red.
+#[test]
+fn bounded_memory_across_many_segments() {
+    const SEGMENTS: usize = 12;
+    const IRIS_PER_SEGMENT: usize = 5;
+
+    let mut sink = CollectSink::default();
+    let mut resolver = SegmentResolver::new(EventEmitter::new(&mut sink));
+
+    open_bounded_memory_segment(&mut resolver, 0);
+    fill_bounded_memory_segment(&mut resolver, 0);
+    for seg in 1..SEGMENTS {
+        let flushed = seg - 1;
+        // Trips the flush of `flushed`; segment `seg` has contributed
+        // nothing yet at this point (only its first term is buffered).
+        open_bounded_memory_segment(&mut resolver, seg);
+        assert_eq!(
+            resolver.buffered_reifier_binding_count(),
+            0,
+            "flushing segment {flushed} (triggered by segment {seg}'s first \
+             event) must have emptied reifier_bindings (cleared at flush), \
+             not accumulated the {expected} reifiers introduced across all \
+             segments seen so far",
+            expected = 2 * seg,
+        );
+        assert_eq!(
+            resolver.buffered_remap_count(),
+            0,
+            "flushing segment {flushed} (triggered by segment {seg}'s first \
+             event) must have emptied the gts-id remap memo (cleared at \
+             flush), not accumulated resolutions across segments"
+        );
+        assert_eq!(
+            resolver.sink().interned_iri_count(),
+            IRIS_PER_SEGMENT,
+            "after flushing segment {flushed}, EventEmitter.iri_map must \
+             hold only that segment's own {IRIS_PER_SEGMENT} IRIs, not the \
+             cumulative total across all segments flushed so far"
+        );
+        fill_bounded_memory_segment(&mut resolver, seg);
+    }
+
+    // No StreamingSink callback failure was latched.
+    assert!(
+        resolver.take_error().is_none(),
+        "the hand-fed fixture is well-formed"
+    );
+    // Flush the final (12th) segment explicitly — nothing downstream ever
+    // starts segment 12 to trigger it automatically — and re-check the same
+    // bound on the last segment too.
+    resolver
+        .finish()
+        .expect("finish resolves the final buffered segment");
+    assert_eq!(
+        resolver.buffered_reifier_binding_count(),
+        0,
+        "the final segment's reifier_bindings must also be cleared at finish()"
+    );
+    assert_eq!(
+        resolver.buffered_remap_count(),
+        0,
+        "the final segment's remap memo must also be cleared at finish()"
+    );
+    assert_eq!(
+        resolver.sink().interned_iri_count(),
+        IRIS_PER_SEGMENT,
+        "the final segment's iri_map must hold only its own \
+         {IRIS_PER_SEGMENT} IRIs, not the cumulative total across all \
+         {SEGMENTS} segments"
+    );
+}

--- a/crates/gts/tests/event_bridge.rs
+++ b/crates/gts/tests/event_bridge.rs
@@ -1,0 +1,683 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Integration tests for the GTS → `RdfEventSink` bridge
+//! (`purrdf_gts::event_stream::{stream_events, GtsEventSink, EventEmitter}`).
+//!
+//! These exercise ONLY public API: a self-contained `CollectSink` folds the
+//! event stream back into canonical `(s, p, o, g)` string tuples and cross-checks
+//! them against the offline `reader::read` union graph, plus the id/scope,
+//! provenance, cancellation, and hard-failure contracts.
+
+use std::collections::HashMap;
+
+use core::ops::ControlFlow;
+
+use purrdf_events::{
+    EventError, EventQuad, EventTerm, EventTermId, EventTriple, RdfEventSink, ScopeId,
+    TextDirection,
+};
+use purrdf_gts::event_stream::{EventEmitter, GtsEventSink, stream_events};
+use purrdf_gts::model::{Graph, Term, TermKind, Triple3};
+use purrdf_gts::reader::{FrameContext, ReadOptions, StreamingSink, read};
+use purrdf_gts::replication::{DiffStatus, diff, inventory, splice};
+use purrdf_gts::segment_decode::SegmentResolver;
+use purrdf_gts::writer::Writer;
+
+// -- fixtures ----------------------------------------------------------------
+
+fn iri(value: &str) -> Term {
+    Term {
+        kind: TermKind::Iri,
+        value: Some(value.to_owned()),
+        datatype: None,
+        lang: None,
+        direction: None,
+        reifier: None,
+    }
+}
+
+fn plain_literal(value: &str) -> Term {
+    Term {
+        kind: TermKind::Literal,
+        value: Some(value.to_owned()),
+        datatype: None,
+        lang: None,
+        direction: None,
+        reifier: None,
+    }
+}
+
+fn lang_literal(value: &str, lang: &str) -> Term {
+    Term {
+        kind: TermKind::Literal,
+        value: Some(value.to_owned()),
+        datatype: None,
+        lang: Some(lang.to_owned()),
+        direction: None,
+        reifier: None,
+    }
+}
+
+fn blank(label: &str) -> Term {
+    Term {
+        kind: TermKind::Bnode,
+        value: Some(label.to_owned()),
+        datatype: None,
+        lang: None,
+        direction: None,
+        reifier: None,
+    }
+}
+
+/// A blank-free two-segment fixture: IRIs + literals + quads across two
+/// independently-rooted segments.
+fn two_segment_rdf_fixture() -> Vec<u8> {
+    let mut a = Writer::new("generic");
+    a.add_terms(&[
+        iri("http://example.org/a/s"),
+        iri("http://example.org/a/p"),
+        plain_literal("alpha"),
+        iri("http://example.org/name"),
+        lang_literal("Purr", "en"),
+    ]);
+    a.add_quads(&[(0, 1, 2, None), (0, 3, 4, None)]);
+    let mut data = a.to_bytes();
+
+    let mut b = Writer::new("generic");
+    b.add_terms(&[
+        iri("http://example.org/b/s"),
+        iri("http://example.org/b/p"),
+        plain_literal("beta"),
+    ]);
+    b.add_quads(&[(0, 1, 2, None)]);
+    data.extend_from_slice(&b.to_bytes());
+    data
+}
+
+// -- canonical rendering -----------------------------------------------------
+
+/// An owned copy of one declared [`EventTerm`], resolvable to a canonical string.
+#[derive(Clone, PartialEq, Eq, Debug)]
+enum OwnedTerm {
+    Iri(String),
+    Blank {
+        label: String,
+        scope: ScopeId,
+    },
+    Literal {
+        lexical: String,
+        datatype: String,
+        language: Option<String>,
+        direction: Option<TextDirection>,
+    },
+    Triple {
+        s: EventTermId,
+        p: EventTermId,
+        o: EventTermId,
+    },
+}
+
+impl OwnedTerm {
+    fn capture(term: EventTerm<'_>) -> Self {
+        match term {
+            EventTerm::Iri(iri) => Self::Iri(iri.to_owned()),
+            EventTerm::Blank { label, scope } => Self::Blank {
+                label: label.to_owned(),
+                scope,
+            },
+            EventTerm::Literal {
+                lexical,
+                datatype,
+                language,
+                direction,
+            } => Self::Literal {
+                lexical: lexical.to_owned(),
+                datatype: datatype.to_owned(),
+                language: language.map(str::to_owned),
+                direction,
+            },
+            EventTerm::Triple(EventTriple { s, p, o }) => Self::Triple { s, p, o },
+        }
+    }
+}
+
+fn render_literal(
+    lexical: &str,
+    datatype: &str,
+    language: Option<&str>,
+    direction: Option<TextDirection>,
+) -> String {
+    let lang = language.map_or_else(String::new, |l| format!("@{l}"));
+    let dir = match direction {
+        Some(TextDirection::Ltr) => "--ltr",
+        Some(TextDirection::Rtl) => "--rtl",
+        None => "",
+    };
+    format!("\"{lexical}\"^^<{datatype}>{lang}{dir}")
+}
+
+// -- collecting sink ---------------------------------------------------------
+
+/// A self-contained sink that buffers declarations and rows, then resolves every
+/// forward reference into canonical `(s, p, o, g)` string tuples on `finish`.
+#[derive(Default)]
+struct CollectSink {
+    terms: HashMap<EventTermId, OwnedTerm>,
+    declaration_order: Vec<(EventTermId, OwnedTerm)>,
+    quads: Vec<EventQuad>,
+    reifiers: Vec<(EventTermId, EventTriple)>,
+    annotations: Vec<(EventTermId, EventTermId, EventTermId)>,
+    resolved_quads: Vec<String>,
+    finish_count: usize,
+    next_scope: u32,
+    break_on_first_quad: bool,
+    frames: Vec<(Vec<u8>, usize, bool)>,
+}
+
+impl CollectSink {
+    fn render(&self, id: EventTermId) -> String {
+        match self
+            .terms
+            .get(&id)
+            .expect("term declared before resolution")
+        {
+            OwnedTerm::Iri(iri) => format!("<{iri}>"),
+            OwnedTerm::Blank { label, scope } => format!("_:{label}@{}", scope.0),
+            OwnedTerm::Literal {
+                lexical,
+                datatype,
+                language,
+                direction,
+            } => render_literal(lexical, datatype, language.as_deref(), *direction),
+            OwnedTerm::Triple { s, p, o } => {
+                format!(
+                    "<<{} {} {}>>",
+                    self.render(*s),
+                    self.render(*p),
+                    self.render(*o)
+                )
+            }
+        }
+    }
+
+    fn quad_tuple(&self, q: &EventQuad) -> String {
+        let graph = q.g.map_or_else(|| "default".to_owned(), |g| self.render(g));
+        format!(
+            "{} {} {} {}",
+            self.render(q.s),
+            self.render(q.p),
+            self.render(q.o),
+            graph
+        )
+    }
+}
+
+impl RdfEventSink for CollectSink {
+    fn term(
+        &mut self,
+        id: EventTermId,
+        term: EventTerm<'_>,
+    ) -> Result<ControlFlow<()>, EventError> {
+        let owned = OwnedTerm::capture(term);
+        self.declaration_order.push((id, owned.clone()));
+        self.terms.insert(id, owned);
+        Ok(ControlFlow::Continue(()))
+    }
+
+    fn quad(&mut self, q: EventQuad) -> Result<ControlFlow<()>, EventError> {
+        if self.break_on_first_quad {
+            return Ok(ControlFlow::Break(()));
+        }
+        self.quads.push(q);
+        Ok(ControlFlow::Continue(()))
+    }
+
+    fn reifier(
+        &mut self,
+        reifier: EventTermId,
+        triple: EventTriple,
+    ) -> Result<ControlFlow<()>, EventError> {
+        self.reifiers.push((reifier, triple));
+        Ok(ControlFlow::Continue(()))
+    }
+
+    fn annotation(
+        &mut self,
+        reifier: EventTermId,
+        p: EventTermId,
+        o: EventTermId,
+    ) -> Result<ControlFlow<()>, EventError> {
+        self.annotations.push((reifier, p, o));
+        Ok(ControlFlow::Continue(()))
+    }
+
+    fn open_scope(&mut self) -> Result<ScopeId, EventError> {
+        self.next_scope += 1;
+        Ok(ScopeId(self.next_scope))
+    }
+
+    fn close_scope(&mut self, _scope: ScopeId) -> Result<ControlFlow<()>, EventError> {
+        Ok(ControlFlow::Continue(()))
+    }
+
+    fn finish(&mut self) -> Result<(), EventError> {
+        self.finish_count += 1;
+        let quads = std::mem::take(&mut self.quads);
+        for q in &quads {
+            self.resolved_quads.push(self.quad_tuple(q));
+        }
+        self.quads = quads;
+        Ok(())
+    }
+}
+
+impl GtsEventSink for CollectSink {
+    fn frame(&mut self, ctx: FrameContext<'_>) -> Result<ControlFlow<()>, EventError> {
+        self.frames
+            .push((ctx.content_id.to_vec(), ctx.range.start, ctx.valid));
+        Ok(ControlFlow::Continue(()))
+    }
+}
+
+// -- offline rendering (mirror of CollectSink::render over a folded Graph) ----
+
+fn render_offline(graph: &Graph, id: usize) -> String {
+    let term = &graph.terms[id];
+    match term.kind {
+        TermKind::Iri => format!("<{}>", term.value.as_deref().unwrap_or_default()),
+        TermKind::Bnode => format!(
+            "_:{}@offline",
+            term.value.clone().unwrap_or_else(|| format!("b{id}"))
+        ),
+        TermKind::Literal => render_literal(
+            term.value.as_deref().unwrap_or_default(),
+            &graph.datatype_iri(term),
+            term.lang.as_deref(),
+            match term.direction.as_deref() {
+                Some("ltr") => Some(TextDirection::Ltr),
+                Some("rtl") => Some(TextDirection::Rtl),
+                _ => None,
+            },
+        ),
+        TermKind::Triple => {
+            let reifier = term.reifier.expect("triple term carries a reifier");
+            let (s, p, o) = graph.reifier(reifier).expect("reifier binding present");
+            format!(
+                "<<{} {} {}>>",
+                render_offline(graph, s),
+                render_offline(graph, p),
+                render_offline(graph, o)
+            )
+        }
+    }
+}
+
+fn offline_quad_tuple(graph: &Graph, quad: (usize, usize, usize, Option<usize>)) -> String {
+    let (s, p, o, g) = quad;
+    let graph_name = g.map_or_else(|| "default".to_owned(), |g| render_offline(graph, g));
+    format!(
+        "{} {} {} {}",
+        render_offline(graph, s),
+        render_offline(graph, p),
+        render_offline(graph, o),
+        graph_name
+    )
+}
+
+// -- tests -------------------------------------------------------------------
+
+/// R7-exec: the bridge's resolved quad-set equals the offline `read` union graph.
+#[test]
+fn bridge_events_equal_offline_read() {
+    let data = two_segment_rdf_fixture();
+
+    let mut sink = CollectSink::default();
+    let result = stream_events(&data, ReadOptions::new(true, None), &mut sink)
+        .expect("stream_events must succeed on a clean fixture");
+    assert!(result.diagnostics.is_empty(), "fixture must stream cleanly");
+    assert_eq!(sink.finish_count, 1, "finish runs exactly once");
+
+    let bridge: std::collections::HashSet<String> = sink.resolved_quads.iter().cloned().collect();
+
+    let graph = read(&data, true, None);
+    assert!(graph.diagnostics.is_empty(), "fixture must fold cleanly");
+    let offline: std::collections::HashSet<String> = graph
+        .quads
+        .iter()
+        .map(|&q| offline_quad_tuple(&graph, q))
+        .collect();
+
+    assert_eq!(
+        bridge, offline,
+        "bridged quads must equal offline union quads"
+    );
+    assert_eq!(bridge.len(), 3, "fixture declares three quads");
+}
+
+/// R7-exec2: the same blank label in two segments resolves to distinct scopes.
+#[test]
+fn per_segment_blank_scopes_are_distinct() {
+    let mut a = Writer::new("generic");
+    a.add_terms(&[
+        iri("http://example.org/a/s"),
+        iri("http://example.org/a/p"),
+        blank("b0"),
+    ]);
+    a.add_quads(&[(0, 1, 2, None)]);
+    let mut data = a.to_bytes();
+
+    let mut b = Writer::new("generic");
+    b.add_terms(&[
+        iri("http://example.org/b/s"),
+        iri("http://example.org/b/p"),
+        blank("b0"),
+    ]);
+    b.add_quads(&[(0, 1, 2, None)]);
+    data.extend_from_slice(&b.to_bytes());
+
+    let mut sink = CollectSink::default();
+    stream_events(&data, ReadOptions::new(true, None), &mut sink).expect("stream ok");
+
+    let blanks: Vec<(String, ScopeId)> = sink
+        .declaration_order
+        .iter()
+        .filter_map(|(_, term)| match term {
+            OwnedTerm::Blank { label, scope } => Some((label.clone(), *scope)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(blanks.len(), 2, "each segment declares one blank");
+    assert_eq!(blanks[0].0, blanks[1].0, "labels are the same _:b0");
+    assert_ne!(
+        blanks[0].1, blanks[1].1,
+        "the two _:b0 must live in distinct scopes"
+    );
+}
+
+/// A `GtsEventSink` recording only `content_id -> byte-offset` from the frame hook.
+#[derive(Default)]
+struct IndexSink {
+    offsets: HashMap<Vec<u8>, usize>,
+    diagnostics: usize,
+}
+
+impl RdfEventSink for IndexSink {
+    fn term(
+        &mut self,
+        _id: EventTermId,
+        _term: EventTerm<'_>,
+    ) -> Result<ControlFlow<()>, EventError> {
+        Ok(ControlFlow::Continue(()))
+    }
+    fn quad(&mut self, _q: EventQuad) -> Result<ControlFlow<()>, EventError> {
+        Ok(ControlFlow::Continue(()))
+    }
+    fn reifier(
+        &mut self,
+        _reifier: EventTermId,
+        _triple: EventTriple,
+    ) -> Result<ControlFlow<()>, EventError> {
+        Ok(ControlFlow::Continue(()))
+    }
+    fn annotation(
+        &mut self,
+        _reifier: EventTermId,
+        _p: EventTermId,
+        _o: EventTermId,
+    ) -> Result<ControlFlow<()>, EventError> {
+        Ok(ControlFlow::Continue(()))
+    }
+    fn open_scope(&mut self) -> Result<ScopeId, EventError> {
+        Ok(ScopeId::DEFAULT)
+    }
+    fn close_scope(&mut self, _scope: ScopeId) -> Result<ControlFlow<()>, EventError> {
+        Ok(ControlFlow::Continue(()))
+    }
+    fn finish(&mut self) -> Result<(), EventError> {
+        Ok(())
+    }
+}
+
+impl GtsEventSink for IndexSink {
+    fn frame(&mut self, ctx: FrameContext<'_>) -> Result<ControlFlow<()>, EventError> {
+        if ctx.valid {
+            self.offsets
+                .insert(ctx.content_id.to_vec(), ctx.range.start);
+        }
+        Ok(ControlFlow::Continue(()))
+    }
+
+    fn gts_diagnostic(
+        &mut self,
+        _ctx: Option<FrameContext<'_>>,
+        _diagnostic: &purrdf_gts::model::Diagnostic,
+    ) -> Result<ControlFlow<()>, EventError> {
+        self.diagnostics += 1;
+        Ok(ControlFlow::Continue(()))
+    }
+}
+
+fn blob_fixture() -> Vec<u8> {
+    let mut w = Writer::new("generic");
+    w.add_blob(b"nine", Some("text/plain"), None);
+    w.add_blob(b"lives", Some("text/plain"), None);
+    w.add_blob(b"purr", Some("text/plain"), None);
+    w.into_bytes()
+}
+
+/// R8-exec: the single-pass `content_id -> offset` index equals the offline
+/// inventory, and a damaged frame surfaces a diagnostic rather than a silent gap.
+#[test]
+fn claimid_offset_index_single_pass() {
+    let data = blob_fixture();
+
+    let mut sink = IndexSink::default();
+    let result = stream_events(&data, ReadOptions::new(true, None), &mut sink).expect("stream ok");
+    assert!(result.diagnostics.is_empty(), "clean fixture");
+
+    let inv = inventory(&data);
+    assert!(!inv.has_problems(), "clean inventory");
+    let expected: HashMap<Vec<u8>, usize> = inv
+        .segments
+        .iter()
+        .flat_map(|s| s.frames.iter())
+        .filter(|f| f.valid)
+        .map(|f| (f.id.clone(), f.start))
+        .collect();
+    assert_eq!(
+        sink.offsets, expected,
+        "streamed frame offsets must equal the offline inventory"
+    );
+    assert!(!sink.offsets.is_empty(), "fixture has valid frames");
+
+    // Damaged variant: corrupt a byte inside the last frame's payload; a
+    // diagnostic must be surfaced, not a silent gap.
+    let last = inv
+        .segments
+        .last()
+        .and_then(|s| s.frames.last())
+        .expect("fixture has frames");
+    let mut damaged = data.clone();
+    let target = last.start + (last.end - last.start) / 2;
+    damaged[target] ^= 0xFF;
+
+    let mut damaged_sink = IndexSink::default();
+    let damaged_result =
+        stream_events(&damaged, ReadOptions::new(true, None), &mut damaged_sink).expect("total");
+    assert!(
+        !damaged_result.diagnostics.is_empty() || damaged_sink.diagnostics > 0,
+        "a damaged frame must surface a diagnostic, not a silent gap"
+    );
+    assert!(
+        damaged_sink.offsets.len() < expected.len(),
+        "the damaged frame must not appear as a clean valid frame"
+    );
+}
+
+/// A successful drive calls `finish` exactly once.
+#[test]
+fn bridge_calls_finish_once() {
+    let data = two_segment_rdf_fixture();
+    let mut sink = CollectSink::default();
+    stream_events(&data, ReadOptions::new(true, None), &mut sink).expect("stream ok");
+    assert_eq!(sink.finish_count, 1);
+    assert_eq!(sink.resolved_quads.len(), 3, "all quads resolved once");
+}
+
+/// A `Break` cancels the drive: `stream_events` returns `Ok`, but the sink is
+/// never finalized and its collected output stays incomplete.
+#[test]
+fn bridge_break_cancels_drive() {
+    let data = two_segment_rdf_fixture();
+    let mut sink = CollectSink {
+        break_on_first_quad: true,
+        ..CollectSink::default()
+    };
+    let result = stream_events(&data, ReadOptions::new(true, None), &mut sink);
+    assert!(result.is_ok(), "cancellation is not an error");
+    assert_eq!(sink.finish_count, 0, "a cancelled drive is never finalized");
+    assert!(
+        sink.resolved_quads.is_empty(),
+        "no quads were resolved (finish never ran)"
+    );
+}
+
+/// Two drives over the same bytes mint an identical `EventTermId` sequence.
+#[test]
+fn stream_ids_are_file_order_deterministic() {
+    let data = two_segment_rdf_fixture();
+
+    let mut first = CollectSink::default();
+    stream_events(&data, ReadOptions::new(true, None), &mut first).expect("stream ok");
+    let mut second = CollectSink::default();
+    stream_events(&data, ReadOptions::new(true, None), &mut second).expect("stream ok");
+
+    assert_eq!(
+        first.declaration_order, second.declaration_order,
+        "id assignment must be a deterministic function of file order"
+    );
+    // And ids really are the dense 0..n minted in order.
+    let minted: Vec<u32> = first.declaration_order.iter().map(|(id, _)| id.0).collect();
+    assert_eq!(minted, (0..minted.len() as u32).collect::<Vec<_>>());
+}
+
+/// R9: re-indexing the whole segment(s) a diff fetched yields the same
+/// `content_id -> offset` map as inventorying just those fetched bytes.
+#[test]
+fn incremental_reindex_from_diff_fetch() {
+    let mut a = Writer::new("generic");
+    a.add_blob(b"local-a", Some("text/plain"), None);
+    a.add_blob(b"local-b", Some("text/plain"), None);
+    let local = a.into_bytes();
+
+    let mut b = Writer::new("generic");
+    b.add_blob(b"remote-c", Some("text/plain"), None);
+    b.add_blob(b"remote-d", Some("text/plain"), None);
+    let mut remote = local.clone();
+    remote.extend_from_slice(&b.to_bytes());
+
+    let inv_local = inventory(&local);
+    let inv_remote = inventory(&remote);
+    let result = diff(&inv_local, &inv_remote);
+    assert_eq!(result.status, DiffStatus::Fetch, "remote extends local");
+
+    // Splice reconstructs the whole remote (sanity on the fetch plan).
+    let spliced = splice(&local, &remote, &result).expect("splice ok");
+    assert_eq!(spliced, remote, "splice must reconstruct remote");
+
+    // The fetched bytes are the whole appended segment(s).
+    let mut fetched = Vec::new();
+    for f in &result.fetch {
+        fetched.extend_from_slice(&remote[f.range.start..f.range.end]);
+    }
+    assert!(!fetched.is_empty(), "there is something to fetch");
+
+    let mut sink = IndexSink::default();
+    stream_events(&fetched, ReadOptions::new(true, None), &mut sink).expect("stream ok");
+
+    let inv_fetched = inventory(&fetched);
+    assert!(
+        !inv_fetched.has_problems(),
+        "fetched bytes inventory cleanly"
+    );
+    let expected: HashMap<Vec<u8>, usize> = inv_fetched
+        .segments
+        .iter()
+        .flat_map(|s| s.frames.iter())
+        .filter(|f| f.valid)
+        .map(|f| (f.id.clone(), f.start))
+        .collect();
+
+    assert_eq!(
+        sink.offsets, expected,
+        "segment-aligned re-index of the fetched bytes must match their inventory"
+    );
+}
+
+/// A graph-scoped reifier cannot be carried on the graph-less RDF event
+/// protocol, so the bridge hard-fails rather than dropping the graph.
+#[test]
+fn graph_scoped_reifier_is_hard_error() {
+    let mut w = Writer::new("generic");
+    w.add_terms(&[
+        iri("http://example.org/s"),
+        iri("http://example.org/p"),
+        iri("http://example.org/o"),
+        iri("http://example.org/g"),
+        iri("http://example.org/reifier"),
+    ]);
+    // reifier id 4 binds (0,1,2) in named graph 3.
+    let binding: Vec<purrdf_gts::model::ReifierRow> = vec![(4, (0, 1, 2), Some(3))];
+    w.add_reifies(&binding);
+    let data = w.into_bytes();
+
+    // The fixture itself is clean at the GTS layer (the graph-scoped reifier is
+    // legal on the container; it is only the graph-less event protocol that
+    // cannot carry it).
+    let graph = read(&data, true, None);
+    assert!(graph.diagnostics.is_empty(), "container fixture is clean");
+    let _: Triple3 = (0, 1, 2);
+
+    let mut sink = CollectSink::default();
+    let err = stream_events(&data, ReadOptions::new(true, None), &mut sink)
+        .expect_err("a graph-scoped reifier must hard-fail on the event protocol");
+    assert!(
+        err.to_string().contains("graph-scoped reifier"),
+        "error names the unrepresentable graph slot: {err}"
+    );
+    assert_eq!(sink.finish_count, 0, "a failed drive is never finalized");
+}
+
+/// R6-exec2: a quad naming an undeclared segment-local term is a hard `Err`.
+///
+/// The GTS `Writer`/`reader` path sanitizes every quad position (an out-of-range
+/// id is diagnosed and dropped, never emitted), so a genuinely dangling quad
+/// reference is not authorable through it. We therefore drive the public
+/// `SegmentResolver` + `EventEmitter` bridge directly with hand-fed streaming
+/// events — the same bridge `stream_events` builds internally — and assert the
+/// resolution phase surfaces the dangling reference as an `Err`.
+#[test]
+fn dangling_term_ref_is_err() {
+    let mut sink = CollectSink::default();
+    let mut resolver = SegmentResolver::new(EventEmitter::new(&mut sink));
+
+    resolver.term(0, 0, &iri("http://example.org/s"));
+    resolver.term(0, 1, &iri("http://example.org/p"));
+    resolver.term(0, 2, &iri("http://example.org/o"));
+    // Quad references gts id 99, which no `term` event ever introduced.
+    resolver.quad(0, (0, 1, 99, None));
+
+    assert!(
+        resolver.take_error().is_none(),
+        "buffering phase latches no error"
+    );
+    let err = resolver
+        .finish()
+        .expect_err("a dangling quad reference must surface at resolution");
+    assert!(
+        err.to_string().contains("dangling term reference"),
+        "error names the dangling reference: {err}"
+    );
+    assert_eq!(sink.finish_count, 0, "the failed drive was never finalized");
+}

--- a/crates/gts/tests/event_bridge.rs
+++ b/crates/gts/tests/event_bridge.rs
@@ -649,14 +649,80 @@ fn graph_scoped_reifier_is_hard_error() {
     assert_eq!(sink.finish_count, 0, "a failed drive is never finalized");
 }
 
-/// R6-exec2: a quad naming an undeclared segment-local term is a hard `Err`.
+/// R6-exec2 (real bytes): a quad naming an undeclared segment-local term id,
+/// authored through the PUBLIC `Writer`, is a hard `Err` when driven through
+/// the PUBLIC `stream_events` byte path — no silent skip, no partial index.
 ///
-/// The GTS `Writer`/`reader` path sanitizes every quad position (an out-of-range
-/// id is diagnosed and dropped, never emitted), so a genuinely dangling quad
-/// reference is not authorable through it. We therefore drive the public
-/// `SegmentResolver` + `EventEmitter` bridge directly with hand-fed streaming
-/// events — the same bridge `stream_events` builds internally — and assert the
-/// resolution phase surfaces the dangling reference as an `Err`.
+/// `Writer::add_quads` takes raw `usize` ids and performs NO client-side
+/// validation, so a quad naming an id no `term` event ever introduced
+/// round-trips into a fully well-formed, correctly content-hashed, correctly
+/// chained GTS frame (contrary to the `dangling_term_ref_is_err` doc comment
+/// below in an earlier revision of this suite, which assumed no such fixture
+/// was authorable). The raw GTS reader is a deliberately permissive Baseline
+/// Reader (GTS-SPEC §7.4/§7.5): `reader::read`/`read_to_sink` themselves stay
+/// `Ok`, diagnosing the row as `PositionConstraint` and dropping it — the
+/// SAME behavior the frozen conformance vector
+/// `vectors/13-position-constraint.expected.json` pins. `EventEmitter`'s
+/// `ResolvedSink::diagnostic` escalates exactly that diagnostic (and its
+/// `ForwardReference` sibling) to a hard `EventError`, so the public
+/// `stream_events` byte path fails closed instead of silently finalizing a
+/// sink that never even saw the dropped quad.
+#[test]
+fn dangling_term_ref_real_bytes_is_err() {
+    let mut w = Writer::new("generic");
+    w.add_terms(&[
+        iri("http://example.org/s"),
+        iri("http://example.org/p"),
+        iri("http://example.org/o"),
+    ]);
+    // Object id 99 was never introduced by any `term` event in this segment.
+    w.add_quads(&[(0, 1, 99, None)]);
+    let data = w.into_bytes();
+
+    // Sanity: the raw GTS reader is intentionally permissive here (Baseline
+    // Reader degrade-and-continue, §7.6) — confirms the fixture reaches
+    // exactly the dangling-reference diagnostic, not some unrelated earlier
+    // hard-fail (a bad chain/hash would abort before position checking runs).
+    let graph = read(&data, true, None);
+    assert_eq!(
+        graph.diagnostics.len(),
+        1,
+        "the raw reader diagnoses exactly the dangling quad: {:?}",
+        graph.diagnostics
+    );
+    assert_eq!(graph.diagnostics[0].code, "PositionConstraint");
+    assert!(
+        graph.quads.is_empty(),
+        "the raw reader drops the dangling quad rather than materializing it"
+    );
+
+    // The public RDF event byte path must fail closed.
+    let mut sink = CollectSink::default();
+    let err = stream_events(&data, ReadOptions::new(true, None), &mut sink)
+        .expect_err("a dangling quad reference must hard-fail stream_events on real bytes");
+    assert!(
+        err.to_string().contains("dangling term reference"),
+        "error names the dangling reference: {err}"
+    );
+
+    // No partial index: the sink never received a single event.
+    assert_eq!(sink.finish_count, 0, "a failed drive is never finalized");
+    assert!(
+        sink.declaration_order.is_empty(),
+        "no term was ever declared to the sink — the segment never resolved"
+    );
+    assert!(
+        sink.quads.is_empty(),
+        "no quad was ever declared to the sink"
+    );
+}
+
+/// R6-exec2 (defense in depth): the SAME `SegmentResolver` + `EventEmitter`
+/// bridge `stream_events` builds internally ALSO hard-fails a dangling quad
+/// reference when driven directly with hand-fed streaming events — pinning
+/// the resolver's own no-optionality contract independent of whatever the
+/// raw byte reader happens to filter first. See
+/// `dangling_term_ref_real_bytes_is_err` above for the real-byte-path proof.
 #[test]
 fn dangling_term_ref_is_err() {
     let mut sink = CollectSink::default();

--- a/crates/gts/tests/replication_diff.rs
+++ b/crates/gts/tests/replication_diff.rs
@@ -1,0 +1,336 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Integration tests for the segment-head-prefix replication diff/splice
+//! surface (`purrdf_gts::replication::{diff, splice, diff_json}`).
+//!
+//! Fixtures are built exclusively through the public `Writer` API (mirroring
+//! `missing_returns_exact_tail_range` in `replication.rs`), except for the
+//! two branches that are only reachable by constructing an [`Inventory`]
+//! directly through its public fields (documented at each call site).
+
+use purrdf_gts::model::StreamableInfo;
+use purrdf_gts::replication::{
+    ByteRange, DiffResult, DiffStatus, FrameInventory, Inventory, SegmentFetch, SegmentInventory,
+    diff, diff_json, inventory, splice,
+};
+use purrdf_gts::writer::Writer;
+
+/// `local` = one `Writer` segment; `remote` = `local` with a second segment appended.
+fn append_fixture() -> (Vec<u8>, Vec<u8>) {
+    let mut first = Writer::new("generic");
+    first.add_blob(b"a", None, None);
+    let local = first.to_bytes();
+
+    let mut second = Writer::new("generic");
+    second.add_blob(b"b", None, None);
+    let b = second.to_bytes();
+
+    let mut remote = local.clone();
+    remote.extend_from_slice(&b);
+    (local, remote)
+}
+
+#[test]
+fn diff_reconstructs_remote_via_splice() {
+    let (local, remote) = append_fixture();
+    let result = diff(&inventory(&local), &inventory(&remote));
+    assert_eq!(result.status, DiffStatus::Fetch);
+    assert!(result.continuous);
+
+    let spliced = splice(&local, &remote, &result).expect("splice should succeed");
+    assert_eq!(spliced, remote);
+    assert!(!inventory(&spliced).has_problems());
+}
+
+#[test]
+fn diff_appends_new_segment_is_fetch() {
+    // A naive frame-`prev` check would see the new segment's first frame
+    // chaining onto its own (independently rooted) header rather than onto
+    // local's head, and wrongly call this `Diverged`. Segment-head-prefix
+    // equality is what proves continuity here.
+    let (local, remote) = append_fixture();
+    let result = diff(&inventory(&local), &inventory(&remote));
+    assert_eq!(result.status, DiffStatus::Fetch);
+    assert!(result.continuous);
+    assert_eq!(result.fetch.len(), 1);
+    assert_eq!(result.fetch[0].remote_index, 1);
+    assert_eq!(result.splice_offset, Some(local.len()));
+}
+
+#[test]
+fn diff_identical_is_current() {
+    let (local, _remote) = append_fixture();
+    let result = diff(&inventory(&local), &inventory(&local));
+    assert_eq!(result.status, DiffStatus::Current);
+    assert!(result.fetch.is_empty());
+    assert!(result.continuous);
+}
+
+#[test]
+fn diff_empty_local_fetches_all() {
+    let (_local, remote) = append_fixture();
+    let empty = inventory(&[]);
+    // `inventory(&[])` reports a fatal `EmptyFile` diagnostic (there is
+    // nothing to decode), but `diff` treats a trivially empty local as a
+    // valid starting point rather than a problem worth erroring out on.
+    assert!(empty.has_problems());
+    assert!(empty.segments.is_empty());
+    let remote_inventory = inventory(&remote);
+
+    let result = diff(&empty, &remote_inventory);
+    assert_eq!(result.status, DiffStatus::Fetch);
+    assert!(result.continuous);
+    assert_eq!(result.fetch.len(), remote_inventory.segments.len());
+    assert_eq!(result.splice_offset, Some(0));
+
+    let spliced = splice(&[], &remote, &result).expect("splice should succeed");
+    assert_eq!(spliced, remote);
+}
+
+#[test]
+fn diff_remote_behind_is_current() {
+    let (local, remote) = append_fixture();
+    // Swap: the bigger file is now local, the smaller one is remote.
+    let result = diff(&inventory(&remote), &inventory(&local));
+    assert_eq!(result.status, DiffStatus::Current);
+    assert!(result.fetch.is_empty());
+    assert!(result.continuous);
+}
+
+#[test]
+fn diff_fork_is_diverged() {
+    let mut wa = Writer::new("generic");
+    wa.add_blob(b"a", None, None);
+    let a = wa.to_bytes();
+
+    let mut wb = Writer::new("generic");
+    wb.add_blob(b"b", None, None);
+    let b = wb.to_bytes();
+
+    let mut wc = Writer::new("generic");
+    wc.add_blob(b"c", None, None);
+    let c = wc.to_bytes();
+
+    let mut local = a.clone();
+    local.extend_from_slice(&b);
+    let mut remote = a;
+    remote.extend_from_slice(&c);
+
+    let result = diff(&inventory(&local), &inventory(&remote));
+    assert_eq!(result.status, DiffStatus::Diverged);
+    assert!(!result.continuous);
+    assert!(result.detail.is_some());
+    assert!(splice(&local, &remote, &result).is_err());
+}
+
+#[test]
+fn diff_problem_inventory_is_error() {
+    let (_local, remote) = append_fixture();
+    // Cut inside the second segment's frame item, well past the last clean
+    // CBOR item boundary, so `iter_items` reports a torn trailing item.
+    let torn = remote[..remote.len() - 5].to_vec();
+    let torn_inventory = inventory(&torn);
+    assert!(
+        torn_inventory.has_problems(),
+        "fixture must actually be torn"
+    );
+
+    let result = diff(&torn_inventory, &inventory(&remote));
+    assert_eq!(result.status, DiffStatus::Error);
+    assert!(!result.continuous);
+    assert!(result.splice_offset.is_none());
+    assert!(result.fetch.is_empty());
+    assert!(result.detail.is_some());
+    assert!(splice(&torn, &remote, &result).is_err());
+}
+
+#[test]
+fn diff_json_schema_and_shape() {
+    let (local, remote) = append_fixture();
+    let result = diff(&inventory(&local), &inventory(&remote));
+    let json = diff_json(&result);
+    assert!(json.contains("\"schema\":\"gts-replication-diff-v1\""));
+    assert!(json.contains("\"status\":\"fetch\""));
+    assert!(json.contains("\"range\":{\"start\":"));
+    assert!(json.contains("\"end\":"));
+    assert!(json.contains("\"length\":"));
+    assert!(json.ends_with('\n'));
+}
+
+#[test]
+fn diff_midsegment_append_is_fetch() {
+    // One `Writer` with three `add_blob` calls yields a single multi-frame
+    // segment. Truncating at the first frame's end offset gives a `local`
+    // whose only segment is a clean, byte-exact prefix of `remote`'s.
+    let mut writer = Writer::new("generic");
+    writer.add_blob(b"x", None, None);
+    writer.add_blob(b"y", None, None);
+    writer.add_blob(b"z", None, None);
+    let remote = writer.to_bytes();
+
+    let remote_inventory = inventory(&remote);
+    assert!(!remote_inventory.has_problems());
+    let cut = remote_inventory.segments[0].frames[0].end;
+    let local = remote[..cut].to_vec();
+    let local_inventory = inventory(&local);
+    assert!(!local_inventory.has_problems());
+    assert_eq!(local_inventory.segments[0].frames.len(), 1);
+
+    let result = diff(&local_inventory, &remote_inventory);
+    assert_eq!(result.status, DiffStatus::Fetch);
+    assert!(result.continuous);
+    assert_eq!(
+        result.fetch,
+        vec![SegmentFetch {
+            remote_index: 0,
+            range: ByteRange {
+                start: local.len(),
+                end: remote.len(),
+            },
+            head: remote_inventory.segments[0].head.clone(),
+        }]
+    );
+    assert_eq!(result.splice_offset, Some(local.len()));
+
+    let spliced = splice(&local, &remote, &result).expect("splice should succeed");
+    assert_eq!(spliced, remote);
+}
+
+/// Build a minimal, "clean" (no diagnostics) single-frame [`FrameInventory`].
+fn synth_frame(frame_index: usize, id: &[u8], prev: Option<&[u8]>, valid: bool) -> FrameInventory {
+    FrameInventory {
+        item_index: frame_index + 1,
+        frame_index,
+        start: 0,
+        end: 0,
+        id: id.to_vec(),
+        frame_type: "blob".to_string(),
+        valid,
+        prev: prev.map(<[u8]>::to_vec),
+    }
+}
+
+/// Build a minimal, "clean" (no diagnostics) [`SegmentInventory`].
+fn synth_segment(
+    index: usize,
+    start: usize,
+    end: usize,
+    head: Option<Vec<u8>>,
+    frames: Vec<FrameInventory>,
+) -> SegmentInventory {
+    SegmentInventory {
+        index,
+        item_start: 0,
+        item_end: frames.len() + 1,
+        start,
+        end,
+        profile: "generic".to_string(),
+        head,
+        frame_count: frames.len(),
+        layout: StreamableInfo::default(),
+        diagnostics: Vec::new(),
+        frames,
+    }
+}
+
+#[test]
+fn diff_midsegment_forged_prev_is_diverged() {
+    // Given `local`/`remote` both pass the `has_problems()` gate and
+    // `local`'s frame ids are a genuine content prefix of `remote`'s, the
+    // reader's own chain-fold guarantees the first new frame's `prev`
+    // equals local's last frame id — so a real, clean GTS byte stream can
+    // never exercise this failure mode (tampering the wire bytes trips the
+    // fold's own `BrokenChain` diagnostic first, landing on `Error`, not
+    // `Diverged`). The check still exists as defense-in-depth for callers
+    // who build an `Inventory` directly, so it is exercised the same way
+    // here: through the public `Inventory`/`SegmentInventory`/
+    // `FrameInventory` fields, with an internally-consistent "clean" shape
+    // (no diagnostics, no torn/fatal markers) but a `prev` that does not
+    // chain onto local's head.
+    let id_a = vec![0xAA; 32];
+    let id_b = vec![0xBB; 32];
+    let unrelated_prev = vec![0xEE; 32];
+
+    let local = Inventory {
+        segments: vec![synth_segment(
+            0,
+            0,
+            100,
+            Some(vec![0x11; 32]),
+            vec![synth_frame(0, &id_a, Some(&[0x00; 32]), true)],
+        )],
+        fatal: None,
+        torn: None,
+        clean_end: 100,
+        item_count: 2,
+    };
+    let remote = Inventory {
+        segments: vec![synth_segment(
+            0,
+            0,
+            200,
+            Some(vec![0x22; 32]),
+            vec![
+                synth_frame(0, &id_a, Some(&[0x00; 32]), true),
+                synth_frame(1, &id_b, Some(&unrelated_prev), true),
+            ],
+        )],
+        fatal: None,
+        torn: None,
+        clean_end: 200,
+        item_count: 3,
+    };
+    assert!(!local.has_problems());
+    assert!(!remote.has_problems());
+
+    let result = diff(&local, &remote);
+    assert_eq!(result.status, DiffStatus::Diverged);
+    assert!(!result.continuous);
+    assert!(result.splice_offset.is_none());
+    assert!(result.detail.is_some());
+}
+
+#[test]
+fn diff_reencoded_common_segment_is_diverged() {
+    // Same segment head, different byte length/alignment: a re-encoded
+    // mirror rather than a linear extension. `Inventory`/`SegmentInventory`
+    // fields are all public, so this branch is driven deterministically
+    // through a synthetic pair rather than hoping a real codec round-trip
+    // happens to re-encode identically.
+    let head = vec![0x77; 32];
+    let local = Inventory {
+        segments: vec![synth_segment(0, 0, 100, Some(head.clone()), Vec::new())],
+        fatal: None,
+        torn: None,
+        clean_end: 100,
+        item_count: 1,
+    };
+    let remote = Inventory {
+        segments: vec![synth_segment(0, 0, 120, Some(head), Vec::new())],
+        fatal: None,
+        torn: None,
+        clean_end: 120,
+        item_count: 1,
+    };
+    assert!(!local.has_problems());
+    assert!(!remote.has_problems());
+
+    let result = diff(&local, &remote);
+    assert_eq!(result.status, DiffStatus::Diverged);
+    assert!(!result.continuous);
+    assert!(result.splice_offset.is_none());
+    assert!(result.detail.is_some());
+    assert!(splice(&[], &[], &result).is_err());
+}
+
+#[test]
+fn diff_result_debug_and_clone_are_available() {
+    // `DiffResult`/`SegmentFetch` are meant to be threaded through calling
+    // code (e.g. logged or retried); confirm the derives are present on the
+    // public surface without over-specifying formatting.
+    let (local, remote) = append_fixture();
+    let result: DiffResult = diff(&inventory(&local), &inventory(&remote));
+    let cloned = result.clone();
+    assert_eq!(format!("{cloned:?}"), format!("{result:?}"));
+}

--- a/crates/gts/tests/streaming_provenance.rs
+++ b/crates/gts/tests/streaming_provenance.rs
@@ -9,7 +9,7 @@
 //! same bytes: both derive their per-frame `(content-id, byte range, wire
 //! type, valid)` from the same frames, so they must agree field-for-field.
 
-use purrdf_gts::model::ByteRange;
+use purrdf_gts::model::{AnnotationRow, ByteRange, OpaqueNode, Quad, ReifierRow, Term};
 use purrdf_gts::reader::{FrameContext, StreamingSink, read_to_sink};
 use purrdf_gts::replication::inventory;
 use purrdf_gts::writer::Writer;
@@ -119,4 +119,131 @@ fn streaming_frame_provenance_matches_offline_inventory() {
             );
         }
     }
+}
+
+// -- frame-before-rows ordering ----------------------------------------------
+
+/// A [`StreamingSink`] that records every event — `frame()` and every row
+/// callback — into ONE interleaved log, tagging each entry so the test can
+/// tell frame markers from row events.
+#[derive(Default)]
+struct OrderingSink {
+    log: Vec<String>,
+}
+
+impl StreamingSink for OrderingSink {
+    fn frame(&mut self, ctx: FrameContext<'_>) {
+        self.log
+            .push(format!("frame:{}:{}", ctx.segment_index, ctx.frame_index));
+    }
+    fn term(&mut self, segment_index: usize, term_id: usize, _term: &Term) {
+        self.log.push(format!("term:{segment_index}:{term_id}"));
+    }
+    fn quad(&mut self, segment_index: usize, _quad: Quad) {
+        self.log.push(format!("quad:{segment_index}"));
+    }
+    fn reifier(&mut self, segment_index: usize, _reifier: ReifierRow) {
+        self.log.push(format!("reifier:{segment_index}"));
+    }
+    fn annotation(&mut self, segment_index: usize, _annotation: AnnotationRow) {
+        self.log.push(format!("annotation:{segment_index}"));
+    }
+    fn blob(
+        &mut self,
+        segment_index: usize,
+        _digest: &str,
+        _meta: Option<&ciborium::value::Value>,
+    ) {
+        self.log.push(format!("blob:{segment_index}"));
+    }
+    fn opaque(&mut self, segment_index: usize, _opaque: &OpaqueNode) {
+        self.log.push(format!("opaque:{segment_index}"));
+    }
+}
+
+/// A single-segment fixture with three frames, each producing a known,
+/// non-empty set of rows: a `terms` frame (3 term rows), a `quads` frame (1
+/// quad row), and a `blob` frame (1 blob row).
+fn three_frame_fixture() -> Vec<u8> {
+    use purrdf_gts::model::TermKind;
+
+    let mut w = Writer::new("generic");
+    w.add_terms(&[
+        Term {
+            kind: TermKind::Iri,
+            value: Some("http://example.org/s".to_string()),
+            datatype: None,
+            lang: None,
+            direction: None,
+            reifier: None,
+        },
+        Term {
+            kind: TermKind::Iri,
+            value: Some("http://example.org/p".to_string()),
+            datatype: None,
+            lang: None,
+            direction: None,
+            reifier: None,
+        },
+        Term {
+            kind: TermKind::Literal,
+            value: Some("o".to_string()),
+            datatype: None,
+            lang: None,
+            direction: None,
+            reifier: None,
+        },
+    ]);
+    w.add_quads(&[(0, 1, 2, None)]);
+    w.add_blob(b"provenance-ordering-fixture", None, None);
+    w.to_bytes()
+}
+
+/// Falsifiable regression test for the `StreamingSink::frame` contract:
+/// "fired once per frame **before its rows are processed**"
+/// (`purrdf_gts::reader::StreamingSink::frame`).
+///
+/// Drives [`read_to_sink`] over a fixture whose three frames each carry a
+/// known, non-empty row set, and asserts the interleaved event log is
+/// exactly `[frame, row*]` per frame, in file order. If `frame()` ever fires
+/// after (or interleaved with a gap after) that frame's own rows, the block
+/// boundary this test walks will not start with a `frame:` tag and the
+/// assertion below fails.
+#[test]
+fn frame_event_precedes_its_own_row_events_for_every_frame() {
+    let data = three_frame_fixture();
+
+    let mut sink = OrderingSink::default();
+    let result = read_to_sink(&data, false, None, &mut sink);
+    assert!(result.diagnostics.is_empty(), "fixture must fold cleanly");
+
+    // Expected `(frame tag, row count)` blocks in file order.
+    let expected_blocks = [("frame:0:0", 3usize), ("frame:0:1", 1), ("frame:0:2", 1)];
+
+    let mut cursor = 0usize;
+    for (frame_tag, row_count) in expected_blocks {
+        assert_eq!(
+            sink.log.get(cursor).map(String::as_str),
+            Some(frame_tag),
+            "expected {frame_tag} at log position {cursor}; full log: {:?}",
+            sink.log
+        );
+        cursor += 1;
+        for offset in 0..row_count {
+            let entry = sink.log.get(cursor + offset).map(String::as_str);
+            assert!(
+                entry.is_some_and(|tag| !tag.starts_with("frame:")),
+                "row #{offset} of {frame_tag} was not a row event (got {entry:?}); \
+                 frame() must fire before its rows — full log: {:?}",
+                sink.log
+            );
+        }
+        cursor += row_count;
+    }
+    assert_eq!(
+        cursor,
+        sink.log.len(),
+        "unexpected trailing events after the last frame's rows: {:?}",
+        sink.log
+    );
 }

--- a/crates/gts/tests/streaming_provenance.rs
+++ b/crates/gts/tests/streaming_provenance.rs
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Integration test for per-frame provenance on the streaming read path
+//! (`purrdf_gts::reader::{FrameContext, StreamingSink::frame}`).
+//!
+//! Cross-checks the streaming `FrameContext` events fired by
+//! [`read_to_sink`] against the offline `replication::inventory` view of the
+//! same bytes: both derive their per-frame `(content-id, byte range, wire
+//! type, valid)` from the same frames, so they must agree field-for-field.
+
+use purrdf_gts::model::ByteRange;
+use purrdf_gts::reader::{FrameContext, StreamingSink, read_to_sink};
+use purrdf_gts::replication::inventory;
+use purrdf_gts::writer::Writer;
+
+/// Owned copy of one streamed [`FrameContext`], captured for later assertion.
+struct CapturedFrame {
+    segment_index: usize,
+    frame_index: usize,
+    content_id: Vec<u8>,
+    start: usize,
+    end: usize,
+    frame_type: String,
+    valid: bool,
+}
+
+/// A [`StreamingSink`] that records every [`FrameContext`] it receives, in
+/// arrival order, and nothing else.
+#[derive(Default)]
+struct CapturingSink {
+    frames: Vec<CapturedFrame>,
+}
+
+impl StreamingSink for CapturingSink {
+    fn frame(&mut self, ctx: FrameContext<'_>) {
+        self.frames.push(CapturedFrame {
+            segment_index: ctx.segment_index,
+            frame_index: ctx.frame_index,
+            content_id: ctx.content_id.to_vec(),
+            start: ctx.range.start,
+            end: ctx.range.end,
+            frame_type: ctx.frame_type.to_string(),
+            valid: ctx.valid,
+        });
+    }
+}
+
+/// A 2-segment fixture: two `Writer::new("generic")` blob-writer outputs
+/// concatenated, mirroring the fixture in `replication.rs`'s own tests.
+fn two_segment_fixture() -> Vec<u8> {
+    let mut first = Writer::new("generic");
+    first.add_blob(b"a", None, None);
+    first.add_blob(b"b", None, None);
+    let mut data = first.to_bytes();
+
+    let mut second = Writer::new("generic");
+    second.add_blob(b"c", None, None);
+    data.extend_from_slice(&second.to_bytes());
+    data
+}
+
+#[test]
+fn streaming_frame_provenance_matches_offline_inventory() {
+    let data = two_segment_fixture();
+
+    let mut sink = CapturingSink::default();
+    let result = read_to_sink(&data, true, None, &mut sink);
+    assert!(result.diagnostics.is_empty(), "fixture must fold cleanly");
+
+    let inv = inventory(&data);
+    assert!(!inv.has_problems(), "fixture must inventory cleanly");
+
+    let expected_total: usize = inv.segments.iter().map(|s| s.frames.len()).sum();
+    assert_eq!(sink.frames.len(), expected_total);
+
+    // Captured frames arrive in file order, one-to-one with the inventory's
+    // segment/frame ordering.
+    let mut captured = sink.frames.iter();
+    for segment in &inv.segments {
+        for frame in &segment.frames {
+            let ctx = captured
+                .next()
+                .expect("streaming sink under-reported frames");
+            assert_eq!(ctx.segment_index, segment.index);
+            assert_eq!(ctx.frame_index, frame.frame_index);
+            assert_eq!(ctx.content_id, frame.id);
+            assert_eq!(ctx.start, frame.start);
+            assert_eq!(ctx.end, frame.end);
+            assert_eq!(ctx.frame_type, frame.frame_type);
+            assert_eq!(ctx.valid, frame.valid);
+        }
+    }
+    assert!(
+        captured.next().is_none(),
+        "streaming sink over-reported frames"
+    );
+
+    // Every valid frame's provenance is independently re-verifiable against
+    // the source bytes.
+    for ctx in &sink.frames {
+        if ctx.valid {
+            let recomputed = FrameContext {
+                segment_index: ctx.segment_index,
+                frame_index: ctx.frame_index,
+                content_id: &ctx.content_id,
+                range: ByteRange {
+                    start: ctx.start,
+                    end: ctx.end,
+                },
+                frame_type: &ctx.frame_type,
+                valid: ctx.valid,
+            };
+            assert!(
+                recomputed.verify(&data),
+                "valid frame at segment {} frame {} should verify",
+                ctx.segment_index,
+                ctx.frame_index
+            );
+        }
+    }
+}

--- a/crates/rdf/src/gts_certify.rs
+++ b/crates/rdf/src/gts_certify.rs
@@ -777,7 +777,7 @@ fn suppressions_ok(pre: &Graph, post: &Graph) -> Result<bool, CertifyError> {
 /// `pre_bytes`/`post_bytes` are UNTRUSTED (an independent verifier's whole
 /// point is to not trust the claimant), so every digest this function
 /// computes over them goes through the fallible RDFC-1.0 canonicalizer
-/// ([`try_refold_digest`]/[`try_effective_digest`], backing
+/// (`try_refold_digest`/`try_effective_digest`, backing
 /// [`try_canonicalize_with`]) rather than the panicking
 /// [`canonicalize_with`]: a pathologically symmetric blank graph that stays
 /// under [`POISON_BLANK_LIMIT`]'s cheap blank-COUNT pre-reject yet exhausts

--- a/crates/rdf/src/gts_import_sink.rs
+++ b/crates/rdf/src/gts_import_sink.rs
@@ -777,7 +777,9 @@ mod tests {
 
     /// A quad that references a GTS term id no `term` event introduced MUST surface
     /// as a hard `Err` (no silent skip), even though resolution is now deferred to
-    /// phase 2.
+    /// phase 2. Hand-fed defense-in-depth for the resolver's own no-optionality
+    /// contract; see `dangling_term_ref_real_bytes_is_err` below for the same
+    /// contract proven through the PUBLIC `import_gts_events` byte path.
     #[test]
     fn gate2_unknown_term_reference_is_err_direct() {
         let mut resolver = SegmentResolver::new(SinkImporter::new());
@@ -788,6 +790,46 @@ mod tests {
         let (_resolver, error) = finish_direct(resolver);
         let err = error.expect("dangling reference must defer an error");
         assert_eq!(err.code, "rdf-ir-dangling-term-ref");
+    }
+
+    /// R6-exec2 (real bytes): a quad naming an undeclared segment-local term id,
+    /// authored through the PUBLIC `purrdf_gts::writer::Writer`, is a hard `Err`
+    /// when driven through the PUBLIC `import_gts_events` byte path — no silent
+    /// skip, no partial `GtsBundle`.
+    ///
+    /// `Writer::add_quads` takes raw `usize` ids and performs NO client-side
+    /// validation, so a quad naming an id no `term` event ever introduced
+    /// round-trips into a fully well-formed, correctly content-hashed, correctly
+    /// chained GTS frame. The raw GTS reader is a deliberately permissive
+    /// Baseline Reader (GTS-SPEC §7.4/§7.5): it diagnoses the row as
+    /// `PositionConstraint` and DROPS it rather than erroring (the same
+    /// degrade-and-continue behavior the frozen conformance vector
+    /// `vectors/13-position-constraint.expected.json` pins). `SinkImporter`'s
+    /// `ResolvedSink::diagnostic` — "the IR is the authority, no degraded fold"
+    /// (module docs above) — promotes ANY reader diagnostic to a hard `Err`
+    /// before phase 2 ever runs, so no partial dataset is ever frozen.
+    #[test]
+    fn dangling_term_ref_real_bytes_is_err() {
+        let mut w = Writer::new("generic");
+        w.add_terms(&[
+            iri_term("http://example.org/s"),
+            iri_term("http://example.org/p"),
+            iri_term("http://example.org/o"),
+        ]);
+        // Object id 99 was never introduced by any `term` event in this segment.
+        w.add_quads(&[(0, 1, 99, None)]);
+        let data = w.into_bytes();
+
+        let err = import_gts_events(&data)
+            .expect_err("a dangling quad reference must hard-fail import_gts_events on real bytes");
+        assert_eq!(
+            err.code, "rdf-ir-gts-fold-diagnostic",
+            "the reader's PositionConstraint diagnostic is promoted to a hard Err: {err:?}"
+        );
+        assert!(
+            err.message.contains("PositionConstraint"),
+            "error names the underlying diagnostic: {err:?}"
+        );
     }
 
     /// Directional literals: GTS `Term` carries no base direction, so the sink path

--- a/crates/rdf/src/gts_import_sink.rs
+++ b/crates/rdf/src/gts_import_sink.rs
@@ -871,7 +871,8 @@ mod tests {
         );
         resolver.quad(0, (0, 1, 2, None));
         let (_resolver, error) = finish_direct(resolver);
-        let err = error.expect("a genuinely dangling reifier binding must STILL fail after phase 2");
+        let err =
+            error.expect("a genuinely dangling reifier binding must STILL fail after phase 2");
         assert_eq!(err.code, "rdf-ir-missing-reifier-binding");
     }
 

--- a/crates/rdf/src/gts_import_sink.rs
+++ b/crates/rdf/src/gts_import_sink.rs
@@ -475,6 +475,8 @@ mod tests {
     use purrdf_gts::reader::StreamingSink;
     use purrdf_gts::writer::Writer;
 
+    use crate::RdfTextDirection;
+
     fn iri_term(value: &str) -> Term {
         Term {
             kind: TermKind::Iri,
@@ -832,8 +834,14 @@ mod tests {
         );
     }
 
-    /// Directional literals: GTS `Term` carries no base direction, so the sink path
-    /// yields `direction == None`, but lexical form, datatype, and language survive.
+    /// Directional literals: this test's INPUT term carries no base direction
+    /// (`direction: None` below), so the resolved literal's direction is `None`.
+    /// GTS `Term` itself DOES carry base direction (see module docs above and
+    /// [`SinkImporter::intern_literal`], which parses it via
+    /// `crate::gts_resolve::parse_gts_direction`); the absent-direction case is
+    /// exercised here, lexical form, datatype, and language survive regardless. See
+    /// `directional_literal_rtl_survives_sink_path` below for the
+    /// direction-PRESENT case.
     #[test]
     fn directional_literal_lexical_lang_survive_sink_path() {
         let mut resolver = SegmentResolver::new(RecordingSink::new());
@@ -868,7 +876,63 @@ mod tests {
             } => {
                 assert_eq!(lexical, "Bonjour", "lexical preserved verbatim");
                 assert_eq!(language, Some("fr"), "language lowercased per C0.1");
-                assert_eq!(direction, None, "GTS cannot carry base direction");
+                assert_eq!(
+                    direction, None,
+                    "this term's input direction was None, not a GTS limitation"
+                );
+            }
+            other => panic!("expected literal, got {other:?}"),
+        }
+    }
+
+    /// Directional literals, direction-PRESENT case: a GTS `Term` whose
+    /// `direction` is `Some("rtl")` (with the RDF 1.2-required language tag)
+    /// survives the sink path intact. `parse_gts_direction`
+    /// (`crate::gts_resolve`) accepts only the literal tokens `"ltr"`/`"rtl"`
+    /// and requires a non-empty `language` whenever `direction` is set;
+    /// `SinkImporter::intern_literal` calls it and stores the resolved
+    /// [`crate::RdfTextDirection`] onto the literal, so the frozen dataset must
+    /// resolve it back as `Some(RdfTextDirection::Rtl)` — proving GTS DOES carry
+    /// base direction end to end through the sink path.
+    #[test]
+    fn directional_literal_rtl_survives_sink_path() {
+        let mut resolver = SegmentResolver::new(RecordingSink::new());
+        resolver.term(0, 0, &iri_term("http://example.org/s"));
+        resolver.term(0, 1, &iri_term("http://example.org/p"));
+        resolver.term(
+            0,
+            2,
+            &Term {
+                kind: TermKind::Literal,
+                value: Some("مرحبا".to_owned()),
+                datatype: None,
+                lang: Some("AR".to_owned()),
+                direction: Some("rtl".to_owned()),
+                reifier: None,
+            },
+        );
+        resolver.quad(0, (0, 1, 2, None));
+        let (mut resolver, error) = finish_direct(resolver);
+        assert!(error.is_none(), "{error:?}");
+
+        let lit_id = resolver.sink().id(0, 2).expect("literal resolved");
+        let dataset = std::mem::take(&mut resolver.sink_mut().inner.builder)
+            .freeze()
+            .expect("freeze");
+        match dataset.resolve(lit_id) {
+            TermRef::Literal {
+                lexical,
+                language,
+                direction,
+                ..
+            } => {
+                assert_eq!(lexical, "مرحبا", "lexical preserved verbatim");
+                assert_eq!(language, Some("ar"), "language lowercased per C0.1");
+                assert_eq!(
+                    direction,
+                    Some(RdfTextDirection::Rtl),
+                    "GTS base direction survives the sink path"
+                );
             }
             other => panic!("expected literal, got {other:?}"),
         }

--- a/crates/rdf/src/gts_import_sink.rs
+++ b/crates/rdf/src/gts_import_sink.rs
@@ -475,9 +475,6 @@ mod tests {
     use purrdf_gts::reader::StreamingSink;
     use purrdf_gts::writer::Writer;
 
-    /// Convenience alias for a resolver wrapping the immutable-IR sink.
-    type Resolver = SegmentResolver<SinkImporter>;
-
     fn iri_term(value: &str) -> Term {
         Term {
             kind: TermKind::Iri,
@@ -503,8 +500,11 @@ mod tests {
     /// Drive the streaming events then run phase 2, returning the resolver plus any
     /// error for post-resolution assertions (the public `import_gts_events` does
     /// both phases from bytes; this exercises the hand-ordered direct-sink path). A
-    /// latched streaming error takes precedence over the phase-2 flush.
-    fn finish_direct(mut resolver: Resolver) -> (Resolver, Option<RdfDiagnostic>) {
+    /// latched streaming error takes precedence over the phase-2 flush. Generic
+    /// over the emit target so it also drives [`RecordingSink`]-wrapped resolvers.
+    fn finish_direct<S: ResolvedSink>(
+        mut resolver: SegmentResolver<S>,
+    ) -> (SegmentResolver<S>, Option<S::Error>) {
         if let Some(error) = resolver.take_error() {
             return (resolver, Some(error));
         }
@@ -513,10 +513,205 @@ mod tests {
     }
 
     /// Resolve `our_id` back to its interned blank `(label, scope)` for assertions.
-    fn blank_scope(resolver: &Resolver, id: TermId) -> (String, BlankScope) {
-        match resolver.sink().builder.resolve(id) {
+    fn blank_scope(builder: &RdfDatasetBuilder, id: TermId) -> (String, BlankScope) {
+        match builder.resolve(id) {
             TermRef::Blank { label, scope } => (label.to_string(), scope),
             other => panic!("expected blank node, got {other:?}"),
+        }
+    }
+
+    /// TEST-ONLY [`ResolvedSink`] wrapping [`SinkImporter`] that additionally
+    /// records `(segment_index, gts_id) → TermId` for every resolved TERM as it
+    /// is interned.
+    ///
+    /// This replaces the removed `SegmentResolver::remap` white-box inspector:
+    /// R8 (bounded-memory streaming fold) forbids the *production* resolver from
+    /// retaining a whole-file `(segment, gts_id) → id` map (it must drop at each
+    /// segment close), but a handful of tests need to observe cross-segment term
+    /// identity (e.g. "the same IRI in two segments resolves to the same id, but
+    /// the same blank label resolves to different ids"). Holding that map here,
+    /// in the test harness, is fine — it is not the hot streaming path.
+    struct RecordingSink {
+        inner: SinkImporter,
+        ids: std::collections::HashMap<(usize, usize), TermId>,
+    }
+
+    impl RecordingSink {
+        fn new() -> Self {
+            Self {
+                inner: SinkImporter::new(),
+                ids: std::collections::HashMap::new(),
+            }
+        }
+
+        /// Look up the target id a segment-local gts id resolved to.
+        fn id(&self, segment_index: usize, gts_id: usize) -> Option<TermId> {
+            self.ids.get(&(segment_index, gts_id)).copied()
+        }
+    }
+
+    impl ResolvedSink for RecordingSink {
+        type Id = TermId;
+        type Error = RdfDiagnostic;
+
+        fn intern_iri(
+            &mut self,
+            segment_index: usize,
+            gts_id: usize,
+            iri: &str,
+        ) -> Result<TermId, RdfDiagnostic> {
+            let id = self.inner.intern_iri(segment_index, gts_id, iri)?;
+            self.ids.insert((segment_index, gts_id), id);
+            Ok(id)
+        }
+
+        fn intern_blank(
+            &mut self,
+            segment_index: usize,
+            gts_id: usize,
+            label: &str,
+        ) -> Result<TermId, RdfDiagnostic> {
+            let id = self.inner.intern_blank(segment_index, gts_id, label)?;
+            self.ids.insert((segment_index, gts_id), id);
+            Ok(id)
+        }
+
+        fn intern_literal(
+            &mut self,
+            segment_index: usize,
+            gts_id: usize,
+            lexical: String,
+            datatype: Option<TermId>,
+            lang: Option<String>,
+            direction: Option<String>,
+        ) -> Result<TermId, RdfDiagnostic> {
+            let id = self.inner.intern_literal(
+                segment_index,
+                gts_id,
+                lexical,
+                datatype,
+                lang,
+                direction,
+            )?;
+            self.ids.insert((segment_index, gts_id), id);
+            Ok(id)
+        }
+
+        fn intern_triple(
+            &mut self,
+            segment_index: usize,
+            gts_id: usize,
+            s: TermId,
+            p: TermId,
+            o: TermId,
+        ) -> Result<TermId, RdfDiagnostic> {
+            let id = self.inner.intern_triple(segment_index, gts_id, s, p, o)?;
+            self.ids.insert((segment_index, gts_id), id);
+            Ok(id)
+        }
+
+        fn push_quad(
+            &mut self,
+            segment_index: usize,
+            s: TermId,
+            p: TermId,
+            o: TermId,
+            g: Option<TermId>,
+        ) -> Result<(), RdfDiagnostic> {
+            self.inner.push_quad(segment_index, s, p, o, g)
+        }
+
+        fn push_reifier(
+            &mut self,
+            segment_index: usize,
+            reifier: TermId,
+            s: TermId,
+            p: TermId,
+            o: TermId,
+            g: Option<TermId>,
+        ) -> Result<(), RdfDiagnostic> {
+            self.inner.push_reifier(segment_index, reifier, s, p, o, g)
+        }
+
+        fn push_annotation(
+            &mut self,
+            segment_index: usize,
+            reifier: TermId,
+            p: TermId,
+            o: TermId,
+            g: Option<TermId>,
+        ) -> Result<(), RdfDiagnostic> {
+            self.inner.push_annotation(segment_index, reifier, p, o, g)
+        }
+
+        fn err_dangling_term(
+            &self,
+            segment_index: usize,
+            gts_id: usize,
+            role: &str,
+        ) -> RdfDiagnostic {
+            self.inner.err_dangling_term(segment_index, gts_id, role)
+        }
+
+        fn err_nesting_limit(&self, segment_index: usize, gts_id: usize) -> RdfDiagnostic {
+            self.inner.err_nesting_limit(segment_index, gts_id)
+        }
+
+        fn err_unbound_triple(&self, segment_index: usize, gts_id: usize) -> RdfDiagnostic {
+            self.inner.err_unbound_triple(segment_index, gts_id)
+        }
+
+        fn err_missing_reifier(&self, segment_index: usize, reifier: usize) -> RdfDiagnostic {
+            self.inner.err_missing_reifier(segment_index, reifier)
+        }
+
+        fn suppression(
+            &mut self,
+            segment_index: usize,
+            suppression: &Suppression,
+        ) -> Result<(), RdfDiagnostic> {
+            self.inner.suppression(segment_index, suppression)
+        }
+
+        fn blob(
+            &mut self,
+            segment_index: usize,
+            digest: &str,
+            meta: Option<&Value>,
+        ) -> Result<(), RdfDiagnostic> {
+            self.inner.blob(segment_index, digest, meta)
+        }
+
+        fn opaque(
+            &mut self,
+            segment_index: usize,
+            opaque: &OpaqueNode,
+        ) -> Result<(), RdfDiagnostic> {
+            self.inner.opaque(segment_index, opaque)
+        }
+
+        fn signature(
+            &mut self,
+            segment_index: usize,
+            signature: &Signature,
+        ) -> Result<(), RdfDiagnostic> {
+            self.inner.signature(segment_index, signature)
+        }
+
+        fn segment_head(&mut self, segment_index: usize, head: &[u8]) -> Result<(), RdfDiagnostic> {
+            self.inner.segment_head(segment_index, head)
+        }
+
+        fn streamable_layout(
+            &mut self,
+            segment_index: usize,
+            info: &StreamableInfo,
+        ) -> Result<(), RdfDiagnostic> {
+            self.inner.streamable_layout(segment_index, info)
+        }
+
+        fn diagnostic(&mut self, diagnostic: &Diagnostic) -> Result<(), RdfDiagnostic> {
+            self.inner.diagnostic(diagnostic)
         }
     }
 
@@ -528,7 +723,7 @@ mod tests {
     /// distinct ids (per-segment scope) while `ex:s` MUST be one shared id.
     #[test]
     fn gate2_multi_segment_blank_scope_isolation_direct() {
-        let mut resolver = SegmentResolver::new(SinkImporter::new());
+        let mut resolver = SegmentResolver::new(RecordingSink::new());
 
         // Segment 0: term 0 = ex:s, term 1 = ex:p, term 2 = _:b1, quad (s p b1).
         resolver.term(0, 0, &iri_term("http://example.org/s"));
@@ -546,10 +741,16 @@ mod tests {
         let (mut resolver, error) = finish_direct(resolver);
         assert!(error.is_none(), "no error expected: {error:?}");
 
-        let seg0_s = resolver.remap(0, 0).expect("segment 0 subject resolved");
-        let seg1_s = resolver.remap(1, 0).expect("segment 1 subject resolved");
-        let seg0_b1 = resolver.remap(0, 2).expect("segment 0 blank resolved");
-        let seg1_b1 = resolver.remap(1, 2).expect("segment 1 blank resolved");
+        let seg0_s = resolver
+            .sink()
+            .id(0, 0)
+            .expect("segment 0 subject resolved");
+        let seg1_s = resolver
+            .sink()
+            .id(1, 0)
+            .expect("segment 1 subject resolved");
+        let seg0_b1 = resolver.sink().id(0, 2).expect("segment 0 blank resolved");
+        let seg1_b1 = resolver.sink().id(1, 2).expect("segment 1 blank resolved");
 
         // The shared IRI interns to ONE id across both segments (value identity).
         assert_eq!(seg0_s, seg1_s, "ex:s is the same node across segments");
@@ -559,14 +760,14 @@ mod tests {
             seg0_b1, seg1_b1,
             "_:b1 in segment 0 and segment 1 are DIFFERENT nodes (scope isolation)"
         );
-        let (label0, scope0) = blank_scope(&resolver, seg0_b1);
-        let (label1, scope1) = blank_scope(&resolver, seg1_b1);
+        let (label0, scope0) = blank_scope(&resolver.sink().inner.builder, seg0_b1);
+        let (label1, scope1) = blank_scope(&resolver.sink().inner.builder, seg1_b1);
         assert_eq!(label0, "b1");
         assert_eq!(label1, "b1");
         assert_eq!(scope0, BlankScope(1), "segment 0 → scope 1");
         assert_eq!(scope1, BlankScope(2), "segment 1 → scope 2");
 
-        let dataset = std::mem::take(&mut resolver.sink_mut().builder)
+        let dataset = std::mem::take(&mut resolver.sink_mut().inner.builder)
             .freeze()
             .expect("freeze");
         // 2 quads, distinct blanks: ex:s, ex:p, b1@s0, ex:p2, b1@s1 = 5 terms.
@@ -593,7 +794,7 @@ mod tests {
     /// yields `direction == None`, but lexical form, datatype, and language survive.
     #[test]
     fn directional_literal_lexical_lang_survive_sink_path() {
-        let mut resolver = SegmentResolver::new(SinkImporter::new());
+        let mut resolver = SegmentResolver::new(RecordingSink::new());
         resolver.term(0, 0, &iri_term("http://example.org/s"));
         resolver.term(0, 1, &iri_term("http://example.org/p"));
         resolver.term(
@@ -612,8 +813,8 @@ mod tests {
         let (mut resolver, error) = finish_direct(resolver);
         assert!(error.is_none(), "{error:?}");
 
-        let lit_id = resolver.remap(0, 2).expect("literal resolved");
-        let dataset = std::mem::take(&mut resolver.sink_mut().builder)
+        let lit_id = resolver.sink().id(0, 2).expect("literal resolved");
+        let dataset = std::mem::take(&mut resolver.sink_mut().inner.builder)
             .freeze()
             .expect("freeze");
         match dataset.resolve(lit_id) {
@@ -635,7 +836,7 @@ mod tests {
     /// object position of the outer triple. (Hand-ordered direct-sink events.)
     #[test]
     fn nested_triple_term_survives_sink_path() {
-        let mut resolver = SegmentResolver::new(SinkImporter::new());
+        let mut resolver = SegmentResolver::new(RecordingSink::new());
         // Inner triple (ex:a ex:p ex:b) reified by reifier r0; outer triple
         // (ex:a ex:asserts <<inner>>) reified by reifier r1.
         resolver.term(0, 0, &iri_term("http://example.org/a"));
@@ -675,9 +876,9 @@ mod tests {
         let (mut resolver, error) = finish_direct(resolver);
         assert!(error.is_none(), "{error:?}");
 
-        let inner = resolver.remap(0, 4).expect("inner triple resolved");
-        let outer = resolver.remap(0, 7).expect("outer triple resolved");
-        let dataset = std::mem::take(&mut resolver.sink_mut().builder)
+        let inner = resolver.sink().id(0, 4).expect("inner triple resolved");
+        let outer = resolver.sink().id(0, 7).expect("outer triple resolved");
+        let dataset = std::mem::take(&mut resolver.sink_mut().inner.builder)
             .freeze()
             .expect("freeze");
         match dataset.resolve(outer) {

--- a/crates/rdf/src/gts_import_sink.rs
+++ b/crates/rdf/src/gts_import_sink.rs
@@ -1,52 +1,42 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The **authoritative** GTS ingestion path: a [`StreamingSink`] that preserves
-//! per-segment blank-node scope while folding into the immutable IR (C2.a).
+//! The **authoritative** GTS ingestion path: an [`RdfDatasetBuilder`]-backed
+//! [`ResolvedSink`] that preserves per-segment blank-node scope while folding
+//! into the immutable IR (C2.a).
 //!
 //! `purrdf_gts::reader::read()` folds every segment into one append-order term
 //! table, which destroys per-segment blank-node scope (the same `_:b1` label in
 //! two different segments names two *different* nodes, but the folded table loses
 //! that). The only place segment identity survives is the streaming sink
 //! callbacks, each of which carries a `segment_index`. This importer therefore
-//! drives [`purrdf_gts::reader::read_to_sink`] and interns each segment's blank
-//! nodes under a per-segment [`BlankScope`] — making this the correctness-bearing
-//! ingestion path for blank-node scope (see `docs/design/819-rdf-ir-dataflow.md`,
-//! *Appendix C0.2* and the `bnode-scope-flatten` loss code).
+//! drives [`purrdf_gts::reader::read_to_sink`] through a
+//! [`SegmentResolver`](purrdf_gts::segment_decode::SegmentResolver) and interns
+//! each segment's blank nodes under a per-segment [`BlankScope`] — making this the
+//! correctness-bearing ingestion path for blank-node scope (see
+//! `docs/design/819-rdf-ir-dataflow.md`, *Appendix C0.2* and the
+//! `bnode-scope-flatten` loss code).
 //!
-//! # Two-phase resolution (event-order independence)
+//! # Subsumed decode core
 //!
-//! `purrdf_gts::writer::Writer::deterministic` emits frames in the order `terms →
-//! quads → reifies → annot`, and the reader dispatches frames in stream order. A
-//! quoted-triple `Term` therefore arrives (in the `terms` frame) carrying only its
-//! `reifier` id — the `reifies` frame that binds that reifier to the triple's
-//! `(s, p, o)` arrives **later**. A single-pass importer that resolves a triple
-//! term the instant its `term` event fires cannot succeed: the binding is not yet
-//! known (`rdf-ir-missing-reifier-binding`).
-//!
-//! This importer is therefore **two-phase**:
-//!
-//! 1. **Streaming phase** (during `read_to_sink`): record RAW per-segment
-//!    descriptors — for each gts term id its kind plus, for triple terms, the
-//!    reifier id linking it to its components — and RAW reifier bindings and
-//!    quad / reifier / annotation rows as gts-id rows. Nothing is resolved or
-//!    failed eagerly on a not-yet-known binding.
-//! 2. **Resolution phase** (after `read_to_sink` returns, before `freeze`): now
-//!    that every `term` and `reifies` event has been seen, resolve each gts term
-//!    to a [`TermId`] — non-triple terms intern directly; triple terms resolve
-//!    their now-complete `(s, p, o)` recursively, inner-first, depth-bounded by
-//!    [`MAX_GTS_TERM_NESTING_DEPTH`] — then push the raw quad / reifier /
-//!    annotation rows through the per-segment remap.
+//! GTS-frame decode and per-segment two-phase resolution — the event-order
+//! independence that lets a quoted-triple `Term` resolve regardless of whether
+//! its `reifies` binding arrived before or after it — live EXACTLY ONCE in
+//! [`purrdf_gts::segment_decode`]. [`SinkImporter`] is the immutable-IR emit
+//! target: it implements [`ResolvedSink`], interning resolved terms into an
+//! [`RdfDatasetBuilder`], pushing resolved quad / reifier / annotation rows, and
+//! mapping the four structured decode failures onto rich [`RdfDiagnostic`]
+//! locations. The [`SegmentResolver`](purrdf_gts::segment_decode::SegmentResolver)
+//! owns the buffering, sorted-key resolution order, and per-segment flush.
 //!
 //! Per the no-optionality / hard-fail doctrine, a *genuinely* dangling term id or
-//! reifier binding — one still unresolved after ALL events are seen — is an `Err`,
-//! never a silent skip. Only the merely out-of-order case now resolves.
-
-use std::collections::HashMap;
+//! reifier binding — one still unresolved after ALL of a segment's events are
+//! seen — is an `Err`, never a silent skip. Only the merely out-of-order case
+//! resolves.
 
 use ciborium::value::Value;
-use purrdf_gts::model::{OpaqueNode, Quad, Signature, StreamableInfo, Suppression, Term, TermKind};
-use purrdf_gts::reader::StreamingSink;
+use purrdf_gts::model::{Diagnostic, OpaqueNode, Signature, StreamableInfo, Suppression};
+use purrdf_gts::segment_decode::{ResolvedSink, SegmentResolver};
 
 use crate::{
     BlankScope, GtsBundle, RdfDatasetBuilder, RdfDiagnostic, RdfEnvelope, RdfLiteral, RdfLocation,
@@ -54,88 +44,42 @@ use crate::{
     RdfSuppressionRecord, TermId, TermRef,
 };
 
-/// Depth bound for resolving nested quoted-triple terms, mirroring the
-/// `MAX_GTS_TERM_NESTING_DEPTH` guard in [`crate::gts`]. A cyclic or absurdly
-/// nested triple term hard-fails rather than recursing without bound.
-const MAX_GTS_TERM_NESTING_DEPTH: usize = 16;
-
-/// A [`StreamingSink`] that folds GTS events into the immutable IR with per-segment
-/// blank-node scope isolation, two-phase so it is independent of `term`/`reifier`/
-/// `quad` event order (see the module docs).
+/// The immutable-IR emit target for GTS ingestion: an [`RdfDatasetBuilder`] that
+/// interns each segment's blank nodes under a per-segment [`BlankScope`]. The
+/// GTS-frame decode and two-phase resolution that drive it live once in
+/// [`purrdf_gts::segment_decode`]; this type only interns resolved terms, pushes
+/// resolved rows, and maps decode failures onto [`RdfDiagnostic`] locations.
 struct SinkImporter {
     /// The fallible IR builder we intern terms and push structure into.
     builder: RdfDatasetBuilder,
-    /// RAW per-segment terms recorded during the streaming phase, keyed by
-    /// `(segment_index, gts_term_id)`. Resolved to [`TermId`]s in phase 2. The
-    /// streaming callbacks cannot resolve a quoted-triple term yet (its reifier
-    /// binding may arrive later), so each term is stashed verbatim.
-    raw_terms: HashMap<(usize, usize), Term>,
-    /// Per-segment map from GTS segment-local term id → our [`TermId`], populated
-    /// during phase-2 resolution. The key is `(segment_index, gts_term_id)`.
-    remaps: HashMap<(usize, usize), TermId>,
-    /// Per-segment reifier bindings (`(segment_index, reifier gts-id) → (s, p, o)
-    /// gts-ids`), recorded from `reifier` events so a Triple term delivered earlier
-    /// (or later) can recover its components THROUGH the segment's remap in phase 2.
-    reifier_bindings: HashMap<(usize, usize), purrdf_gts::model::Triple3>,
-    /// RAW quad rows `(segment_index, (s, p, o, g) gts-ids)`, resolved in phase 2.
-    raw_quads: Vec<(usize, Quad)>,
-    /// RAW reifier rows `(segment_index, reifier gts-id, (s, p, o) gts-ids, graph
-    /// gts-id?)`, resolved in phase 2 to bind the reifier resource (in its named graph)
-    /// to the interned triple.
-    raw_reifiers: Vec<(usize, usize, purrdf_gts::model::Triple3, Option<usize>)>,
-    /// RAW annotation rows `(segment_index, (r, p, v) gts-ids, graph gts-id?)`, resolved
-    /// in phase 2.
-    raw_annotations: Vec<(usize, purrdf_gts::model::Triple3, Option<usize>)>,
     /// Out-of-band material accumulated from blob / signature / suppression /
     /// segment-head / opaque events.
     lookaside: RdfLookaside,
-    /// First deferred error. `StreamingSink` methods return `()`, so a referential
-    /// failure is parked here and surfaced after the reader returns.
-    error: Option<RdfDiagnostic>,
 }
 
 impl SinkImporter {
     fn new() -> Self {
         Self {
             builder: RdfDatasetBuilder::new(),
-            raw_terms: HashMap::new(),
-            remaps: HashMap::new(),
-            reifier_bindings: HashMap::new(),
-            raw_quads: Vec::new(),
-            raw_reifiers: Vec::new(),
-            raw_annotations: Vec::new(),
             lookaside: RdfLookaside::default(),
-            error: None,
         }
     }
+}
 
-    /// Record the first deferred error; later errors do not overwrite it.
-    fn fail(&mut self, diagnostic: RdfDiagnostic) {
-        if self.error.is_none() {
-            self.error = Some(diagnostic);
-        }
-    }
+impl ResolvedSink for SinkImporter {
+    type Id = TermId;
+    type Error = RdfDiagnostic;
 
-    /// Resolve a GTS segment-local term id to its interned [`TermId`], resolving it
-    /// (and any nested quoted triples) on demand if not yet interned. Fails if the
-    /// id was never introduced by a `term` event (a genuinely dangling reference).
-    ///
-    /// This is the phase-2 primitive: it is memoizing (through `self.remaps`) and
-    /// depth-bounded against cyclic quoted triples.
-    fn resolve_term(
+    fn intern_iri(
         &mut self,
         segment_index: usize,
         gts_id: usize,
-        role: &str,
-        depth: usize,
+        iri: &str,
     ) -> Result<TermId, RdfDiagnostic> {
-        if let Some(&id) = self.remaps.get(&(segment_index, gts_id)) {
-            return Ok(id);
-        }
-        if depth > MAX_GTS_TERM_NESTING_DEPTH {
+        if iri.is_empty() {
             return Err(RdfDiagnostic::error(
-                "rdf-ir-term-nesting-limit",
-                "GTS triple-term nesting depth limit exceeded",
+                "rdf-ir-iri-missing-value",
+                "GTS IRI term requires a non-empty value",
             )
             .with_location(
                 RdfLocation::logical("gts:sink")
@@ -143,240 +87,286 @@ impl SinkImporter {
                     .with_gts_term(gts_id),
             ));
         }
-        // MOVE the raw term out: it resolves at most once (every later reference
-        // hits the `remaps` cache above), so taking ownership lets interning
-        // mutably borrow `self.builder` without a borrow conflict AND without
-        // cloning the term's owned strings. A (pathological) cyclic reference now
-        // surfaces as a dangling-term-ref — the term is already removed — rather
-        // than the nesting-limit; both are hard failures and a GTS Writer never
-        // emits cycles. The streaming path is the scope-correct authority, not the
-        // zero-alloc one (that is the `import_graph` contract).
-        let Some(term) = self.raw_terms.remove(&(segment_index, gts_id)) else {
-            return Err(RdfDiagnostic::error(
-                "rdf-ir-dangling-term-ref",
-                format!(
-                    "GTS {role} references segment-{segment_index} term id {gts_id}, \
-                     which no `term` event introduced"
-                ),
-            )
-            .with_location(
-                RdfLocation::logical("gts:sink")
-                    .with_gts_segment(segment_index)
-                    .with_gts_term(gts_id),
-            ));
-        };
-        let our_id = self.intern_raw_term(segment_index, gts_id, term, depth)?;
-        self.remaps.insert((segment_index, gts_id), our_id);
-        Ok(our_id)
+        Ok(self.builder.intern_iri(iri))
     }
 
-    /// Intern one already-located raw term, recursing (inner-first) for quoted
-    /// triples through their reifier binding.
-    ///
-    /// Takes the raw [`Term`] BY VALUE (it was just `remove()`d from `raw_terms`,
-    /// so the sink uniquely owns it) and MOVES its owned strings (`value` / `lang` /
-    /// `direction`) into the interner instead of cloning — completing the
-    /// no-clone path the streaming design promises.
-    fn intern_raw_term(
+    // Per-segment scope isolation (C0.2): scope = segment_index + 1 so the SAME
+    // blank label in different segments interns to DISTINCT ids, while scope 0
+    // stays reserved for the default/global scope.
+    fn intern_blank(
         &mut self,
         segment_index: usize,
-        gts_id: usize,
-        term: Term,
-        depth: usize,
+        _gts_id: usize,
+        label: &str,
     ) -> Result<TermId, RdfDiagnostic> {
-        let our_id = match term.kind {
-            TermKind::Iri => {
-                let Some(iri) = term.value.filter(|value| !value.is_empty()) else {
-                    return Err(RdfDiagnostic::error(
-                        "rdf-ir-iri-missing-value",
-                        "GTS IRI term requires a non-empty value",
-                    )
-                    .with_location(
-                        RdfLocation::logical("gts:sink")
-                            .with_gts_segment(segment_index)
-                            .with_gts_term(gts_id),
-                    ));
-                };
-                self.builder.intern_iri(&iri)
-            }
-            // Per-segment scope isolation (C0.2): scope = segment_index + 1 so the
-            // SAME blank label in different segments interns to DISTINCT ids, while
-            // scope 0 stays reserved for the default/global scope.
-            TermKind::Bnode => {
-                let label = term
-                    .value
-                    .unwrap_or_else(|| format!("gts_bnode_{segment_index}_{gts_id}"));
-                let scope = BlankScope(segment_index as u32 + 1);
-                self.builder.intern_blank(&label, scope)
-            }
-            TermKind::Literal => {
-                let literal = self.literal_from_term(segment_index, term, depth)?;
-                self.builder.intern_literal(literal)
-            }
-            TermKind::Triple => {
-                let Some(reifier_gts_id) = term.reifier else {
-                    return Err(RdfDiagnostic::error(
-                        "rdf-ir-unbound-triple-term",
-                        "GTS triple term has no reifier binding",
-                    )
-                    .with_location(
-                        RdfLocation::logical("gts:sink")
-                            .with_gts_segment(segment_index)
-                            .with_gts_term(gts_id),
-                    ));
-                };
-                let (s, p, o) =
-                    self.resolve_triple_components(segment_index, reifier_gts_id, depth + 1)?;
-                self.builder.intern_triple(s, p, o)
-            }
-        };
-        Ok(our_id)
+        let scope = BlankScope(segment_index as u32 + 1);
+        Ok(self.builder.intern_blank(label, scope))
     }
 
-    /// Build an [`RdfLiteral`] from a GTS literal term, resolving its datatype id
-    /// THROUGH the segment's terms (phase 2).
-    ///
     /// GTS *does* carry RDF 1.2 base direction (`purrdf-gts`'s `Term` has a
-    /// `direction: Option<String>` slot), so it is read here via
-    /// [`parse_gts_direction`](crate::gts_resolve::parse_gts_direction) and preserved
-    /// onto the literal — direction is NOT a projection loss on this path.
-    fn literal_from_term(
+    /// `direction: Option<String>` slot), so it is parsed here via
+    /// [`parse_gts_direction`](crate::gts_resolve::parse_gts_direction) and
+    /// preserved onto the literal — direction is NOT a projection loss on this
+    /// path. The datatype id is already resolved; it MUST resolve to an IRI.
+    fn intern_literal(
         &mut self,
         segment_index: usize,
-        term: Term,
-        depth: usize,
-    ) -> Result<RdfLiteral, RdfDiagnostic> {
-        let datatype = match term.datatype {
-            Some(dt_gts_id) => {
-                let dt_id =
-                    self.resolve_term(segment_index, dt_gts_id, "literal datatype", depth + 1)?;
-                match self.builder.resolve(dt_id) {
-                    TermRef::Iri(iri) => Some(iri.to_string()),
-                    other => {
-                        return Err(RdfDiagnostic::error(
-                            "rdf-ir-literal-datatype-not-iri",
-                            format!("GTS literal datatype must resolve to an IRI, got {other:?}"),
-                        )
-                        .with_location(
-                            RdfLocation::logical("gts:sink")
-                                .with_gts_segment(segment_index)
-                                .with_gts_term(dt_gts_id),
-                        ));
-                    }
+        gts_id: usize,
+        lexical: String,
+        datatype: Option<TermId>,
+        lang: Option<String>,
+        direction: Option<String>,
+    ) -> Result<TermId, RdfDiagnostic> {
+        let datatype = match datatype {
+            Some(dt_id) => match self.builder.resolve(dt_id) {
+                TermRef::Iri(iri) => Some(iri.to_string()),
+                other => {
+                    return Err(RdfDiagnostic::error(
+                        "rdf-ir-literal-datatype-not-iri",
+                        format!("GTS literal datatype must resolve to an IRI, got {other:?}"),
+                    )
+                    .with_location(
+                        RdfLocation::logical("gts:sink")
+                            .with_gts_segment(segment_index)
+                            .with_gts_term(gts_id),
+                    ));
                 }
-            }
+            },
             None => None,
         };
-        // Parse direction (which requires the language tag) BEFORE moving the owned
-        // `value`/`lang`/`direction` strings out of the term.
-        let direction = crate::gts_resolve::parse_gts_direction(
-            term.direction.as_deref(),
-            term.lang.as_deref(),
-        )?;
-        Ok(RdfLiteral {
-            lexical_form: term.value.unwrap_or_default(),
+        // Parse direction (which requires the language tag) before moving the
+        // owned `lexical`/`lang` strings into the literal.
+        let direction =
+            crate::gts_resolve::parse_gts_direction(direction.as_deref(), lang.as_deref())?;
+        Ok(self.builder.intern_literal(RdfLiteral {
+            lexical_form: lexical,
             datatype,
-            language: term.lang,
+            language: lang,
             direction,
-        })
+        }))
     }
 
-    /// Resolve the `(s, p, o)` of the triple a reifier binds, THROUGH this
-    /// segment's terms, with a depth bound against cyclic quoted triples. The
-    /// reifier binding MUST exist by phase 2 (all `reifies` events are in); a
-    /// missing binding here is a genuine dangling reference, hence an `Err`.
-    fn resolve_triple_components(
+    fn intern_triple(
+        &mut self,
+        _segment_index: usize,
+        _gts_id: usize,
+        s: TermId,
+        p: TermId,
+        o: TermId,
+    ) -> Result<TermId, RdfDiagnostic> {
+        Ok(self.builder.intern_triple(s, p, o))
+    }
+
+    fn push_quad(
+        &mut self,
+        _segment_index: usize,
+        s: TermId,
+        p: TermId,
+        o: TermId,
+        g: Option<TermId>,
+    ) -> Result<(), RdfDiagnostic> {
+        self.builder.push_quad(s, p, o, g);
+        Ok(())
+    }
+
+    fn push_reifier(
+        &mut self,
+        _segment_index: usize,
+        reifier: TermId,
+        s: TermId,
+        p: TermId,
+        o: TermId,
+        g: Option<TermId>,
+    ) -> Result<(), RdfDiagnostic> {
+        let triple_term = self.builder.intern_triple(s, p, o);
+        self.builder.push_reifier_in_graph(reifier, triple_term, g);
+        Ok(())
+    }
+
+    fn push_annotation(
+        &mut self,
+        _segment_index: usize,
+        reifier: TermId,
+        p: TermId,
+        o: TermId,
+        g: Option<TermId>,
+    ) -> Result<(), RdfDiagnostic> {
+        self.builder.push_annotation_in_graph(reifier, p, o, g);
+        Ok(())
+    }
+
+    fn err_dangling_term(&self, segment_index: usize, gts_id: usize, role: &str) -> RdfDiagnostic {
+        RdfDiagnostic::error(
+            "rdf-ir-dangling-term-ref",
+            format!(
+                "GTS {role} references segment-{segment_index} term id {gts_id}, \
+                 which no `term` event introduced"
+            ),
+        )
+        .with_location(
+            RdfLocation::logical("gts:sink")
+                .with_gts_segment(segment_index)
+                .with_gts_term(gts_id),
+        )
+    }
+
+    fn err_nesting_limit(&self, segment_index: usize, gts_id: usize) -> RdfDiagnostic {
+        RdfDiagnostic::error(
+            "rdf-ir-term-nesting-limit",
+            "GTS triple-term nesting depth limit exceeded",
+        )
+        .with_location(
+            RdfLocation::logical("gts:sink")
+                .with_gts_segment(segment_index)
+                .with_gts_term(gts_id),
+        )
+    }
+
+    fn err_unbound_triple(&self, segment_index: usize, gts_id: usize) -> RdfDiagnostic {
+        RdfDiagnostic::error(
+            "rdf-ir-unbound-triple-term",
+            "GTS triple term has no reifier binding",
+        )
+        .with_location(
+            RdfLocation::logical("gts:sink")
+                .with_gts_segment(segment_index)
+                .with_gts_term(gts_id),
+        )
+    }
+
+    fn err_missing_reifier(&self, segment_index: usize, reifier: usize) -> RdfDiagnostic {
+        RdfDiagnostic::error(
+            "rdf-ir-missing-reifier-binding",
+            format!(
+                "GTS triple term references reifier {reifier} in segment \
+                 {segment_index} with no recorded binding"
+            ),
+        )
+        .with_location(
+            RdfLocation::logical("gts:sink")
+                .with_gts_segment(segment_index)
+                .with_gts_reifier(reifier),
+        )
+    }
+
+    fn suppression(
+        &mut self,
+        _segment_index: usize,
+        suppression: &Suppression,
+    ) -> Result<(), RdfDiagnostic> {
+        self.lookaside.suppressions.push(RdfSuppressionRecord {
+            reason: suppression.reason.clone(),
+            // `by` is a segment-local term id; we record it as a display hint
+            // only, never as a cross-dataset id (C0.8).
+            by: suppression.by.map(|term_id| format!("term#{term_id}")),
+            targets: suppression
+                .targets
+                .iter()
+                .map(metadata_value_from_cbor)
+                .collect(),
+        });
+        Ok(())
+    }
+
+    fn blob(
+        &mut self,
+        _segment_index: usize,
+        digest: &str,
+        meta: Option<&Value>,
+    ) -> Result<(), RdfDiagnostic> {
+        let metadata = match meta.map(metadata_value_from_cbor) {
+            Some(RdfMetadataValue::Map(map)) => map,
+            Some(value) => {
+                let mut map = std::collections::BTreeMap::new();
+                map.insert("value".to_owned(), value);
+                map
+            }
+            None => std::collections::BTreeMap::new(),
+        };
+        let media_type = metadata
+            .get("mt")
+            .and_then(RdfMetadataValue::as_text)
+            .map(str::to_owned);
+        let representation = metadata
+            .get("rep")
+            .and_then(RdfMetadataValue::as_text)
+            .map(str::to_owned);
+        self.lookaside.blobs.push(crate::RdfBlobRecord {
+            digest: digest.to_owned(),
+            media_type,
+            representation,
+            decoded_len: None,
+            metadata,
+            // The streaming sink delivers a blob's digest + metadata, not its
+            // payload. The content digest above is the blob_id reference; the
+            // streaming path records no segment-head origin here, whereas the
+            // folded read path (`gts::blob_records`) populates it.
+            origin: None,
+        });
+        Ok(())
+    }
+
+    fn opaque(&mut self, _segment_index: usize, opaque: &OpaqueNode) -> Result<(), RdfDiagnostic> {
+        self.lookaside.opaque_nodes.push(RdfOpaqueNodeRecord {
+            id: hex_bytes(&opaque.id),
+            frame_type: opaque.frame_type.clone(),
+            reason: opaque.reason.clone(),
+            signature_status: opaque.sigstat.clone(),
+            public_metadata: opaque.pub_meta.as_ref().map(metadata_value_from_cbor),
+        });
+        Ok(())
+    }
+
+    fn signature(
+        &mut self,
+        _segment_index: usize,
+        signature: &Signature,
+    ) -> Result<(), RdfDiagnostic> {
+        self.lookaside.signatures.push(RdfSignatureRecord {
+            frame_id: hex_bytes(&signature.frame_id),
+            key_id: signature.kid.clone(),
+            status: signature.status.clone(),
+            has_cose: signature.cose.is_some(),
+        });
+        Ok(())
+    }
+
+    fn segment_head(&mut self, segment_index: usize, head: &[u8]) -> Result<(), RdfDiagnostic> {
+        // Grow/patch the per-segment record with its head id.
+        self.ensure_segment_record(segment_index).head = Some(hex_bytes(head));
+        Ok(())
+    }
+
+    fn streamable_layout(
         &mut self,
         segment_index: usize,
-        reifier: usize,
-        depth: usize,
-    ) -> Result<(TermId, TermId, TermId), RdfDiagnostic> {
-        if depth > MAX_GTS_TERM_NESTING_DEPTH {
-            return Err(RdfDiagnostic::error(
-                "rdf-ir-term-nesting-limit",
-                "GTS triple-term nesting depth limit exceeded",
-            )
-            .with_location(
-                RdfLocation::logical("gts:sink")
-                    .with_gts_segment(segment_index)
-                    .with_gts_reifier(reifier),
-            ));
-        }
-        let Some(&(s, p, o)) = self.reifier_bindings.get(&(segment_index, reifier)) else {
-            return Err(RdfDiagnostic::error(
-                "rdf-ir-missing-reifier-binding",
-                format!(
-                    "GTS triple term references reifier {reifier} in segment \
-                     {segment_index} with no recorded binding"
-                ),
-            )
-            .with_location(
-                RdfLocation::logical("gts:sink")
-                    .with_gts_segment(segment_index)
-                    .with_gts_reifier(reifier),
-            ));
-        };
-        let s = self.resolve_term(segment_index, s, "reified subject", depth)?;
-        let p = self.resolve_term(segment_index, p, "reified predicate", depth)?;
-        let o = self.resolve_term(segment_index, o, "reified object", depth)?;
-        Ok((s, p, o))
+        info: &StreamableInfo,
+    ) -> Result<(), RdfDiagnostic> {
+        let record = self.ensure_segment_record(segment_index);
+        record.claimed_streamable = info.claimed;
+        record.covered = info.covered;
+        record.tail = info.tail;
+        Ok(())
     }
 
-    /// Phase 2: resolve every recorded term and push every recorded row, after the
-    /// reader has delivered ALL `term` / `reifies` / `quad` / `annot` events.
-    fn finish(&mut self) -> Result<(), RdfDiagnostic> {
-        // Resolve every introduced term (idempotent through `remaps`). Iterate in a
-        // deterministic order so the interner's allocation order — and thus the
-        // frozen term order — is reproducible for a fixed event stream.
-        let mut keys: Vec<(usize, usize)> = self.raw_terms.keys().copied().collect();
-        keys.sort_unstable();
-        for (segment_index, gts_id) in keys {
-            self.resolve_term(segment_index, gts_id, "term", 0)?;
-        }
-
-        // Quads.
-        let raw_quads = std::mem::take(&mut self.raw_quads);
-        for (segment_index, (s, p, o, g)) in raw_quads {
-            let s = self.resolve_term(segment_index, s, "quad subject", 0)?;
-            let p = self.resolve_term(segment_index, p, "quad predicate", 0)?;
-            let o = self.resolve_term(segment_index, o, "quad object", 0)?;
-            let g = match g {
-                Some(g) => Some(self.resolve_term(segment_index, g, "quad graph name", 0)?),
-                None => None,
-            };
-            self.builder.push_quad(s, p, o, g);
-        }
-
-        // Reifier bindings: bind the reifier resource to the interned triple term.
-        let raw_reifiers = std::mem::take(&mut self.raw_reifiers);
-        for (segment_index, reifier, (s, p, o), graph) in raw_reifiers {
-            let reifier_id = self.resolve_term(segment_index, reifier, "reifier", 0)?;
-            let s = self.resolve_term(segment_index, s, "reified subject", 0)?;
-            let p = self.resolve_term(segment_index, p, "reified predicate", 0)?;
-            let o = self.resolve_term(segment_index, o, "reified object", 0)?;
-            let g = match graph {
-                Some(g) => Some(self.resolve_term(segment_index, g, "reifier graph name", 0)?),
-                None => None,
-            };
-            let triple_term = self.builder.intern_triple(s, p, o);
-            self.builder
-                .push_reifier_in_graph(reifier_id, triple_term, g);
-        }
-
-        // Annotations `(reifier, predicate, object, graph?)`.
-        let raw_annotations = std::mem::take(&mut self.raw_annotations);
-        for (segment_index, (r, p, v), graph) in raw_annotations {
-            let r = self.resolve_term(segment_index, r, "annotation reifier", 0)?;
-            let p = self.resolve_term(segment_index, p, "annotation predicate", 0)?;
-            let v = self.resolve_term(segment_index, v, "annotation object", 0)?;
-            let g = match graph {
-                Some(g) => Some(self.resolve_term(segment_index, g, "annotation graph name", 0)?),
-                None => None,
-            };
-            self.builder.push_annotation_in_graph(r, p, v, g);
-        }
-
-        Ok(())
+    fn diagnostic(&mut self, diagnostic: &Diagnostic) -> Result<(), RdfDiagnostic> {
+        // A reader diagnostic is a hard fold failure on the IR path (the IR is
+        // the authority, no degraded fold). The `SegmentResolver` latches the
+        // first one returned here.
+        Err(RdfDiagnostic::error(
+            "rdf-ir-gts-fold-diagnostic",
+            format!(
+                "GTS fold diagnostic {}: {}",
+                diagnostic.code, diagnostic.detail
+            ),
+        )
+        .with_location({
+            let location = RdfLocation::logical("gts:sink");
+            match diagnostic.frame_index {
+                Some(frame_index) => location.with_gts_frame(frame_index),
+                None => location,
+            }
+        }))
     }
 }
 
@@ -421,154 +411,6 @@ fn metadata_value_from_cbor(value: &Value) -> RdfMetadataValue {
     }
 }
 
-impl StreamingSink for SinkImporter {
-    fn term(&mut self, segment_index: usize, gts_term_id: usize, term: &Term) {
-        if self.error.is_some() {
-            return;
-        }
-        // Streaming phase: stash the raw term verbatim. A quoted-triple term cannot
-        // be resolved yet — its reifier binding may arrive in a later frame — so we
-        // defer ALL resolution to phase 2, where every event has been seen.
-        self.raw_terms
-            .insert((segment_index, gts_term_id), term.clone());
-    }
-
-    fn quad(&mut self, segment_index: usize, quad: Quad) {
-        if self.error.is_some() {
-            return;
-        }
-        self.raw_quads.push((segment_index, quad));
-    }
-
-    fn reifier(&mut self, segment_index: usize, reifier: purrdf_gts::model::ReifierRow) {
-        if self.error.is_some() {
-            return;
-        }
-        // purrdf-gts row-array: `(reifier_id, (s, p, o), graph?)`. The graph slot
-        // records the named graph the reifier was declared in (`None` = default graph)
-        // and is threaded into the IR's graph-scoped statement layer in phase 2.
-        let (reifier_id, triple, graph) = reifier;
-        // Record the reifier → (s, p, o) binding for this segment so a Triple term
-        // (delivered in any order) can resolve its components in phase 2, and stash
-        // the row (with its named graph, if any) so the reifier resource is bound to
-        // the interned triple in phase 2.
-        self.reifier_bindings
-            .insert((segment_index, reifier_id), triple);
-        self.raw_reifiers
-            .push((segment_index, reifier_id, triple, graph));
-    }
-
-    fn annotation(&mut self, segment_index: usize, annotation: purrdf_gts::model::AnnotationRow) {
-        if self.error.is_some() {
-            return;
-        }
-        // Row-array: `(reifier, predicate, value, graph?)`. The graph slot records the
-        // named graph the annotation was asserted in and is threaded into the IR's
-        // graph-scoped statement layer in phase 2.
-        let (reifier, predicate, value, graph) = annotation;
-        self.raw_annotations
-            .push((segment_index, (reifier, predicate, value), graph));
-    }
-
-    fn suppression(&mut self, _segment_index: usize, suppression: &Suppression) {
-        self.lookaside.suppressions.push(RdfSuppressionRecord {
-            reason: suppression.reason.clone(),
-            // `by` is a segment-local term id; we record it as a display hint only,
-            // never as a cross-dataset id (C0.8).
-            by: suppression.by.map(|term_id| format!("term#{term_id}")),
-            targets: suppression
-                .targets
-                .iter()
-                .map(metadata_value_from_cbor)
-                .collect(),
-        });
-    }
-
-    fn blob(&mut self, _segment_index: usize, digest: &str, meta: Option<&Value>) {
-        let metadata = match meta.map(metadata_value_from_cbor) {
-            Some(RdfMetadataValue::Map(map)) => map,
-            Some(value) => {
-                let mut map = std::collections::BTreeMap::new();
-                map.insert("value".to_owned(), value);
-                map
-            }
-            None => std::collections::BTreeMap::new(),
-        };
-        let media_type = metadata
-            .get("mt")
-            .and_then(RdfMetadataValue::as_text)
-            .map(str::to_owned);
-        let representation = metadata
-            .get("rep")
-            .and_then(RdfMetadataValue::as_text)
-            .map(str::to_owned);
-        self.lookaside.blobs.push(crate::RdfBlobRecord {
-            digest: digest.to_owned(),
-            media_type,
-            representation,
-            decoded_len: None,
-            metadata,
-            // The streaming sink delivers a blob's digest + metadata, not its
-            // payload. The content digest above is the blob_id reference; richer
-            // origin (segment-head) enrichment for the streaming path is a
-            // follow-up — the folded read path (`gts::blob_records`) populates it.
-            origin: None,
-        });
-    }
-
-    fn opaque(&mut self, _segment_index: usize, opaque: &OpaqueNode) {
-        self.lookaside.opaque_nodes.push(RdfOpaqueNodeRecord {
-            id: hex_bytes(&opaque.id),
-            frame_type: opaque.frame_type.clone(),
-            reason: opaque.reason.clone(),
-            signature_status: opaque.sigstat.clone(),
-            public_metadata: opaque.pub_meta.as_ref().map(metadata_value_from_cbor),
-        });
-    }
-
-    fn signature(&mut self, _segment_index: usize, signature: &Signature) {
-        self.lookaside.signatures.push(RdfSignatureRecord {
-            frame_id: hex_bytes(&signature.frame_id),
-            key_id: signature.kid.clone(),
-            status: signature.status.clone(),
-            has_cose: signature.cose.is_some(),
-        });
-    }
-
-    fn segment_head(&mut self, segment_index: usize, head: &[u8]) {
-        // Grow/patch the per-segment record with its head id.
-        self.ensure_segment_record(segment_index).head = Some(hex_bytes(head));
-    }
-
-    fn streamable_layout(&mut self, segment_index: usize, info: &StreamableInfo) {
-        let record = self.ensure_segment_record(segment_index);
-        record.claimed_streamable = info.claimed;
-        record.covered = info.covered;
-        record.tail = info.tail;
-    }
-
-    fn diagnostic(&mut self, diagnostic: &purrdf_gts::model::Diagnostic) {
-        // A reader diagnostic is a hard fold failure on the IR path (the IR is the
-        // authority, no degraded fold). Record the first as the deferred error.
-        self.fail(
-            RdfDiagnostic::error(
-                "rdf-ir-gts-fold-diagnostic",
-                format!(
-                    "GTS fold diagnostic {}: {}",
-                    diagnostic.code, diagnostic.detail
-                ),
-            )
-            .with_location({
-                let location = RdfLocation::logical("gts:sink");
-                match diagnostic.frame_index {
-                    Some(frame_index) => location.with_gts_frame(frame_index),
-                    None => location,
-                }
-            }),
-        );
-    }
-}
-
 impl SinkImporter {
     /// Ensure a [`RdfSegmentRecord`] exists for `segment_index`, returning it.
     fn ensure_segment_record(&mut self, segment_index: usize) -> &mut RdfSegmentRecord {
@@ -600,23 +442,27 @@ impl SinkImporter {
 ///
 /// Drives [`purrdf_gts::reader::read_to_sink`] with `allow_segments = true` so a
 /// multi-segment file is delivered as per-segment events (the only place segment
-/// identity survives). Resolution is **two-phase** (see the module docs) so a
-/// quoted-triple term is resolved regardless of whether its `reifies` binding
-/// arrived before or after the term itself. Any reader diagnostic or genuinely
-/// dangling term reference is a HARD failure (`Err`); on success the interned terms
-/// are frozen via [`RdfDatasetBuilder::freeze`] and paired with the envelope.
+/// identity survives) through a
+/// [`SegmentResolver`](purrdf_gts::segment_decode::SegmentResolver) that owns the
+/// two-phase resolution: a quoted-triple term resolves regardless of whether its
+/// `reifies` binding arrived before or after the term itself. Any reader
+/// diagnostic or genuinely dangling term reference is a HARD failure (`Err`) — a
+/// latched streaming error takes precedence over phase-2 resolution; on success
+/// the interned terms are frozen via [`RdfDatasetBuilder::freeze`] and paired with
+/// the envelope.
 pub fn import_gts_events(bytes: &[u8]) -> Result<GtsBundle, RdfDiagnostic> {
-    let mut importer = SinkImporter::new();
-    let _ = purrdf_gts::reader::read_to_sink(bytes, true, None, &mut importer);
+    let mut resolver = SegmentResolver::new(SinkImporter::new());
+    let _ = purrdf_gts::reader::read_to_sink(bytes, true, None, &mut resolver);
 
-    if let Some(error) = importer.error {
+    // A latched streaming error (e.g. a reader diagnostic) precedes phase-2.
+    if let Some(error) = resolver.take_error() {
         return Err(error);
     }
 
-    // Phase 2: now that ALL term / reifier / quad / annotation events are seen,
-    // resolve every term and push every row.
-    importer.finish()?;
+    // Flush the final segment: resolve its terms and push its rows.
+    resolver.finish()?;
 
+    let importer = resolver.into_sink();
     let lookaside = importer.lookaside;
     let dataset = importer.builder.freeze()?;
     Ok(GtsBundle::new(dataset, RdfEnvelope::new(lookaside)))
@@ -625,8 +471,12 @@ pub fn import_gts_events(bytes: &[u8]) -> Result<GtsBundle, RdfDiagnostic> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use purrdf_gts::model::{Graph, Term, Term as GtsTerm, TermKind as GtsKind};
+    use purrdf_gts::model::{Graph, Term, Term as GtsTerm, TermKind, TermKind as GtsKind};
+    use purrdf_gts::reader::StreamingSink;
     use purrdf_gts::writer::Writer;
+
+    /// Convenience alias for a resolver wrapping the immutable-IR sink.
+    type Resolver = SegmentResolver<SinkImporter>;
 
     fn iri_term(value: &str) -> Term {
         Term {
@@ -650,21 +500,21 @@ mod tests {
         }
     }
 
-    /// Drive the streaming events then run phase 2, returning the importer for
-    /// post-resolution assertions (the public `import_gts_events` does both phases
-    /// from bytes; this exercises the hand-ordered direct-sink path).
-    fn finish_direct(mut importer: SinkImporter) -> SinkImporter {
-        if importer.error.is_none()
-            && let Err(diagnostic) = importer.finish()
-        {
-            importer.fail(diagnostic);
+    /// Drive the streaming events then run phase 2, returning the resolver plus any
+    /// error for post-resolution assertions (the public `import_gts_events` does
+    /// both phases from bytes; this exercises the hand-ordered direct-sink path). A
+    /// latched streaming error takes precedence over the phase-2 flush.
+    fn finish_direct(mut resolver: Resolver) -> (Resolver, Option<RdfDiagnostic>) {
+        if let Some(error) = resolver.take_error() {
+            return (resolver, Some(error));
         }
-        importer
+        let error = resolver.finish().err();
+        (resolver, error)
     }
 
     /// Resolve `our_id` back to its interned blank `(label, scope)` for assertions.
-    fn blank_scope(importer: &SinkImporter, id: TermId) -> (String, BlankScope) {
-        match importer.builder.resolve(id) {
+    fn blank_scope(resolver: &Resolver, id: TermId) -> (String, BlankScope) {
+        match resolver.sink().builder.resolve(id) {
             TermRef::Blank { label, scope } => (label.to_string(), scope),
             other => panic!("expected blank node, got {other:?}"),
         }
@@ -678,32 +528,28 @@ mod tests {
     /// distinct ids (per-segment scope) while `ex:s` MUST be one shared id.
     #[test]
     fn gate2_multi_segment_blank_scope_isolation_direct() {
-        let mut importer = SinkImporter::new();
+        let mut resolver = SegmentResolver::new(SinkImporter::new());
 
         // Segment 0: term 0 = ex:s, term 1 = ex:p, term 2 = _:b1, quad (s p b1).
-        importer.term(0, 0, &iri_term("http://example.org/s"));
-        importer.term(0, 1, &iri_term("http://example.org/p"));
-        importer.term(0, 2, &blank_term("b1"));
-        importer.quad(0, (0, 1, 2, None));
+        resolver.term(0, 0, &iri_term("http://example.org/s"));
+        resolver.term(0, 1, &iri_term("http://example.org/p"));
+        resolver.term(0, 2, &blank_term("b1"));
+        resolver.quad(0, (0, 1, 2, None));
 
         // Segment 1: term 0 = ex:s (same IRI value), term 1 = ex:p2, term 2 = _:b1
         // (SAME label, DIFFERENT node), quad (s p2 b1).
-        importer.term(1, 0, &iri_term("http://example.org/s"));
-        importer.term(1, 1, &iri_term("http://example.org/p2"));
-        importer.term(1, 2, &blank_term("b1"));
-        importer.quad(1, (0, 1, 2, None));
+        resolver.term(1, 0, &iri_term("http://example.org/s"));
+        resolver.term(1, 1, &iri_term("http://example.org/p2"));
+        resolver.term(1, 2, &blank_term("b1"));
+        resolver.quad(1, (0, 1, 2, None));
 
-        let mut importer = finish_direct(importer);
-        assert!(
-            importer.error.is_none(),
-            "no error expected: {:?}",
-            importer.error
-        );
+        let (mut resolver, error) = finish_direct(resolver);
+        assert!(error.is_none(), "no error expected: {error:?}");
 
-        let seg0_s = importer.remaps[&(0, 0)];
-        let seg1_s = importer.remaps[&(1, 0)];
-        let seg0_b1 = importer.remaps[&(0, 2)];
-        let seg1_b1 = importer.remaps[&(1, 2)];
+        let seg0_s = resolver.remap(0, 0).expect("segment 0 subject resolved");
+        let seg1_s = resolver.remap(1, 0).expect("segment 1 subject resolved");
+        let seg0_b1 = resolver.remap(0, 2).expect("segment 0 blank resolved");
+        let seg1_b1 = resolver.remap(1, 2).expect("segment 1 blank resolved");
 
         // The shared IRI interns to ONE id across both segments (value identity).
         assert_eq!(seg0_s, seg1_s, "ex:s is the same node across segments");
@@ -713,14 +559,14 @@ mod tests {
             seg0_b1, seg1_b1,
             "_:b1 in segment 0 and segment 1 are DIFFERENT nodes (scope isolation)"
         );
-        let (label0, scope0) = blank_scope(&importer, seg0_b1);
-        let (label1, scope1) = blank_scope(&importer, seg1_b1);
+        let (label0, scope0) = blank_scope(&resolver, seg0_b1);
+        let (label1, scope1) = blank_scope(&resolver, seg1_b1);
         assert_eq!(label0, "b1");
         assert_eq!(label1, "b1");
         assert_eq!(scope0, BlankScope(1), "segment 0 → scope 1");
         assert_eq!(scope1, BlankScope(2), "segment 1 → scope 2");
 
-        let dataset = std::mem::take(&mut importer.builder)
+        let dataset = std::mem::take(&mut resolver.sink_mut().builder)
             .freeze()
             .expect("freeze");
         // 2 quads, distinct blanks: ex:s, ex:p, b1@s0, ex:p2, b1@s1 = 5 terms.
@@ -733,17 +579,13 @@ mod tests {
     /// phase 2.
     #[test]
     fn gate2_unknown_term_reference_is_err_direct() {
-        let mut importer = SinkImporter::new();
-        importer.term(0, 0, &iri_term("http://example.org/s"));
-        importer.term(0, 1, &iri_term("http://example.org/p"));
+        let mut resolver = SegmentResolver::new(SinkImporter::new());
+        resolver.term(0, 0, &iri_term("http://example.org/s"));
+        resolver.term(0, 1, &iri_term("http://example.org/p"));
         // Object id 9 was never introduced.
-        importer.quad(0, (0, 1, 9, None));
-        let importer = finish_direct(importer);
-        assert!(
-            importer.error.is_some(),
-            "dangling reference must defer an error"
-        );
-        let err = importer.error.unwrap();
+        resolver.quad(0, (0, 1, 9, None));
+        let (_resolver, error) = finish_direct(resolver);
+        let err = error.expect("dangling reference must defer an error");
         assert_eq!(err.code, "rdf-ir-dangling-term-ref");
     }
 
@@ -751,10 +593,10 @@ mod tests {
     /// yields `direction == None`, but lexical form, datatype, and language survive.
     #[test]
     fn directional_literal_lexical_lang_survive_sink_path() {
-        let mut importer = SinkImporter::new();
-        importer.term(0, 0, &iri_term("http://example.org/s"));
-        importer.term(0, 1, &iri_term("http://example.org/p"));
-        importer.term(
+        let mut resolver = SegmentResolver::new(SinkImporter::new());
+        resolver.term(0, 0, &iri_term("http://example.org/s"));
+        resolver.term(0, 1, &iri_term("http://example.org/p"));
+        resolver.term(
             0,
             2,
             &Term {
@@ -766,12 +608,12 @@ mod tests {
                 reifier: None,
             },
         );
-        importer.quad(0, (0, 1, 2, None));
-        let mut importer = finish_direct(importer);
-        assert!(importer.error.is_none(), "{:?}", importer.error);
+        resolver.quad(0, (0, 1, 2, None));
+        let (mut resolver, error) = finish_direct(resolver);
+        assert!(error.is_none(), "{error:?}");
 
-        let lit_id = importer.remaps[&(0, 2)];
-        let dataset = std::mem::take(&mut importer.builder)
+        let lit_id = resolver.remap(0, 2).expect("literal resolved");
+        let dataset = std::mem::take(&mut resolver.sink_mut().builder)
             .freeze()
             .expect("freeze");
         match dataset.resolve(lit_id) {
@@ -793,16 +635,16 @@ mod tests {
     /// object position of the outer triple. (Hand-ordered direct-sink events.)
     #[test]
     fn nested_triple_term_survives_sink_path() {
-        let mut importer = SinkImporter::new();
+        let mut resolver = SegmentResolver::new(SinkImporter::new());
         // Inner triple (ex:a ex:p ex:b) reified by reifier r0; outer triple
         // (ex:a ex:asserts <<inner>>) reified by reifier r1.
-        importer.term(0, 0, &iri_term("http://example.org/a"));
-        importer.term(0, 1, &iri_term("http://example.org/p"));
-        importer.term(0, 2, &iri_term("http://example.org/b"));
-        importer.term(0, 3, &iri_term("http://example.org/r0"));
-        importer.reifier(0, (3, (0, 1, 2), None));
+        resolver.term(0, 0, &iri_term("http://example.org/a"));
+        resolver.term(0, 1, &iri_term("http://example.org/p"));
+        resolver.term(0, 2, &iri_term("http://example.org/b"));
+        resolver.term(0, 3, &iri_term("http://example.org/r0"));
+        resolver.reifier(0, (3, (0, 1, 2), None));
         // Inner triple TERM bound to reifier r0 (gts id 3).
-        importer.term(
+        resolver.term(
             0,
             4,
             &Term {
@@ -814,10 +656,10 @@ mod tests {
                 reifier: Some(3),
             },
         );
-        importer.term(0, 5, &iri_term("http://example.org/asserts"));
-        importer.term(0, 6, &iri_term("http://example.org/r1"));
-        importer.reifier(0, (6, (0, 5, 4), None));
-        importer.term(
+        resolver.term(0, 5, &iri_term("http://example.org/asserts"));
+        resolver.term(0, 6, &iri_term("http://example.org/r1"));
+        resolver.reifier(0, (6, (0, 5, 4), None));
+        resolver.term(
             0,
             7,
             &Term {
@@ -829,13 +671,13 @@ mod tests {
                 reifier: Some(6),
             },
         );
-        importer.quad(0, (0, 5, 7, None));
-        let mut importer = finish_direct(importer);
-        assert!(importer.error.is_none(), "{:?}", importer.error);
+        resolver.quad(0, (0, 5, 7, None));
+        let (mut resolver, error) = finish_direct(resolver);
+        assert!(error.is_none(), "{error:?}");
 
-        let inner = importer.remaps[&(0, 4)];
-        let outer = importer.remaps[&(0, 7)];
-        let dataset = std::mem::take(&mut importer.builder)
+        let inner = resolver.remap(0, 4).expect("inner triple resolved");
+        let outer = resolver.remap(0, 7).expect("outer triple resolved");
+        let dataset = std::mem::take(&mut resolver.sink_mut().builder)
             .freeze()
             .expect("freeze");
         match dataset.resolve(outer) {
@@ -849,18 +691,18 @@ mod tests {
     /// Multiple distinct reifiers binding ONE triple all survive.
     #[test]
     fn multiple_reifiers_for_one_triple_survive_sink_path() {
-        let mut importer = SinkImporter::new();
-        importer.term(0, 0, &iri_term("http://example.org/s"));
-        importer.term(0, 1, &iri_term("http://example.org/p"));
-        importer.term(0, 2, &iri_term("http://example.org/o"));
-        importer.term(0, 3, &iri_term("http://example.org/r1"));
-        importer.term(0, 4, &iri_term("http://example.org/r2"));
-        importer.reifier(0, (3, (0, 1, 2), None));
-        importer.reifier(0, (4, (0, 1, 2), None));
-        let mut importer = finish_direct(importer);
-        assert!(importer.error.is_none(), "{:?}", importer.error);
+        let mut resolver = SegmentResolver::new(SinkImporter::new());
+        resolver.term(0, 0, &iri_term("http://example.org/s"));
+        resolver.term(0, 1, &iri_term("http://example.org/p"));
+        resolver.term(0, 2, &iri_term("http://example.org/o"));
+        resolver.term(0, 3, &iri_term("http://example.org/r1"));
+        resolver.term(0, 4, &iri_term("http://example.org/r2"));
+        resolver.reifier(0, (3, (0, 1, 2), None));
+        resolver.reifier(0, (4, (0, 1, 2), None));
+        let (mut resolver, error) = finish_direct(resolver);
+        assert!(error.is_none(), "{error:?}");
 
-        let dataset = std::mem::take(&mut importer.builder)
+        let dataset = std::mem::take(&mut resolver.sink_mut().builder)
             .freeze()
             .expect("freeze");
         let reifiers: Vec<_> = dataset.reifiers().collect();
@@ -1011,11 +853,11 @@ mod tests {
     /// merely out-of-order one (which now resolves).
     #[test]
     fn dangling_reifier_binding_is_err_after_all_events() {
-        let mut importer = SinkImporter::new();
-        importer.term(0, 0, &iri_term("http://example.org/s"));
-        importer.term(0, 1, &iri_term("http://example.org/asserts"));
+        let mut resolver = SegmentResolver::new(SinkImporter::new());
+        resolver.term(0, 0, &iri_term("http://example.org/s"));
+        resolver.term(0, 1, &iri_term("http://example.org/asserts"));
         // Triple term bound to reifier id 99, which NO `reifies` event ever supplies.
-        importer.term(
+        resolver.term(
             0,
             2,
             &Term {
@@ -1027,16 +869,10 @@ mod tests {
                 reifier: Some(99),
             },
         );
-        importer.quad(0, (0, 1, 2, None));
-        let importer = finish_direct(importer);
-        assert!(
-            importer.error.is_some(),
-            "a genuinely dangling reifier binding must STILL fail after phase 2"
-        );
-        assert_eq!(
-            importer.error.unwrap().code,
-            "rdf-ir-missing-reifier-binding"
-        );
+        resolver.quad(0, (0, 1, 2, None));
+        let (_resolver, error) = finish_direct(resolver);
+        let err = error.expect("a genuinely dangling reifier binding must STILL fail after phase 2");
+        assert_eq!(err.code, "rdf-ir-missing-reifier-binding");
     }
 
     /// GATE 2 (b) — REAL multi-segment GTS bytes. Two `Writer::deterministic`


### PR DESCRIPTION
Closes #92

## Summary
Two additive GTS replication conveniences over existing machinery — **no GTS format/wire change** — plus the shared structure that unifies them: a *content-addressed, byte-addressable event stream with provenance*, where `(content-id, ByteRange)` is the provenance unit at segment granularity (diff) and frame granularity (streaming).

### Feature 1 — two-inventory diff → minimal fetch list (`crates/gts/src/replication.rs`)
- `diff(local, remote) -> DiffResult` computes the minimal, deterministically-ordered `Vec<SegmentFetch>` of remote byte ranges to bring a local mirror current, using **segment-head-prefix ordering** (segments are independently rooted, so a whole-segment append's first frame `prev` chains to its own header, not the local head) with a frame-`prev` splice check for a partially-extended trailing segment. Continuity discontinuities → `Diverged`, never a silent fetch.
- `splice(local, remote, result) -> Result<Vec<u8>>` applies the fetch list and re-verifies the reconstruction inventories clean — the consumer's real payload.
- `diff_json` renders schema `gts-replication-diff-v1`, reusing the existing `range_json`. The head-locate scan is factored into a shared `find_frame` used by both `missing()` and `diff()`.

### Feature 2 — streaming RdfEventSink bridge with per-frame provenance
- **2a** (`reader.rs`): the streaming read path now surfaces per-frame `FrameContext { segment_index, frame_index, content_id, range, frame_type, valid }` (with a `verify(source)` self-check) via a default-no-op `StreamingSink::frame` callback; byte offsets are plumbed through `next_stream_item`. Non-streaming path untouched.
- **Shared core** (`segment_decode.rs`): the GTS-frame decode + per-segment two-phase term resolution is extracted into a target-agnostic `ResolvedSink` + `SegmentResolver<S>`, and `purrdf-rdf`'s `SinkImporter` is **refactored onto it** so the decode logic exists exactly once. Resolution is per-segment-at-close (bounded memory), behavior-identical to the previous global two-phase pass.
- **2b** (`event_stream.rs`): `stream_events(data, options, sink)` drives a `&mut dyn GtsEventSink` (an `RdfEventSink` + provenance hooks) on the shared core — segment-local ids → global `EventTermId`, per-segment blank scope → `ScopeId`, datatype-id → IRI string, quoted-triples bound. Honors `ControlFlow::Break` (a cancelled drive is never finalized) and **hard-errors** on graph-scoped reifiers/annotations (the RdfEventSink protocol has no graph slot) rather than silently dropping. Bounded-memory streaming fold per GTS-SPEC §7.7 — index builders (posting lists, ClaimId→byte-offset maps) run in a single pass with no dataset materialized.

## Changes
- `replication.rs`: `diff`/`splice`/`diff_json` + `DiffResult`/`DiffStatus`/`SegmentFetch`; shared `find_frame`; `FrameInventory.prev`.
- `model.rs`: `ByteRange` hoisted to a shared provenance type (`len`/`is_empty`), re-exported from `replication`.
- `reader.rs`: `FrameContext` + `StreamingSink::frame` + byte-offset plumbing.
- `segment_decode.rs` (new): `ResolvedSink` + `SegmentResolver<S>` shared decode core.
- `event_stream.rs` (new): `GtsEventSink` + `EventEmitter` + `stream_events`; `purrdf-events` workspace edge (zero-dep, wasm-clean, acyclic).
- `crates/rdf/src/gts_import_sink.rs`: `SinkImporter` refactored onto the shared core (net −561/+398).
- Tests: `replication_diff.rs` (10), `streaming_provenance.rs`, `event_bridge.rs` (9) — all on the public surface; existing `purrdf-rdf` GTS-import suite green unchanged.
- Bench: `streaming_sink_bench.rs` extended with a bridge-driven counting sink (report-only).
- Doc gate: repaired two pre-existing private-intra-doc-link errors (`compact.rs`, `gts_certify.rs`).

## Gates
`make check` (fmt + clippy pedantic/nursery + build + tests + hygiene), `make wasm`, and `make doc` all green. No Cargo features; determinism preserved (all orderings file-order); no issue refs in source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streaming GTS → RDF event ingestion with a callback-based event sink, deterministic term declarations, and cancellation-safe operation.
  * Introduced frame provenance metadata (byte ranges, validity) during streaming, plus support for GTS event bridging.
  * Added replication diff/splice utilities with JSON reporting and byte-range calculations.
* **Bug Fixes**
  * Enforced stricter RDF 1.2/event-protocol validation (including graph-scoped reifier/annotation handling) and improved invalid-reference reporting.
* **Tests**
  * Expanded integration coverage for event bridging, provenance ordering, indexing, bounded buffering, cancellation, and replication diff/splice behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->