### PR TITLE
feat(cli): the purrdf CLI — convert / query / reason

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "purrdf-cli"
+version = "0.6.0"
+dependencies = [
+ "clap",
+ "memmap2",
+ "purrdf-core",
+ "purrdf-entail",
+ "purrdf-rdf",
+ "purrdf-sparql-eval",
+ "purrdf-sparql-results",
+ "tempfile",
+]
+
+[[package]]
 name = "purrdf-core"
 version = "0.6.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@
 resolver = "2"
 members = [
     "bindings/python",
+    "crates/cli",
     "crates/entail",
     "crates/gts",
     "crates/iri",
@@ -72,6 +73,12 @@ blake3 = { version = "1", features = ["rayon"] }
 boon = "0.6"
 camino = "1"
 ciborium = "0.2"
+# Argument parsing for the `purrdf` CLI (native-only binary crate `crates/cli`).
+# `derive` supplies the `Parser`/`Subcommand`/`ValueEnum` macros the CLI models
+# its command tree with. Not a library dependency, so the wasm gate (which
+# builds `--lib` on an explicit `-p` allowlist that omits `purrdf-cli`) is
+# unaffected.
+clap = { version = "4", features = ["derive"] }
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 csv = "1"
 datatest-stable = "0.3"

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ test: ## Run the workspace test suite.
 	cargo test --workspace --locked
 
 doc: ## Build docs for the 16 publishable crates with rustdoc warnings denied.
-	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --exclude purrdf-capi --exclude purrdf-python --exclude purrdf-sparql-conformance
+	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --exclude purrdf-capi --exclude purrdf-python --exclude purrdf-sparql-conformance --exclude purrdf-cli
 
 book-samples: ## Regenerate deterministic SVG visualization samples embedded in The PurRDF Book.
 	@set -eu; \

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+[package]
+name = "purrdf-cli"
+description = "PurRDF command-line interface: the `purrdf` convert/query/reason pipeline over the native codecs, pack container, SPARQL engine, and entailment closures"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+keywords = ["rdf", "rdf-12", "sparql", "cli", "command-line"]
+categories = ["command-line-utilities"]
+publish = false
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "purrdf"
+path = "src/main.rs"
+
+[dependencies]
+# The native RDF text/statement codec surface: `classify`, `parse_dataset`,
+# `serialize_dataset_to_format`, and `NativeRdfFormat`. This is the format
+# authority the CLI's `--from`/`--to` routing resolves against.
+purrdf-rdf = { workspace = true }
+# The oxigraph-free kernel: the frozen `RdfDataset`/`DatasetView` model, the
+# pack container (`PackBuilder`/`PackView`/`verify_pack`/`dataset_from_view`),
+# the loss ledger, and the `SparqlResult` model.
+purrdf-core = { workspace = true }
+# The native SPARQL engine driving the `query` subcommand over any `DatasetView`.
+purrdf-sparql-eval = { workspace = true }
+# The W3C SPARQL-Results serializers (JSON/XML/CSV/TSV) for SELECT/ASK results.
+purrdf-sparql-results = { workspace = true }
+# The entailment regimes driving the `reason` subcommand's closure materialization.
+purrdf-entail = { workspace = true }
+# Zero-copy memory-mapped reads of on-disk pack files: a pack source is mmap'd
+# and handed to `PackView::from_bytes` with no materialization. Native-only —
+# this crate is never built for wasm32 (it is absent from the `make wasm`
+# `-p` allowlist), so mmap's absence there is a non-issue.
+memmap2 = { workspace = true }
+# Command-tree argument parsing (`Parser`/`Subcommand`/`ValueEnum`).
+clap = { workspace = true }
+
+[dev-dependencies]
+# Isolated temp files/dirs for the integration tests that drive the built binary.
+tempfile = { workspace = true }

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -1,0 +1,265 @@
+<!--
+SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+<p align="center">
+  <a href="https://github.com/Blackcat-Informatics/purrdf">
+    <img src="https://raw.githubusercontent.com/Blackcat-Informatics/purrdf/main/docs/purrdf-logo.svg" alt="PurRDF logo" width="120" height="120">
+  </a>
+</p>
+
+# `purrdf` — the PurRDF command-line interface
+
+[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/Blackcat-Informatics/purrdf/blob/main/LICENSE-MIT)
+[![Repository](https://img.shields.io/badge/repo-Blackcat--Informatics%2Fpurrdf-181717.svg)](https://github.com/Blackcat-Informatics/purrdf)
+
+`purrdf` is the native RDF 1.2 command-line tool of the PurRDF toolkit. It is a
+thin, deterministic shell over the same engines the library exposes — the native
+text/XML/JSON codecs, the pack container, the SPARQL 1.2 evaluator, and the
+entailment closures — so anything the CLI does, it does with byte-for-byte the
+same behavior as the Rust, Python, WebAssembly, and C surfaces.
+
+Every invocation is one `Source → [transform] → Sink` pipeline, exposed as three
+subcommands:
+
+| Subcommand | Pipeline |
+|---|---|
+| [`convert`](#convert) | transcode RDF between syntaxes and the native pack container |
+| [`query`](#query) | evaluate a SPARQL query over an RDF or pack data source |
+| [`reason`](#reason) | materialize an entailment regime's closure over a source graph |
+
+A single global flag, [`--loss-ledger`](#the-loss-ledger), surfaces the
+machine-readable transcode-loss record for whichever conversion ran.
+
+> **This tool mints no vocabulary.** PurRDF is a carrier, not an ontology: every
+> IRI in your data is yours. The `example.org` IRIs below are illustrative
+> fixtures only.
+
+## Installation
+
+`purrdf` is a native-only binary (it memory-maps pack files, so it is never built
+for `wasm32`). Build it from the workspace:
+
+```sh
+cargo build --release -p purrdf-cli
+# the binary is `purrdf`:
+./target/release/purrdf --help
+```
+
+## Formats
+
+Nine native RDF syntaxes plus the native pack container are accepted anywhere a
+format is named (`--from`, `--to`, `--results-format`, or inferred from a path):
+
+| Token | Syntax | Filename extensions |
+|---|---|---|
+| `turtle` (`ttl`) | Turtle | `.ttl` |
+| `trig` | TriG | `.trig` |
+| `ntriples` (`nt`) | N-Triples | `.nt` |
+| `nquads` (`nq`) | N-Quads | `.nq` |
+| `rdfxml` (`rdf`, `xml`) | RDF/XML | `.rdf`, `.xml` |
+| `trix` | TriX | `.trix` |
+| `hextuples` (`hext`) | HexTuples | `.hext` |
+| `jsonld` (`json-ld`) | JSON-LD | `.jsonld` |
+| `yamlld` (`yaml-ld`) | YAML-LD | `.yamlld` |
+| `pack` | PurRDF pack container | `.purrpck`, `.pack` |
+
+**Format inference.** When `--from`/`--to` is omitted, the format is inferred
+from the path's extension. An explicit `--from`/`--to` always wins over the
+extension.
+
+**stdin/stdout.** A path of `-` reads from stdin or writes to stdout. Because `-`
+has no extension, it **requires** an explicit `--from` (for input) or `--to` (for
+output). `convert` defaults both `IN` and `OUT` to `-`.
+
+**The pack container.** A pack is PurRDF's native, lossless RDF 1.2 container. On
+disk it is opened **read-only and memory-mapped**, verified end-to-end
+(`verify_pack`, fail-closed), and handed to the engine zero-copy — no intermediate
+materialization for `convert` passthroughs, `query`, or serialization. A pack
+arriving on stdin is read into a buffer and verified the same way. A `pack → pack`
+`convert` is a verified byte passthrough (no decode/re-encode churn).
+
+## `convert`
+
+```text
+purrdf convert [--from <F>] [--to <F>] [--base <IRI>] [--entailment <R>] [--canonical] [IN] [OUT]
+```
+
+Transcode a source into a target syntax or the pack container.
+
+- `--from <F>` / `--to <F>` — input/output format overrides; inferred from the
+  `IN`/`OUT` extension when omitted.
+- `--base <IRI>` — base IRI for resolving relative IRIs while parsing, also
+  threaded into the serializer as its base.
+- `--entailment <R>` — materialize a regime's closure **in memory** before
+  serializing (see [`reason`](#reason) for the supported regimes and the exit-3
+  boundary; the two lanes reject identically).
+- `--canonical` — emit the RDFC-1.0 canonical N-Quads document instead of `--to`.
+  Canonical output is **always** N-Quads, so `--canonical` overrides (and lets you
+  omit) `--to`.
+
+Transforms compose in a fixed order: entail first, then canonicalize.
+
+```sh
+# Turtle → N-Triples, formats inferred from the extensions.
+purrdf convert people.ttl people.nt
+
+# JSON-LD on stdin → Turtle on stdout (explicit formats required for `-`).
+cat people.jsonld | purrdf convert --from jsonld --to turtle - -
+
+# Pack a graph into the native lossless container, then unpack it.
+purrdf convert people.ttl people.purrpck
+purrdf convert people.purrpck restored.trig
+
+# Emit RDFC-1.0 canonical N-Quads (no `--to` needed; canonical is always N-Quads).
+purrdf convert --canonical people.ttl people.nq
+
+# Materialize the RDFS closure, then canonicalize it.
+purrdf convert --entailment rdfs --canonical people.ttl closure.nq
+
+# Resolve relative IRIs against a base while converting.
+purrdf convert --base http://example.org/ data.ttl data.nt
+```
+
+## `query`
+
+```text
+purrdf query --data <file|pack> [--base <IRI>] [--entailment <R>] [--results-format <FMT>] '<SPARQL>'
+```
+
+Evaluate a SPARQL 1.2 query over a data source. The source is opened as a view (a
+pack is queried **zero-copy**); the query text and the parsed data both resolve
+relative IRIs against `--base`.
+
+- `--data <file|pack>` — the data source (format inferred from its extension).
+- `--base <IRI>` — base IRI applied to both the data parse and the query text.
+- `--entailment <R>` — reconstruct an owned dataset, materialize the regime's
+  closure in memory, and run the query over **the closure** (a pack is rebuilt for
+  this; the zero-copy path is used only without `--entailment`).
+- `--results-format <FMT>` — the result serialization (default `json`).
+
+The **result shape** selects which half of `--results-format` is legal:
+
+- **SELECT / ASK** produce solutions / a boolean → a SPARQL-results format:
+  `json`, `xml`, `csv`, `tsv`.
+- **CONSTRUCT / DESCRIBE** produce a graph → one of the nine RDF syntaxes
+  (`turtle`, `trig`, `ntriples`, `nquads`, `rdfxml`, `trix`, `hextuples`,
+  `jsonld`, `yamlld`).
+
+A shape/format mismatch (e.g. SELECT solutions with `turtle`, or a CONSTRUCT graph
+with `csv`) is a hard runtime error (exit 1). Results always go to stdout.
+
+```sh
+# SELECT → SPARQL Results JSON (the default).
+purrdf query --data people.ttl \
+  'SELECT ?name WHERE { ?p <http://example.org/name> ?name }'
+
+# ASK → CSV.
+purrdf query --data people.ttl --results-format csv \
+  'ASK { ?p <http://example.org/name> "Alice" }'
+
+# CONSTRUCT → Turtle (a graph result serialized through an RDF syntax).
+purrdf query --data people.ttl --results-format turtle \
+  'CONSTRUCT { ?p <http://example.org/label> ?name } WHERE { ?p <http://example.org/name> ?name }'
+
+# Query a pack zero-copy (mmap'd, verified, no materialization).
+purrdf query --data people.purrpck --results-format tsv \
+  'SELECT * WHERE { ?s ?p ?o } LIMIT 10'
+
+# Query the RDFS closure rather than the raw graph.
+purrdf query --data people.ttl --entailment rdfs \
+  'SELECT ?type WHERE { <http://example.org/alice> a ?type }'
+```
+
+## `reason`
+
+```text
+purrdf reason --regime <R> [--base <IRI>] [IN] [OUT]
+```
+
+Materialize an entailment regime's closure over the source graph and write it out
+(the output format is inferred from `OUT`'s extension).
+
+- `--regime <R>` — the entailment regime to close under.
+- `--base <IRI>` — base IRI for the input parse, also threaded into the serializer.
+
+**Supported (materializable) regimes:**
+
+| `--regime` | Meaning |
+|---|---|
+| `simple` | Simple entailment (a faithful copy of the source) |
+| `rdf` | RDF entailment |
+| `rdfs` | RDFS entailment |
+| `owl-rl` | OWL 2 RL entailment |
+
+**The unsupported boundary (exit code 3).** Three regimes cannot be materialized
+by the CLI because they need inputs it has no way to supply, and each is rejected
+with a distinct diagnostic:
+
+- `owl-direct` — OWL Direct (DL) needs the query's class expressions;
+- `rif` — RIF-Core needs a parsed rule set;
+- `d` — datatype (D) entailment is a spec-inherent materialization boundary.
+
+`convert --entailment` shares this boundary and rejects identically.
+
+```sh
+# Materialize the RDFS closure and write it as N-Triples.
+purrdf reason --regime rdfs people.ttl closure.nt
+
+# OWL 2 RL closure from stdin to stdout.
+cat ontology.ttl | purrdf reason --regime owl-rl - closure.ttl
+
+# The unsupported boundary: exits 3 with an explanatory message.
+purrdf reason --regime owl-direct people.ttl out.ttl
+echo $?   # 3
+```
+
+## The loss ledger
+
+`--loss-ledger` is a global flag that surfaces the machine-readable transcode-loss
+record for whichever conversion ran. The ledger is **always computed**; the flag
+only controls where (if anywhere) it is written, via three states:
+
+| Form | Effect |
+|---|---|
+| absent | silent — the ledger is not surfaced |
+| `--loss-ledger` (bare) | render the ledger's JSON to **stderr** |
+| `--loss-ledger=PATH` | write the ledger's JSON to **PATH** |
+
+The `=PATH` spelling is required (the bare form takes no value), so the flag never
+swallows a following subcommand or query string.
+
+The ledger records two kinds of loss when a target syntax cannot carry what the
+source held: the **contract** losses inherent to a `(source-codec → target-codec)`
+pair, and the **realized** counts the serializer actually dropped — RDF 1.2
+statement-layer rows (reifier bindings + annotation triples) when the target has no
+star layer, and literal base directions when the target (TriX / HexTuples) has no
+direction surface. A pack target, a `pack → pack` passthrough, and RDFC-1.0
+canonical N-Quads are lossless, so their ledgers are empty.
+
+```sh
+# Convert to a star-incapable syntax and inspect what was dropped, on stderr.
+purrdf --loss-ledger convert star-data.ttl plain.rdf
+
+# Persist the ledger to a file alongside the output.
+purrdf --loss-ledger=convert.loss.json convert star-data.ttl plain.trix
+```
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | success |
+| `1` | runtime failure — a parse/serialize diagnostic, a pack-integrity failure, an I/O error, or a result/shape mismatch |
+| `2` | usage error — a malformed command line (clap), or a pipeline usage error such as `-` without an explicit format |
+| `3` | unsupported entailment regime — `owl-direct` / `rif` / `d` cannot be materialized by the CLI |
+
+On any failure the error's message is printed to stderr and its category becomes
+the process exit code; nothing is swallowed.
+
+## License
+
+Licensed under either of [MIT](https://github.com/Blackcat-Informatics/purrdf/blob/main/LICENSE-MIT)
+or [Apache-2.0](https://github.com/Blackcat-Informatics/purrdf/blob/main/LICENSE-APACHE)
+at your option.

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -175,13 +175,16 @@ purrdf query --data people.ttl --entailment rdfs \
 ## `reason`
 
 ```text
-purrdf reason --regime <R> [--base <IRI>] [IN] [OUT]
+purrdf reason --regime <R> [--from <F>] [--to <F>] [--base <IRI>] [IN] [OUT]
 ```
 
-Materialize an entailment regime's closure over the source graph and write it out
-(the output format is inferred from `OUT`'s extension).
+Materialize an entailment regime's closure over the source graph and write it out.
 
 - `--regime <R>` — the entailment regime to close under.
+- `--from <F>` / `--to <F>` — input/output format overrides; inferred from the
+  `IN`/`OUT` extension when omitted. `IN`/`OUT` default to `-` (stdin/stdout); a
+  path of `-` has no extension, so it **requires** the matching explicit
+  `--from`/`--to`.
 - `--base <IRI>` — base IRI for the input parse, also threaded into the serializer.
 
 **Supported (materializable) regimes:**
@@ -207,8 +210,8 @@ with a distinct diagnostic:
 # Materialize the RDFS closure and write it as N-Triples.
 purrdf reason --regime rdfs people.ttl closure.nt
 
-# OWL 2 RL closure from stdin to stdout.
-cat ontology.ttl | purrdf reason --regime owl-rl - closure.ttl
+# OWL 2 RL closure from stdin to stdout (explicit formats required for `-`).
+cat ontology.ttl | purrdf reason --regime owl-rl --from ttl --to nt - -
 
 # The unsupported boundary: exits 3 with an explanatory message.
 purrdf reason --regime owl-direct people.ttl out.ttl

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -142,14 +142,20 @@ pub(crate) enum Command {
         /// The entailment regime to close under.
         #[arg(long, value_enum)]
         regime: CliRegime,
+        /// Input format override; inferred from the input extension when omitted.
+        #[arg(long, value_enum)]
+        from: Option<CliRdfFormat>,
+        /// Output format override; inferred from the output extension when omitted.
+        #[arg(long, value_enum)]
+        to: Option<CliRdfFormat>,
         /// Base IRI for resolving relative IRIs while parsing the input; also
         /// threaded into the serializer as its base.
         #[arg(long, value_name = "IRI")]
         base: Option<String>,
-        /// Input path `IN`, or `-` for stdin (which requires a recognizable format).
+        /// Input path `IN`, or `-` for stdin (which requires `--from`).
         #[arg(value_name = "IN", default_value = "-")]
         input: String,
-        /// Output path `OUT` (format inferred from its extension), or `-` for stdout.
+        /// Output path `OUT`, or `-` for stdout (which requires `--to`).
         #[arg(value_name = "OUT", default_value = "-")]
         output: String,
     },

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The clap command tree: the `purrdf` binary's argument model.
+//!
+//! One pipeline, three subcommands ([`Command`]), and one global flag
+//! (`--loss-ledger`). The format / regime / results-format choices are modeled as
+//! [`clap::ValueEnum`] wrappers so `--help` enumerates the legal values and clap
+//! validates them at parse time, and each wrapper carries a total conversion into
+//! its library counterpart.
+//!
+//! ## The `--loss-ledger` tri-state
+//!
+//! `--loss-ledger` is an optional-value global flag whose three states are encoded
+//! as `Option<Option<PathBuf>>`:
+//!
+//! * absent → `None` — do not surface the ledger.
+//! * `--loss-ledger` (bare) → `Some(None)` — render the ledger to **stderr**.
+//! * `--loss-ledger=PATH` → `Some(Some(PATH))` — write the ledger to **PATH**.
+//!
+//! `require_equals` forces the `=PATH` spelling so the optional value never
+//! greedily swallows a following positional (e.g. a subcommand or a query string),
+//! keeping the three states unambiguous.
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand, ValueEnum};
+use purrdf_entail::Regime;
+use purrdf_sparql_results::SparqlResultsFormat;
+
+use crate::format::CliFormat;
+
+/// The `purrdf` command-line interface.
+#[derive(Parser, Debug)]
+#[command(
+    name = "purrdf",
+    version,
+    about = "PurRDF: convert, query, and reason over RDF 1.2 data and native packs",
+    propagate_version = true
+)]
+pub(crate) struct Cli {
+    /// The subcommand to run.
+    #[command(subcommand)]
+    pub(crate) cmd: Command,
+
+    /// Surface the transcode loss ledger: bare writes it to stderr,
+    /// `--loss-ledger=PATH` writes it to PATH.
+    //
+    // `Option<Option<PathBuf>>` is clap's idiom for an optional-value flag (the
+    // three states are: absent / present-bare / present-with-value); it is the
+    // only place this shape appears — `Cli::ledger_target` projects it into the
+    // self-documenting `LedgerTarget` the pipeline actually threads.
+    #[allow(clippy::option_option)]
+    #[arg(
+        long,
+        global = true,
+        value_name = "PATH",
+        num_args = 0..=1,
+        require_equals = true
+    )]
+    pub(crate) loss_ledger: Option<Option<PathBuf>>,
+}
+
+/// Where (if anywhere) the loss ledger should be surfaced — the decoded form of
+/// the `--loss-ledger` tri-state flag.
+#[derive(Debug, Clone)]
+pub(crate) enum LedgerTarget {
+    /// The flag was absent: do not surface the ledger.
+    Silent,
+    /// Bare `--loss-ledger`: render the ledger to stderr.
+    Stderr,
+    /// `--loss-ledger=PATH`: write the ledger to PATH.
+    File(PathBuf),
+}
+
+impl Cli {
+    /// Decode the raw `--loss-ledger` tri-state into a [`LedgerTarget`].
+    pub(crate) fn ledger_target(&self) -> LedgerTarget {
+        match &self.loss_ledger {
+            None => LedgerTarget::Silent,
+            Some(None) => LedgerTarget::Stderr,
+            Some(Some(path)) => LedgerTarget::File(path.clone()),
+        }
+    }
+}
+
+/// The three pipeline subcommands.
+#[derive(Subcommand, Debug)]
+pub(crate) enum Command {
+    /// Convert RDF between syntaxes, and to/from the native pack container.
+    Convert {
+        /// Input format override; inferred from the input extension when omitted.
+        #[arg(long, value_enum)]
+        from: Option<CliRdfFormat>,
+        /// Output format override; inferred from the output extension when omitted.
+        #[arg(long, value_enum)]
+        to: Option<CliRdfFormat>,
+        /// Input path `IN`, or `-` for stdin (which requires `--from`).
+        #[arg(value_name = "IN", default_value = "-")]
+        input: String,
+        /// Output path `OUT`, or `-` for stdout (which requires `--to`).
+        #[arg(value_name = "OUT", default_value = "-")]
+        output: String,
+    },
+    /// Evaluate a SPARQL query over an RDF or pack data source.
+    Query {
+        /// Data-source path (format inferred from its extension). A pack file is
+        /// queried zero-copy.
+        #[arg(long)]
+        data: String,
+        /// SPARQL-results serialization for SELECT/ASK results.
+        #[arg(long, value_enum, default_value_t = ResultsFormat::Json)]
+        results_format: ResultsFormat,
+        /// The SPARQL query text.
+        query: String,
+    },
+    /// Materialize an entailment regime's closure over a source graph.
+    Reason {
+        /// The entailment regime to close under.
+        #[arg(long, value_enum)]
+        regime: CliRegime,
+        /// Input path `IN`, or `-` for stdin (which requires a recognizable format).
+        #[arg(value_name = "IN", default_value = "-")]
+        input: String,
+        /// Output path `OUT` (format inferred from its extension), or `-` for stdout.
+        #[arg(value_name = "OUT", default_value = "-")]
+        output: String,
+    },
+}
+
+/// The input/output format choices `--from`/`--to` accept: the nine native RDF
+/// syntaxes plus the native `pack` container.
+///
+/// Each variant's canonical value is the one `--help` lists; the short
+/// extension/id spellings the native codec [`classify`](purrdf_rdf::classify)
+/// accepts (e.g. `ttl`, `nt`, `nq`) are registered as hidden aliases so the same
+/// name works on the command line and in a filename.
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CliRdfFormat {
+    /// Turtle.
+    #[value(name = "turtle", alias = "ttl")]
+    Turtle,
+    /// TriG.
+    #[value(name = "trig")]
+    Trig,
+    /// N-Triples.
+    #[value(name = "ntriples", alias = "nt", alias = "n-triples")]
+    Ntriples,
+    /// N-Quads.
+    #[value(name = "nquads", alias = "nq", alias = "n-quads")]
+    Nquads,
+    /// RDF/XML.
+    #[value(name = "rdfxml", alias = "rdf", alias = "xml")]
+    Rdfxml,
+    /// TriX.
+    #[value(name = "trix")]
+    Trix,
+    /// HexTuples.
+    #[value(name = "hextuples", alias = "hext")]
+    Hextuples,
+    /// JSON-LD.
+    #[value(name = "jsonld", alias = "json-ld")]
+    Jsonld,
+    /// YAML-LD.
+    #[value(name = "yamlld", alias = "yaml-ld")]
+    Yamlld,
+    /// The native PurRDF pack container.
+    #[value(name = "pack")]
+    Pack,
+}
+
+impl CliRdfFormat {
+    /// Resolve this explicit choice to the pipeline's [`CliFormat`].
+    pub(crate) fn to_cli_format(self) -> CliFormat {
+        use purrdf_rdf::NativeRdfFormat as N;
+        match self {
+            Self::Turtle => CliFormat::Rdf(N::Turtle),
+            Self::Trig => CliFormat::Rdf(N::TriG),
+            Self::Ntriples => CliFormat::Rdf(N::NTriples),
+            Self::Nquads => CliFormat::Rdf(N::NQuads),
+            Self::Rdfxml => CliFormat::Rdf(N::RdfXml),
+            Self::Trix => CliFormat::Rdf(N::TriX),
+            Self::Hextuples => CliFormat::Rdf(N::HexTuples),
+            Self::Jsonld => CliFormat::Rdf(N::JsonLd),
+            Self::Yamlld => CliFormat::Rdf(N::YamlLd),
+            Self::Pack => CliFormat::Pack,
+        }
+    }
+}
+
+/// The SPARQL-results serialization choices `--results-format` accepts.
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResultsFormat {
+    /// SPARQL Results JSON.
+    #[value(name = "json")]
+    Json,
+    /// SPARQL Results XML.
+    #[value(name = "xml")]
+    Xml,
+    /// SPARQL Results CSV.
+    #[value(name = "csv")]
+    Csv,
+    /// SPARQL Results TSV.
+    #[value(name = "tsv")]
+    Tsv,
+}
+
+impl ResultsFormat {
+    /// The library [`SparqlResultsFormat`] this choice maps to.
+    pub(crate) fn to_native(self) -> SparqlResultsFormat {
+        match self {
+            Self::Json => SparqlResultsFormat::Json,
+            Self::Xml => SparqlResultsFormat::Xml,
+            Self::Csv => SparqlResultsFormat::Csv,
+            Self::Tsv => SparqlResultsFormat::Tsv,
+        }
+    }
+}
+
+/// The entailment-regime choices `--regime` accepts.
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CliRegime {
+    /// Simple entailment (a faithful copy of the source).
+    #[value(name = "simple")]
+    Simple,
+    /// RDF entailment.
+    #[value(name = "rdf")]
+    Rdf,
+    /// RDFS entailment.
+    #[value(name = "rdfs")]
+    Rdfs,
+    /// OWL 2 RL entailment.
+    #[value(name = "owl-rl")]
+    OwlRl,
+    /// OWL Direct (DL) entailment — not materializable without query class
+    /// expressions.
+    #[value(name = "owl-direct")]
+    OwlDirect,
+    /// RIF-Core entailment — not materializable without a rule set.
+    #[value(name = "rif")]
+    Rif,
+    /// Datatype (D) entailment — a spec-inherent boundary for materialization.
+    #[value(name = "d")]
+    D,
+}
+
+impl CliRegime {
+    /// The library [`Regime`] this choice maps to.
+    pub(crate) fn to_native(self) -> Regime {
+        match self {
+            Self::Simple => Regime::Simple,
+            Self::Rdf => Regime::Rdf,
+            Self::Rdfs => Regime::Rdfs,
+            Self::OwlRl => Regime::OwlRl,
+            Self::OwlDirect => Regime::OwlDirect,
+            Self::Rif => Regime::Rif,
+            Self::D => Regime::D,
+        }
+    }
+}

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -95,6 +95,19 @@ pub(crate) enum Command {
         /// Output format override; inferred from the output extension when omitted.
         #[arg(long, value_enum)]
         to: Option<CliRdfFormat>,
+        /// Base IRI for resolving relative IRIs while parsing the input; also
+        /// threaded into the serializer as its base.
+        #[arg(long, value_name = "IRI")]
+        base: Option<String>,
+        /// Materialize an entailment regime's closure in memory before
+        /// serializing (applied before `--canonical`).
+        #[arg(long, value_enum, value_name = "REGIME")]
+        entailment: Option<CliRegime>,
+        /// Emit RDFC-1.0 canonical N-Quads instead of `--to`. This overrides the
+        /// target format (canonical output is always N-Quads), so `--to` may be
+        /// omitted; combine with `--entailment` to canonicalize the closure.
+        #[arg(long)]
+        canonical: bool,
         /// Input path `IN`, or `-` for stdin (which requires `--from`).
         #[arg(value_name = "IN", default_value = "-")]
         input: String,

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -142,6 +142,10 @@ pub(crate) enum Command {
         /// The entailment regime to close under.
         #[arg(long, value_enum)]
         regime: CliRegime,
+        /// Base IRI for resolving relative IRIs while parsing the input; also
+        /// threaded into the serializer as its base.
+        #[arg(long, value_name = "IRI")]
+        base: Option<String>,
         /// Input path `IN`, or `-` for stdin (which requires a recognizable format).
         #[arg(value_name = "IN", default_value = "-")]
         input: String,

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -26,6 +26,7 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use purrdf_entail::Regime;
+use purrdf_rdf::NativeRdfFormat;
 use purrdf_sparql_results::SparqlResultsFormat;
 
 use crate::format::CliFormat;
@@ -118,12 +119,21 @@ pub(crate) enum Command {
     /// Evaluate a SPARQL query over an RDF or pack data source.
     Query {
         /// Data-source path (format inferred from its extension). A pack file is
-        /// queried zero-copy.
+        /// queried zero-copy (unless `--entailment` forces materialization).
         #[arg(long)]
         data: String,
-        /// SPARQL-results serialization for SELECT/ASK results.
-        #[arg(long, value_enum, default_value_t = ResultsFormat::Json)]
-        results_format: ResultsFormat,
+        /// Base IRI for resolving relative IRIs while parsing the data AND in the
+        /// query text.
+        #[arg(long, value_name = "IRI")]
+        base: Option<String>,
+        /// Materialize an entailment regime's closure in memory before querying
+        /// (the query then runs over the closure, not the raw view).
+        #[arg(long, value_enum, value_name = "REGIME")]
+        entailment: Option<CliRegime>,
+        /// Result serialization: a SPARQL-results format (json/xml/csv/tsv) for
+        /// SELECT/ASK, or an RDF syntax (turtle/trig/…) for CONSTRUCT/DESCRIBE.
+        #[arg(long, value_enum, default_value_t = QueryFormat::Json)]
+        results_format: QueryFormat,
         /// The SPARQL query text.
         query: String,
     },
@@ -201,9 +211,18 @@ impl CliRdfFormat {
     }
 }
 
-/// The SPARQL-results serialization choices `--results-format` accepts.
+/// The `--results-format` choices the `query` subcommand accepts: a SUPERSET of the
+/// four W3C SPARQL-results serializations (for SELECT solutions / ASK booleans) and
+/// the nine native RDF syntaxes (for CONSTRUCT / DESCRIBE graphs).
+///
+/// The result SHAPE selects which half is legal: a SELECT/ASK result serializes
+/// through a SPARQL-results format, a CONSTRUCT/DESCRIBE graph through an RDF syntax.
+/// A shape/format-kind mismatch (e.g. a graph with `csv`, or solutions with
+/// `turtle`) is a hard error at emit time. [`Self::to_results_format`] and
+/// [`Self::to_rdf_format`] project a choice into whichever half it names.
 #[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ResultsFormat {
+pub(crate) enum QueryFormat {
+    // --- SPARQL-results serializations (SELECT solutions / ASK boolean) ---
     /// SPARQL Results JSON.
     #[value(name = "json")]
     Json,
@@ -216,16 +235,83 @@ pub(crate) enum ResultsFormat {
     /// SPARQL Results TSV.
     #[value(name = "tsv")]
     Tsv,
+    // --- Native RDF syntaxes (CONSTRUCT / DESCRIBE graph) ---
+    /// Turtle.
+    #[value(name = "turtle", alias = "ttl")]
+    Turtle,
+    /// TriG.
+    #[value(name = "trig")]
+    Trig,
+    /// N-Triples.
+    #[value(name = "ntriples", alias = "nt", alias = "n-triples")]
+    Ntriples,
+    /// N-Quads.
+    #[value(name = "nquads", alias = "nq", alias = "n-quads")]
+    Nquads,
+    /// RDF/XML. (`xml` names the SPARQL-results format, so RDF/XML aliases `rdf`.)
+    #[value(name = "rdfxml", alias = "rdf")]
+    Rdfxml,
+    /// TriX.
+    #[value(name = "trix")]
+    Trix,
+    /// HexTuples.
+    #[value(name = "hextuples", alias = "hext")]
+    Hextuples,
+    /// JSON-LD.
+    #[value(name = "jsonld", alias = "json-ld")]
+    Jsonld,
+    /// YAML-LD.
+    #[value(name = "yamlld", alias = "yaml-ld")]
+    Yamlld,
 }
 
-impl ResultsFormat {
-    /// The library [`SparqlResultsFormat`] this choice maps to.
-    pub(crate) fn to_native(self) -> SparqlResultsFormat {
+impl QueryFormat {
+    /// The [`SparqlResultsFormat`] this choice names, or `None` when it names an
+    /// RDF syntax (a graph target).
+    pub(crate) fn to_results_format(self) -> Option<SparqlResultsFormat> {
         match self {
-            Self::Json => SparqlResultsFormat::Json,
-            Self::Xml => SparqlResultsFormat::Xml,
-            Self::Csv => SparqlResultsFormat::Csv,
-            Self::Tsv => SparqlResultsFormat::Tsv,
+            Self::Json => Some(SparqlResultsFormat::Json),
+            Self::Xml => Some(SparqlResultsFormat::Xml),
+            Self::Csv => Some(SparqlResultsFormat::Csv),
+            Self::Tsv => Some(SparqlResultsFormat::Tsv),
+            _ => None,
+        }
+    }
+
+    /// The [`NativeRdfFormat`] this choice names, or `None` when it names a
+    /// SPARQL-results format (a solutions/boolean target).
+    pub(crate) fn to_rdf_format(self) -> Option<NativeRdfFormat> {
+        use NativeRdfFormat as N;
+        match self {
+            Self::Turtle => Some(N::Turtle),
+            Self::Trig => Some(N::TriG),
+            Self::Ntriples => Some(N::NTriples),
+            Self::Nquads => Some(N::NQuads),
+            Self::Rdfxml => Some(N::RdfXml),
+            Self::Trix => Some(N::TriX),
+            Self::Hextuples => Some(N::HexTuples),
+            Self::Jsonld => Some(N::JsonLd),
+            Self::Yamlld => Some(N::YamlLd),
+            _ => None,
+        }
+    }
+
+    /// The canonical CLI token that names this choice (for diagnostics).
+    pub(crate) fn token(self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Xml => "xml",
+            Self::Csv => "csv",
+            Self::Tsv => "tsv",
+            Self::Turtle => "turtle",
+            Self::Trig => "trig",
+            Self::Ntriples => "ntriples",
+            Self::Nquads => "nquads",
+            Self::Rdfxml => "rdfxml",
+            Self::Trix => "trix",
+            Self::Hextuples => "hextuples",
+            Self::Jsonld => "jsonld",
+            Self::Yamlld => "yamlld",
         }
     }
 }

--- a/crates/cli/src/convert.rs
+++ b/crates/cli/src/convert.rs
@@ -86,12 +86,19 @@ pub(crate) fn run(
         return run_with_transforms(source_format, options, input, output, ledger_target);
     }
 
-    // Pack → pack: a verified byte passthrough (no decode/re-encode churn).
+    // Pack → pack: a verified byte passthrough (no decode/re-encode churn). A DISK
+    // pack is mmap-borrowed (no `Vec<u8>` copy of the pack contents); stdin has no
+    // file to map, so it still buffers into a `Vec`.
     let target_format = format::resolve(options.to, output)?;
     if matches!(source_format, CliFormat::Pack) && matches!(target_format, CliFormat::Pack) {
-        let bytes = source::read_bytes(input)?;
-        verify_pack(&bytes)?;
-        sink::write_out(output, &bytes)?;
+        if input == "-" {
+            let bytes = source::read_bytes(input)?;
+            verify_pack(&bytes)?;
+            sink::write_out(output, &bytes)?;
+        } else {
+            let mmap = source::verified_pack_mmap(input)?;
+            sink::write_out(output, &mmap[..])?;
+        }
         return ledger::surface(ledger_target, &LossLedger::new());
     }
 

--- a/crates/cli/src/convert.rs
+++ b/crates/cli/src/convert.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! The `convert` subcommand: `Source → Sink` with no transform.
+//! The `convert` subcommand: `Source → [entail] → [canonicalize] → Sink`.
 //!
 //! Resolve the source and target formats, open the source as a view, and write it
 //! through the [`sink`]. A pack→pack conversion is a verified byte
@@ -9,13 +9,32 @@
 //! combination flows the source view into [`sink::write_rdf`], which serializes to
 //! the target syntax or rebuilds the pack container. The resulting loss ledger is
 //! surfaced under `--loss-ledger`.
+//!
+//! ## Transforms: `--entailment` and `--canonical`
+//!
+//! Two optional transforms compose in a fixed order (entail first, then
+//! canonicalize), and both need a concrete owned dataset — so when either is
+//! present the pipeline reconstructs an `Arc<RdfDataset>` up front (a text source is
+//! parsed, a pack source is rebuilt via [`source::load_dataset`]) instead of taking
+//! the zero-copy view path:
+//!
+//! * `--entailment REGIME` materializes the regime's closure in memory (rejecting
+//!   the non-materializable regimes on the same exit-3 path as `reason`).
+//! * `--canonical` emits the RDFC-1.0 canonical N-Quads document
+//!   ([`canonical_flat_nquads`]) rather than the `--to` format. Canonical output is
+//!   always N-Quads, so `--canonical` OVERRIDES (and lets you omit) `--to`.
 
-use purrdf_core::{DatasetView, LossLedger, verify_pack};
+use std::sync::Arc;
 
-use crate::cli::{CliRdfFormat, LedgerTarget};
+use purrdf_core::{DatasetView, LossLedger, RdfDataset, verify_pack};
+use purrdf_entail::materialize;
+use purrdf_rdf::canonical_flat_nquads;
+
+use crate::cli::{CliRdfFormat, CliRegime, LedgerTarget};
 use crate::error::CliError;
 use crate::format::{self, CliFormat};
 use crate::ledger;
+use crate::reason;
 use crate::sink;
 use crate::source::{self, ViewOp};
 
@@ -36,18 +55,39 @@ impl ViewOp for ConvertOp<'_> {
     }
 }
 
+/// The resolved `convert` flags: the format overrides plus the parse base and the
+/// two optional transforms. Grouping them keeps [`run`]'s signature small and lets
+/// the transform lane borrow them by reference.
+pub(crate) struct ConvertOptions<'a> {
+    /// The `--from` input-format override.
+    pub(crate) from: Option<CliRdfFormat>,
+    /// The `--to` output-format override.
+    pub(crate) to: Option<CliRdfFormat>,
+    /// The `--base` parse/serialize base IRI.
+    pub(crate) base: Option<&'a str>,
+    /// The `--entailment` regime to materialize before serializing.
+    pub(crate) entailment: Option<CliRegime>,
+    /// Whether `--canonical` was set (emit RDFC-1.0 canonical N-Quads).
+    pub(crate) canonical: bool,
+}
+
 /// Run the `convert` subcommand.
 pub(crate) fn run(
-    from: Option<CliRdfFormat>,
-    to: Option<CliRdfFormat>,
+    options: &ConvertOptions<'_>,
     input: &str,
     output: &str,
     ledger_target: &LedgerTarget,
 ) -> Result<(), CliError> {
-    let source_format = format::resolve(from, input)?;
-    let target_format = format::resolve(to, output)?;
+    let source_format = format::resolve(options.from, input)?;
+
+    // The transform lane: either `--entailment` or `--canonical` needs a concrete
+    // owned dataset, so reconstruct one and apply the transforms in order.
+    if options.canonical || options.entailment.is_some() {
+        return run_with_transforms(source_format, options, input, output, ledger_target);
+    }
 
     // Pack → pack: a verified byte passthrough (no decode/re-encode churn).
+    let target_format = format::resolve(options.to, output)?;
     if matches!(source_format, CliFormat::Pack) && matches!(target_format, CliFormat::Pack) {
         let bytes = source::read_bytes(input)?;
         verify_pack(&bytes)?;
@@ -59,13 +99,51 @@ pub(crate) fn run(
     let ledger = source::run_over_input(
         input,
         source_format,
-        None,
+        options.base,
         ConvertOp {
             out: output,
             target: target_format,
-            base: None,
+            base: options.base,
             src_codec,
         },
     )?;
+    ledger::surface(ledger_target, &ledger)
+}
+
+/// The `--entailment` / `--canonical` lane: reconstruct an owned dataset, optionally
+/// materialize its entailment closure, then either emit canonical N-Quads or
+/// serialize to the `--to` target.
+fn run_with_transforms(
+    source_format: CliFormat,
+    options: &ConvertOptions<'_>,
+    input: &str,
+    output: &str,
+    ledger_target: &LedgerTarget,
+) -> Result<(), CliError> {
+    let dataset = source::load_dataset(input, source_format, options.base)?;
+
+    // Entail first: materialize the regime's closure (rejecting the
+    // non-materializable regimes on the same exit-3 path `reason` uses).
+    let dataset: Arc<RdfDataset> = match options.entailment {
+        Some(regime) => {
+            let regime = reason::resolve_materializable_regime(regime)?;
+            materialize(&dataset, regime)?
+        }
+        None => dataset,
+    };
+
+    // Then canonicalize: RDFC-1.0 canonical N-Quads always override `--to`.
+    if options.canonical {
+        let nquads = canonical_flat_nquads(&dataset).map_err(CliError::Runtime)?;
+        sink::write_out(output, nquads.as_bytes())?;
+        // The RDFC-1.0 canonical N-Quads document flattens the RDF 1.2 statement
+        // overlay into plain triples; it is a lossless re-rendering, so no ledger.
+        return ledger::surface(ledger_target, &LossLedger::new());
+    }
+
+    // No `--canonical`: serialize the (possibly entailed) closure to `--to`.
+    let target_format = format::resolve(options.to, output)?;
+    let src_codec = source_format.loss_codec_name();
+    let ledger = sink::write_rdf(&*dataset, output, target_format, options.base, src_codec)?;
     ledger::surface(ledger_target, &ledger)
 }

--- a/crates/cli/src/convert.rs
+++ b/crates/cli/src/convert.rs
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The `convert` subcommand: `Source → Sink` with no transform.
+//!
+//! Resolve the source and target formats, open the source as a view, and write it
+//! through the [`sink`]. A pack→pack conversion is a verified byte
+//! passthrough (re-encoding a pack would be pointless churn); every other
+//! combination flows the source view into [`sink::write_rdf`], which serializes to
+//! the target syntax or rebuilds the pack container. The resulting loss ledger is
+//! surfaced under `--loss-ledger`.
+
+use purrdf_core::{DatasetView, LossLedger, verify_pack};
+
+use crate::cli::{CliRdfFormat, LedgerTarget};
+use crate::error::CliError;
+use crate::format::{self, CliFormat};
+use crate::ledger;
+use crate::sink;
+use crate::source::{self, ViewOp};
+
+/// The generic sink operation for a convert: serialize whichever concrete view the
+/// source resolved to into the target format.
+struct ConvertOp<'a> {
+    out: &'a str,
+    target: CliFormat,
+    base: Option<&'a str>,
+    src_codec: Option<&'a str>,
+}
+
+impl ViewOp for ConvertOp<'_> {
+    type Output = LossLedger;
+
+    fn run<D: DatasetView + Sync>(self, view: &D) -> Result<LossLedger, CliError> {
+        sink::write_rdf(view, self.out, self.target, self.base, self.src_codec)
+    }
+}
+
+/// Run the `convert` subcommand.
+pub(crate) fn run(
+    from: Option<CliRdfFormat>,
+    to: Option<CliRdfFormat>,
+    input: &str,
+    output: &str,
+    ledger_target: &LedgerTarget,
+) -> Result<(), CliError> {
+    let source_format = format::resolve(from, input)?;
+    let target_format = format::resolve(to, output)?;
+
+    // Pack → pack: a verified byte passthrough (no decode/re-encode churn).
+    if matches!(source_format, CliFormat::Pack) && matches!(target_format, CliFormat::Pack) {
+        let bytes = source::read_bytes(input)?;
+        verify_pack(&bytes)?;
+        sink::write_out(output, &bytes)?;
+        return ledger::surface(ledger_target, &LossLedger::new());
+    }
+
+    let src_codec = source_format.loss_codec_name();
+    let ledger = source::run_over_input(
+        input,
+        source_format,
+        None,
+        ConvertOp {
+            out: output,
+            target: target_format,
+            base: None,
+            src_codec,
+        },
+    )?;
+    ledger::surface(ledger_target, &ledger)
+}

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The single CLI error type and its process-exit-code mapping.
+//!
+//! Every fallible step in the pipeline funnels its error into [`CliError`], whose
+//! [`CliError::exit_code`] classifies it into the three-way exit contract the shell
+//! sees:
+//!
+//! * **2** — argument / usage errors ([`CliError::Usage`]). This matches clap's own
+//!   exit code for a malformed command line, so a usage error the pipeline detects
+//!   (e.g. stdin with no explicit format) is indistinguishable to a caller from one
+//!   clap rejects.
+//! * **3** — an entailment-regime boundary the CLI cannot cross
+//!   ([`CliError::UnsupportedRegime`]): the regime needs inputs (query class
+//!   expressions or a rule set) the CLI has no way to supply.
+//! * **1** — every other runtime failure ([`CliError::Runtime`]): a parse/serialize
+//!   diagnostic, a pack-integrity failure, an I/O error, or a results-serialization
+//!   error.
+//!
+//! The `From` conversions below let the pipeline propagate library errors with `?`
+//! while preserving that classification: an [`EntailError::Unsupported`] becomes an
+//! [`CliError::UnsupportedRegime`] (exit 3), and everything else becomes
+//! [`CliError::Runtime`] (exit 1).
+
+use std::fmt;
+
+use purrdf_core::{PackError, RdfDiagnostic};
+use purrdf_entail::EntailError;
+
+/// A CLI-level failure, carrying its rendered message and its exit classification.
+#[derive(Debug)]
+pub(crate) enum CliError {
+    /// An argument / usage error (exit code 2).
+    Usage(String),
+    /// An entailment regime the CLI cannot materialize because it needs extra
+    /// inputs (exit code 3).
+    UnsupportedRegime(String),
+    /// Any other runtime failure — parse, serialize, pack integrity, or I/O
+    /// (exit code 1).
+    Runtime(String),
+}
+
+impl CliError {
+    /// The process exit code for this error's category (2 usage / 3 unsupported
+    /// regime / 1 runtime).
+    pub(crate) fn exit_code(&self) -> i32 {
+        match self {
+            Self::Usage(_) => 2,
+            Self::UnsupportedRegime(_) => 3,
+            Self::Runtime(_) => 1,
+        }
+    }
+}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Usage(msg) | Self::UnsupportedRegime(msg) | Self::Runtime(msg) => {
+                f.write_str(msg)
+            }
+        }
+    }
+}
+
+impl std::error::Error for CliError {}
+
+impl From<RdfDiagnostic> for CliError {
+    fn from(diagnostic: RdfDiagnostic) -> Self {
+        Self::Runtime(diagnostic.to_string())
+    }
+}
+
+impl From<PackError> for CliError {
+    fn from(error: PackError) -> Self {
+        Self::Runtime(error.to_string())
+    }
+}
+
+impl From<std::io::Error> for CliError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Runtime(error.to_string())
+    }
+}
+
+impl From<purrdf_sparql_results::Error> for CliError {
+    fn from(error: purrdf_sparql_results::Error) -> Self {
+        Self::Runtime(error.to_string())
+    }
+}
+
+impl From<EntailError> for CliError {
+    fn from(error: EntailError) -> Self {
+        match &error {
+            EntailError::Unsupported(_) => Self::UnsupportedRegime(error.to_string()),
+            _ => Self::Runtime(error.to_string()),
+        }
+    }
+}

--- a/crates/cli/src/format.rs
+++ b/crates/cli/src/format.rs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Format resolution: the pipeline's input/output format decision.
+//!
+//! [`CliFormat`] is the resolved kind flowing through the pipeline — either one of
+//! the native RDF syntaxes ([`CliFormat::Rdf`]) or the native pack container
+//! ([`CliFormat::Pack`]). [`resolve`] turns an optional explicit `--from`/`--to`
+//! choice plus a path into a [`CliFormat`]: an explicit choice always wins;
+//! otherwise the path's extension is classified (with `purrpck`/`pack` recognized
+//! as the pack container, and every other extension routed through the native
+//! codec [`classify`]). A `-` (stdin/stdout) path has no
+//! extension, so it REQUIRES an explicit format.
+
+use std::path::Path;
+
+use purrdf_rdf::{NativeRdfFormat, classify};
+
+use crate::cli::CliRdfFormat;
+use crate::error::CliError;
+
+/// A resolved input/output format: a native RDF syntax or the pack container.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum CliFormat {
+    /// One of the nine native RDF text/graph syntaxes.
+    Rdf(NativeRdfFormat),
+    /// The native PurRDF pack container.
+    Pack,
+}
+
+impl CliFormat {
+    /// The loss-ledger codec name for this format, or `None` when it carries no
+    /// codec identity (TriX / HexTuples, or a pack).
+    pub(crate) fn loss_codec_name(self) -> Option<&'static str> {
+        match self {
+            Self::Rdf(format) => format.loss_codec_name(),
+            Self::Pack => None,
+        }
+    }
+}
+
+/// The two extensions that name the native pack container.
+const PACK_EXTENSIONS: [&str; 2] = ["purrpck", "pack"];
+
+/// Resolve a `--from`/`--to` choice plus a path into a [`CliFormat`].
+///
+/// Precedence: an explicit choice always wins. Otherwise the path's extension is
+/// classified — `purrpck`/`pack` → [`CliFormat::Pack`], any other extension is
+/// handed (dot-prefixed) to the native codec [`classify`].
+/// A `-` (stdin/stdout) path, or any path without an extension, has nothing to
+/// infer from and is a usage error unless an explicit format was supplied.
+pub(crate) fn resolve(explicit: Option<CliRdfFormat>, path: &str) -> Result<CliFormat, CliError> {
+    if let Some(choice) = explicit {
+        return Ok(choice.to_cli_format());
+    }
+
+    if path == "-" {
+        return Err(CliError::Usage(
+            "reading from / writing to stdin/stdout (`-`) requires an explicit --from/--to format"
+                .to_string(),
+        ));
+    }
+
+    let extension = Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .ok_or_else(|| {
+            CliError::Usage(format!(
+                "cannot infer a format for `{path}`: it has no file extension; \
+                 pass an explicit --from/--to format"
+            ))
+        })?
+        .to_ascii_lowercase();
+
+    if PACK_EXTENSIONS.contains(&extension.as_str()) {
+        return Ok(CliFormat::Pack);
+    }
+
+    let format = classify(&format!(".{extension}")).map_err(|diagnostic| {
+        CliError::Usage(format!(
+            "cannot infer a format for `{path}`: {diagnostic}; \
+             pass an explicit --from/--to format"
+        ))
+    })?;
+    Ok(CliFormat::Rdf(format))
+}

--- a/crates/cli/src/ledger.rs
+++ b/crates/cli/src/ledger.rs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Surfacing the loss ledger under the global `--loss-ledger` flag.
+//!
+//! [`surface`] renders the ledger's stable JSON exactly where the flag's decoded
+//! [`LedgerTarget`] directs: nowhere, stderr, or a file. The rendered JSON already
+//! carries a trailing newline, so the stderr write emits it verbatim.
+
+use purrdf_core::LossLedger;
+
+use crate::cli::LedgerTarget;
+use crate::error::CliError;
+
+/// Surface `ledger` per the decoded `--loss-ledger` target.
+///
+/// * [`LedgerTarget::Silent`] — emit nothing.
+/// * [`LedgerTarget::Stderr`] — write the JSON to stderr.
+/// * [`LedgerTarget::File`] — write the JSON to the given path.
+pub(crate) fn surface(target: &LedgerTarget, ledger: &LossLedger) -> Result<(), CliError> {
+    match target {
+        LedgerTarget::Silent => Ok(()),
+        LedgerTarget::Stderr => {
+            eprint!("{}", ledger.render_json());
+            Ok(())
+        }
+        LedgerTarget::File(path) => {
+            std::fs::write(path, ledger.render_json())?;
+            Ok(())
+        }
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -82,9 +82,19 @@ fn dispatch(cli: &Cli) -> Result<(), CliError> {
         ),
         Command::Reason {
             regime,
+            from,
+            to,
             base,
             input,
             output,
-        } => reason::run(*regime, base.as_deref(), input, output, &ledger_target),
+        } => reason::run(
+            *regime,
+            *from,
+            *to,
+            base.as_deref(),
+            input,
+            output,
+            &ledger_target,
+        ),
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The `purrdf` command-line interface.
+//!
+//! A single `Source → [transform] → Sink` pipeline exposed as three subcommands:
+//!
+//! * `convert` — transcode RDF between the native syntaxes and the pack container;
+//! * `query` — evaluate a SPARQL query over an RDF or pack source;
+//! * `reason` — materialize an entailment regime's closure over a source graph.
+//!
+//! plus the global `--loss-ledger` flag, which surfaces the machine-readable
+//! transcode loss ledger for whichever conversion ran.
+//!
+//! Exit codes: clap rejects a malformed command line with **2**; the pipeline maps
+//! its own failures the same way — usage errors → **2**, an unsupported entailment
+//! regime → **3**, every other runtime failure → **1** (see [`error::CliError`]).
+//! Nothing is swallowed: the error's message is printed to stderr and its category
+//! becomes the process exit code.
+
+mod cli;
+mod convert;
+mod error;
+mod format;
+mod ledger;
+mod query;
+mod reason;
+mod sink;
+mod source;
+
+use clap::Parser;
+
+use crate::cli::{Cli, Command};
+use crate::error::CliError;
+
+fn main() {
+    let parsed = Cli::parse();
+    if let Err(error) = dispatch(&parsed) {
+        eprintln!("purrdf: {error}");
+        std::process::exit(error.exit_code());
+    }
+}
+
+/// Route a parsed command line to its subcommand, threading the decoded global
+/// `--loss-ledger` target through.
+fn dispatch(cli: &Cli) -> Result<(), CliError> {
+    let ledger_target = cli.ledger_target();
+    match &cli.cmd {
+        Command::Convert {
+            from,
+            to,
+            input,
+            output,
+        } => convert::run(*from, *to, input, output, &ledger_target),
+        Command::Query {
+            data,
+            results_format,
+            query,
+        } => query::run(data, *results_format, query, &ledger_target),
+        Command::Reason {
+            regime,
+            input,
+            output,
+        } => reason::run(*regime, input, output, &ledger_target),
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -68,9 +68,18 @@ fn dispatch(cli: &Cli) -> Result<(), CliError> {
         ),
         Command::Query {
             data,
+            base,
+            entailment,
             results_format,
             query,
-        } => query::run(data, *results_format, query, &ledger_target),
+        } => query::run(
+            data,
+            base.as_deref(),
+            *entailment,
+            *results_format,
+            query,
+            &ledger_target,
+        ),
         Command::Reason {
             regime,
             input,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -82,8 +82,9 @@ fn dispatch(cli: &Cli) -> Result<(), CliError> {
         ),
         Command::Reason {
             regime,
+            base,
             input,
             output,
-        } => reason::run(*regime, input, output, &ledger_target),
+        } => reason::run(*regime, base.as_deref(), input, output, &ledger_target),
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -49,9 +49,23 @@ fn dispatch(cli: &Cli) -> Result<(), CliError> {
         Command::Convert {
             from,
             to,
+            base,
+            entailment,
+            canonical,
             input,
             output,
-        } => convert::run(*from, *to, input, output, &ledger_target),
+        } => convert::run(
+            &convert::ConvertOptions {
+                from: *from,
+                to: *to,
+                base: base.as_deref(),
+                entailment: *entailment,
+                canonical: *canonical,
+            },
+            input,
+            output,
+            &ledger_target,
+        ),
         Command::Query {
             data,
             results_format,

--- a/crates/cli/src/query.rs
+++ b/crates/cli/src/query.rs
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The `query` subcommand: evaluate a SPARQL query over a data source.
+//!
+//! The data source is opened as a view (a pack is queried zero-copy) and the
+//! prepared query is evaluated over it with [`NativeSparqlEngine`]. Results are
+//! emitted to stdout:
+//!
+//! * SELECT solutions and ASK booleans go through the W3C SPARQL-results
+//!   serializer in the requested `--results-format`; a shape the chosen format
+//!   cannot carry (e.g. an ASK boolean under CSV) surfaces the serializer's own
+//!   error as a runtime failure.
+//! * a CONSTRUCT/DESCRIBE graph is serialized as **N-Triples** — the core RDF
+//!   projection for a graph result (the full RDF-format dispatch is later work).
+
+use purrdf_core::{DatasetView, SparqlResult};
+use purrdf_rdf::{NativeRdfFormat, serialize_dataset_to_format};
+use purrdf_sparql_eval::{NativeSparqlEngine, PreparedQuery};
+use purrdf_sparql_results::{ResultProvenance, serialize};
+
+use crate::cli::{LedgerTarget, ResultsFormat};
+use crate::error::CliError;
+use crate::format;
+use crate::ledger;
+use crate::sink;
+use crate::source::{self, ViewOp};
+
+/// The generic query operation: evaluate the prepared query over whichever concrete
+/// view the data source resolved to, then emit the result.
+struct QueryOp<'a> {
+    engine: &'a NativeSparqlEngine,
+    prepared: &'a PreparedQuery,
+    results_format: ResultsFormat,
+}
+
+impl ViewOp for QueryOp<'_> {
+    type Output = ();
+
+    fn run<D: DatasetView + Sync>(self, view: &D) -> Result<(), CliError> {
+        let result = self.engine.query_prepared_view(view, self.prepared, &[])?;
+        emit_result(&result, self.results_format)
+    }
+}
+
+/// Emit a SPARQL result to stdout in the chosen results format.
+fn emit_result(result: &SparqlResult, results_format: ResultsFormat) -> Result<(), CliError> {
+    match result {
+        SparqlResult::Solutions { .. } | SparqlResult::Boolean(_) => {
+            let outcome = serialize(
+                result,
+                results_format.to_native(),
+                &ResultProvenance::default(),
+            )?;
+            sink::write_out("-", &outcome.bytes)
+        }
+        SparqlResult::Graph(graph) => {
+            // Core behavior: a CONSTRUCT/DESCRIBE graph is projected to N-Triples.
+            let outcome = serialize_dataset_to_format(&**graph, NativeRdfFormat::NTriples, None)?;
+            sink::write_out("-", &outcome.bytes)
+        }
+    }
+}
+
+/// Run the `query` subcommand.
+pub(crate) fn run(
+    data: &str,
+    results_format: ResultsFormat,
+    query: &str,
+    ledger_target: &LedgerTarget,
+) -> Result<(), CliError> {
+    let data_format = format::resolve(None, data)?;
+
+    let engine = NativeSparqlEngine::new();
+    let prepared = engine.prepare_query(query, None)?;
+
+    source::run_over_input(
+        data,
+        data_format,
+        None,
+        QueryOp {
+            engine: &engine,
+            // `prepared` is an `Arc<PreparedQuery>`; reborrow it as `&PreparedQuery`.
+            prepared: &prepared,
+            results_format,
+        },
+    )?;
+
+    // Querying performs no lossy transcode, but honor the flag uniformly.
+    ledger::surface(ledger_target, &purrdf_core::LossLedger::new())
+}

--- a/crates/cli/src/query.rs
+++ b/crates/cli/src/query.rs
@@ -4,60 +4,110 @@
 //! The `query` subcommand: evaluate a SPARQL query over a data source.
 //!
 //! The data source is opened as a view (a pack is queried zero-copy) and the
-//! prepared query is evaluated over it with [`NativeSparqlEngine`]. Results are
-//! emitted to stdout:
+//! prepared query is evaluated over it with [`NativeSparqlEngine`]. Both the input
+//! parse and the query itself resolve relative IRIs against `--base`.
 //!
-//! * SELECT solutions and ASK booleans go through the W3C SPARQL-results
-//!   serializer in the requested `--results-format`; a shape the chosen format
-//!   cannot carry (e.g. an ASK boolean under CSV) surfaces the serializer's own
-//!   error as a runtime failure.
-//! * a CONSTRUCT/DESCRIBE graph is serialized as **N-Triples** — the core RDF
-//!   projection for a graph result (the full RDF-format dispatch is later work).
+//! ## `--entailment`: query the closure, not the raw view
+//!
+//! Without `--entailment` the query runs over the raw view (text `RdfDataset` or a
+//! zero-copy `PackView`). With `--entailment REGIME` the pipeline reconstructs an
+//! owned `Arc<RdfDataset>` up front (a pack is rebuilt via [`source::load_dataset`]),
+//! materializes the regime's closure IN MEMORY (rejecting the non-materializable
+//! regimes on the same exit-3 path as `reason`), and queries the closure.
+//!
+//! ## The result-shape × format-kind dispatch
+//!
+//! `--results-format` is a superset [`QueryFormat`] of the four SPARQL-results
+//! serializations and the nine RDF syntaxes; the result SHAPE selects which half is
+//! legal:
+//!
+//! * SELECT [`Solutions`](SparqlResult::Solutions) / ASK
+//!   [`Boolean`](SparqlResult::Boolean) + a SPARQL-results format → the W3C results
+//!   serializer to stdout (a format that cannot carry the shape — CSV/TSV vs a
+//!   boolean — surfaces the serializer's own error);
+//! * a CONSTRUCT/DESCRIBE [`Graph`](SparqlResult::Graph) + an RDF syntax → the SAME
+//!   [`sink::write_rdf`] the `convert`/`reason` lanes use, so a star-incapable target
+//!   (e.g. RDF/XML) projects the RDF-1.2 statement layer and the loss ledger records
+//!   the drop (the universal-sink invariant), surfaced under `--loss-ledger`;
+//! * a shape/format-kind MISMATCH (solutions/boolean + an RDF syntax, or a graph +
+//!   a SPARQL-results format) is a hard runtime error (exit 1).
 
-use purrdf_core::{DatasetView, SparqlResult};
-use purrdf_rdf::{NativeRdfFormat, serialize_dataset_to_format};
+use purrdf_core::{DatasetView, LossLedger, SparqlResult};
+use purrdf_entail::materialize;
 use purrdf_sparql_eval::{NativeSparqlEngine, PreparedQuery};
 use purrdf_sparql_results::{ResultProvenance, serialize};
 
-use crate::cli::{LedgerTarget, ResultsFormat};
+use crate::cli::{CliRegime, LedgerTarget, QueryFormat};
 use crate::error::CliError;
-use crate::format;
+use crate::format::{self, CliFormat};
 use crate::ledger;
+use crate::reason;
 use crate::sink;
 use crate::source::{self, ViewOp};
 
 /// The generic query operation: evaluate the prepared query over whichever concrete
-/// view the data source resolved to, then emit the result.
+/// view the data source resolved to, returning the (fully owned) [`SparqlResult`].
+///
+/// A [`SparqlResult`] borrows nothing from the view — `Graph` is an `Arc<RdfDataset>`
+/// and every solution cell is an owned `TermValue` — so the result outlives the
+/// borrowed view and is emitted after `run_over_input` returns.
 struct QueryOp<'a> {
     engine: &'a NativeSparqlEngine,
     prepared: &'a PreparedQuery,
-    results_format: ResultsFormat,
 }
 
 impl ViewOp for QueryOp<'_> {
-    type Output = ();
+    type Output = SparqlResult;
 
-    fn run<D: DatasetView + Sync>(self, view: &D) -> Result<(), CliError> {
-        let result = self.engine.query_prepared_view(view, self.prepared, &[])?;
-        emit_result(&result, self.results_format)
+    fn run<D: DatasetView + Sync>(self, view: &D) -> Result<SparqlResult, CliError> {
+        Ok(self.engine.query_prepared_view(view, self.prepared, &[])?)
     }
 }
 
-/// Emit a SPARQL result to stdout in the chosen results format.
-fn emit_result(result: &SparqlResult, results_format: ResultsFormat) -> Result<(), CliError> {
+/// Emit a SPARQL result to stdout, dispatching on the result shape × format kind, and
+/// surface the loss ledger the emission produced.
+fn emit_result(
+    result: &SparqlResult,
+    results_format: QueryFormat,
+    base: Option<&str>,
+    ledger_target: &LedgerTarget,
+) -> Result<(), CliError> {
     match result {
         SparqlResult::Solutions { .. } | SparqlResult::Boolean(_) => {
-            let outcome = serialize(
-                result,
-                results_format.to_native(),
-                &ResultProvenance::default(),
-            )?;
-            sink::write_out("-", &outcome.bytes)
+            let Some(fmt) = results_format.to_results_format() else {
+                let kind = match result {
+                    SparqlResult::Boolean(_) => "an ASK boolean",
+                    _ => "SELECT solutions",
+                };
+                return Err(CliError::Runtime(format!(
+                    "{kind} result cannot be serialized to the RDF syntax `{}`: a SELECT/ASK \
+                     result needs a SPARQL-results format (json/xml/csv/tsv)",
+                    results_format.token()
+                )));
+            };
+            // The results serializer itself rejects the shapes its format cannot carry
+            // (CSV/TSV reject a boolean); its `Err` maps cleanly to a runtime failure.
+            let outcome = serialize(result, fmt, &ResultProvenance::default())?;
+            sink::write_out("-", &outcome.bytes)?;
+            // A tabular/boolean result performs no lossy transcode; honor the flag
+            // uniformly with an empty ledger.
+            ledger::surface(ledger_target, &LossLedger::new())
         }
         SparqlResult::Graph(graph) => {
-            // Core behavior: a CONSTRUCT/DESCRIBE graph is projected to N-Triples.
-            let outcome = serialize_dataset_to_format(&**graph, NativeRdfFormat::NTriples, None)?;
-            sink::write_out("-", &outcome.bytes)
+            let Some(fmt) = results_format.to_rdf_format() else {
+                return Err(CliError::Runtime(format!(
+                    "a CONSTRUCT/DESCRIBE graph result cannot be serialized to the SPARQL-results \
+                     format `{}`: a graph needs an RDF syntax \
+                     (turtle/trig/ntriples/nquads/rdfxml/trix/hextuples/jsonld/yamlld)",
+                    results_format.token()
+                )));
+            };
+            // The universal sink: a star-incapable target (RDF/XML, TriX, HexTuples)
+            // projects the RDF-1.2 statement layer and records the drop in the ledger.
+            // The graph is freshly constructed, so there is no source codec to seed the
+            // contract-loss half (`None`); only the realized dropped-row counts appear.
+            let ledger = sink::write_rdf(&**graph, "-", CliFormat::Rdf(fmt), base, None)?;
+            ledger::surface(ledger_target, &ledger)
         }
     }
 }
@@ -65,27 +115,37 @@ fn emit_result(result: &SparqlResult, results_format: ResultsFormat) -> Result<(
 /// Run the `query` subcommand.
 pub(crate) fn run(
     data: &str,
-    results_format: ResultsFormat,
+    base: Option<&str>,
+    entailment: Option<CliRegime>,
+    results_format: QueryFormat,
     query: &str,
     ledger_target: &LedgerTarget,
 ) -> Result<(), CliError> {
     let data_format = format::resolve(None, data)?;
 
     let engine = NativeSparqlEngine::new();
-    let prepared = engine.prepare_query(query, None)?;
+    let prepared = engine.prepare_query(query, base)?;
 
-    source::run_over_input(
-        data,
-        data_format,
-        None,
-        QueryOp {
-            engine: &engine,
-            // `prepared` is an `Arc<PreparedQuery>`; reborrow it as `&PreparedQuery`.
-            prepared: &prepared,
-            results_format,
-        },
-    )?;
+    let result = match entailment {
+        Some(regime) => {
+            // The `--entailment` lane: reconstruct an owned dataset (a pack is rebuilt),
+            // materialize the closure in memory, and query THAT.
+            let regime = reason::resolve_materializable_regime(regime)?;
+            let dataset = source::load_dataset(data, data_format, base)?;
+            let closure = materialize(&dataset, regime)?;
+            engine.query_prepared(&closure, &prepared, &[])?
+        }
+        None => source::run_over_input(
+            data,
+            data_format,
+            base,
+            QueryOp {
+                engine: &engine,
+                // `prepared` is an `Arc<PreparedQuery>`; reborrow it as `&PreparedQuery`.
+                prepared: &prepared,
+            },
+        )?,
+    };
 
-    // Querying performs no lossy transcode, but honor the flag uniformly.
-    ledger::surface(ledger_target, &purrdf_core::LossLedger::new())
+    emit_result(&result, results_format, base, ledger_target)
 }

--- a/crates/cli/src/reason.rs
+++ b/crates/cli/src/reason.rs
@@ -6,12 +6,17 @@
 //! Map the requested regime to its library [`Regime`], reject the regimes the CLI
 //! cannot materialize (they need inputs it has no way to supply), load the source
 //! as a concrete dataset, compute the entailment closure, and write it through the
-//! [`sink`] to the output (whose format is inferred from its
-//! extension). The resulting loss ledger is surfaced under `--loss-ledger`.
+//! [`sink`] to the output. Both `--from`/`--to` are resolved up front (mirroring
+//! `convert`): an explicit choice always wins, otherwise the format is inferred
+//! from the input/output path's extension; `-` (stdin/stdout) has no extension and
+//! REQUIRES the explicit override. Resolving both before `load_dataset`/
+//! `materialize` runs means an unresolvable output format fails fast, not after
+//! the source has already been loaded and closed over. The resulting loss ledger
+//! is surfaced under `--loss-ledger`.
 
 use purrdf_entail::{Regime, materialize};
 
-use crate::cli::{CliRegime, LedgerTarget};
+use crate::cli::{CliRdfFormat, CliRegime, LedgerTarget};
 use crate::error::CliError;
 use crate::format;
 use crate::ledger;
@@ -48,6 +53,8 @@ pub(crate) fn resolve_materializable_regime(regime: CliRegime) -> Result<Regime,
 /// Run the `reason` subcommand.
 pub(crate) fn run(
     regime: CliRegime,
+    from: Option<CliRdfFormat>,
+    to: Option<CliRdfFormat>,
     base: Option<&str>,
     input: &str,
     output: &str,
@@ -55,12 +62,16 @@ pub(crate) fn run(
 ) -> Result<(), CliError> {
     let regime = resolve_materializable_regime(regime)?;
 
-    let source_format = format::resolve(None, input)?;
+    // Resolve BOTH formats up front (before touching the source) so an
+    // unresolvable OUT fails fast rather than after the (potentially
+    // expensive) load + materialize work has already run.
+    let source_format = format::resolve(from, input)?;
+    let target_format = format::resolve(to, output)?;
+
     let dataset = source::load_dataset(input, source_format, base)?;
 
     let closure = materialize(&dataset, regime)?;
 
-    let target_format = format::resolve(None, output)?;
     let src_codec = source_format.loss_codec_name();
     let ledger = sink::write_rdf(&*closure, output, target_format, base, src_codec)?;
     ledger::surface(ledger_target, &ledger)

--- a/crates/cli/src/reason.rs
+++ b/crates/cli/src/reason.rs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The `reason` subcommand: `Source → materialize → Sink`.
+//!
+//! Map the requested regime to its library [`Regime`], reject the regimes the CLI
+//! cannot materialize (they need inputs it has no way to supply), load the source
+//! as a concrete dataset, compute the entailment closure, and write it through the
+//! [`sink`] to the output (whose format is inferred from its
+//! extension). The resulting loss ledger is surfaced under `--loss-ledger`.
+
+use purrdf_entail::{Regime, materialize};
+
+use crate::cli::{CliRegime, LedgerTarget};
+use crate::error::CliError;
+use crate::format;
+use crate::ledger;
+use crate::sink;
+use crate::source;
+
+/// Run the `reason` subcommand.
+pub(crate) fn run(
+    regime: CliRegime,
+    input: &str,
+    output: &str,
+    ledger_target: &LedgerTarget,
+) -> Result<(), CliError> {
+    let regime = regime.to_native();
+
+    // These regimes are not materialize-and-match: they need the query's class
+    // expressions (OWL-Direct), a parsed rule set (RIF), or are a spec-inherent
+    // materialization boundary (D). The CLI cannot supply those inputs.
+    if matches!(regime, Regime::OwlDirect | Regime::Rif | Regime::D) {
+        return Err(CliError::UnsupportedRegime(format!(
+            "entailment regime `{regime:?}` cannot be materialized by the CLI: it needs inputs \
+             (query class expressions or a rule set) the CLI has no way to supply"
+        )));
+    }
+
+    let source_format = format::resolve(None, input)?;
+    let dataset = source::load_dataset(input, source_format, None)?;
+
+    let closure = materialize(&dataset, regime)?;
+
+    let target_format = format::resolve(None, output)?;
+    let src_codec = source_format.loss_codec_name();
+    let ledger = sink::write_rdf(&*closure, output, target_format, None, src_codec)?;
+    ledger::surface(ledger_target, &ledger)
+}

--- a/crates/cli/src/reason.rs
+++ b/crates/cli/src/reason.rs
@@ -18,6 +18,25 @@ use crate::ledger;
 use crate::sink;
 use crate::source;
 
+/// Resolve a [`CliRegime`] to its library [`Regime`], rejecting the regimes the CLI
+/// cannot materialize.
+///
+/// OWL-Direct needs the query's class expressions, RIF needs a parsed rule set, and
+/// D (datatype) entailment is a spec-inherent materialization boundary — the CLI has
+/// no way to supply those inputs, so they map to the exit-3
+/// [`CliError::UnsupportedRegime`] path. Shared by `reason` and `convert
+/// --entailment` so both reject identically.
+pub(crate) fn resolve_materializable_regime(regime: CliRegime) -> Result<Regime, CliError> {
+    let regime = regime.to_native();
+    if matches!(regime, Regime::OwlDirect | Regime::Rif | Regime::D) {
+        return Err(CliError::UnsupportedRegime(format!(
+            "entailment regime `{regime:?}` cannot be materialized by the CLI: it needs inputs \
+             (query class expressions or a rule set) the CLI has no way to supply"
+        )));
+    }
+    Ok(regime)
+}
+
 /// Run the `reason` subcommand.
 pub(crate) fn run(
     regime: CliRegime,
@@ -25,17 +44,7 @@ pub(crate) fn run(
     output: &str,
     ledger_target: &LedgerTarget,
 ) -> Result<(), CliError> {
-    let regime = regime.to_native();
-
-    // These regimes are not materialize-and-match: they need the query's class
-    // expressions (OWL-Direct), a parsed rule set (RIF), or are a spec-inherent
-    // materialization boundary (D). The CLI cannot supply those inputs.
-    if matches!(regime, Regime::OwlDirect | Regime::Rif | Regime::D) {
-        return Err(CliError::UnsupportedRegime(format!(
-            "entailment regime `{regime:?}` cannot be materialized by the CLI: it needs inputs \
-             (query class expressions or a rule set) the CLI has no way to supply"
-        )));
-    }
+    let regime = resolve_materializable_regime(regime)?;
 
     let source_format = format::resolve(None, input)?;
     let dataset = source::load_dataset(input, source_format, None)?;

--- a/crates/cli/src/reason.rs
+++ b/crates/cli/src/reason.rs
@@ -28,10 +28,18 @@ use crate::source;
 /// --entailment` so both reject identically.
 pub(crate) fn resolve_materializable_regime(regime: CliRegime) -> Result<Regime, CliError> {
     let regime = regime.to_native();
-    if matches!(regime, Regime::OwlDirect | Regime::Rif | Regime::D) {
+    // Each boundary regime is unsupported for a DIFFERENT spec-inherent reason; name it.
+    let reason = match regime {
+        Regime::OwlDirect => Some(
+            "it needs the query's class expressions, which materialization alone cannot supply",
+        ),
+        Regime::Rif => Some("it needs a parsed RIF rule set, which the CLI has no way to supply"),
+        Regime::D => Some("datatype (D) entailment is a spec-inherent materialization boundary"),
+        Regime::Simple | Regime::Rdf | Regime::Rdfs | Regime::OwlRl => None,
+    };
+    if let Some(reason) = reason {
         return Err(CliError::UnsupportedRegime(format!(
-            "entailment regime `{regime:?}` cannot be materialized by the CLI: it needs inputs \
-             (query class expressions or a rule set) the CLI has no way to supply"
+            "entailment regime `{regime:?}` cannot be materialized by the CLI: {reason}"
         )));
     }
     Ok(regime)
@@ -40,6 +48,7 @@ pub(crate) fn resolve_materializable_regime(regime: CliRegime) -> Result<Regime,
 /// Run the `reason` subcommand.
 pub(crate) fn run(
     regime: CliRegime,
+    base: Option<&str>,
     input: &str,
     output: &str,
     ledger_target: &LedgerTarget,
@@ -47,12 +56,12 @@ pub(crate) fn run(
     let regime = resolve_materializable_regime(regime)?;
 
     let source_format = format::resolve(None, input)?;
-    let dataset = source::load_dataset(input, source_format, None)?;
+    let dataset = source::load_dataset(input, source_format, base)?;
 
     let closure = materialize(&dataset, regime)?;
 
     let target_format = format::resolve(None, output)?;
     let src_codec = source_format.loss_codec_name();
-    let ledger = sink::write_rdf(&*closure, output, target_format, None, src_codec)?;
+    let ledger = sink::write_rdf(&*closure, output, target_format, base, src_codec)?;
     ledger::surface(ledger_target, &ledger)
 }

--- a/crates/cli/src/sink.rs
+++ b/crates/cli/src/sink.rs
@@ -38,12 +38,21 @@ const STATEMENT_ROWS_DROPPED_CODE: &str = "statement-rows-dropped";
 const DIRECTION_DROPPED_CODE: &str = "rdf12-direction-dropped";
 
 /// Write `bytes` to `out`, or to stdout when `out` is `-`.
+///
+/// A downstream consumer that closes its end of the pipe early (the ubiquitous
+/// `purrdf … | head` / `| grep -q` idiom) makes the stdout write fail with
+/// [`std::io::ErrorKind::BrokenPipe`]. Standard Unix filters exit 0 silently on a
+/// downstream EPIPE, so that one error kind is treated as a clean success here; every
+/// other error (including on a file target) still propagates.
 pub(crate) fn write_out(out: &str, bytes: &[u8]) -> Result<(), CliError> {
     if out == "-" {
         let stdout = std::io::stdout();
         let mut handle = stdout.lock();
-        handle.write_all(bytes)?;
-        handle.flush()?;
+        if let Err(error) = handle.write_all(bytes).and_then(|()| handle.flush())
+            && error.kind() != std::io::ErrorKind::BrokenPipe
+        {
+            return Err(error.into());
+        }
     } else {
         std::fs::write(out, bytes)?;
     }

--- a/crates/cli/src/sink.rs
+++ b/crates/cli/src/sink.rs
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The unified output sink: serialize a view to a target format and write it.
+//!
+//! [`write_rdf`] is the one place the pipeline emits a dataset. It handles both
+//! target kinds:
+//!
+//! * an RDF syntax → [`serialize_dataset_to_format`] over the borrowed view (a
+//!   `PackView` serializes with zero materialization), then write the bytes;
+//! * the pack container → reconstruct a concrete dataset via
+//!   [`dataset_from_view`] and build the pack bytes with [`PackBuilder`].
+//!
+//! It returns the [`LossLedger`] for the conversion so `main` can surface it under
+//! `--loss-ledger`. The ledger combines the **contract** losses for the
+//! `(source-codec → target-codec)` pair ([`pair_loss_ledger`], when both codec
+//! names are known) with the **realized** count of RDF-1.2 statement-layer rows the
+//! serializer actually dropped (recorded as a runtime entry only when non-zero).
+
+use std::borrow::Cow;
+use std::io::Write;
+
+use purrdf_core::{
+    DatasetView, LossEntry, LossLedger, PackBuilder, dataset_from_view, pair_loss_ledger,
+};
+use purrdf_rdf::serialize_dataset_to_format;
+
+use crate::error::CliError;
+use crate::format::CliFormat;
+
+/// The runtime loss code recording how many RDF-1.2 statement-layer rows the
+/// serializer dropped because the target format does not carry the star layer.
+const STATEMENT_ROWS_DROPPED_CODE: &str = "statement-rows-dropped";
+
+/// Write `bytes` to `out`, or to stdout when `out` is `-`.
+pub(crate) fn write_out(out: &str, bytes: &[u8]) -> Result<(), CliError> {
+    if out == "-" {
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+        handle.write_all(bytes)?;
+        handle.flush()?;
+    } else {
+        std::fs::write(out, bytes)?;
+    }
+    Ok(())
+}
+
+/// Serialize `view` to `target` and write it to `out`, returning the loss ledger.
+///
+/// `src_codec` is the source format's loss-ledger codec name when known (`None`
+/// for a pack source or a codec-less syntax); it seeds the contract-loss half of
+/// the returned ledger.
+pub(crate) fn write_rdf<D: DatasetView>(
+    view: &D,
+    out: &str,
+    target: CliFormat,
+    base: Option<&str>,
+    src_codec: Option<&str>,
+) -> Result<LossLedger, CliError> {
+    match target {
+        CliFormat::Rdf(format) => {
+            let outcome = serialize_dataset_to_format(view, format, base)?;
+            write_out(out, &outcome.bytes)?;
+            Ok(build_ledger(
+                src_codec,
+                format.loss_codec_name(),
+                outcome.statement_rows_dropped,
+            ))
+        }
+        CliFormat::Pack => {
+            let dataset = dataset_from_view(view)?;
+            let bytes = PackBuilder::build_bytes(&dataset)?;
+            write_out(out, &bytes)?;
+            // A pack is a lossless RDF-1.2 container: no ledger entries.
+            Ok(LossLedger::new())
+        }
+    }
+}
+
+/// Combine the contract losses for `(src_codec → dst_codec)` with the realized
+/// dropped-statement-row count.
+fn build_ledger(
+    src_codec: Option<&str>,
+    dst_codec: Option<&str>,
+    statement_rows_dropped: usize,
+) -> LossLedger {
+    let mut ledger = match (src_codec, dst_codec) {
+        (Some(from), Some(to)) => pair_loss_ledger(from, to),
+        _ => LossLedger::new(),
+    };
+    if statement_rows_dropped > 0 {
+        ledger.record(LossEntry {
+            code: Cow::Borrowed(STATEMENT_ROWS_DROPPED_CODE),
+            from: Cow::Owned(src_codec.unwrap_or("unknown").to_string()),
+            to: Cow::Owned(dst_codec.unwrap_or("unknown").to_string()),
+            note: Cow::Owned(format!(
+                "{statement_rows_dropped} RDF-1.2 statement-layer row(s) (reifier bindings + \
+                 annotation triples) were dropped because the target format does not carry the \
+                 star layer"
+            )),
+            location: None,
+        });
+    }
+    ledger
+}

--- a/crates/cli/src/sink.rs
+++ b/crates/cli/src/sink.rs
@@ -32,6 +32,11 @@ use crate::format::CliFormat;
 /// serializer dropped because the target format does not carry the star layer.
 const STATEMENT_ROWS_DROPPED_CODE: &str = "statement-rows-dropped";
 
+/// The runtime loss code recording how many base-direction object literals the
+/// serializer dropped because the target format (TriX / HexTuples) has no
+/// direction surface — it keeps the language tag but cannot carry `--ltr` / `--rtl`.
+const DIRECTION_DROPPED_CODE: &str = "rdf12-direction-dropped";
+
 /// Write `bytes` to `out`, or to stdout when `out` is `-`.
 pub(crate) fn write_out(out: &str, bytes: &[u8]) -> Result<(), CliError> {
     if out == "-" {
@@ -65,6 +70,7 @@ pub(crate) fn write_rdf<D: DatasetView>(
                 src_codec,
                 format.loss_codec_name(),
                 outcome.statement_rows_dropped,
+                outcome.directional_literals_dropped,
             ))
         }
         CliFormat::Pack => {
@@ -78,11 +84,12 @@ pub(crate) fn write_rdf<D: DatasetView>(
 }
 
 /// Combine the contract losses for `(src_codec → dst_codec)` with the realized
-/// dropped-statement-row count.
+/// dropped-row counts (RDF-1.2 statement-layer rows and base-direction literals).
 fn build_ledger(
     src_codec: Option<&str>,
     dst_codec: Option<&str>,
     statement_rows_dropped: usize,
+    directional_literals_dropped: usize,
 ) -> LossLedger {
     let mut ledger = match (src_codec, dst_codec) {
         (Some(from), Some(to)) => pair_loss_ledger(from, to),
@@ -97,6 +104,19 @@ fn build_ledger(
                 "{statement_rows_dropped} RDF-1.2 statement-layer row(s) (reifier bindings + \
                  annotation triples) were dropped because the target format does not carry the \
                  star layer"
+            )),
+            location: None,
+        });
+    }
+    if directional_literals_dropped > 0 {
+        ledger.record(LossEntry {
+            code: Cow::Borrowed(DIRECTION_DROPPED_CODE),
+            from: Cow::Owned(src_codec.unwrap_or("unknown").to_string()),
+            to: Cow::Owned(dst_codec.unwrap_or("unknown").to_string()),
+            note: Cow::Owned(format!(
+                "{directional_literals_dropped} literal base direction(s) were dropped because \
+                 the target format (TriX / HexTuples) has no direction surface — the language \
+                 tag is retained but `--ltr` / `--rtl` is lost"
             )),
             location: None,
         });

--- a/crates/cli/src/source.rs
+++ b/crates/cli/src/source.rs
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The input source: reading a path (or stdin) into a queryable/serializable view.
+//!
+//! ## Dispatching over a non-object-safe `DatasetView`
+//!
+//! [`DatasetView`] uses return-position `impl Trait` in
+//! its methods, so it is **not** object-safe: there is no `&dyn DatasetView`.
+//! The pipeline therefore cannot erase the concrete view type behind a trait
+//! object. Instead it dispatches by input KIND and runs a **generic operation**
+//! monomorphized per arm:
+//!
+//! * a text/graph source is parsed into a concrete `RdfDataset` and the operation
+//!   runs over `&RdfDataset`;
+//! * a pack source is opened as a `PackView` and the operation runs over
+//!   `&PackView` — zero materialization.
+//!
+//! Because a Rust closure cannot itself be generic, the operation is expressed as
+//! a [`ViewOp`] trait whose single `run` method is generic over the view type;
+//! [`run_over_input`] calls `op.run(&view)` in each arm so the compiler emits one
+//! monomorphization per concrete view.
+//!
+//! ## Pack sources and mmap
+//!
+//! A pack file on disk is opened **read-only** and memory-mapped, then handed to
+//! [`PackView::from_bytes`] zero-copy; the mapping is held alive for the whole
+//! operation. A pack arriving on **stdin** cannot be mmap'd, so it is read into a
+//! `Vec<u8>` and viewed over that buffer instead. Either way the bytes are
+//! **unconditionally** run through [`verify_pack`] (fail-closed integrity) before
+//! any view is opened.
+//!
+//! SAFETY / caveat: the mmap is a read-only view of a file this process does not
+//! mutate. `Mmap::map` is `unsafe` because the OS cannot guarantee another process
+//! won't mutate the backing file underneath the mapping; the CLI's contract is
+//! that a pack file it reads is not concurrently rewritten for the brief duration
+//! of the operation. No concurrent mutation of the mapped file is performed or
+//! tolerated.
+
+use std::fs::File;
+use std::io::Read;
+use std::sync::Arc;
+
+use purrdf_core::{DatasetView, PackView, RdfDataset, dataset_from_view, verify_pack};
+use purrdf_rdf::parse_dataset;
+
+use crate::error::CliError;
+use crate::format::CliFormat;
+
+/// A generic operation to run over whichever concrete [`DatasetView`] the input
+/// resolves to.
+///
+/// The one method is generic over the view type (`D`), which is exactly why this
+/// is a trait rather than a closure: it lets [`run_over_input`] hand the operation
+/// either a `&RdfDataset` or a `&PackView` and have the compiler monomorphize
+/// `run` for each, sidestepping `DatasetView`'s lack of object safety.
+pub(crate) trait ViewOp {
+    /// What the operation produces on success.
+    type Output;
+
+    /// Run the operation over a borrowed concrete view.
+    fn run<D: DatasetView + Sync>(self, view: &D) -> Result<Self::Output, CliError>;
+}
+
+/// Read every byte of a path, or of stdin when `path` is `-`.
+pub(crate) fn read_bytes(path: &str) -> Result<Vec<u8>, CliError> {
+    if path == "-" {
+        let mut buffer = Vec::new();
+        std::io::stdin().read_to_end(&mut buffer)?;
+        Ok(buffer)
+    } else {
+        Ok(std::fs::read(path)?)
+    }
+}
+
+/// Open `path` as the concrete view its `format` implies and run `op` over it.
+///
+/// The text arm parses into an `RdfDataset`; the pack arm mmaps the file (or reads
+/// stdin into a `Vec`), verifies its integrity, and opens a zero-copy `PackView`.
+/// The mmap/`Vec` backing store is held alive for the whole `op.run` call.
+pub(crate) fn run_over_input<Op: ViewOp>(
+    path: &str,
+    format: CliFormat,
+    base: Option<&str>,
+    op: Op,
+) -> Result<Op::Output, CliError> {
+    match format {
+        CliFormat::Rdf(rdf_format) => {
+            let bytes = read_bytes(path)?;
+            let dataset = parse_dataset(&bytes, rdf_format.media_type(), base)?;
+            op.run(&*dataset)
+        }
+        CliFormat::Pack => {
+            if path == "-" {
+                let bytes = read_bytes(path)?;
+                verify_pack(&bytes)?;
+                let view = PackView::from_bytes(&bytes)?;
+                op.run(&view)
+            } else {
+                let file = File::open(path)?;
+                // SAFETY: `file` is opened read-only just above and this process
+                // does not mutate it (nor tolerate concurrent external mutation)
+                // for the brief lifetime of the mapping, which is confined to
+                // this call and dropped before the function returns. This is the
+                // documented external-consumer mmap seam (see the module docs and
+                // `crates/rdf-core/tests/pack_mmap.rs`).
+                let mmap = unsafe { memmap2::Mmap::map(&file)? };
+                verify_pack(&mmap[..])?;
+                let view = PackView::from_bytes(&mmap[..])?;
+                op.run(&view)
+            }
+        }
+    }
+}
+
+/// Open `path` and reconstruct a concrete `Arc<RdfDataset>`, whatever its kind.
+///
+/// The text arm parses directly; the pack arm opens a `PackView` (verified) and
+/// reconstructs a concrete dataset via [`dataset_from_view`]. This is the entry
+/// point for steps that genuinely need an owned dataset (e.g. entailment
+/// materialization, whose `materialize` takes a `&RdfDataset`).
+pub(crate) fn load_dataset(
+    path: &str,
+    format: CliFormat,
+    base: Option<&str>,
+) -> Result<Arc<RdfDataset>, CliError> {
+    match format {
+        CliFormat::Rdf(rdf_format) => {
+            let bytes = read_bytes(path)?;
+            Ok(parse_dataset(&bytes, rdf_format.media_type(), base)?)
+        }
+        CliFormat::Pack => {
+            if path == "-" {
+                let bytes = read_bytes(path)?;
+                verify_pack(&bytes)?;
+                let view = PackView::from_bytes(&bytes)?;
+                Ok(dataset_from_view(&view)?)
+            } else {
+                let file = File::open(path)?;
+                // SAFETY: identical to `run_over_input`'s pack arm — a read-only,
+                // non-concurrently-mutated mapping confined to this call.
+                let mmap = unsafe { memmap2::Mmap::map(&file)? };
+                verify_pack(&mmap[..])?;
+                let view = PackView::from_bytes(&mmap[..])?;
+                Ok(dataset_from_view(&view)?)
+            }
+        }
+    }
+}

--- a/crates/cli/src/source.rs
+++ b/crates/cli/src/source.rs
@@ -73,6 +73,29 @@ pub(crate) fn read_bytes(path: &str) -> Result<Vec<u8>, CliError> {
     }
 }
 
+/// Open a DISK pack `path` read-only, mmap it, and verify its integrity.
+///
+/// This is the mmap seam factored out of the pack arms of [`run_over_input`] and
+/// [`load_dataset`] so a caller that only needs the verified bytes (not a
+/// `PackView`) — e.g. `convert`'s pack→pack byte passthrough — can borrow them
+/// without materializing a `Vec<u8>` copy of the pack. Callers on **stdin** cannot
+/// use this (there is no file to map); they must fall back to [`read_bytes`] +
+/// [`verify_pack`].
+///
+/// SAFETY / caveat: identical to the pack arms above — a read-only mapping of a
+/// file this process does not mutate (nor tolerates concurrent external mutation
+/// of) for the brief lifetime of the mapping, which the caller holds alive only as
+/// long as it needs the borrowed bytes.
+pub(crate) fn verified_pack_mmap(path: &str) -> Result<memmap2::Mmap, CliError> {
+    let file = File::open(path)?;
+    // SAFETY: see the module docs and the identical comment on the pack arms of
+    // `run_over_input` / `load_dataset` — a read-only, non-concurrently-mutated
+    // mapping confined to the caller's use of the returned `Mmap`.
+    let mmap = unsafe { memmap2::Mmap::map(&file)? };
+    verify_pack(&mmap[..])?;
+    Ok(mmap)
+}
+
 /// Open `path` as the concrete view its `format` implies and run `op` over it.
 ///
 /// The text arm parses into an `RdfDataset`; the pack arm mmaps the file (or reads
@@ -97,15 +120,7 @@ pub(crate) fn run_over_input<Op: ViewOp>(
                 let view = PackView::from_bytes(&bytes)?;
                 op.run(&view)
             } else {
-                let file = File::open(path)?;
-                // SAFETY: `file` is opened read-only just above and this process
-                // does not mutate it (nor tolerate concurrent external mutation)
-                // for the brief lifetime of the mapping, which is confined to
-                // this call and dropped before the function returns. This is the
-                // documented external-consumer mmap seam (see the module docs and
-                // `crates/rdf-core/tests/pack_mmap.rs`).
-                let mmap = unsafe { memmap2::Mmap::map(&file)? };
-                verify_pack(&mmap[..])?;
+                let mmap = verified_pack_mmap(path)?;
                 let view = PackView::from_bytes(&mmap[..])?;
                 op.run(&view)
             }
@@ -136,11 +151,7 @@ pub(crate) fn load_dataset(
                 let view = PackView::from_bytes(&bytes)?;
                 Ok(dataset_from_view(&view)?)
             } else {
-                let file = File::open(path)?;
-                // SAFETY: identical to `run_over_input`'s pack arm — a read-only,
-                // non-concurrently-mutated mapping confined to this call.
-                let mmap = unsafe { memmap2::Mmap::map(&file)? };
-                verify_pack(&mmap[..])?;
+                let mmap = verified_pack_mmap(path)?;
                 let view = PackView::from_bytes(&mmap[..])?;
                 Ok(dataset_from_view(&view)?)
             }

--- a/crates/cli/tests/convert_cli.rs
+++ b/crates/cli/tests/convert_cli.rs
@@ -390,6 +390,79 @@ fn directional_literal_per_format_behavior() {
     }
 }
 
+/// Dropping a base direction is NEVER silent: converting a directional literal to TriX
+/// or HexTuples (the only two formats with a language slot but no direction surface)
+/// records the `rdf12-direction-dropped` loss code, while a direction-capable target
+/// (N-Quads) leaves the ledger empty. Complements
+/// [`directional_literal_per_format_behavior`], which pins the emitted bytes.
+#[test]
+fn directional_literal_drop_recorded_in_loss_ledger() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(
+        dir,
+        "dir.nt",
+        "<http://example.org/s> <http://example.org/p> \"hello\"@en--ltr .\n",
+    );
+
+    // TriX / HexTuples: the direction is dropped, so the ledger is non-empty and names
+    // the `rdf12-direction-dropped` code. The emitted bytes still carry the language tag.
+    for dst in ["trix", "hextuples"] {
+        let out_path = path(dir, &format!("dir.{dst}"));
+        let ledger_path = path(dir, &format!("dir.{dst}.ledger.json"));
+        let o = run(&[
+            &format!("--loss-ledger={ledger_path}"),
+            "convert",
+            "--from",
+            "ntriples",
+            "--to",
+            dst,
+            &seed,
+            &out_path,
+        ]);
+        assert!(o.status.success(), "dir -> {dst}: {}", stderr(&o));
+        let ledger = std::fs::read_to_string(&ledger_path).expect("read ledger json");
+        assert!(
+            ledger.contains("rdf12-direction-dropped"),
+            "{dst} ledger must record the dropped base direction; got: {ledger}"
+        );
+        assert!(
+            ledger.contains("\"code\""),
+            "{dst} ledger must be non-empty (carry a loss entry); got: {ledger}"
+        );
+        // Bytes are unchanged: the language tag survives, only the direction is lost.
+        let out_text = std::fs::read_to_string(&out_path).expect("read output");
+        assert!(
+            out_text.contains("en") && !out_text.contains("ltr"),
+            "{dst} must keep the language tag and drop the direction; got: {out_text}"
+        );
+    }
+
+    // N-Quads carries the base direction: the ledger stays empty (no direction drop).
+    let out_path = path(dir, "dir.nq");
+    let ledger_path = path(dir, "dir.nq.ledger.json");
+    let o = run(&[
+        &format!("--loss-ledger={ledger_path}"),
+        "convert",
+        "--from",
+        "ntriples",
+        "--to",
+        "nquads",
+        &seed,
+        &out_path,
+    ]);
+    assert!(o.status.success(), "dir -> nquads: {}", stderr(&o));
+    let ledger = std::fs::read_to_string(&ledger_path).expect("read ledger json");
+    assert!(
+        !ledger.contains("rdf12-direction-dropped"),
+        "nquads preserves direction — must NOT record a drop; got: {ledger}"
+    );
+    assert!(
+        !ledger.contains("\"code\""),
+        "nquads ledger must be empty (no loss entries — direction preserved); got: {ledger}"
+    );
+}
+
 /// An extensionless input with explicit `--from`/`--to` converts correctly.
 #[test]
 fn explicit_formats_on_extensionless_input() {

--- a/crates/cli/tests/convert_cli.rs
+++ b/crates/cli/tests/convert_cli.rs
@@ -637,6 +637,67 @@ fn pack_to_trig_equals_direct_dataset_to_trig() {
     );
 }
 
+/// A DISK pack → pack conversion is a verified byte passthrough: the output file is
+/// byte-identical to the input pack (`convert` mmap-borrows the disk pack rather than
+/// re-encoding it — see `crates/cli/src/convert.rs`'s pack→pack branch and
+/// `crates/cli/src/source.rs::verified_pack_mmap`).
+#[test]
+fn disk_pack_to_pack_is_byte_identical_passthrough() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "seedC.nq", SEED_C);
+
+    let pack_in = path(dir, "in.purrpck");
+    let pack_out = path(dir, "out.purrpck");
+
+    assert!(
+        run(&[
+            "convert", "--from", "nquads", "--to", "pack", &seed, &pack_in
+        ])
+        .status
+        .success(),
+        "seeding the source pack must succeed"
+    );
+
+    let o = run(&["convert", &pack_in, &pack_out]);
+    assert!(
+        o.status.success(),
+        "pack -> pack passthrough must exit 0: {}",
+        stderr(&o)
+    );
+
+    assert_eq!(
+        std::fs::read(&pack_out).expect("read passthrough output"),
+        std::fs::read(&pack_in).expect("read source pack"),
+        "pack -> pack must be a byte-identical passthrough of the input pack"
+    );
+}
+
+/// A truncated/garbage `.purrpck` fed to `convert`'s pack→pack passthrough fails closed
+/// (exit non-zero): `verified_pack_mmap` runs the pack integrity verifier before any
+/// bytes are written to the output.
+#[test]
+fn disk_pack_to_pack_corrupt_input_fails_closed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let bad = write_file(dir, "bad.purrpck", "not a pack file at all — pure garbage");
+    let out = path(dir, "out.purrpck");
+
+    let o = run(&["convert", &bad, &out]);
+    assert!(
+        !o.status.success(),
+        "a corrupt pack must fail closed (exit non-zero)"
+    );
+    assert!(
+        !stderr(&o).is_empty(),
+        "the pack-integrity failure must print a diagnostic to stderr"
+    );
+    assert!(
+        !Path::new(&out).exists(),
+        "a failed passthrough must not leave a partial output file"
+    );
+}
+
 /// A large N-Triples ingress (5000 `example.org` triples) converts to N-Quads with every
 /// triple present and the exact count preserved (correctness at volume, not zero-copy).
 #[test]

--- a/crates/cli/tests/convert_cli.rs
+++ b/crates/cli/tests/convert_cli.rs
@@ -1,0 +1,944 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! End-to-end `convert` coverage that drives the BUILT `purrdf` binary
+//! (`env!("CARGO_BIN_EXE_purrdf")`) — never the library — so every assertion pins the
+//! shipped executable's behavior.
+//!
+//! ## What the three seeds isolate
+//!
+//! Each conversion contract gets its own seed so a failure names exactly one behavior:
+//!
+//! * **SEED A** — a default-graph-only, star-free dataset with rich term shapes (IRIs,
+//!   a blank node, and plain / typed / language-tagged literals). Every one of the nine
+//!   native syntaxes represents it losslessly, so it drives the full 9×9 any↔any matrix:
+//!   for each ordered `(src, dst)` pair the output must be RDFC-1.0 isomorphic to SEED A
+//!   (checked by comparing the `--canonical` N-Quads of the output to SEED A's, which is
+//!   order-independent and thus a true isomorphism test).
+//! * **SEED B** — a default graph + one named graph (star-free). It isolates the
+//!   named-graph PROJECTION contract: dataset-capable targets (N-Quads / TriG) preserve
+//!   the named graph; single-graph targets (Turtle / N-Triples) drop it and the loss
+//!   ledger records the drop.
+//! * **SEED C** — a star-free base quad + one reifier + one annotation. It isolates the
+//!   RDF-1.2 statement-layer contract: star-capable text targets round-trip the layer;
+//!   the star-INcapable `carries_star = false` targets (RDF/XML, TriX, HexTuples) PROJECT
+//!   it to base quads and report the dropped rows in the ledger.
+//!
+//! ## A note on the "TriX / HexTuples fail-closed" expectation
+//!
+//! An earlier design note held that TriX and HexTuples HARD-ERROR on any RDF-1.2
+//! statement layer. That is NOT how the shipped `convert` behaves, and the tests here
+//! assert the REAL, intended behavior instead of the stale note: `serialize_dataset_to_format`
+//! (the CLI's serialization entry point) routes every `carries_star = false` format —
+//! RDF/XML, TriX, and HexTuples alike — through the base-only PROJECTION path, dropping
+//! the statement layer and reporting the dropped-row count. The fail-closed branch that
+//! does exist in the TriX codec is only reachable through the full-statement-layer
+//! `serialize_dataset` entry point, which the CLI never calls. TriX and HexTuples are
+//! also `supports_datasets = true`, so (unlike RDF/XML) they PRESERVE named graphs;
+//! only the star layer projects. See `crates/rdf/src/native_codecs/{serialize,media_type}.rs`.
+//!
+//! ## A note on directional literals
+//!
+//! RDF-1.2 base-direction literals (`"x"@en--ltr`) are NOT universally lossless: TriX's
+//! `<plainLiteral xml:lang>` and the HexTuples 6-field row carry a language slot but no
+//! direction surface, so both silently drop the direction (keeping the language tag).
+//! SEED A therefore omits a directional literal (it must round-trip through ALL nine
+//! formats); `directional_literal_per_format_behavior` covers direction separately and
+//! documents that TriX/HexTuples degrade it to a plain language tag.
+
+use std::fmt::Write as _;
+use std::io::Write as _;
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+
+/// The nine native RDF syntaxes, by their `--from`/`--to` token. Every format appears
+/// as BOTH a source and a destination in the matrix.
+const FORMATS: [&str; 9] = [
+    "turtle",
+    "trig",
+    "ntriples",
+    "nquads",
+    "rdfxml",
+    "trix",
+    "hextuples",
+    "jsonld",
+    "yamlld",
+];
+
+/// SEED A — default-graph-only, star-free, `example.org` only. Rich term shapes that
+/// EVERY one of the nine formats represents losslessly: IRIs, a blank node, and plain /
+/// typed / language-tagged literals. (A directional literal is deliberately excluded —
+/// see the module docs.)
+const SEED_A: &str = concat!(
+    "<http://example.org/s> <http://example.org/p> <http://example.org/o> .\n",
+    "<http://example.org/s> <http://example.org/name> \"Alice\" .\n",
+    "<http://example.org/s> <http://example.org/age> ",
+    "\"42\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
+    "<http://example.org/s> <http://example.org/greeting> \"bonjour\"@fr .\n",
+    "<http://example.org/s> <http://example.org/rel> _:b0 .\n",
+    "_:b0 <http://example.org/kind> \"node\" .\n",
+);
+
+/// SEED B — a default-graph quad + one named-graph quad (star-free). Isolates the
+/// named-graph projection contract.
+const SEED_B: &str = concat!(
+    "<http://example.org/s> <http://example.org/p> <http://example.org/o> .\n",
+    "<http://example.org/gs> <http://example.org/gp> <http://example.org/go> ",
+    "<http://example.org/g1> .\n",
+);
+
+/// SEED C — a star-free base quad + one reifier (`rdf:reifies` a quoted triple) + one
+/// annotation on that reifier. Isolates the RDF-1.2 statement-layer contract.
+const SEED_C: &str = concat!(
+    "<http://example.org/s> <http://example.org/p> <http://example.org/o> .\n",
+    "<http://example.org/r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> ",
+    "<<( <http://example.org/s> <http://example.org/p> <http://example.org/o> )>> .\n",
+    "<http://example.org/r> <http://example.org/certainty> \"0.9\" .\n",
+);
+
+/// A `Command` for the built `purrdf` binary.
+fn purrdf() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_purrdf"))
+}
+
+/// Run `purrdf` with `args`, returning the captured [`Output`].
+fn run(args: &[&str]) -> Output {
+    purrdf()
+        .args(args)
+        .output()
+        .expect("spawn the built purrdf binary")
+}
+
+/// stderr of an [`Output`] as a `String`, for diagnostics + ledger assertions.
+fn stderr(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// Join a name onto `dir`, returning it as an owned `String` (the shape [`run`] wants).
+fn path(dir: &Path, name: &str) -> String {
+    dir.join(name)
+        .to_str()
+        .expect("temp path is valid UTF-8")
+        .to_owned()
+}
+
+/// Write `contents` to `dir/name`, returning the path.
+fn write_file(dir: &Path, name: &str, contents: &str) -> String {
+    let p = path(dir, name);
+    std::fs::write(&p, contents).expect("write fixture file");
+    p
+}
+
+/// The RDFC-1.0 canonical N-Quads document of `input` (parsed as `from`), produced BY
+/// THE BINARY via `--canonical`. Byte-equality of two such documents is an isomorphism
+/// test (canonical N-Quads are order- and blank-label-independent).
+fn canonical(dir: &Path, from: &str, input: &str) -> Vec<u8> {
+    let out = path(dir, "canonical.scratch.nq");
+    let o = run(&["convert", "--from", from, "--canonical", input, &out]);
+    assert!(
+        o.status.success(),
+        "canonicalizing {input} as {from} failed: {}",
+        stderr(&o)
+    );
+    std::fs::read(&out).expect("read canonical scratch output")
+}
+
+/// The full 9×9 any↔any matrix over SEED A: every ordered `(src, dst)` pair converts
+/// with exit 0, non-empty output, and output RDFC-1.0-isomorphic to SEED A.
+#[test]
+fn matrix_seed_a_every_pair_is_isomorphic() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed_a = write_file(dir, "seedA.nq", SEED_A);
+    let canon_a = canonical(dir, "nquads", &seed_a);
+
+    // Render SEED A into each of the nine source syntaxes, and confirm each rendering is
+    // itself isomorphic to SEED A before it feeds the matrix.
+    for src in FORMATS {
+        let src_path = path(dir, &format!("seed.{src}"));
+        let o = run(&[
+            "convert", "--from", "nquads", "--to", src, &seed_a, &src_path,
+        ]);
+        assert!(
+            o.status.success(),
+            "rendering SEED A to {src} failed: {}",
+            stderr(&o)
+        );
+        assert_eq!(
+            canonical(dir, src, &src_path),
+            canon_a,
+            "SEED A rendered as {src} is not isomorphic to SEED A"
+        );
+    }
+
+    // The matrix proper: convert every source rendering to every destination format.
+    for src in FORMATS {
+        let src_path = path(dir, &format!("seed.{src}"));
+        for dst in FORMATS {
+            let out_path = path(dir, &format!("out.{src}.to.{dst}"));
+            let o = run(&["convert", "--from", src, "--to", dst, &src_path, &out_path]);
+            assert!(
+                o.status.success(),
+                "{src} -> {dst} exited nonzero: {}",
+                stderr(&o)
+            );
+            let bytes = std::fs::read(&out_path).expect("read matrix output");
+            assert!(!bytes.is_empty(), "{src} -> {dst} produced empty output");
+            assert_eq!(
+                canonical(dir, dst, &out_path),
+                canon_a,
+                "{src} -> {dst} output is not isomorphic to SEED A"
+            );
+        }
+    }
+}
+
+/// SEED B to a dataset-capable target (N-Quads, TriG) preserves the named-graph quad
+/// (the whole dataset stays isomorphic).
+#[test]
+fn seed_b_named_graph_preserved_by_dataset_targets() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed_b = write_file(dir, "seedB.nq", SEED_B);
+    let canon_b = canonical(dir, "nquads", &seed_b);
+
+    for dst in ["nquads", "trig"] {
+        let out_path = path(dir, &format!("b.{dst}"));
+        let o = run(&[
+            "convert", "--from", "nquads", "--to", dst, &seed_b, &out_path,
+        ]);
+        assert!(o.status.success(), "SEED B -> {dst}: {}", stderr(&o));
+        let text = std::fs::read_to_string(&out_path).expect("read output");
+        assert!(
+            text.contains("http://example.org/g1"),
+            "{dst} must preserve the named graph IRI"
+        );
+        assert_eq!(
+            canonical(dir, dst, &out_path),
+            canon_b,
+            "SEED B -> {dst} must stay isomorphic (nothing dropped)"
+        );
+    }
+}
+
+/// SEED B to a single-graph target (Turtle, N-Triples) drops the named-graph quad
+/// (only the default-graph quad survives) and, under `--loss-ledger`, records the drop.
+#[test]
+fn seed_b_named_graph_projected_away_by_single_graph_targets() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed_b = write_file(dir, "seedB.nq", SEED_B);
+
+    for dst in ["turtle", "ntriples"] {
+        let out_path = path(dir, &format!("b.{dst}"));
+        let o = run(&[
+            "--loss-ledger",
+            "convert",
+            "--from",
+            "nquads",
+            "--to",
+            dst,
+            &seed_b,
+            &out_path,
+        ]);
+        assert!(o.status.success(), "SEED B -> {dst}: {}", stderr(&o));
+        let text = std::fs::read_to_string(&out_path).expect("read output");
+        // The default-graph quad survives; the named-graph quad's terms do NOT.
+        assert!(
+            text.contains("http://example.org/s"),
+            "{dst} must keep the default-graph quad"
+        );
+        assert!(
+            !text.contains("http://example.org/g1"),
+            "{dst} must drop the named graph IRI (projection)"
+        );
+        assert!(
+            !text.contains("http://example.org/gs"),
+            "{dst} must drop the named-graph quad's subject (projection)"
+        );
+        // The loss ledger (on stderr for a bare `--loss-ledger`) records the drop.
+        assert!(
+            stderr(&o).contains("named-graph-dropped"),
+            "{dst} loss ledger must record the named-graph drop; got: {}",
+            stderr(&o)
+        );
+    }
+}
+
+/// SEED C round-trips the RDF-1.2 statement layer through every star-capable text
+/// target (isomorphism holds, so the reifier + annotation survive).
+#[test]
+fn seed_c_statement_layer_roundtrips_star_capable_targets() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed_c = write_file(dir, "seedC.nq", SEED_C);
+    let canon_c = canonical(dir, "nquads", &seed_c);
+
+    for dst in ["nquads", "trig", "turtle", "ntriples", "jsonld", "yamlld"] {
+        let out_path = path(dir, &format!("c.{dst}"));
+        let o = run(&[
+            "convert", "--from", "nquads", "--to", dst, &seed_c, &out_path,
+        ]);
+        assert!(o.status.success(), "SEED C -> {dst}: {}", stderr(&o));
+        let text = std::fs::read_to_string(&out_path).expect("read output");
+        // The annotation predicate surfaces in EVERY star-capable rendering (as a
+        // triple in the line/Turtle family, as an `@annotation` object in JSON-LD /
+        // YAML-LD). The reifier itself is proven present by the isomorphism check below
+        // — its literal spelling differs per syntax (JSON-LD nests it structurally and
+        // never writes the `reifies` token), so it is not asserted textually.
+        assert!(
+            text.contains("certainty"),
+            "{dst} must carry the annotation predicate"
+        );
+        assert_eq!(
+            canonical(dir, dst, &out_path),
+            canon_c,
+            "SEED C -> {dst} must round-trip the statement layer (isomorphic: reifier + annotation)"
+        );
+    }
+}
+
+/// SEED C to a `carries_star = false` target (RDF/XML, TriX, HexTuples) PROJECTS the
+/// statement layer: exit 0, base quad present, star layer gone, and the ledger records
+/// the dropped statement rows. (This is the real behavior; none of these fail-close in
+/// the CLI's serialization path — see the module docs.)
+#[test]
+fn seed_c_statement_layer_projected_by_star_incapable_targets() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed_c = write_file(dir, "seedC.nq", SEED_C);
+
+    for dst in ["rdfxml", "trix", "hextuples"] {
+        let out_path = path(dir, &format!("c.{dst}"));
+        let o = run(&[
+            "--loss-ledger",
+            "convert",
+            "--from",
+            "nquads",
+            "--to",
+            dst,
+            &seed_c,
+            &out_path,
+        ]);
+        assert!(
+            o.status.success(),
+            "SEED C -> {dst} must PROJECT (exit 0), not fail-close: {}",
+            stderr(&o)
+        );
+        let text = std::fs::read_to_string(&out_path).expect("read output");
+        assert!(
+            text.contains("http://example.org/s"),
+            "{dst} must keep the base quad"
+        );
+        assert!(
+            !text.contains("reifies"),
+            "{dst} must drop the reifier binding (projection)"
+        );
+        // The realized dropped-row count is recorded (never a silent drop).
+        assert!(
+            stderr(&o).contains("statement-rows-dropped"),
+            "{dst} loss ledger must record the dropped statement rows; got: {}",
+            stderr(&o)
+        );
+    }
+}
+
+/// Directional (base-direction) literals round-trip through the seven direction-capable
+/// formats, but TriX and HexTuples degrade them to a plain language tag (they have a
+/// language slot but no direction surface). Documents the real per-format behavior.
+#[test]
+fn directional_literal_per_format_behavior() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(
+        dir,
+        "dir.nq",
+        "<http://example.org/s> <http://example.org/greeting> \"hello\"@en--ltr .\n",
+    );
+    let canon = canonical(dir, "nquads", &seed);
+
+    // Direction-capable: full round-trip (isomorphic).
+    for dst in [
+        "turtle", "trig", "ntriples", "nquads", "rdfxml", "jsonld", "yamlld",
+    ] {
+        let out_path = path(dir, &format!("dir.{dst}"));
+        let o = run(&["convert", "--from", "nquads", "--to", dst, &seed, &out_path]);
+        assert!(o.status.success(), "dir -> {dst}: {}", stderr(&o));
+        assert_eq!(
+            canonical(dir, dst, &out_path),
+            canon,
+            "{dst} must preserve the base direction"
+        );
+    }
+
+    // TriX / HexTuples: direction is dropped, language tag retained — so the round-trip
+    // is NOT isomorphic, and the re-canonicalized form loses the `--ltr`.
+    for dst in ["trix", "hextuples"] {
+        let out_path = path(dir, &format!("dir.{dst}"));
+        let o = run(&["convert", "--from", "nquads", "--to", dst, &seed, &out_path]);
+        assert!(o.status.success(), "dir -> {dst}: {}", stderr(&o));
+        let back = canonical(dir, dst, &out_path);
+        assert_ne!(
+            back, canon,
+            "{dst} is expected to drop the base direction (known projection)"
+        );
+        let back_text = String::from_utf8(back).expect("utf-8");
+        assert!(
+            back_text.contains("@en") && !back_text.contains("--ltr"),
+            "{dst} must degrade the directional literal to a plain @en tag; got: {back_text}"
+        );
+    }
+}
+
+/// An extensionless input with explicit `--from`/`--to` converts correctly.
+#[test]
+fn explicit_formats_on_extensionless_input() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "seedA_no_ext", SEED_A);
+    let out = path(dir, "out.ttl");
+    let o = run(&["convert", "--from", "nquads", "--to", "turtle", &seed, &out]);
+    assert!(
+        o.status.success(),
+        "explicit convert failed: {}",
+        stderr(&o)
+    );
+    assert_eq!(
+        canonical(dir, "turtle", &out),
+        canonical(dir, "nquads", &seed),
+        "explicit-format convert must be isomorphic"
+    );
+}
+
+/// An extensionless input with NO `--from` is unresolvable — a usage error (exit 2).
+#[test]
+fn extensionless_input_without_from_is_a_usage_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "seedA_no_ext", SEED_A);
+    let out = path(dir, "out.ttl");
+    let o = run(&["convert", &seed, &out]);
+    assert!(
+        !o.status.success(),
+        "an unresolvable input format must fail"
+    );
+    assert_eq!(o.status.code(), Some(2), "usage errors exit 2");
+}
+
+/// A misleading extension is overridden by an explicit `--from`: a `.txt` file that
+/// actually holds Turtle, and a `.nt` file that actually holds N-Quads, both convert.
+#[test]
+fn explicit_from_overrides_a_misleading_extension() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+
+    // A `.txt` file that is really Turtle.
+    let turtle = "<http://example.org/s> <http://example.org/p> <http://example.org/o> .\n";
+    let txt = write_file(dir, "data.txt", turtle);
+    let out_a = path(dir, "from_txt.nq");
+    let o = run(&[
+        "convert", "--from", "turtle", "--to", "nquads", &txt, &out_a,
+    ]);
+    assert!(o.status.success(), ".txt-as-turtle failed: {}", stderr(&o));
+
+    // A `.nt` file that is really N-Quads (a named graph — which N-Triples could not
+    // carry), converted with `--from nquads` overriding the `.nt` extension.
+    let nt = write_file(dir, "mislabelled.nt", SEED_B);
+    let out_b = path(dir, "from_nt.trig");
+    let o = run(&["convert", "--from", "nquads", "--to", "trig", &nt, &out_b]);
+    assert!(o.status.success(), ".nt-as-nquads failed: {}", stderr(&o));
+    let text = std::fs::read_to_string(&out_b).expect("read output");
+    assert!(
+        text.contains("http://example.org/g1"),
+        "the N-Quads override must preserve the named graph"
+    );
+}
+
+/// stdin `-` in with explicit `--from`, stdout `-` out with explicit `--to`: bytes piped
+/// through the process convert correctly.
+#[test]
+fn stdin_to_stdout_with_explicit_formats() {
+    let mut child = purrdf()
+        .args(["convert", "--from", "nquads", "--to", "turtle", "-", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn purrdf for the stdin pipe");
+    child
+        .stdin
+        .take()
+        .expect("child stdin")
+        .write_all(SEED_A.as_bytes())
+        .expect("write to child stdin");
+    let out = child.wait_with_output().expect("await child");
+    assert!(
+        out.status.success(),
+        "stdin->stdout convert failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf-8 stdout");
+    assert!(
+        stdout.contains("http://example.org/s") && stdout.contains("bonjour"),
+        "the Turtle piped to stdout must carry the converted triples; got: {stdout}"
+    );
+}
+
+/// A text→pack→text round-trip is byte-identical to the equivalent direct text→text
+/// conversion (the pack is a lossless container; the zero-copy pack read re-serializes
+/// identically).
+#[test]
+fn text_via_pack_equals_direct_text() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "seedA.nq", SEED_A);
+
+    let pack = path(dir, "mid.purrpck");
+    let via_pack = path(dir, "via_pack.nt");
+    let direct = path(dir, "direct.nt");
+
+    assert!(
+        run(&["convert", "--from", "nquads", "--to", "pack", &seed, &pack])
+            .status
+            .success()
+    );
+    assert!(
+        run(&[
+            "convert", "--from", "pack", "--to", "ntriples", &pack, &via_pack
+        ])
+        .status
+        .success()
+    );
+    assert!(
+        run(&[
+            "convert", "--from", "nquads", "--to", "ntriples", &seed, &direct
+        ])
+        .status
+        .success()
+    );
+
+    assert_eq!(
+        std::fs::read(&via_pack).expect("read via-pack"),
+        std::fs::read(&direct).expect("read direct"),
+        "text -> pack -> text must equal direct text -> text (byte-identical)"
+    );
+}
+
+/// A pack read (mmap, zero-copy) serialized to TriG is byte-identical to the same
+/// dataset serialized to TriG directly from text — exercising the zero-copy pack→text
+/// serialization path.
+#[test]
+fn pack_to_trig_equals_direct_dataset_to_trig() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "seedB.nq", SEED_B);
+
+    let pack = path(dir, "b.purrpck");
+    let via_pack = path(dir, "via_pack.trig");
+    let direct = path(dir, "direct.trig");
+
+    assert!(
+        run(&["convert", "--from", "nquads", "--to", "pack", &seed, &pack])
+            .status
+            .success()
+    );
+    assert!(
+        run(&[
+            "convert", "--from", "pack", "--to", "trig", &pack, &via_pack
+        ])
+        .status
+        .success()
+    );
+    assert!(
+        run(&[
+            "convert", "--from", "nquads", "--to", "trig", &seed, &direct
+        ])
+        .status
+        .success()
+    );
+
+    assert_eq!(
+        std::fs::read(&via_pack).expect("read via-pack trig"),
+        std::fs::read(&direct).expect("read direct trig"),
+        "zero-copy pack -> trig must equal direct dataset -> trig (byte-identical)"
+    );
+}
+
+/// A large N-Triples ingress (5000 `example.org` triples) converts to N-Quads with every
+/// triple present and the exact count preserved (correctness at volume, not zero-copy).
+#[test]
+fn large_ntriples_ingress_preserves_every_triple() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+
+    let mut big = String::new();
+    for i in 0..5000 {
+        writeln!(
+            big,
+            "<http://example.org/s{i}> <http://example.org/p> <http://example.org/o{i}> ."
+        )
+        .expect("write into String is infallible");
+    }
+    let seed = write_file(dir, "big.nt", &big);
+    let out = path(dir, "big.nq");
+    let o = run(&[
+        "convert", "--from", "ntriples", "--to", "nquads", &seed, &out,
+    ]);
+    assert!(o.status.success(), "large ingress failed: {}", stderr(&o));
+
+    let text = std::fs::read_to_string(&out).expect("read big output");
+    let lines = text.lines().filter(|l| !l.trim().is_empty()).count();
+    assert_eq!(lines, 5000, "every triple must survive the large ingress");
+    assert!(
+        text.contains("http://example.org/s0>"),
+        "first triple present"
+    );
+    assert!(
+        text.contains("http://example.org/s4999>"),
+        "last triple present"
+    );
+}
+
+/// `--canonical` is stable (two runs are byte-identical) and order-independent (two
+/// different serializations of the same data canonicalize to the same bytes).
+#[test]
+fn canonical_output_is_stable_and_serialization_independent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed_nq = write_file(dir, "seedA.nq", SEED_A);
+
+    // Stable: canonicalizing the same input twice yields identical bytes.
+    let c1 = path(dir, "c1.nq");
+    let c2 = path(dir, "c2.nq");
+    assert!(
+        run(&["convert", "--from", "nquads", "--canonical", &seed_nq, &c1])
+            .status
+            .success()
+    );
+    assert!(
+        run(&["convert", "--from", "nquads", "--canonical", &seed_nq, &c2])
+            .status
+            .success()
+    );
+    assert_eq!(
+        std::fs::read(&c1).expect("c1"),
+        std::fs::read(&c2).expect("c2"),
+        "--canonical must be byte-stable across runs"
+    );
+
+    // Serialization-independent: a Turtle rendering of the same data canonicalizes to the
+    // SAME bytes as the N-Quads original.
+    let seed_ttl = path(dir, "seedA.ttl");
+    assert!(
+        run(&[
+            "convert", "--from", "nquads", "--to", "turtle", &seed_nq, &seed_ttl
+        ])
+        .status
+        .success()
+    );
+    assert_eq!(
+        canonical(dir, "turtle", &seed_ttl),
+        canonical(dir, "nquads", &seed_nq),
+        "canonical output must be independent of the input serialization"
+    );
+}
+
+/// A plain conversion run twice is byte-identical: the serializers are deterministic.
+#[test]
+fn conversion_is_deterministic() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "seedA.nq", SEED_A);
+    let a = path(dir, "a.trig");
+    let b = path(dir, "b.trig");
+    assert!(
+        run(&["convert", "--from", "nquads", "--to", "trig", &seed, &a])
+            .status
+            .success()
+    );
+    assert!(
+        run(&["convert", "--from", "nquads", "--to", "trig", &seed, &b])
+            .status
+            .success()
+    );
+    assert_eq!(
+        std::fs::read(&a).expect("a"),
+        std::fs::read(&b).expect("b"),
+        "a conversion run twice must be byte-identical"
+    );
+}
+
+/// `--base` resolves relative IRIs in the input against the supplied base while parsing.
+#[test]
+fn base_resolves_relative_iris_on_parse() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    // Turtle with a relative IRI subject/object, resolved against `--base`.
+    let ttl = write_file(dir, "rel.ttl", "<thing> <http://example.org/p> <other> .\n");
+    let out = path(dir, "resolved.nt");
+    let o = run(&[
+        "convert",
+        "--from",
+        "turtle",
+        "--to",
+        "ntriples",
+        "--base",
+        "http://example.org/base/",
+        &ttl,
+        &out,
+    ]);
+    assert!(o.status.success(), "--base convert failed: {}", stderr(&o));
+    let text = std::fs::read_to_string(&out).expect("read resolved");
+    assert!(
+        text.contains("http://example.org/base/thing"),
+        "relative subject must resolve against --base; got: {text}"
+    );
+    assert!(
+        text.contains("http://example.org/base/other"),
+        "relative object must resolve against --base; got: {text}"
+    );
+}
+
+/// `--entailment rdfs` materializes the closure so an inferred `rdf:type` triple appears
+/// that is ABSENT without the flag — from a TEXT input.
+#[test]
+fn entailment_rdfs_infers_type_from_text_input() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let ttl = write_file(
+        dir,
+        "sub.ttl",
+        concat!(
+            "@prefix ex: <http://example.org/> .\n",
+            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+            "ex:Dog rdfs:subClassOf ex:Animal .\n",
+            "ex:rex a ex:Dog .\n",
+        ),
+    );
+
+    // The inferred triple: `ex:rex a ex:Animal`.
+    let inferred = "<http://example.org/rex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Animal>";
+
+    // Without --entailment: the inference is absent.
+    let plain = path(dir, "plain.nt");
+    assert!(
+        run(&[
+            "convert", "--from", "turtle", "--to", "ntriples", &ttl, &plain
+        ])
+        .status
+        .success()
+    );
+    assert!(
+        !std::fs::read_to_string(&plain)
+            .expect("read plain")
+            .contains(inferred),
+        "the inferred type must be ABSENT without --entailment"
+    );
+
+    // With --entailment rdfs: the inference appears.
+    let entailed = path(dir, "entailed.nt");
+    let o = run(&[
+        "convert",
+        "--from",
+        "turtle",
+        "--to",
+        "ntriples",
+        "--entailment",
+        "rdfs",
+        &ttl,
+        &entailed,
+    ]);
+    assert!(
+        o.status.success(),
+        "--entailment rdfs failed: {}",
+        stderr(&o)
+    );
+    assert!(
+        std::fs::read_to_string(&entailed)
+            .expect("read entailed")
+            .contains(inferred),
+        "the inferred type must appear with --entailment rdfs"
+    );
+}
+
+/// `--entailment rdfs` over a PACK input reconstructs the dataset and materializes the
+/// same inferred triple (the reconstruct-then-entail path).
+#[test]
+fn entailment_rdfs_infers_type_from_pack_input() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let ttl = write_file(
+        dir,
+        "sub.ttl",
+        concat!(
+            "@prefix ex: <http://example.org/> .\n",
+            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+            "ex:Dog rdfs:subClassOf ex:Animal .\n",
+            "ex:rex a ex:Dog .\n",
+        ),
+    );
+    let inferred = "<http://example.org/rex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Animal>";
+
+    // Build a pack, then entail from the pack.
+    let pack = path(dir, "sub.purrpck");
+    assert!(
+        run(&["convert", "--from", "turtle", "--to", "pack", &ttl, &pack])
+            .status
+            .success()
+    );
+    let entailed = path(dir, "entailed_from_pack.nt");
+    let o = run(&[
+        "convert",
+        "--from",
+        "pack",
+        "--to",
+        "ntriples",
+        "--entailment",
+        "rdfs",
+        &pack,
+        &entailed,
+    ]);
+    assert!(
+        o.status.success(),
+        "--entailment rdfs over a pack failed: {}",
+        stderr(&o)
+    );
+    assert!(
+        std::fs::read_to_string(&entailed)
+            .expect("read entailed-from-pack")
+            .contains(inferred),
+        "the inferred type must appear when entailing a reconstructed pack"
+    );
+}
+
+/// `--entailment rdfs --canonical` composes: entail first, then emit canonical N-Quads
+/// containing the inferred triple.
+#[test]
+fn entailment_then_canonical_composes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let ttl = write_file(
+        dir,
+        "sub.ttl",
+        concat!(
+            "@prefix ex: <http://example.org/> .\n",
+            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+            "ex:Dog rdfs:subClassOf ex:Animal .\n",
+            "ex:rex a ex:Dog .\n",
+        ),
+    );
+    let out = path(dir, "closure.nq");
+    let o = run(&[
+        "convert",
+        "--from",
+        "turtle",
+        "--entailment",
+        "rdfs",
+        "--canonical",
+        &ttl,
+        &out,
+    ]);
+    assert!(
+        o.status.success(),
+        "--entailment rdfs --canonical failed: {}",
+        stderr(&o)
+    );
+    let text = std::fs::read_to_string(&out).expect("read closure");
+    assert!(
+        text.contains(
+            "<http://example.org/rex> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Animal>"
+        ),
+        "canonical closure must contain the inferred type; got: {text}"
+    );
+    // Canonical output is stable even after entailment.
+    let out2 = path(dir, "closure2.nq");
+    assert!(
+        run(&[
+            "convert",
+            "--from",
+            "turtle",
+            "--entailment",
+            "rdfs",
+            "--canonical",
+            &ttl,
+            &out2,
+        ])
+        .status
+        .success()
+    );
+    assert_eq!(
+        std::fs::read(&out).expect("closure"),
+        std::fs::read(&out2).expect("closure2"),
+        "entail+canonical must be byte-stable"
+    );
+}
+
+/// An unsupported entailment regime (`d` / `owl-direct` / `rif`) is the exit-3 boundary,
+/// matching `reason`'s classification.
+#[test]
+fn unsupported_entailment_regime_exits_three() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "seedA.nq", SEED_A);
+    let out = path(dir, "out.nq");
+    for regime in ["d", "owl-direct", "rif"] {
+        let o = run(&[
+            "convert",
+            "--from",
+            "nquads",
+            "--to",
+            "nquads",
+            "--entailment",
+            regime,
+            &seed,
+            &out,
+        ]);
+        assert_eq!(
+            o.status.code(),
+            Some(3),
+            "regime {regime} must exit 3 (unsupported); stderr: {}",
+            stderr(&o)
+        );
+    }
+}
+
+/// `--canonical` overrides `--to`: even with `--to turtle` requested, the output is
+/// RDFC-1.0 canonical N-Quads (documented precedence).
+#[test]
+fn canonical_overrides_to_format() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "seedA.nq", SEED_A);
+    let out = path(dir, "out.canon");
+    let o = run(&[
+        "convert",
+        "--from",
+        "nquads",
+        "--to",
+        "turtle",
+        "--canonical",
+        &seed,
+        &out,
+    ]);
+    assert!(
+        o.status.success(),
+        "--canonical over --to failed: {}",
+        stderr(&o)
+    );
+    let text = std::fs::read_to_string(&out).expect("read canonical");
+    // Canonical N-Quads use `<...>` triples with a trailing ` .`, and NEVER Turtle's
+    // `@prefix` directives — proving `--to turtle` was ignored.
+    assert!(
+        !text.contains("@prefix"),
+        "canonical output must NOT be Turtle; got: {text}"
+    );
+    assert!(
+        text.contains("_:c14n0") || text.contains("http://example.org/s>"),
+        "canonical output must be N-Quads; got: {text}"
+    );
+    assert_eq!(
+        text.into_bytes(),
+        canonical(dir, "nquads", &seed),
+        "output must equal the RDFC-1.0 canonical N-Quads of the input"
+    );
+}

