### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,134 +4,166 @@ All notable changes to the PurRDF crate suite are recorded here. The suite
 ships one lockstep version across crates.io, PyPI, and npm; pre-1.0, a minor
 bump may carry breaking changes and a patch bump is bugfix-only.
 
-## [0.5.0] - 2026-07-11
+## [0.6.0] - 2026-07-14
 
-### Breaking Changes
+### Bug Fixes
 
-- **npm/wasm SELECT rows are now single-owner streams.** `SelectResult.rows` is
-  a `QueryBindingRows` iterable rather than an array. This prevents the raw wasm
-  layer from cloning every row and term before the package wrapper materializes
-  them. Consume an indexed row with `result.rows.take(index)`, iterate remaining
-  rows with `for...of`, or explicitly materialize them with
-  `result.rows.toArray()`. Each row can be consumed once. `rows.length` and
-  `result.rowCount` are the original total; `rows.remaining` is the unconsumed
-  count. Call `result.free()` when abandoning unconsumed rows.
-- **The raw wasm cloning getter was removed.** Replace `raw.rows` with
-  `raw.rowCount`, `raw.takeRow(index)`, or `raw.nextRow()`. Move cells from a raw
-  row with `row.takeValue(index)`; the non-consuming `row.get(variable)` remains
-  available when cloning one individual term is intentional.
+- **gts:** Keep original authorship signatures bound across repacks
+- **rdf:** Fail closed instead of panicking when verifying poison packs
+- **rdf:** Anchor compaction projection to the provenance predicate vocabulary
+- **gts:** Make the packaging signature a required compaction parameter
+- **paged:** Enforce G3 quad-disjointness across the side tables
+- **core:** Unify the pack dictionary to one id per term value for DatasetView compatibility
+- **core:** Reject a literal datatype id that does not reference an IRI in the pack decoder
+- **core:** Fail closed in verify_pack when a reconstructed dataset is structurally invalid
+- **core:** Fail closed on FoQ index count-sum overflow in the pack decoder
+- **shapes:** Sh:in enum members match the instance projector encoding
+- **sparql-eval:** Make the fork-join parallel-safety gate registry-aware
+- **gts:** Hard-fail the event bridge on a dangling term reference
+- **gts:** Fire StreamingSink::frame before a frame's rows
 
-Before:
+### Documentation
 
-```js
-const result = engine.select(dataset, query);
-const first = result.rows[0];
-const allRows = result.rows;
-```
+- **design:** Author the PurRDF backend contract (C-clauses + paged G-clauses)
+- **paged:** Fix rustdoc intra-doc link errors denied by the doc gate
+- **core:** Document the pack backend + add the pack_query criterion bench
+- **gts:** Fix rustdoc private-intra-doc-link errors denied by the doc gate
+- **shapes:** Document the value-vocabulary enum projection
+- **gts,rdf:** Demote private intra-doc links to code spans for the doc gate
+- **sparql-eval:** Fix private intra-doc link denied by the doc gate
+- **sparql-eval:** Broaden user_fn module doc to both function kinds
+- **gts,rdf:** Demote private intra-doc links denied by the workspace doc gate
+- **sparql-eval:** Drop plan-id process-flow refs from native-fn tests
+- **core:** Describe the pack module by behavior, dropping plan task refs
+- **core:** Reword residual plan-task phrasing in pack module docs
+- **gts:** Add the §7.7 streaming-fold cross-reference and repair the rustdoc doc gate
+- **gts:** Correct GtsEventSink provenance-ordering doc after the frame fix
+- **gts:** Drop public-to-private intra-doc links tripping the doc gate
 
-After:
+### Features
 
