### PR TITLE
feat(columnar): add deterministic bidirectional Parquet codec

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,13 +105,12 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      # Document exactly the 16 documented crates: the 15 publishable crates
-      # plus the internal purrdf-entail (publish = false), with rustdoc lints
-      # promoted to errors. The other three publish=false crates are excluded
+      # Document exactly the 17 publishable crates with rustdoc lints promoted
+      # to errors. The four publish=false crates are excluded
       # because purrdf-capi's `[lib] name = "purrdf"` collides with the umbrella
       # crate's output filename in a single --workspace doc run.
       - name: Doc (deny warnings)
-        run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --exclude purrdf-capi --exclude purrdf-python --exclude purrdf-sparql-conformance
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --exclude purrdf-capi --exclude purrdf-python --exclude purrdf-sparql-conformance --exclude purrdf-cli
 
   msrv:
     runs-on: ubuntu-latest
@@ -155,6 +154,7 @@ jobs:
             -p purrdf-xsd \
             -p purrdf-gts \
             -p purrdf-core \
+            -p purrdf-columnar \
             -p purrdf-sparql-algebra \
             -p purrdf-sparql-results \
             -p purrdf-sparql-eval \

--- a/.github/workflows/release-cargo.yaml
+++ b/.github/workflows/release-cargo.yaml
@@ -86,6 +86,7 @@ jobs:
             -p purrdf-xsd \
             -p purrdf-gts \
             -p purrdf-core \
+            -p purrdf-columnar \
             -p purrdf-entail \
             -p purrdf-sparql-algebra \
             -p purrdf-sparql-results \
@@ -158,6 +159,7 @@ jobs:
             purrdf-xsd
             purrdf-gts
             purrdf-core
+            purrdf-columnar
             purrdf-entail
             purrdf-sparql-algebra
             purrdf-sparql-results

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Crate map (all under `crates/`, published names in `Cargo.toml`):
 | `purrdf` | Umbrella facade (RDF surface at root; `slice`/`shapes` as modules) |
 | `purrdf-rdf` (`crates/rdf`) | Native text/XML/JSON-LD codecs, GTS adapters, describe, canonicalization |
 | `purrdf-core` (`crates/rdf-core`) | Interned IR kernel, diagnostics, store traits, provenance, RDFC-1.0 |
+| `purrdf-columnar` (`crates/columnar`) | Bidirectional five-table Parquet codec for RDF 1.2 + blobs |
 | `purrdf-gts` (`crates/gts`) | GTS container engine (CBOR log, BLAKE3, COSE) |
 | `purrdf-sparql-{algebra,eval,results}` | SPARQL 1.1/1.2 parser, evaluator, results |
 | `purrdf-shapes` (`crates/shapes`) | SHACL validation (full Core + SHACL-SPARQL + SHACL-AF) and SHACL Rules (`sh:rule` inference) |
@@ -39,7 +40,7 @@ Crate map (all under `crates/`, published names in `Cargo.toml`):
 * **Kernel ring-fence.** `purrdf-core` must never depend on oxigraph or PyO3.
   `purrdf-iri`, `purrdf-xsd`, and `purrdf-events` must keep **zero runtime
   dependencies**.