--- a/crates/cli/tests/convert_cli.rs
+++ b/crates/cli/tests/convert_cli.rs
@@ -975,6 +975,62 @@ fn unsupported_entailment_regime_exits_three() {
     }
 }
 
+/// A downstream consumer closing its end of the stdout pipe early (the ubiquitous
+/// `purrdf … | head` idiom) must NOT surface as a runtime failure: `write_out`
+/// (`crates/cli/src/sink.rs`) treats a `BrokenPipe` write error on stdout as a clean
+/// success. Drives this through a real shell pipe (not a simulated close) so the OS
+/// actually delivers the short write / EPIPE: a large (>64 KiB, past the pipe buffer)
+/// N-Triples output piped into `head -c 5`, which reads a few bytes and exits,
+/// closing its end of the pipe while `purrdf` is still writing. Assert `purrdf`
+/// itself (via `PIPESTATUS[0]`, not the pipeline's overall status) exits 0 and prints
+/// no "Broken pipe" text to stderr — falsifiable: reverting the `sink.rs` fix makes
+/// this fail with a nonzero `PIPESTATUS[0]` and a "Broken pipe" stderr message.
+#[test]
+fn stdout_broken_pipe_exits_clean() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+
+    // A big-enough N-Triples source (well past the OS pipe buffer, typically 64 KiB
+    // on Linux) so `purrdf` is still mid-write when `head -c 5` closes its end.
+    let mut big = String::new();
+    for i in 0..20_000 {
+        writeln!(
+            big,
+            "<http://example.org/s{i}> <http://example.org/p> <http://example.org/o{i}> ."
+        )
+        .expect("write into String is infallible");
+    }
+    let seed = write_file(dir, "big.nt", &big);
+
+    let purrdf_bin = env!("CARGO_BIN_EXE_purrdf");
+    let stderr_path = path(dir, "purrdf.stderr");
+    // `PIPESTATUS[0]` is the FIRST command's (purrdf's) exit status, independent of
+    // `head`'s own (which is what a bare `$?` would give). Redirect purrdf's stderr
+    // to a file so it is inspectable after the shell exits (Output::stderr would
+    // otherwise capture the whole pipeline's, mixed with `head`'s).
+    let script = format!(
+        "{purrdf_bin:?} convert --from ntriples --to ntriples {seed:?} - 2> {stderr_path:?} | \
+         head -c 5 > /dev/null; exit \"${{PIPESTATUS[0]}}\""
+    );
+    let out = Command::new("bash")
+        .arg("-c")
+        .arg(&script)
+        .output()
+        .expect("spawn bash to drive the real pipe");
+
+    let purrdf_stderr = std::fs::read_to_string(&stderr_path).unwrap_or_default();
+    assert!(
+        out.status.success(),
+        "purrdf must exit 0 when stdout's downstream reader closes early; \
+         PIPESTATUS[0]={:?}, purrdf stderr: {purrdf_stderr}",
+        out.status.code()
+    );
+    assert!(
+        !purrdf_stderr.to_lowercase().contains("broken pipe"),
+        "purrdf must not report BrokenPipe as an error; stderr: {purrdf_stderr}"
+    );
+}
+
 /// `--canonical` overrides `--to`: even with `--to turtle` requested, the output is
 /// RDFC-1.0 canonical N-Quads (documented precedence).
 #[test]

