### PR TITLE
feat(rdf): unify JSON-LD/YAML-LD into the native format registry

### DIFF
--- a/crates/rdf-core/src/ir/ingest.rs
+++ b/crates/rdf-core/src/ir/ingest.rs
@@ -113,10 +113,12 @@ pub struct DatasetSink {
     resolving: HashSet<EventTermId>,
     /// RAW quad rows, resolved in phase 2.
     raw_quads: Vec<EventQuad>,
-    /// RAW reifier bindings `(reifier id, triple)`, resolved in phase 2.
-    raw_reifiers: Vec<(EventTermId, EventTriple)>,
-    /// RAW annotation rows `(reifier, predicate, object)`, resolved in phase 2.
-    raw_annotations: Vec<(EventTermId, EventTermId, EventTermId)>,
+    /// RAW reifier bindings `(reifier id, triple, graph)`, resolved in phase 2. The
+    /// graph slot is `None` for a reifier declared via the graph-unaware
+    /// [`reifier`](RdfEventSink::reifier) event (or asserted in the default graph).
+    raw_reifiers: Vec<(EventTermId, EventTriple, Option<EventTermId>)>,
+    /// RAW annotation rows `(reifier, predicate, object, graph)`, resolved in phase 2.
+    raw_annotations: Vec<(EventTermId, EventTermId, EventTermId, Option<EventTermId>)>,
     /// Open scopes. [`ScopeId::DEFAULT`] is always open; [`open_scope`](Self::open_scope)
     /// adds more, [`close_scope`](Self::close_scope) removes (seals) them. Openness is
     /// determined solely by membership here, so a sealed OR never-opened scope id both
@@ -314,8 +316,7 @@ impl RdfEventSink for DatasetSink {
         reifier: EventTermId,
         triple: EventTriple,
     ) -> Result<ControlFlow<()>, EventError> {
-        self.raw_reifiers.push((reifier, triple));
-        Ok(ControlFlow::Continue(()))
+        self.reifier_in_graph(reifier, triple, None)
     }
 
     fn annotation(
@@ -324,7 +325,27 @@ impl RdfEventSink for DatasetSink {
         p: EventTermId,
         o: EventTermId,
     ) -> Result<ControlFlow<()>, EventError> {
-        self.raw_annotations.push((reifier, p, o));
+        self.annotation_in_graph(reifier, p, o, None)
+    }
+
+    fn reifier_in_graph(
+        &mut self,
+        reifier: EventTermId,
+        triple: EventTriple,
+        g: Option<EventTermId>,
+    ) -> Result<ControlFlow<()>, EventError> {
+        self.raw_reifiers.push((reifier, triple, g));
+        Ok(ControlFlow::Continue(()))
+    }
+
+    fn annotation_in_graph(
+        &mut self,
+        reifier: EventTermId,
+        p: EventTermId,
+        o: EventTermId,
+        g: Option<EventTermId>,
+    ) -> Result<ControlFlow<()>, EventError> {
+        self.raw_annotations.push((reifier, p, o, g));
         Ok(ControlFlow::Continue(()))
     }
 
@@ -388,28 +409,37 @@ impl RdfEventSink for DatasetSink {
                 .push_quad(s, p, o, g);
         }
 
-        // Reifier bindings: bind the reifier resource to the interned triple term.
+        // Reifier bindings: bind the reifier resource to the interned triple term,
+        // preserving the graph the binding was declared in.
         let raw_reifiers = std::mem::take(&mut self.raw_reifiers);
-        for (reifier, EventTriple { s, p, o }) in raw_reifiers {
+        for (reifier, EventTriple { s, p, o }, g) in raw_reifiers {
             let reifier_id = self.resolve(reifier, 0)?;
             let s = self.resolve(s, 0)?;
             let p = self.resolve(p, 0)?;
             let o = self.resolve(o, 0)?;
+            let g = match g {
+                Some(g) => Some(self.resolve(g, 0)?),
+                None => None,
+            };
             let builder = self.builder.as_mut().expect("builder present");
             let triple_term = builder.intern_triple(s, p, o);
-            builder.push_reifier(reifier_id, triple_term);
+            builder.push_reifier_in_graph(reifier_id, triple_term, g);
         }
 
-        // Annotations `(reifier, predicate, object)`.
+        // Annotations `(reifier, predicate, object, graph)`.
         let raw_annotations = std::mem::take(&mut self.raw_annotations);
-        for (r, p, v) in raw_annotations {
+        for (r, p, v, g) in raw_annotations {
             let r = self.resolve(r, 0)?;
             let p = self.resolve(p, 0)?;
             let v = self.resolve(v, 0)?;
+            let g = match g {
+                Some(g) => Some(self.resolve(g, 0)?),
+                None => None,
+            };
             self.builder
                 .as_mut()
                 .expect("builder present")
-                .push_annotation(r, p, v);
+                .push_annotation_in_graph(r, p, v, g);
         }
 
         let builder = self.builder.take().expect("builder present");
@@ -543,7 +573,7 @@ impl RdfEventSource for FrozenDatasetSource<'_> {
                 return Ok(());
             }
         }
-        for (reifier, triple) in self.dataset.reifiers() {
+        for (reifier, triple, g) in self.dataset.reifiers_with_graph() {
             // Resolve the bound triple term to its (s, p, o) so the protocol carries a
             // reified statement, not an id-to-id binding.
             let TermRef::Triple { s, p, o } = self.dataset.resolve(triple) else {
@@ -554,15 +584,20 @@ impl RdfEventSource for FrozenDatasetSource<'_> {
                 p: EventTermId(p.index() as u32),
                 o: EventTermId(o.index() as u32),
             };
-            if sink.reifier(EventTermId(reifier.index() as u32), event)? == ControlFlow::Break(()) {
+            let g_event = g.map(|g| EventTermId(g.index() as u32));
+            if sink.reifier_in_graph(EventTermId(reifier.index() as u32), event, g_event)?
+                == ControlFlow::Break(())
+            {
                 return Ok(());
             }
         }
-        for (reifier, p, o) in self.dataset.annotations() {
-            if sink.annotation(
+        for (reifier, p, o, g) in self.dataset.annotations_with_graph() {
+            let g_event = g.map(|g| EventTermId(g.index() as u32));
+            if sink.annotation_in_graph(
                 EventTermId(reifier.index() as u32),
                 EventTermId(p.index() as u32),
                 EventTermId(o.index() as u32),
+                g_event,
             )? == ControlFlow::Break(())
             {
                 return Ok(());
@@ -668,6 +703,51 @@ mod tests {
             quad_values(&original),
             quad_values(&rebuilt),
             "quad value sets match"
+        );
+    }
+
+    #[test]
+    fn round_trip_replay_preserves_reifier_and_annotation_graph_scope() {
+        // The reifier binding AND its annotation live in a NAMED graph, not the
+        // default graph. `FrozenDatasetSource::drive` must thread that graph slot
+        // through the `reifier_in_graph`/`annotation_in_graph` events (not the
+        // graph-unaware `reifier`/`annotation` events, which silently collapse to the
+        // default graph) — otherwise a graph-aware sink replaying this dataset loses
+        // the graph scoping.
+        let mut b = RdfDatasetBuilder::new();
+        let s = iri(&mut b, "s");
+        let p = iri(&mut b, "p");
+        let o = iri(&mut b, "o");
+        let g = iri(&mut b, "g");
+        let triple = b.intern_triple(s, p, o);
+        let r = iri(&mut b, "r");
+        let ann_p = iri(&mut b, "annp");
+        b.push_quad(s, p, o, Some(g));
+        b.push_reifier_in_graph(r, triple, Some(g));
+        b.push_annotation_in_graph(r, ann_p, o, Some(g));
+        let original = b.freeze().expect("fixture freezes");
+
+        let source = FrozenDatasetSource::new(&original);
+        let mut sink = DatasetSink::new();
+        source.drive(&mut sink).expect("drive ok");
+        let rebuilt = sink.into_dataset().expect("frozen after finish");
+
+        assert!(
+            datasets_isomorphic(&original, &rebuilt),
+            "replayed dataset with a graph-scoped reifier/annotation must be isomorphic"
+        );
+        // Direct check: the rebuilt reifier/annotation rows still carry a `Some(graph)`
+        // slot, not `None` (the bug this guards against silently rewrote every graph
+        // slot to `None` on replay).
+        assert!(
+            rebuilt.reifiers_with_graph().all(|(_, _, g)| g.is_some()),
+            "reifier graph slot must survive the replay, not collapse to the default graph"
+        );
+        assert!(
+            rebuilt
+                .annotations_with_graph()
+                .all(|(_, _, _, g)| g.is_some()),
+            "annotation graph slot must survive the replay, not collapse to the default graph"
         );
     }
 

--- a/crates/rdf-events/src/lib.rs
+++ b/crates/rdf-events/src/lib.rs
@@ -584,6 +584,37 @@ pub trait RdfEventSink {
         o: EventTermId,
     ) -> Result<ControlFlow<()>, EventError>;
 
+    /// Like [`reifier`](Self::reifier) but carries the named graph the reifier
+    /// declaration was asserted in (`None` = default graph). Defaults to ignoring the
+    /// graph and delegating to [`reifier`](Self::reifier) — additive, so an existing
+    /// sink that has no notion of graph-scoped reification needs no changes. A sink
+    /// that DOES need the graph dimension (e.g. one replaying a dataset that reifies
+    /// the SAME base triple differently in two named graphs) overrides this instead of
+    /// [`reifier`](Self::reifier).
+    fn reifier_in_graph(
+        &mut self,
+        reifier: EventTermId,
+        triple: EventTriple,
+        g: Option<EventTermId>,
+    ) -> Result<ControlFlow<()>, EventError> {
+        let _ = g;
+        self.reifier(reifier, triple)
+    }
+
+    /// Like [`annotation`](Self::annotation) but carries the named graph the
+    /// annotation was asserted in (`None` = default graph). See
+    /// [`reifier_in_graph`](Self::reifier_in_graph).
+    fn annotation_in_graph(
+        &mut self,
+        reifier: EventTermId,
+        p: EventTermId,
+        o: EventTermId,
+        g: Option<EventTermId>,
+    ) -> Result<ControlFlow<()>, EventError> {
+        let _ = g;
+        self.annotation(reifier, p, o)
+    }
+
     /// Open a fresh blank-node label namespace, returning its [`ScopeId`]. Blank-node
     /// *label* identity is namespaced per scope (see [`close_scope`](Self::close_scope));
     /// the drive-global [`EventTermId`] space is unaffected.

--- a/crates/rdf-wasm/src/codec.rs
+++ b/crates/rdf-wasm/src/codec.rs
@@ -3,31 +3,26 @@
 
 //! Format-name resolution for the native text codecs.
 //!
-//! Accepts both IANA media types and friendly short names, normalising to the exact
-//! media-type strings `purrdf::native_codecs` expects. The codecs themselves ride
-//! purrdf's wasm-clean native codec stack — no oxigraph Store and no purrdf-gts
-//! RDF-codec feature.
+//! Delegates to the ONE core registry (`purrdf::classify`), so the wasm surface accepts
+//! exactly the spellings every other first-party surface does — including JSON-LD and
+//! YAML-LD — and there is no second, drifting format table. The codecs ride purrdf's
+//! wasm-clean native codec stack — no oxigraph Store and no purrdf-gts RDF-codec feature.
 
 /// Resolve a caller-supplied format string to a canonical media type.
 ///
 /// Returns a plain `String` error (NOT a `JsError`) so it is unit-testable on the
 /// native build — constructing a `JsError` calls a wasm-only import that panics off
-/// wasm. The `#[wasm_bindgen]` call sites map the `String` to a `JsError`.
+/// wasm. The `#[wasm_bindgen]` call sites map the `String` to a `JsError`. `classify`
+/// already lowercases and strips any `;charset=…` parameter.
 pub(crate) fn resolve_media_type(format: &str) -> Result<&'static str, String> {
-    let normalized = format.trim().to_ascii_lowercase();
-    Ok(match normalized.as_str() {
-        "text/turtle" | "turtle" | "ttl" => "text/turtle",
-        "application/n-triples" | "n-triples" | "ntriples" | "nt" => "application/n-triples",
-        "application/n-quads" | "n-quads" | "nquads" | "nq" => "application/n-quads",
-        "application/trig" | "trig" => "application/trig",
-        "application/rdf+xml" | "rdf+xml" | "rdf/xml" | "rdfxml" => "application/rdf+xml",
-        other => {
-            return Err(format!(
-                "unsupported RDF format {other:?} \
-                 (use turtle/ntriples/nquads/trig/rdfxml or their media types)"
-            ));
-        }
-    })
+    purrdf::classify(format)
+        .map(purrdf::NativeRdfFormat::media_type)
+        .map_err(|_| {
+            format!(
+                "unsupported RDF format {format:?} (use turtle/ntriples/nquads/trig/rdfxml/\
+                 jsonld/yamlld or their media types)"
+            )
+        })
 }
 
 #[cfg(test)]
@@ -40,14 +35,31 @@ mod tests {
         assert_eq!(resolve_media_type("Turtle").unwrap(), "text/turtle");
         assert_eq!(resolve_media_type("text/turtle").unwrap(), "text/turtle");
         assert_eq!(resolve_media_type("nq").unwrap(), "application/n-quads");
+        // Both RDF/XML spellings the wasm resolver historically accepted still resolve
+        // (absorbed into the core registry), so delegation drops nothing.
         assert_eq!(
             resolve_media_type("rdf/xml").unwrap(),
             "application/rdf+xml"
         );
+        assert_eq!(resolve_media_type("rdfxml").unwrap(), "application/rdf+xml");
+    }
+
+    #[test]
+    fn jsonld_and_yamlld_now_resolve() {
+        assert_eq!(resolve_media_type("jsonld").unwrap(), "application/ld+json");
+        assert_eq!(
+            resolve_media_type("application/ld+json").unwrap(),
+            "application/ld+json"
+        );
+        assert_eq!(
+            resolve_media_type("yaml-ld").unwrap(),
+            "application/ld+yaml"
+        );
+        assert_eq!(resolve_media_type("yamlld").unwrap(), "application/ld+yaml");
     }
 
     #[test]
     fn unknown_format_is_an_error() {
-        assert!(resolve_media_type("yaml-ld").is_err());
+        assert!(resolve_media_type("application/json").is_err());
     }
 }

--- a/crates/rdf-wasm/src/dataset.rs
+++ b/crates/rdf-wasm/src/dataset.rs
@@ -202,7 +202,8 @@ impl Dataset {
 
     /// `parse(input, format, base?)` → a dataset of the parsed quads.
     ///
-    /// `format` is a media type or short name (turtle/ntriples/nquads/trig/rdfxml).
+    /// `format` is a media type or short name
+    /// (turtle/ntriples/nquads/trig/rdfxml/jsonld/yamlld).
     /// Ill-typed literals are preserved verbatim (RDFLib parity), not rejected.
     #[wasm_bindgen(js_name = parse)]
     #[allow(clippy::needless_pass_by_value)] // binding ABI receives owned values
@@ -220,6 +221,10 @@ impl Dataset {
     /// Formats: `turtle` / `ntriples` / `nquads` / `trig` / `rdfxml` / `jsonld`
     /// (JSON-LD-star) / `yamlld` (YAML-LD-star), and their media types — all resolved
     /// through the one core registry.
+    ///
+    /// Object-position quoted-triple terms (RDF-1.2 triple terms) are preserved
+    /// through N-Quads, JSON-LD, and YAML-LD; the other text syntaxes (Turtle,
+    /// N-Triples, TriG, RDF/XML) flatten them.
     #[wasm_bindgen(js_name = serialize)]
     pub fn serialize(&self, format: &str) -> Result<String, JsError> {
         let frozen = self.inner.freeze().map_err(|e| diag_to_err(&e))?;
@@ -404,7 +409,11 @@ mod tests {
         // unified resolver — no side-door, no special-case guard. (JsError is only
         // constructed on the error path, which panics off-wasm, so a passing test never
         // builds one.)
-        let nt = "<https://e/s> <https://e/p> <https://e/o> .\n";
+        // A literal (not just all-IRI terms) is included so term corruption — e.g. a
+        // dropped datatype or lexical-form mangling — would actually be caught by the
+        // isomorphism check below (a quad-count check alone would miss it).
+        let nt = "<https://e/s> <https://e/p> <https://e/o> .\n\
+                  <https://e/s> <https://e/label> \"value\" .\n";
         let Ok(ds) = Dataset::parse(nt, "ntriples", None) else {
             panic!("parse n-triples failed");
         };
@@ -420,11 +429,10 @@ mod tests {
             let Ok(reparsed) = Dataset::parse(&text, fmt, None) else {
                 panic!("re-parse {fmt} failed");
             };
-            assert_eq!(
-                reparsed.size(),
-                ds.size(),
-                "wasm round-trip via {fmt} preserves quad count"
-            );
+            let Ok(iso) = reparsed.isomorphic(&ds) else {
+                panic!("isomorphic {fmt} failed");
+            };
+            assert!(iso, "wasm round-trip via {fmt} preserves the graph");
         }
     }
 

--- a/crates/rdf-wasm/src/dataset.rs
+++ b/crates/rdf-wasm/src/dataset.rs
@@ -217,23 +217,12 @@ impl Dataset {
 
     /// `serialize(format)` → the dataset rendered in `format` (a UTF-8 string).
     ///
-    /// Formats: `turtle` / `ntriples` / `nquads` / `trig` / `rdfxml` (their media types
-    /// too) plus `jsonld` (JSON-LD-star). Note: a quoted-triple term appearing as a quad
-    /// object currently round-trips only through N-Quads (a serializer limitation for
-    /// the other text formats).
+    /// Formats: `turtle` / `ntriples` / `nquads` / `trig` / `rdfxml` / `jsonld`
+    /// (JSON-LD-star) / `yamlld` (YAML-LD-star), and their media types — all resolved
+    /// through the one core registry.
     #[wasm_bindgen(js_name = serialize)]
     pub fn serialize(&self, format: &str) -> Result<String, JsError> {
         let frozen = self.inner.freeze().map_err(|e| diag_to_err(&e))?;
-        // JSON-LD rides the separate first-party codec path (it is not a
-        // `NativeRdfFormat`), so route it before the media-type resolution.
-        let normalized = format.trim().to_ascii_lowercase();
-        if matches!(
-            normalized.as_str(),
-            "jsonld" | "json-ld" | "application/ld+json"
-        ) {
-            return purrdf::native_codecs::jsonld::serialize_dataset_to_jsonld(&frozen)
-                .map_err(|e| diag_to_err(&e));
-        }
         let media_type = resolve_media_type(format).map_err(|e| JsError::new(&e))?;
         let bytes = serialize_dataset(&frozen, media_type, SerializeGraph::Dataset)
             .map_err(|e| diag_to_err(&e))?;
@@ -407,6 +396,36 @@ mod tests {
     fn empty_dataset_has_zero_size() {
         let ds = Dataset::new().unwrap();
         assert_eq!(ds.size(), 0);
+    }
+
+    #[test]
+    fn jsonld_and_yamlld_round_trip_through_the_wasm_surface() {
+        // The wasm parse + serialize surface reaches JSON-LD and YAML-LD through the one
+        // unified resolver — no side-door, no special-case guard. (JsError is only
+        // constructed on the error path, which panics off-wasm, so a passing test never
+        // builds one.)
+        let nt = "<https://e/s> <https://e/p> <https://e/o> .\n";
+        let Ok(ds) = Dataset::parse(nt, "ntriples", None) else {
+            panic!("parse n-triples failed");
+        };
+        for fmt in [
+            "jsonld",
+            "application/ld+json",
+            "yamlld",
+            "application/ld+yaml",
+        ] {
+            let Ok(text) = ds.serialize(fmt) else {
+                panic!("serialize {fmt} failed");
+            };
+            let Ok(reparsed) = Dataset::parse(&text, fmt, None) else {
+                panic!("re-parse {fmt} failed");
+            };
+            assert_eq!(
+                reparsed.size(),
+                ds.size(),
+                "wasm round-trip via {fmt} preserves quad count"
+            );
+        }
     }
 
     #[test]

--- a/crates/rdf-wasm/src/query.rs
+++ b/crates/rdf-wasm/src/query.rs
@@ -492,14 +492,6 @@ fn serialize_graph_result(
     graph: &std::sync::Arc<purrdf::RdfDataset>,
     format: &str,
 ) -> Result<String, JsError> {
-    let normalized = format.trim().to_ascii_lowercase();
-    if matches!(
-        normalized.as_str(),
-        "jsonld" | "json-ld" | "application/ld+json"
-    ) {
-        return purrdf::native_codecs::jsonld::serialize_dataset_to_jsonld(graph)
-            .map_err(|e| diag_to_err(&e));
-    }
     let media_type = resolve_media_type(format).map_err(|e| JsError::new(&e))?;
     let bytes = serialize_dataset(graph, media_type, SerializeGraph::Dataset)
         .map_err(|e| diag_to_err(&e))?;

--- a/crates/rdf/src/native_codecs/codec.rs
+++ b/crates/rdf/src/native_codecs/codec.rs
@@ -28,22 +28,13 @@ use super::span::NoSpans;
 use super::text_parse::LineParseMode;
 use crate::{RdfDataset, RdfDiagnostic};
 
-/// One RDF text format's parse + serialize behavior, plus the two capability predicates
-/// the dispatch sites branch on. Object-safe so [`codec_for`] can hand back a
-/// `&'static dyn RdfCodec` — a COLD dispatch boundary (the media-type router), never the
-/// tokenizer hot loop, so the one indirect call it adds is not on any measured path.
+/// One RDF text format's parse + serialize behavior. Object-safe so [`codec_for`] can
+/// hand back a `&'static dyn RdfCodec` — a COLD dispatch boundary (the media-type
+/// router), never the tokenizer hot loop, so the one indirect call it adds is not on any
+/// measured path. The DATA capability predicates (`carries_star` /
+/// `tokenizer_carries_spans` / `supports_datasets`) live on [`NativeRdfFormat`] itself,
+/// backed by the [`FORMATS`](super::media_type::FORMATS) table, not on this behavior seam.
 pub(super) trait RdfCodec {
-    /// Whether this format carries the RDF-1.2 statement layer (quoted-triple reifiers +
-    /// annotations) under the transcode loss contract. Star-capable formats emit it;
-    /// star-incapable formats drop it as declared loss. Kept aligned with the loss
-    /// ledger (`crates/rdf-core/src/loss.rs`).
-    fn carries_star(&self) -> bool;
-
-    /// Whether this format's parser can record per-statement source spans. Only the
-    /// line/Turtle-family text tokenizer does; the others return an empty span table
-    /// (physical-location fallback by design).
-    fn tokenizer_carries_spans(&self) -> bool;
-
     /// Parse `text` into the frozen IR on the hot (span-free) path. `mode` is honored
     /// only by [`LineCodec`] (the N-Triples/N-Quads chunk-parallel toggle); the
     /// standalone codecs ignore it. Every implementor is panic-guarded, matching the
@@ -65,16 +56,6 @@ pub(super) trait RdfCodec {
 pub(super) struct LineCodec(pub(super) NativeRdfFormat);
 
 impl RdfCodec for LineCodec {
-    fn carries_star(&self) -> bool {
-        // Every format `LineCodec` wraps (Turtle / N-Triples / N-Quads / TriG) is
-        // star-capable; the standalone codecs are the star-incapable ones.
-        true
-    }
-
-    fn tokenizer_carries_spans(&self) -> bool {
-        true
-    }
-
     fn parse(
         &self,
         text: &str,

--- a/crates/rdf/src/native_codecs/codec.rs
+++ b/crates/rdf/src/native_codecs/codec.rs
@@ -76,7 +76,11 @@ impl RdfCodec for LineCodec {
             NativeRdfFormat::TriG => ser_model::to_trig(graph),
             NativeRdfFormat::NTriples => ser_model::to_ntriples(graph)?,
             NativeRdfFormat::NQuads => ser_model::to_nquads(graph),
-            NativeRdfFormat::RdfXml | NativeRdfFormat::TriX | NativeRdfFormat::HexTuples => {
+            NativeRdfFormat::RdfXml
+            | NativeRdfFormat::TriX
+            | NativeRdfFormat::HexTuples
+            | NativeRdfFormat::JsonLd
+            | NativeRdfFormat::YamlLd => {
                 unreachable!("LineCodec only wraps line/Turtle-family formats")
             }
         })
@@ -97,5 +101,7 @@ pub(super) fn codec_for(format: NativeRdfFormat) -> &'static dyn RdfCodec {
         NativeRdfFormat::RdfXml => &super::rdfxml::RdfXmlCodec,
         NativeRdfFormat::TriX => &super::trix::TriXCodec,
         NativeRdfFormat::HexTuples => &super::hextuples::HexTuplesCodec,
+        NativeRdfFormat::JsonLd => &super::jsonld::JsonLdCodec,
+        NativeRdfFormat::YamlLd => &super::jsonld::YamlLdCodec,
     }
 }

--- a/crates/rdf/src/native_codecs/hextuples.rs
+++ b/crates/rdf/src/native_codecs/hextuples.rs
@@ -36,14 +36,6 @@ use crate::{BlankScope, RdfDataset, RdfDatasetBuilder, RdfDiagnostic, RdfLiteral
 pub(super) struct HexTuplesCodec;
 
 impl RdfCodec for HexTuplesCodec {
-    fn carries_star(&self) -> bool {
-        false
-    }
-
-    fn tokenizer_carries_spans(&self) -> bool {
-        false
-    }
-
     fn parse(
         &self,
         text: &str,

--- a/crates/rdf/src/native_codecs/jsonld.rs
+++ b/crates/rdf/src/native_codecs/jsonld.rs
@@ -75,10 +75,21 @@ include!("lpg_prefixes.rs");
 
 /// Default-graph and named-graph node maps returned by [`build_graphs`].
 type GraphNodes = (BTreeMap<String, Value>, BTreeMap<String, Value>);
-/// Reifier lookup: base triple (s,p,o) -> reifier ids that annotate it.
-type ReifierIndex = BTreeMap<(usize, usize, usize), Vec<usize>>;
-/// Annotation lookup: reifier id -> sorted annotation (predicate, value) rows.
-type AnnotationIndex = BTreeMap<usize, Vec<(usize, usize)>>;
+/// Reifier lookup: base triple (s,p,o) in a given graph (`None` = default graph) ->
+/// reifier ids that annotate it. Graph-scoped: the SAME base triple reified by
+/// DIFFERENT reifiers in DIFFERENT named graphs must not cross-contaminate.
+type ReifierIndex = BTreeMap<(usize, usize, usize, Option<usize>), Vec<usize>>;
+/// Annotation lookup: (reifier id, graph) -> sorted annotation (predicate, value)
+/// rows. Graph-scoped alongside [`ReifierIndex`] for the same reason.
+type AnnotationIndex = BTreeMap<(usize, Option<usize>), Vec<(usize, usize)>>;
+
+/// The two graph-scoped lookup indices the node/value-object builders always
+/// consult together, bundled into one reference so a builder needing both takes one
+/// parameter instead of two (keeping argument counts under the pedantic lint cap).
+struct Indexes<'a> {
+    reifier_of: &'a ReifierIndex,
+    annotations_of: &'a AnnotationIndex,
+}
 /// Quads grouped by graph name and then by subject.
 type QuadGroups = BTreeMap<Option<usize>, BTreeMap<usize, Vec<(usize, usize)>>>;
 
@@ -258,9 +269,9 @@ fn build_context() -> Value {
 
 /// Build default-graph nodes and named-graph objects.
 fn build_graphs(graph: &SerGraph) -> Result<GraphNodes, RdfDiagnostic> {
-    // Reifier index: base triple (s,p,o) -> reifier ids that annotate it.
+    // Reifier index: base triple (s,p,o) in graph g -> reifier ids that annotate it.
     let mut reifier_of: ReifierIndex = BTreeMap::new();
-    for &(rid, (s, p, o), _g) in &graph.reifiers {
+    for &(rid, (s, p, o), g) in &graph.reifiers {
         // A triple term is self-reifying: its `reifier` row's "reifier" is the triple
         // term itself (kind `Triple`), carrying the term's components — NOT a real
         // IRI/blank-node reifier. `term_id` has no @id for a `Triple`-kind term, so it
@@ -269,7 +280,7 @@ fn build_graphs(graph: &SerGraph) -> Result<GraphNodes, RdfDiagnostic> {
         if graph.terms[rid].kind == SerTermKind::Triple {
             continue;
         }
-        reifier_of.entry((s, p, o)).or_default().push(rid);
+        reifier_of.entry((s, p, o, g)).or_default().push(rid);
     }
     for list in reifier_of.values_mut() {
         // Sort by the reifier's stable @id, not its input-order term id.
@@ -280,10 +291,10 @@ fn build_graphs(graph: &SerGraph) -> Result<GraphNodes, RdfDiagnostic> {
         });
     }
 
-    // Annotation index: reifier id -> sorted annotation (predicate, value) rows.
+    // Annotation index: (reifier id, graph) -> sorted annotation (predicate, value) rows.
     let mut annotations_of: AnnotationIndex = BTreeMap::new();
-    for &(r, p, v, _g) in &graph.annotations {
-        annotations_of.entry(r).or_default().push((p, v));
+    for &(r, p, v, g) in &graph.annotations {
+        annotations_of.entry((r, g)).or_default().push((p, v));
     }
     for list in annotations_of.values_mut() {
         // Sort by stable predicate @id then stable value key, not raw term ids.
@@ -296,6 +307,11 @@ fn build_graphs(graph: &SerGraph) -> Result<GraphNodes, RdfDiagnostic> {
             })
         });
     }
+
+    let indexes = Indexes {
+        reifier_of: &reifier_of,
+        annotations_of: &annotations_of,
+    };
 
     // Group quads by graph name (None = default graph) and then by subject.
     let mut by_graph: QuadGroups = BTreeMap::new();
@@ -312,10 +328,15 @@ fn build_graphs(graph: &SerGraph) -> Result<GraphNodes, RdfDiagnostic> {
     // its compact `@annotation`, so emit it as a standalone node with an explicit
     // `rdf:reifies` @triple value plus its annotation properties — otherwise the reifier
     // and its annotations are silently dropped. (An asserted base triple keeps the
-    // compact `@annotation` form.) Keyed by `(s,p,o)` to match the `@annotation`
-    // attachment in `build_value_object`, which ignores graph name.
-    let asserted_base: BTreeSet<(usize, usize, usize)> =
-        graph.quads.iter().map(|&(s, p, o, _g)| (s, p, o)).collect();
+    // compact `@annotation` form.) Keyed by `(s,p,o,g)` — GRAPH-SCOPED — to match the
+    // `@annotation` attachment in `build_value_object`, which now also keys on graph
+    // name: the same base triple may be asserted in one graph and orphaned (reified
+    // without assertion) in another.
+    let asserted_base: BTreeSet<(usize, usize, usize, Option<usize>)> = graph
+        .quads
+        .iter()
+        .map(|&(s, p, o, g)| (s, p, o, g))
+        .collect();
     let mut orphan_by_graph: BTreeMap<Option<usize>, Vec<Value>> = BTreeMap::new();
     for &(rid, (s, p, o), g) in &graph.reifiers {
         // A triple term is self-reifying: its `reifier` row's "reifier" is the triple
@@ -325,8 +346,8 @@ fn build_graphs(graph: &SerGraph) -> Result<GraphNodes, RdfDiagnostic> {
         if graph.terms[rid].kind == SerTermKind::Triple {
             continue;
         }
-        if !asserted_base.contains(&(s, p, o)) {
-            let node = build_orphan_reifier_node(graph, rid, s, p, o, &annotations_of)?;
+        if !asserted_base.contains(&(s, p, o, g)) {
+            let node = build_orphan_reifier_node(graph, rid, s, p, o, g, &indexes)?;
             orphan_by_graph.entry(g).or_default().push(node);
         }
     }
@@ -345,7 +366,7 @@ fn build_graphs(graph: &SerGraph) -> Result<GraphNodes, RdfDiagnostic> {
         let mut nodes: Vec<Value> = Vec::new();
         if let Some(subjects) = by_graph.remove(&g) {
             for (s, pos) in subjects {
-                let node = build_node(graph, s, pos, &reifier_of, &annotations_of)?;
+                let node = build_node(graph, s, pos, g, &indexes)?;
                 nodes.push(node);
             }
         }
@@ -386,8 +407,8 @@ fn build_node(
     graph: &SerGraph,
     subject: usize,
     pos: Vec<(usize, usize)>,
-    reifier_of: &ReifierIndex,
-    annotations_of: &AnnotationIndex,
+    g: Option<usize>,
+    indexes: &Indexes<'_>,
 ) -> Result<Value, RdfDiagnostic> {
     let subject_term = &graph.terms[subject];
     let mut node = BTreeMap::new();
@@ -409,15 +430,7 @@ fn build_node(
             types.push(term_ref_value(object_term)?);
         } else {
             let key = curie(predicate_iri);
-            let value = build_value_object(
-                graph,
-                subject,
-                p,
-                o,
-                object_term,
-                reifier_of,
-                annotations_of,
-            )?;
+            let value = build_value_object(graph, subject, p, o, g, object_term, indexes)?;
             props.entry(key).or_default().push(value);
         }
     }
@@ -447,9 +460,9 @@ fn build_value_object(
     subject: usize,
     predicate: usize,
     object: usize,
+    g: Option<usize>,
     object_term: &SerTerm,
-    reifier_of: &ReifierIndex,
-    annotations_of: &AnnotationIndex,
+    indexes: &Indexes<'_>,
 ) -> Result<Value, RdfDiagnostic> {
     let mut value = if object_term.kind == SerTermKind::Triple {
         build_triple_term_value(graph, object_term)?
@@ -457,10 +470,10 @@ fn build_value_object(
         term_to_value(graph, object_term)?
     };
 
-    if let Some(reifiers) = reifier_of.get(&(subject, predicate, object)) {
+    if let Some(reifiers) = indexes.reifier_of.get(&(subject, predicate, object, g)) {
         let annotations: Result<Vec<Value>, _> = reifiers
             .iter()
-            .map(|&rid| build_annotation_node(graph, rid, annotations_of))
+            .map(|&rid| build_annotation_node(graph, rid, g, indexes))
             .collect();
         let annotations = annotations?;
         let ann_value = if annotations.len() == 1 {
@@ -580,13 +593,14 @@ fn term_to_value(graph: &SerGraph, term: &SerTerm) -> Result<Value, RdfDiagnosti
 fn build_annotation_node(
     graph: &SerGraph,
     reifier_id: usize,
-    annotations_of: &AnnotationIndex,
+    g: Option<usize>,
+    indexes: &Indexes<'_>,
 ) -> Result<Value, RdfDiagnostic> {
     let reifier_term = &graph.terms[reifier_id];
     let mut node = BTreeMap::new();
     node.insert("@id".to_string(), Value::String(term_id(reifier_term)?));
 
-    if let Some(anns) = annotations_of.get(&reifier_id) {
+    if let Some(anns) = indexes.annotations_of.get(&(reifier_id, g)) {
         let mut props: BTreeMap<String, Vec<Value>> = BTreeMap::new();
         for &(p, v) in anns {
             let p_term = &graph.terms[p];
@@ -622,9 +636,10 @@ fn build_orphan_reifier_node(
     s: usize,
     p: usize,
     o: usize,
-    annotations_of: &AnnotationIndex,
+    g: Option<usize>,
+    indexes: &Indexes<'_>,
 ) -> Result<Value, RdfDiagnostic> {
-    let Value::Object(entries) = build_annotation_node(graph, reifier_id, annotations_of)? else {
+    let Value::Object(entries) = build_annotation_node(graph, reifier_id, g, indexes)? else {
         unreachable!("build_annotation_node always returns a JSON object");
     };
     let mut node: BTreeMap<String, Value> = entries.into_iter().collect();
@@ -1136,6 +1151,13 @@ fn parse_triple_term(
     let obj = value
         .as_object()
         .ok_or_else(|| decode(format!("@triple must be an object, got {value}")))?;
+    if obj.contains_key("@annotation") {
+        return Err(decode(
+            "@annotation is not permitted inside a @triple object: a triple term \
+             carries no annotation in RDF 1.2; annotate via a separate reifier"
+                .to_string(),
+        ));
+    }
     let subject = obj
         .get("@subject")
         .ok_or_else(|| decode("@triple missing @subject".to_string()))?;

--- a/crates/rdf/src/native_codecs/jsonld.rs
+++ b/crates/rdf/src/native_codecs/jsonld.rs
@@ -1116,8 +1116,19 @@ fn parse_value_object(
 
 /// Reconstruct an RDF-1.2 triple term from a `@triple` object — the inverse of
 /// [`build_nested_triple_node`]. `@subject`/`@object` recurse through
-/// [`parse_value_object`] (so nested triple terms round-trip); `@predicate` is a
-/// CURIE/IRI string expanded through the document `@context`.
+/// [`parse_value_object`] (so nested triple term COMPONENTS round-trip: a triple term
+/// whose subject or object is itself a triple term); `@predicate` is a CURIE/IRI string
+/// expanded through the document `@context`.
+///
+/// A triple *term* carries no annotation of its own in the RDF 1.2 abstract syntax — it
+/// is a bare `(s, p, o)` value. Reification/annotation is always a SEPARATE statement
+/// about a reifier (`?r rdf:reifies <<( s p o )>>` plus annotation triples on `?r`); the
+/// native encoder never emits `@annotation` nested inside a `@triple` component (inner
+/// annotations ride separate reifier quads instead — see
+/// `object_position_triple_term_round_trips_jsonld`/`reifier_and_annotation_round_trip`
+/// in `native_codecs::tests`). So an `@annotation` found on a `@subject`/`@object`
+/// component here is not a well-formed RDF-1.2 term shape; per the no-swallowed-errors
+/// policy this is a hard failure rather than a silent drop or an ad hoc thread-through.
 fn parse_triple_term(
     value: &Value,
     expand: &dyn Fn(&str) -> String,
@@ -1136,10 +1147,24 @@ fn parse_triple_term(
         .get("@object")
         .ok_or_else(|| decode("@triple missing @object".to_string()))?;
 
-    let (subject_term, _) = parse_value_object(subject, expand)?;
+    let (subject_term, subject_ann) = parse_value_object(subject, expand)?;
+    if subject_ann.is_some() {
+        return Err(decode(
+            "@annotation is not permitted inside a @triple component: a triple term \
+             carries no annotation in RDF 1.2; annotate via a separate reifier"
+                .to_string(),
+        ));
+    }
     let predicate_iri = expand(predicate);
     validated_iri_term(&predicate_iri)?;
-    let (object_term, _) = parse_value_object(object, expand)?;
+    let (object_term, object_ann) = parse_value_object(object, expand)?;
+    if object_ann.is_some() {
+        return Err(decode(
+            "@annotation is not permitted inside a @triple component: a triple term \
+             carries no annotation in RDF 1.2; annotate via a separate reifier"
+                .to_string(),
+        ));
+    }
 
     Ok(RdfTerm::triple(RdfTriple::new(
         subject_term,

--- a/crates/rdf/src/native_codecs/jsonld.rs
+++ b/crates/rdf/src/native_codecs/jsonld.rs
@@ -13,7 +13,7 @@
 //! The JSON output is byte-deterministic: every map is a [`BTreeMap`] and every array is
 //! explicitly sorted, so the document does not depend on input append order.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 use std::sync::Arc;
 
@@ -300,14 +300,49 @@ fn build_graphs(graph: &SerGraph) -> Result<GraphNodes, RdfDiagnostic> {
             .push((p, o));
     }
 
+    // A reifier whose base triple is NOT asserted as a quad has no value object to carry
+    // its compact `@annotation`, so emit it as a standalone node with an explicit
+    // `rdf:reifies` @triple value plus its annotation properties — otherwise the reifier
+    // and its annotations are silently dropped. (An asserted base triple keeps the
+    // compact `@annotation` form.) Keyed by `(s,p,o)` to match the `@annotation`
+    // attachment in `build_value_object`, which ignores graph name.
+    let asserted_base: BTreeSet<(usize, usize, usize)> =
+        graph.quads.iter().map(|&(s, p, o, _g)| (s, p, o)).collect();
+    let mut orphan_by_graph: BTreeMap<Option<usize>, Vec<Value>> = BTreeMap::new();
+    for &(rid, (s, p, o), g) in &graph.reifiers {
+        // A triple term is self-reifying: its `reifier` row's "reifier" is the triple
+        // term itself (kind `Triple`), carrying the term's components — NOT a real
+        // IRI/blank-node reifier. Those are emitted as `@triple` objects where they
+        // appear; only genuine reifiers become standalone nodes here.
+        if graph.terms[rid].kind == SerTermKind::Triple {
+            continue;
+        }
+        if !asserted_base.contains(&(s, p, o)) {
+            let node = build_orphan_reifier_node(graph, rid, s, p, o, &annotations_of)?;
+            orphan_by_graph.entry(g).or_default().push(node);
+        }
+    }
+
     let mut default_nodes: BTreeMap<String, Value> = BTreeMap::new();
     let mut named_graphs: BTreeMap<String, Value> = BTreeMap::new();
 
-    for (g, subjects) in by_graph {
+    // Iterate the union of graph names carrying asserted quads OR orphan reifiers (a graph
+    // may carry only orphan reifiers, so `by_graph` alone would miss it).
+    let graph_keys: BTreeSet<Option<usize>> = by_graph
+        .keys()
+        .copied()
+        .chain(orphan_by_graph.keys().copied())
+        .collect();
+    for g in graph_keys {
         let mut nodes: Vec<Value> = Vec::new();
-        for (s, pos) in subjects {
-            let node = build_node(graph, s, pos, &reifier_of, &annotations_of)?;
-            nodes.push(node);
+        if let Some(subjects) = by_graph.remove(&g) {
+            for (s, pos) in subjects {
+                let node = build_node(graph, s, pos, &reifier_of, &annotations_of)?;
+                nodes.push(node);
+            }
+        }
+        if let Some(orphans) = orphan_by_graph.remove(&g) {
+            nodes.extend(orphans);
         }
         // Sort nodes by their @id (or lexical key for bnodes).
         nodes.sort_by_key(node_id_key);
@@ -409,7 +444,7 @@ fn build_value_object(
     annotations_of: &AnnotationIndex,
 ) -> Result<Value, RdfDiagnostic> {
     let mut value = if object_term.kind == SerTermKind::Triple {
-        build_triple_term_value(graph, object_term, reifier_of, annotations_of)?
+        build_triple_term_value(graph, object_term)?
     } else {
         term_to_value(graph, object_term)?
     };
@@ -441,43 +476,54 @@ fn build_value_object(
     Ok(value)
 }
 
-/// Render a triple term (object position) as its JSON-LD-star annotated node
-/// object, using the term's own reifier binding.
-fn build_triple_term_value(
-    graph: &SerGraph,
-    term: &SerTerm,
-    reifier_of: &ReifierIndex,
-    annotations_of: &AnnotationIndex,
-) -> Result<Value, RdfDiagnostic> {
+/// Render a triple term as its distinguishable JSON-LD-star `@triple` object, resolving
+/// its `(s,p,o)` components through the term's own self-reifier binding.
+fn build_triple_term_value(graph: &SerGraph, term: &SerTerm) -> Result<Value, RdfDiagnostic> {
     let (s, p, o) = triple_components(graph, term)
         .ok_or_else(|| parse("triple term with no components".to_string()))?;
-    build_nested_triple_node(graph, s, p, o, reifier_of, annotations_of)
+    build_nested_triple_node(graph, s, p, o)
 }
 
-/// Build the JSON-LD-star annotated node object for a quoted triple (s,p,o).
+/// Build the distinguishable JSON-LD-star `@triple` object for a quoted triple (s,p,o).
+///
+/// A triple term serializes to `{"@triple": {"@subject": …, "@predicate": "<iri>",
+/// "@object": …}}`. The reserved `@triple` key makes it unambiguous vs an `@id` node
+/// object or an `@value` literal, and every part round-trips: `@subject`/`@object` recurse
+/// through the same encoding (nested triple terms work), `@predicate` is the CURIE/IRI the
+/// parser re-expands. Keys are `BTreeMap`-ordered, so the output is byte-deterministic.
 fn build_nested_triple_node(
-    _graph: &SerGraph,
-    _s: usize,
-    _p: usize,
-    _o: usize,
-    _reifier_of: &ReifierIndex,
-    _annotations_of: &AnnotationIndex,
+    graph: &SerGraph,
+    s: usize,
+    p: usize,
+    o: usize,
 ) -> Result<Value, RdfDiagnostic> {
-    // A bare quoted-triple in object position would have to be encoded as
-    // `{"@id": s, <p-curie>: <object>}`, which (a) is indistinguishable from an
-    // ordinary node object and (b) is not parseable back: the parser's `@id`
-    // branch returns only the subject IRI and drops the predicate/object,
-    // silently corrupting the triple term. Rather than emit that lossy,
-    // ambiguous form we fail closed. The lossless, supported representation for
-    // RDF-1.2-star here is the rdf:reifies / `@annotation` form, which is
-    // unaffected by this guard. Full lossless nested-triple-term support
-    // (object-position and annotation-value triple terms) is a deferred
-    // extension requiring a distinguishable JSON-LD-star encoding.
-    Err(parse(
-        "quoted-triple object terms are not yet losslessly serializable in JSON-LD-star; \
-         use the rdf:reifies/@annotation form"
-            .to_string(),
-    ))
+    let subject = encode_triple_component(graph, s)?;
+    let object = encode_triple_component(graph, o)?;
+    let p_term = &graph.terms[p];
+    let p_iri = p_term
+        .value
+        .as_deref()
+        .ok_or_else(|| parse("triple-term predicate missing IRI".to_string()))?;
+
+    let mut triple = BTreeMap::new();
+    triple.insert("@subject".to_string(), subject);
+    triple.insert("@predicate".to_string(), Value::String(curie(p_iri)));
+    triple.insert("@object".to_string(), object);
+
+    let mut map = BTreeMap::new();
+    map.insert("@triple".to_string(), to_json_object(triple));
+    Ok(to_json_object(map))
+}
+
+/// Encode one component (subject or object) of a triple term, recursing on nested triple
+/// terms so `<<( <<( … )>> p o )>>` round-trips.
+fn encode_triple_component(graph: &SerGraph, idx: usize) -> Result<Value, RdfDiagnostic> {
+    let term = &graph.terms[idx];
+    if term.kind == SerTermKind::Triple {
+        build_triple_term_value(graph, term)
+    } else {
+        term_to_value(graph, term)
+    }
 }
 
 /// Convert a single RDF term to its JSON-LD value-object form.
@@ -558,6 +604,29 @@ fn build_annotation_node(
     Ok(to_json_object(node))
 }
 
+/// Build a standalone node for a reifier whose base triple is not asserted:
+/// `{"@id": r, "rdf:reifies": {"@triple": …}, <annotation props>}`. On re-parse the
+/// `rdf:reifies` row folds back into the RDF-1.2 statement layer with its annotations, so
+/// the reifier round-trips instead of being dropped for want of a base value object.
+fn build_orphan_reifier_node(
+    graph: &SerGraph,
+    reifier_id: usize,
+    s: usize,
+    p: usize,
+    o: usize,
+    annotations_of: &AnnotationIndex,
+) -> Result<Value, RdfDiagnostic> {
+    let Value::Object(entries) = build_annotation_node(graph, reifier_id, annotations_of)? else {
+        unreachable!("build_annotation_node always returns a JSON object");
+    };
+    let mut node: BTreeMap<String, Value> = entries.into_iter().collect();
+    node.insert(
+        curie(RDF_REIFIES),
+        build_nested_triple_node(graph, s, p, o)?,
+    );
+    Ok(to_json_object(node))
+}
+
 /// Convert a term to a value object without recursive triple-term handling.
 fn simple_term_value(graph: &SerGraph, term: &SerTerm) -> Result<Value, RdfDiagnostic> {
     match term.kind {
@@ -590,18 +659,10 @@ fn simple_term_value(graph: &SerGraph, term: &SerTerm) -> Result<Value, RdfDiagn
             }
             Ok(to_json_object(map))
         }
-        // Triple-valued annotation objects (an annotation whose value is itself a
-        // quoted triple term) have no distinguishable, losslessly parseable
-        // JSON-LD-star encoding here yet. Emitting a placeholder literal would
-        // silently corrupt RDF-1.2-star data, so we fail closed. Full lossless
-        // nested-triple-term support (both object-position and annotation-value
-        // triple terms) is a deferred extension that requires a distinguishable
-        // JSON-LD-star encoding; until then "lossless or hard-fail" wins.
-        SerTermKind::Triple => Err(parse(
-            "triple-valued annotation objects are not yet losslessly serializable; \
-             refusing to emit a lossy placeholder"
-                .to_string(),
-        )),
+        // Triple-valued annotation objects (an annotation whose value is itself a quoted
+        // triple term) serialize to the same distinguishable `@triple` object as
+        // object-position triple terms, so they round-trip losslessly.
+        SerTermKind::Triple => build_triple_term_value(graph, term),
     }
 }
 
@@ -982,6 +1043,12 @@ fn parse_value_object(
         .ok_or_else(|| decode(format!("expected value object, got {value}")))?;
     let annotation = obj.get("@annotation").cloned();
 
+    // A distinguishable `@triple` object reconstructs an RDF-1.2 triple term (recursing
+    // through `@subject`/`@object`), the inverse of `build_nested_triple_node`.
+    if let Some(triple) = obj.get("@triple") {
+        return Ok((parse_triple_term(triple, expand)?, annotation));
+    }
+
     if let Some(id) = obj.get("@id").and_then(Value::as_str) {
         return Ok((node_id_term(id, expand)?, annotation));
     }
@@ -1023,6 +1090,40 @@ fn parse_value_object(
     };
 
     Ok((RdfTerm::literal(literal), annotation))
+}
+
+/// Reconstruct an RDF-1.2 triple term from a `@triple` object — the inverse of
+/// [`build_nested_triple_node`]. `@subject`/`@object` recurse through
+/// [`parse_value_object`] (so nested triple terms round-trip); `@predicate` is a
+/// CURIE/IRI string expanded through the document `@context`.
+fn parse_triple_term(
+    value: &Value,
+    expand: &dyn Fn(&str) -> String,
+) -> Result<RdfTerm, RdfDiagnostic> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| decode(format!("@triple must be an object, got {value}")))?;
+    let subject = obj
+        .get("@subject")
+        .ok_or_else(|| decode("@triple missing @subject".to_string()))?;
+    let predicate = obj
+        .get("@predicate")
+        .and_then(Value::as_str)
+        .ok_or_else(|| decode("@triple @predicate must be a string".to_string()))?;
+    let object = obj
+        .get("@object")
+        .ok_or_else(|| decode("@triple missing @object".to_string()))?;
+
+    let (subject_term, _) = parse_value_object(subject, expand)?;
+    let predicate_iri = expand(predicate);
+    validated_iri_term(&predicate_iri)?;
+    let (object_term, _) = parse_value_object(object, expand)?;
+
+    Ok(RdfTerm::triple(RdfTriple::new(
+        subject_term,
+        &predicate_iri,
+        object_term,
+    )))
 }
 
 // ── statement-metadata downcast ─────────────────────────────────────────────────────

--- a/crates/rdf/src/native_codecs/jsonld.rs
+++ b/crates/rdf/src/native_codecs/jsonld.rs
@@ -873,7 +873,7 @@ pub fn parse_jsonld(json_bytes: &[u8]) -> Result<Arc<RdfDataset>, RdfDiagnostic>
                     &quads,
                     &subject,
                     &predicate,
-                    graph_name.clone(),
+                    graph_name.as_ref(),
                     &v,
                     &expand,
                 )?;
@@ -971,7 +971,7 @@ fn emit_value_quad(
     quads: &std::cell::RefCell<Vec<RdfQuad>>,
     subject: &RdfTerm,
     predicate: &str,
-    graph_name: Option<RdfTerm>,
+    graph_name: Option<&RdfTerm>,
     value: &Value,
     expand: &dyn Fn(&str) -> String,
 ) -> Result<(), RdfDiagnostic> {
@@ -981,7 +981,7 @@ fn emit_value_quad(
         subject.clone(),
         predicate,
         object.clone(),
-        graph_name,
+        graph_name.cloned(),
     );
 
     if let Some(ann) = annotation {
@@ -1001,8 +1001,16 @@ fn emit_value_quad(
             // `dataset_from_quads` freeze folds it into the reifier table.
             let quoted =
                 RdfTerm::triple(RdfTriple::new(subject.clone(), predicate, object.clone()));
-            // Reifier bindings + annotations always land in the DEFAULT graph.
-            push_quad(quads, reifier.clone(), RDF_REIFIES, quoted, None);
+            // The reifier binding + its annotations land in the SAME graph as the base
+            // triple they annotate (the enclosing @graph), so a reifier on a named-graph
+            // triple round-trips into that named graph rather than the default graph.
+            push_quad(
+                quads,
+                reifier.clone(),
+                RDF_REIFIES,
+                quoted,
+                graph_name.cloned(),
+            );
 
             // The `@id` extraction above (`ann_node.get("@id")…ok_or_else`) returns Err for
             // any non-object node, so reaching here guarantees `ann_node` is a JSON object.
@@ -1022,7 +1030,13 @@ fn emit_value_quad(
                 };
                 for v in vals {
                     let (ann_object, _) = parse_value_object(&v, expand)?;
-                    push_quad(quads, reifier.clone(), &ann_predicate, ann_object, None);
+                    push_quad(
+                        quads,
+                        reifier.clone(),
+                        &ann_predicate,
+                        ann_object,
+                        graph_name.cloned(),
+                    );
                 }
             }
         }

--- a/crates/rdf/src/native_codecs/jsonld.rs
+++ b/crates/rdf/src/native_codecs/jsonld.rs
@@ -20,8 +20,10 @@ use std::sync::Arc;
 use serde_json::Value;
 
 use super::NativeRdfFormat;
+use super::codec::RdfCodec;
 use super::ser_model::{SerGraph, SerTerm, SerTermKind};
 use super::serialize::build_ser_graph;
+use super::text_parse::LineParseMode;
 use crate::{
     RdfDataset, RdfDiagnostic, RdfLiteral, RdfQuad, RdfTerm, RdfTextDirection, RdfTriple,
     SerializeGraph,
@@ -116,6 +118,54 @@ fn to_json_object(map: BTreeMap<String, Value>) -> Value {
     Value::Object(map.into_iter().collect())
 }
 
+/// The JSON-LD-star codec — the registry's behavior seam for `application/ld+json`.
+///
+/// Both `serialize` and `parse` route through the SAME cores the public free functions
+/// use ([`serialize_ser_graph`] / [`parse_jsonld`]), so generic dispatch and the
+/// side-door API are one code path, two entry points. Base IRI / parse mode are ignored:
+/// JSON-LD derives its base from the document's own `@context`, and it has no
+/// line/Turtle-family tokenizer toggle.
+pub(super) struct JsonLdCodec;
+
+impl RdfCodec for JsonLdCodec {
+    fn parse(
+        &self,
+        text: &str,
+        _base_iri: Option<&str>,
+        _mode: LineParseMode,
+    ) -> Result<Arc<RdfDataset>, RdfDiagnostic> {
+        parse_jsonld(text.as_bytes())
+    }
+
+    fn serialize(&self, graph: &SerGraph) -> Result<String, RdfDiagnostic> {
+        serialize_ser_graph(graph)
+    }
+}
+
+/// The YAML-LD-star codec — the registry's behavior seam for `application/ld+yaml`.
+///
+/// Serialize walks the shared JSON-LD-star core then re-emits as YAML;
+/// parse bridges YAML→JSON ([`yamlld_to_jsonld`]) and reuses [`parse_jsonld`]. The
+/// registry path uses the bundled schema reference (the custom-`schema_url` overload
+/// stays on the public [`serialize_dataset_to_yamlld`]).
+pub(super) struct YamlLdCodec;
+
+impl RdfCodec for YamlLdCodec {
+    fn parse(
+        &self,
+        text: &str,
+        _base_iri: Option<&str>,
+        _mode: LineParseMode,
+    ) -> Result<Arc<RdfDataset>, RdfDiagnostic> {
+        let json = yamlld_to_jsonld(text.as_bytes())?;
+        parse_jsonld(json.as_bytes())
+    }
+
+    fn serialize(&self, graph: &SerGraph) -> Result<String, RdfDiagnostic> {
+        serialize_ser_graph_to_yamlld(graph, None)
+    }
+}
+
 /// Serialize the carrier dataset to a deterministic JSON-LD-star document.
 pub fn serialize_dataset_to_jsonld(dataset: &RdfDataset) -> Result<String, RdfDiagnostic> {
     // Build the same first-party graph shape the RDF text serializers walk. A
@@ -162,7 +212,22 @@ pub fn serialize_dataset_to_yamlld(
     dataset: &RdfDataset,
     schema_url: Option<&str>,
 ) -> Result<String, RdfDiagnostic> {
-    let json = serialize_dataset_to_jsonld(dataset)?;
+    let graph = build_ser_graph(
+        dataset,
+        NativeRdfFormat::NQuads,
+        SerializeGraph::Dataset,
+        true,
+    )?;
+    serialize_ser_graph_to_yamlld(&graph, schema_url)
+}
+
+/// Serialize an already-materialized [`SerGraph`] to deterministic YAML-LD-star bytes —
+/// the graph-level core shared by [`serialize_dataset_to_yamlld`] and [`YamlLdCodec`].
+fn serialize_ser_graph_to_yamlld(
+    graph: &SerGraph,
+    schema_url: Option<&str>,
+) -> Result<String, RdfDiagnostic> {
+    let json = serialize_ser_graph(graph)?;
     let value: Value =
         serde_json::from_str(&json).map_err(|e| decode(format!("parse JSON-LD for YAML: {e}")))?;
     let body =

--- a/crates/rdf/src/native_codecs/jsonld.rs
+++ b/crates/rdf/src/native_codecs/jsonld.rs
@@ -261,6 +261,14 @@ fn build_graphs(graph: &SerGraph) -> Result<GraphNodes, RdfDiagnostic> {
     // Reifier index: base triple (s,p,o) -> reifier ids that annotate it.
     let mut reifier_of: ReifierIndex = BTreeMap::new();
     for &(rid, (s, p, o), _g) in &graph.reifiers {
+        // A triple term is self-reifying: its `reifier` row's "reifier" is the triple
+        // term itself (kind `Triple`), carrying the term's components — NOT a real
+        // IRI/blank-node reifier. `term_id` has no @id for a `Triple`-kind term, so it
+        // must never enter the sortable reifier index; skip it here (mirrors the
+        // orphan-reifier guard below).
+        if graph.terms[rid].kind == SerTermKind::Triple {
+            continue;
+        }
         reifier_of.entry((s, p, o)).or_default().push(rid);
     }
     for list in reifier_of.values_mut() {

--- a/crates/rdf/src/native_codecs/media_type.rs
+++ b/crates/rdf/src/native_codecs/media_type.rs
@@ -301,16 +301,80 @@ mod tests {
 
     #[test]
     fn media_type_round_trips_through_classify() {
-        for format in [
-            NativeRdfFormat::Turtle,
-            NativeRdfFormat::TriG,
-            NativeRdfFormat::NTriples,
-            NativeRdfFormat::NQuads,
-            NativeRdfFormat::RdfXml,
-            NativeRdfFormat::TriX,
-            NativeRdfFormat::HexTuples,
+        // Every variant in the registry — a table-driven loop so a new FORMATS row is
+        // covered automatically.
+        for descriptor in FORMATS {
+            assert_eq!(
+                classify(descriptor.format.media_type()).unwrap(),
+                descriptor.format
+            );
+        }
+    }
+
+    #[test]
+    fn classify_resolves_jsonld_and_yamlld() {
+        for id in [
+            "application/ld+json",
+            "ld+json",
+            "jsonld",
+            "json-ld",
+            ".jsonld",
         ] {
-            assert_eq!(classify(format.media_type()).unwrap(), format);
+            assert_eq!(classify(id).unwrap(), NativeRdfFormat::JsonLd, "id {id}");
+        }
+        for id in [
+            "application/ld+yaml",
+            "ld+yaml",
+            "yamlld",
+            "yaml-ld",
+            ".yamlld",
+        ] {
+            assert_eq!(classify(id).unwrap(), NativeRdfFormat::YamlLd, "id {id}");
+        }
+    }
+
+    #[test]
+    fn jsonld_and_yamlld_support_datasets() {
+        assert!(NativeRdfFormat::JsonLd.supports_datasets());
+        assert!(NativeRdfFormat::YamlLd.supports_datasets());
+    }
+
+    #[test]
+    fn descriptor_alias_regression_every_pre_existing_spelling_resolves() {
+        // The FormatDescriptor table refactor must not silently narrow `classify`: every
+        // spelling the pre-table `classify` accepted still resolves to its variant.
+        let cases: &[(&str, NativeRdfFormat)] = &[
+            ("text/turtle", NativeRdfFormat::Turtle),
+            ("application/turtle", NativeRdfFormat::Turtle),
+            ("turtle", NativeRdfFormat::Turtle),
+            ("ttl", NativeRdfFormat::Turtle),
+            ("application/trig", NativeRdfFormat::TriG),
+            ("trig", NativeRdfFormat::TriG),
+            ("application/n-triples", NativeRdfFormat::NTriples),
+            ("n-triples", NativeRdfFormat::NTriples),
+            ("ntriples", NativeRdfFormat::NTriples),
+            ("nt", NativeRdfFormat::NTriples),
+            ("application/n-quads", NativeRdfFormat::NQuads),
+            ("n-quads", NativeRdfFormat::NQuads),
+            ("nquads", NativeRdfFormat::NQuads),
+            ("nq", NativeRdfFormat::NQuads),
+            ("application/rdf+xml", NativeRdfFormat::RdfXml),
+            ("rdf+xml", NativeRdfFormat::RdfXml),
+            ("rdf", NativeRdfFormat::RdfXml),
+            ("owl", NativeRdfFormat::RdfXml),
+            ("xml", NativeRdfFormat::RdfXml),
+            // Absorbed from the wasm resolver so delegation drops nothing.
+            ("rdf/xml", NativeRdfFormat::RdfXml),
+            ("rdfxml", NativeRdfFormat::RdfXml),
+            ("application/trix", NativeRdfFormat::TriX),
+            ("trix", NativeRdfFormat::TriX),
+            ("application/x-hextuples", NativeRdfFormat::HexTuples),
+            ("application/hex+x-ndjson", NativeRdfFormat::HexTuples),
+            ("hext", NativeRdfFormat::HexTuples),
+            ("hextuples", NativeRdfFormat::HexTuples),
+        ];
+        for &(id, expected) in cases {
+            assert_eq!(classify(id).unwrap(), expected, "spelling {id}");
         }
     }
 }

--- a/crates/rdf/src/native_codecs/media_type.rs
+++ b/crates/rdf/src/native_codecs/media_type.rs
@@ -213,8 +213,8 @@ impl NativeRdfFormat {
 ///
 /// The input is lowercased and any `;charset=…` parameter is stripped before
 /// matching, so `text/turtle; charset=utf-8` and `Turtle` both resolve to
-/// [`NativeRdfFormat::Turtle`]. Matching scans [`FORMATS`] for a row whose canonical
-/// `media_type` OR any `alias` equals the normalized input (aliases include `.`-prefixed
+/// [`NativeRdfFormat::Turtle`]. Matching scans the internal format table for a row whose
+/// canonical `media_type` OR any `alias` equals the normalized input (aliases include `.`-prefixed
 /// file extensions, so `.jsonld` resolves too). An unrecognized media type is a HARD
 /// error (`native-codec-unsupported-format`) — there is no degraded default codec.
 pub fn classify(media_type: &str) -> Result<NativeRdfFormat, RdfDiagnostic> {

--- a/crates/rdf/src/native_codecs/media_type.rs
+++ b/crates/rdf/src/native_codecs/media_type.rs
@@ -34,30 +34,153 @@ pub enum NativeRdfFormat {
     HexTuples,
 }
 
+/// The single source of truth for one format's routing + capability metadata.
+///
+/// Every per-format DATA decision (canonical media type, the alias spellings
+/// [`classify`] accepts, star / dataset / span capability, and the
+/// `crates/rdf-core/src/loss.rs` codec name) lives in ONE [`FORMATS`] row rather than
+/// scattered `match NativeRdfFormat` arms. The behavior seam (parse / serialize) stays
+/// the `RdfCodec` vtable in [`codec`](super::codec); this table is purely the data half.
+pub(crate) struct FormatDescriptor {
+    /// The variant this row describes.
+    pub format: NativeRdfFormat,
+    /// The canonical IANA media type — the value [`NativeRdfFormat::media_type`] returns.
+    pub media_type: &'static str,
+    /// Every additional spelling [`classify`] accepts: alternate media types, bare
+    /// format ids, and `.`-prefixed file extensions (all matched after lowercasing +
+    /// charset stripping). The canonical `media_type` is matched separately, so it need
+    /// not be repeated here.
+    pub aliases: &'static [&'static str],
+    /// Whether this format carries the RDF-1.2 statement layer (see
+    /// [`NativeRdfFormat::carries_star`]).
+    pub carries_star: bool,
+    /// Whether this format can carry named graphs (see
+    /// [`NativeRdfFormat::supports_datasets`]).
+    pub supports_datasets: bool,
+    /// Whether this format's parser records per-statement source spans (see
+    /// [`NativeRdfFormat::tokenizer_carries_spans`]).
+    pub tokenizer_carries_spans: bool,
+    /// The `crates/rdf-core/src/loss.rs` canonical codec name, or `None` for formats
+    /// that carry no loss-ledger codec identity (TriX / HexTuples).
+    pub loss_codec_name: Option<&'static str>,
+}
+
+/// The format registry — one row per [`NativeRdfFormat`] variant. The single place a
+/// new syntax's routing + capability data is declared.
+pub(crate) const FORMATS: &[FormatDescriptor] = &[
+    FormatDescriptor {
+        format: NativeRdfFormat::Turtle,
+        media_type: "text/turtle",
+        aliases: &["application/turtle", "turtle", "ttl", ".ttl"],
+        carries_star: true,
+        supports_datasets: false,
+        tokenizer_carries_spans: true,
+        loss_codec_name: Some("turtle"),
+    },
+    FormatDescriptor {
+        format: NativeRdfFormat::TriG,
+        media_type: "application/trig",
+        aliases: &["trig", ".trig"],
+        carries_star: true,
+        supports_datasets: true,
+        tokenizer_carries_spans: true,
+        loss_codec_name: Some("trig"),
+    },
+    FormatDescriptor {
+        format: NativeRdfFormat::NTriples,
+        media_type: "application/n-triples",
+        aliases: &["n-triples", "ntriples", "nt", ".nt"],
+        carries_star: true,
+        supports_datasets: false,
+        tokenizer_carries_spans: true,
+        loss_codec_name: Some("ntriples"),
+    },
+    FormatDescriptor {
+        format: NativeRdfFormat::NQuads,
+        media_type: "application/n-quads",
+        aliases: &["n-quads", "nquads", "nq", ".nq"],
+        carries_star: true,
+        supports_datasets: true,
+        tokenizer_carries_spans: true,
+        loss_codec_name: Some("nquads"),
+    },
+    FormatDescriptor {
+        format: NativeRdfFormat::RdfXml,
+        media_type: "application/rdf+xml",
+        // `rdf/xml` + `rdfxml` are absorbed from the wasm resolver so `classify` is a
+        // strict superset of every spelling any first-party surface accepts.
+        aliases: &[
+            "rdf+xml", "rdf", "owl", "xml", "rdf/xml", "rdfxml", ".rdf", ".owl",
+        ],
+        carries_star: false,
+        supports_datasets: false,
+        tokenizer_carries_spans: false,
+        loss_codec_name: Some("rdfxml"),
+    },
+    FormatDescriptor {
+        format: NativeRdfFormat::TriX,
+        media_type: "application/trix",
+        aliases: &["trix", ".trix"],
+        carries_star: false,
+        supports_datasets: true,
+        tokenizer_carries_spans: false,
+        loss_codec_name: None,
+    },
+    FormatDescriptor {
+        format: NativeRdfFormat::HexTuples,
+        media_type: "application/x-hextuples",
+        aliases: &["application/hex+x-ndjson", "hext", "hextuples", ".hext"],
+        carries_star: false,
+        supports_datasets: true,
+        tokenizer_carries_spans: false,
+        loss_codec_name: None,
+    },
+];
+
+/// The [`FormatDescriptor`] row for a variant. Total over the enum — every variant has a
+/// [`FORMATS`] row, so the lookup never fails (a missing row is a construction bug the
+/// unit tests catch).
+pub(crate) fn descriptor(format: NativeRdfFormat) -> &'static FormatDescriptor {
+    FORMATS
+        .iter()
+        .find(|d| d.format == format)
+        .expect("every NativeRdfFormat variant has a FORMATS row")
+}
+
 impl NativeRdfFormat {
     /// The canonical IANA media type for this format. The inverse of the canonical
     /// rows in [`classify`].
     pub fn media_type(self) -> &'static str {
-        match self {
-            Self::Turtle => "text/turtle",
-            Self::TriG => "application/trig",
-            Self::NTriples => "application/n-triples",
-            Self::NQuads => "application/n-quads",
-            Self::RdfXml => "application/rdf+xml",
-            Self::TriX => "application/trix",
-            Self::HexTuples => "application/x-hextuples",
-        }
+        descriptor(self).media_type
     }
 
-    /// Whether this format can carry named graphs (TriG / N-Quads / TriX / HexTuples).
-    /// Turtle, N-Triples, and RDF/XML are single-graph syntaxes, so a
+    /// Whether this format can carry named graphs (TriG / N-Quads / TriX / HexTuples /
+    /// JSON-LD / YAML-LD). Turtle, N-Triples, and RDF/XML are single-graph syntaxes, so a
     /// `SerializeGraph::Dataset` request against them falls back to the default graph
     /// (see `serialize.rs`).
     pub fn supports_datasets(self) -> bool {
-        matches!(
-            self,
-            Self::TriG | Self::NQuads | Self::TriX | Self::HexTuples
-        )
+        descriptor(self).supports_datasets
+    }
+
+    /// Whether this format carries the RDF-1.2 statement layer (quoted-triple reifiers +
+    /// annotations) under the transcode loss contract. Star-capable formats emit it;
+    /// star-incapable formats drop it as declared loss. Kept aligned with the loss ledger
+    /// (`crates/rdf-core/src/loss.rs`) — see the drift-guard test in `native_codecs`.
+    pub fn carries_star(self) -> bool {
+        descriptor(self).carries_star
+    }
+
+    /// Whether this format's parser can record per-statement source spans. Only the
+    /// line/Turtle-family text tokenizer does; the others return an empty span table
+    /// (physical-location fallback by design).
+    pub fn tokenizer_carries_spans(self) -> bool {
+        descriptor(self).tokenizer_carries_spans
+    }
+
+    /// The `crates/rdf-core/src/loss.rs` canonical codec name, or `None` when this format
+    /// carries no loss-ledger codec identity (TriX / HexTuples).
+    pub fn loss_codec_name(self) -> Option<&'static str> {
+        descriptor(self).loss_codec_name
     }
 }
 
@@ -65,8 +188,10 @@ impl NativeRdfFormat {
 ///
 /// The input is lowercased and any `;charset=…` parameter is stripped before
 /// matching, so `text/turtle; charset=utf-8` and `Turtle` both resolve to
-/// [`NativeRdfFormat::Turtle`]. An unrecognized media type is a HARD error
-/// (`native-codec-unsupported-format`) — there is no degraded default codec.
+/// [`NativeRdfFormat::Turtle`]. Matching scans [`FORMATS`] for a row whose canonical
+/// `media_type` OR any `alias` equals the normalized input (aliases include `.`-prefixed
+/// file extensions, so `.jsonld` resolves too). An unrecognized media type is a HARD
+/// error (`native-codec-unsupported-format`) — there is no degraded default codec.
 pub fn classify(media_type: &str) -> Result<NativeRdfFormat, RdfDiagnostic> {
     let normalized = media_type
         .split(';')
@@ -74,21 +199,16 @@ pub fn classify(media_type: &str) -> Result<NativeRdfFormat, RdfDiagnostic> {
         .unwrap_or(media_type)
         .trim()
         .to_ascii_lowercase();
-    match normalized.as_str() {
-        "text/turtle" | "application/turtle" | "turtle" | "ttl" => Ok(NativeRdfFormat::Turtle),
-        "application/trig" | "trig" => Ok(NativeRdfFormat::TriG),
-        "application/n-triples" | "n-triples" | "ntriples" | "nt" => Ok(NativeRdfFormat::NTriples),
-        "application/n-quads" | "n-quads" | "nquads" | "nq" => Ok(NativeRdfFormat::NQuads),
-        "application/rdf+xml" | "rdf+xml" | "rdf" | "owl" | "xml" => Ok(NativeRdfFormat::RdfXml),
-        "application/trix" | "trix" => Ok(NativeRdfFormat::TriX),
-        "application/x-hextuples" | "application/hex+x-ndjson" | "hext" | "hextuples" => {
-            Ok(NativeRdfFormat::HexTuples)
-        }
-        other => Err(RdfDiagnostic::error(
-            "native-codec-unsupported-format",
-            format!("unsupported RDF media type or format id `{other}`"),
-        )),
-    }
+    FORMATS
+        .iter()
+        .find(|d| d.media_type == normalized || d.aliases.contains(&normalized.as_str()))
+        .map(|d| d.format)
+        .ok_or_else(|| {
+            RdfDiagnostic::error(
+                "native-codec-unsupported-format",
+                format!("unsupported RDF media type or format id `{normalized}`"),
+            )
+        })
 }
 
 #[cfg(test)]

--- a/crates/rdf/src/native_codecs/media_type.rs
+++ b/crates/rdf/src/native_codecs/media_type.rs
@@ -32,6 +32,13 @@ pub enum NativeRdfFormat {
     /// HexTuples — a line-oriented NDJSON quads serialization
     /// (`application/x-hextuples`).
     HexTuples,
+    /// JSON-LD-star — the first-party JSON-LD 1.1 + RDF-1.2-star serialization
+    /// (`application/ld+json`). Star-capable (reifier form AND object-position triple
+    /// terms) and dataset-capable (named graphs).
+    JsonLd,
+    /// YAML-LD-star — the deterministic YAML derivative of [`Self::JsonLd`]
+    /// (`application/ld+yaml`).
+    YamlLd,
 }
 
 /// The single source of truth for one format's routing + capability metadata.
@@ -134,6 +141,24 @@ pub(crate) const FORMATS: &[FormatDescriptor] = &[
         supports_datasets: true,
         tokenizer_carries_spans: false,
         loss_codec_name: None,
+    },
+    FormatDescriptor {
+        format: NativeRdfFormat::JsonLd,
+        media_type: "application/ld+json",
+        aliases: &["ld+json", "jsonld", "json-ld", ".jsonld"],
+        carries_star: true,
+        supports_datasets: true,
+        tokenizer_carries_spans: false,
+        loss_codec_name: Some("jsonld-star"),
+    },
+    FormatDescriptor {
+        format: NativeRdfFormat::YamlLd,
+        media_type: "application/ld+yaml",
+        aliases: &["ld+yaml", "yamlld", "yaml-ld", ".yamlld"],
+        carries_star: true,
+        supports_datasets: true,
+        tokenizer_carries_spans: false,
+        loss_codec_name: Some("yaml-ld-star"),
     },
 ];
 

--- a/crates/rdf/src/native_codecs/mod.rs
+++ b/crates/rdf/src/native_codecs/mod.rs
@@ -279,6 +279,37 @@ mod tests {
     }
 
     #[test]
+    fn annotation_directly_inside_triple_object_is_rejected() {
+        // An `@annotation` placed DIRECTLY inside the `@triple` object itself (a
+        // SIBLING of `@subject`/`@predicate`/`@object`, not nested under a component)
+        // is equally not well-formed RDF-1.2: a triple *term* carries no annotation of
+        // its own. Previously this key was read past and silently ignored rather than
+        // rejected.
+        let json = r#"{
+            "@id": "https://e/s",
+            "https://e/asserts": {
+                "@triple": {
+                    "@subject": { "@id": "https://e/s" },
+                    "@predicate": "https://e/p",
+                    "@object": { "@id": "https://e/o" },
+                    "@annotation": {
+                        "@id": "https://e/r",
+                        "https://e/confidence": { "@value": "0.9" }
+                    }
+                }
+            }
+        }"#;
+        let err = parse_dataset(json.as_bytes(), "application/ld+json", None)
+            .expect_err("@annotation directly inside a @triple object must be rejected");
+        assert_eq!(err.code, "native-jsonld-decode");
+        assert!(
+            err.message
+                .contains("not permitted inside a @triple object"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     fn inline_triple_term_and_real_reifier_share_base_triple_round_trips_jsonld() {
         // The SAME base triple (s,p,o) is BOTH asserted as an object-position triple
         // term (which pushes a self-reifier sentinel keyed by the Triple-kind term
@@ -357,6 +388,47 @@ mod tests {
     }
 
     #[test]
+    fn same_base_triple_reified_differently_in_two_named_graphs_round_trips_jsonld() {
+        // The SAME base triple (s,p,o) is asserted in TWO distinct named graphs, each
+        // reified by a DIFFERENT reifier with a DIFFERENT annotation value. The
+        // reifier/annotation lookup keys previously discarded the graph slot, so every
+        // reifier for (s,p,o) got attached to the value object in EVERY graph carrying
+        // that triple — fabricating reifier bindings the author never placed. Six quads
+        // go in (2 asserted triples + 2 reifier bindings + 2 annotations); the round-trip
+        // must come back isomorphic, not cross-contaminated to ~10 quads.
+        let mut b = RdfDatasetBuilder::new();
+        let s = b.intern_iri("https://e/s");
+        let p = b.intern_iri("https://e/p");
+        let o = b.intern_iri("https://e/o");
+        let g1 = b.intern_iri("https://e/g1");
+        let g2 = b.intern_iri("https://e/g2");
+        let triple = b.intern_triple(s, p, o);
+        let conf = b.intern_iri("https://e/confidence");
+
+        let r1 = b.intern_iri("https://e/r1");
+        let val1 = b.intern_literal(RdfLiteral::typed(
+            "0.1",
+            "http://www.w3.org/2001/XMLSchema#decimal",
+        ));
+        b.push_quad(s, p, o, Some(g1));
+        b.push_reifier_in_graph(r1, triple, Some(g1));
+        b.push_annotation_in_graph(r1, conf, val1, Some(g1));
+
+        let r2 = b.intern_iri("https://e/r2");
+        let val2 = b.intern_literal(RdfLiteral::typed(
+            "0.9",
+            "http://www.w3.org/2001/XMLSchema#decimal",
+        ));
+        b.push_quad(s, p, o, Some(g2));
+        b.push_reifier_in_graph(r2, triple, Some(g2));
+        b.push_annotation_in_graph(r2, conf, val2, Some(g2));
+
+        let ds = b.freeze().expect("freeze");
+        assert_round_trips(&ds, "application/ld+json");
+        assert_round_trips(&ds, "application/ld+yaml");
+    }
+
+    #[test]
     fn gts_codec_backend_reaches_jsonld_and_yamlld_no_side_door() {
         // The GENERIC backend (RdfParserBackend + RdfSerializer) reaches JSON-LD/YAML-LD
         // through classify + codec_for — proving no `native_codecs::jsonld::` side-door is
@@ -365,13 +437,14 @@ mod tests {
         let s = b.intern_iri("https://e/s");
         let p = b.intern_iri("https://e/p");
         let o = b.intern_iri("https://e/o");
+        let g = b.intern_iri("https://e/g");
         let triple = b.intern_triple(s, p, o);
         let r = b.intern_iri("https://e/r");
         let conf = b.intern_iri("https://e/confidence");
         let val = b.intern_literal(RdfLiteral::simple("high"));
-        b.push_quad(s, p, o, None);
-        b.push_reifier(r, triple);
-        b.push_annotation(r, conf, val);
+        b.push_quad(s, p, o, Some(g));
+        b.push_reifier_in_graph(r, triple, Some(g));
+        b.push_annotation_in_graph(r, conf, val, Some(g));
         let ds = b.freeze().expect("freeze");
 
         let backend = GtsCodecBackend;

--- a/crates/rdf/src/native_codecs/mod.rs
+++ b/crates/rdf/src/native_codecs/mod.rs
@@ -206,6 +206,37 @@ mod tests {
     }
 
     #[test]
+    fn inline_triple_term_and_real_reifier_share_base_triple_round_trips_jsonld() {
+        // The SAME base triple (s,p,o) is BOTH asserted as an object-position triple
+        // term (which pushes a self-reifier sentinel keyed by the Triple-kind term
+        // itself into `graph.reifiers`) AND carries a genuine IRI reifier with an
+        // annotation. Building the JSON-LD `reifier_of` index used to sort ALL
+        // `graph.reifiers` rows for a given (s,p,o) by their `@id`, including the
+        // sentinel — but a `Triple`-kind term has no `@id`, so `term_id` returned
+        // `Err` and the comparator's `.expect(...)` panicked. `reifier_of` must skip
+        // Triple-kind sentinel rows so this collision no longer panics.
+        let mut b = RdfDatasetBuilder::new();
+        let s = b.intern_iri("https://e/s");
+        let p = b.intern_iri("https://e/p");
+        let o = b.intern_iri("https://e/o");
+        let inner = b.intern_triple(s, p, o);
+        let asserts = b.intern_iri("https://e/asserts");
+        let subj = b.intern_iri("https://e/subj");
+        b.push_quad(subj, asserts, inner, None); // object-position triple term for (s,p,o)
+        let r = b.intern_iri("https://e/r");
+        let conf = b.intern_iri("https://e/confidence");
+        let val = b.intern_literal(RdfLiteral::typed(
+            "0.9",
+            "http://www.w3.org/2001/XMLSchema#decimal",
+        ));
+        b.push_reifier(r, inner); // real reifier on the SAME (s,p,o)
+        b.push_annotation(r, conf, val);
+        let ds = b.freeze().expect("freeze");
+        assert_round_trips(&ds, "application/ld+json");
+        assert_round_trips(&ds, "application/ld+yaml");
+    }
+
+    #[test]
     fn triple_valued_annotation_round_trips_jsonld() {
         // An annotation whose VALUE is itself a triple term exercises the
         // annotation-value `@triple` path (`simple_term_value`'s `Triple` arm).

--- a/crates/rdf/src/native_codecs/mod.rs
+++ b/crates/rdf/src/native_codecs/mod.rs
@@ -564,6 +564,55 @@ mod tests {
     }
 
     #[test]
+    fn yamlld_adversarial_scalar_round_trips() {
+        // The "Norway problem": YAML's implicit-typing resolver reinterprets bare
+        // scalars like `true`, `no`, `~`, `1.0`, `0755`, or `2020-01-01` as
+        // bool/null/number/timestamp on re-parse unless the emitter quotes them.
+        // Every lexical form below is exactly one of those adversarial tokens; the
+        // round-trip bar is LOSSLESS (`assert_round_trips` requires isomorphism), so
+        // the JSON->YAML bridge must force-quote them rather than let serde_yaml's
+        // default resolver re-coerce the type.
+        let adversarial = [
+            "true",
+            "false",
+            "null",
+            "~",
+            "no",
+            "yes",
+            "on",
+            "off",
+            "1.0",
+            "0755",
+            "0x1A",
+            "1_000",
+            "",
+            "2020-01-01",
+        ];
+        let mut b = RdfDatasetBuilder::new();
+        let s = b.intern_iri("https://e/s");
+        for (i, scalar) in adversarial.iter().enumerate() {
+            // The scalar as a plain literal — implied xsd:string (no datatype IRI).
+            let p_plain = b.intern_iri(&format!("https://e/plain{i}"));
+            let plain = b.intern_literal(RdfLiteral::simple(*scalar));
+            b.push_quad(s, p_plain, plain, None);
+
+            // The same scalar as an EXPLICIT (non-numeric, non-boolean) xsd:string
+            // typed literal — the lexical form must survive verbatim either way.
+            let p_typed = b.intern_iri(&format!("https://e/typed{i}"));
+            let typed = b.intern_literal(RdfLiteral::typed(
+                *scalar,
+                "http://www.w3.org/2001/XMLSchema#string",
+            ));
+            b.push_quad(s, p_typed, typed, None);
+        }
+        let ds = b.freeze().expect("freeze");
+        // JSON-LD as a control: JSON has no ambiguous bare-scalar resolver, so this
+        // must always pass and isolates any failure to the YAML bridge.
+        assert_round_trips(&ds, "application/ld+json");
+        assert_round_trips(&ds, "application/ld+yaml");
+    }
+
+    #[test]
     fn backend_parses_into_event_sink() {
         let mut sink = DatasetSink::new();
         GtsCodecBackend

--- a/crates/rdf/src/native_codecs/mod.rs
+++ b/crates/rdf/src/native_codecs/mod.rs
@@ -147,11 +147,21 @@ mod tests {
         let o = b.intern_iri("https://e/o");
         b.push_quad(s, p, o, None);
         let ds = b.freeze().expect("freeze");
-        assert_round_trips(&ds, "text/turtle");
-        assert_round_trips(&ds, "application/n-triples");
-        assert_round_trips(&ds, "application/trig");
-        assert_round_trips(&ds, "application/n-quads");
-        assert_round_trips(&ds, "application/rdf+xml");
+        // Every bidirectional format round-trips a basic graph isomorphically — JSON-LD /
+        // YAML-LD alongside the FULL declared peer set (including TriX / HexTuples).
+        for media_type in [
+            "text/turtle",
+            "application/n-triples",
+            "application/trig",
+            "application/n-quads",
+            "application/rdf+xml",
+            "application/trix",
+            "application/x-hextuples",
+            "application/ld+json",
+            "application/ld+yaml",
+        ] {
+            assert_round_trips(&ds, media_type);
+        }
     }
 
     #[test]
@@ -215,6 +225,145 @@ mod tests {
         let ds = b.freeze().expect("freeze");
         assert_round_trips(&ds, "application/ld+json");
         assert_round_trips(&ds, "application/ld+yaml");
+    }
+
+    #[test]
+    fn reifier_on_named_graph_triple_round_trips_jsonld() {
+        // A reifier binding AND its annotation live on a triple INSIDE a named graph.
+        // JSON-LD must thread the reifier/annotation graph slot, not force it to the
+        // default graph — otherwise the round-trip is not isomorphic.
+        let mut b = RdfDatasetBuilder::new();
+        let s = b.intern_iri("https://e/s");
+        let p = b.intern_iri("https://e/p");
+        let o = b.intern_iri("https://e/o");
+        let g = b.intern_iri("https://e/g");
+        let triple = b.intern_triple(s, p, o);
+        let r = b.intern_iri("https://e/r");
+        let conf = b.intern_iri("https://e/confidence");
+        let val = b.intern_literal(RdfLiteral::typed(
+            "0.9",
+            "http://www.w3.org/2001/XMLSchema#decimal",
+        ));
+        b.push_quad(s, p, o, Some(g));
+        b.push_reifier_in_graph(r, triple, Some(g));
+        b.push_annotation_in_graph(r, conf, val, Some(g));
+        let ds = b.freeze().expect("freeze");
+        assert_round_trips(&ds, "application/ld+json");
+        assert_round_trips(&ds, "application/ld+yaml");
+    }
+
+    #[test]
+    fn gts_codec_backend_reaches_jsonld_and_yamlld_no_side_door() {
+        // The GENERIC backend (RdfParserBackend + RdfSerializer) reaches JSON-LD/YAML-LD
+        // through classify + codec_for — proving no `native_codecs::jsonld::` side-door is
+        // needed. A named-graph + reifier dataset exercises the star + dataset paths.
+        let mut b = RdfDatasetBuilder::new();
+        let s = b.intern_iri("https://e/s");
+        let p = b.intern_iri("https://e/p");
+        let o = b.intern_iri("https://e/o");
+        let triple = b.intern_triple(s, p, o);
+        let r = b.intern_iri("https://e/r");
+        let conf = b.intern_iri("https://e/confidence");
+        let val = b.intern_literal(RdfLiteral::simple("high"));
+        b.push_quad(s, p, o, None);
+        b.push_reifier(r, triple);
+        b.push_annotation(r, conf, val);
+        let ds = b.freeze().expect("freeze");
+
+        let backend = GtsCodecBackend;
+        for media_type in ["application/ld+json", "application/ld+yaml"] {
+            // Serialize through the generic RdfSerializer.
+            let mut bytes = Vec::new();
+            backend
+                .serialize(
+                    &ds,
+                    RdfSerializeRequest {
+                        media_type,
+                        graph: SerializeGraph::Dataset,
+                        base_iri: None,
+                    },
+                    &mut bytes,
+                )
+                .expect("generic serialize");
+            // Parse back through the generic RdfParserBackend into a frozen dataset.
+            let mut sink = DatasetSink::new();
+            backend
+                .parse_into(
+                    RdfParseRequest {
+                        bytes: &bytes,
+                        media_type,
+                        base_iri: None,
+                        source_name: None,
+                    },
+                    &mut sink,
+                )
+                .expect("generic parse");
+            let reparsed = sink.into_dataset().expect("sink finished");
+            assert!(
+                datasets_isomorphic(&ds, &reparsed),
+                "GtsCodecBackend round-trip via {media_type} must be isomorphic"
+            );
+        }
+    }
+
+    #[test]
+    fn jsonld_yamlld_are_star_capable_no_rows_dropped() {
+        // JSON-LD / YAML-LD are star-capable, so `serialize_dataset_to_format` reports
+        // ZERO dropped statement rows even when the dataset carries reifiers/annotations.
+        let mut b = RdfDatasetBuilder::new();
+        let s = b.intern_iri("https://e/s");
+        let p = b.intern_iri("https://e/p");
+        let o = b.intern_iri("https://e/o");
+        let triple = b.intern_triple(s, p, o);
+        let r = b.intern_iri("https://e/r");
+        let conf = b.intern_iri("https://e/confidence");
+        let val = b.intern_literal(RdfLiteral::simple("high"));
+        b.push_quad(s, p, o, None);
+        b.push_reifier(r, triple);
+        b.push_annotation(r, conf, val);
+        let ds = b.freeze().expect("freeze");
+        for format in [NativeRdfFormat::JsonLd, NativeRdfFormat::YamlLd] {
+            let outcome = serialize_dataset_to_format(&ds, format, None).expect("serialize");
+            assert_eq!(
+                outcome.statement_rows_dropped, 0,
+                "{format:?} is star-capable, so no statement rows drop"
+            );
+        }
+    }
+
+    #[test]
+    fn registry_capabilities_stay_consistent_with_the_loss_ledger() {
+        use crate::loss::{supports_quads, supports_stars};
+
+        // The registry (FORMATS) and rdf-core::loss are two hand-maintained capability
+        // tables that MUST agree. For every loss-named format, the descriptor bool equals
+        // the independent loss.rs predicate — so neither can silently drift.
+        let mut unnamed: Vec<NativeRdfFormat> = Vec::new();
+        for descriptor in media_type::FORMATS {
+            let format = descriptor.format;
+            match format.loss_codec_name() {
+                Some(name) => {
+                    assert_eq!(
+                        format.carries_star(),
+                        supports_stars(name),
+                        "{format:?} carries_star vs loss::supports_stars({name})"
+                    );
+                    assert_eq!(
+                        format.supports_datasets(),
+                        supports_quads(name),
+                        "{format:?} supports_datasets vs loss::supports_quads({name})"
+                    );
+                }
+                None => unnamed.push(format),
+            }
+        }
+        // Exactly TriX and HexTuples carry no loss codec name, so no format silently
+        // escapes the consistency check.
+        assert_eq!(
+            unnamed,
+            vec![NativeRdfFormat::TriX, NativeRdfFormat::HexTuples],
+            "only TriX / HexTuples may lack a loss codec name"
+        );
     }
 
     #[test]

--- a/crates/rdf/src/native_codecs/mod.rs
+++ b/crates/rdf/src/native_codecs/mod.rs
@@ -206,6 +206,79 @@ mod tests {
     }
 
     #[test]
+    fn nested_triple_term_with_inner_reifier_round_trips_jsonld() {
+        // A depth-2 nested triple term: the OUTER triple term's subject is itself a
+        // triple term (the INNER one), and the inner triple carries a reifier +
+        // annotation. Every other star round-trip test in this module nests only one
+        // level deep (a triple term appearing in a quad's object position); this is
+        // the first to nest a triple term INSIDE another triple term's component,
+        // which is the only path that exercises the `encode_triple_component` /
+        // `parse_triple_term` recursion (jsonld.rs) — previously zero coverage.
+        let mut b = RdfDatasetBuilder::new();
+        let s = b.intern_iri("https://e/s");
+        let p = b.intern_iri("https://e/p");
+        let o = b.intern_iri("https://e/o");
+        let inner = b.intern_triple(s, p, o); // depth-1 triple term: <<( s p o )>>
+        let p2 = b.intern_iri("https://e/p2");
+        let o2 = b.intern_iri("https://e/o2");
+        let outer = b.intern_triple(inner, p2, o2); // depth-2: subject is itself a triple term
+        let subj = b.intern_iri("https://e/subj");
+        let asserts = b.intern_iri("https://e/asserts");
+        b.push_quad(subj, asserts, outer, None); // assert the nested term in object position
+
+        // Reifier + annotation live on the INNER triple, not the outer one.
+        let r = b.intern_iri("https://e/r");
+        let conf = b.intern_iri("https://e/confidence");
+        let val = b.intern_literal(RdfLiteral::typed(
+            "0.9",
+            "http://www.w3.org/2001/XMLSchema#decimal",
+        ));
+        b.push_reifier(r, inner);
+        b.push_annotation(r, conf, val);
+
+        let ds = b.freeze().expect("freeze");
+        assert_round_trips(&ds, "application/ld+json");
+        assert_round_trips(&ds, "application/ld+yaml");
+    }
+
+    #[test]
+    fn annotation_inside_triple_component_is_rejected() {
+        // The RDF 1.2 abstract syntax gives a triple *term* no annotation of its own —
+        // annotation/reification is always a SEPARATE statement about a reifier
+        // (`?r rdf:reifies <<( s p o )>>` plus annotation triples on `?r`). purrdf's own
+        // encoder never emits `@annotation` nested inside a `@triple` component (see
+        // `nested_triple_term_with_inner_reifier_round_trips_jsonld` above, where the
+        // inner triple's annotation rides a separate reifier quad instead). So a
+        // hand-authored document with `@annotation` under a `@triple` component's
+        // `@subject`/`@object` is not a well-formed RDF-1.2 term shape and must hard-fail
+        // rather than silently drop the annotation.
+        let json = r#"{
+            "@id": "https://e/s",
+            "https://e/asserts": {
+                "@triple": {
+                    "@subject": {
+                        "@id": "https://e/s",
+                        "@annotation": {
+                            "@id": "https://e/r",
+                            "https://e/confidence": { "@value": "0.9" }
+                        }
+                    },
+                    "@predicate": "https://e/p",
+                    "@object": { "@id": "https://e/o" }
+                }
+            }
+        }"#;
+        let err = parse_dataset(json.as_bytes(), "application/ld+json", None)
+            .expect_err("@annotation inside a @triple component must be rejected");
+        assert_eq!(err.code, "native-jsonld-decode");
+        assert!(
+            err.message
+                .contains("not permitted inside a @triple component"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     fn inline_triple_term_and_real_reifier_share_base_triple_round_trips_jsonld() {
         // The SAME base triple (s,p,o) is BOTH asserted as an object-position triple
         // term (which pushes a self-reifier sentinel keyed by the Triple-kind term

--- a/crates/rdf/src/native_codecs/mod.rs
+++ b/crates/rdf/src/native_codecs/mod.rs
@@ -172,6 +172,49 @@ mod tests {
         let ds = b.freeze().expect("freeze");
         assert_round_trips(&ds, "application/n-triples");
         assert_round_trips(&ds, "text/turtle");
+        // The reifier/@annotation form also round-trips through JSON-LD/YAML-LD.
+        assert_round_trips(&ds, "application/ld+json");
+        assert_round_trips(&ds, "application/ld+yaml");
+    }
+
+    #[test]
+    fn object_position_triple_term_round_trips_jsonld() {
+        // A quad whose object is an RDF-1.2 triple term — the exact construct N-Quads
+        // round-trips (`quoted_triple_term_round_trips`). The distinguishable `@triple`
+        // encoding makes it round-trip losslessly through JSON-LD and YAML-LD too, so
+        // `carries_star == true` is honest for these formats.
+        let mut b = RdfDatasetBuilder::new();
+        let s = b.intern_iri("https://e/s");
+        let p = b.intern_iri("https://e/p");
+        let o = b.intern_iri("https://e/o");
+        let inner = b.intern_triple(s, p, o);
+        let asserts = b.intern_iri("https://e/asserts");
+        b.push_quad(s, asserts, inner, None);
+        let ds = b.freeze().expect("freeze");
+        assert_round_trips(&ds, "application/ld+json");
+        assert_round_trips(&ds, "application/ld+yaml");
+    }
+
+    #[test]
+    fn triple_valued_annotation_round_trips_jsonld() {
+        // An annotation whose VALUE is itself a triple term exercises the
+        // annotation-value `@triple` path (`simple_term_value`'s `Triple` arm).
+        let mut b = RdfDatasetBuilder::new();
+        let s = b.intern_iri("https://e/s");
+        let p = b.intern_iri("https://e/p");
+        let o = b.intern_iri("https://e/o");
+        let base = b.intern_triple(s, p, o);
+        let r = b.intern_iri("https://e/r");
+        b.push_reifier(r, base);
+        let derived = b.intern_iri("https://e/derivedFrom");
+        let x = b.intern_iri("https://e/x");
+        let y = b.intern_iri("https://e/y");
+        let z = b.intern_iri("https://e/z");
+        let ann_triple = b.intern_triple(x, y, z);
+        b.push_annotation(r, derived, ann_triple);
+        let ds = b.freeze().expect("freeze");
+        assert_round_trips(&ds, "application/ld+json");
+        assert_round_trips(&ds, "application/ld+yaml");
     }
 
     #[test]

--- a/crates/rdf/src/native_codecs/parse.rs
+++ b/crates/rdf/src/native_codecs/parse.rs
@@ -154,7 +154,7 @@ pub fn parse_dataset_with(
 
     let format = classify(media_type)?;
 
-    if super::codec::codec_for(format).tokenizer_carries_spans() {
+    if format.tokenizer_carries_spans() {
         // Line/Turtle family: UTF-8 is only required by the text tokenizer, so validate
         // it here where the span-carrying pipeline consumes it.
         let text = std::str::from_utf8(bytes)

--- a/crates/rdf/src/native_codecs/rdfxml.rs
+++ b/crates/rdf/src/native_codecs/rdfxml.rs
@@ -56,14 +56,6 @@ use crate::{
 pub(super) struct RdfXmlCodec;
 
 impl RdfCodec for RdfXmlCodec {
-    fn carries_star(&self) -> bool {
-        false
-    }
-
-    fn tokenizer_carries_spans(&self) -> bool {
-        false
-    }
-
     fn parse(
         &self,
         text: &str,

--- a/crates/rdf/src/native_codecs/serialize.rs
+++ b/crates/rdf/src/native_codecs/serialize.rs
@@ -439,10 +439,10 @@ fn direction_str(direction: RdfTextDirection) -> String {
 #[cfg(test)]
 mod serialize_to_format_tests {
     //! Coverage for the universal-transcoder helper
-    //! [`serialize_dataset_to_format`], ported onto the native codecs in.
-    //! (JSON-LD is no longer routed through this helper — it has no [`NativeRdfFormat`]
-    //! variant — so the JSON-LD drop accounting is exercised in
-    //! `crates/pipeline/src/transcode.rs` via the native `yaml_ld` serializer.)
+    //! [`serialize_dataset_to_format`], ported onto the native codecs. JSON-LD and
+    //! YAML-LD are now first-class [`NativeRdfFormat`] variants routed through this
+    //! helper, so their star-drop accounting is exercised alongside the others (they are
+    //! star-capable, so the count is 0).
     use super::*;
     use crate::{RdfDatasetBuilder, TermFactory, parse_dataset};
     use std::sync::Arc;

--- a/crates/rdf/src/native_codecs/serialize.rs
+++ b/crates/rdf/src/native_codecs/serialize.rs
@@ -124,7 +124,7 @@ pub fn serialize_dataset_to_format(
     _base_iri: Option<&str>,
 ) -> Result<SerializeOutcome, RdfDiagnostic> {
     let media_type = format.media_type();
-    if super::codec::codec_for(format).carries_star() {
+    if format.carries_star() {
         let bytes = serialize_dataset(dataset, media_type, SerializeGraph::Dataset)?;
         Ok(SerializeOutcome {
             bytes,

--- a/crates/rdf/src/native_codecs/text_parse.rs
+++ b/crates/rdf/src/native_codecs/text_parse.rs
@@ -138,8 +138,13 @@ pub(super) fn parse_to_gts_graph_mode<S: SpanCollector>(
         NativeRdfFormat::RdfXml => {
             return Err(err("RDF/XML is not a line/Turtle-family format"));
         }
-        NativeRdfFormat::TriX | NativeRdfFormat::HexTuples => {
-            return Err(err("TriX / HexTuples are not line/Turtle-family formats"));
+        NativeRdfFormat::TriX
+        | NativeRdfFormat::HexTuples
+        | NativeRdfFormat::JsonLd
+        | NativeRdfFormat::YamlLd => {
+            return Err(err(
+                "TriX / HexTuples / JSON-LD / YAML-LD are not line/Turtle-family formats",
+            ));
         }
     };
     build_gts_graph(&statements)

--- a/crates/rdf/src/native_codecs/trix.rs
+++ b/crates/rdf/src/native_codecs/trix.rs
@@ -35,14 +35,6 @@ use crate::{BlankScope, RdfDataset, RdfDatasetBuilder, RdfDiagnostic, RdfLiteral
 pub(super) struct TriXCodec;
 
 impl RdfCodec for TriXCodec {
-    fn carries_star(&self) -> bool {
-        false
-    }
-
-    fn tokenizer_carries_spans(&self) -> bool {
-        false
-    }
-
     fn parse(
         &self,
         text: &str,


### PR DESCRIPTION
Closes #105

## Summary

Folds JSON-LD-star / YAML-LD-star into the single native codec registry so they dispatch uniformly like the other seven syntaxes — reachable from the generic `RdfSerializer`/`RdfParserBackend` (`GtsCodecBackend`) and `classify`/`parse_dataset`/`serialize_dataset` with **no side door**. Two review-driven, user-approved decisions shaped the work beyond the issue text (per `.goals` no-compromises / RDF-1.2-first-class): implement the lossless RDF-1.2 triple-term encoding now, and refactor format metadata to a single source of truth.

## Changes

- **`FormatDescriptor` table (single source of truth)** — collapsed the five parallel `match NativeRdfFormat` sites (`media_type`/`classify`/`supports_datasets` + per-codec `carries_star`/`tokenizer_carries_spans`) into one `const FORMATS` table. `carries_star`/`tokenizer_carries_spans` moved off the `RdfCodec` trait onto `NativeRdfFormat` (they are format data). Adding a format is now one row + one codec impl.
- **`NativeRdfFormat::{JsonLd, YamlLd}` variants** — `application/ld+json` / `application/ld+yaml` (+ `jsonld`/`json-ld`/`.jsonld` and `yamlld`/`yaml-ld`/`.yamlld` aliases), star-capable, dataset-capable, loss names `jsonld-star`/`yaml-ld-star`. `JsonLdCodec`/`YamlLdCodec` share the existing serialize/parse cores with the public free functions (one code path, two entry points).
- **Lossless RDF-1.2 triple-term encoding** — object-position and annotation-value quoted-triple terms now serialize to a distinguishable `{"@triple":{"@subject":…,"@predicate":"<iri>","@object":…}}` value object (recursive, byte-deterministic) with a symmetric parse branch, retiring two `Err` hard-fail sites. Also fixed a pre-existing star-fidelity bug: reifiers whose base triple is unasserted (and reifiers on named-graph triples) were dropped / relocated to the default graph — now they round-trip.
- **Unified wasm resolver** — `rdf-wasm`'s `resolve_media_type` now delegates to `purrdf::classify` (a strict superset absorbing the wasm-only `rdf/xml`/`rdfxml` spellings); deleted the inline JSON-LD serialize guards, retiring the duplicate dispatch path. JSON-LD/YAML-LD are now reachable from the wasm parse+serialize surface.
- **Production-surface tests** — round-trips for the full bidirectional peer set (incl. TriX/HexTuples) + JSON-LD/YAML-LD via both `serialize_dataset`/`parse_dataset` and `GtsCodecBackend`; object-position + annotation-value triple terms; reifier-on-named-graph; star-drop-count == 0; a drift-proof test pinning registry capabilities to `rdf-core::loss` for every loss-named format; classify + full alias-regression coverage.

## Gates

`make check`, `make wasm`, `make doc` all green. Deterministic output, no minted IRIs, no Cargo features, wasm32-clean. Existing side-door callers (Python bindings, tests) unchanged and passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class JSON-LD and YAML-LD support across parsing and serialization (including RDF-star triple terms, reifiers, and annotations).
  * Improved media-type recognition with canonical types, aliases, extensions, and parameter handling.

* **Bug Fixes**
  * Improved JSON-LD/YAML-LD round-trip fidelity and losslessness, including correct named-graph placement for reifier and annotation data.
  * Unified graph result serialization to consistently resolve and serialize via the requested media type.

* **Tests**
  * Added comprehensive JSON-LD/YAML-LD wasm round-trip regression coverage and expanded codec backend test matrices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->