-```js
-const result = engine.select(dataset, query);
-const first = result.rows.take(0);
-const remainingRows = result.rows.toArray();
+- **gts:** Deterministic in-band pack dictionaries for the zstd dct codec
+- **gts:** In-band zstd dct codec with finalized pack dictionaries
+- **gts:** Train and pin an in-band pack dictionary in streamable compaction
+- **gts:** Bind detached signatures under an MMR root with a packaging head sig
+- **rdf:** CompactionCertificate and verify_compaction refold-equivalence API
+- **rdf:** Witness the suppression-compaction commuting square on both digests
+- **gts:** Compress compaction blobs against the pinned in-band dict
+- **core:** Make DatasetView an unsealed, id-agnostic read seam
+- **core:** Add GlobalTermId + GlobalDictionary u64 identity layer
+- **core:** Add PagedDataset — id-agnostic demand-paged DatasetView over a u64 dictionary
+- **sparql-eval:** Generify the evaluator over D: DatasetView
+- **sparql-eval:** Make the binding layer id-generic over D::Id
+- **core:** Add freeze-refusal + deterministic compaction to PagedDataset
+- **paged:** Add from_parts warm-restart constructor for PagedDataset
+- **core:** Id-agnostic DatasetView seam + paged u64 backend served by the evaluator
+- **gts:** Certified signature-preserving compaction with in-band dict codec
+- **core:** Succinct rank/select + bit-packed IntVector primitives for the pack codec
+- **core:** Four-section PFC value dictionary for the pack codec
+- **core:** Graph-partitioned succinct bitmap-triples with FoQ all-pattern indexes
+- **core:** RDF 1.2 reifier + annotation side-tables for the pack codec
+- **core:** Deterministic pack container framing + zero-copy PackView reader
+- **core:** Implement DatasetView for PackView (PackId, all-pattern query seam)
+- **core:** Certified read-only projection — verify_pack recomputes the RDFC-1.0 digest
+- **shapes:** Project value vocabularies to enum $defs (projection-only)
+- **shapes:** Resolve sh:class / rdfs:range value-vocab refs to enum $defs
+- **sparql-eval:** Native Rust-closure user-function registry + dispatch
+- **sparql-eval:** Native Rust-closure user-function registry
+- **shapes:** Project value vocabularies to enum $defs (projection-only)
+- **gts:** Two-inventory replication diff, splice reconstruction, and diff_json
+- **gts:** Surface per-frame provenance (content-id + byte range) on the streaming read path
+- **gts:** Stream GTS frames into an RdfEventSink with per-frame provenance
+- **gts:** Two-inventory diff/splice fetch-list + streaming RdfEventSink bridge on a shared decode core
+- **core:** Read-only succinct HDTQ-style pack codec as a DatasetView backend
 
-// For bounded-memory processing, stream instead:
-for (const row of engine.select(dataset, query).rows) {
-  consume(row);
-}
-```
+### Other
 
-Python query-result classes and the C ABI function signatures are unchanged.
+- **shapes:** Apply rustfmt to json_schema.rs
+- **sparql-eval:** Rustfmt the native-scorer test helper
 
 ### Performance
 
-- **Core IR:** the common provenance-free freeze path sorts quads directly;
-  provenance remapping uses a dense vector; interners use fixed-key `ahash`; and
-  borrowed IRI, blank, literal, and structural triple lookup avoids temporary
-  `TermValue` trees. On the deterministic 3,200-quad fixture, allocated bytes
-  fell from 1,312,246 to 1,211,366 (7.7%) and peak live bytes from 471,104 to
-  415,296 (11.8%).
-- **SPARQL and XSD:** parser tokens move out of the cursor, whitespace and fixed
-  temporal fields avoid intermediate collections, DISTINCT/GROUP BY own keys
-  and rows once, and graph-result serialization writes ID-native terms directly
-  to the output buffer.
-- **Reasoning:** SPARQL, entailment, and OWL concept interners store canonical
-  values once. RIF joins use subject/predicate/object postings, choose the
-  smallest available candidate set, and backtrack one reusable binding buffer.
-- **SHACL and ShEx:** deterministic term sorting renders one key per value, and
-  ShEx structural expressions and predicate-direction maps compile once per
-  validation engine rather than once per focus node.
-- **GTS:** canonical CBOR map keys are sorted by borrowed encoded keys and values
-  stream directly to writers and BLAKE3. On the deterministic 2,000-quad
-  snapshot, allocations fell from 32,040 to 14,027 (56.2%) and allocated bytes
-  from 2,277,740 to 982,840 (56.8%).
-- **Visualization and slices:** incoming statement references are counted in one
-  pass. Slice ownership parses each RDF artifact once, walks ID-native terms once,
-  and reuses the catalog's parsed manifest projection.
-- **Bindings:** Python moves SELECT rows while sharing one immutable variable
-  array; wasm moves rows, cells, strings, and nested triple terms; C pattern
-  cursors no longer allocate a result-sized `Vec<QuadIds>`.
+- **paged:** Fold the G3 seal probe into a single map insert
+- **paged:** Stream the paged read path instead of collecting a Vec
+- **shapes:** Scan rdfs:range once per dataset for value-vocab $ref mapping
+- **shapes:** Compute first_literal via single-pass running minimum
+- **sparql-eval:** Lend native-fn args as &[&TermValue], drop per-call deep clone
+- **gts:** Drop the streaming bridge's iri_map at each segment close
+- **gts:** Hash the streaming decode maps with the fixed-key ahash policy
 
-### Rust API
+### Refactor
 