--- a/crates/cli/tests/help_cli.rs
+++ b/crates/cli/tests/help_cli.rs
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `--help` surface: the built `purrdf` binary lists every subcommand, and each
+//! subcommand's `--help` lists its options and the `ValueEnum` choices. Drives the
+//! real binary via `CARGO_BIN_EXE_purrdf`.
+
+use std::process::Command;
+
+/// The path to the built `purrdf` binary this integration test target links against.
+const PURRDF: &str = env!("CARGO_BIN_EXE_purrdf");
+
+/// Run `purrdf` with `args`, returning (exit-code, stdout, stderr).
+fn run(args: &[&str]) -> (i32, String, String) {
+    let output = Command::new(PURRDF)
+        .args(args)
+        .output()
+        .expect("spawn purrdf");
+    (
+        output.status.code().expect("exit code"),
+        String::from_utf8(output.stdout).expect("utf-8 stdout"),
+        String::from_utf8(output.stderr).expect("utf-8 stderr"),
+    )
+}
+
+#[test]
+fn top_level_help_lists_all_subcommands() {
+    let (code, stdout, _) = run(&["--help"]);
+    assert_eq!(code, 0, "`--help` exits 0");
+    for subcommand in ["convert", "query", "reason"] {
+        assert!(
+            stdout.contains(subcommand),
+            "top-level help must list `{subcommand}`; got:\n{stdout}"
+        );
+    }
+    assert!(
+        stdout.contains("--loss-ledger"),
+        "top-level help must mention the global --loss-ledger flag"
+    );
+}
+
+#[test]
+fn convert_help_lists_options_and_format_choices() {
+    let (code, stdout, _) = run(&["convert", "--help"]);
+    assert_eq!(code, 0, "`convert --help` exits 0");
+    for option in ["--from", "--to", "IN", "OUT"] {
+        assert!(
+            stdout.contains(option),
+            "convert help must list `{option}` (IN/OUT are positional); got:\n{stdout}"
+        );
+    }
+    for choice in [
+        "turtle", "ntriples", "nquads", "rdfxml", "jsonld", "yamlld", "pack",
+    ] {
+        assert!(
+            stdout.contains(choice),
+            "convert help must list the `{choice}` format choice; got:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn query_help_lists_options_and_results_choices() {
+    let (code, stdout, _) = run(&["query", "--help"]);
+    assert_eq!(code, 0, "`query --help` exits 0");
+    for option in ["--data", "--results-format"] {
+        assert!(
+            stdout.contains(option),
+            "query help must list `{option}`; got:\n{stdout}"
+        );
+    }
+    for choice in ["json", "xml", "csv", "tsv"] {
+        assert!(
+            stdout.contains(choice),
+            "query help must list the `{choice}` results format; got:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn reason_help_lists_options_and_regime_choices() {
+    let (code, stdout, _) = run(&["reason", "--help"]);
+    assert_eq!(code, 0, "`reason --help` exits 0");
+    for option in ["--regime", "IN", "OUT"] {
+        assert!(
+            stdout.contains(option),
+            "reason help must list `{option}` (IN/OUT are positional); got:\n{stdout}"
+        );
+    }
+    for choice in ["simple", "rdfs", "owl-rl", "owl-direct"] {
+        assert!(
+            stdout.contains(choice),
+            "reason help must list the `{choice}` regime; got:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn unknown_flag_is_a_usage_error_exit_2() {
+    let (code, _, stderr) = run(&["convert", "--nonexistent-flag"]);
+    assert_eq!(code, 2, "clap rejects an unknown flag with exit 2");
+    assert!(!stderr.is_empty(), "clap prints a diagnostic to stderr");
+}

--- a/crates/cli/tests/loss_ledger_cli.rs
+++ b/crates/cli/tests/loss_ledger_cli.rs
@@ -1,0 +1,597 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Dedicated end-to-end coverage of the global `--loss-ledger` flag, driving the
+//! BUILT `purrdf` binary (`env!("CARGO_BIN_EXE_purrdf")`) — never the library — so
+//! every assertion pins the shipped executable's surfacing contract. All fixtures
+//! use `example.org`.
+//!
+//! Where `convert_cli.rs` / `query_cli.rs` assert *that* a particular conversion
+//! records a particular loss code, this suite pins the flag's SURFACING semantics
+//! independently:
+//!
+//! * **the tri-state** — absent → silent (nothing on stderr, clean conversion on
+//!   stdout); bare `--loss-ledger` → the JSON goes to STDERR while STDOUT stays the
+//!   clean conversion; `--loss-ledger=PATH` → the JSON is written to PATH
+//!   byte-identically to what bare mode writes to stderr, with stderr empty;
+//! * **the empty-vs-non-empty contract** — a lossy conversion yields a non-empty
+//!   `losses` array carrying the realized/contract codes; a lossless one yields an
+//!   empty `losses` array (the versioned envelope is still present, but no `"code"`
+//!   field appears);
+//! * **determinism** — the same lossy conversion's ledger JSON is byte-identical
+//!   across runs;
+//! * **the universal-sink invariant** — `query`-CONSTRUCT and `reason`, not just
+//!   `convert`, feed the same sink, so both surface the ledger under the flag;
+//! * **flag position** — `--loss-ledger` is `global = true`, so it is accepted both
+//!   BEFORE the subcommand (`purrdf --loss-ledger convert …`) and AFTER it
+//!   (`purrdf convert … --loss-ledger`), and both positions produce the same ledger.
+
+use std::process::{Command, Output};
+
+/// The path to the built `purrdf` binary this integration target links against.
+const PURRDF: &str = env!("CARGO_BIN_EXE_purrdf");
+
+/// SEED C — a star-free base quad + one reifier (`rdf:reifies` a quoted triple) +
+/// one annotation on that reifier. Serializing it to a star-INcapable target
+/// (RDF/XML) drops the RDF-1.2 statement layer, so the ledger is non-empty.
+const SEED_C: &str = concat!(
+    "<http://example.org/s> <http://example.org/p> <http://example.org/o> .\n",
+    "<http://example.org/r> <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> ",
+    "<<( <http://example.org/s> <http://example.org/p> <http://example.org/o> )>> .\n",
+    "<http://example.org/r> <http://example.org/certainty> \"0.9\" .\n",
+);
+
+/// A TriG document with one named graph plus a default-graph triple. Converting it
+/// to a single-graph target (Turtle) drops the named graph, so the ledger records a
+/// `named-graph-dropped` loss.
+const NAMED_GRAPH_TRIG: &str = concat!(
+    "<http://example.org/g1> {\n",
+    "  <http://example.org/gs> <http://example.org/gp> <http://example.org/go> .\n",
+    "}\n",
+    "<http://example.org/d> <http://example.org/p> <http://example.org/o> .\n",
+);
+
+/// A plain, star-free, default-graph Turtle triple. Every syntax carries it
+/// losslessly, so a conversion to N-Triples leaves the ledger empty.
+const PLAIN_TTL: &str = "<http://example.org/s> <http://example.org/p> <http://example.org/o> .\n";
+
+/// A `Command` for the built `purrdf` binary.
+fn purrdf() -> Command {
+    Command::new(PURRDF)
+}
+
+/// Run `purrdf` with `args`, returning the captured [`Output`].
+fn run(args: &[&str]) -> Output {
+    purrdf()
+        .args(args)
+        .output()
+        .expect("spawn the built purrdf binary")
+}
+
+/// stdout of an [`Output`] as a `String`.
+fn stdout(out: &Output) -> String {
+    String::from_utf8(out.stdout.clone()).expect("utf-8 stdout")
+}
+
+/// stderr of an [`Output`] as a `String`.
+fn stderr(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// Join a name onto `dir`, returning it as an owned `String`.
+fn path(dir: &std::path::Path, name: &str) -> String {
+    dir.join(name)
+        .to_str()
+        .expect("temp path is valid UTF-8")
+        .to_owned()
+}
+
+/// Write `contents` to `dir/name`, returning the path.
+fn write_file(dir: &std::path::Path, name: &str, contents: &str) -> String {
+    let p = path(dir, name);
+    std::fs::write(&p, contents).expect("write fixture file");
+    p
+}
+
+/// A ledger JSON string is "non-empty" iff it carries at least one `"code"` field
+/// (the versioned envelope always carries `schema_version` + a `losses` array, so
+/// the envelope alone is not enough).
+fn ledger_is_empty(json: &str) -> bool {
+    assert!(
+        json.contains("\"schema_version\""),
+        "any surfaced ledger must carry the versioned envelope; got:\n{json}"
+    );
+    assert!(
+        json.contains("\"losses\""),
+        "any surfaced ledger must carry a `losses` array; got:\n{json}"
+    );
+    !json.contains("\"code\"")
+}
+
+/// A lossy `nquads -> rdfxml` conversion of SEED C (a reifier + annotation) records
+/// the star-drop into a NON-EMPTY ledger under bare `--loss-ledger` (on stderr).
+/// The binary emits the realized `statement-rows-dropped` code AND the contract
+/// `rdf12-star-unrepresentable` code — both are asserted against the real output.
+#[test]
+fn lossy_nq_to_rdfxml_reifier_records_the_star_drop() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "seedC.nq", SEED_C);
+    let out = path(dir, "out.rdf");
+
+    let o = run(&[
+        "--loss-ledger",
+        "convert",
+        "--from",
+        "nquads",
+        "--to",
+        "rdfxml",
+        &seed,
+        &out,
+    ]);
+    assert!(
+        o.status.success(),
+        "nq -> rdfxml must exit 0; stderr:\n{}",
+        stderr(&o)
+    );
+
+    let ledger = stderr(&o);
+    assert!(
+        !ledger_is_empty(&ledger),
+        "a lossy nq -> rdfxml must produce a non-empty ledger; got:\n{ledger}"
+    );
+    // The realized dropped-row code the serializer emits when it strips the star layer.
+    assert!(
+        ledger.contains("statement-rows-dropped"),
+        "the ledger must record the realized statement-layer drop; got:\n{ledger}"
+    );
+    // The contract star-drop code for the (nquads -> rdfxml) pair.
+    assert!(
+        ledger.contains("rdf12-star-unrepresentable"),
+        "the ledger must record the contract star-unrepresentable loss; got:\n{ledger}"
+    );
+}
+
+/// A lossy `trig -> turtle` conversion dropping a named graph records the
+/// `named-graph-dropped` code into a non-empty ledger under bare `--loss-ledger`.
+#[test]
+fn lossy_trig_to_turtle_records_the_named_graph_drop() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "named.trig", NAMED_GRAPH_TRIG);
+    let out = path(dir, "out.ttl");
+
+    let o = run(&[
+        "--loss-ledger",
+        "convert",
+        "--from",
+        "trig",
+        "--to",
+        "turtle",
+        &seed,
+        &out,
+    ]);
+    assert!(
+        o.status.success(),
+        "trig -> turtle must exit 0; stderr:\n{}",
+        stderr(&o)
+    );
+
+    let ledger = stderr(&o);
+    assert!(
+        !ledger_is_empty(&ledger),
+        "a lossy trig -> turtle must produce a non-empty ledger; got:\n{ledger}"
+    );
+    assert!(
+        ledger.contains("named-graph-dropped"),
+        "the ledger must record the dropped named graph; got:\n{ledger}"
+    );
+}
+
+/// A lossless `nquads -> trig` conversion (both dataset- AND star-capable) leaves the
+/// `losses` array EMPTY: the versioned envelope is present but no `"code"` appears.
+/// (SEED C's statement layer round-trips, so nothing is dropped.)
+#[test]
+fn lossless_nq_to_trig_has_empty_losses() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "seedC.nq", SEED_C);
+    let out = path(dir, "out.trig");
+    let ledger_path = path(dir, "ledger.json");
+
+    let o = run(&[
+        &format!("--loss-ledger={ledger_path}"),
+        "convert",
+        "--from",
+        "nquads",
+        "--to",
+        "trig",
+        &seed,
+        &out,
+    ]);
+    assert!(
+        o.status.success(),
+        "nq -> trig must exit 0; stderr:\n{}",
+        stderr(&o)
+    );
+
+    let ledger = std::fs::read_to_string(&ledger_path).expect("read ledger json");
+    assert!(
+        ledger_is_empty(&ledger),
+        "nq -> trig is lossless — the losses array must be empty (no \"code\"); got:\n{ledger}"
+    );
+}
+
+/// A lossless star-free `turtle -> ntriples` conversion (default graph only) leaves
+/// the `losses` array EMPTY.
+#[test]
+fn lossless_ttl_to_nt_has_empty_losses() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "plain.ttl", PLAIN_TTL);
+    let out = path(dir, "out.nt");
+    let ledger_path = path(dir, "ledger.json");
+
+    let o = run(&[
+        &format!("--loss-ledger={ledger_path}"),
+        "convert",
+        "--from",
+        "turtle",
+        "--to",
+        "ntriples",
+        &seed,
+        &out,
+    ]);
+    assert!(
+        o.status.success(),
+        "ttl -> nt must exit 0; stderr:\n{}",
+        stderr(&o)
+    );
+
+    let ledger = std::fs::read_to_string(&ledger_path).expect("read ledger json");
+    assert!(
+        ledger_is_empty(&ledger),
+        "ttl -> nt is lossless — the losses array must be empty (no \"code\"); got:\n{ledger}"
+    );
+}
+
+/// ABSENT flag: a LOSSY conversion with NO `--loss-ledger` emits NOTHING on stderr,
+/// and stdout carries ONLY the clean conversion output — the ledger never leaks into
+/// the converted document. (trig -> turtle to stdout `-` drops a named graph.)
+#[test]
+fn absent_flag_is_silent_and_stdout_is_clean() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "named.trig", NAMED_GRAPH_TRIG);
+
+    let o = run(&["convert", "--from", "trig", "--to", "turtle", &seed, "-"]);
+    assert!(
+        o.status.success(),
+        "trig -> turtle must exit 0; stderr:\n{}",
+        stderr(&o)
+    );
+
+    // Nothing leaks to stderr.
+    assert!(
+        o.stderr.is_empty(),
+        "an absent --loss-ledger must leave stderr EMPTY; got:\n{}",
+        stderr(&o)
+    );
+    // stdout is the converted Turtle — the surviving default-graph triple — and NOT
+    // any part of the ledger JSON.
+    let body = stdout(&o);
+    assert!(
+        body.contains("http://example.org/d"),
+        "stdout must carry the converted Turtle document; got:\n{body}"
+    );
+    assert!(
+        !body.contains("schema_version")
+            && !body.contains("\"losses\"")
+            && !body.contains("named-graph-dropped"),
+        "the ledger must NOT leak into the conversion on stdout; got:\n{body}"
+    );
+}
+
+/// BARE `--loss-ledger`: the JSON goes to STDERR and the clean conversion goes to
+/// STDOUT — the two streams are cleanly separated.
+#[test]
+fn bare_flag_separates_ledger_on_stderr_from_conversion_on_stdout() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "named.trig", NAMED_GRAPH_TRIG);
+
+    let o = run(&[
+        "--loss-ledger",
+        "convert",
+        "--from",
+        "trig",
+        "--to",
+        "turtle",
+        &seed,
+        "-",
+    ]);
+    assert!(
+        o.status.success(),
+        "trig -> turtle must exit 0; stderr:\n{}",
+        stderr(&o)
+    );
+
+    // stdout: the clean converted Turtle, with no ledger contamination.
+    let body = stdout(&o);
+    assert!(
+        body.contains("http://example.org/d"),
+        "stdout must carry the converted Turtle; got:\n{body}"
+    );
+    assert!(
+        !body.contains("schema_version") && !body.contains("named-graph-dropped"),
+        "the ledger must NOT appear on stdout under bare --loss-ledger; got:\n{body}"
+    );
+
+    // stderr: the ledger JSON, non-empty, naming the dropped named graph.
+    let ledger = stderr(&o);
+    assert!(
+        ledger.contains("\"schema_version\"") && ledger.contains("named-graph-dropped"),
+        "the ledger JSON must be on stderr under bare --loss-ledger; got:\n{ledger}"
+    );
+}
+
+/// `--loss-ledger=PATH`: the JSON is written to PATH byte-identically to what bare
+/// mode writes to stderr for the SAME conversion; stderr is empty; stdout is the
+/// clean conversion output.
+#[test]
+fn path_flag_matches_bare_stderr_byte_for_byte_and_leaves_streams_clean() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "seedC.nq", SEED_C);
+
+    // Bare mode: capture the ledger from stderr (output to a discardable file).
+    let out_bare = path(dir, "bare.rdf");
+    let bare = run(&[
+        "--loss-ledger",
+        "convert",
+        "--from",
+        "nquads",
+        "--to",
+        "rdfxml",
+        &seed,
+        &out_bare,
+    ]);
+    assert!(
+        bare.status.success(),
+        "bare nq -> rdfxml must exit 0; stderr:\n{}",
+        stderr(&bare)
+    );
+    let bare_ledger_bytes = bare.stderr;
+
+    // Path mode: the SAME conversion, ledger to a file, conversion to stdout `-`.
+    let ledger_path = path(dir, "ledger.json");
+    let path_run = run(&[
+        &format!("--loss-ledger={ledger_path}"),
+        "convert",
+        "--from",
+        "nquads",
+        "--to",
+        "rdfxml",
+        &seed,
+        "-",
+    ]);
+    assert!(
+        path_run.status.success(),
+        "path nq -> rdfxml must exit 0; stderr:\n{}",
+        stderr(&path_run)
+    );
+
+    // stderr is empty when the ledger is redirected to a file.
+    assert!(
+        path_run.stderr.is_empty(),
+        "--loss-ledger=PATH must leave stderr EMPTY; got:\n{}",
+        stderr(&path_run)
+    );
+    // stdout carries the clean RDF/XML conversion (the base triple survives).
+    let body = stdout(&path_run);
+    assert!(
+        body.contains("http://example.org/s") && !body.contains("schema_version"),
+        "stdout must carry the clean RDF/XML conversion (no ledger); got:\n{body}"
+    );
+
+    // The file written by =PATH is byte-identical to bare mode's stderr.
+    let file_ledger_bytes = std::fs::read(&ledger_path).expect("read ledger file");
+    assert_eq!(
+        file_ledger_bytes, bare_ledger_bytes,
+        "--loss-ledger=PATH must write byte-identically to bare mode's stderr"
+    );
+}
+
+/// The ledger JSON is DETERMINISTIC: the same lossy conversion produces byte-identical
+/// ledger files across two runs.
+#[test]
+fn ledger_json_is_deterministic_across_runs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "seedC.nq", SEED_C);
+    let out = path(dir, "out.rdf");
+
+    let ledger_a = path(dir, "a.json");
+    let ledger_b = path(dir, "b.json");
+    for ledger in [&ledger_a, &ledger_b] {
+        let o = run(&[
+            &format!("--loss-ledger={ledger}"),
+            "convert",
+            "--from",
+            "nquads",
+            "--to",
+            "rdfxml",
+            &seed,
+            &out,
+        ]);
+        assert!(
+            o.status.success(),
+            "nq -> rdfxml must exit 0; stderr:\n{}",
+            stderr(&o)
+        );
+    }
+
+    assert_eq!(
+        std::fs::read(&ledger_a).expect("read a"),
+        std::fs::read(&ledger_b).expect("read b"),
+        "the same lossy conversion's ledger JSON must be byte-identical across runs"
+    );
+}
+
+/// `--loss-ledger` is a GLOBAL flag: it is accepted BOTH before the subcommand
+/// (`purrdf --loss-ledger convert …`) and AFTER it (`purrdf convert … --loss-ledger`),
+/// and both positions surface the SAME ledger.
+#[test]
+fn global_flag_works_before_and_after_the_subcommand() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "named.trig", NAMED_GRAPH_TRIG);
+    let out = path(dir, "out.ttl");
+
+    // Documented position: BEFORE the subcommand.
+    let before = run(&[
+        "--loss-ledger",
+        "convert",
+        "--from",
+        "trig",
+        "--to",
+        "turtle",
+        &seed,
+        &out,
+    ]);
+    assert!(
+        before.status.success(),
+        "flag before the subcommand must exit 0; stderr:\n{}",
+        stderr(&before)
+    );
+    assert!(
+        stderr(&before).contains("named-graph-dropped"),
+        "the flag before the subcommand must surface the ledger; got:\n{}",
+        stderr(&before)
+    );
+
+    // `global = true` also accepts it AFTER the subcommand (trailing).
+    let after = run(&[
+        "convert",
+        "--from",
+        "trig",
+        "--to",
+        "turtle",
+        &seed,
+        &out,
+        "--loss-ledger",
+    ]);
+    assert!(
+        after.status.success(),
+        "flag after the subcommand must exit 0; stderr:\n{}",
+        stderr(&after)
+    );
+    assert!(
+        stderr(&after).contains("named-graph-dropped"),
+        "the flag after the subcommand must surface the ledger; got:\n{}",
+        stderr(&after)
+    );
+
+    // Both positions produce the identical ledger bytes.
+    assert_eq!(
+        before.stderr, after.stderr,
+        "the ledger must be identical whether --loss-ledger precedes or follows the subcommand"
+    );
+}
+
+/// UNIVERSAL-SINK INVARIANT (query-CONSTRUCT): a CONSTRUCT whose result carries an
+/// RDF-1.2 reifier (minted via the annotation syntax `{| … |}`) serialized to a
+/// star-INcapable RDF format (RDF/XML) PROJECTS the statement layer, and — surfaced
+/// here via `--loss-ledger=PATH` (a variant distinct from `query_cli.rs`, which pins
+/// the bare-stderr path) — the file ledger is non-empty. The graph has no source
+/// codec, so the drop is recorded as the realized `statement-rows-dropped`.
+#[test]
+fn query_construct_reifier_to_rdfxml_via_path_records_the_universal_drop() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let ttl = write_file(
+        dir,
+        "data.ttl",
+        "@prefix ex: <http://example.org/> .\nex:s ex:p ex:o .\n",
+    );
+    let ledger_path = path(dir, "query.json");
+
+    let o = run(&[
+        &format!("--loss-ledger={ledger_path}"),
+        "query",
+        "--data",
+        &ttl,
+        "--results-format",
+        "rdfxml",
+        "CONSTRUCT { ?s ?p ?o {| <http://example.org/certainty> \"0.9\" |} } WHERE { ?s ?p ?o }",
+    ]);
+    assert!(
+        o.status.success(),
+        "CONSTRUCT reifier -> rdfxml must PROJECT (exit 0); stderr:\n{}",
+        stderr(&o)
+    );
+    // stderr is empty (the ledger is redirected to the file); stdout carries the RDF/XML.
+    assert!(
+        o.stderr.is_empty(),
+        "--loss-ledger=PATH must leave stderr EMPTY; got:\n{}",
+        stderr(&o)
+    );
+    assert!(
+        stdout(&o).contains("http://example.org/s"),
+        "the base triple must survive the projection on stdout; got:\n{}",
+        stdout(&o)
+    );
+
+    let ledger = std::fs::read_to_string(&ledger_path).expect("read query ledger");
+    assert!(
+        !ledger_is_empty(&ledger),
+        "the query-CONSTRUCT universal-sink drop must produce a non-empty ledger; got:\n{ledger}"
+    );
+    assert!(
+        ledger.contains("statement-rows-dropped"),
+        "the query ledger must record the dropped statement rows; got:\n{ledger}"
+    );
+}
+
+/// `reason` also feeds the universal sink: a `reason --regime simple` closure over
+/// SEED C (a reifier + annotation) serialized to a star-INcapable target (RDF/XML)
+/// drops the statement layer, and `--loss-ledger=PATH` surfaces the non-empty ledger —
+/// proving the `reason` lane records losses exactly like `convert`/`query`.
+#[test]
+fn reason_closure_to_star_incapable_target_surfaces_the_ledger() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(dir, "seedC.nq", SEED_C);
+    let out = path(dir, "closure.rdf");
+    let ledger_path = path(dir, "reason.json");
+
+    let o = run(&[
+        &format!("--loss-ledger={ledger_path}"),
+        "reason",
+        "--regime",
+        "simple",
+        &seed,
+        &out,
+    ]);
+    assert!(
+        o.status.success(),
+        "reason simple -> rdfxml must exit 0; stderr:\n{}",
+        stderr(&o)
+    );
+    // The closure keeps the base triple but drops the star layer under RDF/XML.
+    let body = std::fs::read_to_string(&out).expect("read closure");
+    assert!(
+        body.contains("http://example.org/s") && !body.contains("reifies"),
+        "the reason closure must project the statement layer for a star-incapable target; got:\n{body}"
+    );
+
+    let ledger = std::fs::read_to_string(&ledger_path).expect("read reason ledger");
+    assert!(
+        !ledger_is_empty(&ledger),
+        "the reason universal-sink drop must produce a non-empty ledger; got:\n{ledger}"
+    );
+    assert!(
+        ledger.contains("statement-rows-dropped"),
+        "the reason ledger must record the dropped statement rows; got:\n{ledger}"
+    );
+}