-* **Everything is wasm-able.** Every release crate (all 15 published crates,
+* **Everything is wasm-able.** Every release crate (all 17 published crates,
   `purrdf-wasm` included) must build for `wasm32-unknown-unknown` — CI
   hard-fails otherwise (`make wasm` locally). Never add a dependency that
   drags in threads, the filesystem, C toolchains, or wall-clock/RNG syscalls

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,6 +1255,7 @@ dependencies = [
 name = "purrdf"
 version = "0.6.0"
 dependencies = [
+ "purrdf-columnar",
  "purrdf-entail",
  "purrdf-events",
  "purrdf-gts",
@@ -1293,6 +1294,17 @@ dependencies = [
  "purrdf-sparql-eval",
  "purrdf-sparql-results",
  "tempfile",
+]
+
+[[package]]
+name = "purrdf-columnar"
+version = "0.6.0"
+dependencies = [
+ "criterion",
+ "pretty_assertions",
+ "proptest",
+ "purrdf-core",
+ "structured-zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ resolver = "2"
 members = [
     "bindings/python",
     "crates/cli",
+    "crates/columnar",
     "crates/entail",
     "crates/gts",
     "crates/iri",
@@ -45,6 +46,7 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
 purrdf = { path = "crates/purrdf", version = "0.6.0" }
+purrdf-columnar = { path = "crates/columnar", version = "0.6.0" }
 purrdf-core = { path = "crates/rdf-core", version = "0.6.0" }
 purrdf-entail = { path = "crates/entail", version = "0.6.0" }
 purrdf-events = { path = "crates/rdf-events", version = "0.6.0" }

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 CARGO_TARGET_DIR ?= target
 CAPI_HEADER := crates/rdf-capi/include/purrdf.h
 
-.PHONY: help metadata fmt check book book-samples check-issue-refs changelog bump release-tags test doc bench bench-python pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-size wasm-pkg-test wasm-pkg-bench playground playground-smoke \
+.PHONY: help metadata fmt check book book-samples check-issue-refs changelog bump release-tags test doc bench bench-python columnar-oracle pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-size wasm-pkg-test wasm-pkg-bench playground playground-smoke \
 	capi-build capi-header capi-check capi-install
 
 # The changelog generator is pinned so the committed CHANGELOG.md and the notes
@@ -136,7 +136,10 @@ book: book-samples ## Build The PurRDF Book (mdBook user guide) into docs/book/b
 	mdbook build docs/book
 
 bench: ## Run criterion benchmarks (report-only; never a gate).
-	cargo bench -p purrdf-gts -p purrdf-core -p purrdf-rdf -p purrdf-sparql-eval -p purrdf-shapes -p purrdf-wasm
+	cargo bench -p purrdf-gts -p purrdf-core -p purrdf-columnar -p purrdf-rdf -p purrdf-sparql-eval -p purrdf-shapes -p purrdf-wasm
+
+columnar-oracle: ## Verify production Parquet files through the dev-only DuckDB oracle.
+	bash scripts/check-columnar-oracle.sh
 
 bench-python: ## Compare the rdflib compat shim vs. real rdflib (report-only; NOT a test gate). See docs/BENCHMARKS.md.
 	cd bindings/python && uv run maturin develop && uv run python benchmarks/bench_compat.py

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ release-tags: ## Cut + push rust-v/py-v/npm-v tags for VERSION after coherence c
 test: ## Run the workspace test suite.
 	cargo test --workspace --locked
 
-doc: ## Build docs for the 16 publishable crates with rustdoc warnings denied.
+doc: ## Build docs for the 17 publishable crates with rustdoc warnings denied.
 	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --exclude purrdf-capi --exclude purrdf-python --exclude purrdf-sparql-conformance --exclude purrdf-cli
 
 book-samples: ## Regenerate deterministic SVG visualization samples embedded in The PurRDF Book.
@@ -165,7 +165,7 @@ rdf-core-hygiene: ## Prove the kernel ring-fence: no oxigraph/PyO3 in purrdf-cor
 wasm: ## Prove the release crates build for wasm32-unknown-unknown (SKIP locally if target absent; CI hard-fails).
 	@if rustup target list --installed 2>/dev/null | grep -qx wasm32-unknown-unknown; then \
 		cargo check --locked --target wasm32-unknown-unknown --lib \
-			-p purrdf-events -p purrdf-iri -p purrdf-xsd -p purrdf-gts -p purrdf-core \
+			-p purrdf-events -p purrdf-iri -p purrdf-xsd -p purrdf-gts -p purrdf-core -p purrdf-columnar \
 			-p purrdf-sparql-algebra -p purrdf-sparql-results -p purrdf-sparql-eval \
 			-p purrdf-rdf -p purrdf-slice -p purrdf-shapes -p purrdf-shex -p purrdf-entail \
 			-p purrdf-validate -p purrdf -p purrdf-wasm; \

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -17,6 +17,11 @@ Copied from `gmeow-ontology`:
 - SHACL/shape validation: `shacl` copied as `shapes`
 - Carrier IR and dataset/slice wrappers: `slice`
 - Python package sources under `python/src/purrdf`
+- The normalized five-table Parquet projection in
+  `crates/pipeline/src/stages/parquet.rs` was used as the migration reference for
+  `purrdf-columnar`; PurRDF replaces its Arrow/Snappy writer-only path with the
+  first-party bidirectional RDF 1.2-complete codec documented in
+  `docs/COLUMNAR.md`.
 
 Copied from `gmeow-gts`:
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ for drift. Built with cargo-c: `make capi-build`.
 | [`purrdf`](./crates/purrdf/) | Umbrella facade: the RDF surface at the root, `slice` and `shapes` as modules. Start here. |
 | [`purrdf-rdf`](./crates/rdf/) | RDF 1.2 implementation: native codecs, GTS adapters, describe, canonicalization entry points. |
 | [`purrdf-core`](./crates/rdf-core/) | The kernel: interned IR, diagnostics, store traits, provenance, loss ledger, RDFC-1.0. |
+| [`purrdf-columnar`](./crates/columnar/) | Bidirectional, byte-deterministic five-table Parquet codec for RDF 1.2 and content-addressed blobs. |
 | [`purrdf-gts`](./crates/gts/) | GTS container engine: reader, writer, fold, verify, COSE sign/encrypt. |
 | [`purrdf-sparql-algebra`](./crates/sparql-algebra/) | SPARQL 1.1/1.2 parser → query algebra AST. |
 | [`purrdf-sparql-eval`](./crates/sparql-eval/) | Multiset SPARQL evaluator in interned `TermId` space. |

--- a/crates/columnar/Cargo.toml
+++ b/crates/columnar/Cargo.toml
@@ -34,3 +34,9 @@ structured-zstd = { workspace = true }
 criterion = { workspace = true }
 pretty_assertions = { workspace = true }
 proptest = { workspace = true }
+
+[[bench]]
+# End-to-end fixed-schema writer/reader latency over a representative RDF 1.2
+# dataset and blob store. Report-only; no performance winner is asserted.
+name = "codec"
+harness = false

--- a/crates/columnar/Cargo.toml
+++ b/crates/columnar/Cargo.toml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+[package]
+name = "purrdf-columnar"
+description = "PurRDF's byte-deterministic, bidirectional five-table Parquet codec for RDF 1.2 datasets"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/purrdf-columnar"
+rust-version.workspace = true
+readme = "README.md"
+keywords = ["rdf", "rdf-12", "parquet", "columnar", "duckdb"]
+categories = ["encoding", "data-structures", "wasm"]
+
+[package.metadata.docs.rs]
+all-features = true
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["rlib"]
+path = "src/lib.rs"
+name = "purrdf_columnar"
+
+[dependencies]
+purrdf-core = { workspace = true }
+structured-zstd = { workspace = true }
+
+[dev-dependencies]
+criterion = { workspace = true }
+pretty_assertions = { workspace = true }
+proptest = { workspace = true }

--- a/crates/columnar/README.md
+++ b/crates/columnar/README.md
@@ -25,6 +25,10 @@ The exact schema and invariants are documented in
 [`docs/COLUMNAR.md`](../../docs/COLUMNAR.md). Most applications should access
 this crate as `purrdf::columnar` through the umbrella `purrdf` crate.
 
+`make columnar-oracle` writes a production-surface ZSTD fixture and asks the
+DuckDB CLI to read every file, verify representative row counts, and confirm
+that annotated text and raw payloads surface as `VARCHAR` and `BLOB`.
+
 ## License
 
 Licensed under either of

--- a/crates/columnar/README.md
+++ b/crates/columnar/README.md
@@ -1,0 +1,35 @@
+<!--
+SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# purrdf-columnar
+
+`purrdf-columnar` is PurRDF's first-party, byte-deterministic Parquet bridge for
+DataFrame and SQL consumers. It maps an RDF 1.2 `DatasetView` and its
+content-addressed blob store onto exactly five flat tables:
+
+- `terms.parquet`
+- `quads.parquet`
+- `reifiers.parquet`
+- `annotations.parquet`
+- `blobs.parquet`
+
+The crate implements the deliberately narrow Parquet subset it writes: INT64
+and BYTE_ARRAY physical columns, PLAIN values, RLE definition levels, Data Page
+V2, and either UNCOMPRESSED or ZSTD page bodies. It does not wrap Arrow,
+parquet-rs, or a general Thrift runtime. All APIs are in-memory and build for
+`wasm32-unknown-unknown`.
+
+The exact schema and invariants are documented in
+[`docs/COLUMNAR.md`](../../docs/COLUMNAR.md). Most applications should access
+this crate as `purrdf::columnar` through the umbrella `purrdf` crate.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0, or
+- MIT license
+
+at your option.

--- a/crates/columnar/benches/codec.rs
+++ b/crates/columnar/benches/codec.rs
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Bench targets are not public API: `criterion_group!` expands to a `pub fn`.
+#![allow(missing_docs)]
+
+//! Report-only end-to-end measurements for the five-table columnar codec.
+
+use std::sync::Arc;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use purrdf_columnar::{Compression, read, write};
+use purrdf_core::{BlankScope, ContentStore, RdfDataset, RdfDatasetBuilder, RdfLiteral};
+
+const ROWS: u32 = 500;
+
+fn fixture() -> (Arc<RdfDataset>, ContentStore) {
+    let mut builder = RdfDatasetBuilder::new();
+    let predicate = builder.intern_iri("https://example.org/p");
+    let graph = builder.intern_iri("https://example.org/g");
+    for row in 0..ROWS {
+        let subject = builder.intern_iri(&format!("https://example.org/s{row}"));
+        let blank = builder.intern_blank(&format!("b{row}"), BlankScope(row % 8));
+        let literal = builder.intern_literal(RdfLiteral::typed(
+            row.to_string(),
+            "http://www.w3.org/2001/XMLSchema#integer",
+        ));
+        builder.push_quad(subject, predicate, blank, None);
+        builder.push_quad(blank, predicate, literal, Some(graph));
+    }
+    let mut blobs = ContentStore::new();
+    for row in 0..16 {
+        blobs.insert(format!("payload-{row:04}").into_bytes());
+    }
+    (
+        builder.freeze().expect("benchmark fixture is valid RDF"),
+        blobs,
+    )
+}
+
+fn bench_codec(c: &mut Criterion) {
+    let (dataset, blobs) = fixture();
+    let encoded = write(&*dataset, &blobs, Compression::Zstd)
+        .expect("benchmark fixture encodes as ZSTD Parquet");
+    let mut group = c.benchmark_group("columnar_codec_1000_quads");
+    group.bench_function("write_uncompressed", |bencher| {
+        bencher.iter(|| {
+            std::hint::black_box(
+                write(&*dataset, &blobs, Compression::Uncompressed)
+                    .expect("benchmark fixture encodes"),
+            )
+        });
+    });
+    group.bench_function("write_zstd", |bencher| {
+        bencher.iter(|| {
+            std::hint::black_box(
+                write(&*dataset, &blobs, Compression::Zstd).expect("benchmark fixture encodes"),
+            )
+        });
+    });
+    group.bench_function("read_zstd", |bencher| {
+        bencher.iter(|| {
+            std::hint::black_box(read(&encoded.files).expect("benchmark fixture decodes"))
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_codec);
+criterion_main!(benches);

--- a/crates/columnar/examples/write_oracle_fixture.rs
+++ b/crates/columnar/examples/write_oracle_fixture.rs
@@ -50,5 +50,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for (table, bytes) in encoded.files.iter() {
         fs::write(output.join(table.file_name()), bytes)?;
     }
+
+    let empty_output = output.join("empty");
+    fs::create_dir_all(&empty_output)?;
+    let empty = RdfDatasetBuilder::new().freeze()?;
+    let empty_encoded = write(&*empty, &ContentStore::new(), Compression::Uncompressed)?;
+    for (table, bytes) in empty_encoded.files.iter() {
+        fs::write(empty_output.join(table.file_name()), bytes)?;
+    }
     Ok(())
 }

--- a/crates/columnar/examples/write_oracle_fixture.rs
+++ b/crates/columnar/examples/write_oracle_fixture.rs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Write a deterministic five-file fixture for external Parquet oracles.
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use purrdf_columnar::{Compression, write};
+use purrdf_core::{BlankScope, ContentStore, RdfDatasetBuilder, RdfLiteral, RdfTextDirection};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let output = env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .ok_or("usage: write_oracle_fixture OUTPUT_DIRECTORY")?;
+    fs::create_dir_all(&output)?;
+
+    let mut builder = RdfDatasetBuilder::new();
+    let subject = builder.intern_blank("subject", BlankScope(5));
+    let predicate = builder.intern_iri("https://example.org/predicate");
+    let object = builder.intern_literal(RdfLiteral::typed("17", "https://example.org/integer"));
+    let directional = builder.intern_literal(RdfLiteral {
+        lexical_form: "مرحبا".to_owned(),
+        datatype: None,
+        language: Some("ar".to_owned()),
+        direction: Some(RdfTextDirection::Rtl),
+    });
+    let graph = builder.intern_iri("https://example.org/graph");
+    let empty_graph = builder.intern_iri("https://example.org/empty");
+    builder.declare_named_graph(empty_graph);
+    builder.push_quad(subject, predicate, object, None);
+    builder.push_quad(subject, predicate, directional, Some(graph));
+
+    let triple = builder.intern_triple(subject, predicate, directional);
+    let reifier = builder.intern_blank("reifier", BlankScope(5));
+    builder.push_reifier_in_graph(reifier, triple, Some(graph));
+    builder.push_annotation_in_graph(reifier, predicate, object, None);
+    let dataset = builder.freeze()?;
+
+    let mut blobs = ContentStore::new();
+    blobs.insert(b"first payload".to_vec());
+    blobs.insert(b"second payload".to_vec());
+    let encoded = write(&*dataset, &blobs, Compression::Zstd)?;
+    assert!(
+        encoded.losses.is_empty(),
+        "columnar fixture must be lossless"
+    );
+    for (table, bytes) in encoded.files.iter() {
+        fs::write(output.join(table.file_name()), bytes)?;
+    }
+    Ok(())
+}

--- a/crates/columnar/src/compact.rs
+++ b/crates/columnar/src/compact.rs
@@ -69,11 +69,6 @@ impl CompactWriter {
             .expect("field headers are written only inside a struct") = id;
     }
 
-    pub(crate) fn i16_field(&mut self, id: i16, value: i16) {
-        self.field_header(id, TYPE_I16);
-        write_varint(&mut self.bytes, zigzag_encode(i64::from(value)));
-    }
-
     pub(crate) fn i32_field(&mut self, id: i16, value: i32) {
         self.field_header(id, TYPE_I32);
         write_varint(&mut self.bytes, zigzag_encode(i64::from(value)));
@@ -222,13 +217,6 @@ impl<'a> CompactReader<'a> {
         }
         state.last_field = id;
         Ok(Some(CompactField { id, field_type }))
-    }
-
-    pub(crate) fn read_i16(&mut self, field: CompactField) -> Result<i16, ColumnarError> {
-        Self::expect_type(field, TYPE_I16, "compact i16")?;
-        let value = self.read_signed("compact i16")?;
-        i16::try_from(value)
-            .map_err(|_| ColumnarError::malformed("compact i16", "value exceeds i16"))
     }
 
     pub(crate) fn read_i32(&mut self, field: CompactField) -> Result<i32, ColumnarError> {
@@ -504,8 +492,7 @@ mod tests {
             writer.string_field(4, "meow");
             writer.list_i32_field(5, &[0, 3, -9]);
             writer.struct_field(21, |writer| {
-                writer.i16_field(1, 7);
-                writer.bool_field(2, false);
+                writer.bool_field(1, false);
             });
         });
 
@@ -525,8 +512,6 @@ mod tests {
         let field = reader.next_field(&mut root).unwrap().unwrap();
         assert_eq!(field.id, 21, "long-form field id survives");
         let mut nested = CompactReader::expect_struct(field).unwrap();
-        let field = reader.next_field(&mut nested).unwrap().unwrap();
-        assert_eq!(reader.read_i16(field).unwrap(), 7);
         let field = reader.next_field(&mut nested).unwrap().unwrap();
         assert!(!reader.read_bool(field).unwrap());
         assert!(reader.next_field(&mut nested).unwrap().is_none());

--- a/crates/columnar/src/compact.rs
+++ b/crates/columnar/src/compact.rs
@@ -1,0 +1,577 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Minimal Thrift Compact Protocol writer/reader for Parquet metadata.
+//!
+//! There is deliberately no RPC message layer: Parquet serializes bare Thrift
+//! structs. The implementation covers every base/container type needed to skip
+//! unknown fields safely, while construction helpers expose only the field shapes
+//! the fixed Parquet profile emits.
+
+use purrdf_core::ir::pack::bits::{read_varint, write_varint, zigzag_decode, zigzag_encode};
+
+use crate::ColumnarError;
+
+pub(crate) const TYPE_STOP: u8 = 0;
+pub(crate) const TYPE_BOOL_TRUE: u8 = 1;
+pub(crate) const TYPE_BOOL_FALSE: u8 = 2;
+pub(crate) const TYPE_I8: u8 = 3;
+pub(crate) const TYPE_I16: u8 = 4;
+pub(crate) const TYPE_I32: u8 = 5;
+pub(crate) const TYPE_I64: u8 = 6;
+pub(crate) const TYPE_DOUBLE: u8 = 7;
+pub(crate) const TYPE_BINARY: u8 = 8;
+pub(crate) const TYPE_LIST: u8 = 9;
+pub(crate) const TYPE_SET: u8 = 10;
+pub(crate) const TYPE_MAP: u8 = 11;
+pub(crate) const TYPE_STRUCT: u8 = 12;
+
+const MAX_METADATA_COLLECTION_ITEMS: usize = 1_024;
+const MAX_SKIP_DEPTH: usize = 64;
+
+#[derive(Debug, Default)]
+pub(crate) struct CompactWriter {
+    bytes: Vec<u8>,
+    last_fields: Vec<i16>,
+}
+
+impl CompactWriter {
+    pub(crate) fn root(build: impl FnOnce(&mut Self)) -> Vec<u8> {
+        let mut writer = Self::default();
+        writer.write_struct(build);
+        writer.bytes
+    }
+
+    fn write_struct(&mut self, build: impl FnOnce(&mut Self)) {
+        self.last_fields.push(0);
+        build(self);
+        self.bytes.push(TYPE_STOP);
+        self.last_fields
+            .pop()
+            .expect("struct field stack is balanced");
+    }
+
+    fn field_header(&mut self, id: i16, field_type: u8) {
+        let previous = *self
+            .last_fields
+            .last()
+            .expect("field headers are written only inside a struct");
+        let delta = id - previous;
+        if (1..=15).contains(&delta) {
+            self.bytes.push(((delta as u8) << 4) | field_type);
+        } else {
+            self.bytes.push(field_type);
+            write_varint(&mut self.bytes, zigzag_encode(i64::from(id)));
+        }
+        *self
+            .last_fields
+            .last_mut()
+            .expect("field headers are written only inside a struct") = id;
+    }
+
+    pub(crate) fn i16_field(&mut self, id: i16, value: i16) {
+        self.field_header(id, TYPE_I16);
+        write_varint(&mut self.bytes, zigzag_encode(i64::from(value)));
+    }
+
+    pub(crate) fn i32_field(&mut self, id: i16, value: i32) {
+        self.field_header(id, TYPE_I32);
+        write_varint(&mut self.bytes, zigzag_encode(i64::from(value)));
+    }
+
+    pub(crate) fn i64_field(&mut self, id: i16, value: i64) {
+        self.field_header(id, TYPE_I64);
+        write_varint(&mut self.bytes, zigzag_encode(value));
+    }
+
+    pub(crate) fn bool_field(&mut self, id: i16, value: bool) {
+        self.field_header(
+            id,
+            if value {
+                TYPE_BOOL_TRUE
+            } else {
+                TYPE_BOOL_FALSE
+            },
+        );
+    }
+
+    pub(crate) fn binary_field(&mut self, id: i16, value: &[u8]) {
+        self.field_header(id, TYPE_BINARY);
+        self.binary_value(value);
+    }
+
+    pub(crate) fn string_field(&mut self, id: i16, value: &str) {
+        self.binary_field(id, value.as_bytes());
+    }
+
+    pub(crate) fn struct_field(&mut self, id: i16, build: impl FnOnce(&mut Self)) {
+        self.field_header(id, TYPE_STRUCT);
+        self.write_struct(build);
+    }
+
+    pub(crate) fn list_i32_field(&mut self, id: i16, values: &[i32]) {
+        self.field_header(id, TYPE_LIST);
+        self.list_header(values.len(), TYPE_I32);
+        for &value in values {
+            write_varint(&mut self.bytes, zigzag_encode(i64::from(value)));
+        }
+    }
+
+    pub(crate) fn list_string_field(&mut self, id: i16, values: &[&str]) {
+        self.field_header(id, TYPE_LIST);
+        self.list_header(values.len(), TYPE_BINARY);
+        for value in values {
+            self.binary_value(value.as_bytes());
+        }
+    }
+
+    pub(crate) fn list_struct_field<T>(
+        &mut self,
+        id: i16,
+        values: &[T],
+        mut write: impl FnMut(&mut Self, &T),
+    ) {
+        self.field_header(id, TYPE_LIST);
+        self.list_header(values.len(), TYPE_STRUCT);
+        for value in values {
+            self.write_struct(|writer| write(writer, value));
+        }
+    }
+
+    fn list_header(&mut self, len: usize, element_type: u8) {
+        if len < 15 {
+            self.bytes.push(((len as u8) << 4) | element_type);
+        } else {
+            self.bytes.push(0xf0 | element_type);
+            write_varint(&mut self.bytes, len as u64);
+        }
+    }
+
+    fn binary_value(&mut self, value: &[u8]) {
+        write_varint(&mut self.bytes, value.len() as u64);
+        self.bytes.extend_from_slice(value);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CompactField {
+    pub(crate) id: i16,
+    pub(crate) field_type: u8,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct StructState {
+    last_field: i16,
+    stopped: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct CompactReader<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> CompactReader<'a> {
+    pub(crate) fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    pub(crate) fn position(&self) -> usize {
+        self.pos
+    }
+
+    pub(crate) fn is_finished(&self) -> bool {
+        self.pos == self.bytes.len()
+    }
+
+    pub(crate) fn next_field(
+        &mut self,
+        state: &mut StructState,
+    ) -> Result<Option<CompactField>, ColumnarError> {
+        if state.stopped {
+            return Ok(None);
+        }
+        let header = self.read_u8("compact field header")?;
+        let field_type = header & 0x0f;
+        if field_type == TYPE_STOP {
+            if header != TYPE_STOP {
+                return Err(ColumnarError::malformed(
+                    "compact field header",
+                    "STOP field carries a non-zero delta",
+                ));
+            }
+            state.stopped = true;
+            return Ok(None);
+        }
+        Self::validate_type(field_type)?;
+        let delta = i16::from(header >> 4);
+        let id = if delta == 0 {
+            let raw = self.read_signed("compact field id")?;
+            i16::try_from(raw)
+                .map_err(|_| ColumnarError::malformed("compact field id", "value exceeds i16"))?
+        } else {
+            state.last_field.checked_add(delta).ok_or_else(|| {
+                ColumnarError::malformed("compact field id", "delta overflows i16")
+            })?
+        };
+        if id <= 0 {
+            return Err(ColumnarError::malformed(
+                "compact field id",
+                "field ids must be positive",
+            ));
+        }
+        state.last_field = id;
+        Ok(Some(CompactField { id, field_type }))
+    }
+
+    pub(crate) fn read_i16(&mut self, field: CompactField) -> Result<i16, ColumnarError> {
+        Self::expect_type(field, TYPE_I16, "compact i16")?;
+        let value = self.read_signed("compact i16")?;
+        i16::try_from(value)
+            .map_err(|_| ColumnarError::malformed("compact i16", "value exceeds i16"))
+    }
+
+    pub(crate) fn read_i32(&mut self, field: CompactField) -> Result<i32, ColumnarError> {
+        Self::expect_type(field, TYPE_I32, "compact i32")?;
+        let value = self.read_signed("compact i32")?;
+        i32::try_from(value)
+            .map_err(|_| ColumnarError::malformed("compact i32", "value exceeds i32"))
+    }
+
+    pub(crate) fn read_i64(&mut self, field: CompactField) -> Result<i64, ColumnarError> {
+        Self::expect_type(field, TYPE_I64, "compact i64")?;
+        self.read_signed("compact i64")
+    }
+
+    pub(crate) fn read_bool(&self, field: CompactField) -> Result<bool, ColumnarError> {
+        match field.field_type {
+            TYPE_BOOL_TRUE => Ok(true),
+            TYPE_BOOL_FALSE => Ok(false),
+            _ => Err(ColumnarError::malformed(
+                "compact bool",
+                format!("field {} has type {}", field.id, field.field_type),
+            )),
+        }
+    }
+
+    pub(crate) fn read_binary(&mut self, field: CompactField) -> Result<&'a [u8], ColumnarError> {
+        Self::expect_type(field, TYPE_BINARY, "compact binary")?;
+        self.binary_value()
+    }
+
+    pub(crate) fn read_string(&mut self, field: CompactField) -> Result<&'a str, ColumnarError> {
+        let bytes = self.read_binary(field)?;
+        std::str::from_utf8(bytes)
+            .map_err(|_| ColumnarError::malformed("compact string", "invalid UTF-8"))
+    }
+
+    pub(crate) fn expect_struct(field: CompactField) -> Result<StructState, ColumnarError> {
+        Self::expect_type(field, TYPE_STRUCT, "compact struct")?;
+        Ok(StructState::default())
+    }
+
+    pub(crate) fn read_list_header(
+        &mut self,
+        field: CompactField,
+    ) -> Result<(usize, u8), ColumnarError> {
+        Self::expect_type(field, TYPE_LIST, "compact list")?;
+        self.list_header()
+    }
+
+    pub(crate) fn read_list_i32(&mut self, field: CompactField) -> Result<Vec<i32>, ColumnarError> {
+        let (len, element_type) = self.read_list_header(field)?;
+        if element_type != TYPE_I32 {
+            return Err(ColumnarError::malformed(
+                "compact i32 list",
+                format!("element type is {element_type}"),
+            ));
+        }
+        let mut values = Vec::with_capacity(len);
+        for _ in 0..len {
+            let value = self.read_signed("compact list i32")?;
+            values.push(
+                i32::try_from(value).map_err(|_| {
+                    ColumnarError::malformed("compact list i32", "value exceeds i32")
+                })?,
+            );
+        }
+        Ok(values)
+    }
+
+    pub(crate) fn read_list_strings(
+        &mut self,
+        field: CompactField,
+    ) -> Result<Vec<String>, ColumnarError> {
+        let (len, element_type) = self.read_list_header(field)?;
+        if element_type != TYPE_BINARY {
+            return Err(ColumnarError::malformed(
+                "compact string list",
+                format!("element type is {element_type}"),
+            ));
+        }
+        let mut values = Vec::with_capacity(len);
+        for _ in 0..len {
+            let value = self.binary_value()?;
+            values.push(
+                std::str::from_utf8(value)
+                    .map_err(|_| ColumnarError::malformed("compact string list", "invalid UTF-8"))?
+                    .to_owned(),
+            );
+        }
+        Ok(values)
+    }
+
+    pub(crate) fn skip_field(&mut self, field: CompactField) -> Result<(), ColumnarError> {
+        if matches!(field.field_type, TYPE_BOOL_TRUE | TYPE_BOOL_FALSE) {
+            return Ok(());
+        }
+        self.skip_value(field.field_type, 0)
+    }
+
+    fn skip_value(&mut self, value_type: u8, depth: usize) -> Result<(), ColumnarError> {
+        if depth >= MAX_SKIP_DEPTH {
+            return Err(ColumnarError::LimitExceeded {
+                context: "compact nesting depth",
+                value: depth as u64,
+                maximum: MAX_SKIP_DEPTH as u64,
+            });
+        }
+        match value_type {
+            TYPE_BOOL_TRUE | TYPE_BOOL_FALSE | TYPE_I8 => {
+                self.read_u8("compact value")?;
+            }
+            TYPE_I16 | TYPE_I32 | TYPE_I64 => {
+                self.read_unsigned("compact integer")?;
+            }
+            TYPE_DOUBLE => {
+                self.take(8, "compact double")?;
+            }
+            TYPE_BINARY => {
+                self.binary_value()?;
+            }
+            TYPE_LIST | TYPE_SET => {
+                let (len, element_type) = self.list_header()?;
+                for _ in 0..len {
+                    self.skip_value(element_type, depth + 1)?;
+                }
+            }
+            TYPE_MAP => {
+                let len = self.read_collection_len("compact map")?;
+                if len > 0 {
+                    let types = self.read_u8("compact map types")?;
+                    let key_type = types >> 4;
+                    let value_type = types & 0x0f;
+                    Self::validate_type(key_type)?;
+                    Self::validate_type(value_type)?;
+                    for _ in 0..len {
+                        self.skip_value(key_type, depth + 1)?;
+                        self.skip_value(value_type, depth + 1)?;
+                    }
+                }
+            }
+            TYPE_STRUCT => {
+                let mut state = StructState::default();
+                while let Some(field) = self.next_field(&mut state)? {
+                    if matches!(field.field_type, TYPE_BOOL_TRUE | TYPE_BOOL_FALSE) {
+                        continue;
+                    }
+                    self.skip_value(field.field_type, depth + 1)?;
+                }
+            }
+            TYPE_STOP => {
+                return Err(ColumnarError::malformed(
+                    "compact value",
+                    "STOP is not a value type",
+                ));
+            }
+            _ => unreachable!("validated compact type"),
+        }
+        Ok(())
+    }
+
+    fn list_header(&mut self) -> Result<(usize, u8), ColumnarError> {
+        let header = self.read_u8("compact list header")?;
+        let element_type = header & 0x0f;
+        Self::validate_type(element_type)?;
+        if element_type == TYPE_STOP {
+            return Err(ColumnarError::malformed(
+                "compact list header",
+                "STOP is not a valid element type",
+            ));
+        }
+        let short_len = usize::from(header >> 4);
+        let len = if short_len == 15 {
+            self.read_collection_len("compact list")?
+        } else {
+            short_len
+        };
+        Ok((len, element_type))
+    }
+
+    fn read_collection_len(&mut self, context: &'static str) -> Result<usize, ColumnarError> {
+        let value = self.read_unsigned(context)?;
+        let len = usize::try_from(value)
+            .map_err(|_| ColumnarError::malformed(context, "length exceeds usize"))?;
+        if len > MAX_METADATA_COLLECTION_ITEMS {
+            return Err(ColumnarError::limit(
+                context,
+                len,
+                MAX_METADATA_COLLECTION_ITEMS,
+            ));
+        }
+        Ok(len)
+    }
+
+    fn binary_value(&mut self) -> Result<&'a [u8], ColumnarError> {
+        let value = self.read_unsigned("compact binary length")?;
+        let len = usize::try_from(value).map_err(|_| {
+            ColumnarError::malformed("compact binary length", "value exceeds usize")
+        })?;
+        self.take(len, "compact binary")
+    }
+
+    fn read_signed(&mut self, context: &'static str) -> Result<i64, ColumnarError> {
+        self.read_unsigned(context).map(zigzag_decode)
+    }
+
+    fn read_unsigned(&mut self, context: &'static str) -> Result<u64, ColumnarError> {
+        read_varint(self.bytes, &mut self.pos)
+            .map_err(|error| ColumnarError::malformed(context, error.to_string()))
+    }
+
+    fn read_u8(&mut self, context: &'static str) -> Result<u8, ColumnarError> {
+        let byte = *self
+            .bytes
+            .get(self.pos)
+            .ok_or_else(|| ColumnarError::truncated(context, self.pos + 1, self.bytes.len()))?;
+        self.pos += 1;
+        Ok(byte)
+    }
+
+    fn take(&mut self, len: usize, context: &'static str) -> Result<&'a [u8], ColumnarError> {
+        let end = self
+            .pos
+            .checked_add(len)
+            .ok_or_else(|| ColumnarError::malformed(context, "byte range overflows usize"))?;
+        let value = self
+            .bytes
+            .get(self.pos..end)
+            .ok_or_else(|| ColumnarError::truncated(context, end, self.bytes.len()))?;
+        self.pos = end;
+        Ok(value)
+    }
+
+    fn expect_type(
+        field: CompactField,
+        expected: u8,
+        context: &'static str,
+    ) -> Result<(), ColumnarError> {
+        if field.field_type == expected {
+            Ok(())
+        } else {
+            Err(ColumnarError::malformed(
+                context,
+                format!(
+                    "field {} has type {}, expected {expected}",
+                    field.id, field.field_type
+                ),
+            ))
+        }
+    }
+
+    fn validate_type(value_type: u8) -> Result<(), ColumnarError> {
+        if value_type <= TYPE_STRUCT {
+            Ok(())
+        } else {
+            Err(ColumnarError::Unsupported {
+                context: "compact type",
+                value: i64::from(value_type),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_round_trips_scalars_lists_and_nested_structs() {
+        let bytes = CompactWriter::root(|writer| {
+            writer.i32_field(1, -17);
+            writer.i64_field(2, i64::MIN);
+            writer.bool_field(3, true);
+            writer.string_field(4, "meow");
+            writer.list_i32_field(5, &[0, 3, -9]);
+            writer.struct_field(21, |writer| {
+                writer.i16_field(1, 7);
+                writer.bool_field(2, false);
+            });
+        });
+
+        let mut reader = CompactReader::new(&bytes);
+        let mut root = StructState::default();
+
+        let field = reader.next_field(&mut root).unwrap().unwrap();
+        assert_eq!(reader.read_i32(field).unwrap(), -17);
+        let field = reader.next_field(&mut root).unwrap().unwrap();
+        assert_eq!(reader.read_i64(field).unwrap(), i64::MIN);
+        let field = reader.next_field(&mut root).unwrap().unwrap();
+        assert!(reader.read_bool(field).unwrap());
+        let field = reader.next_field(&mut root).unwrap().unwrap();
+        assert_eq!(reader.read_string(field).unwrap(), "meow");
+        let field = reader.next_field(&mut root).unwrap().unwrap();
+        assert_eq!(reader.read_list_i32(field).unwrap(), vec![0, 3, -9]);
+        let field = reader.next_field(&mut root).unwrap().unwrap();
+        assert_eq!(field.id, 21, "long-form field id survives");
+        let mut nested = CompactReader::expect_struct(field).unwrap();
+        let field = reader.next_field(&mut nested).unwrap().unwrap();
+        assert_eq!(reader.read_i16(field).unwrap(), 7);
+        let field = reader.next_field(&mut nested).unwrap().unwrap();
+        assert!(!reader.read_bool(field).unwrap());
+        assert!(reader.next_field(&mut nested).unwrap().is_none());
+        assert!(reader.next_field(&mut root).unwrap().is_none());
+        assert!(reader.is_finished());
+    }
+
+    #[test]
+    fn unknown_nested_field_is_skipped_without_desynchronizing() {
+        let bytes = CompactWriter::root(|writer| {
+            writer.struct_field(1, |writer| {
+                writer.list_string_field(1, &["a", "b"]);
+            });
+            writer.i32_field(2, 42);
+        });
+        let mut reader = CompactReader::new(&bytes);
+        let mut root = StructState::default();
+        let unknown = reader.next_field(&mut root).unwrap().unwrap();
+        reader.skip_field(unknown).unwrap();
+        let answer = reader.next_field(&mut root).unwrap().unwrap();
+        assert_eq!(reader.read_i32(answer).unwrap(), 42);
+        assert!(reader.next_field(&mut root).unwrap().is_none());
+        assert!(reader.is_finished());
+    }
+
+    #[test]
+    fn compact_rejects_truncation_and_oversized_collection() {
+        let bytes = CompactWriter::root(|writer| writer.string_field(1, "abc"));
+        let mut reader = CompactReader::new(&bytes[..bytes.len() - 2]);
+        let mut root = StructState::default();
+        let field = reader.next_field(&mut root).unwrap().unwrap();
+        assert!(matches!(
+            reader.read_string(field),
+            Err(ColumnarError::Truncated { .. })
+        ));
+
+        let mut oversized = vec![0x19, 0xf5];
+        write_varint(&mut oversized, (MAX_METADATA_COLLECTION_ITEMS + 1) as u64);
+        oversized.push(TYPE_STOP);
+        let mut reader = CompactReader::new(&oversized);
+        let mut root = StructState::default();
+        let field = reader.next_field(&mut root).unwrap().unwrap();
+        assert!(matches!(
+            reader.read_list_i32(field),
+            Err(ColumnarError::LimitExceeded { .. })
+        ));
+    }
+}

--- a/crates/columnar/src/error.rs
+++ b/crates/columnar/src/error.rs
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Typed failures from the narrow columnar codec.
+
+use std::fmt;
+
+/// A fail-closed Parquet encoding, decoding, or RDF reconstruction error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ColumnarError {
+    /// Input ended before a required byte range was available.
+    Truncated {
+        /// Structure being decoded.
+        context: &'static str,
+        /// Exclusive byte position or length required.
+        needed: usize,
+        /// Bytes available in the enclosing buffer.
+        available: usize,
+    },
+    /// Bytes were present but violated the fixed schema or encoding contract.
+    Malformed {
+        /// Structure being decoded or constructed.
+        context: &'static str,
+        /// Stable diagnostic detail.
+        detail: String,
+    },
+    /// A valid Parquet construct falls outside PurRDF's deliberately narrow profile.
+    Unsupported {
+        /// Unsupported field or construct.
+        context: &'static str,
+        /// Observed numeric discriminator.
+        value: i64,
+    },
+    /// A count or byte length exceeds a representable or safety bound.
+    LimitExceeded {
+        /// Bounded structure.
+        context: &'static str,
+        /// Observed value.
+        value: u64,
+        /// Maximum accepted value.
+        maximum: u64,
+    },
+}
+
+impl ColumnarError {
+    pub(crate) fn malformed(context: &'static str, detail: impl Into<String>) -> Self {
+        Self::Malformed {
+            context,
+            detail: detail.into(),
+        }
+    }
+
+    pub(crate) fn truncated(context: &'static str, needed: usize, available: usize) -> Self {
+        Self::Truncated {
+            context,
+            needed,
+            available,
+        }
+    }
+
+    pub(crate) fn limit(context: &'static str, value: usize, maximum: usize) -> Self {
+        Self::LimitExceeded {
+            context,
+            value: value as u64,
+            maximum: maximum as u64,
+        }
+    }
+}
+
+impl fmt::Display for ColumnarError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Truncated {
+                context,
+                needed,
+                available,
+            } => write!(
+                f,
+                "columnar {context} is truncated: needs {needed} bytes, has {available}"
+            ),
+            Self::Malformed { context, detail } => {
+                write!(f, "columnar {context} is malformed: {detail}")
+            }
+            Self::Unsupported { context, value } => {
+                write!(f, "columnar {context} value {value} is unsupported")
+            }
+            Self::LimitExceeded {
+                context,
+                value,
+                maximum,
+            } => write!(
+                f,
+                "columnar {context} value {value} exceeds maximum {maximum}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ColumnarError {}

--- a/crates/columnar/src/files.rs
+++ b/crates/columnar/src/files.rs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The fixed in-memory set of Parquet files.
+
+use crate::schema::Table;
+
+/// Exactly one Parquet file for each member of [`Table::ALL`].
+///
+/// The array form uses [`Table::ALL`] order. Keeping the set closed prevents a
+/// caller from accidentally omitting an empty table, which would make the
+/// five-table dataset projection incomplete.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParquetFiles {
+    files: [Vec<u8>; 5],
+}
+
+impl ParquetFiles {
+    /// Construct the complete file set in [`Table::ALL`] order.
+    #[must_use]
+    pub fn from_array(files: [Vec<u8>; 5]) -> Self {
+        Self { files }
+    }
+
+    /// Borrow one table's Parquet bytes.
+    #[must_use]
+    pub fn get(&self, table: Table) -> &[u8] {
+        &self.files[table_index(table)]
+    }
+
+    /// Iterate every `(table, bytes)` pair in canonical dependency order.
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (Table, &[u8])> {
+        Table::ALL
+            .into_iter()
+            .zip(self.files.iter().map(Vec::as_slice))
+    }
+
+    /// Consume the set as an array in [`Table::ALL`] order.
+    #[must_use]
+    pub fn into_array(self) -> [Vec<u8>; 5] {
+        self.files
+    }
+}
+
+const fn table_index(table: Table) -> usize {
+    match table {
+        Table::Terms => 0,
+        Table::Quads => 1,
+        Table::Reifiers => 2,
+        Table::Annotations => 3,
+        Table::Blobs => 4,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn array_and_table_views_share_canonical_order() {
+        let files = ParquetFiles::from_array([vec![0], vec![1], vec![2], vec![3], vec![4]]);
+        for (index, (table, bytes)) in files.iter().enumerate() {
+            assert_eq!(table, Table::ALL[index]);
+            assert_eq!(bytes, [index as u8]);
+            assert_eq!(files.get(table), bytes);
+        }
+    }
+}

--- a/crates/columnar/src/lib.rs
+++ b/crates/columnar/src/lib.rs
@@ -22,9 +22,13 @@
 
 mod compact;
 pub mod error;
+mod files;
 mod parquet;
 pub mod schema;
+mod writer;
 
 pub use error::ColumnarError;
+pub use files::ParquetFiles;
 pub use parquet::Compression;
 pub use schema::{ColumnSchema, PhysicalType, Repetition, Table, TableSchema};
+pub use writer::{ColumnarWrite, write};

--- a/crates/columnar/src/lib.rs
+++ b/crates/columnar/src/lib.rs
@@ -20,6 +20,11 @@
 )]
 #![forbid(unsafe_code)]
 
+mod compact;
+pub mod error;
+mod parquet;
 pub mod schema;
 
+pub use error::ColumnarError;
+pub use parquet::Compression;
 pub use schema::{ColumnSchema, PhysicalType, Repetition, Table, TableSchema};

--- a/crates/columnar/src/lib.rs
+++ b/crates/columnar/src/lib.rs
@@ -24,11 +24,13 @@ mod compact;
 pub mod error;
 mod files;
 mod parquet;
+mod reader;
 pub mod schema;
 mod writer;
 
 pub use error::ColumnarError;
 pub use files::ParquetFiles;
 pub use parquet::Compression;
+pub use reader::{ColumnarRead, read};
 pub use schema::{ColumnSchema, PhysicalType, Repetition, Table, TableSchema};
 pub use writer::{ColumnarWrite, write};

--- a/crates/columnar/src/lib.rs
+++ b/crates/columnar/src/lib.rs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! PurRDF's first-party, byte-deterministic Parquet bridge.
+//!
+//! The codec projects an RDF 1.2 [`purrdf_core::DatasetView`] plus a
+//! [`purrdf_core::ContentStore`] into the fixed five-table schema exposed by
+//! [`schema`]. Its deliberately narrow Parquet subset keeps the implementation
+//! wasm-clean and auditable: INT64/BYTE_ARRAY columns, flat OPTIONAL fields,
+//! PLAIN values, RLE definition levels, Data Page V2, and UNCOMPRESSED or ZSTD
+//! page bodies.
+//!
+//! No vocabulary is built into this crate. Every IRI is carried from the caller's
+//! dataset verbatim.
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/Blackcat-Informatics/purrdf/main/docs/purrdf-logo.svg"
+)]
+#![doc(
+    html_favicon_url = "https://raw.githubusercontent.com/Blackcat-Informatics/purrdf/main/docs/purrdf-logo.svg"
+)]
+#![forbid(unsafe_code)]
+
+pub mod schema;
+
+pub use schema::{ColumnSchema, PhysicalType, Repetition, Table, TableSchema};

--- a/crates/columnar/src/parquet.rs
+++ b/crates/columnar/src/parquet.rs
@@ -29,6 +29,12 @@ const CODEC_UNCOMPRESSED: i32 = 0;
 const CODEC_ZSTD: i32 = 6;
 const PAGE_TYPE_DATA_V2: i32 = 3;
 
+// The fixed profile keeps one decoded table resident at a time. Bound both the
+// column slots and their uncompressed value bytes so hostile metadata cannot
+// turn a small compressed input into an allocator-sized request.
+const MAX_DECODED_TABLE_BYTES: usize = 256 * 1024 * 1024;
+const MAX_INITIAL_ROW_CAPACITY: usize = 65_536;
+
 /// Page compression selected for one deterministic five-table write.
 ///
 /// This is a runtime value, never a Cargo feature: both modes are always
@@ -143,6 +149,22 @@ impl ColumnValues {
         }
         Ok(out)
     }
+
+    fn plain_len(&self) -> Result<usize, ColumnarError> {
+        match self {
+            Self::Int64(values) => values
+                .len()
+                .saturating_sub(self.null_count())
+                .checked_mul(size_of::<i64>())
+                .ok_or_else(table_budget_overflow),
+            Self::ByteArray(values) => values.iter().flatten().try_fold(0usize, |total, value| {
+                total
+                    .checked_add(size_of::<i32>())
+                    .and_then(|total| total.checked_add(value.len()))
+                    .ok_or_else(table_budget_overflow)
+            }),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -154,66 +176,126 @@ pub(crate) struct TableData {
 
 impl TableData {
     pub(crate) fn new(table: Table, columns: Vec<ColumnValues>) -> Result<Self, ColumnarError> {
-        let schema = table.schema();
-        if columns.len() != schema.columns.len() {
-            return Err(ColumnarError::malformed(
-                "table columns",
-                format!(
-                    "{} has {} columns, expected {}",
-                    table.name(),
-                    columns.len(),
-                    schema.columns.len()
-                ),
-            ));
-        }
-        let row_count = columns.first().map_or(0, ColumnValues::len);
-        if row_count > i32::MAX as usize {
-            return Err(ColumnarError::LimitExceeded {
-                context: "Parquet row count",
-                value: row_count as u64,
-                maximum: i32::MAX as u64,
-            });
-        }
-        for (column, expected) in columns.iter().zip(schema.columns) {
-            if column.len() != row_count {
-                return Err(ColumnarError::malformed(
-                    "table columns",
-                    format!(
-                        "{}.{} has {} rows, expected {row_count}",
-                        table.name(),
-                        expected.name,
-                        column.len()
-                    ),
-                ));
-            }
-            if column.physical_type() != expected.physical_type {
-                return Err(ColumnarError::malformed(
-                    "table columns",
-                    format!(
-                        "{}.{} has physical type {:?}, expected {:?}",
-                        table.name(),
-                        expected.name,
-                        column.physical_type(),
-                        expected.physical_type
-                    ),
-                ));
-            }
-            if expected.repetition == Repetition::Required && column.null_count() != 0 {
-                return Err(ColumnarError::malformed(
-                    "table columns",
-                    format!(
-                        "required column {}.{} contains null",
-                        table.name(),
-                        expected.name
-                    ),
-                ));
-            }
-        }
+        let row_count = validate_table_columns(table, &columns)?;
+        validate_decoded_table_budget(table, row_count, plain_columns_len(&columns)?)?;
         Ok(Self {
             table,
             columns,
             row_count,
         })
+    }
+}
+
+fn validate_table_columns(table: Table, columns: &[ColumnValues]) -> Result<usize, ColumnarError> {
+    let schema = table.schema();
+    if columns.len() != schema.columns.len() {
+        return Err(ColumnarError::malformed(
+            "table columns",
+            format!(
+                "{} has {} columns, expected {}",
+                table.name(),
+                columns.len(),
+                schema.columns.len()
+            ),
+        ));
+    }
+    let row_count = columns.first().map_or(0, ColumnValues::len);
+    if row_count > i32::MAX as usize {
+        return Err(ColumnarError::LimitExceeded {
+            context: "Parquet row count",
+            value: row_count as u64,
+            maximum: i32::MAX as u64,
+        });
+    }
+    for (column, expected) in columns.iter().zip(schema.columns) {
+        if column.len() != row_count {
+            return Err(ColumnarError::malformed(
+                "table columns",
+                format!(
+                    "{}.{} has {} rows, expected {row_count}",
+                    table.name(),
+                    expected.name,
+                    column.len()
+                ),
+            ));
+        }
+        if column.physical_type() != expected.physical_type {
+            return Err(ColumnarError::malformed(
+                "table columns",
+                format!(
+                    "{}.{} has physical type {:?}, expected {:?}",
+                    table.name(),
+                    expected.name,
+                    column.physical_type(),
+                    expected.physical_type
+                ),
+            ));
+        }
+        if expected.repetition == Repetition::Required && column.null_count() != 0 {
+            return Err(ColumnarError::malformed(
+                "table columns",
+                format!(
+                    "required column {}.{} contains null",
+                    table.name(),
+                    expected.name
+                ),
+            ));
+        }
+    }
+    Ok(row_count)
+}
+
+fn plain_columns_len(columns: &[ColumnValues]) -> Result<usize, ColumnarError> {
+    columns.iter().try_fold(0usize, |total, column| {
+        total
+            .checked_add(column.plain_len()?)
+            .ok_or_else(table_budget_overflow)
+    })
+}
+
+fn validate_decoded_table_budget(
+    table: Table,
+    row_count: usize,
+    uncompressed_bytes: usize,
+) -> Result<(), ColumnarError> {
+    let bytes_per_row = table
+        .schema()
+        .columns
+        .iter()
+        .try_fold(0usize, |total, column| {
+            let slot = match column.physical_type {
+                PhysicalType::Int64 => size_of::<Option<i64>>(),
+                PhysicalType::ByteArray => size_of::<Option<Vec<u8>>>(),
+            };
+            total.checked_add(slot).ok_or_else(table_budget_overflow)
+        })?;
+    let decoded_bytes = bytes_per_row
+        .checked_mul(row_count)
+        .and_then(|slots| slots.checked_add(uncompressed_bytes))
+        .ok_or_else(table_budget_overflow)?;
+    if decoded_bytes > MAX_DECODED_TABLE_BYTES {
+        return Err(ColumnarError::LimitExceeded {
+            context: "decoded Parquet table bytes",
+            value: decoded_bytes as u64,
+            maximum: MAX_DECODED_TABLE_BYTES as u64,
+        });
+    }
+    Ok(())
+}
+
+fn table_budget_overflow() -> ColumnarError {
+    ColumnarError::LimitExceeded {
+        context: "decoded Parquet table bytes",
+        value: u64::MAX,
+        maximum: MAX_DECODED_TABLE_BYTES as u64,
+    }
+}
+
+pub(crate) const fn bounded_row_capacity(row_count: usize) -> usize {
+    if row_count < MAX_INITIAL_ROW_CAPACITY {
+        row_count
+    } else {
+        MAX_INITIAL_ROW_CAPACITY
     }
 }
 
@@ -261,6 +343,22 @@ pub(crate) fn write_table(
         }
     }
 
+    let total_uncompressed = columns.iter().try_fold(0i64, |total, column| {
+        total
+            .checked_add(column.total_uncompressed_size)
+            .ok_or_else(|| {
+                ColumnarError::malformed(
+                    "row group metadata",
+                    "uncompressed byte total overflows i64",
+                )
+            })
+    })?;
+    validate_decoded_table_budget(
+        data.table,
+        data.row_count,
+        nonnegative_usize(total_uncompressed, "row group uncompressed byte size")?,
+    )?;
+
     let footer = encode_file_metadata(data, &columns);
     let footer_len = u32::try_from(footer.len()).map_err(|_| ColumnarError::LimitExceeded {
         context: "Parquet footer length",
@@ -274,13 +372,14 @@ pub(crate) fn write_table(
 }
 
 fn validate_table_data(data: &TableData) -> Result<(), ColumnarError> {
-    let rebuilt = TableData::new(data.table, data.columns.clone())?;
-    if rebuilt.row_count != data.row_count {
+    let row_count = validate_table_columns(data.table, &data.columns)?;
+    validate_decoded_table_budget(data.table, row_count, plain_columns_len(&data.columns)?)?;
+    if row_count != data.row_count {
         return Err(ColumnarError::malformed(
             "table row count",
             format!(
                 "stored row count {} disagrees with columns {}",
-                data.row_count, rebuilt.row_count
+                data.row_count, row_count
             ),
         ));
     }
@@ -306,12 +405,13 @@ fn encode_column(
         Vec::new()
     };
     let plain = values.encode_plain()?;
+    let plain_len = plain.len();
     let compressed_values = match compression {
-        Compression::Uncompressed => plain.clone(),
+        Compression::Uncompressed => plain,
         Compression::Zstd => compress_slice_to_vec(&plain, CompressionLevel::Level(3)),
     };
     let uncompressed_page_size = checked_i32_len(
-        definitions.len().checked_add(plain.len()).ok_or_else(|| {
+        definitions.len().checked_add(plain_len).ok_or_else(|| {
             ColumnarError::malformed("Parquet page size", "length addition overflows usize")
         })?,
         "Parquet uncompressed page size",
@@ -563,6 +663,32 @@ pub(crate) fn read_table(bytes: &[u8], table: Table) -> Result<TableData, Column
     }
 
     let row_group = &metadata.row_groups[0];
+    let declared_uncompressed_total =
+        row_group.columns.iter().try_fold(0i64, |total, column| {
+            total
+                .checked_add(column.metadata.total_uncompressed_size)
+                .ok_or_else(|| {
+                    ColumnarError::malformed(
+                        "row group metadata",
+                        "uncompressed byte total overflows i64",
+                    )
+                })
+        })?;
+    if row_group.total_byte_size != declared_uncompressed_total {
+        return Err(ColumnarError::malformed(
+            "row group metadata",
+            "total_byte_size disagrees with column chunks",
+        ));
+    }
+    validate_decoded_table_budget(
+        table,
+        row_count,
+        nonnegative_usize(
+            declared_uncompressed_total,
+            "row group uncompressed byte size",
+        )?,
+    )?;
+
     let mut cursor = PARQUET_MAGIC.len();
     let mut decoded = Vec::with_capacity(row_group.columns.len());
     let mut uncompressed_total = 0i64;
@@ -609,7 +735,6 @@ pub(crate) fn read_table(bytes: &[u8], table: Table) -> Result<TableData, Column
         let page = page_region
             .get(..page_len)
             .ok_or_else(|| ColumnarError::truncated("column page", page_len, page_region.len()))?;
-        decoded.push(decode_page(page, &header, schema, row_count, compression)?);
 
         let computed_uncompressed = i64::try_from(header.header_len)
             .expect("header length fits i64")
@@ -638,6 +763,9 @@ pub(crate) fn read_table(bytes: &[u8], table: Table) -> Result<TableData, Column
                 ),
             ));
         }
+        // Validate every metadata cross-reference before allocating the decoded
+        // column or entering the decompressor.
+        decoded.push(decode_page(page, &header, schema, row_count, compression)?);
         uncompressed_total += computed_uncompressed;
         compressed_total += computed_compressed;
         cursor = cursor.checked_add(page_len).ok_or_else(|| {
@@ -650,7 +778,7 @@ pub(crate) fn read_table(bytes: &[u8], table: Table) -> Result<TableData, Column
             format!("pages end at {cursor}, footer begins at {footer_start}"),
         ));
     }
-    if row_group.total_byte_size != uncompressed_total {
+    if declared_uncompressed_total != uncompressed_total {
         return Err(ColumnarError::malformed(
             "row group metadata",
             "total_byte_size disagrees with column chunks",
@@ -1315,6 +1443,13 @@ fn decode_page(
                 "smaller than definition-level section",
             )
         })?;
+    if plain_len > MAX_DECODED_TABLE_BYTES {
+        return Err(ColumnarError::LimitExceeded {
+            context: "uncompressed Parquet page value bytes",
+            value: plain_len as u64,
+            maximum: MAX_DECODED_TABLE_BYTES as u64,
+        });
+    }
     let plain = match compression {
         Compression::Uncompressed => {
             if encoded_values.len() != plain_len {
@@ -1361,7 +1496,7 @@ fn decode_page(
 
 fn decode_definition_levels(bytes: &[u8], row_count: usize) -> Result<Vec<bool>, ColumnarError> {
     let mut pos = 0usize;
-    let mut levels = Vec::with_capacity(row_count);
+    let mut levels = Vec::with_capacity(bounded_row_capacity(row_count));
     while levels.len() < row_count {
         let header = read_varint(bytes, &mut pos)
             .map_err(|error| ColumnarError::malformed("definition-level RLE", error.to_string()))?;
@@ -1409,7 +1544,7 @@ fn decode_plain(
     let mut pos = 0usize;
     match physical_type {
         PhysicalType::Int64 => {
-            let mut values = Vec::with_capacity(definitions.len());
+            let mut values = Vec::with_capacity(bounded_row_capacity(definitions.len()));
             for &present in definitions {
                 if !present {
                     values.push(None);
@@ -1435,7 +1570,7 @@ fn decode_plain(
             Ok(ColumnValues::Int64(values))
         }
         PhysicalType::ByteArray => {
-            let mut values = Vec::with_capacity(definitions.len());
+            let mut values = Vec::with_capacity(bounded_row_capacity(definitions.len()));
             for &present in definitions {
                 if !present {
                     values.push(None);
@@ -1586,5 +1721,50 @@ mod tests {
         let mut encoded = encode_definition_levels([true, true, false].into_iter());
         encoded.push(0);
         assert!(decode_definition_levels(&encoded, 3).is_err());
+    }
+
+    #[test]
+    fn decoded_table_budget_rejects_adversarial_row_counts() {
+        assert!(matches!(
+            validate_decoded_table_budget(Table::Quads, i32::MAX as usize, 0),
+            Err(ColumnarError::LimitExceeded {
+                context: "decoded Parquet table bytes",
+                ..
+            })
+        ));
+        assert_eq!(bounded_row_capacity(usize::MAX), 65_536);
+    }
+
+    #[test]
+    fn oversized_zstd_output_is_rejected_before_allocation() {
+        let oversized = MAX_DECODED_TABLE_BYTES + 1;
+        let header = ParsedPageHeader {
+            page_type: PAGE_TYPE_DATA_V2,
+            uncompressed_page_size: i32::try_from(oversized).unwrap(),
+            compressed_page_size: 0,
+            data_v2: ParsedDataPageV2 {
+                num_values: 1,
+                num_nulls: 0,
+                num_rows: 1,
+                encoding: ENCODING_PLAIN,
+                definition_levels_byte_length: 0,
+                repetition_levels_byte_length: 0,
+                is_compressed: true,
+            },
+            header_len: 0,
+        };
+        assert!(matches!(
+            decode_page(
+                &[],
+                &header,
+                &Table::Quads.schema().columns[0],
+                1,
+                Compression::Zstd,
+            ),
+            Err(ColumnarError::LimitExceeded {
+                context: "uncompressed Parquet page value bytes",
+                ..
+            })
+        ));
     }
 }

--- a/crates/columnar/src/parquet.rs
+++ b/crates/columnar/src/parquet.rs
@@ -1,0 +1,1590 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Narrow, deterministic Parquet Data Page V2 encoder/decoder.
+
+use std::collections::BTreeMap;
+
+use purrdf_core::ir::pack::bits::{read_varint, write_varint};
+use structured_zstd::decoding::FrameDecoder;
+use structured_zstd::encoding::{CompressionLevel, compress_slice_to_vec};
+
+use crate::compact::{CompactField, CompactReader, CompactWriter, StructState, TYPE_STRUCT};
+use crate::{ColumnSchema, ColumnarError, PhysicalType, Repetition, Table};
+
+const PARQUET_MAGIC: &[u8; 4] = b"PAR1";
+const FILE_VERSION: i32 = 1;
+const SCHEMA_VERSION: &str = "1";
+const META_SCHEMA_VERSION: &str = "purrdf.columnar.schema-version";
+const META_TABLE: &str = "purrdf.columnar.table";
+
+const PARQUET_TYPE_INT64: i32 = 2;
+const PARQUET_TYPE_BYTE_ARRAY: i32 = 6;
+const REPETITION_REQUIRED: i32 = 0;
+const REPETITION_OPTIONAL: i32 = 1;
+const CONVERTED_TYPE_UTF8: i32 = 0;
+const ENCODING_PLAIN: i32 = 0;
+const ENCODING_RLE: i32 = 3;
+const CODEC_UNCOMPRESSED: i32 = 0;
+const CODEC_ZSTD: i32 = 6;
+const PAGE_TYPE_DATA_V2: i32 = 3;
+
+/// Page compression selected for one deterministic five-table write.
+///
+/// This is a runtime value, never a Cargo feature: both modes are always
+/// compiled and readable on every supported target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Compression {
+    /// Store PLAIN value bodies verbatim.
+    #[default]
+    Uncompressed,
+    /// Compress each PLAIN value body as one deterministic Zstandard frame.
+    Zstd,
+}
+
+impl Compression {
+    const fn parquet_id(self) -> i32 {
+        match self {
+            Self::Uncompressed => CODEC_UNCOMPRESSED,
+            Self::Zstd => CODEC_ZSTD,
+        }
+    }
+
+    fn from_parquet_id(value: i32) -> Result<Self, ColumnarError> {
+        match value {
+            CODEC_UNCOMPRESSED => Ok(Self::Uncompressed),
+            CODEC_ZSTD => Ok(Self::Zstd),
+            _ => Err(ColumnarError::Unsupported {
+                context: "Parquet compression codec",
+                value: i64::from(value),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ColumnValues {
+    Int64(Vec<Option<i64>>),
+    ByteArray(Vec<Option<Vec<u8>>>),
+}
+
+impl ColumnValues {
+    pub(crate) fn int64(values: Vec<Option<i64>>) -> Self {
+        Self::Int64(values)
+    }
+
+    pub(crate) fn bytes(values: Vec<Option<Vec<u8>>>) -> Self {
+        Self::ByteArray(values)
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Int64(values) => values.len(),
+            Self::ByteArray(values) => values.len(),
+        }
+    }
+
+    fn physical_type(&self) -> PhysicalType {
+        match self {
+            Self::Int64(_) => PhysicalType::Int64,
+            Self::ByteArray(_) => PhysicalType::ByteArray,
+        }
+    }
+
+    fn null_count(&self) -> usize {
+        match self {
+            Self::Int64(values) => values.iter().filter(|value| value.is_none()).count(),
+            Self::ByteArray(values) => values.iter().filter(|value| value.is_none()).count(),
+        }
+    }
+
+    fn definition_levels(&self) -> impl Iterator<Item = bool> + '_ {
+        enum Iter<'a> {
+            Int(std::slice::Iter<'a, Option<i64>>),
+            Bytes(std::slice::Iter<'a, Option<Vec<u8>>>),
+        }
+        impl Iterator for Iter<'_> {
+            type Item = bool;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                match self {
+                    Self::Int(values) => values.next().map(Option::is_some),
+                    Self::Bytes(values) => values.next().map(Option::is_some),
+                }
+            }
+        }
+        match self {
+            Self::Int64(values) => Iter::Int(values.iter()),
+            Self::ByteArray(values) => Iter::Bytes(values.iter()),
+        }
+    }
+
+    fn encode_plain(&self) -> Result<Vec<u8>, ColumnarError> {
+        let mut out = Vec::new();
+        match self {
+            Self::Int64(values) => {
+                out.reserve(values.len().saturating_sub(self.null_count()) * size_of::<i64>());
+                for value in values.iter().flatten() {
+                    out.extend_from_slice(&value.to_le_bytes());
+                }
+            }
+            Self::ByteArray(values) => {
+                for value in values.iter().flatten() {
+                    let len =
+                        i32::try_from(value.len()).map_err(|_| ColumnarError::LimitExceeded {
+                            context: "PLAIN BYTE_ARRAY length",
+                            value: value.len() as u64,
+                            maximum: i32::MAX as u64,
+                        })?;
+                    out.extend_from_slice(&len.to_le_bytes());
+                    out.extend_from_slice(value);
+                }
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TableData {
+    pub(crate) table: Table,
+    pub(crate) columns: Vec<ColumnValues>,
+    pub(crate) row_count: usize,
+}
+
+impl TableData {
+    pub(crate) fn new(table: Table, columns: Vec<ColumnValues>) -> Result<Self, ColumnarError> {
+        let schema = table.schema();
+        if columns.len() != schema.columns.len() {
+            return Err(ColumnarError::malformed(
+                "table columns",
+                format!(
+                    "{} has {} columns, expected {}",
+                    table.name(),
+                    columns.len(),
+                    schema.columns.len()
+                ),
+            ));
+        }
+        let row_count = columns.first().map_or(0, ColumnValues::len);
+        if row_count > i32::MAX as usize {
+            return Err(ColumnarError::LimitExceeded {
+                context: "Parquet row count",
+                value: row_count as u64,
+                maximum: i32::MAX as u64,
+            });
+        }
+        for (column, expected) in columns.iter().zip(schema.columns) {
+            if column.len() != row_count {
+                return Err(ColumnarError::malformed(
+                    "table columns",
+                    format!(
+                        "{}.{} has {} rows, expected {row_count}",
+                        table.name(),
+                        expected.name,
+                        column.len()
+                    ),
+                ));
+            }
+            if column.physical_type() != expected.physical_type {
+                return Err(ColumnarError::malformed(
+                    "table columns",
+                    format!(
+                        "{}.{} has physical type {:?}, expected {:?}",
+                        table.name(),
+                        expected.name,
+                        column.physical_type(),
+                        expected.physical_type
+                    ),
+                ));
+            }
+            if expected.repetition == Repetition::Required && column.null_count() != 0 {
+                return Err(ColumnarError::malformed(
+                    "table columns",
+                    format!(
+                        "required column {}.{} contains null",
+                        table.name(),
+                        expected.name
+                    ),
+                ));
+            }
+        }
+        Ok(Self {
+            table,
+            columns,
+            row_count,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct EncodedColumn {
+    physical_type: i32,
+    encodings: Vec<i32>,
+    path: &'static str,
+    codec: i32,
+    num_values: i64,
+    total_uncompressed_size: i64,
+    total_compressed_size: i64,
+    data_page_offset: i64,
+}
+
+pub(crate) fn write_table(
+    data: &TableData,
+    compression: Compression,
+) -> Result<Vec<u8>, ColumnarError> {
+    validate_table_data(data)?;
+    let mut out = PARQUET_MAGIC.to_vec();
+    let mut columns = Vec::with_capacity(data.columns.len());
+
+    if data.row_count > 0 {
+        for (values, schema) in data.columns.iter().zip(data.table.schema().columns) {
+            let data_page_offset = i64::try_from(out.len()).map_err(|_| {
+                ColumnarError::limit("Parquet file offset", out.len(), i64::MAX as usize)
+            })?;
+            let encoded = encode_column(values, schema, data.row_count, compression)?;
+            out.extend_from_slice(&encoded.bytes);
+            columns.push(EncodedColumn {
+                physical_type: parquet_physical_type(schema.physical_type),
+                encodings: if schema.repetition == Repetition::Optional {
+                    vec![ENCODING_PLAIN, ENCODING_RLE]
+                } else {
+                    vec![ENCODING_PLAIN]
+                },
+                path: schema.name,
+                codec: compression.parquet_id(),
+                num_values: data.row_count as i64,
+                total_uncompressed_size: encoded.total_uncompressed_size,
+                total_compressed_size: encoded.total_compressed_size,
+                data_page_offset,
+            });
+        }
+    }
+
+    let footer = encode_file_metadata(data, &columns);
+    let footer_len = u32::try_from(footer.len()).map_err(|_| ColumnarError::LimitExceeded {
+        context: "Parquet footer length",
+        value: footer.len() as u64,
+        maximum: u32::MAX as u64,
+    })?;
+    out.extend_from_slice(&footer);
+    out.extend_from_slice(&footer_len.to_le_bytes());
+    out.extend_from_slice(PARQUET_MAGIC);
+    Ok(out)
+}
+
+fn validate_table_data(data: &TableData) -> Result<(), ColumnarError> {
+    let rebuilt = TableData::new(data.table, data.columns.clone())?;
+    if rebuilt.row_count != data.row_count {
+        return Err(ColumnarError::malformed(
+            "table row count",
+            format!(
+                "stored row count {} disagrees with columns {}",
+                data.row_count, rebuilt.row_count
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct EncodedPage {
+    bytes: Vec<u8>,
+    total_uncompressed_size: i64,
+    total_compressed_size: i64,
+}
+
+fn encode_column(
+    values: &ColumnValues,
+    schema: &ColumnSchema,
+    row_count: usize,
+    compression: Compression,
+) -> Result<EncodedPage, ColumnarError> {
+    let definitions = if schema.repetition == Repetition::Optional {
+        encode_definition_levels(values.definition_levels())
+    } else {
+        Vec::new()
+    };
+    let plain = values.encode_plain()?;
+    let compressed_values = match compression {
+        Compression::Uncompressed => plain.clone(),
+        Compression::Zstd => compress_slice_to_vec(&plain, CompressionLevel::Level(3)),
+    };
+    let uncompressed_page_size = checked_i32_len(
+        definitions.len().checked_add(plain.len()).ok_or_else(|| {
+            ColumnarError::malformed("Parquet page size", "length addition overflows usize")
+        })?,
+        "Parquet uncompressed page size",
+    )?;
+    let compressed_page_size = checked_i32_len(
+        definitions
+            .len()
+            .checked_add(compressed_values.len())
+            .ok_or_else(|| {
+                ColumnarError::malformed("Parquet page size", "length addition overflows usize")
+            })?,
+        "Parquet compressed page size",
+    )?;
+    let definition_len = checked_i32_len(definitions.len(), "definition-level byte length")?;
+    let row_count = i32::try_from(row_count).expect("TableData bounded row count");
+    let null_count = i32::try_from(values.null_count()).expect("null count <= row count");
+    let header = CompactWriter::root(|writer| {
+        writer.i32_field(1, PAGE_TYPE_DATA_V2);
+        writer.i32_field(2, uncompressed_page_size);
+        writer.i32_field(3, compressed_page_size);
+        writer.struct_field(8, |writer| {
+            writer.i32_field(1, row_count);
+            writer.i32_field(2, null_count);
+            writer.i32_field(3, row_count);
+            writer.i32_field(4, ENCODING_PLAIN);
+            writer.i32_field(5, definition_len);
+            writer.i32_field(6, 0);
+            writer.bool_field(7, compression == Compression::Zstd);
+        });
+    });
+    let mut bytes = Vec::with_capacity(header.len() + definitions.len() + compressed_values.len());
+    bytes.extend_from_slice(&header);
+    bytes.extend_from_slice(&definitions);
+    bytes.extend_from_slice(&compressed_values);
+    let total_uncompressed_size = i64::try_from(header.len()).expect("header length fits i64")
+        + i64::from(uncompressed_page_size);
+    let total_compressed_size = i64::try_from(bytes.len()).map_err(|_| {
+        ColumnarError::limit("column chunk byte length", bytes.len(), i64::MAX as usize)
+    })?;
+    Ok(EncodedPage {
+        bytes,
+        total_uncompressed_size,
+        total_compressed_size,
+    })
+}
+
+fn encode_definition_levels(levels: impl Iterator<Item = bool>) -> Vec<u8> {
+    let mut levels = levels.peekable();
+    let mut out = Vec::new();
+    while let Some(level) = levels.next() {
+        let mut run_len = 1u64;
+        while levels.next_if_eq(&level).is_some() {
+            run_len += 1;
+        }
+        write_varint(&mut out, run_len << 1);
+        out.push(u8::from(level));
+    }
+    out
+}
+
+fn encode_file_metadata(data: &TableData, columns: &[EncodedColumn]) -> Vec<u8> {
+    let schema_nodes: Vec<Option<&ColumnSchema>> = std::iter::once(None)
+        .chain(data.table.schema().columns.iter().map(Some))
+        .collect();
+    let row_groups = if data.row_count == 0 {
+        &[][..]
+    } else {
+        &[()][..]
+    };
+    let metadata = [
+        (META_SCHEMA_VERSION, SCHEMA_VERSION),
+        (META_TABLE, data.table.name()),
+    ];
+
+    CompactWriter::root(|writer| {
+        writer.i32_field(1, FILE_VERSION);
+        writer.list_struct_field(2, &schema_nodes, |writer, node| match node {
+            None => {
+                writer.string_field(4, "schema");
+                writer.i32_field(5, data.table.schema().columns.len() as i32);
+            }
+            Some(column) => write_schema_element(writer, column),
+        });
+        writer.i64_field(3, data.row_count as i64);
+        writer.list_struct_field(4, row_groups, |writer, _| {
+            writer.list_struct_field(1, columns, write_column_chunk);
+            writer.i64_field(
+                2,
+                columns
+                    .iter()
+                    .map(|column| column.total_uncompressed_size)
+                    .sum(),
+            );
+            writer.i64_field(3, data.row_count as i64);
+            writer.i64_field(5, 4);
+            writer.i64_field(
+                6,
+                columns
+                    .iter()
+                    .map(|column| column.total_compressed_size)
+                    .sum(),
+            );
+        });
+        writer.list_struct_field(5, &metadata, |writer, (key, value)| {
+            writer.string_field(1, key);
+            writer.string_field(2, value);
+        });
+    })
+}
+
+fn write_schema_element(writer: &mut CompactWriter, column: &ColumnSchema) {
+    writer.i32_field(1, parquet_physical_type(column.physical_type));
+    writer.i32_field(
+        3,
+        match column.repetition {
+            Repetition::Required => REPETITION_REQUIRED,
+            Repetition::Optional => REPETITION_OPTIONAL,
+        },
+    );
+    writer.string_field(4, column.name);
+    if column.utf8 {
+        writer.i32_field(6, CONVERTED_TYPE_UTF8);
+        writer.struct_field(10, |writer| {
+            writer.struct_field(1, |_| {});
+        });
+    }
+}
+
+fn write_column_chunk(writer: &mut CompactWriter, column: &EncodedColumn) {
+    writer.i64_field(2, 0);
+    writer.struct_field(3, |writer| {
+        writer.i32_field(1, column.physical_type);
+        writer.list_i32_field(2, &column.encodings);
+        writer.list_string_field(3, &[column.path]);
+        writer.i32_field(4, column.codec);
+        writer.i64_field(5, column.num_values);
+        writer.i64_field(6, column.total_uncompressed_size);
+        writer.i64_field(7, column.total_compressed_size);
+        writer.i64_field(9, column.data_page_offset);
+    });
+}
+
+const fn parquet_physical_type(physical_type: PhysicalType) -> i32 {
+    match physical_type {
+        PhysicalType::Int64 => PARQUET_TYPE_INT64,
+        PhysicalType::ByteArray => PARQUET_TYPE_BYTE_ARRAY,
+    }
+}
+
+fn checked_i32_len(len: usize, context: &'static str) -> Result<i32, ColumnarError> {
+    i32::try_from(len).map_err(|_| ColumnarError::LimitExceeded {
+        context,
+        value: len as u64,
+        maximum: i32::MAX as u64,
+    })
+}
+
+// ── Metadata reader ────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct ParsedSchemaElement {
+    physical_type: Option<i32>,
+    repetition: Option<i32>,
+    name: String,
+    num_children: Option<i32>,
+    converted_type: Option<i32>,
+    logical_utf8: bool,
+}
+
+#[derive(Debug)]
+struct ParsedColumnMeta {
+    physical_type: i32,
+    encodings: Vec<i32>,
+    path: Vec<String>,
+    codec: i32,
+    num_values: i64,
+    total_uncompressed_size: i64,
+    total_compressed_size: i64,
+    data_page_offset: i64,
+}
+
+#[derive(Debug)]
+struct ParsedColumnChunk {
+    file_offset: i64,
+    metadata: ParsedColumnMeta,
+}
+
+#[derive(Debug)]
+struct ParsedRowGroup {
+    columns: Vec<ParsedColumnChunk>,
+    total_byte_size: i64,
+    num_rows: i64,
+    file_offset: Option<i64>,
+    total_compressed_size: Option<i64>,
+}
+
+#[derive(Debug)]
+struct ParsedFileMeta {
+    version: i32,
+    schema: Vec<ParsedSchemaElement>,
+    num_rows: i64,
+    row_groups: Vec<ParsedRowGroup>,
+    metadata: BTreeMap<String, String>,
+}
+
+#[derive(Debug)]
+struct ParsedDataPageV2 {
+    num_values: i32,
+    num_nulls: i32,
+    num_rows: i32,
+    encoding: i32,
+    definition_levels_byte_length: i32,
+    repetition_levels_byte_length: i32,
+    is_compressed: bool,
+}
+
+#[derive(Debug)]
+struct ParsedPageHeader {
+    page_type: i32,
+    uncompressed_page_size: i32,
+    compressed_page_size: i32,
+    data_v2: ParsedDataPageV2,
+    header_len: usize,
+}
+
+pub(crate) fn read_table(bytes: &[u8], table: Table) -> Result<TableData, ColumnarError> {
+    let (footer_start, footer) = split_parquet_file(bytes)?;
+    let metadata = parse_file_metadata(footer)?;
+    validate_file_metadata(&metadata, table)?;
+    let row_count = nonnegative_usize(metadata.num_rows, "Parquet file row count")?;
+
+    if row_count == 0 {
+        if footer_start != PARQUET_MAGIC.len() {
+            return Err(ColumnarError::malformed(
+                "empty Parquet table",
+                "zero-row file contains page bytes",
+            ));
+        }
+        let columns = table
+            .schema()
+            .columns
+            .iter()
+            .map(|column| match column.physical_type {
+                PhysicalType::Int64 => ColumnValues::Int64(Vec::new()),
+                PhysicalType::ByteArray => ColumnValues::ByteArray(Vec::new()),
+            })
+            .collect();
+        return TableData::new(table, columns);
+    }
+
+    let row_group = &metadata.row_groups[0];
+    let mut cursor = PARQUET_MAGIC.len();
+    let mut decoded = Vec::with_capacity(row_group.columns.len());
+    let mut uncompressed_total = 0i64;
+    let mut compressed_total = 0i64;
+    let mut observed_compression = None;
+    for ((chunk, schema), expected_index) in row_group
+        .columns
+        .iter()
+        .zip(table.schema().columns)
+        .zip(0usize..)
+    {
+        let column = &chunk.metadata;
+        let offset = nonnegative_usize(column.data_page_offset, "data page offset")?;
+        if offset != cursor {
+            return Err(ColumnarError::malformed(
+                "column chunk layout",
+                format!(
+                    "column {expected_index} starts at {offset}, expected contiguous offset {cursor}"
+                ),
+            ));
+        }
+        let compression = Compression::from_parquet_id(column.codec)?;
+        if let Some(previous) = observed_compression {
+            if previous != compression {
+                return Err(ColumnarError::malformed(
+                    "column chunk compression",
+                    "one table mixes compression codecs",
+                ));
+            }
+        } else {
+            observed_compression = Some(compression);
+        }
+        let page_region = bytes
+            .get(offset..footer_start)
+            .ok_or_else(|| ColumnarError::truncated("column page", offset, footer_start))?;
+        let header = parse_page_header(page_region)?;
+        let body_len = nonnegative_usize(
+            i64::from(header.compressed_page_size),
+            "compressed page size",
+        )?;
+        let page_len = header.header_len.checked_add(body_len).ok_or_else(|| {
+            ColumnarError::malformed("column page", "page length overflows usize")
+        })?;
+        let page = page_region
+            .get(..page_len)
+            .ok_or_else(|| ColumnarError::truncated("column page", page_len, page_region.len()))?;
+        decoded.push(decode_page(page, &header, schema, row_count, compression)?);
+
+        let computed_uncompressed = i64::try_from(header.header_len)
+            .expect("header length fits i64")
+            + i64::from(header.uncompressed_page_size);
+        if computed_uncompressed != column.total_uncompressed_size {
+            return Err(ColumnarError::malformed(
+                "column metadata",
+                format!(
+                    "{}.{} uncompressed size {} disagrees with page {computed_uncompressed}",
+                    table.name(),
+                    schema.name,
+                    column.total_uncompressed_size
+                ),
+            ));
+        }
+        let computed_compressed = i64::try_from(page_len)
+            .map_err(|_| ColumnarError::limit("column page length", page_len, i64::MAX as usize))?;
+        if computed_compressed != column.total_compressed_size {
+            return Err(ColumnarError::malformed(
+                "column metadata",
+                format!(
+                    "{}.{} compressed size {} disagrees with page {computed_compressed}",
+                    table.name(),
+                    schema.name,
+                    column.total_compressed_size
+                ),
+            ));
+        }
+        uncompressed_total += computed_uncompressed;
+        compressed_total += computed_compressed;
+        cursor = cursor.checked_add(page_len).ok_or_else(|| {
+            ColumnarError::malformed("column chunk layout", "offset overflows usize")
+        })?;
+    }
+    if cursor != footer_start {
+        return Err(ColumnarError::malformed(
+            "column chunk layout",
+            format!("pages end at {cursor}, footer begins at {footer_start}"),
+        ));
+    }
+    if row_group.total_byte_size != uncompressed_total {
+        return Err(ColumnarError::malformed(
+            "row group metadata",
+            "total_byte_size disagrees with column chunks",
+        ));
+    }
+    if row_group.total_compressed_size != Some(compressed_total) {
+        return Err(ColumnarError::malformed(
+            "row group metadata",
+            "total_compressed_size disagrees with column chunks",
+        ));
+    }
+    TableData::new(table, decoded)
+}
+
+fn split_parquet_file(bytes: &[u8]) -> Result<(usize, &[u8]), ColumnarError> {
+    if bytes.len() < 12 {
+        return Err(ColumnarError::truncated("Parquet file", 12, bytes.len()));
+    }
+    if bytes.get(..4) != Some(PARQUET_MAGIC) || bytes.get(bytes.len() - 4..) != Some(PARQUET_MAGIC)
+    {
+        return Err(ColumnarError::malformed(
+            "Parquet file",
+            "missing PAR1 magic",
+        ));
+    }
+    let footer_len = u32::from_le_bytes(
+        bytes[bytes.len() - 8..bytes.len() - 4]
+            .try_into()
+            .expect("four-byte footer length"),
+    ) as usize;
+    let footer_start = bytes
+        .len()
+        .checked_sub(8)
+        .and_then(|end| end.checked_sub(footer_len))
+        .ok_or_else(|| {
+            ColumnarError::malformed("Parquet footer", "declared length exceeds file")
+        })?;
+    if footer_start < PARQUET_MAGIC.len() {
+        return Err(ColumnarError::malformed(
+            "Parquet footer",
+            "footer overlaps leading magic",
+        ));
+    }
+    Ok((footer_start, &bytes[footer_start..bytes.len() - 8]))
+}
+
+fn parse_file_metadata(bytes: &[u8]) -> Result<ParsedFileMeta, ColumnarError> {
+    let mut reader = CompactReader::new(bytes);
+    let mut state = StructState::default();
+    let mut version = None;
+    let mut schema = None;
+    let mut num_rows = None;
+    let mut row_groups = None;
+    let mut metadata = None;
+    while let Some(field) = reader.next_field(&mut state)? {
+        match field.id {
+            1 => set_once(&mut version, reader.read_i32(field)?, "file version")?,
+            2 => {
+                let values = parse_struct_list(&mut reader, field, parse_schema_element)?;
+                set_once(&mut schema, values, "file schema")?;
+            }
+            3 => set_once(&mut num_rows, reader.read_i64(field)?, "file row count")?,
+            4 => {
+                let values = parse_struct_list(&mut reader, field, parse_row_group)?;
+                set_once(&mut row_groups, values, "file row groups")?;
+            }
+            5 => {
+                let pairs = parse_struct_list(&mut reader, field, parse_key_value)?;
+                let mut map = BTreeMap::new();
+                for (key, value) in pairs {
+                    if map.insert(key.clone(), value).is_some() {
+                        return Err(ColumnarError::malformed(
+                            "file key/value metadata",
+                            format!("duplicate key {key}"),
+                        ));
+                    }
+                }
+                set_once(&mut metadata, map, "file key/value metadata")?;
+            }
+            _ => reader.skip_field(field)?,
+        }
+    }
+    if !reader.is_finished() {
+        return Err(ColumnarError::malformed(
+            "Parquet footer",
+            "trailing compact bytes",
+        ));
+    }
+    Ok(ParsedFileMeta {
+        version: required(version, "file version")?,
+        schema: required(schema, "file schema")?,
+        num_rows: required(num_rows, "file row count")?,
+        row_groups: required(row_groups, "file row groups")?,
+        metadata: required(metadata, "file key/value metadata")?,
+    })
+}
+
+fn parse_schema_element(
+    reader: &mut CompactReader<'_>,
+    state: &mut StructState,
+) -> Result<ParsedSchemaElement, ColumnarError> {
+    let mut physical_type = None;
+    let mut repetition = None;
+    let mut name = None;
+    let mut num_children = None;
+    let mut converted_type = None;
+    let mut logical_utf8 = None;
+    while let Some(field) = reader.next_field(state)? {
+        match field.id {
+            1 => set_once(
+                &mut physical_type,
+                reader.read_i32(field)?,
+                "schema physical type",
+            )?,
+            3 => set_once(
+                &mut repetition,
+                reader.read_i32(field)?,
+                "schema repetition",
+            )?,
+            4 => set_once(
+                &mut name,
+                reader.read_string(field)?.to_owned(),
+                "schema name",
+            )?,
+            5 => set_once(
+                &mut num_children,
+                reader.read_i32(field)?,
+                "schema child count",
+            )?,
+            6 => set_once(
+                &mut converted_type,
+                reader.read_i32(field)?,
+                "schema converted type",
+            )?,
+            10 => set_once(
+                &mut logical_utf8,
+                parse_logical_type(reader, field)?,
+                "schema logical type",
+            )?,
+            _ => reader.skip_field(field)?,
+        }
+    }
+    Ok(ParsedSchemaElement {
+        physical_type,
+        repetition,
+        name: required(name, "schema name")?,
+        num_children,
+        converted_type,
+        logical_utf8: logical_utf8.unwrap_or(false),
+    })
+}
+
+fn parse_logical_type(
+    reader: &mut CompactReader<'_>,
+    field: CompactField,
+) -> Result<bool, ColumnarError> {
+    let mut logical = CompactReader::expect_struct(field)?;
+    let mut utf8 = false;
+    while let Some(field) = reader.next_field(&mut logical)? {
+        if field.id == 1 {
+            if utf8 {
+                return Err(ColumnarError::malformed(
+                    "logical type",
+                    "duplicate STRING member",
+                ));
+            }
+            let mut string_type = CompactReader::expect_struct(field)?;
+            if let Some(inner) = reader.next_field(&mut string_type)? {
+                reader.skip_field(inner)?;
+                while let Some(inner) = reader.next_field(&mut string_type)? {
+                    reader.skip_field(inner)?;
+                }
+                return Err(ColumnarError::malformed(
+                    "logical STRING type",
+                    "STRING marker struct is not empty",
+                ));
+            }
+            utf8 = true;
+        } else {
+            reader.skip_field(field)?;
+            return Err(ColumnarError::Unsupported {
+                context: "Parquet logical type field",
+                value: i64::from(field.id),
+            });
+        }
+    }
+    Ok(utf8)
+}
+
+fn parse_row_group(
+    reader: &mut CompactReader<'_>,
+    state: &mut StructState,
+) -> Result<ParsedRowGroup, ColumnarError> {
+    let mut columns = None;
+    let mut total_byte_size = None;
+    let mut num_rows = None;
+    let mut file_offset = None;
+    let mut total_compressed_size = None;
+    while let Some(field) = reader.next_field(state)? {
+        match field.id {
+            1 => set_once(
+                &mut columns,
+                parse_struct_list(reader, field, parse_column_chunk)?,
+                "row group columns",
+            )?,
+            2 => set_once(
+                &mut total_byte_size,
+                reader.read_i64(field)?,
+                "row group byte size",
+            )?,
+            3 => set_once(
+                &mut num_rows,
+                reader.read_i64(field)?,
+                "row group row count",
+            )?,
+            5 => set_once(
+                &mut file_offset,
+                reader.read_i64(field)?,
+                "row group file offset",
+            )?,
+            6 => set_once(
+                &mut total_compressed_size,
+                reader.read_i64(field)?,
+                "row group compressed size",
+            )?,
+            _ => reader.skip_field(field)?,
+        }
+    }
+    Ok(ParsedRowGroup {
+        columns: required(columns, "row group columns")?,
+        total_byte_size: required(total_byte_size, "row group byte size")?,
+        num_rows: required(num_rows, "row group row count")?,
+        file_offset,
+        total_compressed_size,
+    })
+}
+
+fn parse_column_chunk(
+    reader: &mut CompactReader<'_>,
+    state: &mut StructState,
+) -> Result<ParsedColumnChunk, ColumnarError> {
+    let mut file_offset = None;
+    let mut metadata = None;
+    while let Some(field) = reader.next_field(state)? {
+        match field.id {
+            2 => set_once(
+                &mut file_offset,
+                reader.read_i64(field)?,
+                "column chunk file offset",
+            )?,
+            3 => {
+                let mut nested = CompactReader::expect_struct(field)?;
+                set_once(
+                    &mut metadata,
+                    parse_column_metadata(reader, &mut nested)?,
+                    "column metadata",
+                )?;
+            }
+            _ => reader.skip_field(field)?,
+        }
+    }
+    Ok(ParsedColumnChunk {
+        file_offset: required(file_offset, "column chunk file offset")?,
+        metadata: required(metadata, "column metadata")?,
+    })
+}
+
+fn parse_column_metadata(
+    reader: &mut CompactReader<'_>,
+    state: &mut StructState,
+) -> Result<ParsedColumnMeta, ColumnarError> {
+    let mut physical_type = None;
+    let mut encodings = None;
+    let mut path = None;
+    let mut codec = None;
+    let mut num_values = None;
+    let mut total_uncompressed_size = None;
+    let mut total_compressed_size = None;
+    let mut data_page_offset = None;
+    while let Some(field) = reader.next_field(state)? {
+        match field.id {
+            1 => set_once(
+                &mut physical_type,
+                reader.read_i32(field)?,
+                "column physical type",
+            )?,
+            2 => set_once(
+                &mut encodings,
+                reader.read_list_i32(field)?,
+                "column encodings",
+            )?,
+            3 => set_once(&mut path, reader.read_list_strings(field)?, "column path")?,
+            4 => set_once(
+                &mut codec,
+                reader.read_i32(field)?,
+                "column compression codec",
+            )?,
+            5 => set_once(
+                &mut num_values,
+                reader.read_i64(field)?,
+                "column value count",
+            )?,
+            6 => set_once(
+                &mut total_uncompressed_size,
+                reader.read_i64(field)?,
+                "column uncompressed size",
+            )?,
+            7 => set_once(
+                &mut total_compressed_size,
+                reader.read_i64(field)?,
+                "column compressed size",
+            )?,
+            9 => set_once(
+                &mut data_page_offset,
+                reader.read_i64(field)?,
+                "column data page offset",
+            )?,
+            _ => reader.skip_field(field)?,
+        }
+    }
+    Ok(ParsedColumnMeta {
+        physical_type: required(physical_type, "column physical type")?,
+        encodings: required(encodings, "column encodings")?,
+        path: required(path, "column path")?,
+        codec: required(codec, "column compression codec")?,
+        num_values: required(num_values, "column value count")?,
+        total_uncompressed_size: required(total_uncompressed_size, "column uncompressed size")?,
+        total_compressed_size: required(total_compressed_size, "column compressed size")?,
+        data_page_offset: required(data_page_offset, "column data page offset")?,
+    })
+}
+
+fn parse_key_value(
+    reader: &mut CompactReader<'_>,
+    state: &mut StructState,
+) -> Result<(String, String), ColumnarError> {
+    let mut key = None;
+    let mut value = None;
+    while let Some(field) = reader.next_field(state)? {
+        match field.id {
+            1 => set_once(
+                &mut key,
+                reader.read_string(field)?.to_owned(),
+                "metadata key",
+            )?,
+            2 => set_once(
+                &mut value,
+                reader.read_string(field)?.to_owned(),
+                "metadata value",
+            )?,
+            _ => reader.skip_field(field)?,
+        }
+    }
+    Ok((
+        required(key, "metadata key")?,
+        required(value, "metadata value")?,
+    ))
+}
+
+fn parse_struct_list<T>(
+    reader: &mut CompactReader<'_>,
+    field: CompactField,
+    mut parse: impl FnMut(&mut CompactReader<'_>, &mut StructState) -> Result<T, ColumnarError>,
+) -> Result<Vec<T>, ColumnarError> {
+    let (len, element_type) = reader.read_list_header(field)?;
+    if element_type != TYPE_STRUCT {
+        return Err(ColumnarError::malformed(
+            "compact struct list",
+            format!("element type is {element_type}"),
+        ));
+    }
+    let mut values = Vec::with_capacity(len);
+    for _ in 0..len {
+        let mut state = StructState::default();
+        values.push(parse(reader, &mut state)?);
+    }
+    Ok(values)
+}
+
+fn validate_file_metadata(metadata: &ParsedFileMeta, table: Table) -> Result<(), ColumnarError> {
+    if metadata.version != FILE_VERSION {
+        return Err(ColumnarError::Unsupported {
+            context: "Parquet file version",
+            value: i64::from(metadata.version),
+        });
+    }
+    let expected_metadata = BTreeMap::from([
+        (META_SCHEMA_VERSION.to_owned(), SCHEMA_VERSION.to_owned()),
+        (META_TABLE.to_owned(), table.name().to_owned()),
+    ]);
+    if metadata.metadata != expected_metadata {
+        return Err(ColumnarError::malformed(
+            "Parquet key/value metadata",
+            format!(
+                "observed {:?}, expected {:?}",
+                metadata.metadata, expected_metadata
+            ),
+        ));
+    }
+    let expected_schema = table.schema();
+    if metadata.schema.len() != expected_schema.columns.len() + 1 {
+        return Err(ColumnarError::malformed(
+            "Parquet schema",
+            format!(
+                "has {} nodes, expected {}",
+                metadata.schema.len(),
+                expected_schema.columns.len() + 1
+            ),
+        ));
+    }
+    let root = &metadata.schema[0];
+    if root.physical_type.is_some()
+        || root.repetition.is_some()
+        || root.name != "schema"
+        || root.num_children != Some(expected_schema.columns.len() as i32)
+        || root.converted_type.is_some()
+        || root.logical_utf8
+    {
+        return Err(ColumnarError::malformed(
+            "Parquet schema root",
+            "root shape differs from the fixed flat schema",
+        ));
+    }
+    for (observed, expected) in metadata.schema[1..].iter().zip(expected_schema.columns) {
+        let expected_repetition = match expected.repetition {
+            Repetition::Required => REPETITION_REQUIRED,
+            Repetition::Optional => REPETITION_OPTIONAL,
+        };
+        if observed.physical_type != Some(parquet_physical_type(expected.physical_type))
+            || observed.repetition != Some(expected_repetition)
+            || observed.name != expected.name
+            || observed.num_children.is_some()
+            || observed.converted_type != expected.utf8.then_some(CONVERTED_TYPE_UTF8)
+            || observed.logical_utf8 != expected.utf8
+        {
+            return Err(ColumnarError::malformed(
+                "Parquet schema leaf",
+                format!("column {} differs from the fixed schema", expected.name),
+            ));
+        }
+    }
+
+    let row_count = nonnegative_usize(metadata.num_rows, "Parquet file row count")?;
+    if row_count > i32::MAX as usize {
+        return Err(ColumnarError::LimitExceeded {
+            context: "Parquet file row count",
+            value: row_count as u64,
+            maximum: i32::MAX as u64,
+        });
+    }
+    if row_count == 0 {
+        if !metadata.row_groups.is_empty() {
+            return Err(ColumnarError::malformed(
+                "Parquet row groups",
+                "zero-row table must have no row groups",
+            ));
+        }
+        return Ok(());
+    }
+    if metadata.row_groups.len() != 1 {
+        return Err(ColumnarError::malformed(
+            "Parquet row groups",
+            format!("has {}, expected one", metadata.row_groups.len()),
+        ));
+    }
+    let row_group = &metadata.row_groups[0];
+    if row_group.num_rows != metadata.num_rows
+        || row_group.file_offset != Some(PARQUET_MAGIC.len() as i64)
+        || row_group.total_compressed_size.is_none()
+        || row_group.columns.len() != expected_schema.columns.len()
+    {
+        return Err(ColumnarError::malformed(
+            "Parquet row group",
+            "row count, offset, size, or column count differs from the fixed profile",
+        ));
+    }
+    for (column, expected) in row_group.columns.iter().zip(expected_schema.columns) {
+        let metadata = &column.metadata;
+        let expected_encodings = if expected.repetition == Repetition::Optional {
+            vec![ENCODING_PLAIN, ENCODING_RLE]
+        } else {
+            vec![ENCODING_PLAIN]
+        };
+        if column.file_offset != 0
+            || metadata.physical_type != parquet_physical_type(expected.physical_type)
+            || metadata.encodings != expected_encodings
+            || metadata.path != [expected.name]
+            || metadata.num_values != row_group.num_rows
+            || metadata.total_uncompressed_size <= 0
+            || metadata.total_compressed_size <= 0
+        {
+            return Err(ColumnarError::malformed(
+                "Parquet column metadata",
+                format!("column {} differs from the fixed profile", expected.name),
+            ));
+        }
+        Compression::from_parquet_id(metadata.codec)?;
+    }
+    Ok(())
+}
+
+fn parse_page_header(bytes: &[u8]) -> Result<ParsedPageHeader, ColumnarError> {
+    let mut reader = CompactReader::new(bytes);
+    let mut state = StructState::default();
+    let mut page_type = None;
+    let mut uncompressed_page_size = None;
+    let mut compressed_page_size = None;
+    let mut data_v2 = None;
+    while let Some(field) = reader.next_field(&mut state)? {
+        match field.id {
+            1 => set_once(&mut page_type, reader.read_i32(field)?, "page type")?,
+            2 => set_once(
+                &mut uncompressed_page_size,
+                reader.read_i32(field)?,
+                "uncompressed page size",
+            )?,
+            3 => set_once(
+                &mut compressed_page_size,
+                reader.read_i32(field)?,
+                "compressed page size",
+            )?,
+            8 => {
+                let mut nested = CompactReader::expect_struct(field)?;
+                set_once(
+                    &mut data_v2,
+                    parse_data_page_v2(&mut reader, &mut nested)?,
+                    "data page v2 header",
+                )?;
+            }
+            _ => reader.skip_field(field)?,
+        }
+    }
+    Ok(ParsedPageHeader {
+        page_type: required(page_type, "page type")?,
+        uncompressed_page_size: required(uncompressed_page_size, "uncompressed page size")?,
+        compressed_page_size: required(compressed_page_size, "compressed page size")?,
+        data_v2: required(data_v2, "data page v2 header")?,
+        header_len: reader.position(),
+    })
+}
+
+fn parse_data_page_v2(
+    reader: &mut CompactReader<'_>,
+    state: &mut StructState,
+) -> Result<ParsedDataPageV2, ColumnarError> {
+    let mut num_values = None;
+    let mut num_nulls = None;
+    let mut num_rows = None;
+    let mut encoding = None;
+    let mut definition_levels_byte_length = None;
+    let mut repetition_levels_byte_length = None;
+    let mut is_compressed = None;
+    while let Some(field) = reader.next_field(state)? {
+        match field.id {
+            1 => set_once(
+                &mut num_values,
+                reader.read_i32(field)?,
+                "data page value count",
+            )?,
+            2 => set_once(
+                &mut num_nulls,
+                reader.read_i32(field)?,
+                "data page null count",
+            )?,
+            3 => set_once(
+                &mut num_rows,
+                reader.read_i32(field)?,
+                "data page row count",
+            )?,
+            4 => set_once(&mut encoding, reader.read_i32(field)?, "data page encoding")?,
+            5 => set_once(
+                &mut definition_levels_byte_length,
+                reader.read_i32(field)?,
+                "definition-level byte length",
+            )?,
+            6 => set_once(
+                &mut repetition_levels_byte_length,
+                reader.read_i32(field)?,
+                "repetition-level byte length",
+            )?,
+            7 => set_once(
+                &mut is_compressed,
+                reader.read_bool(field)?,
+                "data page compression flag",
+            )?,
+            _ => reader.skip_field(field)?,
+        }
+    }
+    Ok(ParsedDataPageV2 {
+        num_values: required(num_values, "data page value count")?,
+        num_nulls: required(num_nulls, "data page null count")?,
+        num_rows: required(num_rows, "data page row count")?,
+        encoding: required(encoding, "data page encoding")?,
+        definition_levels_byte_length: required(
+            definition_levels_byte_length,
+            "definition-level byte length",
+        )?,
+        repetition_levels_byte_length: required(
+            repetition_levels_byte_length,
+            "repetition-level byte length",
+        )?,
+        is_compressed: is_compressed.unwrap_or(true),
+    })
+}
+
+fn decode_page(
+    page: &[u8],
+    header: &ParsedPageHeader,
+    schema: &ColumnSchema,
+    row_count: usize,
+    compression: Compression,
+) -> Result<ColumnValues, ColumnarError> {
+    if header.page_type != PAGE_TYPE_DATA_V2 {
+        return Err(ColumnarError::Unsupported {
+            context: "Parquet page type",
+            value: i64::from(header.page_type),
+        });
+    }
+    let data = &header.data_v2;
+    let expected_rows = i32::try_from(row_count).expect("row count bounded by metadata check");
+    if data.num_values != expected_rows
+        || data.num_rows != expected_rows
+        || data.num_nulls < 0
+        || data.num_nulls > expected_rows
+        || data.encoding != ENCODING_PLAIN
+        || data.repetition_levels_byte_length != 0
+        || data.is_compressed != (compression == Compression::Zstd)
+    {
+        return Err(ColumnarError::malformed(
+            "Data Page V2 header",
+            "counts, encoding, repetition levels, or compression flag differ from profile",
+        ));
+    }
+    let definition_len = nonnegative_usize(
+        i64::from(data.definition_levels_byte_length),
+        "definition-level byte length",
+    )?;
+    if (schema.repetition == Repetition::Required && definition_len != 0)
+        || (schema.repetition == Repetition::Optional && definition_len == 0)
+    {
+        return Err(ColumnarError::malformed(
+            "definition levels",
+            "presence disagrees with schema nullability",
+        ));
+    }
+    let body = page
+        .get(header.header_len..)
+        .ok_or_else(|| ColumnarError::truncated("page body", header.header_len, page.len()))?;
+    let definitions_bytes = body
+        .get(..definition_len)
+        .ok_or_else(|| ColumnarError::truncated("definition levels", definition_len, body.len()))?;
+    let encoded_values = &body[definition_len..];
+    let uncompressed_body = nonnegative_usize(
+        i64::from(header.uncompressed_page_size),
+        "uncompressed page size",
+    )?;
+    let plain_len = uncompressed_body
+        .checked_sub(definition_len)
+        .ok_or_else(|| {
+            ColumnarError::malformed(
+                "uncompressed page size",
+                "smaller than definition-level section",
+            )
+        })?;
+    let plain = match compression {
+        Compression::Uncompressed => {
+            if encoded_values.len() != plain_len {
+                return Err(ColumnarError::malformed(
+                    "uncompressed value body",
+                    format!("has {} bytes, expected {plain_len}", encoded_values.len()),
+                ));
+            }
+            encoded_values.to_vec()
+        }
+        Compression::Zstd => {
+            let mut plain = vec![0; plain_len];
+            let written = FrameDecoder::new()
+                .decode_all(encoded_values, &mut plain)
+                .map_err(|error| {
+                    ColumnarError::malformed("Zstandard page body", error.to_string())
+                })?;
+            if written != plain_len {
+                return Err(ColumnarError::malformed(
+                    "Zstandard page body",
+                    format!("decoded {written} bytes, expected {plain_len}"),
+                ));
+            }
+            plain
+        }
+    };
+    let definitions = if schema.repetition == Repetition::Optional {
+        decode_definition_levels(definitions_bytes, row_count)?
+    } else {
+        vec![true; row_count]
+    };
+    let observed_nulls = definitions.iter().filter(|present| !**present).count();
+    if observed_nulls != data.num_nulls as usize {
+        return Err(ColumnarError::malformed(
+            "definition levels",
+            format!(
+                "encode {observed_nulls} nulls, header declares {}",
+                data.num_nulls
+            ),
+        ));
+    }
+    decode_plain(&plain, schema.physical_type, &definitions)
+}
+
+fn decode_definition_levels(bytes: &[u8], row_count: usize) -> Result<Vec<bool>, ColumnarError> {
+    let mut pos = 0usize;
+    let mut levels = Vec::with_capacity(row_count);
+    while levels.len() < row_count {
+        let header = read_varint(bytes, &mut pos)
+            .map_err(|error| ColumnarError::malformed("definition-level RLE", error.to_string()))?;
+        if header & 1 != 0 {
+            return Err(ColumnarError::Unsupported {
+                context: "definition-level bit-packed run",
+                value: header as i64,
+            });
+        }
+        let run_len = usize::try_from(header >> 1).map_err(|_| {
+            ColumnarError::malformed("definition-level RLE", "run length exceeds usize")
+        })?;
+        if run_len == 0 || run_len > row_count - levels.len() {
+            return Err(ColumnarError::malformed(
+                "definition-level RLE",
+                "zero or overlong run",
+            ));
+        }
+        let level = *bytes.get(pos).ok_or_else(|| {
+            ColumnarError::truncated("definition-level RLE value", pos + 1, bytes.len())
+        })?;
+        pos += 1;
+        if level > 1 {
+            return Err(ColumnarError::malformed(
+                "definition-level RLE value",
+                format!("level is {level}, expected 0 or 1"),
+            ));
+        }
+        levels.extend(std::iter::repeat_n(level == 1, run_len));
+    }
+    if pos != bytes.len() {
+        return Err(ColumnarError::malformed(
+            "definition levels",
+            "trailing bytes after final run",
+        ));
+    }
+    Ok(levels)
+}
+
+fn decode_plain(
+    bytes: &[u8],
+    physical_type: PhysicalType,
+    definitions: &[bool],
+) -> Result<ColumnValues, ColumnarError> {
+    let mut pos = 0usize;
+    match physical_type {
+        PhysicalType::Int64 => {
+            let mut values = Vec::with_capacity(definitions.len());
+            for &present in definitions {
+                if !present {
+                    values.push(None);
+                    continue;
+                }
+                let end = pos.checked_add(8).ok_or_else(|| {
+                    ColumnarError::malformed("PLAIN INT64", "offset overflows usize")
+                })?;
+                let raw = bytes
+                    .get(pos..end)
+                    .ok_or_else(|| ColumnarError::truncated("PLAIN INT64", end, bytes.len()))?;
+                values.push(Some(i64::from_le_bytes(
+                    raw.try_into().expect("eight-byte INT64"),
+                )));
+                pos = end;
+            }
+            if pos != bytes.len() {
+                return Err(ColumnarError::malformed(
+                    "PLAIN INT64",
+                    "trailing bytes after values",
+                ));
+            }
+            Ok(ColumnValues::Int64(values))
+        }
+        PhysicalType::ByteArray => {
+            let mut values = Vec::with_capacity(definitions.len());
+            for &present in definitions {
+                if !present {
+                    values.push(None);
+                    continue;
+                }
+                let length_end = pos.checked_add(4).ok_or_else(|| {
+                    ColumnarError::malformed("PLAIN BYTE_ARRAY", "offset overflows usize")
+                })?;
+                let raw_len = bytes.get(pos..length_end).ok_or_else(|| {
+                    ColumnarError::truncated("PLAIN BYTE_ARRAY length", length_end, bytes.len())
+                })?;
+                let len =
+                    i32::from_le_bytes(raw_len.try_into().expect("four-byte BYTE_ARRAY length"));
+                if len < 0 {
+                    return Err(ColumnarError::malformed(
+                        "PLAIN BYTE_ARRAY length",
+                        "negative length",
+                    ));
+                }
+                pos = length_end;
+                let end = pos.checked_add(len as usize).ok_or_else(|| {
+                    ColumnarError::malformed("PLAIN BYTE_ARRAY", "offset overflows usize")
+                })?;
+                let value = bytes.get(pos..end).ok_or_else(|| {
+                    ColumnarError::truncated("PLAIN BYTE_ARRAY value", end, bytes.len())
+                })?;
+                values.push(Some(value.to_vec()));
+                pos = end;
+            }
+            if pos != bytes.len() {
+                return Err(ColumnarError::malformed(
+                    "PLAIN BYTE_ARRAY",
+                    "trailing bytes after values",
+                ));
+            }
+            Ok(ColumnValues::ByteArray(values))
+        }
+    }
+}
+
+fn set_once<T>(slot: &mut Option<T>, value: T, context: &'static str) -> Result<(), ColumnarError> {
+    if slot.replace(value).is_some() {
+        Err(ColumnarError::malformed(context, "duplicate field"))
+    } else {
+        Ok(())
+    }
+}
+
+fn required<T>(slot: Option<T>, context: &'static str) -> Result<T, ColumnarError> {
+    slot.ok_or_else(|| ColumnarError::malformed(context, "required field is absent"))
+}
+
+fn nonnegative_usize(value: i64, context: &'static str) -> Result<usize, ColumnarError> {
+    usize::try_from(value)
+        .map_err(|_| ColumnarError::malformed(context, "value is negative or exceeds usize"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn quads() -> TableData {
+        TableData::new(
+            Table::Quads,
+            vec![
+                ColumnValues::int64(vec![Some(1), Some(4), Some(7)]),
+                ColumnValues::int64(vec![Some(2), Some(5), Some(8)]),
+                ColumnValues::int64(vec![Some(3), Some(6), Some(9)]),
+                ColumnValues::int64(vec![None, Some(10), None]),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn both_compression_modes_round_trip_and_are_deterministic() {
+        let data = quads();
+        for compression in [Compression::Uncompressed, Compression::Zstd] {
+            let first = write_table(&data, compression).unwrap();
+            let second = write_table(&data, compression).unwrap();
+            assert_eq!(first, second);
+            assert_eq!(read_table(&first, Table::Quads).unwrap(), data);
+        }
+    }
+
+    #[test]
+    fn empty_table_has_all_schema_but_no_pages() {
+        let data = TableData::new(
+            Table::Blobs,
+            vec![
+                ColumnValues::bytes(Vec::new()),
+                ColumnValues::bytes(Vec::new()),
+            ],
+        )
+        .unwrap();
+        let bytes = write_table(&data, Compression::Zstd).unwrap();
+        assert_eq!(read_table(&bytes, Table::Blobs).unwrap(), data);
+        let (footer_start, _) = split_parquet_file(&bytes).unwrap();
+        assert_eq!(footer_start, 4);
+    }
+
+    #[test]
+    fn required_null_and_mismatched_lengths_are_rejected() {
+        assert!(
+            TableData::new(
+                Table::Quads,
+                vec![
+                    ColumnValues::int64(vec![None]),
+                    ColumnValues::int64(vec![Some(1)]),
+                    ColumnValues::int64(vec![Some(2)]),
+                    ColumnValues::int64(vec![None]),
+                ],
+            )
+            .is_err()
+        );
+        assert!(
+            TableData::new(
+                Table::Quads,
+                vec![
+                    ColumnValues::int64(vec![Some(0)]),
+                    ColumnValues::int64(Vec::new()),
+                    ColumnValues::int64(vec![Some(0)]),
+                    ColumnValues::int64(vec![None]),
+                ],
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn wrong_table_and_corruption_fail_closed() {
+        let mut bytes = write_table(&quads(), Compression::Uncompressed).unwrap();
+        assert!(read_table(&bytes, Table::Annotations).is_err());
+
+        bytes[0] ^= 0xff;
+        assert!(matches!(
+            read_table(&bytes, Table::Quads),
+            Err(ColumnarError::Malformed { .. })
+        ));
+    }
+
+    #[test]
+    fn definition_rle_rejects_bitpacked_and_trailing_data() {
+        assert!(matches!(
+            decode_definition_levels(&[3, 0], 8),
+            Err(ColumnarError::Unsupported { .. })
+        ));
+        let mut encoded = encode_definition_levels([true, true, false].into_iter());
+        encoded.push(0);
+        assert!(decode_definition_levels(&encoded, 3).is_err());
+    }
+}

--- a/crates/columnar/src/parquet.rs
+++ b/crates/columnar/src/parquet.rs
@@ -265,7 +265,7 @@ pub(crate) fn write_table(
     let footer_len = u32::try_from(footer.len()).map_err(|_| ColumnarError::LimitExceeded {
         context: "Parquet footer length",
         value: footer.len() as u64,
-        maximum: u32::MAX as u64,
+        maximum: u64::from(u32::MAX),
     })?;
     out.extend_from_slice(&footer);
     out.extend_from_slice(&footer_len.to_le_bytes());
@@ -396,7 +396,7 @@ fn encode_file_metadata(data: &TableData, columns: &[EncodedColumn]) -> Vec<u8> 
             Some(column) => write_schema_element(writer, column),
         });
         writer.i64_field(3, data.row_count as i64);
-        writer.list_struct_field(4, row_groups, |writer, _| {
+        writer.list_struct_field(4, row_groups, |writer, ()| {
             writer.list_struct_field(1, columns, write_column_chunk);
             writer.i64_field(
                 2,

--- a/crates/columnar/src/reader.rs
+++ b/crates/columnar/src/reader.rs
@@ -1,0 +1,811 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Strict five-table columnar-to-RDF reconstruction.
+
+use std::collections::BTreeMap;
+use std::str;
+use std::sync::Arc;
+
+use purrdf_core::{
+    BlankScope, ContentDigest, ContentStore, LossLedger, RdfDataset, RdfDatasetBuilder, RdfLiteral,
+    RdfTextDirection, TermId, TermValue,
+};
+
+use crate::error::ColumnarError;
+use crate::files::ParquetFiles;
+use crate::parquet::{ColumnValues, TableData, read_table};
+use crate::schema::Table;
+
+type QuadRow = (usize, usize, usize, Option<usize>);
+type ReifierRow = (usize, usize, usize, usize, Option<usize>);
+
+const RDF_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
+
+/// The result of a complete Parquet-to-RDF conversion.
+#[derive(Debug, Clone)]
+pub struct ColumnarRead {
+    /// Reconstructed, structurally validated RDF 1.2 dataset.
+    pub dataset: Arc<RdfDataset>,
+    /// Reconstructed and digest-verified content-addressed payloads.
+    pub blobs: ContentStore,
+    /// Losses observed while reconstructing the dataset.
+    pub losses: LossLedger,
+}
+
+/// Read PurRDF's exact five-table Parquet profile back into RDF and blob values.
+///
+/// This is deliberately not a general Parquet reader. In addition to validating
+/// the physical file profile, it enforces the canonical dictionary and row order,
+/// rejects dangling or contradictory references, verifies every blob digest, and
+/// runs the reconstructed dataset through the kernel's structural validator.
+///
+/// # Errors
+///
+/// Returns [`ColumnarError`] for malformed Parquet, schema/profile drift, invalid
+/// UTF-8 or RDF term records, non-canonical ordering, invalid references, blob
+/// digest mismatches, or RDF positional violations.
+pub fn read(files: &ParquetFiles) -> Result<ColumnarRead, ColumnarError> {
+    let terms = read_table(files.get(Table::Terms), Table::Terms)?;
+    let quads = read_table(files.get(Table::Quads), Table::Quads)?;
+    let reifiers = read_table(files.get(Table::Reifiers), Table::Reifiers)?;
+    let annotations = read_table(files.get(Table::Annotations), Table::Annotations)?;
+    let blobs = read_table(files.get(Table::Blobs), Table::Blobs)?;
+
+    let dictionary = Dictionary::decode(&terms)?;
+    let quad_rows = decode_quad_rows(&quads, &dictionary.named_graphs)?;
+    let reifier_rows = decode_reifier_rows(&reifiers, &dictionary.named_graphs)?;
+    let annotation_rows = decode_quad_rows(&annotations, &dictionary.named_graphs)?;
+    let content_store = decode_blobs(&blobs)?;
+    let dataset = reconstruct_dataset(&dictionary, &quad_rows, &reifier_rows, &annotation_rows)?;
+
+    Ok(ColumnarRead {
+        dataset,
+        blobs: content_store,
+        losses: LossLedger::new(),
+    })
+}
+
+#[derive(Debug, Clone)]
+enum TermRecord {
+    Iri(String),
+    Literal {
+        lexical: String,
+        datatype: usize,
+        language: Option<String>,
+        direction: Option<RdfTextDirection>,
+    },
+    Blank {
+        label: String,
+        scope: BlankScope,
+    },
+    Triple {
+        s: usize,
+        p: usize,
+        o: usize,
+    },
+}
+
+struct Dictionary {
+    values: Vec<TermValue>,
+    named_graphs: Vec<bool>,
+    value_ids: BTreeMap<TermValue, usize>,
+}
+
+impl Dictionary {
+    fn decode(data: &TableData) -> Result<Self, ColumnarError> {
+        let records = parse_term_records(data)?;
+        let values = resolve_term_records(&records)?;
+        ensure_strict_order(&values, "term dictionary order")?;
+
+        let named_column = int_column(data, 10)?;
+        let mut named_graphs = Vec::with_capacity(values.len());
+        for (row, value) in values.iter().enumerate() {
+            let flag = required_i64(named_column, row, "terms.named_graph")?;
+            let named = match flag {
+                0 => false,
+                1 => true,
+                _ => {
+                    return Err(ColumnarError::malformed(
+                        "terms.named_graph",
+                        format!("row {row} has flag {flag}, expected 0 or 1"),
+                    ));
+                }
+            };
+            if named && !matches!(value, TermValue::Iri(_) | TermValue::Blank { .. }) {
+                return Err(ColumnarError::malformed(
+                    "terms.named_graph",
+                    format!("row {row} marks a literal or triple term as a graph name"),
+                ));
+            }
+            named_graphs.push(named);
+        }
+        let value_ids = values
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(id, value)| (value, id))
+            .collect();
+        Ok(Self {
+            values,
+            named_graphs,
+            value_ids,
+        })
+    }
+}
+
+fn parse_term_records(data: &TableData) -> Result<Vec<TermRecord>, ColumnarError> {
+    let ids = int_column(data, 0)?;
+    let kinds = int_column(data, 1)?;
+    let lex = bytes_column(data, 2)?;
+    let datatypes = int_column(data, 3)?;
+    let languages = bytes_column(data, 4)?;
+    let directions = int_column(data, 5)?;
+    let scopes = int_column(data, 6)?;
+    let triple_subjects = int_column(data, 7)?;
+    let triple_predicates = int_column(data, 8)?;
+    let triple_objects = int_column(data, 9)?;
+    let mut records = Vec::with_capacity(data.row_count);
+
+    for row in 0..data.row_count {
+        let id = required_i64(ids, row, "terms.id")?;
+        if id != row as i64 {
+            return Err(ColumnarError::malformed(
+                "terms.id",
+                format!("row {row} has id {id}; ids must be dense and zero-based"),
+            ));
+        }
+        let kind = required_i64(kinds, row, "terms.kind")?;
+        records.push(match kind {
+            0 => parse_iri_record(
+                row,
+                lex,
+                datatypes,
+                languages,
+                directions,
+                scopes,
+                triple_subjects,
+                triple_predicates,
+                triple_objects,
+            )?,
+            1 => parse_literal_record(
+                row,
+                data.row_count,
+                lex,
+                datatypes,
+                languages,
+                directions,
+                scopes,
+                triple_subjects,
+                triple_predicates,
+                triple_objects,
+            )?,
+            2 => parse_blank_record(
+                row,
+                lex,
+                datatypes,
+                languages,
+                directions,
+                scopes,
+                triple_subjects,
+                triple_predicates,
+                triple_objects,
+            )?,
+            3 => parse_triple_record(
+                row,
+                data.row_count,
+                lex,
+                datatypes,
+                languages,
+                directions,
+                scopes,
+                triple_subjects,
+                triple_predicates,
+                triple_objects,
+            )?,
+            _ => {
+                return Err(ColumnarError::Unsupported {
+                    context: "terms.kind",
+                    value: kind,
+                });
+            }
+        });
+    }
+    Ok(records)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn parse_iri_record(
+    row: usize,
+    lex: &[Option<Vec<u8>>],
+    datatypes: &[Option<i64>],
+    languages: &[Option<Vec<u8>>],
+    directions: &[Option<i64>],
+    scopes: &[Option<i64>],
+    triple_subjects: &[Option<i64>],
+    triple_predicates: &[Option<i64>],
+    triple_objects: &[Option<i64>],
+) -> Result<TermRecord, ColumnarError> {
+    ensure_null_i64(row, datatypes, "terms.datatype")?;
+    ensure_null_bytes(row, languages, "terms.lang")?;
+    ensure_null_i64(row, directions, "terms.direction")?;
+    ensure_null_i64(row, scopes, "terms.scope")?;
+    ensure_null_i64(row, triple_subjects, "terms.triple_s")?;
+    ensure_null_i64(row, triple_predicates, "terms.triple_p")?;
+    ensure_null_i64(row, triple_objects, "terms.triple_o")?;
+    Ok(TermRecord::Iri(required_utf8(lex, row, "terms.lex")?))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn parse_literal_record(
+    row: usize,
+    term_count: usize,
+    lex: &[Option<Vec<u8>>],
+    datatypes: &[Option<i64>],
+    languages: &[Option<Vec<u8>>],
+    directions: &[Option<i64>],
+    scopes: &[Option<i64>],
+    triple_subjects: &[Option<i64>],
+    triple_predicates: &[Option<i64>],
+    triple_objects: &[Option<i64>],
+) -> Result<TermRecord, ColumnarError> {
+    ensure_null_i64(row, scopes, "terms.scope")?;
+    ensure_null_i64(row, triple_subjects, "terms.triple_s")?;
+    ensure_null_i64(row, triple_predicates, "terms.triple_p")?;
+    ensure_null_i64(row, triple_objects, "terms.triple_o")?;
+    let direction = match directions[row] {
+        None => None,
+        Some(0) => Some(RdfTextDirection::Ltr),
+        Some(1) => Some(RdfTextDirection::Rtl),
+        Some(value) => {
+            return Err(ColumnarError::Unsupported {
+                context: "terms.direction",
+                value,
+            });
+        }
+    };
+    Ok(TermRecord::Literal {
+        lexical: required_utf8(lex, row, "terms.lex")?,
+        datatype: required_term_ref(datatypes, row, term_count, "terms.datatype")?,
+        language: optional_utf8(languages, row, "terms.lang")?,
+        direction,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn parse_blank_record(
+    row: usize,
+    lex: &[Option<Vec<u8>>],
+    datatypes: &[Option<i64>],
+    languages: &[Option<Vec<u8>>],
+    directions: &[Option<i64>],
+    scopes: &[Option<i64>],
+    triple_subjects: &[Option<i64>],
+    triple_predicates: &[Option<i64>],
+    triple_objects: &[Option<i64>],
+) -> Result<TermRecord, ColumnarError> {
+    ensure_null_i64(row, datatypes, "terms.datatype")?;
+    ensure_null_bytes(row, languages, "terms.lang")?;
+    ensure_null_i64(row, directions, "terms.direction")?;
+    ensure_null_i64(row, triple_subjects, "terms.triple_s")?;
+    ensure_null_i64(row, triple_predicates, "terms.triple_p")?;
+    ensure_null_i64(row, triple_objects, "terms.triple_o")?;
+    let scope = required_i64(scopes, row, "terms.scope")?;
+    let scope = u32::try_from(scope).map_err(|_| {
+        ColumnarError::malformed(
+            "terms.scope",
+            format!("row {row} has out-of-range scope {scope}"),
+        )
+    })?;
+    Ok(TermRecord::Blank {
+        label: required_utf8(lex, row, "terms.lex")?,
+        scope: BlankScope(scope),
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn parse_triple_record(
+    row: usize,
+    term_count: usize,
+    lex: &[Option<Vec<u8>>],
+    datatypes: &[Option<i64>],
+    languages: &[Option<Vec<u8>>],
+    directions: &[Option<i64>],
+    scopes: &[Option<i64>],
+    triple_subjects: &[Option<i64>],
+    triple_predicates: &[Option<i64>],
+    triple_objects: &[Option<i64>],
+) -> Result<TermRecord, ColumnarError> {
+    ensure_null_bytes(row, lex, "terms.lex")?;
+    ensure_null_i64(row, datatypes, "terms.datatype")?;
+    ensure_null_bytes(row, languages, "terms.lang")?;
+    ensure_null_i64(row, directions, "terms.direction")?;
+    ensure_null_i64(row, scopes, "terms.scope")?;
+    Ok(TermRecord::Triple {
+        s: required_term_ref(triple_subjects, row, term_count, "terms.triple_s")?,
+        p: required_term_ref(triple_predicates, row, term_count, "terms.triple_p")?,
+        o: required_term_ref(triple_objects, row, term_count, "terms.triple_o")?,
+    })
+}
+
+fn resolve_term_records(records: &[TermRecord]) -> Result<Vec<TermValue>, ColumnarError> {
+    let mut states = vec![0u8; records.len()];
+    let mut values = vec![None; records.len()];
+    for index in 0..records.len() {
+        resolve_term_record(index, records, &mut states, &mut values)?;
+    }
+    values
+        .into_iter()
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| ColumnarError::malformed("term dictionary", "unresolved term record"))
+}
+
+fn resolve_term_record(
+    index: usize,
+    records: &[TermRecord],
+    states: &mut [u8],
+    values: &mut [Option<TermValue>],
+) -> Result<TermValue, ColumnarError> {
+    if let Some(value) = &values[index] {
+        return Ok(value.clone());
+    }
+    if states[index] == 1 {
+        return Err(ColumnarError::malformed(
+            "term dictionary",
+            "cyclic triple-term reference",
+        ));
+    }
+    states[index] = 1;
+    let record = records[index].clone();
+    let value = match record {
+        TermRecord::Iri(iri) => TermValue::Iri(iri),
+        TermRecord::Literal {
+            lexical,
+            datatype,
+            language,
+            direction,
+        } => {
+            let datatype = resolve_term_record(datatype, records, states, values)?;
+            let TermValue::Iri(datatype) = datatype else {
+                return Err(ColumnarError::malformed(
+                    "terms.datatype",
+                    format!("literal row {index} references a non-IRI datatype"),
+                ));
+            };
+            if let Some(language) = &language {
+                if language.is_empty() || language != &language.to_lowercase() {
+                    return Err(ColumnarError::malformed(
+                        "terms.lang",
+                        format!("literal row {index} has a non-canonical language tag"),
+                    ));
+                }
+                if datatype != RDF_LANG_STRING {
+                    return Err(ColumnarError::malformed(
+                        "terms.datatype",
+                        format!("language literal row {index} does not use rdf:langString"),
+                    ));
+                }
+            } else if direction.is_some() {
+                return Err(ColumnarError::malformed(
+                    "terms.direction",
+                    format!("literal row {index} has a direction without a language tag"),
+                ));
+            }
+            TermValue::Literal {
+                lexical_form: lexical,
+                datatype,
+                language,
+                direction,
+            }
+        }
+        TermRecord::Blank { label, scope } => TermValue::Blank { label, scope },
+        TermRecord::Triple { s, p, o } => TermValue::Triple {
+            s: Box::new(resolve_term_record(s, records, states, values)?),
+            p: Box::new(resolve_term_record(p, records, states, values)?),
+            o: Box::new(resolve_term_record(o, records, states, values)?),
+        },
+    };
+    states[index] = 2;
+    values[index] = Some(value.clone());
+    Ok(value)
+}
+
+fn decode_quad_rows(
+    data: &TableData,
+    named_graphs: &[bool],
+) -> Result<Vec<QuadRow>, ColumnarError> {
+    let first = int_column(data, 0)?;
+    let second = int_column(data, 1)?;
+    let third = int_column(data, 2)?;
+    let graphs = int_column(data, 3)?;
+    let mut rows = Vec::with_capacity(data.row_count);
+    for row in 0..data.row_count {
+        rows.push((
+            required_term_ref(first, row, named_graphs.len(), "row first term")?,
+            required_term_ref(second, row, named_graphs.len(), "row second term")?,
+            required_term_ref(third, row, named_graphs.len(), "row third term")?,
+            optional_graph_ref(graphs, row, named_graphs)?,
+        ));
+    }
+    ensure_strict_order(&rows, "quad-like row order")?;
+    Ok(rows)
+}
+
+fn decode_reifier_rows(
+    data: &TableData,
+    named_graphs: &[bool],
+) -> Result<Vec<ReifierRow>, ColumnarError> {
+    let reifiers = int_column(data, 0)?;
+    let subjects = int_column(data, 1)?;
+    let predicates = int_column(data, 2)?;
+    let objects = int_column(data, 3)?;
+    let graphs = int_column(data, 4)?;
+    let mut rows = Vec::with_capacity(data.row_count);
+    for row in 0..data.row_count {
+        rows.push((
+            required_term_ref(reifiers, row, named_graphs.len(), "reifiers.reifier")?,
+            required_term_ref(subjects, row, named_graphs.len(), "reifiers.s")?,
+            required_term_ref(predicates, row, named_graphs.len(), "reifiers.p")?,
+            required_term_ref(objects, row, named_graphs.len(), "reifiers.o")?,
+            optional_graph_ref(graphs, row, named_graphs)?,
+        ));
+    }
+    ensure_strict_order(&rows, "reifier row order")?;
+    Ok(rows)
+}
+
+fn decode_blobs(data: &TableData) -> Result<ContentStore, ColumnarError> {
+    let digests = bytes_column(data, 0)?;
+    let payloads = bytes_column(data, 1)?;
+    let mut previous = None;
+    let mut store = ContentStore::new();
+    for row in 0..data.row_count {
+        let digest_bytes = required_bytes(digests, row, "blobs.digest")?;
+        let digest_text = str::from_utf8(digest_bytes).map_err(|_| {
+            ColumnarError::malformed("blobs.digest", format!("row {row} is not UTF-8"))
+        })?;
+        let digest = ContentDigest::from_hex(digest_text).ok_or_else(|| {
+            ColumnarError::malformed(
+                "blobs.digest",
+                format!("row {row} is not a 64-digit SHA-256 hex value"),
+            )
+        })?;
+        if digest_text != digest.to_hex() {
+            return Err(ColumnarError::malformed(
+                "blobs.digest",
+                format!("row {row} is not canonical lowercase hexadecimal"),
+            ));
+        }
+        if previous.is_some_and(|value| value >= digest) {
+            return Err(ColumnarError::malformed(
+                "blob row order",
+                "digests are not strictly increasing",
+            ));
+        }
+        let payload = required_bytes(payloads, row, "blobs.bytes")?.to_vec();
+        store.insert_checked(digest, payload).map_err(|error| {
+            ColumnarError::malformed("blobs.bytes", format!("row {row}: {error}"))
+        })?;
+        previous = Some(digest);
+    }
+    Ok(store)
+}
+
+fn reconstruct_dataset(
+    dictionary: &Dictionary,
+    quads: &[QuadRow],
+    reifiers: &[ReifierRow],
+    annotations: &[QuadRow],
+) -> Result<Arc<RdfDataset>, ColumnarError> {
+    let mut builder = RdfDatasetBuilder::new();
+    let ids: Vec<_> = dictionary
+        .values
+        .iter()
+        .map(|value| intern_value(&mut builder, value))
+        .collect();
+    for (index, &named) in dictionary.named_graphs.iter().enumerate() {
+        if named {
+            builder.declare_named_graph(ids[index]);
+        }
+    }
+    for &(s, p, o, g) in quads {
+        builder.push_quad(ids[s], ids[p], ids[o], g.map(|id| ids[id]));
+    }
+    for &(reifier, s, p, o, g) in reifiers {
+        let triple_value = TermValue::Triple {
+            s: Box::new(dictionary.values[s].clone()),
+            p: Box::new(dictionary.values[p].clone()),
+            o: Box::new(dictionary.values[o].clone()),
+        };
+        let triple = dictionary.value_ids.get(&triple_value).ok_or_else(|| {
+            ColumnarError::malformed(
+                "reifier binding",
+                "component tuple has no corresponding triple term",
+            )
+        })?;
+        builder.push_reifier_in_graph(ids[reifier], ids[*triple], g.map(|id| ids[id]));
+    }
+    for &(reifier, predicate, value, graph) in annotations {
+        builder.push_annotation_in_graph(
+            ids[reifier],
+            ids[predicate],
+            ids[value],
+            graph.map(|id| ids[id]),
+        );
+    }
+    builder
+        .freeze()
+        .map_err(|error| ColumnarError::malformed("RDF reconstruction", error.to_string()))
+}
+
+fn intern_value(builder: &mut RdfDatasetBuilder, value: &TermValue) -> TermId {
+    match value {
+        TermValue::Iri(iri) => builder.intern_iri(iri),
+        TermValue::Blank { label, scope } => builder.intern_blank(label, *scope),
+        TermValue::Literal {
+            lexical_form,
+            datatype,
+            language,
+            direction,
+        } => builder.intern_literal(RdfLiteral {
+            lexical_form: lexical_form.clone(),
+            datatype: Some(datatype.clone()),
+            language: language.clone(),
+            direction: *direction,
+        }),
+        TermValue::Triple { s, p, o } => {
+            let s = intern_value(builder, s);
+            let p = intern_value(builder, p);
+            let o = intern_value(builder, o);
+            builder.intern_triple(s, p, o)
+        }
+    }
+}
+
+fn int_column(data: &TableData, index: usize) -> Result<&[Option<i64>], ColumnarError> {
+    match data.columns.get(index) {
+        Some(ColumnValues::Int64(values)) => Ok(values),
+        _ => Err(ColumnarError::malformed(
+            "table column",
+            format!("{}.{} is not INT64", data.table.name(), index),
+        )),
+    }
+}
+
+fn bytes_column(data: &TableData, index: usize) -> Result<&[Option<Vec<u8>>], ColumnarError> {
+    match data.columns.get(index) {
+        Some(ColumnValues::ByteArray(values)) => Ok(values),
+        _ => Err(ColumnarError::malformed(
+            "table column",
+            format!("{}.{} is not BYTE_ARRAY", data.table.name(), index),
+        )),
+    }
+}
+
+fn required_i64(
+    column: &[Option<i64>],
+    row: usize,
+    context: &'static str,
+) -> Result<i64, ColumnarError> {
+    column[row].ok_or_else(|| {
+        ColumnarError::malformed(context, format!("required value is null at row {row}"))
+    })
+}
+
+fn required_bytes<'a>(
+    column: &'a [Option<Vec<u8>>],
+    row: usize,
+    context: &'static str,
+) -> Result<&'a [u8], ColumnarError> {
+    column[row].as_deref().ok_or_else(|| {
+        ColumnarError::malformed(context, format!("required value is null at row {row}"))
+    })
+}
+
+fn required_utf8(
+    column: &[Option<Vec<u8>>],
+    row: usize,
+    context: &'static str,
+) -> Result<String, ColumnarError> {
+    let value = required_bytes(column, row, context)?;
+    str::from_utf8(value)
+        .map(str::to_owned)
+        .map_err(|_| ColumnarError::malformed(context, format!("row {row} is not valid UTF-8")))
+}
+
+fn optional_utf8(
+    column: &[Option<Vec<u8>>],
+    row: usize,
+    context: &'static str,
+) -> Result<Option<String>, ColumnarError> {
+    column[row]
+        .as_deref()
+        .map(|value| {
+            str::from_utf8(value).map(str::to_owned).map_err(|_| {
+                ColumnarError::malformed(context, format!("row {row} is not valid UTF-8"))
+            })
+        })
+        .transpose()
+}
+
+fn required_term_ref(
+    column: &[Option<i64>],
+    row: usize,
+    term_count: usize,
+    context: &'static str,
+) -> Result<usize, ColumnarError> {
+    let value = required_i64(column, row, context)?;
+    let id = usize::try_from(value).map_err(|_| {
+        ColumnarError::malformed(context, format!("row {row} has negative term id {value}"))
+    })?;
+    if id >= term_count {
+        return Err(ColumnarError::malformed(
+            context,
+            format!("row {row} references term {id}, but dictionary has {term_count} rows"),
+        ));
+    }
+    Ok(id)
+}
+
+fn optional_graph_ref(
+    column: &[Option<i64>],
+    row: usize,
+    named_graphs: &[bool],
+) -> Result<Option<usize>, ColumnarError> {
+    let Some(value) = column[row] else {
+        return Ok(None);
+    };
+    let graph = usize::try_from(value).map_err(|_| {
+        ColumnarError::malformed(
+            "graph reference",
+            format!("row {row} has negative id {value}"),
+        )
+    })?;
+    if graph >= named_graphs.len() {
+        return Err(ColumnarError::malformed(
+            "graph reference",
+            format!("row {row} references missing term {graph}"),
+        ));
+    }
+    if !named_graphs[graph] {
+        return Err(ColumnarError::malformed(
+            "graph reference",
+            format!("row {row} references term {graph} not marked as a named graph"),
+        ));
+    }
+    Ok(Some(graph))
+}
+
+fn ensure_null_i64(
+    row: usize,
+    column: &[Option<i64>],
+    context: &'static str,
+) -> Result<(), ColumnarError> {
+    if column[row].is_some() {
+        return Err(ColumnarError::malformed(
+            context,
+            format!("value must be null for term kind at row {row}"),
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_null_bytes(
+    row: usize,
+    column: &[Option<Vec<u8>>],
+    context: &'static str,
+) -> Result<(), ColumnarError> {
+    if column[row].is_some() {
+        return Err(ColumnarError::malformed(
+            context,
+            format!("value must be null for term kind at row {row}"),
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_strict_order<T: Ord>(values: &[T], context: &'static str) -> Result<(), ColumnarError> {
+    if values.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return Err(ColumnarError::malformed(
+            context,
+            "rows are not strictly increasing",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use purrdf_core::{
+        BlankScope, DatasetView, RdfDatasetBuilder, RdfLiteral, RdfTextDirection,
+        datasets_isomorphic,
+    };
+
+    use super::*;
+    use crate::parquet::{Compression, write_table};
+    use crate::writer::write;
+
+    fn fixture() -> (Arc<RdfDataset>, ContentStore) {
+        let mut builder = RdfDatasetBuilder::new();
+        let subject = builder.intern_blank("subject", BlankScope(3));
+        let predicate = builder.intern_iri("https://example.org/p");
+        let object = builder.intern_literal(RdfLiteral {
+            lexical_form: "bonjour".to_owned(),
+            datatype: None,
+            language: Some("fr".to_owned()),
+            direction: Some(RdfTextDirection::Ltr),
+        });
+        let graph = builder.intern_iri("https://example.org/graph");
+        let empty_graph = builder.intern_iri("https://example.org/empty");
+        builder.declare_named_graph(empty_graph);
+        builder.push_quad(subject, predicate, object, Some(graph));
+        let triple = builder.intern_triple(subject, predicate, object);
+        let reifier = builder.intern_blank("reifier", BlankScope(3));
+        builder.push_reifier_in_graph(reifier, triple, Some(graph));
+        builder.push_annotation_in_graph(reifier, predicate, object, None);
+
+        let mut blobs = ContentStore::new();
+        blobs.insert(b"first".to_vec());
+        blobs.insert(b"second".to_vec());
+        (builder.freeze().unwrap(), blobs)
+    }
+
+    #[test]
+    fn full_conversion_round_trips_and_rewrites_identically() {
+        let (dataset, blobs) = fixture();
+        let encoded = write(&*dataset, &blobs, Compression::Zstd).unwrap();
+        let decoded = read(&encoded.files).unwrap();
+        assert!(datasets_isomorphic(&dataset, &decoded.dataset));
+        assert_eq!(decoded.blobs, blobs);
+        assert!(encoded.losses.is_empty());
+        assert!(decoded.losses.is_empty());
+
+        let graph_names: Vec<_> = decoded
+            .dataset
+            .named_graphs()
+            .map(|id| match decoded.dataset.resolve(id) {
+                purrdf_core::TermRef::Iri(iri) => iri.to_owned(),
+                _ => panic!("fixture graph names are IRIs"),
+            })
+            .collect();
+        assert_eq!(graph_names.len(), 2);
+        assert!(graph_names.iter().any(|iri| iri.ends_with("/empty")));
+
+        let rewritten = write(&*decoded.dataset, &decoded.blobs, Compression::Zstd).unwrap();
+        assert_eq!(rewritten.files, encoded.files);
+    }
+
+    #[test]
+    fn semantic_reader_rejects_non_dense_term_ids() {
+        let (dataset, blobs) = fixture();
+        let encoded = write(&*dataset, &blobs, Compression::Uncompressed).unwrap();
+        let mut array = encoded.files.into_array();
+        let mut terms = read_table(&array[0], Table::Terms).unwrap();
+        let ColumnValues::Int64(ids) = &mut terms.columns[0] else {
+            panic!("terms.id is INT64");
+        };
+        ids[0] = Some(9);
+        array[0] = write_table(&terms, Compression::Uncompressed).unwrap();
+        assert!(matches!(
+            read(&ParquetFiles::from_array(array)),
+            Err(ColumnarError::Malformed { .. })
+        ));
+    }
+
+    #[test]
+    fn semantic_reader_rehashes_blob_payloads() {
+        let (dataset, blobs) = fixture();
+        let encoded = write(&*dataset, &blobs, Compression::Uncompressed).unwrap();
+        let mut array = encoded.files.into_array();
+        let mut blob_table = read_table(&array[4], Table::Blobs).unwrap();
+        let ColumnValues::ByteArray(payloads) = &mut blob_table.columns[1] else {
+            panic!("blobs.bytes is BYTE_ARRAY");
+        };
+        payloads[0].as_mut().unwrap().push(0xff);
+        array[4] = write_table(&blob_table, Compression::Uncompressed).unwrap();
+        assert!(matches!(
+            read(&ParquetFiles::from_array(array)),
+            Err(ColumnarError::Malformed { .. })
+        ));
+    }
+}

--- a/crates/columnar/src/reader.rs
+++ b/crates/columnar/src/reader.rs
@@ -14,7 +14,7 @@ use purrdf_core::{
 
 use crate::error::ColumnarError;
 use crate::files::ParquetFiles;
-use crate::parquet::{ColumnValues, TableData, read_table};
+use crate::parquet::{ColumnValues, TableData, bounded_row_capacity, read_table};
 use crate::schema::Table;
 
 type QuadRow = (usize, usize, usize, Option<usize>);
@@ -42,21 +42,30 @@ pub struct ColumnarRead {
 ///
 /// # Errors
 ///
-/// Returns [`ColumnarError`] for malformed Parquet, schema/profile drift, invalid
-/// UTF-8 or RDF term records, non-canonical ordering, invalid references, blob
-/// digest mismatches, or RDF positional violations.
+/// Returns [`ColumnarError`] for malformed Parquet, schema/profile drift, safety
+/// budget exhaustion, invalid UTF-8 or RDF term records, non-canonical ordering,
+/// invalid references, blob digest mismatches, or RDF positional violations.
 pub fn read(files: &ParquetFiles) -> Result<ColumnarRead, ColumnarError> {
-    let terms = read_table(files.get(Table::Terms), Table::Terms)?;
-    let quads = read_table(files.get(Table::Quads), Table::Quads)?;
-    let reifiers = read_table(files.get(Table::Reifiers), Table::Reifiers)?;
-    let annotations = read_table(files.get(Table::Annotations), Table::Annotations)?;
-    let blobs = read_table(files.get(Table::Blobs), Table::Blobs)?;
-
-    let dictionary = Dictionary::decode(&terms)?;
-    let quad_rows = decode_quad_rows(&quads, &dictionary.named_graphs)?;
-    let reifier_rows = decode_reifier_rows(&reifiers, &dictionary.named_graphs)?;
-    let annotation_rows = decode_quad_rows(&annotations, &dictionary.named_graphs)?;
-    let content_store = decode_blobs(&blobs)?;
+    let dictionary = {
+        let terms = read_table(files.get(Table::Terms), Table::Terms)?;
+        Dictionary::decode(&terms)?
+    };
+    let quad_rows = {
+        let quads = read_table(files.get(Table::Quads), Table::Quads)?;
+        decode_quad_rows(&quads, &dictionary.named_graphs)?
+    };
+    let reifier_rows = {
+        let reifiers = read_table(files.get(Table::Reifiers), Table::Reifiers)?;
+        decode_reifier_rows(&reifiers, &dictionary.named_graphs)?
+    };
+    let annotation_rows = {
+        let annotations = read_table(files.get(Table::Annotations), Table::Annotations)?;
+        decode_quad_rows(&annotations, &dictionary.named_graphs)?
+    };
+    let content_store = {
+        let blobs = read_table(files.get(Table::Blobs), Table::Blobs)?;
+        decode_blobs(&blobs)?
+    };
     let dataset = reconstruct_dataset(&dictionary, &quad_rows, &reifier_rows, &annotation_rows)?;
 
     Ok(ColumnarRead {
@@ -99,7 +108,7 @@ impl Dictionary {
         ensure_strict_order(&values, "term dictionary order")?;
 
         let named_column = int_column(data, 10)?;
-        let mut named_graphs = Vec::with_capacity(values.len());
+        let mut named_graphs = Vec::with_capacity(bounded_row_capacity(values.len()));
         for (row, value) in values.iter().enumerate() {
             let flag = required_i64(named_column, row, "terms.named_graph")?;
             let named = match flag {
@@ -145,7 +154,7 @@ fn parse_term_records(data: &TableData) -> Result<Vec<TermRecord>, ColumnarError
     let triple_subjects = int_column(data, 7)?;
     let triple_predicates = int_column(data, 8)?;
     let triple_objects = int_column(data, 9)?;
-    let mut records = Vec::with_capacity(data.row_count);
+    let mut records = Vec::with_capacity(bounded_row_capacity(data.row_count));
 
     for row in 0..data.row_count {
         let id = required_i64(ids, row, "terms.id")?;
@@ -418,7 +427,7 @@ fn decode_quad_rows(
     let second = int_column(data, 1)?;
     let third = int_column(data, 2)?;
     let graphs = int_column(data, 3)?;
-    let mut rows = Vec::with_capacity(data.row_count);
+    let mut rows = Vec::with_capacity(bounded_row_capacity(data.row_count));
     for row in 0..data.row_count {
         rows.push((
             required_term_ref(first, row, named_graphs.len(), "row first term")?,
@@ -440,7 +449,7 @@ fn decode_reifier_rows(
     let predicates = int_column(data, 2)?;
     let objects = int_column(data, 3)?;
     let graphs = int_column(data, 4)?;
-    let mut rows = Vec::with_capacity(data.row_count);
+    let mut rows = Vec::with_capacity(bounded_row_capacity(data.row_count));
     for row in 0..data.row_count {
         rows.push((
             required_term_ref(reifiers, row, named_graphs.len(), "reifiers.reifier")?,

--- a/crates/columnar/src/reader.rs
+++ b/crates/columnar/src/reader.rs
@@ -62,7 +62,7 @@ pub fn read(files: &ParquetFiles) -> Result<ColumnarRead, ColumnarError> {
     Ok(ColumnarRead {
         dataset,
         blobs: content_store,
-        losses: LossLedger::new(),
+        losses: LossLedger::default(),
     })
 }
 

--- a/crates/columnar/src/schema.rs
+++ b/crates/columnar/src/schema.rs
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! The closed five-table columnar schema.
+
+/// A Parquet physical type used by the columnar contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PhysicalType {
+    /// A signed 64-bit integer.
+    Int64,
+    /// An arbitrary byte string.
+    ByteArray,
+}
+
+/// Whether a flat column is required or nullable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Repetition {
+    /// Every row carries exactly one value.
+    Required,
+    /// A row carries zero or one value, encoded through definition levels.
+    Optional,
+}
+
+/// One primitive column in a [`TableSchema`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ColumnSchema {
+    /// Stable field name in the Parquet schema.
+    pub name: &'static str,
+    /// Parquet physical storage type.
+    pub physical_type: PhysicalType,
+    /// Required or optional cardinality.
+    pub repetition: Repetition,
+    /// Whether a BYTE_ARRAY column carries the standard UTF8 annotation.
+    pub utf8: bool,
+}
+
+impl ColumnSchema {
+    const fn int64(name: &'static str, repetition: Repetition) -> Self {
+        Self {
+            name,
+            physical_type: PhysicalType::Int64,
+            repetition,
+            utf8: false,
+        }
+    }
+
+    const fn bytes(name: &'static str, repetition: Repetition, utf8: bool) -> Self {
+        Self {
+            name,
+            physical_type: PhysicalType::ByteArray,
+            repetition,
+            utf8,
+        }
+    }
+}
+
+/// The schema of one logical table/file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TableSchema {
+    /// Logical table name, also used in file metadata.
+    pub name: &'static str,
+    /// Deterministic output filename.
+    pub file_name: &'static str,
+    /// Primitive columns in schema order.
+    pub columns: &'static [ColumnSchema],
+}
+
+/// One member of the closed five-table dataset projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Table {
+    /// Unified RDF term dictionary.
+    Terms,
+    /// Base RDF quad set.
+    Quads,
+    /// RDF 1.2 reifier bindings.
+    Reifiers,
+    /// RDF 1.2 statement annotations.
+    Annotations,
+    /// Content-addressed blob payloads.
+    Blobs,
+}
+
+impl Table {
+    /// Every table in canonical dependency order.
+    pub const ALL: [Self; 5] = [
+        Self::Terms,
+        Self::Quads,
+        Self::Reifiers,
+        Self::Annotations,
+        Self::Blobs,
+    ];
+
+    /// The normative schema for this table.
+    pub const fn schema(self) -> &'static TableSchema {
+        match self {
+            Self::Terms => &TERMS,
+            Self::Quads => &QUADS,
+            Self::Reifiers => &REIFIERS,
+            Self::Annotations => &ANNOTATIONS,
+            Self::Blobs => &BLOBS,
+        }
+    }
+
+    /// The stable logical table name.
+    pub const fn name(self) -> &'static str {
+        self.schema().name
+    }
+
+    /// The stable Parquet filename.
+    pub const fn file_name(self) -> &'static str {
+        self.schema().file_name
+    }
+}
+
+const TERMS_COLUMNS: &[ColumnSchema] = &[
+    ColumnSchema::int64("id", Repetition::Required),
+    ColumnSchema::int64("kind", Repetition::Required),
+    ColumnSchema::bytes("lex", Repetition::Optional, true),
+    ColumnSchema::int64("datatype", Repetition::Optional),
+    ColumnSchema::bytes("lang", Repetition::Optional, true),
+    ColumnSchema::int64("direction", Repetition::Optional),
+    ColumnSchema::int64("scope", Repetition::Optional),
+    ColumnSchema::int64("triple_s", Repetition::Optional),
+    ColumnSchema::int64("triple_p", Repetition::Optional),
+    ColumnSchema::int64("triple_o", Repetition::Optional),
+    ColumnSchema::int64("named_graph", Repetition::Required),
+];
+
+const QUADS_COLUMNS: &[ColumnSchema] = &[
+    ColumnSchema::int64("s", Repetition::Required),
+    ColumnSchema::int64("p", Repetition::Required),
+    ColumnSchema::int64("o", Repetition::Required),
+    ColumnSchema::int64("g", Repetition::Optional),
+];
+
+const REIFIERS_COLUMNS: &[ColumnSchema] = &[
+    ColumnSchema::int64("reifier", Repetition::Required),
+    ColumnSchema::int64("s", Repetition::Required),
+    ColumnSchema::int64("p", Repetition::Required),
+    ColumnSchema::int64("o", Repetition::Required),
+    ColumnSchema::int64("g", Repetition::Optional),
+];
+
+const ANNOTATIONS_COLUMNS: &[ColumnSchema] = &[
+    ColumnSchema::int64("reifier", Repetition::Required),
+    ColumnSchema::int64("predicate", Repetition::Required),
+    ColumnSchema::int64("value", Repetition::Required),
+    ColumnSchema::int64("g", Repetition::Optional),
+];
+
+const BLOBS_COLUMNS: &[ColumnSchema] = &[
+    ColumnSchema::bytes("digest", Repetition::Required, true),
+    ColumnSchema::bytes("bytes", Repetition::Required, false),
+];
+
+const TERMS: TableSchema = TableSchema {
+    name: "terms",
+    file_name: "terms.parquet",
+    columns: TERMS_COLUMNS,
+};
+
+const QUADS: TableSchema = TableSchema {
+    name: "quads",
+    file_name: "quads.parquet",
+    columns: QUADS_COLUMNS,
+};
+
+const REIFIERS: TableSchema = TableSchema {
+    name: "reifiers",
+    file_name: "reifiers.parquet",
+    columns: REIFIERS_COLUMNS,
+};
+
+const ANNOTATIONS: TableSchema = TableSchema {
+    name: "annotations",
+    file_name: "annotations.parquet",
+    columns: ANNOTATIONS_COLUMNS,
+};
+
+const BLOBS: TableSchema = TableSchema {
+    name: "blobs",
+    file_name: "blobs.parquet",
+    columns: BLOBS_COLUMNS,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn five_table_names_and_files_are_unique() {
+        assert_eq!(Table::ALL.len(), 5);
+        assert_eq!(
+            Table::ALL
+                .iter()
+                .map(|table| table.name())
+                .collect::<BTreeSet<_>>()
+                .len(),
+            5
+        );
+        assert_eq!(
+            Table::ALL
+                .iter()
+                .map(|table| table.file_name())
+                .collect::<BTreeSet<_>>()
+                .len(),
+            5
+        );
+    }
+
+    #[test]
+    fn schema_uses_only_the_closed_physical_type_set() {
+        for table in Table::ALL {
+            assert!(!table.schema().columns.is_empty());
+            for column in table.schema().columns {
+                assert!(matches!(
+                    column.physical_type,
+                    PhysicalType::Int64 | PhysicalType::ByteArray
+                ));
+                assert!(!column.utf8 || column.physical_type == PhysicalType::ByteArray);
+            }
+        }
+    }
+}

--- a/crates/columnar/src/writer.rs
+++ b/crates/columnar/src/writer.rs
@@ -85,23 +85,29 @@ struct SourceRows<Id> {
     named_graphs: Vec<Id>,
 }
 
-impl<Id: Copy> SourceRows<Id> {
+impl<Id: purrdf_core::ViewTermId> SourceRows<Id> {
     fn collect<D>(view: &D) -> Self
     where
         D: DatasetView<Id = Id>,
     {
+        let quads: Vec<_> = view.quads().collect();
+        let reifiers: Vec<_> = view.reifier_quads().collect();
+        let annotations: Vec<_> = view.annotation_quads().collect();
+        let mut named_graphs: BTreeSet<_> = view.named_graphs().collect();
+        named_graphs.extend(quads.iter().filter_map(|quad| quad.g));
+        named_graphs.extend(reifiers.iter().filter_map(|quad| quad.g));
+        named_graphs.extend(annotations.iter().filter_map(|quad| quad.g));
         Self {
-            quads: view.quads().collect(),
-            reifiers: view.reifier_quads().collect(),
-            annotations: view.annotation_quads().collect(),
-            named_graphs: view.named_graphs().collect(),
+            quads,
+            reifiers,
+            annotations,
+            named_graphs: named_graphs.into_iter().collect(),
         }
     }
 
     fn resolve_all<D>(&self, resolver: &mut Resolver<'_, D>) -> Result<(), ColumnarError>
     where
         D: DatasetView<Id = Id>,
-        Id: purrdf_core::ViewTermId,
     {
         for quad in &self.quads {
             resolve_quad(resolver, quad, true)?;

--- a/crates/columnar/src/writer.rs
+++ b/crates/columnar/src/writer.rs
@@ -540,7 +540,8 @@ fn build_blobs_table(blobs: &ContentStore) -> Result<TableData, ColumnarError> {
 #[cfg(test)]
 mod tests {
     use purrdf_core::{
-        BlankScope, ContentStore, RdfDataset, RdfDatasetBuilder, RdfLiteral, RdfTextDirection,
+        BlankScope, ContentStore, PackBuilder, PackView, RdfDataset, RdfDatasetBuilder, RdfLiteral,
+        RdfTextDirection,
     };
 
     use super::*;
@@ -613,5 +614,72 @@ mod tests {
             assert_eq!(read_table(bytes, table).unwrap().row_count, 0);
         }
         assert!(written.losses.is_empty());
+    }
+
+    #[test]
+    fn pack_view_and_native_dataset_emit_identical_files() {
+        let mut builder = RdfDatasetBuilder::new();
+        let subject = builder.intern_blank("subject", BlankScope(9));
+        let predicate = builder.intern_iri("https://example.org/p");
+        let object = builder.intern_literal(RdfLiteral::simple("object"));
+        let graph = builder.intern_iri("https://example.org/graph");
+        builder.push_quad(subject, predicate, object, Some(graph));
+        let triple = builder.intern_triple(subject, predicate, object);
+        let reifier = builder.intern_iri("https://example.org/reifier");
+        builder.push_reifier_in_graph(reifier, triple, Some(graph));
+        builder.push_annotation(reifier, predicate, object);
+        let dataset = builder.freeze().unwrap();
+        let blobs = ContentStore::new();
+        let pack_bytes = PackBuilder::build_bytes(&dataset).unwrap();
+        let pack = PackView::from_bytes(&pack_bytes).unwrap();
+        let native = write(&*dataset, &blobs, Compression::Zstd).unwrap();
+        let packed = write(&pack, &blobs, Compression::Zstd).unwrap();
+        assert_eq!(packed, native);
+    }
+
+    #[test]
+    fn term_and_quad_ingest_order_do_not_change_bytes() {
+        fn build(reverse: bool) -> std::sync::Arc<RdfDataset> {
+            let mut builder = RdfDatasetBuilder::new();
+            let (subject, second_subject, predicate, object, graph, reifier) = if reverse {
+                let reifier = builder.intern_iri("https://example.org/reifier");
+                let graph = builder.intern_iri("https://example.org/graph");
+                let object = builder.intern_literal(RdfLiteral::simple("object"));
+                let predicate = builder.intern_iri("https://example.org/p");
+                let second_subject = builder.intern_iri("https://example.org/second");
+                let subject = builder.intern_blank("subject", BlankScope(4));
+                (subject, second_subject, predicate, object, graph, reifier)
+            } else {
+                let subject = builder.intern_blank("subject", BlankScope(4));
+                let second_subject = builder.intern_iri("https://example.org/second");
+                let predicate = builder.intern_iri("https://example.org/p");
+                let object = builder.intern_literal(RdfLiteral::simple("object"));
+                let graph = builder.intern_iri("https://example.org/graph");
+                let reifier = builder.intern_iri("https://example.org/reifier");
+                (subject, second_subject, predicate, object, graph, reifier)
+            };
+            let rows = [
+                (subject, predicate, object, None),
+                (second_subject, predicate, subject, Some(graph)),
+            ];
+            for &(s, p, o, g) in if reverse {
+                rows.iter().rev().collect::<Vec<_>>()
+            } else {
+                rows.iter().collect()
+            } {
+                builder.push_quad(s, p, o, g);
+            }
+            let triple = builder.intern_triple(subject, predicate, object);
+            builder.push_reifier_in_graph(reifier, triple, Some(graph));
+            builder.push_annotation(reifier, predicate, object);
+            builder.freeze().unwrap()
+        }
+
+        let blobs = ContentStore::new();
+        for compression in [Compression::Uncompressed, Compression::Zstd] {
+            let forward = write(&*build(false), &blobs, compression).unwrap();
+            let reverse = write(&*build(true), &blobs, compression).unwrap();
+            assert_eq!(forward, reverse);
+        }
     }
 }

--- a/crates/columnar/src/writer.rs
+++ b/crates/columnar/src/writer.rs
@@ -73,7 +73,7 @@ pub fn write<D: DatasetView>(
 
     Ok(ColumnarWrite {
         files: ParquetFiles::from_array(files),
-        losses: LossLedger::new(),
+        losses: LossLedger::default(),
     })
 }
 

--- a/crates/columnar/src/writer.rs
+++ b/crates/columnar/src/writer.rs
@@ -1,0 +1,611 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Generic RDF-to-columnar projection.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use purrdf_core::{
+    ContentStore, DatasetView, LossLedger, QuadIds, RdfTextDirection, TermRef, TermValue,
+};
+
+use crate::error::ColumnarError;
+use crate::files::ParquetFiles;
+use crate::parquet::{ColumnValues, Compression, TableData, write_table};
+use crate::schema::Table;
+
+type QuadRow = (i64, i64, i64, Option<i64>);
+type ReifierRow = (i64, i64, i64, i64, Option<i64>);
+
+/// The result of a complete RDF-to-Parquet conversion.
+///
+/// Columnar projection is lossless, so a successful conversion currently
+/// returns an empty runtime loss ledger. The ledger is still computed and
+/// carried on every call so downstream conversion pipelines have one uniform
+/// observability contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColumnarWrite {
+    /// All five Parquet files, including valid zero-row files.
+    pub files: ParquetFiles,
+    /// Losses observed while projecting the dataset.
+    pub losses: LossLedger,
+}
+
+/// Project any RDF 1.2 [`DatasetView`] and [`ContentStore`] into five Parquet files.
+///
+/// Term ids are reassigned from the canonical [`TermValue`] order, so output is
+/// independent of backend-local ids and ingest order. `compression` is a runtime
+/// encoding choice; both modes carry identical RDF semantics.
+///
+/// # Errors
+///
+/// Returns [`ColumnarError`] if the source view violates the `DatasetView`
+/// structural contract, a table exceeds the Parquet profile's bounds, the blob
+/// store fails integrity verification, or encoding fails.
+pub fn write<D: DatasetView>(
+    view: &D,
+    blobs: &ContentStore,
+    compression: Compression,
+) -> Result<ColumnarWrite, ColumnarError> {
+    blobs
+        .verify_all()
+        .map_err(|error| ColumnarError::malformed("content store", error.to_string()))?;
+
+    let source = SourceRows::collect(view);
+    let mut resolver = Resolver::new(view);
+    source.resolve_all(&mut resolver)?;
+    let dictionary = Dictionary::build(&resolver, &source.named_graphs)?;
+
+    let tables = [
+        build_terms_table(&dictionary)?,
+        build_quads_table(&source, &resolver, &dictionary)?,
+        build_reifiers_table(&source, &resolver, &dictionary)?,
+        build_annotations_table(&source, &resolver, &dictionary)?,
+        build_blobs_table(blobs)?,
+    ];
+    let mut encoded = Vec::with_capacity(Table::ALL.len());
+    for table in &tables {
+        encoded.push(write_table(table, compression)?);
+    }
+    let files: [Vec<u8>; 5] = encoded.try_into().map_err(|_| {
+        ColumnarError::malformed("table set", "writer did not produce exactly five files")
+    })?;
+
+    Ok(ColumnarWrite {
+        files: ParquetFiles::from_array(files),
+        losses: LossLedger::new(),
+    })
+}
+
+#[derive(Debug)]
+struct SourceRows<Id> {
+    quads: Vec<QuadIds<Id>>,
+    reifiers: Vec<QuadIds<Id>>,
+    annotations: Vec<QuadIds<Id>>,
+    named_graphs: Vec<Id>,
+}
+
+impl<Id: Copy> SourceRows<Id> {
+    fn collect<D>(view: &D) -> Self
+    where
+        D: DatasetView<Id = Id>,
+    {
+        Self {
+            quads: view.quads().collect(),
+            reifiers: view.reifier_quads().collect(),
+            annotations: view.annotation_quads().collect(),
+            named_graphs: view.named_graphs().collect(),
+        }
+    }
+
+    fn resolve_all<D>(&self, resolver: &mut Resolver<'_, D>) -> Result<(), ColumnarError>
+    where
+        D: DatasetView<Id = Id>,
+        Id: purrdf_core::ViewTermId,
+    {
+        for quad in &self.quads {
+            resolve_quad(resolver, quad, true)?;
+        }
+        for quad in &self.reifiers {
+            resolver.resolve(quad.s)?;
+            resolver.resolve(quad.o)?;
+            resolve_graph(resolver, quad.g)?;
+        }
+        for quad in &self.annotations {
+            resolve_quad(resolver, quad, true)?;
+        }
+        for &graph in &self.named_graphs {
+            resolver.resolve(graph)?;
+        }
+        Ok(())
+    }
+}
+
+fn resolve_quad<D: DatasetView>(
+    resolver: &mut Resolver<'_, D>,
+    quad: &QuadIds<D::Id>,
+    include_predicate: bool,
+) -> Result<(), ColumnarError> {
+    resolver.resolve(quad.s)?;
+    if include_predicate {
+        resolver.resolve(quad.p)?;
+    }
+    resolver.resolve(quad.o)?;
+    resolve_graph(resolver, quad.g)
+}
+
+fn resolve_graph<D: DatasetView>(
+    resolver: &mut Resolver<'_, D>,
+    graph: Option<D::Id>,
+) -> Result<(), ColumnarError> {
+    if let Some(graph) = graph {
+        resolver.resolve(graph)?;
+    }
+    Ok(())
+}
+
+struct Resolver<'a, D: DatasetView> {
+    view: &'a D,
+    values: BTreeMap<D::Id, TermValue>,
+    active: BTreeSet<D::Id>,
+}
+
+impl<'a, D: DatasetView> Resolver<'a, D> {
+    fn new(view: &'a D) -> Self {
+        Self {
+            view,
+            values: BTreeMap::new(),
+            active: BTreeSet::new(),
+        }
+    }
+
+    fn resolve(&mut self, id: D::Id) -> Result<TermValue, ColumnarError> {
+        if let Some(value) = self.values.get(&id) {
+            return Ok(value.clone());
+        }
+        if !self.active.insert(id) {
+            return Err(ColumnarError::malformed(
+                "term graph",
+                "cyclic triple-term reference",
+            ));
+        }
+
+        let value = match self.view.resolve(id) {
+            TermRef::Iri(iri) => TermValue::Iri(iri.to_owned()),
+            TermRef::Blank { label, scope } => TermValue::Blank {
+                label: label.to_owned(),
+                scope,
+            },
+            TermRef::Literal {
+                lexical,
+                datatype,
+                language,
+                direction,
+            } => {
+                let datatype = self.resolve(datatype)?;
+                let TermValue::Iri(datatype) = datatype else {
+                    return Err(ColumnarError::malformed(
+                        "literal datatype",
+                        "datatype id does not resolve to an IRI",
+                    ));
+                };
+                TermValue::Literal {
+                    lexical_form: lexical.to_owned(),
+                    datatype,
+                    language: language.map(str::to_owned),
+                    direction,
+                }
+            }
+            TermRef::Triple { s, p, o } => TermValue::Triple {
+                s: Box::new(self.resolve(s)?),
+                p: Box::new(self.resolve(p)?),
+                o: Box::new(self.resolve(o)?),
+            },
+        };
+        self.active.remove(&id);
+        self.values.insert(id, value.clone());
+        Ok(value)
+    }
+
+    fn get(&self, id: D::Id) -> Result<&TermValue, ColumnarError> {
+        self.values
+            .get(&id)
+            .ok_or_else(|| ColumnarError::malformed("term closure", "source id was not resolved"))
+    }
+}
+
+struct Dictionary {
+    terms: Vec<TermValue>,
+    ids: BTreeMap<TermValue, i64>,
+    named_graphs: BTreeSet<TermValue>,
+}
+
+impl Dictionary {
+    fn build<D: DatasetView>(
+        resolver: &Resolver<'_, D>,
+        named_graph_ids: &[D::Id],
+    ) -> Result<Self, ColumnarError> {
+        let terms: Vec<_> = resolver
+            .values
+            .values()
+            .cloned()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        if terms.len() > i32::MAX as usize {
+            return Err(ColumnarError::limit(
+                "term dictionary",
+                terms.len(),
+                i32::MAX as usize,
+            ));
+        }
+        let mut ids = BTreeMap::new();
+        for (index, term) in terms.iter().enumerate() {
+            let id = i64::try_from(index)
+                .map_err(|_| ColumnarError::limit("term id", index, i64::MAX as usize))?;
+            ids.insert(term.clone(), id);
+        }
+        let named_graphs = named_graph_ids
+            .iter()
+            .map(|&id| resolver.get(id).cloned())
+            .collect::<Result<_, _>>()?;
+        Ok(Self {
+            terms,
+            ids,
+            named_graphs,
+        })
+    }
+
+    fn id(&self, value: &TermValue) -> Result<i64, ColumnarError> {
+        self.ids.get(value).copied().ok_or_else(|| {
+            ColumnarError::malformed("term reference", "value is absent from dictionary")
+        })
+    }
+
+    fn source_id<D: DatasetView>(
+        &self,
+        resolver: &Resolver<'_, D>,
+        id: D::Id,
+    ) -> Result<i64, ColumnarError> {
+        self.id(resolver.get(id)?)
+    }
+
+    fn graph_id<D: DatasetView>(
+        &self,
+        resolver: &Resolver<'_, D>,
+        id: Option<D::Id>,
+    ) -> Result<Option<i64>, ColumnarError> {
+        id.map(|id| self.source_id(resolver, id)).transpose()
+    }
+}
+
+fn build_terms_table(dictionary: &Dictionary) -> Result<TableData, ColumnarError> {
+    let capacity = dictionary.terms.len();
+    let mut ids = Vec::with_capacity(capacity);
+    let mut kinds = Vec::with_capacity(capacity);
+    let mut lex = Vec::with_capacity(capacity);
+    let mut datatypes = Vec::with_capacity(capacity);
+    let mut languages = Vec::with_capacity(capacity);
+    let mut directions = Vec::with_capacity(capacity);
+    let mut scopes = Vec::with_capacity(capacity);
+    let mut triple_subjects = Vec::with_capacity(capacity);
+    let mut triple_predicates = Vec::with_capacity(capacity);
+    let mut triple_objects = Vec::with_capacity(capacity);
+    let mut named_graphs = Vec::with_capacity(capacity);
+
+    for (index, term) in dictionary.terms.iter().enumerate() {
+        ids.push(Some(index as i64));
+        append_term_columns(
+            dictionary,
+            term,
+            &mut kinds,
+            &mut lex,
+            &mut datatypes,
+            &mut languages,
+            &mut directions,
+            &mut scopes,
+            &mut triple_subjects,
+            &mut triple_predicates,
+            &mut triple_objects,
+        )?;
+        named_graphs.push(Some(i64::from(dictionary.named_graphs.contains(term))));
+    }
+
+    TableData::new(
+        Table::Terms,
+        vec![
+            ColumnValues::int64(ids),
+            ColumnValues::int64(kinds),
+            ColumnValues::bytes(lex),
+            ColumnValues::int64(datatypes),
+            ColumnValues::bytes(languages),
+            ColumnValues::int64(directions),
+            ColumnValues::int64(scopes),
+            ColumnValues::int64(triple_subjects),
+            ColumnValues::int64(triple_predicates),
+            ColumnValues::int64(triple_objects),
+            ColumnValues::int64(named_graphs),
+        ],
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_term_columns(
+    dictionary: &Dictionary,
+    term: &TermValue,
+    kinds: &mut Vec<Option<i64>>,
+    lex: &mut Vec<Option<Vec<u8>>>,
+    datatypes: &mut Vec<Option<i64>>,
+    languages: &mut Vec<Option<Vec<u8>>>,
+    directions: &mut Vec<Option<i64>>,
+    scopes: &mut Vec<Option<i64>>,
+    triple_subjects: &mut Vec<Option<i64>>,
+    triple_predicates: &mut Vec<Option<i64>>,
+    triple_objects: &mut Vec<Option<i64>>,
+) -> Result<(), ColumnarError> {
+    let mut row = TermColumns::default();
+    match term {
+        TermValue::Iri(iri) => {
+            row.kind = 0;
+            row.lex = Some(iri.as_bytes().to_vec());
+        }
+        TermValue::Literal {
+            lexical_form,
+            datatype,
+            language,
+            direction,
+        } => {
+            row.kind = 1;
+            row.lex = Some(lexical_form.as_bytes().to_vec());
+            row.datatype = Some(dictionary.id(&TermValue::Iri(datatype.clone()))?);
+            row.language = language.as_ref().map(|value| value.as_bytes().to_vec());
+            row.direction = direction.map(direction_id);
+        }
+        TermValue::Blank { label, scope } => {
+            row.kind = 2;
+            row.lex = Some(label.as_bytes().to_vec());
+            row.scope = Some(i64::from(scope.ordinal()));
+        }
+        TermValue::Triple { s, p, o } => {
+            row.kind = 3;
+            row.triple_s = Some(dictionary.id(s)?);
+            row.triple_p = Some(dictionary.id(p)?);
+            row.triple_o = Some(dictionary.id(o)?);
+        }
+    }
+    kinds.push(Some(row.kind));
+    lex.push(row.lex);
+    datatypes.push(row.datatype);
+    languages.push(row.language);
+    directions.push(row.direction);
+    scopes.push(row.scope);
+    triple_subjects.push(row.triple_s);
+    triple_predicates.push(row.triple_p);
+    triple_objects.push(row.triple_o);
+    Ok(())
+}
+
+#[derive(Default)]
+struct TermColumns {
+    kind: i64,
+    lex: Option<Vec<u8>>,
+    datatype: Option<i64>,
+    language: Option<Vec<u8>>,
+    direction: Option<i64>,
+    scope: Option<i64>,
+    triple_s: Option<i64>,
+    triple_p: Option<i64>,
+    triple_o: Option<i64>,
+}
+
+const fn direction_id(direction: RdfTextDirection) -> i64 {
+    match direction {
+        RdfTextDirection::Ltr => 0,
+        RdfTextDirection::Rtl => 1,
+    }
+}
+
+fn build_quads_table<D: DatasetView>(
+    source: &SourceRows<D::Id>,
+    resolver: &Resolver<'_, D>,
+    dictionary: &Dictionary,
+) -> Result<TableData, ColumnarError> {
+    let rows = source
+        .quads
+        .iter()
+        .map(|quad| {
+            Ok((
+                dictionary.source_id(resolver, quad.s)?,
+                dictionary.source_id(resolver, quad.p)?,
+                dictionary.source_id(resolver, quad.o)?,
+                dictionary.graph_id(resolver, quad.g)?,
+            ))
+        })
+        .collect::<Result<BTreeSet<_>, ColumnarError>>()?;
+    table_from_quad_rows(Table::Quads, rows)
+}
+
+fn build_reifiers_table<D: DatasetView>(
+    source: &SourceRows<D::Id>,
+    resolver: &Resolver<'_, D>,
+    dictionary: &Dictionary,
+) -> Result<TableData, ColumnarError> {
+    let mut rows = BTreeSet::new();
+    for quad in &source.reifiers {
+        let TermValue::Triple { s, p, o } = resolver.get(quad.o)? else {
+            return Err(ColumnarError::malformed(
+                "reifier binding",
+                "object is not a triple term",
+            ));
+        };
+        rows.insert((
+            dictionary.source_id(resolver, quad.s)?,
+            dictionary.id(s)?,
+            dictionary.id(p)?,
+            dictionary.id(o)?,
+            dictionary.graph_id(resolver, quad.g)?,
+        ));
+    }
+    table_from_reifier_rows(rows)
+}
+
+fn build_annotations_table<D: DatasetView>(
+    source: &SourceRows<D::Id>,
+    resolver: &Resolver<'_, D>,
+    dictionary: &Dictionary,
+) -> Result<TableData, ColumnarError> {
+    let rows = source
+        .annotations
+        .iter()
+        .map(|quad| {
+            Ok((
+                dictionary.source_id(resolver, quad.s)?,
+                dictionary.source_id(resolver, quad.p)?,
+                dictionary.source_id(resolver, quad.o)?,
+                dictionary.graph_id(resolver, quad.g)?,
+            ))
+        })
+        .collect::<Result<BTreeSet<_>, ColumnarError>>()?;
+    table_from_quad_rows(Table::Annotations, rows)
+}
+
+fn table_from_quad_rows(table: Table, rows: BTreeSet<QuadRow>) -> Result<TableData, ColumnarError> {
+    let mut first = Vec::with_capacity(rows.len());
+    let mut second = Vec::with_capacity(rows.len());
+    let mut third = Vec::with_capacity(rows.len());
+    let mut graphs = Vec::with_capacity(rows.len());
+    for (a, b, c, graph) in rows {
+        first.push(Some(a));
+        second.push(Some(b));
+        third.push(Some(c));
+        graphs.push(graph);
+    }
+    TableData::new(
+        table,
+        vec![
+            ColumnValues::int64(first),
+            ColumnValues::int64(second),
+            ColumnValues::int64(third),
+            ColumnValues::int64(graphs),
+        ],
+    )
+}
+
+fn table_from_reifier_rows(rows: BTreeSet<ReifierRow>) -> Result<TableData, ColumnarError> {
+    let mut reifiers = Vec::with_capacity(rows.len());
+    let mut subjects = Vec::with_capacity(rows.len());
+    let mut predicates = Vec::with_capacity(rows.len());
+    let mut objects = Vec::with_capacity(rows.len());
+    let mut graphs = Vec::with_capacity(rows.len());
+    for (reifier, subject, predicate, object, graph) in rows {
+        reifiers.push(Some(reifier));
+        subjects.push(Some(subject));
+        predicates.push(Some(predicate));
+        objects.push(Some(object));
+        graphs.push(graph);
+    }
+    TableData::new(
+        Table::Reifiers,
+        vec![
+            ColumnValues::int64(reifiers),
+            ColumnValues::int64(subjects),
+            ColumnValues::int64(predicates),
+            ColumnValues::int64(objects),
+            ColumnValues::int64(graphs),
+        ],
+    )
+}
+
+fn build_blobs_table(blobs: &ContentStore) -> Result<TableData, ColumnarError> {
+    let mut rows: Vec<_> = blobs.iter().collect();
+    rows.sort_unstable_by_key(|(digest, _)| **digest);
+    let mut digests = Vec::with_capacity(rows.len());
+    let mut bytes = Vec::with_capacity(rows.len());
+    for (digest, payload) in rows {
+        digests.push(Some(digest.to_hex().into_bytes()));
+        bytes.push(Some(payload.clone()));
+    }
+    TableData::new(
+        Table::Blobs,
+        vec![ColumnValues::bytes(digests), ColumnValues::bytes(bytes)],
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use purrdf_core::{
+        BlankScope, ContentStore, RdfDataset, RdfDatasetBuilder, RdfLiteral, RdfTextDirection,
+    };
+
+    use super::*;
+    use crate::parquet::read_table;
+
+    fn fixture() -> (std::sync::Arc<RdfDataset>, ContentStore) {
+        let mut builder = RdfDatasetBuilder::new();
+        let subject = builder.intern_blank("subject", BlankScope(7));
+        let predicate = builder.intern_iri("https://example.org/p");
+        let object = builder.intern_literal(RdfLiteral::typed("42", "https://example.org/integer"));
+        let directional = builder.intern_literal(RdfLiteral {
+            lexical_form: "مرحبا".to_owned(),
+            datatype: None,
+            language: Some("ar".to_owned()),
+            direction: Some(RdfTextDirection::Rtl),
+        });
+        let graph = builder.intern_iri("https://example.org/graph");
+        let empty_graph = builder.intern_iri("https://example.org/empty");
+        builder.declare_named_graph(empty_graph);
+        builder.push_quad(subject, predicate, object, Some(graph));
+
+        let triple = builder.intern_triple(subject, predicate, directional);
+        let reifier = builder.intern_blank("reifier", BlankScope(7));
+        builder.push_reifier_in_graph(reifier, triple, Some(graph));
+        builder.push_annotation_in_graph(reifier, predicate, object, None);
+
+        let mut blobs = ContentStore::new();
+        blobs.insert(b"columnar payload".to_vec());
+        (builder.freeze().unwrap(), blobs)
+    }
+
+    #[test]
+    fn writer_projects_all_rdf_layers_and_is_deterministic() {
+        let (dataset, blobs) = fixture();
+        let first = write(&*dataset, &blobs, Compression::Zstd).unwrap();
+        let second = write(&*dataset, &blobs, Compression::Zstd).unwrap();
+        assert_eq!(first, second);
+        assert!(first.losses.is_empty());
+        assert_eq!(first.files.iter().len(), Table::ALL.len());
+
+        let terms = read_table(first.files.get(Table::Terms), Table::Terms).unwrap();
+        let quads = read_table(first.files.get(Table::Quads), Table::Quads).unwrap();
+        let reifiers = read_table(first.files.get(Table::Reifiers), Table::Reifiers).unwrap();
+        let annotations =
+            read_table(first.files.get(Table::Annotations), Table::Annotations).unwrap();
+        let blob_rows = read_table(first.files.get(Table::Blobs), Table::Blobs).unwrap();
+        assert!(terms.row_count >= 10);
+        assert_eq!(quads.row_count, 1);
+        assert_eq!(reifiers.row_count, 1);
+        assert_eq!(annotations.row_count, 1);
+        assert_eq!(blob_rows.row_count, 1);
+
+        let ColumnValues::Int64(named_graphs) = &terms.columns[10] else {
+            panic!("named_graph must be INT64");
+        };
+        assert_eq!(
+            named_graphs
+                .iter()
+                .filter(|value| **value == Some(1))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn empty_input_still_writes_five_valid_zero_row_files() {
+        let dataset = RdfDatasetBuilder::new().freeze().unwrap();
+        let written = write(&*dataset, &ContentStore::new(), Compression::Uncompressed).unwrap();
+        for (table, bytes) in written.files.iter() {
+            assert_eq!(read_table(bytes, table).unwrap().row_count, 0);
+        }
+        assert!(written.losses.is_empty());
+    }
+}

--- a/crates/purrdf/Cargo.toml
+++ b/crates/purrdf/Cargo.toml
@@ -26,6 +26,7 @@ crate-type = ["rlib"]
 path = "src/lib.rs"
 
 [dependencies]
+purrdf-columnar = { workspace = true }
 purrdf-rdf = { workspace = true }
 purrdf-slice = { workspace = true }
 purrdf-shapes = { workspace = true }

--- a/crates/purrdf/README.md
+++ b/crates/purrdf/README.md
@@ -118,6 +118,7 @@ let schema = purrdf::shex::parse_shexc(
 | Module | Sub-crate(s) |
 | --- | --- |
 | (root) | [`purrdf-rdf`](https://crates.io/crates/purrdf-rdf) — core types, codecs, GTS/text adapters |
+| `columnar` | [`purrdf-columnar`](https://crates.io/crates/purrdf-columnar) (five-table Parquet codec) |
 | `gts` | [`purrdf-gts`](https://crates.io/crates/purrdf-gts) + the RDF-level GTS adapter |
 | `sparql` | [`purrdf-sparql-algebra`](https://crates.io/crates/purrdf-sparql-algebra) + [`purrdf-sparql-eval`](https://crates.io/crates/purrdf-sparql-eval) + [`purrdf-sparql-results`](https://crates.io/crates/purrdf-sparql-results) |
 | `shapes` | [`purrdf-shapes`](https://crates.io/crates/purrdf-shapes) (SHACL) |

--- a/crates/purrdf/src/lib.rs
+++ b/crates/purrdf/src/lib.rs
@@ -12,6 +12,7 @@
 //! | Module | Sub-crate(s) |
 //! |---|---|
 //! | (root) | [`purrdf_rdf`] — core types, codecs, GTS/text adapters |
+//! | [`columnar`] | [`purrdf_columnar`] (five-table Parquet codec) |
 //! | [`gts`] | [`purrdf_gts`] (container engine) + the [`purrdf_rdf`] GTS adapter |
 //! | [`sparql`] | [`purrdf_sparql_eval`] + [`purrdf_sparql_algebra`] + [`purrdf_sparql_results`] |
 //! | [`shapes`] | [`purrdf_shapes`] (SHACL) |
@@ -73,6 +74,11 @@ pub mod profile;
 pub use profile::{OntologyProfile, ReifierVocab};
 pub mod reasoning;
 pub use reasoning::{QueryEntailment, ReasoningError, query_with_entailment};
+
+/// Bidirectional, byte-deterministic five-table Parquet codec.
+pub mod columnar {
+    pub use purrdf_columnar::*;
+}
 
 // ── consumer-config types, surfaced directly ────────────────────────────────
 // A consumer parameterizes an emitter without reaching into a sub-crate.
@@ -175,6 +181,8 @@ mod tests {
 
     #[test]
     fn facade_exposes_the_completed_umbrella() {
+        assert_eq!(columnar::Table::ALL.len(), 5);
+
         // gts: the container engine (its `model`) and the rdf-level adapter
         // (`read_graph`) are both reachable under the one `gts` module.
         assert!(!format!("{:?}", gts::model::TermKind::Iri).is_empty());

--- a/docs/COLUMNAR.md
+++ b/docs/COLUMNAR.md
@@ -100,3 +100,13 @@ The reader is intentionally not a general Parquet engine. It accepts this exact
 schema and encoding profile and fails closed on structural drift, unsupported
 features, malformed references, invalid RDF positions, decompression size
 mismatches, or trailing data.
+
+## Decode safety budget
+
+Before allocating a decoded column or entering Zstd, the reader cross-checks the
+row-group, column-chunk, and page sizes and estimates the table's resident column
+slots plus uncompressed value bytes. That fixed-profile working set may not
+exceed 256 MiB per table. Metadata-derived vectors initially reserve at most
+65,536 rows, and the public reader decodes and releases one physical table at a
+time. Inputs beyond the ceiling fail with `ColumnarError::LimitExceeded`; the
+writer applies the same budget so it cannot emit files its paired reader rejects.

--- a/docs/COLUMNAR.md
+++ b/docs/COLUMNAR.md
@@ -1,0 +1,102 @@
+<!--
+SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# PurRDF columnar schema
+
+`purrdf-columnar` represents one RDF 1.2 dataset and one content-addressed blob
+store as a closed set of five Parquet files. A `ParquetFiles` value always
+contains all five files, including valid zero-row files for empty tables.
+
+Every table is flat. The only Parquet physical types are `INT64` and
+`BYTE_ARRAY`; textual byte arrays carry the standard UTF8 annotation. Required
+columns contain one value per row. Optional columns use definition level 0 for
+null and 1 for present.
+
+## Tables
+
+### `terms.parquet`
+
+| Column | Type | Cardinality | Meaning |
+| --- | --- | --- | --- |
+| `id` | INT64 | required | Dense, zero-based columnar term id. |
+| `kind` | INT64 | required | `0` IRI, `1` literal, `2` blank node, `3` triple term. |
+| `lex` | UTF8 | optional | IRI, literal lexical form, or blank label; null for triple terms. |
+| `datatype` | INT64 | optional | Term id of a literal's datatype IRI. |
+| `lang` | UTF8 | optional | Lower-cased language tag. |
+| `direction` | INT64 | optional | `0` left-to-right, `1` right-to-left. |
+| `scope` | INT64 | optional | Blank-node scope ordinal. |
+| `triple_s` | INT64 | optional | Triple-term subject id. |
+| `triple_p` | INT64 | optional | Triple-term predicate id. |
+| `triple_o` | INT64 | optional | Triple-term object id. |
+| `named_graph` | INT64 | required | `1` when the term names a declared graph, otherwise `0`. |
+
+The term dictionary is the recursive closure of every term reachable from base
+quads, reifier bindings, annotations, and named-graph declarations. Rows are
+ordered by a canonical value encoding, not by backend-local ids. This retains
+explicitly declared empty named graphs and makes bytes independent of a
+`DatasetView` implementation's id allocation.
+
+### `quads.parquet`
+
+| Column | Type | Cardinality | Meaning |
+| --- | --- | --- | --- |
+| `s` | INT64 | required | Subject term id. |
+| `p` | INT64 | required | Predicate term id. |
+| `o` | INT64 | required | Object term id. |
+| `g` | INT64 | optional | Named-graph term id; null is the default graph. |
+
+Rows are unique and sorted by `(s, p, o, g)` with the default graph before
+named graphs.
+
+### `reifiers.parquet`
+
+| Column | Type | Cardinality | Meaning |
+| --- | --- | --- | --- |
+| `reifier` | INT64 | required | Reifier resource term id. |
+| `s` | INT64 | required | Reified statement subject id. |
+| `p` | INT64 | required | Reified statement predicate id. |
+| `o` | INT64 | required | Reified statement object id. |
+| `g` | INT64 | optional | Graph of the binding; null is the default graph. |
+
+Rows are unique and sorted by `(reifier, s, p, o, g)`.
+
+### `annotations.parquet`
+
+| Column | Type | Cardinality | Meaning |
+| --- | --- | --- | --- |
+| `reifier` | INT64 | required | Annotated reifier term id. |
+| `predicate` | INT64 | required | Annotation predicate term id. |
+| `value` | INT64 | required | Annotation object term id. |
+| `g` | INT64 | optional | Graph of the annotation; null is the default graph. |
+
+Rows are unique and sorted by `(reifier, predicate, value, g)`.
+
+### `blobs.parquet`
+
+| Column | Type | Cardinality | Meaning |
+| --- | --- | --- | --- |
+| `digest` | UTF8 | required | Lowercase SHA-256 digest, 64 hexadecimal characters. |
+| `bytes` | BYTE_ARRAY | required | Content-addressed payload bytes. |
+
+Rows are sorted by raw digest bytes. A reader re-hashes every payload and
+rejects a mismatch; it never repairs or re-files corrupt content.
+
+## Parquet profile
+
+Each non-empty table is one row group with one Data Page V2 per column. Values
+use PLAIN encoding. Optional-column definition levels use the Parquet RLE
+hybrid's run-length form; there are no repetition levels because the schema is
+flat. A write chooses one codec for all value bodies: UNCOMPRESSED or ZSTD.
+Zstd is a runtime choice backed by the always-present pure-Rust
+`structured-zstd` dependency, never a Cargo feature.
+
+Page headers and file metadata use Thrift Compact Protocol. Files carry stable
+key/value metadata identifying columnar schema version `1` and their logical
+table. The writer emits no clock, RNG, filesystem, or ambient producer data.
+
+The reader is intentionally not a general Parquet engine. It accepts this exact
+schema and encoding profile and fails closed on structural drift, unsupported
+features, malformed references, invalid RDF positions, decompression size
+mismatches, or trailing data.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -72,6 +72,7 @@ Use that same publisher configuration for these crates:
 - `purrdf-xsd`
 - `purrdf-gts`
 - `purrdf-core`
+- `purrdf-columnar`
 - `purrdf-entail`
 - `purrdf-sparql-algebra`
 - `purrdf-sparql-results`
@@ -89,11 +90,11 @@ be configured. Bootstrap publishes for new crate records therefore use an
 explicit token. After those crate records exist, enable the Trusted Publisher
 entries above and use the GitHub release workflow for future releases.
 
-`purrdf-python`, `purrdf-sparql-conformance`, `purrdf-entail`, and `purrdf-capi`
+`purrdf-python`, `purrdf-sparql-conformance`, `purrdf-cli`, and `purrdf-capi`
 remain workspace crates, but they are not in this crates.io release lane.
 `purrdf-python` is the PyPI extension package under `bindings/python`, the
-conformance harness is an internal W3C fixture runner, `purrdf-entail` is an
-internal PurRDF entailment/reasoning crate with no publishable dependents, and
+conformance harness is an internal W3C fixture runner, `purrdf-cli` is the
+native command-line package, and
 the C ABI is a native artifact that should get a separate release lane if/when it
 is shipped.
 

--- a/docs/book/src/concepts/codecs.md
+++ b/docs/book/src/concepts/codecs.md
@@ -96,6 +96,19 @@ and hands `PackView::from_bytes` the resulting borrowed slice. See the
 [the backend contract](https://github.com/Blackcat-Informatics/purrdf/blob/main/docs/design/purrdf-backend-contract.md)
 for the full contract.
 
+## The columnar Parquet codec
+
+`purrdf::columnar` exposes the bidirectional SQL/DataFrame interchange path.
+It maps any `DatasetView` plus a content-addressed blob store to five standard
+Parquet files (`terms`, `quads`, `reifiers`, `annotations`, and `blobs`) and
+reads that exact profile back without Arrow or a general Parquet runtime. The
+mapping retains RDF 1.2 triple terms, reifiers, annotations, graph scope,
+directional literals, blank-node scope, and explicitly empty named graphs.
+
+The files are byte-deterministic and readable by engines such as DuckDB. See
+the [normative columnar schema](https://github.com/Blackcat-Informatics/purrdf/blob/main/docs/COLUMNAR.md)
+for every field and the deliberately narrow Parquet profile.
+
 ## Conformance
 
 The codecs are gated by the W3C `rdf-tests` syntax corpus, vendored and frozen

--- a/docs/book/src/getting-started/rust.md
+++ b/docs/book/src/getting-started/rust.md
@@ -81,7 +81,7 @@ let schema = purrdf::shex::parse_shexc(
 ## When to depend on a sub-crate instead
 
 Most applications should stop at `purrdf`. The sub-crates
-(`purrdf-core`, `purrdf-rdf`, `purrdf-sparql-eval`, `purrdf-shapes`,
+(`purrdf-core`, `purrdf-rdf`, `purrdf-columnar`, `purrdf-sparql-eval`, `purrdf-shapes`,
 `purrdf-shex`, `purrdf-gts`, `purrdf-entail`, `purrdf-validate`,
 `purrdf-slice`, `purrdf-iri`, `purrdf-xsd`, `purrdf-events`) exist for
 consumers that want exactly one engine — for example, a tool that only needs

--- a/scripts/bootstrap-crates-io.sh
+++ b/scripts/bootstrap-crates-io.sh
@@ -39,6 +39,7 @@ crates=(
   purrdf-xsd
   purrdf-gts
   purrdf-core
+  purrdf-columnar
   purrdf-entail
   purrdf-sparql-algebra
   purrdf-sparql-results

--- a/scripts/check-columnar-oracle.sh
+++ b/scripts/check-columnar-oracle.sh
@@ -41,4 +41,17 @@ if [[ "${types}" != $'BIGINT,VARCHAR\nBLOB' ]]; then
   exit 1
 fi
 
-echo "OK: DuckDB read all five PurRDF columnar files with expected rows and types"
+empty_counts="$(duckdb -csv -noheader -c "
+SELECT
+  (SELECT count(*) FROM read_parquet('${tmp}/empty/terms.parquet')),
+  (SELECT count(*) FROM read_parquet('${tmp}/empty/quads.parquet')),
+  (SELECT count(*) FROM read_parquet('${tmp}/empty/reifiers.parquet')),
+  (SELECT count(*) FROM read_parquet('${tmp}/empty/annotations.parquet')),
+  (SELECT count(*) FROM read_parquet('${tmp}/empty/blobs.parquet'));
+")"
+if [[ "${empty_counts}" != "0,0,0,0,0" ]]; then
+  echo "ERROR: DuckDB observed unexpected rows in empty columnar files: ${empty_counts}" >&2
+  exit 1
+fi
+
+echo "OK: DuckDB read populated and empty PurRDF columnar files with expected rows and types"

--- a/scripts/check-columnar-oracle.sh
+++ b/scripts/check-columnar-oracle.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+set -euo pipefail
+
+if ! command -v duckdb >/dev/null 2>&1; then
+  echo "ERROR: DuckDB CLI is required for the dev-only columnar oracle" >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+cargo run --quiet --locked -p purrdf-columnar --example write_oracle_fixture -- "${tmp}"
+
+counts="$(duckdb -csv -noheader -c "
+SELECT
+  (SELECT count(*) FROM read_parquet('${tmp}/quads.parquet')),
+  (SELECT count(*) FROM read_parquet('${tmp}/reifiers.parquet')),
+  (SELECT count(*) FROM read_parquet('${tmp}/annotations.parquet')),
+  (SELECT count(*) FROM read_parquet('${tmp}/blobs.parquet')),
+  (SELECT count(*) FROM read_parquet('${tmp}/terms.parquet') WHERE named_graph = 1),
+  (SELECT count(*) FROM read_parquet('${tmp}/terms.parquet')
+    WHERE kind = 1 AND lang = 'ar' AND direction = 1);
+")"
+if [[ "${counts}" != "2,1,1,2,2,1" ]]; then
+  echo "ERROR: DuckDB observed unexpected columnar fixture counts: ${counts}" >&2
+  exit 1
+fi
+
+types="$(duckdb -csv -noheader -c "
+SELECT typeof(id), typeof(lex)
+FROM read_parquet('${tmp}/terms.parquet') LIMIT 1;
+SELECT typeof(bytes)
+FROM read_parquet('${tmp}/blobs.parquet') LIMIT 1;
+")"
+if [[ "${types}" != $'BIGINT,VARCHAR\nBLOB' ]]; then
+  echo "ERROR: DuckDB observed unexpected Parquet types:" >&2
+  printf '%s\n' "${types}" >&2
+  exit 1
+fi
+
+echo "OK: DuckDB read all five PurRDF columnar files with expected rows and types"


### PR DESCRIPTION
Closes #107

## Requirements covered

- add the publishable, wasm-clean `purrdf-columnar` crate and umbrella `purrdf::columnar` surface
- project RDF 1.2 plus `ContentStore` into the fixed `terms`, `quads`, `reifiers`, `annotations`, and `blobs` tables
- provide a strict bidirectional reader/writer with always-present loss ledgers
- emit byte-deterministic UNCOMPRESSED or ZSTD Parquet without Arrow, parquet-rs, or a general Thrift runtime
- prove external SQL compatibility, backend independence, and ingest-order independence

## Implementation

- defines the closed INT64/BYTE_ARRAY schema and canonical five-file container
- implements bounded Thrift Compact metadata plus PLAIN, RLE definition levels, Data Page V2, and deterministic `structured-zstd` pages
- canonicalizes arbitrary `DatasetView` ids through recursive `TermValue` ordering, retaining scoped blanks, directional literals, triple terms, RDF 1.2 side tables, declared empty graphs, and real blob payloads
- reconstructs through `RdfDatasetBuilder` and fails closed on schema drift, malformed references/order/nullability, RDF positional errors, and blob digest mismatch
- wires workspace publishing, wasm CI, release documentation, umbrella exports, benchmark coverage, and a dev-only DuckDB oracle

## Validation

- `make check`
- `make doc`
- `cargo package -p purrdf-columnar --locked`
- `make columnar-oracle` (DuckDB 1.5.4; populated ZSTD and all five zero-row files)
- `cargo bench -p purrdf-columnar --bench codec --no-run --locked`

Focused coverage includes byte-identical repeated builds, reversed allocation/ingest order, native `RdfDataset` versus `PackView`, full write-read-write stability, exact RDF isomorphism, empty loss ledgers, corruption rejection, empty tables, and both compression modes.

## Plan executed

1. Define the crate, schema, workspace/release wiring, and public contract.
2. Implement the deterministic narrow Parquet/Thrift kernel.
3. Add the generic dataset/blob writer.
4. Add strict semantic RDF/blob reconstruction.
5. Add cross-backend, determinism, DuckDB, benchmark, wasm, package, and full-workspace acceptance.

## Residual risk

The reader intentionally accepts only PurRDF schema version 1 and the exact profile emitted here; general Parquet constructs remain out of scope. DuckDB is the committed external oracle because PyArrow is not installed in the development environment.