-- Added `RdfDataset::quads_for_pattern_cursor` and `QuadPatternCursor`, an
-  `Arc`-pinned owned iterator over the same selected quad index and residual
-  filter used by borrowed pattern queries. It remains valid after other dataset
-  handles are dropped and does not collect matching rows.
-- Added borrowed dataset term writers and borrowed term lookup methods for
-  allocation-sensitive crate consumers.
+- **shapes:** Panic! directly for value-vocab enum-key twin guard
+- **gts:** Hoist ByteRange to a shared model type and record FrameInventory.prev
+- **gts:** Extract shared per-segment decode core and subsume the GTS import sink onto it
+- **gts:** Bound the streaming decode core to one segment's memory
 
-### Compatibility
+### Testing
 
-- RDF, SPARQL, SHACL, ShEx, visualization, and GTS semantic ordering remains
-  deterministic. Graph serialization is byte-equal to the prior owned path, and
-  every frozen GTS item re-encodes byte-for-byte.
-- The optimization evidence above uses allocation counters, exact bytes, and
-  bounded candidate-work assertions. No wall-clock claim is made from the shared
-  high-contention development host.
+- **gts:** Freeze in-band dict-compaction vectors with drift guards and docs
+- **rdf:** Exercise the pack/tail seam chain across the boundary
+- **gts:** Re-freeze the streamable-compacted vector to the current format
+- **gts:** Assert the streamable-compacted pack pins no dct header entry
+- **sparql-eval:** Prove SPARQL served directly over a multi-page PagedDataset
+- **paged:** Cover property paths, aggregates, and subqueries on the paged backend
+- **core:** Demonstrate mmap-able zero-copy PackView over a memory-mapped file
+- **sparql-eval:** SPARQL-over-pack end-to-end parity with RdfDataset
+- **shapes:** Prove value-vocab enum round-trip and open-validator decoupling
+- **shapes:** Cover value-vocab class-key clash guard and multi-range tiebreak
+- **sparql-eval:** Native scorer push-down + determinism (FILTER/ORDER BY/NaN/parallel)
+- **gts:** Assert the streaming decode core's memory is bounded per segment
+- **rdf:** Actually exercise GTS base-direction preservation on the sink path
+
+## [0.5.0] - 2026-07-12
+
+### Bug Fixes
+
+- **shapes:** Key JSON-Schema $defs resolution set by def_key so cross-namespace local-name twins never dangle a $ref
+- **wasm:** Free empty SELECT result handle without iteration
+- **serialize:** Emit RDF 1.2 triple terms as non-asserting <<>>
+
+### Documentation
+
+- **conformance:** Record expanded Python parity suite
+- **shapes:** Correct resolve_id doc to match variant-specific lookup
+
+### Other
+
+- Optimize Rust ownership and hot paths for 0.5.0
+
+### Performance
+
+- **core:** Remove owned lookup and freeze overhead
+- **query:** Move parser tokens and stream results
+- **reasoning:** Store terms once and index RIF joins
+- **validation:** Cache sort keys and compile ShEx once
+- **gts:** Stream deterministic CBOR without value clones
+- **viz:** Linearize projection and ownership analysis
+- **bindings:** Stream result ownership across FFI
+- **reasoning:** Reuse RIF chase frontier index across fixpoint iterations
+- **query:** Bound parser reparse fork to the braced block
+
+### Testing
+
+- **bench:** Cover SPARQL graph serialization and DISTINCT allocation paths
+- **bench:** Cover SHACL canonical sort and ShEx prepared-shape paths
 
 ## [0.4.3] - 2026-07-10
 
 ### Bug Fixes
 
-- **rdf:** Complete deterministic viz semantics
-- **rdf:** Make RDF visualization graph-readable
-- **rdf:** Refine visualization routing and labels
-- **rdf:** Make dense visualization routes traceable
-- **wasm:** Accept npm 12 pack output
-- **rdf:** Address visualization review findings
+- **ci:** Serialize SPARQL conformance tallies
 
-### Documentation
+### Other
 
-- **rdf:** Qualify visualization projection link
-
-### Features
-
-- **rdf:** Add statement incidence viz projection
-- **rdf:** Add renderer-neutral viz scenes
-- **rdf:** Add deterministic layered viz layout
-- **rdf:** Emit semantic RDF 1.2 SVG
-- **wasm:** Expose RDF visualization exports
-- **rdf:** Publish generated visualization samples
-
-### Performance
-
-- **rdf:** Reuse visualization projection scratch state
+- Add semantic RDF 1.2 visualization exports
 
 ## [0.4.2] - 2026-07-10
-
-### Bug Fixes
-
-- Refresh lockfile for RIF parser
-
-### Features
-
-- Expose entailed SPARQL and RIF parsing
 
 ### Other
 
 - Harden npm wasm RDF 1.2 toolkit