--- a/crates/cli/tests/query_cli.rs
+++ b/crates/cli/tests/query_cli.rs
@@ -448,6 +448,43 @@ fn corrupt_pack_fails_closed() {
     );
 }
 
+/// `--entailment` shares the exit-3 unsupported-regime boundary with `reason`
+/// (`crates/cli/src/reason.rs::resolve_materializable_regime`, wired into `query` via
+/// `crates/cli/src/query.rs`): `owl-direct`, `rif`, and `d` each need inputs (query class
+/// expressions or a rule set) the CLI cannot materialize, so `query --entailment` on any
+/// of them must exit code **3**, not merely fail.
+#[test]
+fn entailment_boundary_regimes_exit_three() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let ttl = write_file(dir, "data.ttl", DATA_TTL);
+    let query = "SELECT ?o WHERE { ?s <http://example.org/knows> ?o }";
+
+    for regime in ["owl-direct", "rif", "d"] {
+        let out = run(&[
+            "query",
+            "--data",
+            &ttl,
+            "--entailment",
+            regime,
+            "--results-format",
+            "json",
+            query,
+        ]);
+        assert_eq!(
+            out.status.code(),
+            Some(3),
+            "query --entailment {regime} must exit code 3 (unsupported-regime boundary); stderr:\n{}",
+            stderr(&out)
+        );
+        assert!(
+            stderr(&out).contains("cannot be materialized"),
+            "query --entailment {regime} must explain it cannot be materialized; got:\n{}",
+            stderr(&out)
+        );
+    }
+}
+
 /// A SELECT piped through stdout is stable enough to run as a process smoke (the binary
 /// spawns, reads the file, and writes results) — a belt-and-suspenders check that the
 /// query path does not deadlock on a captured stdout pipe.

