### PR TITLE
bench(core): measure wavelet indexes against pack FoQ

### DIFF
--- a/crates/rdf-core/Cargo.toml
+++ b/crates/rdf-core/Cargo.toml
@@ -117,3 +117,11 @@ harness = false
 # `make check`.
 name = "pack_query"
 harness = false
+
+[[bench]]
+# Internal, non-shipped comparison of the pack codec's FoQ posting indexes with
+# a pointerless bitmap wavelet-matrix candidate over the existing Sp/So
+# sequences. Measures bytes, deterministic build cost, and the three
+# unbound-subject query shapes; no winner is asserted.
+name = "pack_index_compare"
+harness = false

--- a/crates/rdf-core/benches/pack_index_compare.rs
+++ b/crates/rdf-core/benches/pack_index_compare.rs
@@ -95,20 +95,23 @@ fn report_space_curve() {
         );
     }
 
-    let mut lower = 28_415u64;
-    let mut upper = 65_536u64;
-    assert!(reference_space(lower).wavelet_index < reference_space(lower).foq_index);
-    assert!(reference_space(upper).wavelet_index > reference_space(upper).foq_index);
-    while lower + 1 < upper {
-        let middle = lower + (upper - lower) / 2;
-        if reference_space(middle).wavelet_index <= reference_space(middle).foq_index {
-            lower = middle;
-        } else {
-            upper = middle;
+    let mut previous = reference_space(1)
+        .wavelet_index
+        .cmp(&reference_space(1).foq_index);
+    let mut flip_count = 0u64;
+    let mut last_flip = None;
+    for rows in 2..=1_048_576 {
+        let space = reference_space(rows);
+        let ordering = space.wavelet_index.cmp(&space.foq_index);
+        if ordering != previous {
+            flip_count += 1;
+            last_flip = Some((rows, previous, ordering));
+            previous = ordering;
         }
     }
+    let (last_rows, last_previous, last_current) = last_flip.expect("the ordering changes");
     eprintln!(
-        "pack-index-crossover last-wavelet-smaller-rows={lower} first-wavelet-larger-rows={upper}"
+        "pack-index-ordering-scan max-rows=1048576 flips={flip_count} last-rows={last_rows} last-previous={last_previous:?} last-current={last_current:?}"
     );
 }
 

--- a/crates/rdf-core/benches/pack_index_compare.rs
+++ b/crates/rdf-core/benches/pack_index_compare.rs
@@ -1,0 +1,372 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Bench targets are not public API: `criterion_group!` expands to a `pub fn`,
+// which would otherwise trip the workspace `missing_docs` lint.
+#![allow(missing_docs)]
+
+//! Report-only experiment comparing the shipped pack codec's FoQ posting-list
+//! indexes with a non-shipped pointerless bitmap wavelet matrix over the same
+//! deterministic Sp/So adjacency sequences. The comparison deliberately keeps
+//! the shared adjacency fixed and does not alter the pack wire format.
+
+#[path = "support/pack_index.rs"]
+mod pack_index;
+
+use std::sync::Arc;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use pack_index::{Adjacency, FoqIndexes, WaveletIndexes, reference_space, reference_triples};
+use purrdf_core::{
+    DatasetView, GraphMatch, PackBuilder, PackId, PackView, RdfDataset, RdfDatasetBuilder,
+    TermValue,
+};
+
+const QUERY_ROWS: usize = 65_536;
+
+fn numeric_iri(role: char, value: u64) -> String {
+    format!("http://example.org/{role}/{value:020}")
+}
+
+fn build_dataset(triples: &[(u64, u64, u64)]) -> Arc<RdfDataset> {
+    let mut subjects: Vec<_> = triples.iter().map(|&(s, _, _)| s).collect();
+    subjects.sort_unstable();
+    subjects.dedup();
+    let mut predicates: Vec<_> = triples.iter().map(|&(_, p, _)| p).collect();
+    predicates.sort_unstable();
+    predicates.dedup();
+    let mut objects: Vec<_> = triples.iter().map(|&(_, _, o)| o).collect();
+    objects.sort_unstable();
+    objects.dedup();
+
+    let mut builder = RdfDatasetBuilder::new();
+    let subject_ids: Vec<_> = subjects
+        .iter()
+        .map(|&value| builder.intern_iri(&numeric_iri('s', value)))
+        .collect();
+    let predicate_ids: Vec<_> = predicates
+        .iter()
+        .map(|&value| builder.intern_iri(&numeric_iri('p', value)))
+        .collect();
+    let object_ids: Vec<_> = objects
+        .iter()
+        .map(|&value| builder.intern_iri(&numeric_iri('o', value)))
+        .collect();
+
+    for &(subject, predicate, object) in triples {
+        let subject = subject_ids[subjects.binary_search(&subject).expect("subject present")];
+        let predicate = predicate_ids[predicates
+            .binary_search(&predicate)
+            .expect("predicate present")];
+        let object = object_ids[objects.binary_search(&object).expect("object present")];
+        builder.push_quad(subject, predicate, object, None);
+    }
+    builder.freeze().expect("reference dataset is valid")
+}
+
+fn pack_term(pack: &PackView<'_>, role: char, value: u64) -> PackId {
+    pack.term_id_by_value(&TermValue::iri(numeric_iri(role, value)))
+        .expect("reference term is packed")
+}
+
+fn report_space_curve() {
+    eprintln!(
+        "pack-index-space rows triples shared-bytes foq-index-bytes wavelet-index-bytes foq-total-bytes wavelet-total-bytes"
+    );
+    for rows in [
+        1_024u64,
+        16_384,
+        28_414,
+        28_415,
+        65_536,
+        262_144,
+        25_000_000,
+        250_000_000,
+    ] {
+        let space = reference_space(rows);
+        eprintln!(
+            "pack-index-space {rows} {} {} {} {} {} {}",
+            space.triples,
+            space.shared,
+            space.foq_index,
+            space.wavelet_index,
+            space.foq_total(),
+            space.wavelet_total(),
+        );
+    }
+
+    let mut lower = 28_415u64;
+    let mut upper = 65_536u64;
+    assert!(reference_space(lower).wavelet_index < reference_space(lower).foq_index);
+    assert!(reference_space(upper).wavelet_index > reference_space(upper).foq_index);
+    while lower + 1 < upper {
+        let middle = lower + (upper - lower) / 2;
+        if reference_space(middle).wavelet_index <= reference_space(middle).foq_index {
+            lower = middle;
+        } else {
+            upper = middle;
+        }
+    }
+    eprintln!(
+        "pack-index-crossover last-wavelet-smaller-rows={lower} first-wavelet-larger-rows={upper}"
+    );
+}
+
+fn bench_pack_index_hypothesis(c: &mut Criterion) {
+    report_space_curve();
+
+    let triples = reference_triples(QUERY_ROWS);
+    let adjacency = Adjacency::from_triples(&triples);
+    let foq = FoqIndexes::build(&adjacency);
+    let wavelet = WaveletIndexes::build(&adjacency);
+    let dataset = build_dataset(&triples);
+    let pack_bytes = PackBuilder::build_bytes(&dataset).expect("reference dataset packs");
+    let pack = PackView::from_bytes(&pack_bytes).expect("reference pack opens");
+
+    let dense_predicate = 0;
+    let dense_object = 0;
+    let sparse_predicate = 32 + (QUERY_ROWS as u64 - 1) % 1_024;
+    let sparse_object = 4_354 + QUERY_ROWS as u64 - 1;
+
+    let dense_predicate_local = adjacency
+        .predicate_local(dense_predicate)
+        .expect("dense predicate present");
+    let dense_object_local = adjacency
+        .object_local(dense_object)
+        .expect("dense object present");
+    let sparse_predicate_local = adjacency
+        .predicate_local(sparse_predicate)
+        .expect("sparse predicate present");
+    let sparse_object_local = adjacency
+        .object_local(sparse_object)
+        .expect("sparse object present");
+
+    let dense_predicate_term = pack_term(&pack, 'p', dense_predicate);
+    let dense_object_term = pack_term(&pack, 'o', dense_object);
+    let sparse_predicate_term = pack_term(&pack, 'p', sparse_predicate);
+    let sparse_object_term = pack_term(&pack, 'o', sparse_object);
+
+    let expected_dense_predicate = pack
+        .quads_for_pattern(None, Some(dense_predicate_term), None, GraphMatch::Any)
+        .count();
+    let expected_dense_object = pack
+        .quads_for_pattern(None, None, Some(dense_object_term), GraphMatch::Any)
+        .count();
+    let expected_dense_pair = pack
+        .quads_for_pattern(
+            None,
+            Some(dense_predicate_term),
+            Some(dense_object_term),
+            GraphMatch::Any,
+        )
+        .count();
+    let expected_sparse_predicate = pack
+        .quads_for_pattern(None, Some(sparse_predicate_term), None, GraphMatch::Any)
+        .count();
+    let expected_sparse_object = pack
+        .quads_for_pattern(None, None, Some(sparse_object_term), GraphMatch::Any)
+        .count();
+    let expected_sparse_pair = pack
+        .quads_for_pattern(
+            None,
+            Some(sparse_predicate_term),
+            Some(sparse_object_term),
+            GraphMatch::Any,
+        )
+        .count();
+
+    assert_eq!(
+        foq.predicate_count(&adjacency, dense_predicate_local),
+        expected_dense_predicate
+    );
+    assert_eq!(
+        wavelet.predicate_count(&adjacency, dense_predicate_local),
+        expected_dense_predicate
+    );
+    assert_eq!(foq.object_count(dense_object_local), expected_dense_object);
+    assert_eq!(
+        wavelet.object_count(dense_object_local),
+        expected_dense_object
+    );
+    assert_eq!(
+        foq.predicate_object_count(dense_predicate_local, dense_object_local),
+        expected_dense_pair
+    );
+    assert_eq!(
+        wavelet.predicate_object_count(&adjacency, dense_predicate_local, dense_object_local),
+        expected_dense_pair
+    );
+    assert_eq!(
+        foq.predicate_count(&adjacency, sparse_predicate_local),
+        expected_sparse_predicate
+    );
+    assert_eq!(
+        wavelet.predicate_count(&adjacency, sparse_predicate_local),
+        expected_sparse_predicate
+    );
+    assert_eq!(
+        foq.object_count(sparse_object_local),
+        expected_sparse_object
+    );
+    assert_eq!(
+        wavelet.object_count(sparse_object_local),
+        expected_sparse_object
+    );
+    assert_eq!(
+        foq.predicate_object_count(sparse_predicate_local, sparse_object_local),
+        expected_sparse_pair
+    );
+    assert_eq!(
+        wavelet.predicate_object_count(&adjacency, sparse_predicate_local, sparse_object_local),
+        expected_sparse_pair
+    );
+
+    eprintln!(
+        "pack-index-context rows={} triples={} pack-bytes={} foq-index-bytes={} wavelet-index-bytes={}",
+        QUERY_ROWS,
+        triples.len(),
+        pack_bytes.len(),
+        foq.index_serialized_len(),
+        wavelet.index_serialized_len(),
+    );
+
+    {
+        let mut build = c.benchmark_group("pack_index_build");
+        build.bench_function("production_pack", |b| {
+            b.iter(|| {
+                std::hint::black_box(
+                    PackBuilder::build_bytes(&dataset).expect("reference dataset packs"),
+                )
+            });
+        });
+        build.bench_function("isolated_foq", |b| {
+            b.iter(|| std::hint::black_box(FoqIndexes::build(&adjacency)));
+        });
+        build.bench_function("isolated_wavelet", |b| {
+            b.iter(|| std::hint::black_box(WaveletIndexes::build(&adjacency)));
+        });
+        build.finish();
+    }
+
+    let mut query = c.benchmark_group("pack_index_query");
+    query.bench_function("production_foq/predicate_dense", |b| {
+        b.iter(|| {
+            std::hint::black_box(
+                pack.quads_for_pattern(None, Some(dense_predicate_term), None, GraphMatch::Any)
+                    .count(),
+            )
+        });
+    });
+    query.bench_function("isolated_foq/predicate_dense", |b| {
+        b.iter(|| std::hint::black_box(foq.predicate_count(&adjacency, dense_predicate_local)));
+    });
+    query.bench_function("isolated_wavelet/predicate_dense", |b| {
+        b.iter(|| std::hint::black_box(wavelet.predicate_count(&adjacency, dense_predicate_local)));
+    });
+    query.bench_function("production_foq/object_dense", |b| {
+        b.iter(|| {
+            std::hint::black_box(
+                pack.quads_for_pattern(None, None, Some(dense_object_term), GraphMatch::Any)
+                    .count(),
+            )
+        });
+    });
+    query.bench_function("isolated_foq/object_dense", |b| {
+        b.iter(|| std::hint::black_box(foq.object_count(dense_object_local)));
+    });
+    query.bench_function("isolated_wavelet/object_dense", |b| {
+        b.iter(|| std::hint::black_box(wavelet.object_count(dense_object_local)));
+    });
+    query.bench_function("production_foq/pair_dense", |b| {
+        b.iter(|| {
+            std::hint::black_box(
+                pack.quads_for_pattern(
+                    None,
+                    Some(dense_predicate_term),
+                    Some(dense_object_term),
+                    GraphMatch::Any,
+                )
+                .count(),
+            )
+        });
+    });
+    query.bench_function("isolated_foq/pair_dense", |b| {
+        b.iter(|| {
+            std::hint::black_box(
+                foq.predicate_object_count(dense_predicate_local, dense_object_local),
+            )
+        });
+    });
+    query.bench_function("isolated_wavelet/pair_dense", |b| {
+        b.iter(|| {
+            std::hint::black_box(wavelet.predicate_object_count(
+                &adjacency,
+                dense_predicate_local,
+                dense_object_local,
+            ))
+        });
+    });
+    query.bench_function("production_foq/predicate_sparse", |b| {
+        b.iter(|| {
+            std::hint::black_box(
+                pack.quads_for_pattern(None, Some(sparse_predicate_term), None, GraphMatch::Any)
+                    .count(),
+            )
+        });
+    });
+    query.bench_function("isolated_foq/predicate_sparse", |b| {
+        b.iter(|| std::hint::black_box(foq.predicate_count(&adjacency, sparse_predicate_local)));
+    });
+    query.bench_function("isolated_wavelet/predicate_sparse", |b| {
+        b.iter(|| {
+            std::hint::black_box(wavelet.predicate_count(&adjacency, sparse_predicate_local))
+        });
+    });
+    query.bench_function("production_foq/object_sparse", |b| {
+        b.iter(|| {
+            std::hint::black_box(
+                pack.quads_for_pattern(None, None, Some(sparse_object_term), GraphMatch::Any)
+                    .count(),
+            )
+        });
+    });
+    query.bench_function("isolated_foq/object_sparse", |b| {
+        b.iter(|| std::hint::black_box(foq.object_count(sparse_object_local)));
+    });
+    query.bench_function("isolated_wavelet/object_sparse", |b| {
+        b.iter(|| std::hint::black_box(wavelet.object_count(sparse_object_local)));
+    });
+    query.bench_function("production_foq/pair_sparse", |b| {
+        b.iter(|| {
+            std::hint::black_box(
+                pack.quads_for_pattern(
+                    None,
+                    Some(sparse_predicate_term),
+                    Some(sparse_object_term),
+                    GraphMatch::Any,
+                )
+                .count(),
+            )
+        });
+    });
+    query.bench_function("isolated_foq/pair_sparse", |b| {
+        b.iter(|| {
+            std::hint::black_box(
+                foq.predicate_object_count(sparse_predicate_local, sparse_object_local),
+            )
+        });
+    });
+    query.bench_function("isolated_wavelet/pair_sparse", |b| {
+        b.iter(|| {
+            std::hint::black_box(wavelet.predicate_object_count(
+                &adjacency,
+                sparse_predicate_local,
+                sparse_object_local,
+            ))
+        });
+    });
+    query.finish();
+}
+
+criterion_group!(benches, bench_pack_index_hypothesis);
+criterion_main!(benches);

--- a/crates/rdf-core/benches/support/pack_index.rs
+++ b/crates/rdf-core/benches/support/pack_index.rs
@@ -622,9 +622,8 @@ fn wavelet_space(len: u64, max_value: u64) -> u64 {
 }
 
 fn cycle_delta_space(rows: u64, cycle: u64, position_offset: u64) -> u64 {
-    (0..rows.min(cycle))
-        .map(|residue| cycle_list_space(rows, cycle, residue, position_offset))
-        .sum()
+    let lists = rows.min(cycle);
+    unique_delta_space(lists, position_offset) + (rows - lists) * varint_space(3 * cycle)
 }
 
 fn cycle_list_space(rows: u64, cycle: u64, residue: u64, position_offset: u64) -> u64 {

--- a/crates/rdf-core/benches/support/pack_index.rs
+++ b/crates/rdf-core/benches/support/pack_index.rs
@@ -1,0 +1,665 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// This module is included by both the benchmark and its correctness test; each
+// target intentionally exercises a different subset of the experiment helpers.
+#![allow(dead_code)]
+
+use std::cmp::Ordering;
+
+use purrdf_core::ir::pack::bits::{
+    BitVec, DeltaListRef, IntVector, RankSelect, bits_for, write_delta_list,
+};
+
+#[derive(Debug, Clone)]
+pub(crate) struct Adjacency {
+    sp: Vec<u64>,
+    bp: RankSelect,
+    so: Vec<u64>,
+    bo: RankSelect,
+    predicate_values: Vec<u64>,
+    object_values: Vec<u64>,
+}
+
+impl Adjacency {
+    pub(crate) fn from_triples(triples: &[(u64, u64, u64)]) -> Self {
+        let mut triples = triples.to_vec();
+        triples.sort_unstable();
+        triples.dedup();
+
+        let mut subject_values: Vec<_> = triples.iter().map(|&(s, _, _)| s).collect();
+        subject_values.sort_unstable();
+        subject_values.dedup();
+        let mut predicate_values: Vec<_> = triples.iter().map(|&(_, p, _)| p).collect();
+        predicate_values.sort_unstable();
+        predicate_values.dedup();
+        let mut object_values: Vec<_> = triples.iter().map(|&(_, _, o)| o).collect();
+        object_values.sort_unstable();
+        object_values.dedup();
+
+        let mut local: Vec<_> = triples
+            .into_iter()
+            .map(|(s, p, o)| {
+                (
+                    subject_values.binary_search(&s).expect("subject present") as u64,
+                    predicate_values
+                        .binary_search(&p)
+                        .expect("predicate present") as u64,
+                    object_values.binary_search(&o).expect("object present") as u64,
+                )
+            })
+            .collect();
+        local.sort_unstable();
+
+        let mut sp = Vec::new();
+        let mut bp = BitVec::new();
+        let mut so = Vec::with_capacity(local.len());
+        let mut bo = BitVec::new();
+        let mut i = 0usize;
+        while i < local.len() {
+            let subject = local[i].0;
+            let mut j = i;
+            while j < local.len() && local[j].0 == subject {
+                let predicate = local[j].1;
+                sp.push(predicate);
+                let mut k = j;
+                while k < local.len() && local[k].0 == subject && local[k].1 == predicate {
+                    so.push(local[k].2);
+                    let last = k + 1 == local.len()
+                        || local[k + 1].0 != subject
+                        || local[k + 1].1 != predicate;
+                    bo.push(last);
+                    k += 1;
+                }
+                let last = k == local.len() || local[k].0 != subject;
+                bp.push(last);
+                j = k;
+            }
+            i = j;
+        }
+
+        Self {
+            sp,
+            bp: bp.freeze(),
+            so,
+            bo: bo.freeze(),
+            predicate_values,
+            object_values,
+        }
+    }
+
+    pub(crate) fn predicate_local(&self, value: u64) -> Option<u64> {
+        self.predicate_values
+            .binary_search(&value)
+            .ok()
+            .map(|i| i as u64)
+    }
+
+    pub(crate) fn object_local(&self, value: u64) -> Option<u64> {
+        self.object_values
+            .binary_search(&value)
+            .ok()
+            .map(|i| i as u64)
+    }
+
+    pub(crate) fn sp_len(&self) -> usize {
+        self.sp.len()
+    }
+
+    pub(crate) fn so_len(&self) -> usize {
+        self.so.len()
+    }
+
+    fn pair_slice(&self, sp_position: u64) -> (usize, usize) {
+        let position = sp_position as usize;
+        let start = if position == 0 {
+            0
+        } else {
+            self.bo
+                .select1(position - 1)
+                .expect("one boundary per Sp entry")
+                + 1
+        };
+        let end = self
+            .bo
+            .select1(position)
+            .expect("one boundary per Sp entry")
+            + 1;
+        (start, end)
+    }
+
+    fn owner_of_object_position(&self, so_position: usize) -> u64 {
+        self.bo.rank1(so_position) as u64
+    }
+
+    pub(crate) fn shared_serialized_len(&self) -> usize {
+        let mut sp = IntVector::with_width(bits_for(
+            self.predicate_values.len().saturating_sub(1) as u64
+        ));
+        for &value in &self.sp {
+            sp.push(value);
+        }
+        let mut so =
+            IntVector::with_width(bits_for(self.object_values.len().saturating_sub(1) as u64));
+        for &value in &self.so {
+            so.push(value);
+        }
+        sp.serialized_len()
+            + self.bp.serialized_len()
+            + so.serialized_len()
+            + self.bo.serialized_len()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PostingIndex {
+    offsets: IntVector,
+    counts: IntVector,
+    data: Vec<u8>,
+}
+
+impl PostingIndex {
+    fn build(alphabet_len: usize, entries: impl IntoIterator<Item = (u64, u64)>) -> Self {
+        let mut positions = vec![Vec::new(); alphabet_len];
+        for (value, position) in entries {
+            positions[value as usize].push(position);
+        }
+
+        let mut data = Vec::new();
+        let mut raw_offsets = Vec::with_capacity(alphabet_len);
+        let mut raw_counts = Vec::with_capacity(alphabet_len);
+        for list in &positions {
+            raw_offsets.push(data.len() as u64);
+            raw_counts.push(list.len() as u64);
+            write_delta_list(&mut data, list);
+        }
+        let mut offsets =
+            IntVector::with_width(bits_for(raw_offsets.iter().copied().max().unwrap_or(0)));
+        let mut counts =
+            IntVector::with_width(bits_for(raw_counts.iter().copied().max().unwrap_or(0)));
+        for offset in raw_offsets {
+            offsets.push(offset);
+        }
+        for count in raw_counts {
+            counts.push(count);
+        }
+        Self {
+            offsets,
+            counts,
+            data,
+        }
+    }
+
+    fn positions(&self, value: u64) -> Vec<u64> {
+        let count = self.counts.get(value as usize) as usize;
+        let offset = self.offsets.get(value as usize) as usize;
+        DeltaListRef::new(&self.data[offset..], count)
+            .map(|item| item.expect("bench-built delta list is valid"))
+            .collect()
+    }
+
+    fn serialized_len(&self) -> usize {
+        self.offsets.serialized_len()
+            + self.counts.serialized_len()
+            + size_of::<u64>()
+            + self.data.len()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FoqIndexes {
+    predicates: PostingIndex,
+    predicate_totals: IntVector,
+    objects: PostingIndex,
+}
+
+impl FoqIndexes {
+    pub(crate) fn build(adjacency: &Adjacency) -> Self {
+        let predicates = PostingIndex::build(
+            adjacency.predicate_values.len(),
+            adjacency
+                .sp
+                .iter()
+                .copied()
+                .enumerate()
+                .map(|(position, value)| (value, position as u64)),
+        );
+        let objects = PostingIndex::build(
+            adjacency.object_values.len(),
+            adjacency
+                .so
+                .iter()
+                .copied()
+                .enumerate()
+                .map(|(position, value)| (value, adjacency.owner_of_object_position(position))),
+        );
+
+        let mut totals = vec![0u64; adjacency.predicate_values.len()];
+        for (position, &predicate) in adjacency.sp.iter().enumerate() {
+            let (start, end) = adjacency.pair_slice(position as u64);
+            totals[predicate as usize] += (end - start) as u64;
+        }
+        let mut predicate_totals =
+            IntVector::with_width(bits_for(totals.iter().copied().max().unwrap_or(0)));
+        for total in totals {
+            predicate_totals.push(total);
+        }
+
+        Self {
+            predicates,
+            predicate_totals,
+            objects,
+        }
+    }
+
+    pub(crate) fn predicate_count(&self, adjacency: &Adjacency, predicate: u64) -> usize {
+        self.predicates
+            .positions(predicate)
+            .into_iter()
+            .map(|position| {
+                let (start, end) = adjacency.pair_slice(position);
+                end - start
+            })
+            .sum()
+    }
+
+    pub(crate) fn object_count(&self, object: u64) -> usize {
+        self.objects.positions(object).len()
+    }
+
+    pub(crate) fn predicate_object_count(&self, predicate: u64, object: u64) -> usize {
+        intersect_count(
+            &self.predicates.positions(predicate),
+            &self.objects.positions(object),
+        )
+    }
+
+    pub(crate) fn index_serialized_len(&self) -> usize {
+        self.predicates.serialized_len()
+            + self.predicate_totals.serialized_len()
+            + self.objects.serialized_len()
+    }
+
+    pub(crate) fn serialized_len(&self, adjacency: &Adjacency) -> usize {
+        adjacency.shared_serialized_len() + self.index_serialized_len()
+    }
+
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(self.index_serialized_len());
+        bytes.extend_from_slice(&self.predicates.offsets.to_bytes());
+        bytes.extend_from_slice(&self.predicates.counts.to_bytes());
+        bytes.extend_from_slice(&self.predicate_totals.to_bytes());
+        bytes.extend_from_slice(&(self.predicates.data.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&self.predicates.data);
+        bytes.extend_from_slice(&self.objects.offsets.to_bytes());
+        bytes.extend_from_slice(&self.objects.counts.to_bytes());
+        bytes.extend_from_slice(&(self.objects.data.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&self.objects.data);
+        bytes
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WaveletMatrix {
+    len: usize,
+    width: u32,
+    max_value: u64,
+    levels: Vec<RankSelect>,
+    zeros: Vec<usize>,
+}
+
+impl WaveletMatrix {
+    pub(crate) fn build(values: &[u64]) -> Self {
+        let max_value = values.iter().copied().max().unwrap_or(0);
+        let width = if values.is_empty() {
+            0
+        } else {
+            bits_for(max_value)
+        };
+        let mut current = values.to_vec();
+        let mut levels = Vec::with_capacity(width as usize);
+        let mut zeros = Vec::with_capacity(width as usize);
+
+        for shift in (0..width).rev() {
+            let mut bits = BitVec::new();
+            let mut zero_values = Vec::with_capacity(current.len());
+            let mut one_values = Vec::with_capacity(current.len());
+            for &value in &current {
+                let one = ((value >> shift) & 1) != 0;
+                bits.push(one);
+                if one {
+                    one_values.push(value);
+                } else {
+                    zero_values.push(value);
+                }
+            }
+            zeros.push(zero_values.len());
+            zero_values.extend(one_values);
+            current = zero_values;
+            levels.push(bits.freeze());
+        }
+
+        Self {
+            len: values.len(),
+            width,
+            max_value,
+            levels,
+            zeros,
+        }
+    }
+
+    pub(crate) fn access(&self, position: usize) -> Option<u64> {
+        if position >= self.len {
+            return None;
+        }
+        let mut position = position;
+        let mut value = 0u64;
+        for (level, bitmap) in self.levels.iter().enumerate() {
+            let one = bitmap.rank1(position + 1) != bitmap.rank1(position);
+            let shift = self.width as usize - level - 1;
+            if one {
+                value |= 1u64 << shift;
+                position = self.zeros[level] + bitmap.rank1(position);
+            } else {
+                position = bitmap.rank0(position);
+            }
+        }
+        Some(value)
+    }
+
+    pub(crate) fn rank(&self, value: u64, end: usize) -> usize {
+        if value > self.max_value || end > self.len {
+            return 0;
+        }
+        let mut start = 0usize;
+        let mut end = end;
+        for (level, bitmap) in self.levels.iter().enumerate() {
+            let shift = self.width as usize - level - 1;
+            if ((value >> shift) & 1) == 0 {
+                start = bitmap.rank0(start);
+                end = bitmap.rank0(end);
+            } else {
+                start = self.zeros[level] + bitmap.rank1(start);
+                end = self.zeros[level] + bitmap.rank1(end);
+            }
+        }
+        end - start
+    }
+
+    pub(crate) fn select(&self, value: u64, occurrence: usize) -> Option<usize> {
+        if value > self.max_value {
+            return None;
+        }
+        let mut start = 0usize;
+        let mut end = self.len;
+        for (level, bitmap) in self.levels.iter().enumerate() {
+            let shift = self.width as usize - level - 1;
+            if ((value >> shift) & 1) == 0 {
+                start = bitmap.rank0(start);
+                end = bitmap.rank0(end);
+            } else {
+                start = self.zeros[level] + bitmap.rank1(start);
+                end = self.zeros[level] + bitmap.rank1(end);
+            }
+        }
+        if occurrence >= end - start {
+            return None;
+        }
+        let mut position = start + occurrence;
+        for level in (0..self.levels.len()).rev() {
+            let shift = self.width as usize - level - 1;
+            position = if ((value >> shift) & 1) == 0 {
+                self.levels[level].select0(position)?
+            } else {
+                self.levels[level].select1(position - self.zeros[level])?
+            };
+        }
+        Some(position)
+    }
+
+    fn positions(&self, value: u64) -> Vec<u64> {
+        (0..self.rank(value, self.len))
+            .map(|occurrence| {
+                self.select(value, occurrence)
+                    .expect("occurrence is below rank") as u64
+            })
+            .collect()
+    }
+
+    pub(crate) fn serialized_len(&self) -> usize {
+        size_of::<u8>()
+            + size_of::<u64>()
+            + size_of::<u32>()
+            + self
+                .levels
+                .iter()
+                .map(|level| 2 * size_of::<u64>() + level.serialized_len())
+                .sum::<usize>()
+    }
+
+    fn append_bytes(&self, bytes: &mut Vec<u8>) {
+        bytes.push(1);
+        bytes.extend_from_slice(&(self.len as u64).to_le_bytes());
+        bytes.extend_from_slice(&self.width.to_le_bytes());
+        for (&zero_count, level) in self.zeros.iter().zip(&self.levels) {
+            let level_bytes = level.to_bytes();
+            bytes.extend_from_slice(&(zero_count as u64).to_le_bytes());
+            bytes.extend_from_slice(&(level_bytes.len() as u64).to_le_bytes());
+            bytes.extend_from_slice(&level_bytes);
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WaveletIndexes {
+    predicates: WaveletMatrix,
+    objects: WaveletMatrix,
+}
+
+impl WaveletIndexes {
+    pub(crate) fn build(adjacency: &Adjacency) -> Self {
+        Self {
+            predicates: WaveletMatrix::build(&adjacency.sp),
+            objects: WaveletMatrix::build(&adjacency.so),
+        }
+    }
+
+    pub(crate) fn predicate_count(&self, adjacency: &Adjacency, predicate: u64) -> usize {
+        self.predicates
+            .positions(predicate)
+            .into_iter()
+            .map(|position| {
+                let (start, end) = adjacency.pair_slice(position);
+                end - start
+            })
+            .sum()
+    }
+
+    pub(crate) fn object_count(&self, object: u64) -> usize {
+        self.objects.positions(object).len()
+    }
+
+    pub(crate) fn predicate_object_count(
+        &self,
+        adjacency: &Adjacency,
+        predicate: u64,
+        object: u64,
+    ) -> usize {
+        let predicate_positions = self.predicates.positions(predicate);
+        let object_positions: Vec<_> = self
+            .objects
+            .positions(object)
+            .into_iter()
+            .map(|position| adjacency.owner_of_object_position(position as usize))
+            .collect();
+        intersect_count(&predicate_positions, &object_positions)
+    }
+
+    pub(crate) fn index_serialized_len(&self) -> usize {
+        self.predicates.serialized_len() + self.objects.serialized_len()
+    }
+
+    pub(crate) fn serialized_len(&self, adjacency: &Adjacency) -> usize {
+        adjacency.shared_serialized_len() + self.index_serialized_len()
+    }
+
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(self.index_serialized_len());
+        self.predicates.append_bytes(&mut bytes);
+        self.objects.append_bytes(&mut bytes);
+        bytes
+    }
+}
+
+fn intersect_count(left: &[u64], right: &[u64]) -> usize {
+    let (mut i, mut j, mut count) = (0usize, 0usize, 0usize);
+    while i < left.len() && j < right.len() {
+        match left[i].cmp(&right[j]) {
+            Ordering::Less => i += 1,
+            Ordering::Greater => j += 1,
+            Ordering::Equal => {
+                count += 1;
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+    count
+}
+
+pub(crate) fn reference_triples(rows: usize) -> Vec<(u64, u64, u64)> {
+    let mut triples = Vec::with_capacity(rows * 4);
+    for subject in 0..rows as u64 {
+        triples.push((subject, 0, 0));
+        triples.push((subject, 0, 1 + subject % 257));
+        triples.push((subject, 1 + subject % 31, 258 + subject % 4096));
+        triples.push((subject, 32 + subject % 1024, 4354 + subject));
+    }
+    triples
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ReferenceSpace {
+    pub(crate) triples: u64,
+    pub(crate) shared: u64,
+    pub(crate) foq_index: u64,
+    pub(crate) wavelet_index: u64,
+}
+
+impl ReferenceSpace {
+    pub(crate) fn foq_total(self) -> u64 {
+        self.shared + self.foq_index
+    }
+
+    pub(crate) fn wavelet_total(self) -> u64 {
+        self.shared + self.wavelet_index
+    }
+}
+
+pub(crate) fn reference_space(rows: u64) -> ReferenceSpace {
+    assert!(rows > 0, "the reference workload requires at least one row");
+
+    let predicate_alphabet = 1 + rows.min(31) + rows.min(1_024);
+    let object_alphabet = 1 + rows.min(257) + rows.min(4_096) + rows;
+    let sp_len = rows.checked_mul(3).expect("Sp length fits u64");
+    let so_len = rows.checked_mul(4).expect("So length fits u64");
+
+    let shared = int_vector_space(sp_len, predicate_alphabet - 1)
+        + rank_select_space(sp_len)
+        + int_vector_space(so_len, object_alphabet - 1)
+        + rank_select_space(so_len);
+
+    let predicate_data = cycle_delta_space(rows, 1, 0)
+        + cycle_delta_space(rows, 31, 1)
+        + cycle_delta_space(rows, 1_024, 2);
+    let last_predicate_list = cycle_list_space(rows, 1_024, rows.min(1_024) - 1, 2);
+    let predicate_offsets_max = predicate_data - last_predicate_list;
+    let predicate_index = int_vector_space(predicate_alphabet, predicate_offsets_max)
+        + int_vector_space(predicate_alphabet, rows)
+        + int_vector_space(predicate_alphabet, rows * 2)
+        + size_of::<u64>() as u64
+        + predicate_data;
+
+    let object_data = cycle_delta_space(rows, 1, 0)
+        + cycle_delta_space(rows, 257, 0)
+        + cycle_delta_space(rows, 4_096, 1)
+        + unique_delta_space(rows, 2);
+    let last_object_list = varint_space(3 * (rows - 1) + 2);
+    let object_offsets_max = object_data - last_object_list;
+    let object_index = int_vector_space(object_alphabet, object_offsets_max)
+        + int_vector_space(object_alphabet, rows)
+        + size_of::<u64>() as u64
+        + object_data;
+
+    let wavelet_index =
+        wavelet_space(sp_len, predicate_alphabet - 1) + wavelet_space(so_len, object_alphabet - 1);
+
+    ReferenceSpace {
+        triples: so_len,
+        shared,
+        foq_index: predicate_index + object_index,
+        wavelet_index,
+    }
+}
+
+fn int_vector_space(len: u64, max_value: u64) -> u64 {
+    let width = u64::from(bits_for(max_value));
+    12 + len
+        .checked_mul(width)
+        .expect("IntVector bit length fits u64")
+        .div_ceil(64)
+        * 8
+}
+
+fn rank_select_space(len: u64) -> u64 {
+    let words = len.div_ceil(64);
+    32 + words.div_ceil(8) * 8 + words * 10
+}
+
+fn wavelet_space(len: u64, max_value: u64) -> u64 {
+    let width = u64::from(bits_for(max_value));
+    13 + width * (2 * size_of::<u64>() as u64 + rank_select_space(len))
+}
+
+fn cycle_delta_space(rows: u64, cycle: u64, position_offset: u64) -> u64 {
+    (0..rows.min(cycle))
+        .map(|residue| cycle_list_space(rows, cycle, residue, position_offset))
+        .sum()
+}
+
+fn cycle_list_space(rows: u64, cycle: u64, residue: u64, position_offset: u64) -> u64 {
+    let count = 1 + (rows - 1 - residue) / cycle;
+    varint_space(3 * residue + position_offset) + (count - 1) * varint_space(3 * cycle)
+}
+
+fn unique_delta_space(rows: u64, position_offset: u64) -> u64 {
+    (1..=10)
+        .map(|bytes| {
+            let lower = if bytes == 1 {
+                0
+            } else {
+                1u64 << (7 * (bytes - 1))
+            };
+            let upper = if bytes == 10 {
+                u64::MAX
+            } else {
+                (1u64 << (7 * bytes)) - 1
+            };
+            arithmetic_positions_in_range(rows, position_offset, lower, upper) * bytes
+        })
+        .sum()
+}
+
+fn arithmetic_positions_in_range(rows: u64, offset: u64, lower: u64, upper: u64) -> u64 {
+    let first = lower.saturating_sub(offset).div_ceil(3);
+    let last = upper.saturating_sub(offset) / 3;
+    if first >= rows || first > last {
+        0
+    } else {
+        (rows - 1).min(last) - first + 1
+    }
+}
+
+fn varint_space(value: u64) -> u64 {
+    u64::from((64 - value.leading_zeros()).max(1)).div_ceil(7)
+}

--- a/crates/rdf-core/tests/pack_index_compare.rs
+++ b/crates/rdf-core/tests/pack_index_compare.rs
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#![allow(dead_code, missing_docs)]
+
+#[path = "../benches/support/pack_index.rs"]
+mod pack_index;
+
+use pack_index::{
+    Adjacency, FoqIndexes, WaveletIndexes, WaveletMatrix, reference_space, reference_triples,
+};
+
+#[test]
+fn wavelet_access_rank_and_select_match_plain_sequences() {
+    let sequences = [
+        Vec::new(),
+        vec![0],
+        vec![3, 0, 5, 3, 7, 0, 3, 1, 5, 2, 3],
+        (0..257).map(|i| (i * 37) % 19).collect(),
+    ];
+
+    for sequence in sequences {
+        let matrix = WaveletMatrix::build(&sequence);
+        for (position, &expected) in sequence.iter().enumerate() {
+            assert_eq!(matrix.access(position), Some(expected));
+        }
+        assert_eq!(matrix.access(sequence.len()), None);
+
+        for value in 0..=sequence.iter().copied().max().unwrap_or(0) + 1 {
+            for end in 0..=sequence.len() {
+                let expected = sequence[..end]
+                    .iter()
+                    .filter(|&&candidate| candidate == value)
+                    .count();
+                assert_eq!(matrix.rank(value, end), expected);
+            }
+            let positions: Vec<_> = sequence
+                .iter()
+                .enumerate()
+                .filter_map(|(position, &candidate)| (candidate == value).then_some(position))
+                .collect();
+            for (occurrence, &expected) in positions.iter().enumerate() {
+                assert_eq!(matrix.select(value, occurrence), Some(expected));
+            }
+            assert_eq!(matrix.select(value, positions.len()), None);
+        }
+    }
+}
+
+#[test]
+fn wavelet_and_foq_queries_match_reference_triples() {
+    let triples = reference_triples(2_048);
+    let adjacency = Adjacency::from_triples(&triples);
+    let foq = FoqIndexes::build(&adjacency);
+    let wavelet = WaveletIndexes::build(&adjacency);
+
+    for predicate in [0, 1, 31, 32, 777, 1_055] {
+        let local = adjacency
+            .predicate_local(predicate)
+            .expect("reference predicate is present");
+        let expected = triples
+            .iter()
+            .filter(|&&(_, candidate, _)| candidate == predicate)
+            .count();
+        assert_eq!(foq.predicate_count(&adjacency, local), expected);
+        assert_eq!(wavelet.predicate_count(&adjacency, local), expected);
+    }
+
+    for object in [0, 1, 257, 258, 4_354, 5_000, 6_401] {
+        let local = adjacency
+            .object_local(object)
+            .expect("reference object is present");
+        let expected = triples
+            .iter()
+            .filter(|&&(_, _, candidate)| candidate == object)
+            .count();
+        assert_eq!(foq.object_count(local), expected);
+        assert_eq!(wavelet.object_count(local), expected);
+    }
+
+    for (predicate, object) in [(0, 0), (0, 1), (1, 258), (777, 6_401)] {
+        let predicate_local = adjacency
+            .predicate_local(predicate)
+            .expect("reference predicate is present");
+        let object_local = adjacency
+            .object_local(object)
+            .expect("reference object is present");
+        let expected = triples
+            .iter()
+            .filter(|&&(_, candidate_p, candidate_o)| {
+                candidate_p == predicate && candidate_o == object
+            })
+            .count();
+        assert_eq!(
+            foq.predicate_object_count(predicate_local, object_local),
+            expected
+        );
+        assert_eq!(
+            wavelet.predicate_object_count(&adjacency, predicate_local, object_local),
+            expected
+        );
+    }
+}
+
+#[test]
+fn experiment_builds_are_byte_deterministic() {
+    let adjacency = Adjacency::from_triples(&reference_triples(1_024));
+    let foq_a = FoqIndexes::build(&adjacency);
+    let foq_b = FoqIndexes::build(&adjacency);
+    let wavelet_a = WaveletIndexes::build(&adjacency);
+    let wavelet_b = WaveletIndexes::build(&adjacency);
+
+    assert_eq!(foq_a.to_bytes(), foq_b.to_bytes());
+    assert_eq!(wavelet_a.to_bytes(), wavelet_b.to_bytes());
+    assert_eq!(foq_a.to_bytes().len(), foq_a.index_serialized_len());
+    assert_eq!(wavelet_a.to_bytes().len(), wavelet_a.index_serialized_len());
+}
+
+#[test]
+fn reference_space_model_matches_materialized_encodings() {
+    for rows in [1, 31, 257, 1_024, 4_096, 16_384] {
+        let adjacency = Adjacency::from_triples(&reference_triples(rows));
+        let foq = FoqIndexes::build(&adjacency);
+        let wavelet = WaveletIndexes::build(&adjacency);
+        let model = reference_space(rows as u64);
+
+        assert_eq!(model.triples, adjacency.so_len() as u64);
+        assert_eq!(model.shared, adjacency.shared_serialized_len() as u64);
+        assert_eq!(model.foq_index, foq.index_serialized_len() as u64);
+        assert_eq!(model.wavelet_index, wavelet.index_serialized_len() as u64);
+        assert_eq!(model.foq_total(), foq.serialized_len(&adjacency) as u64);
+        assert_eq!(
+            model.wavelet_total(),
+            wavelet.serialized_len(&adjacency) as u64
+        );
+    }
+}

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -123,12 +123,14 @@ and excluded.
 | 100,000,000 | 489,959,547 | 571,486,284 | 935,662,769 | 1,017,189,506 |
 | 1,000,000,000 | 5,284,861,054 | 6,230,470,670 | 10,116,892,394 | 11,062,502,010 |
 
-For this distribution, the wavelet index is last smaller at 61,182 rows
-(244,728 triples) and first larger at 61,183 rows (244,732 triples). At the two
-requested large scales it uses 16.6% and 17.9% more index bytes; including the
-shared adjacency, the complete structure is 8.7% and 9.3% larger. This result
-applies to the concrete rank-directory bitmap representation measured here, not
-to an RRR entropy-coded representation.
+At small sizes, 64-bit word rounding causes narrow ordering oscillations: an
+exact scan through 1,048,576 rows finds 68 flips. The final flip in that scan is
+from smaller to larger at 61,183 rows (244,732 triples); the wavelet index stays
+larger through the rest of the scan and at both target-scale model points. At
+the two requested large scales it uses 16.6% and 17.9% more index bytes;
+including the shared adjacency, the complete structure is 8.7% and 9.3% larger.
+This result applies to the concrete rank-directory bitmap representation
+measured here, not to an RRR entropy-coded representation.
 
 #### Representative timing result
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -30,6 +30,8 @@ They live under `crates/*/benches/`:
 - `crates/rdf-core/benches/mutable.rs` — copy-on-write mutation paths.
 - `crates/rdf-core/benches/intern_content_id.rs` — content-addressing
   recognition cost for ordinary vs. genuine content-id IRIs.
+- `crates/rdf-core/benches/pack_index_compare.rs` — the shipped pack codec's
+  FoQ posting indexes vs. an internal bitmap wavelet-matrix candidate.
 - `crates/rdf/benches/native_codecs.rs` — text/XML/JSON-LD codec throughput.
 - `crates/sparql-algebra/benches/tokenize.rs` — SPARQL/Turtle lexer hot path
   (`IRIREF`, string literals, comments).
@@ -67,6 +69,7 @@ Additional benches are run package-by-package, e.g.
 | `crates/rdf-core/benches/ir_layout.rs` | AoS / SoA / predicate-adjacency IR layout trade-offs (latency, allocations, peak RSS). |
 | `crates/rdf-core/benches/mutable.rs` | Copy-on-write mutation paths on the immutable IR. |
 | `crates/rdf-core/benches/intern_content_id.rs` | Extra intern-time cost when content-addressing is enabled: prefix-miss baseline, prefix-hit decode, and side-table insert. |
+| `crates/rdf-core/benches/pack_index_compare.rs` | Exact bytes, build latency, and unbound-subject query latency for the shipped FoQ posting indexes vs. a non-shipped bitmap wavelet matrix over the same pack adjacency. |
 | `crates/rdf/benches/native_codecs.rs` | Throughput of the native Turtle, TriG, N-Triples, N-Quads, RDF/XML, and JSON-LD serializers/parsers. |
 | `crates/sparql-algebra/benches/tokenize.rs` | Lexer throughput on long IRI bodies, escaped string literals, and comment tails. |
 | `crates/sparql-eval/benches/query_eval.rs` | End-to-end SPARQL SELECT latency including BGP joins, filters, and aggregates. |
@@ -78,6 +81,77 @@ Additional benches are run package-by-package, e.g.
 | `crates/gts/benches/authoring.rs` | GTS container authoring: append, hash, and CBOR-log construction throughput. |
 | `crates/rdf-wasm/benches/query_engine_reuse.rs` | Binding-level SELECT overhead for reused package-root `QueryEngine` instances vs. fresh construction. |
 | `crates/iri/benches/parse.rs` | `purrdf_iri::parse` component validation across scheme, authority, path, query, and fragment classes. |
+
+### Pack FoQ vs. bitmap wavelet matrix
+
+The pack-index comparison is an internal format-selection experiment; the
+wavelet matrix is not part of the library API or pack wire format. It stores one
+rank/select bitmap per alphabet bit over each existing `Sp` and `So` sequence.
+The FoQ comparand reproduces the shipped bit-packed offsets/counts and
+delta-varint posting data. Both candidates retain the same `Sp`/`Bp`/`So`/`Bo`
+adjacency, so the index-only and adjacency-plus-index totals are reported
+separately.
+
+Each deterministic row emits four `example.org` triples. The row contains a
+dense predicate and object, bounded cyclic predicate/object families, and a
+unique long-tail object. This supplies dense and sparse bindings for `(?,p,?)`,
+`(?,?,o)`, and `(?,p,o)` without RNG. Tests compare both candidates with a plain
+vector oracle and the real `PackView` results. The closed-form space model is
+checked against materialized encodings at alphabet-width boundaries before it
+is used for the 100-million and 1-billion-triple rows below.
+
+Run the correctness test, a short timing sample, or the one-pass space/query
+smoke mode with:
+
+```sh
+cargo test -p purrdf-core --test pack_index_compare --locked
+cargo bench -p purrdf-core --bench pack_index_compare --locked -- --quick
+cargo bench -p purrdf-core --bench pack_index_compare --locked -- --test
+```
+
+#### Representative space result
+
+These exact encoded byte counts use the workload above. “Total” is the shared
+adjacency plus the selected index; dictionary and outer pack framing are common
+and excluded.
+
+| triples | FoQ index | wavelet index | FoQ total | wavelet total |
+| ---: | ---: | ---: | ---: | ---: |
+| 65,536 | 280,221 | 263,162 | 490,485 | 473,426 |
+| 262,144 | 1,102,389 | 1,139,034 | 2,008,717 | 2,045,362 |
+| 1,048,576 | 4,480,461 | 4,912,570 | 8,367,653 | 8,799,762 |
+| 100,000,000 | 489,959,547 | 571,486,284 | 935,662,769 | 1,017,189,506 |
+| 1,000,000,000 | 5,284,861,054 | 6,230,470,670 | 10,116,892,394 | 11,062,502,010 |
+
+For this distribution, the wavelet index is last smaller at 61,182 rows
+(244,728 triples) and first larger at 61,183 rows (244,732 triples). At the two
+requested large scales it uses 16.6% and 17.9% more index bytes; including the
+shared adjacency, the complete structure is 8.7% and 9.3% larger. This result
+applies to the concrete rank-directory bitmap representation measured here, not
+to an RRR entropy-coded representation.
+
+#### Representative timing result
+
+This `--quick` snapshot was taken on 2026-07-14 with `rustc 1.96.1`, Linux
+7.1.3, and an AMD Ryzen AI MAX+ 395 (16 cores / 32 threads). The query fixture is
+262,144 triples. “Production” is the real `PackView` FoQ path; the isolated
+columns remove dictionary/view overhead and are the direct index comparison.
+Values are Criterion point estimates rounded to three significant figures.
+
+| operation | production FoQ | isolated FoQ | isolated wavelet | wavelet / FoQ |
+| --- | ---: | ---: | ---: | ---: |
+| build complete pack / index | 336 ms | 12.5 ms | 7.21 ms | 0.58× |
+| `(?,p,?)`, dense | 5.22 ms | 3.76 ms | 31.3 ms | 8.31× |
+| `(?,?,o)`, dense | 671 µs | 76.3 µs | 45.0 ms | 590× |
+| `(?,p,o)`, dense | 658 µs | 162 µs | 70.5 ms | 436× |
+| `(?,p,?)`, sparse | 3.13 µs | 2.19 µs | 13.2 µs | 6.01× |
+| `(?,?,o)`, sparse | 79.6 ns | 13.6 ns | 431 ns | 31.7× |
+| `(?,p,o)`, sparse | 247 ns | 144 ns | 11.7 µs | 81.4× |
+
+The bitmap wavelet matrix builds its isolated indexes about 42% faster, but it
+is larger at the target scales and regresses every measured query shape. The
+measured production decision is therefore to retain both FoQ posting indexes;
+pack bytes and decoding behavior remain unchanged.
 
 ## Python compat harness (`bench_compat.py`)
 

--- a/docs/book/src/project/performance.md
+++ b/docs/book/src/project/performance.md
@@ -32,7 +32,7 @@ shipped layout is whichever wins.
 
 | Layer | What it measures | How to run |
 | --- | --- | --- |
-| **Rust criterion suites** | Native engine hot paths — IR layout, copy-on-write mutation, codecs, SPARQL lexing/evaluation/planning, SHACL validation, entailment chase, GTS authoring, IRI parsing. | `make bench` |
+| **Rust criterion suites** | Native engine hot paths — IR layout, copy-on-write mutation, pack index alternatives, codecs, SPARQL lexing/evaluation/planning, SHACL validation, entailment chase, GTS authoring, IRI parsing. | `make bench` |
 | **Python compat harness** | `purrdf.compat.rdflib` (the native-backed drop-in) vs. the real rdflib 7.x on parse, serialize, SPARQL, and triple-pattern iteration, over a deterministic `example.org` corpus. | `make bench-python` |
 
 Both layers are report-only: they are never part of `make check`, and no test
@@ -57,6 +57,7 @@ planner decisions can be audited without running the query
 ```sh
 make bench                              # the default criterion set
 cargo bench -p purrdf-iri --bench parse # a single package's bench
+cargo bench -p purrdf-core --bench pack_index_compare # pack index experiment
 make bench-python                       # the rdflib comparison harness
 ```
 


### PR DESCRIPTION
## Summary

- add an internal, non-shipped Criterion comparison between the succinct pack
  codec's FoQ delta-varint posting indexes and a pointerless bitmap wavelet
  matrix over the same `Sp`/`So` sequences
- prove wavelet `access`/`rank`/`select`, query cardinality parity with the real
  `PackView`, deterministic rebuilds, and exact space-model parity with
  materialized encodings
- record the host-qualified measurements, target-scale byte model, exact
  small-size ordering behavior, and benchmark reproduction commands
- retain both production FoQ indexes: no pack bytes, format version, decoder,
  public API, dependency, or generated artifact changes

The hypothesis was measured before any production edit. The bitmap candidate
builds faster, but loses both the target-scale space comparison and every query
cell, so it does not satisfy the replacement criterion.

## Representative results

The query fixture has 262,144 deterministic `example.org` triples. Timings are
from a Criterion `--quick` snapshot on Linux 7.1.3, rustc 1.96.1, AMD Ryzen AI
MAX+ 395; they are report-only and host-dependent.

| operation | isolated FoQ | isolated wavelet | wavelet / FoQ |
| --- | ---: | ---: | ---: |
| build | 12.5 ms | 7.21 ms | 0.58x |
| `(?,p,?)`, dense | 3.76 ms | 31.3 ms | 8.31x |
| `(?,?,o)`, dense | 76.3 us | 45.0 ms | 590x |
| `(?,p,o)`, dense | 162 us | 70.5 ms | 436x |
| `(?,p,?)`, sparse | 2.19 us | 13.2 us | 6.01x |
| `(?,?,o)`, sparse | 13.6 ns | 431 ns | 31.7x |
| `(?,p,o)`, sparse | 144 ns | 11.7 us | 81.4x |

The exact, materialization-checked model gives:

| triples | FoQ index | wavelet index | difference |
| ---: | ---: | ---: | ---: |
| 100,000,000 | 489,959,547 B | 571,486,284 B | +16.6% |
| 1,000,000,000 | 5,284,861,054 B | 6,230,470,670 B | +17.9% |

Fixed-word rounding produces 68 narrow ordering flips in the exact scan through
1,048,576 rows. The final flip in that scan is from wavelet-smaller to
wavelet-larger at 61,183 rows (244,732 triples); the candidate remains larger
through the rest of the scan and at both target projections.

This decision applies to the concrete rank-directory bitmap wavelet matrix
measured here; it makes no claim about an RRR entropy-coded implementation.

## Validation

- `make check`
- `cargo bench -p purrdf-core --no-run --locked`
- `cargo bench -p purrdf-core --bench pack_index_compare --locked -- --quick`
- `cargo bench -p purrdf-core --bench pack_index_compare --locked -- --test`
- `make doc`
- mechanical deferral scan over `origin/main...HEAD`
- `python3 scripts/check-issue-refs.py`
- signed-commit and clean-worktree verification

Closes #97


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new native performance benchmark comparing alternative packed index strategies.
  * Included instructions for running the benchmark locally, along with representative space and timing results.

* **Tests**
  * Added coverage validating index query consistency, deterministic serialization, and reported storage sizes across multiple dataset sizes.

* **Benchmarking**
  * Added build-time, query-time, and storage-size comparisons for dense and sparse workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->