+- Expose entailed SPARQL and RIF parsing
 
 ## [0.4.1] - 2026-07-09
 
@@ -661,3 +693,5 @@ Python query-result classes and the C ABI function signatures are unchanged.
 ### Other
 
 - First commit
+
+

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,8 +21,8 @@ authors:
   - family-names: "Audley"
     given-names: "Patrick"
     orcid: "https://orcid.org/0000-0003-4382-7625"
-version: "0.5.0"
-date-released: "2026-07-12"
+version: "0.6.0"
+date-released: "2026-07-13"
 license:
   - Apache-2.0
   - MIT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "purrdf-entail",
  "purrdf-events",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1311,11 +1311,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "0.5.0"
+version = "0.6.0"
 
 [[package]]
 name = "purrdf-gts"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ahash",
  "ciborium",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "boon",
  "criterion",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1422,7 +1422,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "hex",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -43,21 +43,21 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "0.5.0" }
-purrdf-core = { path = "crates/rdf-core", version = "0.5.0" }
-purrdf-entail = { path = "crates/entail", version = "0.5.0" }
-purrdf-events = { path = "crates/rdf-events", version = "0.5.0" }
-purrdf-gts = { path = "crates/gts", version = "0.5.0" }
-purrdf-iri = { path = "crates/iri", version = "0.5.0" }
-purrdf-rdf = { path = "crates/rdf", version = "0.5.0" }
-purrdf-shapes = { path = "crates/shapes", version = "0.5.0" }
-purrdf-shex = { path = "crates/shex", version = "0.5.0" }
-purrdf-slice = { path = "crates/slice", version = "0.5.0" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.5.0" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.5.0" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "0.5.0" }
-purrdf-validate = { path = "crates/validate", version = "0.5.0" }
-purrdf-xsd = { path = "crates/xsd", version = "0.5.0" }
+purrdf = { path = "crates/purrdf", version = "0.6.0" }
+purrdf-core = { path = "crates/rdf-core", version = "0.6.0" }
+purrdf-entail = { path = "crates/entail", version = "0.6.0" }
+purrdf-events = { path = "crates/rdf-events", version = "0.6.0" }
+purrdf-gts = { path = "crates/gts", version = "0.6.0" }
+purrdf-iri = { path = "crates/iri", version = "0.6.0" }
+purrdf-rdf = { path = "crates/rdf", version = "0.6.0" }
+purrdf-shapes = { path = "crates/shapes", version = "0.6.0" }
+purrdf-shex = { path = "crates/shex", version = "0.6.0" }
+purrdf-slice = { path = "crates/slice", version = "0.6.0" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.6.0" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.6.0" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "0.6.0" }
+purrdf-validate = { path = "crates/validate", version = "0.6.0" }
+purrdf-xsd = { path = "crates/xsd", version = "0.6.0" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.5.0" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.6.0" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -78,4 +78,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "0.5.0"
+version = "0.6.0"

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -51,7 +51,7 @@ serde_json = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.5.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.6.0" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.5.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.6.0" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.


### PR DESCRIPTION
## Release prep — 0.6.0

Lockstep version bump + regenerated changelog for the next suite release. Cut from `main` at the current HEAD (`4002433`, #101 merged).

### What this does
- `make bump VERSION=0.6.0` — sets the version across crates.io / PyPI / npm lanes (workspace `Cargo.toml` + 18 internal path-dep pins, `bindings/python/{pyproject.toml,Cargo.toml,uv.lock}`, `crates/rdf-wasm/js/package.json`, `CITATION.cff`) + refreshed `Cargo.lock`.
- `make changelog` — regenerated `CHANGELOG.md` deterministically from conventional-commit history under a `## [0.6.0]` header (git-cliff 2.13.1), `#NNN` tokens stripped.

### Version rationale
Minor bump: **33 `feat` commits** since `v0.5.0` — the read-only succinct pack codec (#101), id-agnostic `DatasetView` seam + paged u64 backend (#96), certified GTS compaction (#95), two-inventory GTS diff/splice + streaming `RdfEventSink` bridge (#100), value-vocabulary enum `$defs` projection (#98), and the native Rust-closure user-function registry (#99) — plus 13 fixes.

### Gate
- `make check` (fmt + clippy `-D warnings` + build + workspace tests + hygiene + version-coherence + `make wasm`) — **exit 0**.
- `scripts/check-versions.py` — coherent across all three lanes.

### After merge (release cut — runs from `main`, not this branch)
```
make release-tags VERSION=0.6.0
```
cuts + pushes `rust-v0.6.0`, `py-v0.6.0`, `npm-v0.6.0`, each triggering its trusted-publishing lane; the cargo lane also publishes a GitHub Release sliced from `CHANGELOG.md`.