--- a/crates/cli/tests/query_cli.rs
+++ b/crates/cli/tests/query_cli.rs
@@ -1,0 +1,484 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! End-to-end `query` coverage that drives the BUILT `purrdf` binary
+//! (`env!("CARGO_BIN_EXE_purrdf")`) — never the library — so every assertion pins the
+//! shipped executable's behavior. All fixtures use `example.org`.
+//!
+//! ## The result-shape × format-kind dispatch this exercises
+//!
+//! `--results-format` is a superset of the four SPARQL-results serializations and the
+//! nine RDF syntaxes; the result SHAPE selects which half is legal:
+//!
+//! * SELECT solutions / ASK boolean → a SPARQL-results format (json/xml/csv/tsv);
+//! * a CONSTRUCT/DESCRIBE graph → an RDF syntax, serialized through the SAME universal
+//!   sink `convert` uses (so a star-incapable target projects the RDF-1.2 statement
+//!   layer and the loss ledger records the drop);
+//! * a shape/format-kind mismatch (solutions/boolean + an RDF syntax, or a graph + a
+//!   SPARQL-results format) is a hard error (exit non-zero).
+//!
+//! ## A note on CONSTRUCT reifiers and the universal-sink invariant
+//!
+//! A CONSTRUCT whose template uses the RDF-1.2 annotation syntax (`{| ... |}`) mints a
+//! reifier that lives in the dataset's STATEMENT-LAYER overlay — so serializing the
+//! result to a `carries_star = false` target (RDF/XML) PROJECTS the layer to base
+//! quads and records the dropped rows, exactly as `convert` does. (A plain
+//! `rdf:reifies <<( … )>>` triple that merely flows through a variable binding is a
+//! nested triple TERM, not an overlay row, and RDF/XML would emit it via
+//! `parseType="Triple"` instead — so the reifier test deliberately uses the annotation
+//! syntax to drive the overlay/projection path.)
+
+use std::process::{Command, Output, Stdio};
+
+/// The path to the built `purrdf` binary this integration test target links against.
+const PURRDF: &str = env!("CARGO_BIN_EXE_purrdf");
+
+/// A default-graph fixture with rich term shapes (an IRI object and a plain literal),
+/// enough to drive SELECT / ASK / CONSTRUCT / DESCRIBE over `example.org`.
+const DATA_TTL: &str = concat!(
+    "@prefix ex: <http://example.org/> .\n",
+    "ex:alice ex:knows ex:bob .\n",
+    "ex:alice ex:name \"Alice\" .\n",
+);
+
+/// A `Command` for the built `purrdf` binary.
+fn purrdf() -> Command {
+    Command::new(PURRDF)
+}
+
+/// Run `purrdf` with `args`, returning the captured [`Output`].
+fn run(args: &[&str]) -> Output {
+    purrdf().args(args).output().expect("spawn purrdf")
+}
+
+/// stdout of an [`Output`] as a `String`.
+fn stdout(out: &Output) -> String {
+    String::from_utf8(out.stdout.clone()).expect("utf-8 stdout")
+}
+
+/// stderr of an [`Output`] as a `String`, for diagnostics + ledger assertions.
+fn stderr(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// Write `contents` to `dir/name` and return the path as an owned string.
+fn write_file(dir: &std::path::Path, name: &str, contents: &str) -> String {
+    let p = dir.join(name);
+    std::fs::write(&p, contents).expect("write fixture");
+    p.to_str().expect("utf-8 path").to_owned()
+}
+
+/// The SAME SELECT over (a) a Turtle file and (b) an mmap'd `.purrpck` pack built from
+/// identical data yields byte-identical, non-vacuous results — file/pack query parity.
+#[test]
+fn select_file_and_pack_are_byte_identical_and_non_vacuous() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let ttl = write_file(dir, "data.ttl", DATA_TTL);
+    let query = "SELECT ?o WHERE { ?s <http://example.org/knows> ?o }";
+
+    // (a) Query the Turtle file.
+    let file_out = run(&["query", "--data", &ttl, "--results-format", "json", query]);
+    assert!(
+        file_out.status.success(),
+        "query over the turtle file must exit 0; stderr:\n{}",
+        stderr(&file_out)
+    );
+    let file_json = stdout(&file_out);
+    assert!(
+        file_json.contains("http://example.org/bob"),
+        "the SELECT must bind at least one row (ex:bob); got:\n{file_json}"
+    );
+
+    // (b) Build a pack from the same data, then query it (mmap'd, zero-copy).
+    let pack = write_file(dir, "data.purrpck", "");
+    let build = run(&["convert", "--from", "turtle", "--to", "pack", &ttl, &pack]);
+    assert!(
+        build.status.success(),
+        "building the pack must exit 0; stderr:\n{}",
+        stderr(&build)
+    );
+    let pack_out = run(&["query", "--data", &pack, "--results-format", "json", query]);
+    assert!(
+        pack_out.status.success(),
+        "query over the pack must exit 0; stderr:\n{}",
+        stderr(&pack_out)
+    );
+
+    assert_eq!(
+        file_json,
+        stdout(&pack_out),
+        "the SELECT result must be byte-identical whether queried over the turtle file or its pack"
+    );
+}
+
+/// Each of the four SPARQL-results formats (json / xml / csv / tsv) serializes a SELECT
+/// non-vacuously and DETERMINISTICALLY (two runs are byte-identical). TSV and XML are
+/// explicit acceptance criteria and are covered here alongside JSON and CSV.
+#[test]
+fn select_all_four_result_formats_are_non_vacuous_and_deterministic() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let ttl = write_file(dir, "data.ttl", DATA_TTL);
+    let query = "SELECT ?o WHERE { ?s <http://example.org/knows> ?o }";
+
+    for fmt in ["json", "xml", "csv", "tsv"] {
+        let first = run(&["query", "--data", &ttl, "--results-format", fmt, query]);
+        assert!(
+            first.status.success(),
+            "SELECT --results-format {fmt} must exit 0; stderr:\n{}",
+            stderr(&first)
+        );
+        let body = stdout(&first);
+        assert!(
+            body.contains("http://example.org/bob"),
+            "SELECT --results-format {fmt} must be non-vacuous (bind ex:bob); got:\n{body}"
+        );
+
+        // Deterministic: a second identical run yields byte-identical bytes.
+        let second = run(&["query", "--data", &ttl, "--results-format", fmt, query]);
+        assert!(second.status.success(), "second {fmt} run must exit 0");
+        assert_eq!(
+            first.stdout, second.stdout,
+            "SELECT --results-format {fmt} must be byte-deterministic across runs"
+        );
+    }
+}
+
+/// An ASK with `--results-format json` returns a JSON boolean result (the W3C
+/// `{"head":{},"boolean":true}` shape).
+#[test]
+fn ask_json_returns_a_boolean_shape() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let ttl = write_file(dir, "data.ttl", DATA_TTL);
+
+    let out = run(&[
+        "query",
+        "--data",
+        &ttl,
+        "--results-format",
+        "json",
+        "ASK { ?s <http://example.org/knows> ?o }",
+    ]);
+    assert!(
+        out.status.success(),
+        "ASK json must exit 0; stderr:\n{}",
+        stderr(&out)
+    );
+    let body = stdout(&out);
+    assert!(
+        body.contains("\"boolean\"") && body.contains("true"),
+        "the ASK JSON must carry a boolean result (true); got:\n{body}"
+    );
+}
+
+/// A CONSTRUCT to Turtle AND a DESCRIBE to Turtle both surface their triples in the RDF
+/// output (the graph → RDF-syntax half of the dispatch).
+#[test]
+fn construct_and_describe_to_turtle_surface_their_triples() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let ttl = write_file(dir, "data.ttl", DATA_TTL);
+
+    // CONSTRUCT a fresh `ex:friend` edge from the `ex:knows` edge.
+    let construct = run(&[
+        "query",
+        "--data",
+        &ttl,
+        "--results-format",
+        "turtle",
+        "CONSTRUCT { ?s <http://example.org/friend> ?o } WHERE { ?s <http://example.org/knows> ?o }",
+    ]);
+    assert!(
+        construct.status.success(),
+        "CONSTRUCT -> turtle must exit 0; stderr:\n{}",
+        stderr(&construct)
+    );
+    let construct_body = stdout(&construct);
+    assert!(
+        construct_body.contains("http://example.org/friend")
+            && construct_body.contains("http://example.org/bob"),
+        "the CONSTRUCTed triple must appear in the Turtle output; got:\n{construct_body}"
+    );
+
+    // DESCRIBE alice: her two triples must appear.
+    let describe = run(&[
+        "query",
+        "--data",
+        &ttl,
+        "--results-format",
+        "turtle",
+        "DESCRIBE <http://example.org/alice>",
+    ]);
+    assert!(
+        describe.status.success(),
+        "DESCRIBE -> turtle must exit 0; stderr:\n{}",
+        stderr(&describe)
+    );
+    let describe_body = stdout(&describe);
+    assert!(
+        describe_body.contains("http://example.org/knows") && describe_body.contains("Alice"),
+        "the DESCRIBEd triples must appear in the Turtle output; got:\n{describe_body}"
+    );
+}
+
+/// A CONSTRUCT whose result carries an RDF-1.2 reifier (minted via the annotation
+/// syntax `{| … |}`) serialized to a star-INcapable RDF format (RDF/XML) PROJECTS the
+/// statement layer, and under `--loss-ledger` the ledger records the drop — the
+/// universal-sink invariant, identical to `convert`'s behavior.
+#[test]
+fn construct_reifier_to_rdfxml_records_the_loss_ledger_drop() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let ttl = write_file(
+        dir,
+        "data.ttl",
+        "@prefix ex: <http://example.org/> .\nex:s ex:p ex:o .\n",
+    );
+
+    let out = run(&[
+        "--loss-ledger",
+        "query",
+        "--data",
+        &ttl,
+        "--results-format",
+        "rdfxml",
+        "CONSTRUCT { ?s ?p ?o {| <http://example.org/certainty> \"0.9\" |} } WHERE { ?s ?p ?o }",
+    ]);
+    assert!(
+        out.status.success(),
+        "CONSTRUCT reifier -> rdfxml must PROJECT (exit 0), not fail-close; stderr:\n{}",
+        stderr(&out)
+    );
+    // The projected RDF/XML keeps the base triple but not the reifies binding.
+    let body = stdout(&out);
+    assert!(
+        body.contains("http://example.org/s"),
+        "the base triple must survive the projection; got:\n{body}"
+    );
+    assert!(
+        !body.contains("reifies"),
+        "the reifier binding must be projected away for a star-incapable target; got:\n{body}"
+    );
+    // The bare `--loss-ledger` renders the ledger to stderr, recording the dropped rows.
+    let ledger = stderr(&out);
+    assert!(
+        ledger.contains("statement-rows-dropped"),
+        "the loss ledger must record the dropped statement rows (universal-sink invariant); \
+         got:\n{ledger}"
+    );
+}
+
+/// A shape/format-kind mismatch is a hard error (exit non-zero, diagnostic on stderr):
+/// `csv` on a CONSTRUCT graph, `turtle` on SELECT solutions, and `turtle` on an ASK
+/// boolean.
+#[test]
+fn shape_format_mismatches_are_hard_errors() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let ttl = write_file(dir, "data.ttl", DATA_TTL);
+
+    // A graph result with a SPARQL-results format.
+    let graph_with_results = run(&[
+        "query",
+        "--data",
+        &ttl,
+        "--results-format",
+        "csv",
+        "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }",
+    ]);
+    assert!(
+        !graph_with_results.status.success(),
+        "a CONSTRUCT graph with --results-format csv must fail"
+    );
+    assert!(
+        !stderr(&graph_with_results).is_empty(),
+        "the graph/results-format mismatch must print a diagnostic to stderr"
+    );
+
+    // Solutions with an RDF syntax.
+    let solutions_with_rdf = run(&[
+        "query",
+        "--data",
+        &ttl,
+        "--results-format",
+        "turtle",
+        "SELECT ?o WHERE { ?s <http://example.org/knows> ?o }",
+    ]);
+    assert!(
+        !solutions_with_rdf.status.success(),
+        "a SELECT with --results-format turtle must fail"
+    );
+    assert!(
+        !stderr(&solutions_with_rdf).is_empty(),
+        "the solutions/RDF-syntax mismatch must print a diagnostic to stderr"
+    );
+
+    // A boolean with an RDF syntax.
+    let boolean_with_rdf = run(&[
+        "query",
+        "--data",
+        &ttl,
+        "--results-format",
+        "turtle",
+        "ASK { ?s ?p ?o }",
+    ]);
+    assert!(
+        !boolean_with_rdf.status.success(),
+        "an ASK with --results-format turtle must fail"
+    );
+    assert!(
+        !stderr(&boolean_with_rdf).is_empty(),
+        "the boolean/RDF-syntax mismatch must print a diagnostic to stderr"
+    );
+}
+
+/// `--entailment rdfs` materializes the RDFS closure IN MEMORY before querying: a SELECT
+/// whose match requires `rdfs:subClassOf` entailment binds its row WITH the flag and
+/// binds NOTHING without it.
+#[test]
+fn entailment_rdfs_reveals_a_binding_absent_without_it() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let ttl = write_file(
+        dir,
+        "sub.ttl",
+        concat!(
+            "@prefix ex: <http://example.org/> .\n",
+            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+            "ex:Dog rdfs:subClassOf ex:Animal .\n",
+            "ex:rex a ex:Dog .\n",
+        ),
+    );
+    // `ex:rex a ex:Animal` holds ONLY under the RDFS subClassOf closure.
+    let query = "SELECT ?x WHERE { ?x a <http://example.org/Animal> }";
+
+    // Without --entailment: no row.
+    let plain = run(&["query", "--data", &ttl, "--results-format", "tsv", query]);
+    assert!(
+        plain.status.success(),
+        "the plain query must exit 0; stderr:\n{}",
+        stderr(&plain)
+    );
+    assert!(
+        !stdout(&plain).contains("http://example.org/rex"),
+        "ex:rex must NOT bind without --entailment; got:\n{}",
+        stdout(&plain)
+    );
+
+    // With --entailment rdfs: the inferred binding appears.
+    let entailed = run(&[
+        "query",
+        "--data",
+        &ttl,
+        "--entailment",
+        "rdfs",
+        "--results-format",
+        "tsv",
+        query,
+    ]);
+    assert!(
+        entailed.status.success(),
+        "--entailment rdfs query must exit 0; stderr:\n{}",
+        stderr(&entailed)
+    );
+    assert!(
+        stdout(&entailed).contains("http://example.org/rex"),
+        "ex:rex must bind under --entailment rdfs (subClassOf closure); got:\n{}",
+        stdout(&entailed)
+    );
+}
+
+/// `--base` resolves relative IRIs in the DATA while parsing, so a query naming the
+/// resolved absolute IRI matches.
+#[test]
+fn base_resolves_relative_iris_in_the_data() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    // A relative-IRI subject resolved against `--base`.
+    let ttl = write_file(dir, "rel.ttl", "<thing> <http://example.org/p> \"hit\" .\n");
+
+    let out = run(&[
+        "query",
+        "--data",
+        &ttl,
+        "--base",
+        "http://example.org/base/",
+        "--results-format",
+        "tsv",
+        "SELECT ?o WHERE { <http://example.org/base/thing> <http://example.org/p> ?o }",
+    ]);
+    assert!(
+        out.status.success(),
+        "--base query must exit 0; stderr:\n{}",
+        stderr(&out)
+    );
+    assert!(
+        stdout(&out).contains("hit"),
+        "the relative subject must resolve against --base so the query matches; got:\n{}",
+        stdout(&out)
+    );
+}
+
+/// A truncated/garbage `.purrpck` passed to `--data` fails closed (exit non-zero): the
+/// pack integrity verifier rejects it before any view is opened.
+#[test]
+fn corrupt_pack_fails_closed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let bad = write_file(dir, "bad.purrpck", "not a pack file at all — pure garbage");
+
+    let out = run(&[
+        "query",
+        "--data",
+        &bad,
+        "--results-format",
+        "json",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+    ]);
+    assert!(
+        !out.status.success(),
+        "a corrupt pack must fail closed (exit non-zero); stdout:\n{}",
+        stdout(&out)
+    );
+    assert!(
+        !stderr(&out).is_empty(),
+        "the pack-integrity failure must print a diagnostic to stderr"
+    );
+}
+
+/// A SELECT piped through stdout is stable enough to run as a process smoke (the binary
+/// spawns, reads the file, and writes results) — a belt-and-suspenders check that the
+/// query path does not deadlock on a captured stdout pipe.
+#[test]
+fn select_writes_results_to_a_captured_stdout_pipe() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let ttl = write_file(dir, "data.ttl", DATA_TTL);
+
+    let child = purrdf()
+        .args([
+            "query",
+            "--data",
+            &ttl,
+            "--results-format",
+            "tsv",
+            "SELECT ?o WHERE { ?s <http://example.org/knows> ?o }",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn purrdf query");
+    let out = child.wait_with_output().expect("await query child");
+    assert!(
+        out.status.success(),
+        "piped SELECT must exit 0; stderr:\n{}",
+        stderr(&out)
+    );
+    assert!(
+        stdout(&out).contains("http://example.org/bob"),
+        "the piped TSV must carry the bound object; got:\n{}",
+        stdout(&out)
+    );
+}

--- a/crates/cli/tests/reason_cli.rs
+++ b/crates/cli/tests/reason_cli.rs
@@ -1,0 +1,435 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! End-to-end `reason` coverage that drives the BUILT `purrdf` binary
+//! (`env!("CARGO_BIN_EXE_purrdf")`) — never the library — so every assertion pins the
+//! shipped executable's entailment behavior.
+//!
+//! ## What each regime asserts
+//!
+//! Every supported regime gets a fixture with a KNOWN entailment, and the test asserts
+//! the SPECIFIC inferred N-Triples line is present in the output (the closure is written
+//! to a `.nt` file so the output is deterministic, line-based text and substring
+//! assertions are robust). The exact inferred lines below were confirmed by driving the
+//! binary directly, not assumed:
+//!
+//! * **simple** — a faithful copy: the output quad SET equals the input (nothing added).
+//! * **rdf** — predicate-typing: every resource used in predicate position is asserted an
+//!   `rdf:Property`.
+//! * **rdfs** — the RDFS rule set: `subClassOf` type propagation, `domain`/`range` typing,
+//!   and `subPropertyOf` triple propagation.
+//! * **owl-rl** — OWL 2 RL beyond RDFS: `owl:SymmetricProperty` and
+//!   `owl:TransitiveProperty` closure.
+//!
+//! The three non-materializable regimes (`owl-direct`, `rif`, `d`) are the exit-3
+//! boundary (they need query class expressions or a rule set the CLI cannot supply), and
+//! a `.purrpck` pack source exercises the pack→dataset reconstruction path inside
+//! `reason`.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+/// The rdf:type IRI, spelled out (the inferred-triple assertions key on it).
+const RDF_TYPE: &str = "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>";
+
+/// A `Command` for the built `purrdf` binary.
+fn purrdf() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_purrdf"))
+}
+
+/// Run `purrdf` with `args`, returning the captured [`Output`].
+fn run(args: &[&str]) -> Output {
+    purrdf()
+        .args(args)
+        .output()
+        .expect("spawn the built purrdf binary")
+}
+
+/// stderr of an [`Output`] as a `String`, for diagnostics + boundary assertions.
+fn stderr(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// Join a name onto `dir`, returning it as an owned `String` (the shape [`run`] wants).
+fn path(dir: &Path, name: &str) -> String {
+    dir.join(name)
+        .to_str()
+        .expect("temp path is valid UTF-8")
+        .to_owned()
+}
+
+/// Write `contents` to `dir/name`, returning the path.
+fn write_file(dir: &Path, name: &str, contents: &str) -> String {
+    let p = path(dir, name);
+    std::fs::write(&p, contents).expect("write fixture file");
+    p
+}
+
+/// The non-empty, trimmed lines of a file as a sorted `Vec` (a set-equality helper for
+/// line-based N-Triples output).
+fn sorted_lines(p: &str) -> Vec<String> {
+    let text = std::fs::read_to_string(p).expect("read output file");
+    let mut lines: Vec<String> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(ToOwned::to_owned)
+        .collect();
+    lines.sort();
+    lines
+}
+
+/// `reason --regime simple` is a faithful copy: the output quad SET equals the input.
+/// Simple entailment adds nothing beyond a faithful reproduction of the source.
+#[test]
+fn simple_is_identity_closure() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let input = concat!(
+        "<http://example.org/a> <http://example.org/knows> <http://example.org/b> .\n",
+        "<http://example.org/b> <http://example.org/name> \"Bob\" .\n",
+    );
+    let seed = write_file(dir, "simple.nt", input);
+    let out = path(dir, "out.nt");
+
+    let o = run(&["reason", "--regime", "simple", &seed, &out]);
+    assert!(o.status.success(), "simple reason failed: {}", stderr(&o));
+
+    // Every input triple is present, and NOTHING was added: the set is identical.
+    assert_eq!(
+        sorted_lines(&out),
+        sorted_lines(&seed),
+        "simple entailment must be a faithful identity copy (set-equal to the input)"
+    );
+}
+
+/// `reason --regime rdf` asserts predicate-typing: every resource used in predicate
+/// position is inferred to be an `rdf:Property`. From `ex:a ex:knows ex:b .` the closure
+/// contains `ex:knows a rdf:Property`.
+#[test]
+fn rdf_infers_predicate_is_property() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(
+        dir,
+        "rdf.nt",
+        "<http://example.org/a> <http://example.org/knows> <http://example.org/b> .\n",
+    );
+    let out = path(dir, "out.nt");
+
+    let o = run(&["reason", "--regime", "rdf", &seed, &out]);
+    assert!(o.status.success(), "rdf reason failed: {}", stderr(&o));
+
+    let inferred = format!(
+        "<http://example.org/knows> {RDF_TYPE} \
+         <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property>"
+    );
+    let text = std::fs::read_to_string(&out).expect("read output");
+    assert!(
+        text.contains(&inferred),
+        "rdf entailment must type the predicate as rdf:Property; got: {text}"
+    );
+    // The original triple survives too.
+    assert!(
+        text.contains("<http://example.org/a> <http://example.org/knows> <http://example.org/b>"),
+        "the original triple must be preserved; got: {text}"
+    );
+}
+
+/// `reason --regime rdfs` runs the RDFS rule set. A `subClassOf` chain propagates
+/// `rdf:type`; `rdfs:domain` / `rdfs:range` type the subject / object of a use of the
+/// property; and `rdfs:subPropertyOf` propagates the base triple onto the super-property.
+#[test]
+fn rdfs_infers_subclass_domain_range_and_subproperty() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(
+        dir,
+        "rdfs.ttl",
+        concat!(
+            "@prefix ex: <http://example.org/> .\n",
+            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+            // subClassOf → type propagation.
+            "ex:Dog rdfs:subClassOf ex:Animal .\n",
+            "ex:rex a ex:Dog .\n",
+            // domain + range → subject/object typing.
+            "ex:knows rdfs:domain ex:Person .\n",
+            "ex:knows rdfs:range ex:Person .\n",
+            "ex:a ex:knows ex:b .\n",
+            // subPropertyOf → triple propagation.
+            "ex:loves rdfs:subPropertyOf ex:knows .\n",
+            "ex:c ex:loves ex:d .\n",
+        ),
+    );
+    let out = path(dir, "out.nt");
+
+    let o = run(&["reason", "--regime", "rdfs", &seed, &out]);
+    assert!(o.status.success(), "rdfs reason failed: {}", stderr(&o));
+    let text = std::fs::read_to_string(&out).expect("read output");
+
+    // subClassOf: ex:rex a ex:Animal.
+    assert!(
+        text.contains(&format!(
+            "<http://example.org/rex> {RDF_TYPE} <http://example.org/Animal>"
+        )),
+        "rdfs must infer `ex:rex a ex:Animal` via subClassOf; got: {text}"
+    );
+    // domain: ex:a a ex:Person.
+    assert!(
+        text.contains(&format!(
+            "<http://example.org/a> {RDF_TYPE} <http://example.org/Person>"
+        )),
+        "rdfs must infer `ex:a a ex:Person` via rdfs:domain; got: {text}"
+    );
+    // range: ex:b a ex:Person.
+    assert!(
+        text.contains(&format!(
+            "<http://example.org/b> {RDF_TYPE} <http://example.org/Person>"
+        )),
+        "rdfs must infer `ex:b a ex:Person` via rdfs:range; got: {text}"
+    );
+    // subPropertyOf: ex:c ex:knows ex:d (propagated from ex:c ex:loves ex:d).
+    assert!(
+        text.contains("<http://example.org/c> <http://example.org/knows> <http://example.org/d>"),
+        "rdfs must propagate `ex:c ex:knows ex:d` via subPropertyOf; got: {text}"
+    );
+}
+
+/// `reason --regime owl-rl` runs OWL 2 RL — strictly beyond RDFS. An
+/// `owl:SymmetricProperty` yields the reversed triple, and an `owl:TransitiveProperty`
+/// closes a two-hop chain.
+#[test]
+fn owl_rl_infers_symmetric_and_transitive() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(
+        dir,
+        "owlrl.ttl",
+        concat!(
+            "@prefix ex: <http://example.org/> .\n",
+            "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n",
+            // Symmetric: ex:a ex:knows ex:b ⇒ ex:b ex:knows ex:a.
+            "ex:knows a owl:SymmetricProperty .\n",
+            "ex:a ex:knows ex:b .\n",
+            // Transitive: ex:x ex:before ex:y, ex:y ex:before ex:z ⇒ ex:x ex:before ex:z.
+            "ex:before a owl:TransitiveProperty .\n",
+            "ex:x ex:before ex:y .\n",
+            "ex:y ex:before ex:z .\n",
+        ),
+    );
+    let out = path(dir, "out.nt");
+
+    let o = run(&["reason", "--regime", "owl-rl", &seed, &out]);
+    assert!(o.status.success(), "owl-rl reason failed: {}", stderr(&o));
+    let text = std::fs::read_to_string(&out).expect("read output");
+
+    // Symmetry.
+    assert!(
+        text.contains("<http://example.org/b> <http://example.org/knows> <http://example.org/a>"),
+        "owl-rl must infer the symmetric `ex:b ex:knows ex:a`; got: {text}"
+    );
+    // Transitivity.
+    assert!(
+        text.contains("<http://example.org/x> <http://example.org/before> <http://example.org/z>"),
+        "owl-rl must infer the transitive `ex:x ex:before ex:z`; got: {text}"
+    );
+}
+
+/// The three non-materializable regimes (`owl-direct`, `rif`, `d`) each exit with code 3
+/// and print a diagnostic to stderr naming why: they need query class expressions or a
+/// rule set the CLI has no way to supply.
+#[test]
+fn boundary_regimes_exit_three_with_diagnostic() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(
+        dir,
+        "seed.nt",
+        "<http://example.org/a> <http://example.org/knows> <http://example.org/b> .\n",
+    );
+    let out = path(dir, "out.nt");
+
+    // Each boundary regime is unsupported for a DISTINCT spec-inherent reason; the
+    // diagnostic must name that specific reason, not a generic catch-all.
+    for (regime, expected_reason) in [
+        ("owl-direct", "class expressions"),
+        ("rif", "rule set"),
+        ("d", "datatype"),
+    ] {
+        let o = run(&["reason", "--regime", regime, &seed, &out]);
+        assert_eq!(
+            o.status.code(),
+            Some(3),
+            "regime {regime} must exit 3 (unsupported boundary); stderr: {}",
+            stderr(&o)
+        );
+        let err = stderr(&o);
+        assert!(
+            err.contains("cannot be materialized"),
+            "regime {regime} must explain it cannot be materialized; got: {err}"
+        );
+        assert!(
+            err.contains(expected_reason),
+            "regime {regime} must name its specific reason ({expected_reason:?}); got: {err}"
+        );
+    }
+}
+
+/// `reason` over a `.purrpck` PACK source reconstructs the dataset and materializes the
+/// closure — exercising the pack→dataset reconstruction path inside `reason`. The
+/// inferred RDFS type appears just as it does from a text source.
+#[test]
+fn pack_input_is_reconstructed_and_reasoned() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let ttl = write_file(
+        dir,
+        "sub.ttl",
+        concat!(
+            "@prefix ex: <http://example.org/> .\n",
+            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+            "ex:Dog rdfs:subClassOf ex:Animal .\n",
+            "ex:rex a ex:Dog .\n",
+        ),
+    );
+
+    // Build a pack from the RDFS fixture, then reason over the pack.
+    let pack = path(dir, "sub.purrpck");
+    let o = run(&["convert", "--from", "turtle", "--to", "pack", &ttl, &pack]);
+    assert!(
+        o.status.success(),
+        "building the pack failed: {}",
+        stderr(&o)
+    );
+
+    let out = path(dir, "out.nt");
+    let o = run(&["reason", "--regime", "rdfs", &pack, &out]);
+    assert!(
+        o.status.success(),
+        "reason over a pack failed: {}",
+        stderr(&o)
+    );
+    let text = std::fs::read_to_string(&out).expect("read output");
+    assert!(
+        text.contains(&format!(
+            "<http://example.org/rex> {RDF_TYPE} <http://example.org/Animal>"
+        )),
+        "reasoning over a reconstructed pack must yield `ex:rex a ex:Animal`; got: {text}"
+    );
+}
+
+/// A `reason` run twice produces byte-identical output: the closure and serializer are
+/// deterministic.
+#[test]
+fn reason_output_is_deterministic() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(
+        dir,
+        "rdfs.ttl",
+        concat!(
+            "@prefix ex: <http://example.org/> .\n",
+            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+            "ex:Dog rdfs:subClassOf ex:Animal .\n",
+            "ex:rex a ex:Dog .\n",
+        ),
+    );
+    let a = path(dir, "a.nt");
+    let b = path(dir, "b.nt");
+
+    assert!(
+        run(&["reason", "--regime", "rdfs", &seed, &a])
+            .status
+            .success()
+    );
+    assert!(
+        run(&["reason", "--regime", "rdfs", &seed, &b])
+            .status
+            .success()
+    );
+    assert_eq!(
+        std::fs::read(&a).expect("read a"),
+        std::fs::read(&b).expect("read b"),
+        "a reason run twice must be byte-identical"
+    );
+}
+
+/// `--base` resolves relative IRIs in the source before reasoning: a Turtle input with
+/// relative IRI terms, reasoned under `--base`, yields absolute IRIs in the output.
+#[test]
+fn base_resolves_relative_iris_before_reasoning() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    // Turtle carries relative IRIs (N-Triples would reject them); `--base` resolves them.
+    let seed = write_file(
+        dir,
+        "rel.ttl",
+        "<thing> <http://example.org/knows> <other> .\n",
+    );
+    let out = path(dir, "out.nt");
+
+    let o = run(&[
+        "reason",
+        "--regime",
+        "rdf",
+        "--base",
+        "http://example.org/base/",
+        &seed,
+        &out,
+    ]);
+    assert!(o.status.success(), "--base reason failed: {}", stderr(&o));
+    let text = std::fs::read_to_string(&out).expect("read output");
+    assert!(
+        text.contains("http://example.org/base/thing"),
+        "relative subject must resolve against --base; got: {text}"
+    );
+    assert!(
+        text.contains("http://example.org/base/other"),
+        "relative object must resolve against --base; got: {text}"
+    );
+}
+
+/// `reason` to a `.purrpck` OUTPUT produces a valid pack whose reconstructed contents
+/// carry the inferred triple (re-converting the pack back to text shows the inference).
+#[test]
+fn pack_output_is_a_valid_pack_carrying_the_inference() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(
+        dir,
+        "rdfs.ttl",
+        concat!(
+            "@prefix ex: <http://example.org/> .\n",
+            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+            "ex:Dog rdfs:subClassOf ex:Animal .\n",
+            "ex:rex a ex:Dog .\n",
+        ),
+    );
+
+    // Reason directly INTO a pack.
+    let pack = path(dir, "closure.purrpck");
+    let o = run(&["reason", "--regime", "rdfs", &seed, &pack]);
+    assert!(
+        o.status.success(),
+        "reason to a pack failed: {}",
+        stderr(&o)
+    );
+
+    // Re-convert the pack to N-Triples: a valid pack whose contents carry the inference.
+    let back = path(dir, "back.nt");
+    let o = run(&[
+        "convert", "--from", "pack", "--to", "ntriples", &pack, &back,
+    ]);
+    assert!(
+        o.status.success(),
+        "re-converting the closure pack failed: {}",
+        stderr(&o)
+    );
+    let text = std::fs::read_to_string(&back).expect("read reconverted output");
+    assert!(
+        text.contains(&format!(
+            "<http://example.org/rex> {RDF_TYPE} <http://example.org/Animal>"
+        )),
+        "the closure pack must carry the inferred `ex:rex a ex:Animal`; got: {text}"
+    );
+}

--- a/crates/cli/tests/reason_cli.rs
+++ b/crates/cli/tests/reason_cli.rs
@@ -318,6 +318,85 @@ fn pack_input_is_reconstructed_and_reasoned() {
     );
 }
 
+/// `reason --from --to - -` reads a Turtle fixture from stdin and writes N-Triples to
+/// stdout — the gap this module exists to close: `-`/`-` (the documented default) is
+/// otherwise unreachable without `--from`/`--to`. Asserts exit 0 and the RDFS-inferred
+/// `rdf:type` triple in the captured stdout.
+#[test]
+fn stdin_to_stdout_with_from_and_to() {
+    use std::io::Write as _;
+    use std::process::Stdio;
+
+    let input = concat!(
+        "@prefix ex: <http://example.org/> .\n",
+        "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+        "ex:Dog rdfs:subClassOf ex:Animal .\n",
+        "ex:rex a ex:Dog .\n",
+    );
+
+    let mut child = purrdf()
+        .args([
+            "reason", "--regime", "rdfs", "--from", "ttl", "--to", "nt", "-", "-",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn the built purrdf binary");
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(input.as_bytes())
+        .expect("write fixture to stdin");
+    let out = child.wait_with_output().expect("wait for purrdf");
+
+    assert!(
+        out.status.success(),
+        "stdin->stdout reason failed: {}",
+        stderr(&out)
+    );
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        text.contains(&format!(
+            "<http://example.org/rex> {RDF_TYPE} <http://example.org/Animal>"
+        )),
+        "stdin->stdout reason must infer `ex:rex a ex:Animal` on stdout; got: {text}"
+    );
+}
+
+/// `reason --to nt <fixture.ttl> -` reads a file and writes N-Triples to stdout: the
+/// file->stdout half of the same gap (`OUT` defaults to `-`, which requires `--to`).
+#[test]
+fn file_to_stdout_with_to() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(
+        dir,
+        "rdfs.ttl",
+        concat!(
+            "@prefix ex: <http://example.org/> .\n",
+            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+            "ex:Dog rdfs:subClassOf ex:Animal .\n",
+            "ex:rex a ex:Dog .\n",
+        ),
+    );
+
+    let o = run(&["reason", "--regime", "rdfs", &seed, "-", "--to", "nt"]);
+    assert!(
+        o.status.success(),
+        "file->stdout reason failed: {}",
+        stderr(&o)
+    );
+    let text = String::from_utf8_lossy(&o.stdout);
+    assert!(
+        text.contains(&format!(
+            "<http://example.org/rex> {RDF_TYPE} <http://example.org/Animal>"
+        )),
+        "file->stdout reason must infer `ex:rex a ex:Animal` on stdout; got: {text}"
+    );
+}
+
 /// A `reason` run twice produces byte-identical output: the closure and serializer are
 /// deterministic.
 #[test]

--- a/crates/cli/tests/smoke_cli.rs
+++ b/crates/cli/tests/smoke_cli.rs
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! End-to-end smoke of the three subcommands, driving the built `purrdf` binary
+//! over `example.org` fixtures written to a temp dir:
+//!
+//! * `convert --from ttl --to nt` produces the expected N-Triples;
+//! * `query --results-format json` returns a row, and the SAME query over a pack
+//!   built via `convert --to pack` is byte-identical;
+//! * `reason --regime rdfs` materializes the inferred `rdf:type` triple;
+//! * `reason --regime owl-direct` exits with the unsupported-regime code 3.
+
+use std::path::Path;
+use std::process::Command;
+
+/// The path to the built `purrdf` binary.
+const PURRDF: &str = env!("CARGO_BIN_EXE_purrdf");
+
+/// Run `purrdf` with `args`, returning (exit-code, stdout-bytes, stderr-string).
+fn run(args: &[&str]) -> (i32, Vec<u8>, String) {
+    let output = Command::new(PURRDF)
+        .args(args)
+        .output()
+        .expect("spawn purrdf");
+    (
+        output.status.code().expect("exit code"),
+        output.stdout,
+        String::from_utf8(output.stderr).expect("utf-8 stderr"),
+    )
+}
+
+/// Write `contents` to `dir/name` and return the path as an owned string.
+fn write_fixture(dir: &Path, name: &str, contents: &str) -> String {
+    let path = dir.join(name);
+    std::fs::write(&path, contents).expect("write fixture");
+    path.to_str().expect("utf-8 path").to_owned()
+}
+
+#[test]
+fn convert_turtle_to_ntriples_produces_expected_triples() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let input = write_fixture(
+        dir.path(),
+        "in.ttl",
+        "@prefix ex: <http://example.org/> .\nex:alice ex:knows ex:bob .\n",
+    );
+
+    let (code, stdout, stderr) = run(&["convert", "--from", "ttl", "--to", "nt", &input, "-"]);
+    assert_eq!(code, 0, "convert exits 0; stderr:\n{stderr}");
+    let stdout = String::from_utf8(stdout).expect("utf-8 stdout");
+    assert_eq!(
+        stdout,
+        "<http://example.org/alice> <http://example.org/knows> <http://example.org/bob> .\n",
+        "convert must emit the canonical single N-Triples line"
+    );
+}
+
+#[test]
+fn query_json_row_matches_between_turtle_and_pack() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let input = write_fixture(
+        dir.path(),
+        "in.ttl",
+        "@prefix ex: <http://example.org/> .\nex:alice ex:knows ex:bob .\n",
+    );
+    let query = "SELECT ?o WHERE { ?s <http://example.org/knows> ?o }";
+
+    // Query over the Turtle source.
+    let (code, ttl_stdout, stderr) =
+        run(&["query", "--data", &input, "--results-format", "json", query]);
+    assert_eq!(code, 0, "query over turtle exits 0; stderr:\n{stderr}");
+    let ttl_stdout = String::from_utf8(ttl_stdout).expect("utf-8 stdout");
+    assert!(
+        ttl_stdout.contains("http://example.org/bob"),
+        "the SELECT must return the bound object; got:\n{ttl_stdout}"
+    );
+
+    // Build a pack from the same source, then query it.
+    let pack = dir.path().join("data.purrpck");
+    let pack = pack.to_str().expect("utf-8 path");
+    let (code, _, stderr) = run(&["convert", &input, pack]);
+    assert_eq!(
+        code, 0,
+        "convert to pack exits 0 (formats inferred from extensions); stderr:\n{stderr}"
+    );
+
+    let (code, pack_stdout, stderr) =
+        run(&["query", "--data", pack, "--results-format", "json", query]);
+    assert_eq!(code, 0, "query over pack exits 0; stderr:\n{stderr}");
+    let pack_stdout = String::from_utf8(pack_stdout).expect("utf-8 stdout");
+
+    assert_eq!(
+        ttl_stdout, pack_stdout,
+        "the JSON result must be byte-identical whether queried over turtle or its pack"
+    );
+}
+
+#[test]
+fn reason_rdfs_infers_rdf_type() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let input = write_fixture(
+        dir.path(),
+        "sub.ttl",
+        "@prefix ex: <http://example.org/> .\n\
+         @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\
+         ex:Dog rdfs:subClassOf ex:Animal .\n\
+         ex:rex a ex:Dog .\n",
+    );
+    let output = dir.path().join("closure.nt");
+    let output = output.to_str().expect("utf-8 path");
+
+    let (code, _, stderr) = run(&["reason", "--regime", "rdfs", &input, output]);
+    assert_eq!(code, 0, "reason exits 0; stderr:\n{stderr}");
+
+    let closure = std::fs::read_to_string(output).expect("read closure");
+    // RDFS subClassOf entailment: ex:rex is inferred to be an ex:Animal.
+    assert!(
+        closure.contains(
+            "<http://example.org/rex> \
+             <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> \
+             <http://example.org/Animal> ."
+        ),
+        "the inferred `ex:rex a ex:Animal` triple must be present; got:\n{closure}"
+    );
+}
+
+#[test]
+fn reason_owl_direct_exits_with_unsupported_regime_code_3() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let input = write_fixture(
+        dir.path(),
+        "sub.ttl",
+        "@prefix ex: <http://example.org/> .\nex:rex a ex:Dog .\n",
+    );
+    let output = dir.path().join("out.nt");
+    let output = output.to_str().expect("utf-8 path");
+
+    let (code, _, stderr) = run(&["reason", "--regime", "owl-direct", &input, output]);
+    assert_eq!(
+        code, 3,
+        "owl-direct is an unsupported-regime boundary (exit 3); stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.is_empty(),
+        "the unsupported-regime failure must print a diagnostic to stderr"
+    );
+}

--- a/crates/rdf-core/src/ir/mod.rs
+++ b/crates/rdf-core/src/ir/mod.rs
@@ -71,7 +71,10 @@ pub use global::{GlobalDictionary, GlobalTermId};
 pub use ingest::{DatasetSink, FrozenDatasetSource};
 pub use mutable::{MutableDataset, QuadValues};
 #[doc(hidden)]
-pub use pack::{PackBuilder, PackDigest, PackError, PackId, PackView, pack_digest, verify_pack};
+pub use pack::{
+    PackBuilder, PackDigest, PackError, PackId, PackView, dataset_from_view, pack_digest,
+    verify_pack,
+};
 pub use paged::{
     CountingDemandProvider, InMemoryPageProvider, PageFault, PageId, PagePart, PageProvider,
     PageTranslation, PagedDataset, PagedFreezeError, PagedQuadOverlap, PagedQuadTable,

--- a/crates/rdf-core/src/ir/pack/certify.rs
+++ b/crates/rdf-core/src/ir/pack/certify.rs
@@ -229,7 +229,7 @@ fn reconstruct<D: DatasetView>(view: &D) -> RdfDatasetBuilder {
 /// projection — a mmap'd [`PackView`], a paged backend, or any other `DatasetView`
 /// — that must feed a transform requiring a concrete `RdfDataset` (e.g. the
 /// reasoner) uses this to materialize one. Both entry points share the single
-/// [`reconstruct`] loop (SUBSUME, no second copy).
+/// `reconstruct` loop (SUBSUME, no second copy).
 ///
 /// The reconstruction replays all three components the view exposes — base quads
 /// ([`DatasetView::quads`]), RDF-1.2 reifier bindings

--- a/crates/rdf-core/src/ir/pack/certify.rs
+++ b/crates/rdf-core/src/ir/pack/certify.rs
@@ -39,10 +39,14 @@
 //! (NOT `push_quad` — the side-table rows are a distinct structural component,
 //! not ordinary quads; see [`crate::ir::canon`]'s `Component` enum).
 
+use std::sync::Arc;
+
 use sha2::{Digest, Sha256};
 
 use crate::dataset_view::DatasetView;
-use crate::{CanonHash, RdfDatasetBuilder, RdfLiteral, TermId, TermRef, TermValue};
+use crate::{
+    CanonHash, RdfDataset, RdfDatasetBuilder, RdfDiagnostic, RdfLiteral, TermId, TermRef, TermValue,
+};
 
 use super::container::{PackError, PackView};
 
@@ -166,15 +170,20 @@ fn reintern<V: DatasetView>(b: &mut RdfDatasetBuilder, v: &V, id: V::Id) -> Term
     intern_value(b, &value)
 }
 
-/// Independently reconstruct an `RdfDatasetBuilder` from `view`'s
-/// [`DatasetView`] surface: every base quad, then every reifier binding, then
-/// every statement annotation — the exact three components
+/// Independently reconstruct an `RdfDatasetBuilder` from ANY [`DatasetView`]'s
+/// surface: every base quad, then every reifier binding, then every statement
+/// annotation — the exact three components
 /// [`crate::ir::canon::collect_components`] folds into the RDFC-1.0 digest (see
 /// the [module docs](self)). Each blank's original `(label, scope)` (C0.2)
 /// round-trips through [`to_value`]/[`intern_value`] unchanged; that choice is
 /// moot for the digest either way, since RDFC-1.0 canonicalizes blank labels
 /// away entirely (structure alone drives the canonical `_:c14nN` assignment).
-fn reconstruct(view: &PackView<'_>) -> RdfDatasetBuilder {
+///
+/// This is the SOLE re-intern loop: [`verify_pack`] (which reconstructs, freezes,
+/// and recomputes the digest) and the public [`dataset_from_view`] (which
+/// reconstructs and freezes into an `Arc<RdfDataset>`) both drive it, so there is
+/// exactly one place the base-quad / reifier / annotation replay lives.
+fn reconstruct<D: DatasetView>(view: &D) -> RdfDatasetBuilder {
     let mut b = RdfDatasetBuilder::new();
 
     for q in view.quads() {
@@ -205,6 +214,41 @@ fn reconstruct(view: &PackView<'_>) -> RdfDatasetBuilder {
     }
 
     b
+}
+
+// ---------------------------------------------------------------------------
+// dataset_from_view: any DatasetView -> Arc<RdfDataset>
+// ---------------------------------------------------------------------------
+
+/// Reconstruct a concrete, frozen [`Arc<RdfDataset>`] from ANY [`DatasetView`] by
+/// re-interning every term BY VALUE into a fresh [`RdfDatasetBuilder`].
+///
+/// This is the public, view-generic counterpart to [`verify_pack`]'s internal
+/// reconstruct-then-freeze: where `verify_pack` throws the reconstruction away
+/// after corroborating the digest, this HANDS IT BACK. A caller holding a read-only
+/// projection — a mmap'd [`PackView`], a paged backend, or any other `DatasetView`
+/// — that must feed a transform requiring a concrete `RdfDataset` (e.g. the
+/// reasoner) uses this to materialize one. Both entry points share the single
+/// [`reconstruct`] loop (SUBSUME, no second copy).
+///
+/// The reconstruction replays all three components the view exposes — base quads
+/// ([`DatasetView::quads`]), RDF-1.2 reifier bindings
+/// ([`DatasetView::reifier_quads`], pushed through the reifier side-table entry
+/// point, NOT `push_quad`), and statement annotations
+/// ([`DatasetView::annotation_quads`]) — so the RDF-1.2 overlay survives the round
+/// trip losslessly (a view with no side-tables simply replays zero of them). Blank
+/// `(label, scope)` identity round-trips unchanged; RDFC-1.0 isomorphism is
+/// therefore preserved (see the [module docs](self)).
+///
+/// # Errors
+///
+/// [`RdfDiagnostic`] if the reconstructed rows fail [`RdfDatasetBuilder::freeze`]'s
+/// structural validation (C0 positional constraints, id-reference validity,
+/// triple-term acyclicity) — the same fail-closed contract every builder freeze
+/// carries. For a well-formed source view this cannot trip; the `Result` exists so
+/// an untrusted or hand-assembled view fails closed rather than panicking.
+pub fn dataset_from_view<D: DatasetView>(view: &D) -> Result<Arc<RdfDataset>, RdfDiagnostic> {
+    reconstruct(view).freeze()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rdf-core/src/ir/pack/mod.rs
+++ b/crates/rdf-core/src/ir/pack/mod.rs
@@ -77,7 +77,7 @@ pub mod triples;
 pub mod view;
 
 #[doc(hidden)]
-pub use certify::{PackDigest, pack_digest, verify_pack};
+pub use certify::{PackDigest, dataset_from_view, pack_digest, verify_pack};
 #[doc(hidden)]
 pub use container::{PackBuilder, PackError, PackView};
 #[doc(hidden)]

--- a/crates/rdf-core/src/lib.rs
+++ b/crates/rdf-core/src/lib.rs
@@ -115,7 +115,10 @@ pub use ir::{
     canonicalize_with, dataset_diff, datasets_isomorphic, try_canonicalize, try_canonicalize_with,
 };
 #[doc(hidden)]
-pub use ir::{PackBuilder, PackDigest, PackError, PackId, PackView, pack_digest, verify_pack};
+pub use ir::{
+    PackBuilder, PackDigest, PackError, PackId, PackView, dataset_from_view, pack_digest,
+    verify_pack,
+};
 pub use lookaside::{
     RdfBlobOrigin, RdfBlobRecord, RdfLookaside, RdfLookasideKind, RdfLookasideResource,
     RdfMetadataEntry, RdfMetadataValue, RdfOpaqueNodeRecord, RdfSegmentRecord, RdfSignatureRecord,

--- a/crates/rdf/src/native_codecs/media_type.rs
+++ b/crates/rdf/src/native_codecs/media_type.rs
@@ -48,6 +48,12 @@ pub enum NativeRdfFormat {
 /// `crates/rdf-core/src/loss.rs` codec name) lives in ONE [`FORMATS`] row rather than
 /// scattered `match NativeRdfFormat` arms. The behavior seam (parse / serialize) stays
 /// the `RdfCodec` vtable in [`codec`](super::codec); this table is purely the data half.
+///
+/// The independent per-format capability flags (star / direction / datasets / spans) are
+/// orthogonal boolean facts, not a state machine — collapsing them into an enum would
+/// obscure the one-fact-per-column table, so the `struct_excessive_bools` lint is
+/// intentionally allowed here.
+#[allow(clippy::struct_excessive_bools)]
 pub(crate) struct FormatDescriptor {
     /// The variant this row describes.
     pub format: NativeRdfFormat,
@@ -61,6 +67,10 @@ pub(crate) struct FormatDescriptor {
     /// Whether this format carries the RDF-1.2 statement layer (see
     /// [`NativeRdfFormat::carries_star`]).
     pub carries_star: bool,
+    /// Whether this format can carry an RDF-1.2 literal base direction (see
+    /// [`NativeRdfFormat::carries_direction`]). `false` only for TriX and HexTuples,
+    /// which have a language slot but no direction surface.
+    pub carries_direction: bool,
     /// Whether this format can carry named graphs (see
     /// [`NativeRdfFormat::supports_datasets`]).
     pub supports_datasets: bool,
@@ -80,6 +90,7 @@ pub(crate) const FORMATS: &[FormatDescriptor] = &[
         media_type: "text/turtle",
         aliases: &["application/turtle", "turtle", "ttl", ".ttl"],
         carries_star: true,
+        carries_direction: true,
         supports_datasets: false,
         tokenizer_carries_spans: true,
         loss_codec_name: Some("turtle"),
@@ -89,6 +100,7 @@ pub(crate) const FORMATS: &[FormatDescriptor] = &[
         media_type: "application/trig",
         aliases: &["trig", ".trig"],
         carries_star: true,
+        carries_direction: true,
         supports_datasets: true,
         tokenizer_carries_spans: true,
         loss_codec_name: Some("trig"),
@@ -98,6 +110,7 @@ pub(crate) const FORMATS: &[FormatDescriptor] = &[
         media_type: "application/n-triples",
         aliases: &["n-triples", "ntriples", "nt", ".nt"],
         carries_star: true,
+        carries_direction: true,
         supports_datasets: false,
         tokenizer_carries_spans: true,
         loss_codec_name: Some("ntriples"),
@@ -107,6 +120,7 @@ pub(crate) const FORMATS: &[FormatDescriptor] = &[
         media_type: "application/n-quads",
         aliases: &["n-quads", "nquads", "nq", ".nq"],
         carries_star: true,
+        carries_direction: true,
         supports_datasets: true,
         tokenizer_carries_spans: true,
         loss_codec_name: Some("nquads"),
@@ -120,6 +134,7 @@ pub(crate) const FORMATS: &[FormatDescriptor] = &[
             "rdf+xml", "rdf", "owl", "xml", "rdf/xml", "rdfxml", ".rdf", ".owl",
         ],
         carries_star: false,
+        carries_direction: true,
         supports_datasets: false,
         tokenizer_carries_spans: false,
         loss_codec_name: Some("rdfxml"),
@@ -129,6 +144,7 @@ pub(crate) const FORMATS: &[FormatDescriptor] = &[
         media_type: "application/trix",
         aliases: &["trix", ".trix"],
         carries_star: false,
+        carries_direction: false,
         supports_datasets: true,
         tokenizer_carries_spans: false,
         loss_codec_name: None,
@@ -138,6 +154,7 @@ pub(crate) const FORMATS: &[FormatDescriptor] = &[
         media_type: "application/x-hextuples",
         aliases: &["application/hex+x-ndjson", "hext", "hextuples", ".hext"],
         carries_star: false,
+        carries_direction: false,
         supports_datasets: true,
         tokenizer_carries_spans: false,
         loss_codec_name: None,
@@ -147,6 +164,7 @@ pub(crate) const FORMATS: &[FormatDescriptor] = &[
         media_type: "application/ld+json",
         aliases: &["ld+json", "jsonld", "json-ld", ".jsonld"],
         carries_star: true,
+        carries_direction: true,
         supports_datasets: true,
         tokenizer_carries_spans: false,
         loss_codec_name: Some("jsonld-star"),
@@ -156,6 +174,7 @@ pub(crate) const FORMATS: &[FormatDescriptor] = &[
         media_type: "application/ld+yaml",
         aliases: &["ld+yaml", "yamlld", "yaml-ld", ".yamlld"],
         carries_star: true,
+        carries_direction: true,
         supports_datasets: true,
         tokenizer_carries_spans: false,
         loss_codec_name: Some("yaml-ld-star"),
@@ -193,6 +212,14 @@ impl NativeRdfFormat {
     /// (`crates/rdf-core/src/loss.rs`) — see the drift-guard test in `native_codecs`.
     pub fn carries_star(self) -> bool {
         descriptor(self).carries_star
+    }
+
+    /// Whether this format can carry an RDF-1.2 literal base direction. Every format
+    /// except TriX and HexTuples emits the direction losslessly; those two have a
+    /// language slot but no direction surface, so they drop it as declared loss
+    /// (recorded on the loss ledger — never a silent drop; CONSTITUTION P7).
+    pub fn carries_direction(self) -> bool {
+        descriptor(self).carries_direction
     }
 
     /// Whether this format's parser can record per-statement source spans. Only the
@@ -274,6 +301,28 @@ mod tests {
     fn trix_and_hextuples_support_datasets() {
         assert!(NativeRdfFormat::TriX.supports_datasets());
         assert!(NativeRdfFormat::HexTuples.supports_datasets());
+    }
+
+    #[test]
+    fn only_trix_and_hextuples_drop_direction() {
+        // TriX / HexTuples have a language slot but no base-direction surface.
+        assert!(!NativeRdfFormat::TriX.carries_direction());
+        assert!(!NativeRdfFormat::HexTuples.carries_direction());
+        // Every other format carries the RDF-1.2 base direction losslessly.
+        for format in [
+            NativeRdfFormat::Turtle,
+            NativeRdfFormat::TriG,
+            NativeRdfFormat::NTriples,
+            NativeRdfFormat::NQuads,
+            NativeRdfFormat::RdfXml,
+            NativeRdfFormat::JsonLd,
+            NativeRdfFormat::YamlLd,
+        ] {
+            assert!(
+                format.carries_direction(),
+                "{format:?} must carry base direction"
+            );
+        }
     }
 
     #[test]

--- a/crates/rdf/src/native_codecs/ser_model.rs
+++ b/crates/rdf/src/native_codecs/ser_model.rs
@@ -68,6 +68,70 @@ impl SerGraph {
             .find(|(r, _, _)| *r == rid)
             .map(|(_, spo, _)| *spo)
     }
+
+    /// Reorder the base quads and the RDF 1.2 statement layer into a **canonical,
+    /// backend-independent** order, keyed on each row's rendered term text.
+    ///
+    /// The term-table indices a [`SerGraph`] carries are assigned in the interning
+    /// order of whichever [`DatasetView`](crate::DatasetView) fed the builder, so two
+    /// backends holding the SAME dataset (e.g. the production `RdfDataset` and a
+    /// `PackView` over its pack bytes) index their terms differently and thus iterate
+    /// quads in different orders. Sorting on the *rendered value* — a pure function of
+    /// the term, identical across backends — makes the emitted document byte-identical
+    /// regardless of backend and removes the interning-order dependence from the
+    /// serializer (CONSTITUTION: serializers are deterministic).
+    ///
+    /// The lookup in [`Self::reifier`] is by id, so permuting `reifiers` never changes
+    /// which binding a quoted-triple term resolves to; the self-reifier sentinel rows
+    /// (skipped on output) are permuted harmlessly among the real reifier rows.
+    pub(crate) fn sort_canonical(&mut self) {
+        let quad_key = |&(s, p, o, g): &SerQuad| -> Vec<String> {
+            vec![
+                render_term(self, s),
+                render_term(self, p),
+                render_term(self, o),
+                g.map(|g| render_term(self, g)).unwrap_or_default(),
+            ]
+        };
+        let reifier_key = |&(r, (s, p, o), g): &SerReifierRow| -> Vec<String> {
+            vec![
+                render_term(self, r),
+                render_term(self, s),
+                render_term(self, p),
+                render_term(self, o),
+                g.map(|g| render_term(self, g)).unwrap_or_default(),
+            ]
+        };
+        let annotation_key = |&(r, p, o, g): &SerAnnotationRow| -> Vec<String> {
+            vec![
+                render_term(self, r),
+                render_term(self, p),
+                render_term(self, o),
+                g.map(|g| render_term(self, g)).unwrap_or_default(),
+            ]
+        };
+
+        // Precompute every sort key up front (all immutable borrows of `self`) so the
+        // three rewrites below hold no live borrow of `self` while reassigning its
+        // fields.
+        let mut quads: Vec<(Vec<String>, SerQuad)> =
+            self.quads.iter().map(|q| (quad_key(q), *q)).collect();
+        let mut reifiers: Vec<(Vec<String>, SerReifierRow)> =
+            self.reifiers.iter().map(|r| (reifier_key(r), *r)).collect();
+        let mut annotations: Vec<(Vec<String>, SerAnnotationRow)> = self
+            .annotations
+            .iter()
+            .map(|a| (annotation_key(a), *a))
+            .collect();
+
+        quads.sort_by(|a, b| a.0.cmp(&b.0));
+        reifiers.sort_by(|a, b| a.0.cmp(&b.0));
+        annotations.sort_by(|a, b| a.0.cmp(&b.0));
+
+        self.quads = quads.into_iter().map(|(_, q)| q).collect();
+        self.reifiers = reifiers.into_iter().map(|(_, r)| r).collect();
+        self.annotations = annotations.into_iter().map(|(_, a)| a).collect();
+    }
 }
 
 /// Crockford Base32 alphabet (the ULID rendering alphabet).

--- a/crates/rdf/src/native_codecs/serialize.rs
+++ b/crates/rdf/src/native_codecs/serialize.rs
@@ -101,6 +101,12 @@ pub struct SerializeOutcome {
     /// triples) dropped because the target format does not carry the star layer in
     /// the transcode contract. Zero for star-capable formats.
     pub statement_rows_dropped: usize,
+    /// The number of base-quad object literals whose RDF-1.2 base direction was
+    /// dropped because the target format has no direction surface (TriX / HexTuples
+    /// keep the language tag but cannot carry `--ltr` / `--rtl`). Zero for every
+    /// direction-capable format. Recorded as declared loss — never a silent drop
+    /// (CONSTITUTION P7).
+    pub directional_literals_dropped: usize,
 }
 
 /// Serialize the frozen IR to a concrete [`NativeRdfFormat`], returning the bytes and
@@ -124,11 +130,20 @@ pub fn serialize_dataset_to_format<D: DatasetView>(
     _base_iri: Option<&str>,
 ) -> Result<SerializeOutcome, RdfDiagnostic> {
     let media_type = format.media_type();
+    // A base direction is dropped independently of the star layer: RDF/XML is
+    // star-incapable yet carries direction, while TriX / HexTuples carry neither. Count
+    // the affected object literals up front for whichever branch emits.
+    let directional_literals_dropped = if format.carries_direction() {
+        0
+    } else {
+        count_directional_object_literals(dataset)
+    };
     if format.carries_star() {
         let bytes = serialize_dataset(dataset, media_type, SerializeGraph::Dataset)?;
         Ok(SerializeOutcome {
             bytes,
             statement_rows_dropped: 0,
+            directional_literals_dropped,
         })
     } else {
         let bytes = serialize_dataset_base_only(dataset, media_type, SerializeGraph::Dataset)?;
@@ -137,8 +152,28 @@ pub fn serialize_dataset_to_format<D: DatasetView>(
         Ok(SerializeOutcome {
             bytes,
             statement_rows_dropped,
+            directional_literals_dropped,
         })
     }
+}
+
+/// Count the base-quad OBJECT literals whose resolved term carries an RDF-1.2 base
+/// direction. Used to record declared loss when serializing to a format with no
+/// direction surface (TriX / HexTuples) — the drop is the realized count the caller
+/// attaches to the loss ledger, never a silent loss (CONSTITUTION P7).
+fn count_directional_object_literals<D: DatasetView>(dataset: &D) -> usize {
+    dataset
+        .quads()
+        .filter(|q| {
+            matches!(
+                dataset.resolve(q.o),
+                TermRef::Literal {
+                    direction: Some(_),
+                    ..
+                }
+            )
+        })
+        .count()
 }
 
 /// Build the first-party [`SerGraph`] from the frozen IR, applying the
@@ -588,6 +623,54 @@ mod serialize_to_format_tests {
             .expect("serialize to RDF/XML");
         // No reifiers/annotations in the dataset → nothing to drop.
         assert_eq!(out.statement_rows_dropped, 0);
+        // RDF/XML carries a base direction: nothing dropped there either.
+        assert_eq!(out.directional_literals_dropped, 0);
         assert!(text_of(&out).contains("https://example.org/s"));
+    }
+
+    // ── base-direction drop accounting (TriX / HexTuples only) ─────────────────────
+
+    /// A dataset with one base-direction object literal (`"hello"@en--ltr`).
+    fn directional_literal_dataset() -> Arc<RdfDataset> {
+        let nt = "<https://example.org/s> <https://example.org/greeting> \"hello\"@en--ltr .\n";
+        parse_dataset(nt.as_bytes(), "application/n-triples", None)
+            .expect("directional_literal_dataset parse")
+    }
+
+    #[test]
+    fn directional_literal_dropped_by_trix_and_hextuples() {
+        let ds = directional_literal_dataset();
+        for format in [NativeRdfFormat::TriX, NativeRdfFormat::HexTuples] {
+            let out = serialize_dataset_to_format(&ds, format, None)
+                .expect("serialize to a direction-incapable format");
+            assert_eq!(
+                out.directional_literals_dropped, 1,
+                "{format:?} must record the dropped base direction"
+            );
+            // The bytes still emit the language tag (only the direction is lost).
+            let text = text_of(&out);
+            assert!(text.contains("en"), "{format:?} keeps the language tag");
+        }
+    }
+
+    #[test]
+    fn directional_literal_preserved_by_direction_capable_formats() {
+        let ds = directional_literal_dataset();
+        for format in [
+            NativeRdfFormat::Turtle,
+            NativeRdfFormat::TriG,
+            NativeRdfFormat::NTriples,
+            NativeRdfFormat::NQuads,
+            NativeRdfFormat::RdfXml,
+            NativeRdfFormat::JsonLd,
+            NativeRdfFormat::YamlLd,
+        ] {
+            let out = serialize_dataset_to_format(&ds, format, None)
+                .expect("serialize to a direction-capable format");
+            assert_eq!(
+                out.directional_literals_dropped, 0,
+                "{format:?} carries the base direction — nothing dropped"
+            );
+        }
     }
 }

--- a/crates/rdf/src/native_codecs/serialize.rs
+++ b/crates/rdf/src/native_codecs/serialize.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Frozen [`RdfDataset`] IR → native RDF text egress.
+//! Frozen [`RdfDataset`](crate::RdfDataset) IR → native RDF text egress.
 //!
 //! Builds a first-party [`SerGraph`](super::ser_model::SerGraph) from the frozen IR —
 //! interning every IR term into the graph's term table, materializing literal datatypes
@@ -23,29 +23,29 @@ use std::io::Write;
 use super::media_type::{NativeRdfFormat, classify};
 use super::ser_model::{SerAnnotationRow, SerGraph, SerReifierRow, SerTerm, SerTermKind};
 use crate::ir::TermRef;
-use crate::{RdfDataset, RdfDiagnostic, RdfTextDirection, SerializeGraph, TermId, TermValue};
+use crate::{DatasetView, RdfDiagnostic, RdfTextDirection, SerializeGraph, TermValue};
 
 /// The `xsd:string` datatype IRI: a literal of this datatype with no language is a
 /// plain literal and is emitted WITHOUT an explicit `^^<…>`, so it round-trips back to
 /// the same plain form (matching the purrdf-gts native projection).
 const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
 
-/// Serialize a frozen [`RdfDataset`] to RDF text of `media_type`, honoring the
+/// Serialize a frozen [`RdfDataset`](crate::RdfDataset) to RDF text of `media_type`, honoring the
 /// [`SerializeGraph`] selection. Returns the serialized bytes.
 ///
 /// The full RDF 1.2 statement layer (reifier bindings + annotations) is emitted for
 /// every star-capable format. To serialize the base quads ONLY — for a star-incapable
 /// projection target where the statement layer is declared loss (RDF/XML, JSON-LD in
 /// the transcode contract) — use [`serialize_dataset_base_only`].
-pub fn serialize_dataset(
-    dataset: &RdfDataset,
+pub fn serialize_dataset<D: DatasetView>(
+    dataset: &D,
     media_type: &str,
     selection: SerializeGraph<'_>,
 ) -> Result<Vec<u8>, RdfDiagnostic> {
     serialize_dataset_inner(dataset, media_type, selection, true)
 }
 
-/// Serialize a frozen [`RdfDataset`] to RDF text of `media_type`, emitting ONLY the
+/// Serialize a frozen [`RdfDataset`](crate::RdfDataset) to RDF text of `media_type`, emitting ONLY the
 /// base quads and DROPPING the RDF 1.2 statement layer (reifier bindings +
 /// annotations).
 ///
@@ -54,16 +54,16 @@ pub fn serialize_dataset(
 /// declared loss (`rdf12-star-unrepresentable` / `rdf12-star-jsonld-rejected`) — the
 /// drop here is never silent (CONSTITUTION P7), it is the realized count the caller
 /// attaches to the loss ledger.
-pub fn serialize_dataset_base_only(
-    dataset: &RdfDataset,
+pub fn serialize_dataset_base_only<D: DatasetView>(
+    dataset: &D,
     media_type: &str,
     selection: SerializeGraph<'_>,
 ) -> Result<Vec<u8>, RdfDiagnostic> {
     serialize_dataset_inner(dataset, media_type, selection, false)
 }
 
-fn serialize_dataset_inner(
-    dataset: &RdfDataset,
+fn serialize_dataset_inner<D: DatasetView>(
+    dataset: &D,
     media_type: &str,
     selection: SerializeGraph<'_>,
     include_statement_layer: bool,
@@ -78,9 +78,9 @@ fn serialize_dataset_inner(
     Ok(text.into_bytes())
 }
 
-/// Serialize a frozen [`RdfDataset`] into the given writer.
-pub(crate) fn serialize_into<W: Write>(
-    dataset: &RdfDataset,
+/// Serialize a frozen [`RdfDataset`](crate::RdfDataset) into the given writer.
+pub(crate) fn serialize_into<D: DatasetView, W: Write>(
+    dataset: &D,
     media_type: &str,
     selection: SerializeGraph<'_>,
     mut output: W,
@@ -91,7 +91,7 @@ pub(crate) fn serialize_into<W: Write>(
         .map_err(|e| RdfDiagnostic::error("native-codec-write", e.to_string()))
 }
 
-/// Outcome of serializing an [`RdfDataset`] to a concrete RDF format through the
+/// Outcome of serializing an [`RdfDataset`](crate::RdfDataset) to a concrete RDF format through the
 /// native codecs (universal transcoder helper, ported onto the native path).
 #[derive(Debug, Clone)]
 pub struct SerializeOutcome {
@@ -118,8 +118,8 @@ pub struct SerializeOutcome {
 /// Graph selection follows [`SerializeGraph::Dataset`]: dataset-capable formats
 /// (N-Quads, TriG) emit all named graphs; the single-graph syntaxes (Turtle,
 /// N-Triples, RDF/XML) flatten to the default graph.
-pub fn serialize_dataset_to_format(
-    dataset: &RdfDataset,
+pub fn serialize_dataset_to_format<D: DatasetView>(
+    dataset: &D,
     format: NativeRdfFormat,
     _base_iri: Option<&str>,
 ) -> Result<SerializeOutcome, RdfDiagnostic> {
@@ -132,7 +132,8 @@ pub fn serialize_dataset_to_format(
         })
     } else {
         let bytes = serialize_dataset_base_only(dataset, media_type, SerializeGraph::Dataset)?;
-        let statement_rows_dropped = dataset.reifiers().count() + dataset.annotations().count();
+        let statement_rows_dropped =
+            dataset.reifier_quads().count() + dataset.annotation_quads().count();
         Ok(SerializeOutcome {
             bytes,
             statement_rows_dropped,
@@ -146,8 +147,8 @@ pub fn serialize_dataset_to_format(
 /// `pub(crate)` so the JSON-LD / YAML-LD codec ([`super::jsonld`]) can build the same
 /// first-party graph shape it walks (a dataset-capable `format` such as
 /// [`NativeRdfFormat::NQuads`] preserves named graphs).
-pub(crate) fn build_ser_graph(
-    dataset: &RdfDataset,
+pub(crate) fn build_ser_graph<D: DatasetView>(
+    dataset: &D,
     format: NativeRdfFormat,
     selection: SerializeGraph<'_>,
     include_statement_layer: bool,
@@ -158,7 +159,7 @@ pub(crate) fn build_ser_graph(
     // participates — matching the oxigraph backend's filter exactly.
     let mut graph = SerGraph {
         terms: Vec::new(),
-        quads: Vec::with_capacity(dataset.quad_count()),
+        quads: Vec::with_capacity(dataset.len_hint().unwrap_or(0)),
         reifiers: Vec::new(),
         annotations: Vec::new(),
     };
@@ -178,7 +179,7 @@ pub(crate) fn build_ser_graph(
                 graph.quads.push((s, p, o, g));
             }
             if include_statement_layer {
-                push_statement_rows(&mut interner, dataset, &mut graph)?;
+                push_statement_rows(&mut interner, dataset, &mut graph, false)?;
             }
         }
         SerializeGraph::Dataset | SerializeGraph::DefaultGraph => {
@@ -191,8 +192,12 @@ pub(crate) fn build_ser_graph(
                 let o = interner.intern(dataset, quad.o)?;
                 graph.quads.push((s, p, o, None));
             }
+            // A single-graph (flattened) projection drops named-graph QUADS above, so
+            // it must likewise drop graph-scoped STATEMENT ROWS — otherwise the
+            // single-graph serializers' `ensure_default_graph_projection` guard rejects
+            // a graph-scoped reifier/annotation that has no home in the default graph.
             if include_statement_layer {
-                push_statement_rows(&mut interner, dataset, &mut graph)?;
+                push_statement_rows(&mut interner, dataset, &mut graph, true)?;
             }
         }
         SerializeGraph::Named(name) => {
@@ -219,28 +224,47 @@ pub(crate) fn build_ser_graph(
     graph
         .annotations
         .extend(std::mem::take(&mut interner.annotations));
+    // Impose a canonical, value-based row order so the emitted document is
+    // byte-identical across `DatasetView` backends (whose term-table interning order —
+    // and hence quad iteration order — differs) and independent of insertion order.
+    graph.sort_canonical();
     Ok(graph)
 }
 
 /// Push the RDF 1.2 statement layer (reifier bindings + annotations) onto the graph,
 /// interning their terms. The reifier bindings land in `interner.reifiers`; the
 /// annotation triples in `interner.annotations`.
-fn push_statement_rows(
+fn push_statement_rows<D: DatasetView>(
     interner: &mut SerGraphInterner,
-    dataset: &RdfDataset,
+    dataset: &D,
     _graph: &mut SerGraph,
+    default_graph_only: bool,
 ) -> Result<(), RdfDiagnostic> {
-    for (reifier, triple, graph) in dataset.reifiers_with_graph() {
-        let reifier_id = interner.intern(dataset, reifier)?;
-        let (s, p, o) = interner.intern_triple_components(dataset, triple)?;
-        let g = graph.map(|g| interner.intern(dataset, g)).transpose()?;
+    // `reifier_quads()` yields each side-table binding as a virtual quad
+    // `(s = reifier, p = rdf:reifies, o = triple-term, g = graph)`. The `rdf:reifies`
+    // predicate id (`q.p`) is the fixed virtual edge and is not materialized here — the
+    // reifier row carries the resolved triple components directly.
+    for q in dataset.reifier_quads() {
+        // A flattened single-graph projection carries only the default graph, so a
+        // graph-scoped binding is dropped exactly as its named-graph quads are.
+        if default_graph_only && q.g.is_some() {
+            continue;
+        }
+        let reifier_id = interner.intern(dataset, q.s)?;
+        let (s, p, o) = interner.intern_triple_components(dataset, q.o)?;
+        let g = q.g.map(|g| interner.intern(dataset, g)).transpose()?;
         interner.reifiers.push((reifier_id, (s, p, o), g));
     }
-    for (reifier, predicate, object, graph) in dataset.annotations_with_graph() {
-        let r = interner.intern(dataset, reifier)?;
-        let p = interner.intern(dataset, predicate)?;
-        let o = interner.intern(dataset, object)?;
-        let g = graph.map(|g| interner.intern(dataset, g)).transpose()?;
+    // `annotation_quads()` yields each annotation as `(s = reifier, p = predicate,
+    // o = object, g = graph)`.
+    for q in dataset.annotation_quads() {
+        if default_graph_only && q.g.is_some() {
+            continue;
+        }
+        let r = interner.intern(dataset, q.s)?;
+        let p = interner.intern(dataset, q.p)?;
+        let o = interner.intern(dataset, q.o)?;
+        let g = q.g.map(|g| interner.intern(dataset, g)).transpose()?;
         interner.annotations.push((r, p, o, g));
     }
     Ok(())
@@ -272,7 +296,7 @@ impl SerGraphInterner {
     }
 
     /// Intern an IR term id into the first-party term table, returning its index.
-    fn intern(&mut self, dataset: &RdfDataset, id: TermId) -> Result<usize, RdfDiagnostic> {
+    fn intern<D: DatasetView>(&mut self, dataset: &D, id: D::Id) -> Result<usize, RdfDiagnostic> {
         let value = term_value(dataset, id);
         if let Some(&idx) = self.memo.get(&value) {
             return Ok(idx);
@@ -365,10 +389,10 @@ impl SerGraphInterner {
 
     /// Resolve a triple-term id to the `(s, p, o)` term indices of its components
     /// (interning each), for a statement-layer reifier binding.
-    fn intern_triple_components(
+    fn intern_triple_components<D: DatasetView>(
         &mut self,
-        dataset: &RdfDataset,
-        triple: TermId,
+        dataset: &D,
+        triple: D::Id,
     ) -> Result<(usize, usize, usize), RdfDiagnostic> {
         match dataset.resolve(triple) {
             TermRef::Triple { s, p, o } => {
@@ -392,7 +416,7 @@ impl SerGraphInterner {
 }
 
 /// The dataset-independent value of an IR term, for the interner memo.
-fn term_value(dataset: &RdfDataset, id: TermId) -> TermValue {
+fn term_value<D: DatasetView>(dataset: &D, id: D::Id) -> TermValue {
     match dataset.resolve(id) {
         TermRef::Iri(iri) => TermValue::Iri(iri.to_owned()),
         TermRef::Blank { label, scope } => TermValue::Blank {
@@ -419,7 +443,7 @@ fn term_value(dataset: &RdfDataset, id: TermId) -> TermValue {
 }
 
 /// Resolve an IR term id known to be an IRI (a literal datatype) to its IRI string.
-fn iri_of(dataset: &RdfDataset, id: TermId) -> Result<String, RdfDiagnostic> {
+fn iri_of<D: DatasetView>(dataset: &D, id: D::Id) -> Result<String, RdfDiagnostic> {
     match dataset.resolve(id) {
         TermRef::Iri(iri) => Ok(iri.to_owned()),
         other => Err(RdfDiagnostic::error(
@@ -444,7 +468,7 @@ mod serialize_to_format_tests {
     //! helper, so their star-drop accounting is exercised alongside the others (they are
     //! star-capable, so the count is 0).
     use super::*;
-    use crate::{RdfDatasetBuilder, TermFactory, parse_dataset};
+    use crate::{RdfDataset, RdfDatasetBuilder, TermFactory, parse_dataset};
     use std::sync::Arc;
 
     /// A star-free dataset: 1 default-graph quad + 1 named-graph quad.

--- a/crates/rdf/tests/common/mod.rs
+++ b/crates/rdf/tests/common/mod.rs
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared test fixture for the pack/serializer parity guards
+//! (`pack_reconstruct_roundtrip.rs` and `serialize_pack_parity.rs`).
+//!
+//! Both guards need the SAME rich RDF-1.2 dataset — default + named graphs, every
+//! literal shape, a scoped blank node, a quoted-triple term, a reifier with a
+//! default-scoped AND a graph-scoped annotation, `example.org` IRIs only — so a single
+//! copy lives here instead of drifting across two files.
+
+use std::sync::Arc;
+
+use purrdf_core::{BlankScope, RdfDataset, RdfDatasetBuilder, RdfLiteral, RdfTextDirection};
+
+/// Build the rich fixture `RdfDataset`, mirroring
+/// `crates/sparql-eval/tests/pack_query_e2e.rs`: default graph (with a two-hop `knows`
+/// join chain, a term used as both predicate and subject, every literal shape — simple,
+/// typed, language-tagged, directional — a scoped blank node, and an RDF 1.2 triple
+/// term asserted as an object) + 2 named graphs + a reifier with a default-scoped AND a
+/// graph-scoped annotation. `example.org` IRIs ONLY.
+pub(crate) fn build_fixture() -> Arc<RdfDataset> {
+    let mut b = RdfDatasetBuilder::new();
+
+    let alice = b.intern_iri("http://example.org/alice");
+    let bob = b.intern_iri("http://example.org/bob");
+    let carol = b.intern_iri("http://example.org/carol");
+    let knows = b.intern_iri("http://example.org/knows");
+    let age = b.intern_iri("http://example.org/age");
+    let name = b.intern_iri("http://example.org/name");
+    let sees = b.intern_iri("http://example.org/sees");
+    let likes = b.intern_iri("http://example.org/likes");
+    let greeting = b.intern_iri("http://example.org/greeting");
+    let confidence = b.intern_iri("http://example.org/confidence");
+    let high = b.intern_iri("http://example.org/high");
+    let source = b.intern_iri("http://example.org/source");
+    let doc = b.intern_iri("http://example.org/doc");
+    let meta = b.intern_iri("http://example.org/meta");
+    let states_fact = b.intern_iri("http://example.org/statesFact");
+    let reifier = b.intern_iri("http://example.org/r");
+    let graph1 = b.intern_iri("http://example.org/graph1");
+    let graph2 = b.intern_iri("http://example.org/graph2");
+
+    let blank = b.intern_blank("b1", BlankScope::DEFAULT);
+
+    let forty_two = b.intern_literal(RdfLiteral {
+        lexical_form: "42".to_string(),
+        datatype: Some("http://www.w3.org/2001/XMLSchema#integer".to_string()),
+        language: None,
+        direction: None,
+    });
+    let alice_name_en = b.intern_literal(RdfLiteral {
+        lexical_form: "Alice".to_string(),
+        datatype: None,
+        language: Some("en".to_string()),
+        direction: None,
+    });
+    let anon_name = b.intern_literal(RdfLiteral {
+        lexical_form: "Anon".to_string(),
+        datatype: None,
+        language: None,
+        direction: None,
+    });
+    let knows_label = b.intern_literal(RdfLiteral {
+        lexical_form: "the knows predicate".to_string(),
+        datatype: None,
+        language: None,
+        direction: None,
+    });
+    let hello_ltr = b.intern_literal(RdfLiteral {
+        lexical_form: "Hello".to_string(),
+        datatype: None,
+        language: Some("en".to_string()),
+        direction: Some(RdfTextDirection::Ltr),
+    });
+    let carol_age = b.intern_literal(RdfLiteral {
+        lexical_form: "30".to_string(),
+        datatype: Some("http://www.w3.org/2001/XMLSchema#integer".to_string()),
+        language: None,
+        direction: None,
+    });
+
+    // The RDF 1.2 triple term `<<( alice knows bob )>>`, asserted as an OBJECT below and
+    // reified further down — occupies both roles.
+    let alice_knows_bob = b.intern_triple(alice, knows, bob);
+
+    // -- Default graph ----------------------------------------------------------
+    b.push_quad(alice, knows, bob, None);
+    b.push_quad(bob, knows, carol, None);
+    b.push_quad(alice, age, forty_two, None);
+    b.push_quad(alice, name, alice_name_en, None);
+    // `knows` used as a SUBJECT here and as a PREDICATE above.
+    b.push_quad(knows, name, knows_label, None);
+    b.push_quad(blank, name, anon_name, None);
+    b.push_quad(bob, sees, blank, None);
+    b.push_quad(alice, greeting, hello_ltr, None);
+    b.push_quad(meta, states_fact, alice_knows_bob, None);
+
+    // -- Named graph 1 ------------------------------------------------------------
+    b.push_quad(carol, age, carol_age, Some(graph1));
+    b.push_quad(bob, knows, carol, Some(graph1));
+
+    // -- Named graph 2 ------------------------------------------------------------
+    b.push_quad(carol, likes, alice, Some(graph2));
+
+    // -- Reifier + annotations -----------------------------------------------------
+    b.push_reifier(reifier, alice_knows_bob);
+    b.push_annotation(reifier, confidence, high);
+    // A second, graph-scoped annotation on the SAME reifier.
+    b.push_annotation_in_graph(reifier, source, doc, Some(graph1));
+
+    b.freeze().expect("fixture dataset must validate")
+}

--- a/crates/rdf/tests/pack_reconstruct_roundtrip.rs
+++ b/crates/rdf/tests/pack_reconstruct_roundtrip.rs
@@ -16,112 +16,11 @@
 //! trip. The same rich fixture (`example.org` only) exercises every seam the pack
 //! codec claims to unify.
 
-use std::sync::Arc;
-
-use purrdf_core::{
-    BlankScope, PackBuilder, PackView, RdfDataset, RdfDatasetBuilder, RdfLiteral, RdfTextDirection,
-    dataset_from_view, datasets_isomorphic,
-};
+use purrdf_core::{PackBuilder, PackView, dataset_from_view, datasets_isomorphic};
 use purrdf_rdf::{NativeRdfFormat, serialize_dataset_to_format};
 
-/// Build the rich fixture `RdfDataset`, mirroring
-/// `crates/sparql-eval/tests/pack_query_e2e.rs`: default graph (with a two-hop `knows`
-/// join chain, a term used as both predicate and subject, every literal shape — simple,
-/// typed, language-tagged, directional — a scoped blank node, and an RDF 1.2 triple
-/// term asserted as an object) + 2 named graphs + a reifier with a default-scoped AND a
-/// graph-scoped annotation. `example.org` IRIs ONLY.
-fn build_fixture() -> Arc<RdfDataset> {
-    let mut b = RdfDatasetBuilder::new();
-
-    let alice = b.intern_iri("http://example.org/alice");
-    let bob = b.intern_iri("http://example.org/bob");
-    let carol = b.intern_iri("http://example.org/carol");
-    let knows = b.intern_iri("http://example.org/knows");
-    let age = b.intern_iri("http://example.org/age");
-    let name = b.intern_iri("http://example.org/name");
-    let sees = b.intern_iri("http://example.org/sees");
-    let likes = b.intern_iri("http://example.org/likes");
-    let greeting = b.intern_iri("http://example.org/greeting");
-    let confidence = b.intern_iri("http://example.org/confidence");
-    let high = b.intern_iri("http://example.org/high");
-    let source = b.intern_iri("http://example.org/source");
-    let doc = b.intern_iri("http://example.org/doc");
-    let meta = b.intern_iri("http://example.org/meta");
-    let states_fact = b.intern_iri("http://example.org/statesFact");
-    let reifier = b.intern_iri("http://example.org/r");
-    let graph1 = b.intern_iri("http://example.org/graph1");
-    let graph2 = b.intern_iri("http://example.org/graph2");
-
-    let blank = b.intern_blank("b1", BlankScope::DEFAULT);
-
-    let forty_two = b.intern_literal(RdfLiteral {
-        lexical_form: "42".to_string(),
-        datatype: Some("http://www.w3.org/2001/XMLSchema#integer".to_string()),
-        language: None,
-        direction: None,
-    });
-    let alice_name_en = b.intern_literal(RdfLiteral {
-        lexical_form: "Alice".to_string(),
-        datatype: None,
-        language: Some("en".to_string()),
-        direction: None,
-    });
-    let anon_name = b.intern_literal(RdfLiteral {
-        lexical_form: "Anon".to_string(),
-        datatype: None,
-        language: None,
-        direction: None,
-    });
-    let knows_label = b.intern_literal(RdfLiteral {
-        lexical_form: "the knows predicate".to_string(),
-        datatype: None,
-        language: None,
-        direction: None,
-    });
-    let hello_ltr = b.intern_literal(RdfLiteral {
-        lexical_form: "Hello".to_string(),
-        datatype: None,
-        language: Some("en".to_string()),
-        direction: Some(RdfTextDirection::Ltr),
-    });
-    let carol_age = b.intern_literal(RdfLiteral {
-        lexical_form: "30".to_string(),
-        datatype: Some("http://www.w3.org/2001/XMLSchema#integer".to_string()),
-        language: None,
-        direction: None,
-    });
-
-    // The RDF 1.2 triple term `<<( alice knows bob )>>`, asserted as an OBJECT below and
-    // reified further down — occupies both roles.
-    let alice_knows_bob = b.intern_triple(alice, knows, bob);
-
-    // -- Default graph ----------------------------------------------------------
-    b.push_quad(alice, knows, bob, None);
-    b.push_quad(bob, knows, carol, None);
-    b.push_quad(alice, age, forty_two, None);
-    b.push_quad(alice, name, alice_name_en, None);
-    // `knows` used as a SUBJECT here and as a PREDICATE above.
-    b.push_quad(knows, name, knows_label, None);
-    b.push_quad(blank, name, anon_name, None);
-    b.push_quad(bob, sees, blank, None);
-    b.push_quad(alice, greeting, hello_ltr, None);
-    b.push_quad(meta, states_fact, alice_knows_bob, None);
-
-    // -- Named graph 1 ------------------------------------------------------------
-    b.push_quad(carol, age, carol_age, Some(graph1));
-    b.push_quad(bob, knows, carol, Some(graph1));
-
-    // -- Named graph 2 ------------------------------------------------------------
-    b.push_quad(carol, likes, alice, Some(graph2));
-
-    // -- Reifier + annotations -----------------------------------------------------
-    b.push_reifier(reifier, alice_knows_bob);
-    b.push_annotation(reifier, confidence, high);
-    // A second, graph-scoped annotation on the SAME reifier.
-    b.push_annotation_in_graph(reifier, source, doc, Some(graph1));
-
-    b.freeze().expect("fixture dataset must validate")
-}
+mod common;
+use common::build_fixture;
 
 /// The headline: reconstruct the rich fixture straight off its `PackView` and prove the
 /// result is the same dataset — isomorphic by RDFC-1.0 digest AND byte-identical in a

--- a/crates/rdf/tests/pack_reconstruct_roundtrip.rs
+++ b/crates/rdf/tests/pack_reconstruct_roundtrip.rs
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Reconstruction round-trip: the public, `DatasetView`-generic reconstructor
+//! [`dataset_from_view`] materializes a concrete [`Arc<RdfDataset>`] from a mmap'd
+//! [`PackView`], and that reconstruction is IDENTICAL to the source dataset the pack
+//! was built from — isomorphic by RDFC-1.0 digest AND byte-identical when serialized
+//! to a star-capable format.
+//!
+//! This is the ingress twin of the serializer parity guard in
+//! `serialize_pack_parity.rs` and the query parity guard in
+//! `crates/sparql-eval/tests/pack_query_e2e.rs`: it proves a caller holding only a
+//! read-only pack projection can recover a full `RdfDataset` (to feed a transform
+//! that needs one, e.g. the reasoner) with zero loss — every base quad, every RDF-1.2
+//! reifier binding, and every default- and graph-scoped annotation survive the round
+//! trip. The same rich fixture (`example.org` only) exercises every seam the pack
+//! codec claims to unify.
+
+use std::sync::Arc;
+
+use purrdf_core::{
+    BlankScope, PackBuilder, PackView, RdfDataset, RdfDatasetBuilder, RdfLiteral, RdfTextDirection,
+    dataset_from_view, datasets_isomorphic,
+};
+use purrdf_rdf::{NativeRdfFormat, serialize_dataset_to_format};
+
+/// Build the rich fixture `RdfDataset`, mirroring
+/// `crates/sparql-eval/tests/pack_query_e2e.rs`: default graph (with a two-hop `knows`
+/// join chain, a term used as both predicate and subject, every literal shape — simple,
+/// typed, language-tagged, directional — a scoped blank node, and an RDF 1.2 triple
+/// term asserted as an object) + 2 named graphs + a reifier with a default-scoped AND a
+/// graph-scoped annotation. `example.org` IRIs ONLY.
+fn build_fixture() -> Arc<RdfDataset> {
+    let mut b = RdfDatasetBuilder::new();
+
+    let alice = b.intern_iri("http://example.org/alice");
+    let bob = b.intern_iri("http://example.org/bob");
+    let carol = b.intern_iri("http://example.org/carol");
+    let knows = b.intern_iri("http://example.org/knows");
+    let age = b.intern_iri("http://example.org/age");
+    let name = b.intern_iri("http://example.org/name");
+    let sees = b.intern_iri("http://example.org/sees");
+    let likes = b.intern_iri("http://example.org/likes");
+    let greeting = b.intern_iri("http://example.org/greeting");
+    let confidence = b.intern_iri("http://example.org/confidence");
+    let high = b.intern_iri("http://example.org/high");
+    let source = b.intern_iri("http://example.org/source");
+    let doc = b.intern_iri("http://example.org/doc");
+    let meta = b.intern_iri("http://example.org/meta");
+    let states_fact = b.intern_iri("http://example.org/statesFact");
+    let reifier = b.intern_iri("http://example.org/r");
+    let graph1 = b.intern_iri("http://example.org/graph1");
+    let graph2 = b.intern_iri("http://example.org/graph2");
+
+    let blank = b.intern_blank("b1", BlankScope::DEFAULT);
+
+    let forty_two = b.intern_literal(RdfLiteral {
+        lexical_form: "42".to_string(),
+        datatype: Some("http://www.w3.org/2001/XMLSchema#integer".to_string()),
+        language: None,
+        direction: None,
+    });
+    let alice_name_en = b.intern_literal(RdfLiteral {
+        lexical_form: "Alice".to_string(),
+        datatype: None,
+        language: Some("en".to_string()),
+        direction: None,
+    });
+    let anon_name = b.intern_literal(RdfLiteral {
+        lexical_form: "Anon".to_string(),
+        datatype: None,
+        language: None,
+        direction: None,
+    });
+    let knows_label = b.intern_literal(RdfLiteral {
+        lexical_form: "the knows predicate".to_string(),
+        datatype: None,
+        language: None,
+        direction: None,
+    });
+    let hello_ltr = b.intern_literal(RdfLiteral {
+        lexical_form: "Hello".to_string(),
+        datatype: None,
+        language: Some("en".to_string()),
+        direction: Some(RdfTextDirection::Ltr),
+    });
+    let carol_age = b.intern_literal(RdfLiteral {
+        lexical_form: "30".to_string(),
+        datatype: Some("http://www.w3.org/2001/XMLSchema#integer".to_string()),
+        language: None,
+        direction: None,
+    });
+
+    // The RDF 1.2 triple term `<<( alice knows bob )>>`, asserted as an OBJECT below and
+    // reified further down — occupies both roles.
+    let alice_knows_bob = b.intern_triple(alice, knows, bob);
+
+    // -- Default graph ----------------------------------------------------------
+    b.push_quad(alice, knows, bob, None);
+    b.push_quad(bob, knows, carol, None);
+    b.push_quad(alice, age, forty_two, None);
+    b.push_quad(alice, name, alice_name_en, None);
+    // `knows` used as a SUBJECT here and as a PREDICATE above.
+    b.push_quad(knows, name, knows_label, None);
+    b.push_quad(blank, name, anon_name, None);
+    b.push_quad(bob, sees, blank, None);
+    b.push_quad(alice, greeting, hello_ltr, None);
+    b.push_quad(meta, states_fact, alice_knows_bob, None);
+
+    // -- Named graph 1 ------------------------------------------------------------
+    b.push_quad(carol, age, carol_age, Some(graph1));
+    b.push_quad(bob, knows, carol, Some(graph1));
+
+    // -- Named graph 2 ------------------------------------------------------------
+    b.push_quad(carol, likes, alice, Some(graph2));
+
+    // -- Reifier + annotations -----------------------------------------------------
+    b.push_reifier(reifier, alice_knows_bob);
+    b.push_annotation(reifier, confidence, high);
+    // A second, graph-scoped annotation on the SAME reifier.
+    b.push_annotation_in_graph(reifier, source, doc, Some(graph1));
+
+    b.freeze().expect("fixture dataset must validate")
+}
+
+/// The headline: reconstruct the rich fixture straight off its `PackView` and prove the
+/// result is the same dataset — isomorphic by RDFC-1.0 digest AND byte-identical in a
+/// star-capable serialization.
+#[test]
+fn dataset_from_view_roundtrips_the_full_fixture() {
+    let ds = build_fixture();
+
+    // Build the pack, open a read-only view over it, and reconstruct a concrete dataset.
+    let bytes = PackBuilder::build_bytes(&ds).expect("pack build");
+    let view = PackView::from_bytes(&bytes).expect("pack opens");
+    let rebuilt = dataset_from_view(&view).expect("reconstruct from view");
+
+    // 1) Direct dataset isomorphism (RDFC-1.0 blank-node canonicalization under the hood).
+    assert!(
+        datasets_isomorphic(&rebuilt, &ds), // deref-coerces Arc<RdfDataset> -> &RdfDataset
+        "reconstruction must be isomorphic to the source dataset"
+    );
+
+    // 2) Isomorphism by RDFC-1.0 content digest: build a pack from the reconstruction and
+    //    compare its stored RDFC-1.0 digest to the source pack's. Equal digests certify
+    //    the two datasets canonicalize identically (base quads + reifier + annotations).
+    let rebuilt_bytes = PackBuilder::build_bytes(&rebuilt).expect("pack build from reconstruction");
+    let rebuilt_view = PackView::from_bytes(&rebuilt_bytes).expect("rebuilt pack opens");
+    assert_eq!(
+        view.rdfc_digest(),
+        rebuilt_view.rdfc_digest(),
+        "reconstruction's RDFC-1.0 digest must equal the source pack's"
+    );
+
+    // 3) Byte-identical N-Quads (a star-capable format: the triple-term-as-object base
+    //    quad and the reifier/annotation side-tables all serialize losslessly).
+    let rebuilt_nq = serialize_dataset_to_format(&*rebuilt, NativeRdfFormat::NQuads, None)
+        .expect("serialize reconstruction to NQuads")
+        .bytes;
+    let source_nq = serialize_dataset_to_format(&*ds, NativeRdfFormat::NQuads, None)
+        .expect("serialize source to NQuads")
+        .bytes;
+    assert_eq!(
+        rebuilt_nq, source_nq,
+        "reconstruction must serialize byte-identically to the source in NQuads"
+    );
+    assert!(
+        !source_nq.is_empty(),
+        "non-vacuous: the fixture is non-empty"
+    );
+}

--- a/crates/rdf/tests/serialize_pack_parity.rs
+++ b/crates/rdf/tests/serialize_pack_parity.rs
@@ -14,112 +14,11 @@
 //! it certifies that the pack codec preserves the quad/term/side-table iteration order
 //! the serializer folds into its deterministic output.
 
-use std::sync::Arc;
-
-use purrdf_core::{
-    BlankScope, DatasetView, PackBuilder, PackView, RdfDataset, RdfDatasetBuilder, RdfLiteral,
-    RdfTextDirection,
-};
+use purrdf_core::{DatasetView, PackBuilder, PackView};
 use purrdf_rdf::{NativeRdfFormat, serialize_dataset_to_format};
 
-/// Build the rich fixture `RdfDataset`, mirroring
-/// `crates/sparql-eval/tests/pack_query_e2e.rs`: default graph (with a two-hop `knows`
-/// join chain, a term used as both predicate and subject, every literal shape — simple,
-/// typed, language-tagged, directional — a scoped blank node, and an RDF 1.2 triple
-/// term asserted as an object) + 2 named graphs + a reifier with a default-scoped AND a
-/// graph-scoped annotation. `example.org` IRIs ONLY.
-fn build_fixture() -> Arc<RdfDataset> {
-    let mut b = RdfDatasetBuilder::new();
-
-    let alice = b.intern_iri("http://example.org/alice");
-    let bob = b.intern_iri("http://example.org/bob");
-    let carol = b.intern_iri("http://example.org/carol");
-    let knows = b.intern_iri("http://example.org/knows");
-    let age = b.intern_iri("http://example.org/age");
-    let name = b.intern_iri("http://example.org/name");
-    let sees = b.intern_iri("http://example.org/sees");
-    let likes = b.intern_iri("http://example.org/likes");
-    let greeting = b.intern_iri("http://example.org/greeting");
-    let confidence = b.intern_iri("http://example.org/confidence");
-    let high = b.intern_iri("http://example.org/high");
-    let source = b.intern_iri("http://example.org/source");
-    let doc = b.intern_iri("http://example.org/doc");
-    let meta = b.intern_iri("http://example.org/meta");
-    let states_fact = b.intern_iri("http://example.org/statesFact");
-    let reifier = b.intern_iri("http://example.org/r");
-    let graph1 = b.intern_iri("http://example.org/graph1");
-    let graph2 = b.intern_iri("http://example.org/graph2");
-
-    let blank = b.intern_blank("b1", BlankScope::DEFAULT);
-
-    let forty_two = b.intern_literal(RdfLiteral {
-        lexical_form: "42".to_string(),
-        datatype: Some("http://www.w3.org/2001/XMLSchema#integer".to_string()),
-        language: None,
-        direction: None,
-    });
-    let alice_name_en = b.intern_literal(RdfLiteral {
-        lexical_form: "Alice".to_string(),
-        datatype: None,
-        language: Some("en".to_string()),
-        direction: None,
-    });
-    let anon_name = b.intern_literal(RdfLiteral {
-        lexical_form: "Anon".to_string(),
-        datatype: None,
-        language: None,
-        direction: None,
-    });
-    let knows_label = b.intern_literal(RdfLiteral {
-        lexical_form: "the knows predicate".to_string(),
-        datatype: None,
-        language: None,
-        direction: None,
-    });
-    let hello_ltr = b.intern_literal(RdfLiteral {
-        lexical_form: "Hello".to_string(),
-        datatype: None,
-        language: Some("en".to_string()),
-        direction: Some(RdfTextDirection::Ltr),
-    });
-    let carol_age = b.intern_literal(RdfLiteral {
-        lexical_form: "30".to_string(),
-        datatype: Some("http://www.w3.org/2001/XMLSchema#integer".to_string()),
-        language: None,
-        direction: None,
-    });
-
-    // The RDF 1.2 triple term `<<( alice knows bob )>>`, asserted as an OBJECT below and
-    // reified further down — occupies both roles.
-    let alice_knows_bob = b.intern_triple(alice, knows, bob);
-
-    // -- Default graph ----------------------------------------------------------
-    b.push_quad(alice, knows, bob, None);
-    b.push_quad(bob, knows, carol, None);
-    b.push_quad(alice, age, forty_two, None);
-    b.push_quad(alice, name, alice_name_en, None);
-    // `knows` used as a SUBJECT here and as a PREDICATE above.
-    b.push_quad(knows, name, knows_label, None);
-    b.push_quad(blank, name, anon_name, None);
-    b.push_quad(bob, sees, blank, None);
-    b.push_quad(alice, greeting, hello_ltr, None);
-    b.push_quad(meta, states_fact, alice_knows_bob, None);
-
-    // -- Named graph 1 ------------------------------------------------------------
-    b.push_quad(carol, age, carol_age, Some(graph1));
-    b.push_quad(bob, knows, carol, Some(graph1));
-
-    // -- Named graph 2 ------------------------------------------------------------
-    b.push_quad(carol, likes, alice, Some(graph2));
-
-    // -- Reifier + annotations -----------------------------------------------------
-    b.push_reifier(reifier, alice_knows_bob);
-    b.push_annotation(reifier, confidence, high);
-    // A second, graph-scoped annotation on the SAME reifier.
-    b.push_annotation_in_graph(reifier, source, doc, Some(graph1));
-
-    b.freeze().expect("fixture dataset must validate")
-}
+mod common;
+use common::build_fixture;
 
 /// Every native RDF format the serializer targets.
 const ALL_FORMATS: &[NativeRdfFormat] = &[

--- a/crates/rdf/tests/serialize_pack_parity.rs
+++ b/crates/rdf/tests/serialize_pack_parity.rs
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Serializer parity across `DatasetView` backends: the native RDF serializer
+//! ([`serialize_dataset_to_format`]) is generic over any [`DatasetView`], so the SAME
+//! rich fixture serialized through the production [`RdfDataset`] and through a
+//! [`PackView`] opened over that dataset's pack bytes must be BYTE-IDENTICAL for every
+//! [`NativeRdfFormat`] — and report the same star-layer drop count.
+//!
+//! This is the egress twin of the query-side parity guard in
+//! `crates/sparql-eval/tests/pack_query_e2e.rs`: it proves a `PackView` (or any
+//! `DatasetView`) serializes straight to RDF text with zero materialization and no
+//! behavioral divergence from the source dataset. Byte-identity is the strong claim —
+//! it certifies that the pack codec preserves the quad/term/side-table iteration order
+//! the serializer folds into its deterministic output.
+
+use std::sync::Arc;
+
+use purrdf_core::{
+    BlankScope, DatasetView, PackBuilder, PackView, RdfDataset, RdfDatasetBuilder, RdfLiteral,
+    RdfTextDirection,
+};
+use purrdf_rdf::{NativeRdfFormat, serialize_dataset_to_format};
+
+/// Build the rich fixture `RdfDataset`, mirroring
+/// `crates/sparql-eval/tests/pack_query_e2e.rs`: default graph (with a two-hop `knows`
+/// join chain, a term used as both predicate and subject, every literal shape — simple,
+/// typed, language-tagged, directional — a scoped blank node, and an RDF 1.2 triple
+/// term asserted as an object) + 2 named graphs + a reifier with a default-scoped AND a
+/// graph-scoped annotation. `example.org` IRIs ONLY.
+fn build_fixture() -> Arc<RdfDataset> {
+    let mut b = RdfDatasetBuilder::new();
+
+    let alice = b.intern_iri("http://example.org/alice");
+    let bob = b.intern_iri("http://example.org/bob");
+    let carol = b.intern_iri("http://example.org/carol");
+    let knows = b.intern_iri("http://example.org/knows");
+    let age = b.intern_iri("http://example.org/age");
+    let name = b.intern_iri("http://example.org/name");
+    let sees = b.intern_iri("http://example.org/sees");
+    let likes = b.intern_iri("http://example.org/likes");
+    let greeting = b.intern_iri("http://example.org/greeting");
+    let confidence = b.intern_iri("http://example.org/confidence");
+    let high = b.intern_iri("http://example.org/high");
+    let source = b.intern_iri("http://example.org/source");
+    let doc = b.intern_iri("http://example.org/doc");
+    let meta = b.intern_iri("http://example.org/meta");
+    let states_fact = b.intern_iri("http://example.org/statesFact");
+    let reifier = b.intern_iri("http://example.org/r");
+    let graph1 = b.intern_iri("http://example.org/graph1");
+    let graph2 = b.intern_iri("http://example.org/graph2");
+
+    let blank = b.intern_blank("b1", BlankScope::DEFAULT);
+
+    let forty_two = b.intern_literal(RdfLiteral {
+        lexical_form: "42".to_string(),
+        datatype: Some("http://www.w3.org/2001/XMLSchema#integer".to_string()),
+        language: None,
+        direction: None,
+    });
+    let alice_name_en = b.intern_literal(RdfLiteral {
+        lexical_form: "Alice".to_string(),
+        datatype: None,
+        language: Some("en".to_string()),
+        direction: None,
+    });
+    let anon_name = b.intern_literal(RdfLiteral {
+        lexical_form: "Anon".to_string(),
+        datatype: None,
+        language: None,
+        direction: None,
+    });
+    let knows_label = b.intern_literal(RdfLiteral {
+        lexical_form: "the knows predicate".to_string(),
+        datatype: None,
+        language: None,
+        direction: None,
+    });
+    let hello_ltr = b.intern_literal(RdfLiteral {
+        lexical_form: "Hello".to_string(),
+        datatype: None,
+        language: Some("en".to_string()),
+        direction: Some(RdfTextDirection::Ltr),
+    });
+    let carol_age = b.intern_literal(RdfLiteral {
+        lexical_form: "30".to_string(),
+        datatype: Some("http://www.w3.org/2001/XMLSchema#integer".to_string()),
+        language: None,
+        direction: None,
+    });
+
+    // The RDF 1.2 triple term `<<( alice knows bob )>>`, asserted as an OBJECT below and
+    // reified further down — occupies both roles.
+    let alice_knows_bob = b.intern_triple(alice, knows, bob);
+
+    // -- Default graph ----------------------------------------------------------
+    b.push_quad(alice, knows, bob, None);
+    b.push_quad(bob, knows, carol, None);
+    b.push_quad(alice, age, forty_two, None);
+    b.push_quad(alice, name, alice_name_en, None);
+    // `knows` used as a SUBJECT here and as a PREDICATE above.
+    b.push_quad(knows, name, knows_label, None);
+    b.push_quad(blank, name, anon_name, None);
+    b.push_quad(bob, sees, blank, None);
+    b.push_quad(alice, greeting, hello_ltr, None);
+    b.push_quad(meta, states_fact, alice_knows_bob, None);
+
+    // -- Named graph 1 ------------------------------------------------------------
+    b.push_quad(carol, age, carol_age, Some(graph1));
+    b.push_quad(bob, knows, carol, Some(graph1));
+
+    // -- Named graph 2 ------------------------------------------------------------
+    b.push_quad(carol, likes, alice, Some(graph2));
+
+    // -- Reifier + annotations -----------------------------------------------------
+    b.push_reifier(reifier, alice_knows_bob);
+    b.push_annotation(reifier, confidence, high);
+    // A second, graph-scoped annotation on the SAME reifier.
+    b.push_annotation_in_graph(reifier, source, doc, Some(graph1));
+
+    b.freeze().expect("fixture dataset must validate")
+}
+
+/// Every native RDF format the serializer targets.
+const ALL_FORMATS: &[NativeRdfFormat] = &[
+    NativeRdfFormat::Turtle,
+    NativeRdfFormat::TriG,
+    NativeRdfFormat::NTriples,
+    NativeRdfFormat::NQuads,
+    NativeRdfFormat::RdfXml,
+    NativeRdfFormat::TriX,
+    NativeRdfFormat::HexTuples,
+    NativeRdfFormat::JsonLd,
+    NativeRdfFormat::YamlLd,
+];
+
+/// Whether `fmt` is a classic star-incapable quad syntax with NO RDF-1.2 triple-term
+/// surface at all: it cannot serialize the fixture's triple-term-as-object base quad
+/// (`meta statesFact <<( alice knows bob )>>`) and, by deliberate design, HARD-errors
+/// on it rather than dropping it silently (see `native_codecs::trix` /
+/// `native_codecs::hextuples`). Every other format either carries the star layer or,
+/// like RDF/XML, has a triple-term surface for the base quad while dropping only the
+/// reifier/annotation statement layer.
+fn is_classic_no_triple_term_surface(fmt: NativeRdfFormat) -> bool {
+    matches!(fmt, NativeRdfFormat::TriX | NativeRdfFormat::HexTuples)
+}
+
+#[test]
+fn pack_view_serializes_identically_to_source_dataset() {
+    let ds = build_fixture();
+    let bytes = PackBuilder::build_bytes(&ds).expect("pack build");
+    let view = PackView::from_bytes(&bytes).expect("pack opens");
+
+    // Sanity: the fixture actually carries a star layer, so the parity check genuinely
+    // exercises the reifier/annotation side tables (a check over star-free data would
+    // be vacuous for the star-drop accounting).
+    assert!(view.reifier_quads().count() >= 1, "fixture has a reifier");
+    assert!(
+        view.annotation_quads().count() >= 2,
+        "fixture has two annotations"
+    );
+
+    // At least one format must succeed with real bytes, so the whole matrix is never a
+    // vacuous "every backend errored identically" pass.
+    let mut succeeded = 0usize;
+
+    for &fmt in ALL_FORMATS {
+        let from_source = serialize_dataset_to_format(&*ds, fmt, None);
+        let from_pack = serialize_dataset_to_format(&view, fmt, None);
+
+        match (from_source, from_pack) {
+            (Ok(source), Ok(pack)) => {
+                // The `PackView` (id space `PackId`) and the source `RdfDataset` (id
+                // space `TermId`) intern terms in different orders, so byte-identity
+                // here certifies the serializer's canonical, value-based ordering is
+                // fully backend-independent.
+                assert!(
+                    !source.bytes.is_empty(),
+                    "{fmt:?}: source serialization must be non-vacuous"
+                );
+                assert!(
+                    !pack.bytes.is_empty(),
+                    "{fmt:?}: pack serialization must be non-vacuous"
+                );
+                assert_eq!(
+                    source.bytes, pack.bytes,
+                    "{fmt:?}: PackView serialization must be BYTE-IDENTICAL to the source RdfDataset"
+                );
+                assert_eq!(
+                    source.statement_rows_dropped, pack.statement_rows_dropped,
+                    "{fmt:?}: star-layer drop count must match across backends"
+                );
+                assert!(
+                    !is_classic_no_triple_term_surface(fmt),
+                    "{fmt:?}: a classic no-triple-term format must NOT serialize the \
+                     triple-term-as-object fixture — it is expected to hard-error"
+                );
+                succeeded += 1;
+            }
+            (Err(source), Err(pack)) => {
+                // Parity holds on the error path too: a format that cannot represent the
+                // fixture must fail IDENTICALLY on both backends (same code + message),
+                // never diverge (one erroring while the other emits partial output).
+                assert!(
+                    is_classic_no_triple_term_surface(fmt),
+                    "{fmt:?}: unexpected serialize error on both backends: {}",
+                    source.message
+                );
+                assert_eq!(
+                    source.code, pack.code,
+                    "{fmt:?}: error code must match across backends"
+                );
+                assert_eq!(
+                    source.message, pack.message,
+                    "{fmt:?}: error message must match across backends"
+                );
+            }
+            (source, pack) => panic!(
+                "{fmt:?}: PackView and source diverge (one Ok, one Err): source={source:?} pack={pack:?}"
+            ),
+        }
+    }
+
+    assert!(
+        succeeded >= 7,
+        "expected the star-capable + RDF/XML formats to serialize; only {succeeded} did"
+    );
+}


### PR DESCRIPTION
Closes #106

## Summary
The first user-facing PurRDF binary — new native-only crate `purrdf-cli` (binary `purrdf`) — glue over the existing codec, SPARQL, and entailment engines, structured as one `Source → [entail]? → Sink` pipeline. `convert` / `query` / `reason` + a global `--loss-ledger`. Query and convert stream an mmap'd `.purrpck` pack with **zero materialization**; the serializer was generalized over `DatasetView`, unifying convert's RDF sink with CONSTRUCT/DESCRIBE query results.

## Library changes (subsume/extend)
- **`DatasetView`-generic serializer** (`purrdf-rdf`): a `PackView` (or any view, incl. a CONSTRUCT result graph) serializes to any of the 9 syntaxes with zero materialization. A canonical value-keyed row sort makes output byte-identical across backends and insertion-order independent. + a byte-parity test.
- **Public `dataset_from_view<D: DatasetView>`** (`purrdf-core`): subsumes the private pack `reconstruct` loop into one shared, generic bridge (`verify_pack` unchanged).
- **Bug fix**: TriX/HexTuples base-direction drop is now recorded in the loss ledger (`rdf12-direction-dropped`) instead of being a silent loss; new `carries_direction()` capability. Serialized bytes unchanged.

## CLI
- `convert --from --to [--base] [--entailment] [--canonical] IN OUT` — any↔any over the 9 syntaxes + the native `pack` container; extension inference or explicit; stdin/stdout `-`; mmap'd zero-copy pack path; `--canonical` = RDFC-1.0 N-Quads.
- `query --data <file|pack> [--base] [--entailment] --results-format <json|xml|csv|tsv|…9 RDF> '<SPARQL>'` — SELECT/ASK → W3C results; CONSTRUCT/DESCRIBE → the unified RDF sink; zero-copy pack query; shape/format mismatches hard-error.
- `reason --regime <simple|rdf|rdfs|owl-rl> [--base] IN OUT` — via `materialize`; owl-direct/rif/d → per-regime hard error (exit 3).
- Global `--loss-ledger[=PATH]` (absent→silent, bare→stderr, =PATH→file; always computed; never leaks to stdout). Exit codes 0/1/2/3.

## Verification
- 61 CLI integration tests drive the **built binary** (full 9×9 convert matrix via canonical-N-Quads isomorphism; all four SELECT/ASK formats; CONSTRUCT/DESCRIBE; per-regime inferences; loss-ledger tri-state).
- Library: serialize↔PackView byte-parity; RDFC-digest reconstruct isomorphism.
- `make check` + `make wasm` + `make doc` all green. `purrdf-cli` is native-only (excluded from the wasm allowlist by omission; excluded from docs like capi/python). No minted IRIs; `example.org` fixtures; deterministic output; no Cargo features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `purrdf` command-line tool with `convert`, `query`, and `reason` commands.
  * Supports RDF format conversion, native pack files, SPARQL queries, entailment reasoning, canonical output, stdin/stdout pipelines, and base IRI handling.
  * Added optional loss-ledger reporting to stderr or a file.
  * Added deterministic serialization and improved preservation of RDF graphs, annotations, and direction metadata where supported.

* **Documentation**
  * Added comprehensive CLI usage documentation, supported formats, options, and exit codes.

* **Bug Fixes**
  * Improved format-loss reporting for unsupported graph, statement-layer, and directional-literal features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->