### PR TITLE
feat(rdf): add native bidirectional OKF codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ but it assumes nothing about your ontology or application.
   string arena, copy-on-write mutation), with triple terms in object position,
   reifier/annotation side-tables, and base-direction literals (`rdf:dirLangString`).
 - **Native codecs** — first-party parsers/serializers for **Turtle, TriG, N-Triples,
-  N-Quads, RDF/XML, JSON-LD (star), and YAML-LD**; byte-deterministic output.
+  N-Quads, RDF/XML, JSON-LD (star), and YAML-LD**, plus bidirectional OKF Markdown
+  bundles with caller-supplied vocabulary; byte-deterministic output.
 - **Canonicalization** — W3C **RDFC-1.0** dataset canonicalization, tested against the
   W3C fixture suite.
 - **SPARQL 1.1/1.2** — native parser → algebra → multiset evaluator over the interned

--- a/crates/rdf-core/src/ir/event_sink.rs
+++ b/crates/rdf-core/src/ir/event_sink.rs
@@ -54,10 +54,34 @@ pub trait RdfDatasetVisitor {
         let _ = (reifier, triple);
     }
 
+    /// Like [`reifier`](Self::reifier), but carries the named graph in which the
+    /// reifier binding was asserted (`None` = default graph). The default keeps
+    /// existing visitors source-compatible by delegating to the graph-unaware
+    /// callback. A projection whose fidelity depends on graph placement overrides
+    /// this method.
+    fn reifier_in_graph(&mut self, reifier: TermId, triple: TermId, graph: Option<TermId>) {
+        let _ = graph;
+        self.reifier(reifier, triple);
+    }
+
     /// A `(reifier, predicate, object)` statement annotation. All three ids were
     /// declared earlier.
     fn annotation(&mut self, reifier: TermId, predicate: TermId, object: TermId) {
         let _ = (reifier, predicate, object);
+    }
+
+    /// Like [`annotation`](Self::annotation), but carries the named graph in which
+    /// the annotation was asserted (`None` = default graph). The default delegates
+    /// to the graph-unaware callback for compatibility.
+    fn annotation_in_graph(
+        &mut self,
+        reifier: TermId,
+        predicate: TermId,
+        object: TermId,
+        graph: Option<TermId>,
+    ) {
+        let _ = graph;
+        self.annotation(reifier, predicate, object);
     }
 }
 
@@ -75,11 +99,11 @@ impl RdfDataset {
         for quad in self.quads() {
             sink.quad(quad);
         }
-        for (reifier, triple) in self.reifiers() {
-            sink.reifier(reifier, triple);
+        for (reifier, triple, graph) in self.reifiers_with_graph() {
+            sink.reifier_in_graph(reifier, triple, graph);
         }
-        for (reifier, predicate, object) in self.annotations() {
-            sink.annotation(reifier, predicate, object);
+        for (reifier, predicate, object, graph) in self.annotations_with_graph() {
+            sink.annotation_in_graph(reifier, predicate, object, graph);
         }
     }
 }
@@ -177,6 +201,50 @@ mod tests {
         assert_eq!(sink.quads, ds.quads().collect::<Vec<_>>());
         assert_eq!(sink.reifiers, ds.reifiers().collect::<Vec<_>>());
         assert_eq!(sink.annotations, ds.annotations().collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn emit_preserves_reifier_and_annotation_graph_slots() {
+        #[derive(Default)]
+        struct GraphAwareSink {
+            reifiers: Vec<(TermId, TermId, Option<TermId>)>,
+            annotations: Vec<(TermId, TermId, TermId, Option<TermId>)>,
+        }
+
+        impl RdfDatasetVisitor for GraphAwareSink {
+            fn reifier_in_graph(&mut self, reifier: TermId, triple: TermId, graph: Option<TermId>) {
+                self.reifiers.push((reifier, triple, graph));
+            }
+
+            fn annotation_in_graph(
+                &mut self,
+                reifier: TermId,
+                predicate: TermId,
+                object: TermId,
+                graph: Option<TermId>,
+            ) {
+                self.annotations.push((reifier, predicate, object, graph));
+            }
+        }
+
+        let mut b = RdfDatasetBuilder::new();
+        let (s, p, o) = (iri(&mut b, "s"), iri(&mut b, "p"), iri(&mut b, "o"));
+        let graph = iri(&mut b, "graph");
+        let triple = b.intern_triple(s, p, o);
+        let reifier = iri(&mut b, "reifier");
+        let annotation_predicate = iri(&mut b, "confidence");
+        b.push_reifier_in_graph(reifier, triple, Some(graph));
+        b.push_annotation_in_graph(reifier, annotation_predicate, o, Some(graph));
+        let ds = b.freeze().expect("valid");
+
+        let mut sink = GraphAwareSink::default();
+        ds.emit(&mut sink);
+
+        assert_eq!(sink.reifiers, vec![(reifier, triple, Some(graph))]);
+        assert_eq!(
+            sink.annotations,
+            vec![(reifier, annotation_predicate, o, Some(graph))]
+        );
     }
 
     #[test]

--- a/crates/rdf-core/src/lib.rs
+++ b/crates/rdf-core/src/lib.rs
@@ -131,8 +131,8 @@ pub use lookaside::{
 pub use loss::{
     LossEntry, LossLedger, PROJECTION_CODECS, assert_ledger_complete, assert_ledger_sound,
     check_ledger_complete, check_ledger_sound, gts_to_rdf_loss_ledger, loss_matrix_json,
-    pair_loss_ledger, profile_for, rdf_gts_loss_matrix_json, rdf_to_gts_loss_ledger,
-    registered_pairs,
+    okf_to_rdf_loss_ledger, pair_loss_ledger, profile_for, rdf_gts_loss_matrix_json,
+    rdf_to_gts_loss_ledger, rdf_to_okf_loss_ledger, registered_pairs,
 };
 pub use model::{
     RdfAnnotation, RdfLiteral, RdfQuad, RdfReifier, RdfTerm, RdfTermKind, RdfTextDirection,

--- a/crates/rdf-core/src/loss.rs
+++ b/crates/rdf-core/src/loss.rs
@@ -23,7 +23,8 @@
 //! conversion accumulating located losses as it runs). [`registered_pairs`] and
 //! [`profile_for`] enumerate the closed set of `(from, to)` pairs and loss codes
 //! known across BOTH disciplines, including the non-syntax `shacl`→`json-schema`
-//! shapes projection; [`loss_matrix_json`] renders that same enumerable registry.
+//! shapes projection and the bidirectional RDF 1.2 dataset↔OKF profile;
+//! [`loss_matrix_json`] renders that same enumerable registry.
 
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
@@ -189,6 +190,79 @@ pub fn gts_to_rdf_loss_ledger() -> LossLedger {
             "`purrdf_gts::reader::read()` folds all segments into one term table, collapsing \
              per-segment blank-node scope; the distinct scopes are recovered only via the \
              streaming-event importer.",
+        ),
+        location: None,
+    }])
+}
+
+/// The closed loss contract for projecting an arbitrary RDF 1.2 dataset to an
+/// OKF Markdown bundle.
+///
+/// OKF is a deliberately narrow authoring profile. Profile quads in the default
+/// graph and its derived Markdown-link statement layer are representable; named
+/// graph placement, other RDF/OWL statements, and unrelated RDF 1.2
+/// reifier/annotation rows are not. The native OKF writer records only the codes
+/// that occur for the dataset being written, while this contract enumerates every
+/// code it is permitted to record.
+pub fn rdf_to_okf_loss_ledger() -> LossLedger {
+    LossLedger::contract(vec![
+        LossEntry {
+            code: Cow::Borrowed("named-graph-dropped"),
+            from: Cow::Borrowed("rdf-1.2-dataset"),
+            to: Cow::Borrowed("okf"),
+            note: Cow::Borrowed(
+                "OKF documents have no named-graph placement; a quad asserted outside the \
+                 default graph cannot be represented in Markdown frontmatter or body text.",
+            ),
+            location: None,
+        },
+        LossEntry {
+            code: Cow::Borrowed("okf-annotation-dropped"),
+            from: Cow::Borrowed("rdf-1.2-dataset"),
+            to: Cow::Borrowed("okf"),
+            note: Cow::Borrowed(
+                "An RDF 1.2 annotation outside the exact caller-configured OKF Markdown-link \
+                 profile has no OKF representation and is omitted from the bundle.",
+            ),
+            location: None,
+        },
+        LossEntry {
+            code: Cow::Borrowed("okf-non-profile-quad-dropped"),
+            from: Cow::Borrowed("rdf-1.2-dataset"),
+            to: Cow::Borrowed("okf"),
+            note: Cow::Borrowed(
+                "An RDF statement outside the caller-configured OKF profile, including an \
+                 OWL axiom, has no Markdown/frontmatter field and is omitted from the bundle.",
+            ),
+            location: None,
+        },
+        LossEntry {
+            code: Cow::Borrowed("okf-reifier-dropped"),
+            from: Cow::Borrowed("rdf-1.2-dataset"),
+            to: Cow::Borrowed("okf"),
+            note: Cow::Borrowed(
+                "An RDF 1.2 reifier outside the exact caller-configured OKF Markdown-link \
+                 profile has no OKF representation and is omitted from the bundle.",
+            ),
+            location: None,
+        },
+    ])
+}
+
+/// The closed loss contract for lifting an OKF Markdown bundle into an RDF 1.2
+/// event stream.
+///
+/// Frontmatter-less `index.md` files are navigation-only pages: their body is not
+/// attached to an OKF concept and therefore does not enter the RDF profile. The
+/// reader records each skipped page with this code and a file location.
+pub fn okf_to_rdf_loss_ledger() -> LossLedger {
+    LossLedger::contract(vec![LossEntry {
+        code: Cow::Borrowed("okf-navigation-page-dropped"),
+        from: Cow::Borrowed("okf"),
+        to: Cow::Borrowed("rdf-1.2-dataset"),
+        note: Cow::Borrowed(
+            "A frontmatter-less index.md navigation page has no OKF concept subject and is \
+             omitted from the RDF profile; its path is recorded on the runtime loss entry.",
         ),
         location: None,
     }])
@@ -556,7 +630,9 @@ fn static_str(cow: &Cow<'static, str>) -> &'static str {
 
 /// The single source of truth every enumerable-registry consumer reads: the
 /// RDF↔GTS direction ledgers ([`rdf_to_gts_loss_ledger`] /
-/// [`gts_to_rdf_loss_ledger`]) plus [`transcode_and_shapes_entries`] (the full
+/// [`gts_to_rdf_loss_ledger`]), RDF↔OKF direction ledgers
+/// ([`rdf_to_okf_loss_ledger`] / [`okf_to_rdf_loss_ledger`]), plus
+/// [`transcode_and_shapes_entries`] (the full
 /// syntax/projection transcode matrix over `SYNTAX_CODECS` × `(SYNTAX_CODECS ∪
 /// PROJECTION_CODECS)` AND the non-syntax shapes pair `("shacl", "json-schema")`).
 ///
@@ -569,6 +645,8 @@ fn registry_entries() -> Vec<LossEntry> {
     let mut entries: Vec<LossEntry> = Vec::new();
     entries.extend_from_slice(rdf_to_gts_loss_ledger().entries());
     entries.extend_from_slice(gts_to_rdf_loss_ledger().entries());
+    entries.extend_from_slice(rdf_to_okf_loss_ledger().entries());
+    entries.extend_from_slice(okf_to_rdf_loss_ledger().entries());
     entries.extend(transcode_and_shapes_entries());
     entries
 }
@@ -1244,6 +1322,26 @@ mod tests {
             profile.contains("named-graph-dropped"),
             "profile_for(\"trig\", \"turtle\") missing named-graph-dropped: {profile:?}"
         );
+    }
+
+    #[test]
+    fn okf_direction_profiles_are_closed_and_registered() {
+        let write_profile = profile_for("rdf-1.2-dataset", "okf");
+        assert_eq!(
+            write_profile,
+            BTreeSet::from([
+                "named-graph-dropped",
+                "okf-annotation-dropped",
+                "okf-non-profile-quad-dropped",
+                "okf-reifier-dropped",
+            ])
+        );
+        assert_eq!(
+            profile_for("okf", "rdf-1.2-dataset"),
+            BTreeSet::from(["okf-navigation-page-dropped"])
+        );
+        assert!(check_ledger_sound(&rdf_to_okf_loss_ledger(), "rdf-1.2-dataset", "okf").is_ok());
+        assert!(check_ledger_sound(&okf_to_rdf_loss_ledger(), "okf", "rdf-1.2-dataset").is_ok());
     }
 
     /// Build a hand-rolled, owned runtime [`LossEntry`] for the mechanical

--- a/crates/rdf/README.md
+++ b/crates/rdf/README.md
@@ -26,6 +26,9 @@ loss ledger) and adds what the kernel deliberately leaves out:
 - **Native text codecs** — first-party parsers/serializers for Turtle, TriG,
   N-Triples, N-Quads, and RDF/XML, plus JSON-LD (star) and YAML-LD; parsing
   can optionally record a source-position span table for diagnostics.
+- **Native OKF codec** — bidirectional Open Knowledge Format Markdown bundles
+  over the RDF event seams, with caller-owned vocabulary, deterministic YAML,
+  and an always-computed loss ledger.
 - **RDF 1.2 statement layer** — reifier bindings and annotations survive every
   star-capable round-trip; star-incapable projections drop them *loudly*, with
   the realized count handed to the loss ledger.
@@ -91,6 +94,45 @@ the structural triple term.
 
 Malformed input is a typed `RdfDiagnostic` with a source location where the
 codec can provide one — never a silent partial parse.
+
+### Open Knowledge Format bundles
+
+OKF uses a deterministic in-memory bundle so the same API works on native and
+`wasm32-unknown-unknown` targets. PurRDF never chooses a directory, archive, or
+vocabulary for the caller: filesystem materialization is outside the codec, and
+the namespace, document base, and recognized frontmatter keys are mandatory.
+
+```rust
+use purrdf_rdf::{
+    DatasetSink, OkfBundle, OkfConfig, lift_okf_bundle, write_okf_bundle,
+};
+
+let config = OkfConfig::new(
+    "https://example.org/okf#",
+    "https://example.org/doc/",
+    ["type", "title"],
+)?;
+let bundle = OkfBundle::from_documents([(
+    "concept.md",
+    "---\ntype: Concept\ntitle: Example\n---\nBody.\n",
+)])?;
+
+let mut sink = DatasetSink::new();
+let read = lift_okf_bundle(&bundle, &config, &mut sink)?;
+assert!(read.losses.is_empty());
+let dataset = sink.into_dataset().expect("the lift finished the sink");
+
+let written = write_okf_bundle(&dataset, &config)?;
+assert!(written.losses.is_empty());
+assert_eq!(written.documents, 1);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+The reader drives any `RdfEventSink`; the writer is itself an
+`RdfDatasetVisitor`. Relative Markdown links preserve their exact RDF 1.2
+reifier and occurrence annotations. RDF rows outside the configured OKF
+profile are omitted only with deterministic, source-located `LossLedger`
+entries; ambiguous profile data hard-fails.
 
 ## Part of PurRDF
 

--- a/crates/rdf/src/lib.rs
+++ b/crates/rdf/src/lib.rs
@@ -91,6 +91,10 @@ pub mod viz;
 pub use dataset_io::dataset_from_bytes;
 pub use gts_import_graph::import_gts_graph;
 pub use gts_import_sink::import_gts_events;
+pub use native_codecs::okf::{
+    OkfBundle, OkfConfig, OkfError, OkfReadOutcome, OkfWriteOutcome, OkfWriter, lift_okf_bundle,
+    write_okf_bundle,
+};
 pub use native_codecs::{
     GtsCodecBackend, NativeRdfFormat, ParseOptions, SerializeOutcome, SpanTable, classify,
     parse_dataset, parse_dataset_with, serialize_dataset, serialize_dataset_base_only,

--- a/crates/rdf/src/lib.rs
+++ b/crates/rdf/src/lib.rs
@@ -125,9 +125,10 @@ pub use purrdf_core::{
     UnitMetadata, ViewOperationStatus, assert_ledger_complete, assert_ledger_sound, canonicalize,
     canonicalize_with, check_ledger_complete, check_ledger_sound, check_provenance, dataset_diff,
     datasets_isomorphic, emit_annotation, emit_quad, emit_reifier, emit_resource, emit_term,
-    fno_to_ntriples, fno_to_quads, gts_to_rdf_loss_ledger, loss_matrix_json, pair_loss_ledger,
-    profile_for, rdf_gts_loss_matrix_json, rdf_to_gts_loss_ledger, registered_pairs, rule_iri,
-    smallvec, try_canonicalize, try_canonicalize_with,
+    fno_to_ntriples, fno_to_quads, gts_to_rdf_loss_ledger, loss_matrix_json,
+    okf_to_rdf_loss_ledger, pair_loss_ledger, profile_for, rdf_gts_loss_matrix_json,
+    rdf_to_gts_loss_ledger, rdf_to_okf_loss_ledger, registered_pairs, rule_iri, smallvec,
+    try_canonicalize, try_canonicalize_with,
 };
 pub use purrdf_core::{
     PackBuilder, PackDigest, PackError, PackId, PackView, dataset_from_view, pack_digest,

--- a/crates/rdf/src/native_codecs/mod.rs
+++ b/crates/rdf/src/native_codecs/mod.rs
@@ -33,6 +33,8 @@ mod serialize;
 // validate / pipeline consumers share, so all three call it here (the codec previously
 // lived in `purrdf-pipeline::stages::yaml_ld`, above `rdf` and `validate`).
 pub mod jsonld;
+/// Native in-memory Open Knowledge Format Markdown-bundle codec.
+pub mod okf;
 // First-party N-Triples / N-Quads / Turtle / TriG text parser: lowers
 // directly to the in-memory GtsGraph the statement-layer fold consumes, replacing the
 // purrdf-gts text codecs for the line/Turtle family.

--- a/crates/rdf/src/native_codecs/okf/mod.rs
+++ b/crates/rdf/src/native_codecs/okf/mod.rs
@@ -1,0 +1,435 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Native Open Knowledge Format (OKF) Markdown-bundle codec.
+//!
+//! OKF is a deterministic in-memory bundle of UTF-8 Markdown documents with YAML
+//! frontmatter. This module deliberately owns no filesystem API: callers can map
+//! [`OkfBundle`](crate::native_codecs::okf::OkfBundle) entries to directories, archives, browser
+//! storage, or another transport without making the release crate non-wasm. The RDF vocabulary and
+//! document base are mandatory caller configuration; PurRDF provides no namespace
+//! default and mints no vocabulary IRI.
+
+mod reader;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+pub use reader::lift_okf_bundle;
+
+use crate::LossLedger;
+
+/// Maximum number of documents accepted by one in-memory bundle.
+pub const MAX_OKF_DOCUMENTS: usize = 65_536;
+/// Maximum UTF-8 byte length of one Markdown document.
+pub const MAX_OKF_DOCUMENT_BYTES: usize = 16 * 1024 * 1024;
+/// Maximum aggregate UTF-8 byte length of one bundle.
+pub const MAX_OKF_BUNDLE_BYTES: usize = 256 * 1024 * 1024;
+/// Maximum UTF-8 byte length of one relative bundle path.
+pub const MAX_OKF_PATH_BYTES: usize = 4_096;
+/// Maximum YAML-frontmatter byte length of one document.
+pub const MAX_OKF_FRONTMATTER_BYTES: usize = 1024 * 1024;
+/// Maximum number of YAML nodes in one document's frontmatter.
+pub const MAX_OKF_YAML_NODES: usize = 65_536;
+/// Maximum YAML nesting depth in one document's frontmatter.
+pub const MAX_OKF_YAML_DEPTH: usize = 64;
+/// Maximum number of Markdown links scanned from one document body.
+pub const MAX_OKF_LINKS_PER_DOCUMENT: usize = 65_536;
+
+const RESERVED_PROFILE_KEYS: &[&str] = &[
+    "body",
+    "json",
+    "linkOccurrence",
+    "linkText",
+    "links",
+    "path",
+];
+
+/// A typed hard failure from OKF configuration, parsing, lifting, or writing.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OkfError {
+    detail: String,
+}
+
+impl OkfError {
+    pub(super) fn new(detail: impl Into<String>) -> Self {
+        Self {
+            detail: detail.into(),
+        }
+    }
+
+    /// The stable human-readable error detail.
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+}
+
+impl fmt::Display for OkfError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.detail)
+    }
+}
+
+impl std::error::Error for OkfError {}
+
+/// Mandatory caller-owned OKF vocabulary and frontmatter profile.
+///
+/// There is intentionally no [`Default`] implementation. The caller must choose
+/// the namespace from which profile predicate IRIs are derived, the base used for
+/// documents without an explicit `resource`, and the exact set of frontmatter keys
+/// the application recognizes. `type` is always required; unrecognized authored
+/// keys hard-fail instead of leaking into an invented vocabulary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OkfConfig {
+    namespace: String,
+    document_base_iri: String,
+    recognized_keys: BTreeSet<String>,
+    predicates: BTreeMap<String, String>,
+    path_predicate: String,
+    body_predicate: String,
+    links_predicate: String,
+    link_text_predicate: String,
+    link_occurrence_predicate: String,
+    json_datatype: String,
+}
+
+impl OkfConfig {
+    /// Validate and construct a mandatory OKF profile.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OkfError`] when either IRI is not absolute, a namespace/base does
+    /// not end in a safe joining delimiter (`#`, `/`, or `:`), `type` is absent,
+    /// or a recognized key is unsafe/reserved.
+    pub fn new<I, S>(
+        namespace: impl Into<String>,
+        document_base_iri: impl Into<String>,
+        recognized_keys: I,
+    ) -> Result<Self, OkfError>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let namespace = namespace.into();
+        let document_base_iri = document_base_iri.into();
+        validate_join_base("OKF namespace", &namespace)?;
+        validate_join_base("OKF document base IRI", &document_base_iri)?;
+
+        let recognized_keys: BTreeSet<String> =
+            recognized_keys.into_iter().map(Into::into).collect();
+        if !recognized_keys.contains("type") {
+            return Err(OkfError::new(
+                "OKF recognized-frontmatter profile must include the required `type` key",
+            ));
+        }
+        if recognized_keys.len() > MAX_OKF_YAML_NODES {
+            return Err(OkfError::new(format!(
+                "OKF recognized-frontmatter profile has {} keys; limit is {MAX_OKF_YAML_NODES}",
+                recognized_keys.len()
+            )));
+        }
+
+        let mut predicates = BTreeMap::new();
+        for key in &recognized_keys {
+            validate_profile_key(key)?;
+            if RESERVED_PROFILE_KEYS.contains(&key.as_str()) {
+                return Err(OkfError::new(format!(
+                    "OKF frontmatter key `{key}` is reserved for the RDF bundle profile"
+                )));
+            }
+            let iri = format!("{namespace}{key}");
+            validate_absolute_iri("OKF predicate", &iri)?;
+            predicates.insert(key.clone(), iri);
+        }
+
+        let system_iri = |local: &str| -> Result<String, OkfError> {
+            let iri = format!("{namespace}{local}");
+            validate_absolute_iri("OKF system predicate", &iri)?;
+            Ok(iri)
+        };
+        let path_predicate = system_iri("path")?;
+        let body_predicate = system_iri("body")?;
+        let links_predicate = system_iri("links")?;
+        let link_text_predicate = system_iri("linkText")?;
+        let link_occurrence_predicate = system_iri("linkOccurrence")?;
+        let json_datatype = system_iri("json")?;
+
+        Ok(Self {
+            namespace,
+            document_base_iri,
+            recognized_keys,
+            predicates,
+            path_predicate,
+            body_predicate,
+            links_predicate,
+            link_text_predicate,
+            link_occurrence_predicate,
+            json_datatype,
+        })
+    }
+
+    /// The caller-supplied vocabulary namespace.
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    /// The caller-supplied document base used when `resource` is absent.
+    pub fn document_base_iri(&self) -> &str {
+        &self.document_base_iri
+    }
+
+    /// Recognized frontmatter keys in deterministic lexical order.
+    pub fn recognized_keys(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.recognized_keys.iter().map(String::as_str)
+    }
+
+    /// The configured predicate IRI for a recognized frontmatter key.
+    pub fn predicate_iri(&self, key: &str) -> Option<&str> {
+        self.predicates.get(key).map(String::as_str)
+    }
+
+    /// Profile predicate carrying a document's normalized bundle path.
+    pub fn path_predicate(&self) -> &str {
+        &self.path_predicate
+    }
+
+    /// Profile predicate carrying the authoritative Markdown body literal.
+    pub fn body_predicate(&self) -> &str {
+        &self.body_predicate
+    }
+
+    /// Profile predicate carrying a relative Markdown-link edge.
+    pub fn links_predicate(&self) -> &str {
+        &self.links_predicate
+    }
+
+    /// Annotation predicate carrying a Markdown link's visible text.
+    pub fn link_text_predicate(&self) -> &str {
+        &self.link_text_predicate
+    }
+
+    /// Annotation predicate carrying a Markdown link's one-based occurrence.
+    pub fn link_occurrence_predicate(&self) -> &str {
+        &self.link_occurrence_predicate
+    }
+
+    /// Datatype IRI used for canonical JSON representations of structured YAML.
+    pub fn json_datatype(&self) -> &str {
+        &self.json_datatype
+    }
+
+    pub(super) fn recognizes(&self, key: &str) -> bool {
+        self.recognized_keys.contains(key)
+    }
+}
+
+/// A deterministic, validated in-memory OKF Markdown bundle.
+///
+/// Paths are normalized POSIX-relative `.md` names and iteration is lexical by
+/// path. Documents are UTF-8 [`String`] values, so invalid body/frontmatter bytes
+/// cannot enter the codec. Construction enforces the public resource limits.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct OkfBundle {
+    documents: BTreeMap<String, String>,
+    total_bytes: usize,
+}
+
+impl OkfBundle {
+    /// Construct an empty bundle.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Construct a bundle from path/document pairs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OkfError`] on a duplicate/unsafe path or a resource-limit breach.
+    pub fn from_documents<I, P, D>(documents: I) -> Result<Self, OkfError>
+    where
+        I: IntoIterator<Item = (P, D)>,
+        P: Into<String>,
+        D: Into<String>,
+    {
+        let mut bundle = Self::new();
+        for (path, document) in documents {
+            bundle.insert(path, document)?;
+        }
+        Ok(bundle)
+    }
+
+    /// Insert one document while preserving all path and size invariants.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OkfError`] on a duplicate/unsafe path or a resource-limit breach.
+    pub fn insert(
+        &mut self,
+        path: impl Into<String>,
+        document: impl Into<String>,
+    ) -> Result<(), OkfError> {
+        let path = path.into();
+        let document = document.into();
+        validate_relative_markdown_path(&path)?;
+        if self.documents.contains_key(&path) {
+            return Err(OkfError::new(format!(
+                "duplicate OKF document path `{path}`"
+            )));
+        }
+        if self.documents.len() >= MAX_OKF_DOCUMENTS {
+            return Err(OkfError::new(format!(
+                "OKF bundle exceeds the {MAX_OKF_DOCUMENTS}-document limit"
+            )));
+        }
+        if document.len() > MAX_OKF_DOCUMENT_BYTES {
+            return Err(OkfError::new(format!(
+                "OKF document `{path}` is {} bytes; limit is {MAX_OKF_DOCUMENT_BYTES}",
+                document.len()
+            )));
+        }
+        let total = self
+            .total_bytes
+            .checked_add(document.len())
+            .ok_or_else(|| OkfError::new("OKF bundle byte count overflow"))?;
+        if total > MAX_OKF_BUNDLE_BYTES {
+            return Err(OkfError::new(format!(
+                "OKF bundle is {total} bytes; limit is {MAX_OKF_BUNDLE_BYTES}"
+            )));
+        }
+        self.total_bytes = total;
+        self.documents.insert(path, document);
+        Ok(())
+    }
+
+    /// Borrow a document by its normalized path.
+    pub fn get(&self, path: &str) -> Option<&str> {
+        self.documents.get(path).map(String::as_str)
+    }
+
+    /// Documents in deterministic lexical path order.
+    pub fn documents(&self) -> impl ExactSizeIterator<Item = (&str, &str)> {
+        self.documents
+            .iter()
+            .map(|(path, document)| (path.as_str(), document.as_str()))
+    }
+
+    /// Number of documents in the bundle.
+    pub fn len(&self) -> usize {
+        self.documents.len()
+    }
+
+    /// Whether the bundle contains no documents.
+    pub fn is_empty(&self) -> bool {
+        self.documents.is_empty()
+    }
+
+    /// Aggregate UTF-8 byte length of all documents.
+    pub fn total_bytes(&self) -> usize {
+        self.total_bytes
+    }
+}
+
+/// Report from lifting an OKF bundle through an RDF event sink.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OkfReadOutcome {
+    /// Always-computed runtime loss ledger.
+    pub losses: LossLedger,
+    /// Number of concept documents emitted into the sink.
+    pub documents: usize,
+    /// Number of frontmatter-less navigation indexes explicitly skipped.
+    pub navigation_pages: usize,
+    /// Whether the sink requested early cancellation. A cancelled drive is not
+    /// finished, matching the [`purrdf_events::RdfEventSource`] contract.
+    pub cancelled: bool,
+}
+
+pub(super) fn validate_relative_markdown_path(path: &str) -> Result<(), OkfError> {
+    if path.is_empty() {
+        return Err(OkfError::new("OKF document path must not be empty"));
+    }
+    if path.len() > MAX_OKF_PATH_BYTES {
+        return Err(OkfError::new(format!(
+            "OKF document path is {} bytes; limit is {MAX_OKF_PATH_BYTES}",
+            path.len()
+        )));
+    }
+    if path.starts_with('/')
+        || path.contains('\\')
+        || path.contains('\0')
+        || path
+            .split('/')
+            .any(|component| component.is_empty() || component == "." || component == "..")
+    {
+        return Err(OkfError::new(format!("unsafe OKF relative path `{path}`")));
+    }
+    if std::path::Path::new(path)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        != Some("md")
+    {
+        return Err(OkfError::new(format!(
+            "OKF document path `{path}` must end in `.md`"
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn validate_absolute_iri(label: &str, value: &str) -> Result<(), OkfError> {
+    let iri = purrdf_iri::parse(value)
+        .map_err(|error| OkfError::new(format!("invalid {label} `{value}`: {error}")))?;
+    if !iri.has_scheme() {
+        return Err(OkfError::new(format!(
+            "{label} `{value}` must be an absolute IRI"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_join_base(label: &str, value: &str) -> Result<(), OkfError> {
+    validate_absolute_iri(label, value)?;
+    if !value.ends_with(['#', '/', ':']) {
+        return Err(OkfError::new(format!(
+            "{label} `{value}` must end in `#`, `/`, or `:` before local names are appended"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_profile_key(key: &str) -> Result<(), OkfError> {
+    let mut chars = key.chars();
+    let Some(first) = chars.next() else {
+        return Err(OkfError::new("OKF frontmatter keys must not be empty"));
+    };
+    if !(first.is_ascii_alphabetic() || first == '_')
+        || !chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+    {
+        return Err(OkfError::new(format!(
+            "unsafe OKF frontmatter key `{key}`; expected an ASCII identifier"
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn minted_document_iri(config: &OkfConfig, path: &str) -> Result<String, OkfError> {
+    let iri = format!("{}{}", config.document_base_iri, percent_encode_path(path));
+    validate_absolute_iri("minted OKF document IRI", &iri)?;
+    Ok(iri)
+}
+
+fn percent_encode_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for byte in path.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' | b'/' => {
+                out.push(char::from(byte));
+            }
+            _ => {
+                const HEX: &[u8; 16] = b"0123456789ABCDEF";
+                out.push('%');
+                out.push(char::from(HEX[usize::from(byte >> 4)]));
+                out.push(char::from(HEX[usize::from(byte & 0x0f)]));
+            }
+        }
+    }
+    out
+}

--- a/crates/rdf/src/native_codecs/okf/mod.rs
+++ b/crates/rdf/src/native_codecs/okf/mod.rs
@@ -11,11 +11,13 @@
 //! default and mints no vocabulary IRI.
 
 mod reader;
+mod writer;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 pub use reader::lift_okf_bundle;
+pub use writer::{OkfWriteOutcome, OkfWriter, write_okf_bundle};
 
 use crate::LossLedger;
 
@@ -220,6 +222,11 @@ impl OkfConfig {
 
     pub(super) fn recognizes(&self, key: &str) -> bool {
         self.recognized_keys.contains(key)
+    }
+
+    pub(super) fn key_for_predicate<'a>(&'a self, iri: &str) -> Option<&'a str> {
+        let local = iri.strip_prefix(&self.namespace)?;
+        self.recognized_keys.get(local).map(String::as_str)
     }
 }
 

--- a/crates/rdf/src/native_codecs/okf/mod.rs
+++ b/crates/rdf/src/native_codecs/okf/mod.rs
@@ -74,6 +74,78 @@ impl fmt::Display for OkfError {
 
 impl std::error::Error for OkfError {}
 
+pub(super) fn decimal_lexical_from_f64(value: f64) -> Result<String, OkfError> {
+    if !value.is_finite() {
+        return Err(OkfError::new(
+            "non-finite YAML numbers are not valid OKF values",
+        ));
+    }
+    expand_decimal_exponent(&value.to_string())
+}
+
+fn expand_decimal_exponent(lexical: &str) -> Result<String, OkfError> {
+    let Some(exponent_offset) = lexical.find(['e', 'E']) else {
+        return Ok(lexical.to_owned());
+    };
+    let (mantissa, exponent) = lexical.split_at(exponent_offset);
+    let exponent = exponent[1..].parse::<i32>().map_err(|error| {
+        OkfError::new(format!(
+            "invalid internal OKF decimal exponent `{lexical}`: {error}"
+        ))
+    })?;
+    let (sign, unsigned) = if let Some(unsigned) = mantissa.strip_prefix('-') {
+        ("-", unsigned)
+    } else {
+        ("", mantissa.strip_prefix('+').unwrap_or(mantissa))
+    };
+    if unsigned.is_empty()
+        || unsigned.matches('.').count() > 1
+        || !unsigned
+            .bytes()
+            .all(|byte| byte == b'.' || byte.is_ascii_digit())
+    {
+        return Err(OkfError::new(format!(
+            "invalid internal OKF decimal mantissa `{lexical}`"
+        )));
+    }
+
+    let digits_before_decimal = unsigned.find('.').unwrap_or(unsigned.len());
+    let digits: String = unsigned.chars().filter(|ch| *ch != '.').collect();
+    if digits.is_empty() {
+        return Err(OkfError::new(format!(
+            "invalid internal OKF decimal mantissa `{lexical}`"
+        )));
+    }
+    let decimal_position = i64::try_from(digits_before_decimal)
+        .map_err(|_| OkfError::new("internal OKF decimal position overflow"))?
+        .checked_add(i64::from(exponent))
+        .ok_or_else(|| OkfError::new("internal OKF decimal exponent overflow"))?;
+
+    let mut expanded = String::with_capacity(sign.len() + digits.len() + 2);
+    expanded.push_str(sign);
+    if decimal_position <= 0 {
+        expanded.push_str("0.");
+        let zeros = usize::try_from(-decimal_position)
+            .map_err(|_| OkfError::new("internal OKF decimal padding overflow"))?;
+        expanded.extend(std::iter::repeat_n('0', zeros));
+        expanded.push_str(&digits);
+        return Ok(expanded);
+    }
+
+    let decimal_position = usize::try_from(decimal_position)
+        .map_err(|_| OkfError::new("internal OKF decimal position overflow"))?;
+    if decimal_position >= digits.len() {
+        expanded.push_str(&digits);
+        expanded.extend(std::iter::repeat_n('0', decimal_position - digits.len()));
+    } else {
+        let (integer, fraction) = digits.split_at(decimal_position);
+        expanded.push_str(integer);
+        expanded.push('.');
+        expanded.push_str(fraction);
+    }
+    Ok(expanded)
+}
+
 /// Mandatory caller-owned OKF vocabulary and frontmatter profile.
 ///
 /// There is intentionally no [`Default`] implementation. The caller must choose
@@ -439,4 +511,25 @@ fn percent_encode_path(path: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expand_decimal_exponent;
+
+    #[test]
+    fn exponent_form_expands_to_xsd_decimal_lexical_space() {
+        assert_eq!(
+            expand_decimal_exponent("1e-5").expect("small exponent"),
+            "0.00001"
+        );
+        assert_eq!(
+            expand_decimal_exponent("1.25E+20").expect("large exponent"),
+            "125000000000000000000"
+        );
+        assert_eq!(
+            expand_decimal_exponent("-1.25e-3").expect("signed exponent"),
+            "-0.00125"
+        );
+    }
 }

--- a/crates/rdf/src/native_codecs/okf/reader.rs
+++ b/crates/rdf/src/native_codecs/okf/reader.rs
@@ -27,7 +27,7 @@ const XSD_DATETIME: &str = "http://www.w3.org/2001/XMLSchema#dateTime";
 enum StrictNumber {
     Signed(i64),
     Unsigned(u64),
-    Decimal(f64),
+    Decimal(String),
 }
 
 impl StrictNumber {
@@ -35,7 +35,7 @@ impl StrictNumber {
         match self {
             Self::Signed(value) => value.to_string(),
             Self::Unsigned(value) => value.to_string(),
-            Self::Decimal(value) => value.to_string(),
+            Self::Decimal(value) => value.clone(),
         }
     }
 
@@ -50,8 +50,11 @@ impl StrictNumber {
         let number = match self {
             Self::Signed(value) => serde_json::Number::from(*value),
             Self::Unsigned(value) => serde_json::Number::from(*value),
-            Self::Decimal(value) => serde_json::Number::from_f64(*value)
-                .ok_or_else(|| OkfError::new("OKF YAML contains a non-finite number"))?,
+            Self::Decimal(value) => {
+                serde_json::from_str::<serde_json::Number>(value).map_err(|error| {
+                    OkfError::new(format!("invalid OKF decimal `{value}`: {error}"))
+                })?
+            }
         };
         Ok(serde_json::Value::Number(number))
     }
@@ -149,7 +152,13 @@ impl<'de> Visitor<'de> for StrictValueVisitor {
                 "non-finite YAML numbers are not valid OKF values",
             ));
         }
-        Ok(StrictValue::Number(StrictNumber::Decimal(value)))
+        let lexical = value.to_string();
+        let parsed = purrdf_xsd::parse_by_iri(&lexical, XSD_DECIMAL)
+            .map_err(E::custom)?
+            .ok_or_else(|| E::custom("internal OKF decimal datatype is not recognized"))?;
+        Ok(StrictValue::Number(StrictNumber::Decimal(
+            parsed.canonical_lexical(),
+        )))
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
@@ -197,10 +206,10 @@ struct ParsedDocument {
 }
 
 #[derive(Clone, Debug)]
-struct MarkdownLink {
-    text: String,
-    target: String,
-    ordinal: usize,
+pub(super) struct MarkdownLink {
+    pub(super) text: String,
+    pub(super) target: String,
+    pub(super) ordinal: usize,
 }
 
 type ParsedFrontmatter = (BTreeMap<String, StrictValue>, String);
@@ -516,6 +525,19 @@ fn build_event_graph(
                 }
                 "timestamp" => {
                     let text = scalar(value, key, &document.path)?;
+                    purrdf_xsd::parse_by_iri(&text, XSD_DATETIME)
+                        .map_err(|error| {
+                            document_error(
+                                &document.path,
+                                format!("invalid timestamp `{text}`: {error}"),
+                            )
+                        })?
+                        .ok_or_else(|| {
+                            document_error(
+                                &document.path,
+                                "internal OKF timestamp datatype is not recognized",
+                            )
+                        })?;
                     graph.quad_literal(subject, predicate, &text, XSD_DATETIME)?;
                 }
                 "type" | "title" | "description" => {
@@ -686,7 +708,10 @@ fn document_error(path: &str, detail: impl fmt::Display) -> OkfError {
     OkfError::new(format!("{path}: {detail}"))
 }
 
-fn extract_markdown_links(body: &str, path: &str) -> Result<Vec<MarkdownLink>, OkfError> {
+pub(super) fn extract_markdown_links(
+    body: &str,
+    path: &str,
+) -> Result<Vec<MarkdownLink>, OkfError> {
     let bytes = body.as_bytes();
     let mut links = Vec::new();
     let mut cursor = 0;
@@ -805,7 +830,10 @@ fn unescape_markdown(value: &str) -> String {
     out
 }
 
-fn resolve_link_path(source_path: &str, target: &str) -> Result<Option<String>, OkfError> {
+pub(super) fn resolve_link_path(
+    source_path: &str,
+    target: &str,
+) -> Result<Option<String>, OkfError> {
     let target = target.split('#').next().unwrap_or(target);
     if target.is_empty()
         || target.starts_with('/')
@@ -952,6 +980,20 @@ mod tests {
         let error =
             lift_okf_bundle(&bundle, &config(), &mut sink).expect_err("dangling link must fail");
         assert!(error.to_string().contains("dangling Markdown link"));
+        assert!(sink.dataset().is_none());
+    }
+
+    #[test]
+    fn invalid_timestamp_hard_fails_before_driving_the_sink() {
+        let bundle = OkfBundle::from_documents([(
+            "concept.md",
+            "---\ntype: Concept\ntimestamp: yesterday\n---\nbody\n",
+        )])
+        .expect("bundle");
+        let mut sink = DatasetSink::new();
+        let error = lift_okf_bundle(&bundle, &config(), &mut sink)
+            .expect_err("invalid xsd:dateTime must fail");
+        assert!(error.detail().contains("invalid timestamp"));
         assert!(sink.dataset().is_none());
     }
 

--- a/crates/rdf/src/native_codecs/okf/reader.rs
+++ b/crates/rdf/src/native_codecs/okf/reader.rs
@@ -12,8 +12,8 @@ use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 
 use super::{
     MAX_OKF_FRONTMATTER_BYTES, MAX_OKF_LINKS_PER_DOCUMENT, MAX_OKF_YAML_DEPTH, MAX_OKF_YAML_NODES,
-    OkfBundle, OkfConfig, OkfError, OkfReadOutcome, minted_document_iri, validate_absolute_iri,
-    validate_relative_markdown_path,
+    OkfBundle, OkfConfig, OkfError, OkfReadOutcome, decimal_lexical_from_f64, minted_document_iri,
+    validate_absolute_iri, validate_relative_markdown_path,
 };
 use crate::{LossEntry, LossLedger, RdfLocation};
 
@@ -147,12 +147,7 @@ impl<'de> Visitor<'de> for StrictValueVisitor {
     where
         E: de::Error,
     {
-        if !value.is_finite() {
-            return Err(E::custom(
-                "non-finite YAML numbers are not valid OKF values",
-            ));
-        }
-        let lexical = value.to_string();
+        let lexical = decimal_lexical_from_f64(value).map_err(E::custom)?;
         let parsed = purrdf_xsd::parse_by_iri(&lexical, XSD_DECIMAL)
             .map_err(E::custom)?
             .ok_or_else(|| E::custom("internal OKF decimal datatype is not recognized"))?;

--- a/crates/rdf/src/native_codecs/okf/reader.rs
+++ b/crates/rdf/src/native_codecs/okf/reader.rs
@@ -1,0 +1,1039 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet};
+
+use core::fmt;
+use core::ops::ControlFlow;
+
+use purrdf_events::{EventQuad, EventTerm, EventTermId, EventTriple, RdfEventSink, ScopeId};
+use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
+
+use super::{
+    MAX_OKF_FRONTMATTER_BYTES, MAX_OKF_LINKS_PER_DOCUMENT, MAX_OKF_YAML_DEPTH, MAX_OKF_YAML_NODES,
+    OkfBundle, OkfConfig, OkfError, OkfReadOutcome, minted_document_iri, validate_absolute_iri,
+    validate_relative_markdown_path,
+};
+use crate::{LossEntry, LossLedger, RdfLocation};
+
+const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
+const XSD_BOOLEAN: &str = "http://www.w3.org/2001/XMLSchema#boolean";
+const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+const XSD_DECIMAL: &str = "http://www.w3.org/2001/XMLSchema#decimal";
+const XSD_DATETIME: &str = "http://www.w3.org/2001/XMLSchema#dateTime";
+
+#[derive(Clone, Debug, PartialEq)]
+enum StrictNumber {
+    Signed(i64),
+    Unsigned(u64),
+    Decimal(f64),
+}
+
+impl StrictNumber {
+    fn lexical(&self) -> String {
+        match self {
+            Self::Signed(value) => value.to_string(),
+            Self::Unsigned(value) => value.to_string(),
+            Self::Decimal(value) => value.to_string(),
+        }
+    }
+
+    fn datatype(&self) -> &'static str {
+        match self {
+            Self::Signed(_) | Self::Unsigned(_) => XSD_INTEGER,
+            Self::Decimal(_) => XSD_DECIMAL,
+        }
+    }
+
+    fn to_json(&self) -> Result<serde_json::Value, OkfError> {
+        let number = match self {
+            Self::Signed(value) => serde_json::Number::from(*value),
+            Self::Unsigned(value) => serde_json::Number::from(*value),
+            Self::Decimal(value) => serde_json::Number::from_f64(*value)
+                .ok_or_else(|| OkfError::new("OKF YAML contains a non-finite number"))?,
+        };
+        Ok(serde_json::Value::Number(number))
+    }
+}
+
+/// YAML value decoded through a duplicate-rejecting map visitor. `serde_yaml::Value`
+/// accepts duplicate mapping keys with last-write behavior; that would silently
+/// erase authored frontmatter, so the OKF reader owns this strict value tree.
+#[derive(Clone, Debug, PartialEq)]
+enum StrictValue {
+    Null,
+    Bool(bool),
+    Number(StrictNumber),
+    String(String),
+    Sequence(Vec<Self>),
+    Mapping(BTreeMap<String, Self>),
+}
+
+impl StrictValue {
+    fn scalar_text(&self) -> Option<String> {
+        match self {
+            Self::Bool(value) => Some(value.to_string()),
+            Self::Number(value) => Some(value.lexical()),
+            Self::String(value) => Some(value.clone()),
+            Self::Null | Self::Sequence(_) | Self::Mapping(_) => None,
+        }
+    }
+
+    fn to_json(&self) -> Result<serde_json::Value, OkfError> {
+        match self {
+            Self::Null => Ok(serde_json::Value::Null),
+            Self::Bool(value) => Ok(serde_json::Value::Bool(*value)),
+            Self::Number(value) => value.to_json(),
+            Self::String(value) => Ok(serde_json::Value::String(value.clone())),
+            Self::Sequence(values) => values
+                .iter()
+                .map(Self::to_json)
+                .collect::<Result<Vec<_>, _>>()
+                .map(serde_json::Value::Array),
+            Self::Mapping(values) => {
+                let mut object = serde_json::Map::new();
+                for (key, value) in values {
+                    object.insert(key.clone(), value.to_json()?);
+                }
+                Ok(serde_json::Value::Object(object))
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for StrictValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(StrictValueVisitor)
+    }
+}
+
+struct StrictValueVisitor;
+
+impl<'de> Visitor<'de> for StrictValueVisitor {
+    type Value = StrictValue;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a finite YAML scalar, sequence, or string-keyed mapping")
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(StrictValue::Null)
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(StrictValue::Null)
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(StrictValue::Bool(value))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(StrictValue::Number(StrictNumber::Signed(value)))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(StrictValue::Number(StrictNumber::Unsigned(value)))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        if !value.is_finite() {
+            return Err(E::custom(
+                "non-finite YAML numbers are not valid OKF values",
+            ));
+        }
+        Ok(StrictValue::Number(StrictNumber::Decimal(value)))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(StrictValue::String(value.to_owned()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(StrictValue::String(value))
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::with_capacity(sequence.size_hint().unwrap_or(0).min(1_024));
+        while let Some(value) = sequence.next_element()? {
+            values.push(value);
+        }
+        Ok(StrictValue::Sequence(values))
+    }
+
+    fn visit_map<A>(self, mut mapping: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut values = BTreeMap::new();
+        while let Some((key, value)) = mapping.next_entry::<String, StrictValue>()? {
+            if values.insert(key.clone(), value).is_some() {
+                return Err(<A::Error as de::Error>::custom(format!(
+                    "duplicate YAML mapping key `{key}`"
+                )));
+            }
+        }
+        Ok(StrictValue::Mapping(values))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ParsedDocument {
+    path: String,
+    subject_iri: String,
+    fields: BTreeMap<String, StrictValue>,
+    body: String,
+    links: Vec<MarkdownLink>,
+}
+
+#[derive(Clone, Debug)]
+struct MarkdownLink {
+    text: String,
+    target: String,
+    ordinal: usize,
+}
+
+type ParsedFrontmatter = (BTreeMap<String, StrictValue>, String);
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum OwnedEventTerm {
+    Iri(String),
+    Blank(String),
+    Literal { lexical: String, datatype: String },
+}
+
+#[derive(Default)]
+struct EventGraph {
+    ids: BTreeMap<OwnedEventTerm, EventTermId>,
+    terms: Vec<OwnedEventTerm>,
+    quads: Vec<EventQuad>,
+    reifiers: Vec<(EventTermId, EventTriple)>,
+    annotations: Vec<(EventTermId, EventTermId, EventTermId)>,
+}
+
+impl EventGraph {
+    fn intern(&mut self, term: OwnedEventTerm) -> Result<EventTermId, OkfError> {
+        if let Some(&id) = self.ids.get(&term) {
+            return Ok(id);
+        }
+        let index = u32::try_from(self.terms.len())
+            .map_err(|_| OkfError::new("OKF event stream exceeds the u32 term-id space"))?;
+        let id = EventTermId(index);
+        self.ids.insert(term.clone(), id);
+        self.terms.push(term);
+        Ok(id)
+    }
+
+    fn iri(&mut self, iri: &str) -> Result<EventTermId, OkfError> {
+        self.intern(OwnedEventTerm::Iri(iri.to_owned()))
+    }
+
+    fn blank(&mut self, label: String) -> Result<EventTermId, OkfError> {
+        self.intern(OwnedEventTerm::Blank(label))
+    }
+
+    fn literal(&mut self, lexical: &str, datatype: &str) -> Result<EventTermId, OkfError> {
+        self.intern(OwnedEventTerm::Literal {
+            lexical: lexical.to_owned(),
+            datatype: datatype.to_owned(),
+        })
+    }
+
+    fn quad_iri(
+        &mut self,
+        subject: EventTermId,
+        predicate: &str,
+        object: &str,
+    ) -> Result<(), OkfError> {
+        let predicate = self.iri(predicate)?;
+        let object = self.iri(object)?;
+        self.quads.push(EventQuad {
+            s: subject,
+            p: predicate,
+            o: object,
+            g: None,
+        });
+        Ok(())
+    }
+
+    fn quad_literal(
+        &mut self,
+        subject: EventTermId,
+        predicate: &str,
+        lexical: &str,
+        datatype: &str,
+    ) -> Result<(), OkfError> {
+        let predicate = self.iri(predicate)?;
+        let object = self.literal(lexical, datatype)?;
+        self.quads.push(EventQuad {
+            s: subject,
+            p: predicate,
+            o: object,
+            g: None,
+        });
+        Ok(())
+    }
+}
+
+/// Lift a deterministic OKF Markdown bundle into any RDF 1.2 event sink.
+///
+/// Parsing and profile validation complete before the first sink callback, so a
+/// malformed bundle cannot leave a partially-driven sink. Terms are then declared
+/// before references; a non-cancelled drive calls [`RdfEventSink::finish`] exactly
+/// once. Relative Markdown links are emitted as RDF 1.2 reifiers plus link-text and
+/// occurrence annotations.
+///
+/// # Errors
+///
+/// Returns [`OkfError`] for malformed YAML/Markdown, unrecognized keys, unsafe or
+/// dangling paths, profile ambiguity, resource-limit breaches, or a sink error.
+pub fn lift_okf_bundle<S: RdfEventSink + ?Sized>(
+    bundle: &OkfBundle,
+    config: &OkfConfig,
+    sink: &mut S,
+) -> Result<OkfReadOutcome, OkfError> {
+    let (documents, losses, navigation_pages) = parse_documents(bundle, config)?;
+    let mut graph = build_event_graph(&documents, config)?;
+    graph.quads.sort();
+    graph.reifiers.sort();
+    graph.annotations.sort();
+    let cancelled = drive_event_graph(&graph, config, sink)?;
+    Ok(OkfReadOutcome {
+        losses,
+        documents: documents.len(),
+        navigation_pages,
+        cancelled,
+    })
+}
+
+fn parse_documents(
+    bundle: &OkfBundle,
+    config: &OkfConfig,
+) -> Result<(Vec<ParsedDocument>, LossLedger, usize), OkfError> {
+    let mut documents = Vec::with_capacity(bundle.len());
+    let mut subjects = BTreeMap::<String, String>::new();
+    let mut losses = LossLedger::new();
+    let mut navigation_pages = 0;
+
+    for (path, markdown) in bundle.documents() {
+        let Some((fields, body)) = parse_frontmatter(path, markdown)? else {
+            if path.rsplit('/').next() == Some("index.md") {
+                navigation_pages += 1;
+                losses.record(LossEntry {
+                    code: Cow::Borrowed("okf-navigation-page-dropped"),
+                    from: Cow::Borrowed("okf"),
+                    to: Cow::Borrowed("rdf-1.2-dataset"),
+                    note: Cow::Borrowed(
+                        "Frontmatter-less index.md is navigation-only and has no RDF concept subject.",
+                    ),
+                    location: Some(Box::new(RdfLocation::file(path))),
+                });
+                continue;
+            }
+            return Err(document_error(path, "missing YAML frontmatter"));
+        };
+
+        for key in fields.keys() {
+            if !config.recognizes(key) {
+                return Err(document_error(
+                    path,
+                    format!("unrecognized frontmatter key `{key}`"),
+                ));
+            }
+        }
+        let type_value = required_scalar(&fields, "type", path)?;
+        if type_value.is_empty() {
+            return Err(document_error(path, "required `type` must not be empty"));
+        }
+
+        let subject_iri = match fields.get("resource") {
+            Some(value) => {
+                let resource = scalar(value, "resource", path)?;
+                validate_absolute_iri("OKF resource", &resource)?;
+                resource
+            }
+            None => minted_document_iri(config, path)?,
+        };
+        if let Some(first_path) = subjects.insert(subject_iri.clone(), path.to_owned()) {
+            return Err(document_error(
+                path,
+                format!("resource `{subject_iri}` is already used by document `{first_path}`"),
+            ));
+        }
+        let links = extract_markdown_links(&body, path)?;
+        documents.push(ParsedDocument {
+            path: path.to_owned(),
+            subject_iri,
+            fields,
+            body,
+            links,
+        });
+    }
+
+    Ok((documents, losses, navigation_pages))
+}
+
+fn parse_frontmatter(path: &str, markdown: &str) -> Result<Option<ParsedFrontmatter>, OkfError> {
+    let opening_len = if markdown.starts_with("---\n") {
+        4
+    } else if markdown.starts_with("---\r\n") {
+        5
+    } else {
+        return Ok(None);
+    };
+
+    let mut offset = opening_len;
+    while offset <= markdown.len() {
+        let relative_end = markdown[offset..].find('\n');
+        let line_end = relative_end.map_or(markdown.len(), |position| offset + position);
+        let line = markdown[offset..line_end].trim_end_matches('\r');
+        let after_line = if line_end < markdown.len() {
+            line_end + 1
+        } else {
+            line_end
+        };
+        if line == "---" {
+            let yaml = &markdown[opening_len..offset];
+            if yaml.len() > MAX_OKF_FRONTMATTER_BYTES {
+                return Err(document_error(
+                    path,
+                    format!(
+                        "YAML frontmatter is {} bytes; limit is {MAX_OKF_FRONTMATTER_BYTES}",
+                        yaml.len()
+                    ),
+                ));
+            }
+            let value: StrictValue = serde_yaml::from_str(yaml).map_err(|error| {
+                document_error(path, format!("invalid YAML frontmatter: {error}"))
+            })?;
+            validate_yaml_tree(&value, path)?;
+            let StrictValue::Mapping(fields) = value else {
+                return Err(document_error(path, "YAML frontmatter must be a mapping"));
+            };
+            return Ok(Some((fields, markdown[after_line..].to_owned())));
+        }
+        if line_end == markdown.len() {
+            break;
+        }
+        offset = after_line;
+    }
+    Err(document_error(
+        path,
+        "YAML frontmatter is missing its closing `---` fence",
+    ))
+}
+
+fn validate_yaml_tree(value: &StrictValue, path: &str) -> Result<(), OkfError> {
+    fn visit(
+        value: &StrictValue,
+        depth: usize,
+        nodes: &mut usize,
+        path: &str,
+    ) -> Result<(), OkfError> {
+        if depth > MAX_OKF_YAML_DEPTH {
+            return Err(document_error(
+                path,
+                format!("YAML nesting exceeds depth {MAX_OKF_YAML_DEPTH}"),
+            ));
+        }
+        *nodes = nodes
+            .checked_add(1)
+            .ok_or_else(|| document_error(path, "YAML node count overflow"))?;
+        if *nodes > MAX_OKF_YAML_NODES {
+            return Err(document_error(
+                path,
+                format!("YAML tree exceeds {MAX_OKF_YAML_NODES} nodes"),
+            ));
+        }
+        match value {
+            StrictValue::Sequence(values) => {
+                for child in values {
+                    visit(child, depth + 1, nodes, path)?;
+                }
+            }
+            StrictValue::Mapping(values) => {
+                for child in values.values() {
+                    visit(child, depth + 1, nodes, path)?;
+                }
+            }
+            StrictValue::Null
+            | StrictValue::Bool(_)
+            | StrictValue::Number(_)
+            | StrictValue::String(_) => {}
+        }
+        Ok(())
+    }
+
+    let mut nodes = 0;
+    visit(value, 0, &mut nodes, path)
+}
+
+fn build_event_graph(
+    documents: &[ParsedDocument],
+    config: &OkfConfig,
+) -> Result<EventGraph, OkfError> {
+    let mut graph = EventGraph::default();
+    let mut subjects_by_path = BTreeMap::new();
+
+    for document in documents {
+        let subject = graph.iri(&document.subject_iri)?;
+        subjects_by_path.insert(document.path.clone(), subject);
+        graph.quad_literal(subject, config.path_predicate(), &document.path, XSD_STRING)?;
+
+        for (key, value) in &document.fields {
+            let predicate = config.predicate_iri(key).ok_or_else(|| {
+                document_error(&document.path, format!("unconfigured key `{key}`"))
+            })?;
+            match key.as_str() {
+                "resource" => {
+                    let resource = scalar(value, key, &document.path)?;
+                    graph.quad_iri(subject, predicate, &resource)?;
+                }
+                "tags" => {
+                    let StrictValue::Sequence(values) = value else {
+                        return Err(document_error(
+                            &document.path,
+                            "frontmatter `tags` must be a YAML sequence",
+                        ));
+                    };
+                    let mut tags = BTreeSet::new();
+                    for value in values {
+                        tags.insert(scalar(value, "tags", &document.path)?);
+                    }
+                    for tag in tags {
+                        graph.quad_literal(subject, predicate, &tag, XSD_STRING)?;
+                    }
+                }
+                "timestamp" => {
+                    let text = scalar(value, key, &document.path)?;
+                    graph.quad_literal(subject, predicate, &text, XSD_DATETIME)?;
+                }
+                "type" | "title" | "description" => {
+                    let text = scalar(value, key, &document.path)?;
+                    graph.quad_literal(subject, predicate, &text, XSD_STRING)?;
+                }
+                _ => emit_extension(
+                    &mut graph,
+                    subject,
+                    predicate,
+                    value,
+                    config.json_datatype(),
+                )?,
+            }
+        }
+        graph.quad_literal(subject, config.body_predicate(), &document.body, XSD_STRING)?;
+    }
+
+    for (document_index, document) in documents.iter().enumerate() {
+        let source = subjects_by_path[&document.path];
+        for link in &document.links {
+            let Some(target_path) = resolve_link_path(&document.path, &link.target)? else {
+                continue;
+            };
+            let Some(&target) = subjects_by_path.get(&target_path) else {
+                return Err(document_error(
+                    &document.path,
+                    format!("dangling Markdown link target `{}`", link.target),
+                ));
+            };
+            let predicate = graph.iri(config.links_predicate())?;
+            graph.quads.push(EventQuad {
+                s: source,
+                p: predicate,
+                o: target,
+                g: None,
+            });
+
+            let reifier = graph.blank(format!("okf_link_{document_index}_{}", link.ordinal))?;
+            graph.reifiers.push((
+                reifier,
+                EventTriple {
+                    s: source,
+                    p: predicate,
+                    o: target,
+                },
+            ));
+            let text_predicate = graph.iri(config.link_text_predicate())?;
+            let text = graph.literal(&link.text, XSD_STRING)?;
+            graph.annotations.push((reifier, text_predicate, text));
+            let occurrence_predicate = graph.iri(config.link_occurrence_predicate())?;
+            let occurrence = graph.literal(&(link.ordinal + 1).to_string(), XSD_INTEGER)?;
+            graph
+                .annotations
+                .push((reifier, occurrence_predicate, occurrence));
+        }
+    }
+
+    Ok(graph)
+}
+
+fn emit_extension(
+    graph: &mut EventGraph,
+    subject: EventTermId,
+    predicate: &str,
+    value: &StrictValue,
+    json_datatype: &str,
+) -> Result<(), OkfError> {
+    match value {
+        StrictValue::Bool(flag) => {
+            graph.quad_literal(subject, predicate, &flag.to_string(), XSD_BOOLEAN)
+        }
+        StrictValue::Number(number) => {
+            graph.quad_literal(subject, predicate, &number.lexical(), number.datatype())
+        }
+        StrictValue::String(text) => graph.quad_literal(subject, predicate, text, XSD_STRING),
+        StrictValue::Null | StrictValue::Sequence(_) | StrictValue::Mapping(_) => {
+            let json = serde_json::to_string(&value.to_json()?)
+                .map_err(|error| OkfError::new(format!("cannot encode OKF JSON value: {error}")))?;
+            graph.quad_literal(subject, predicate, &json, json_datatype)
+        }
+    }
+}
+
+fn drive_event_graph<S: RdfEventSink + ?Sized>(
+    graph: &EventGraph,
+    config: &OkfConfig,
+    sink: &mut S,
+) -> Result<bool, OkfError> {
+    if is_break(
+        sink.base(config.document_base_iri())
+            .map_err(|error| event_error(&error))?,
+    ) {
+        return Ok(true);
+    }
+    for (index, term) in graph.terms.iter().enumerate() {
+        let id = EventTermId(
+            u32::try_from(index).map_err(|_| OkfError::new("OKF event term index exceeds u32"))?,
+        );
+        let event = match term {
+            OwnedEventTerm::Iri(iri) => EventTerm::Iri(iri),
+            OwnedEventTerm::Blank(label) => EventTerm::Blank {
+                label,
+                scope: ScopeId::DEFAULT,
+            },
+            OwnedEventTerm::Literal { lexical, datatype } => EventTerm::Literal {
+                lexical,
+                datatype,
+                language: None,
+                direction: None,
+            },
+        };
+        if is_break(sink.term(id, event).map_err(|error| event_error(&error))?) {
+            return Ok(true);
+        }
+    }
+    for &quad in &graph.quads {
+        if is_break(sink.quad(quad).map_err(|error| event_error(&error))?) {
+            return Ok(true);
+        }
+    }
+    for &(reifier, triple) in &graph.reifiers {
+        if is_break(
+            sink.reifier(reifier, triple)
+                .map_err(|error| event_error(&error))?,
+        ) {
+            return Ok(true);
+        }
+    }
+    for &(reifier, predicate, object) in &graph.annotations {
+        if is_break(
+            sink.annotation(reifier, predicate, object)
+                .map_err(|error| event_error(&error))?,
+        ) {
+            return Ok(true);
+        }
+    }
+    sink.finish().map_err(|error| event_error(&error))?;
+    Ok(false)
+}
+
+fn event_error(error: &purrdf_events::EventError) -> OkfError {
+    OkfError::new(format!("OKF event sink failed: {error}"))
+}
+
+fn is_break(flow: ControlFlow<()>) -> bool {
+    flow == ControlFlow::Break(())
+}
+
+fn required_scalar(
+    fields: &BTreeMap<String, StrictValue>,
+    key: &str,
+    path: &str,
+) -> Result<String, OkfError> {
+    let value = fields
+        .get(key)
+        .ok_or_else(|| document_error(path, format!("missing required `{key}` frontmatter")))?;
+    scalar(value, key, path)
+}
+
+fn scalar(value: &StrictValue, key: &str, path: &str) -> Result<String, OkfError> {
+    value
+        .scalar_text()
+        .ok_or_else(|| document_error(path, format!("frontmatter `{key}` must be a scalar value")))
+}
+
+fn document_error(path: &str, detail: impl fmt::Display) -> OkfError {
+    OkfError::new(format!("{path}: {detail}"))
+}
+
+fn extract_markdown_links(body: &str, path: &str) -> Result<Vec<MarkdownLink>, OkfError> {
+    let bytes = body.as_bytes();
+    let mut links = Vec::new();
+    let mut cursor = 0;
+    while cursor < bytes.len() {
+        let Some(relative_open) = body[cursor..].find('[') else {
+            break;
+        };
+        let open = cursor + relative_open;
+        if escaped(bytes, open)
+            || (open > 0 && bytes[open - 1] == b'!' && !escaped(bytes, open - 1))
+        {
+            cursor = open + 1;
+            continue;
+        }
+        let Some(close) = find_unescaped(bytes, open + 1, b']') else {
+            break;
+        };
+        let mut paren = close + 1;
+        while paren < bytes.len() && bytes[paren].is_ascii_whitespace() {
+            paren += 1;
+        }
+        if paren >= bytes.len() || bytes[paren] != b'(' {
+            cursor = close + 1;
+            continue;
+        }
+        let Some(end) = find_closing_paren(bytes, paren + 1) else {
+            return Err(document_error(
+                path,
+                "unterminated Markdown link destination",
+            ));
+        };
+        let raw_target = body[paren + 1..end].trim();
+        let target = markdown_destination(raw_target)
+            .ok_or_else(|| document_error(path, "empty Markdown link destination"))?;
+        if links.len() >= MAX_OKF_LINKS_PER_DOCUMENT {
+            return Err(document_error(
+                path,
+                format!("Markdown body exceeds {MAX_OKF_LINKS_PER_DOCUMENT} links"),
+            ));
+        }
+        links.push(MarkdownLink {
+            text: unescape_markdown(&body[open + 1..close]),
+            target,
+            ordinal: links.len(),
+        });
+        cursor = end + 1;
+    }
+    Ok(links)
+}
+
+fn find_unescaped(bytes: &[u8], mut cursor: usize, needle: u8) -> Option<usize> {
+    while cursor < bytes.len() {
+        if bytes[cursor] == needle && !escaped(bytes, cursor) {
+            return Some(cursor);
+        }
+        cursor += 1;
+    }
+    None
+}
+
+fn find_closing_paren(bytes: &[u8], mut cursor: usize) -> Option<usize> {
+    let mut depth = 1usize;
+    while cursor < bytes.len() {
+        if escaped(bytes, cursor) {
+            cursor += 1;
+        } else if bytes[cursor] == b'(' {
+            depth += 1;
+        } else if bytes[cursor] == b')' {
+            depth -= 1;
+            if depth == 0 {
+                return Some(cursor);
+            }
+        }
+        cursor += 1;
+    }
+    None
+}
+
+fn escaped(bytes: &[u8], offset: usize) -> bool {
+    let mut slashes = 0;
+    let mut cursor = offset;
+    while cursor > 0 && bytes[cursor - 1] == b'\\' {
+        slashes += 1;
+        cursor -= 1;
+    }
+    slashes % 2 == 1
+}
+
+fn markdown_destination(raw: &str) -> Option<String> {
+    if let Some(rest) = raw.strip_prefix('<') {
+        let end = rest.find('>')?;
+        return Some(unescape_markdown(&rest[..end]));
+    }
+    let mut end = raw.len();
+    for (index, ch) in raw.char_indices() {
+        if ch.is_whitespace() && !escaped(raw.as_bytes(), index) {
+            end = index;
+            break;
+        }
+    }
+    (end > 0).then(|| unescape_markdown(&raw[..end]))
+}
+
+fn unescape_markdown(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut chars = value.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            if let Some(next) = chars.next() {
+                out.push(next);
+            }
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn resolve_link_path(source_path: &str, target: &str) -> Result<Option<String>, OkfError> {
+    let target = target.split('#').next().unwrap_or(target);
+    if target.is_empty()
+        || target.starts_with('/')
+        || target.starts_with("//")
+        || purrdf_iri::parse(target).is_ok_and(|iri| iri.has_scheme())
+    {
+        return Ok(None);
+    }
+
+    let mut components: Vec<&str> = source_path.split('/').collect();
+    components.pop();
+    for component in target.split('/') {
+        match component {
+            "" | "." => {}
+            ".." => {
+                if components.pop().is_none() {
+                    return Err(OkfError::new(format!(
+                        "Markdown link `{target}` escapes the OKF bundle root"
+                    )));
+                }
+            }
+            value => components.push(value),
+        }
+    }
+    let normalized = components.join("/");
+    if std::path::Path::new(&normalized)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        != Some("md")
+    {
+        return Ok(None);
+    }
+    validate_relative_markdown_path(&normalized)?;
+    Ok(Some(normalized))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DatasetSink, SerializeGraph, check_ledger_sound};
+    use purrdf_events::EventError;
+
+    fn config() -> OkfConfig {
+        OkfConfig::new(
+            "https://example.org/okf#",
+            "https://example.org/doc/",
+            [
+                "type",
+                "title",
+                "description",
+                "resource",
+                "tags",
+                "timestamp",
+                "active",
+                "count",
+                "producer",
+            ],
+        )
+        .expect("valid config")
+    }
+
+    fn bundle() -> OkfBundle {
+        OkfBundle::from_documents([
+            (
+                "index.md",
+                "# Navigation\n\n- [Schema](concepts/schema.md)\n",
+            ),
+            (
+                "concepts/schema.md",
+                "---\ntype: Schema\ntitle: Event Schema\n---\nColumns: id.\n",
+            ),
+            (
+                "concepts/table.md",
+                "---\ntype: Table\ntitle: Events\nresource: https://example.org/data/events\ntags:\n- analytics\n- stable\nactive: true\ncount: 7\nproducer:\n  name: fixture\n---\nSee [Schema](schema.md).\n",
+            ),
+        ])
+        .expect("valid bundle")
+    }
+
+    #[test]
+    fn lift_emits_profile_links_and_structured_extensions() {
+        let mut sink = DatasetSink::new();
+        let outcome = lift_okf_bundle(&bundle(), &config(), &mut sink).expect("lift");
+        assert_eq!(outcome.documents, 2);
+        assert_eq!(outcome.navigation_pages, 1);
+        assert!(!outcome.cancelled);
+        assert_eq!(outcome.losses.entries().len(), 1);
+        assert_eq!(
+            outcome.losses.entries()[0].code,
+            "okf-navigation-page-dropped"
+        );
+        assert!(check_ledger_sound(&outcome.losses, "okf", "rdf-1.2-dataset").is_ok());
+
+        let dataset = sink.into_dataset().expect("sink finished");
+        assert_eq!(dataset.quad_count(), 15);
+        assert_eq!(dataset.reifiers().count(), 1);
+        assert_eq!(dataset.annotations().count(), 2);
+        let text = String::from_utf8(
+            crate::native_codecs::serialize_dataset(
+                dataset.as_ref(),
+                "application/n-quads",
+                SerializeGraph::Dataset,
+            )
+            .expect("serialize"),
+        )
+        .expect("UTF-8");
+        assert!(text.contains("<https://example.org/okf#producer>"));
+        assert!(text.contains("^^<https://example.org/okf#json>"));
+        assert!(text.contains("<https://example.org/okf#links>"));
+        assert!(text.contains("<https://example.org/okf#linkText> \"Schema\""));
+        assert!(text.contains("<https://example.org/doc/concepts/schema.md>"));
+    }
+
+    #[test]
+    fn duplicate_and_unknown_frontmatter_keys_hard_fail_before_finish() {
+        for markdown in [
+            "---\ntype: Concept\ntype: Other\n---\nbody\n",
+            "---\ntype: Concept\nunconfigured: value\n---\nbody\n",
+        ] {
+            let bundle = OkfBundle::from_documents([("concept.md", markdown)]).expect("bundle");
+            let mut sink = DatasetSink::new();
+            let error = lift_okf_bundle(&bundle, &config(), &mut sink)
+                .expect_err("invalid frontmatter must fail");
+            assert!(
+                error.to_string().contains("duplicate")
+                    || error.to_string().contains("unrecognized"),
+                "unexpected error: {error}"
+            );
+            assert!(
+                sink.dataset().is_none(),
+                "invalid input must not finish sink"
+            );
+        }
+    }
+
+    #[test]
+    fn dangling_relative_markdown_link_hard_fails() {
+        let bundle = OkfBundle::from_documents([(
+            "concept.md",
+            "---\ntype: Concept\n---\nSee [missing](missing.md).\n",
+        )])
+        .expect("bundle");
+        let mut sink = DatasetSink::new();
+        let error =
+            lift_okf_bundle(&bundle, &config(), &mut sink).expect_err("dangling link must fail");
+        assert!(error.to_string().contains("dangling Markdown link"));
+        assert!(sink.dataset().is_none());
+    }
+
+    #[derive(Default)]
+    struct CancellingSink {
+        finished: bool,
+    }
+
+    impl RdfEventSink for CancellingSink {
+        fn term(
+            &mut self,
+            _id: EventTermId,
+            _term: EventTerm<'_>,
+        ) -> Result<ControlFlow<()>, EventError> {
+            Ok(ControlFlow::Break(()))
+        }
+
+        fn quad(&mut self, _quad: EventQuad) -> Result<ControlFlow<()>, EventError> {
+            Ok(ControlFlow::Continue(()))
+        }
+
+        fn reifier(
+            &mut self,
+            _reifier: EventTermId,
+            _triple: EventTriple,
+        ) -> Result<ControlFlow<()>, EventError> {
+            Ok(ControlFlow::Continue(()))
+        }
+
+        fn annotation(
+            &mut self,
+            _reifier: EventTermId,
+            _predicate: EventTermId,
+            _object: EventTermId,
+        ) -> Result<ControlFlow<()>, EventError> {
+            Ok(ControlFlow::Continue(()))
+        }
+
+        fn open_scope(&mut self) -> Result<ScopeId, EventError> {
+            Ok(ScopeId::DEFAULT)
+        }
+
+        fn close_scope(&mut self, _scope: ScopeId) -> Result<ControlFlow<()>, EventError> {
+            Ok(ControlFlow::Continue(()))
+        }
+
+        fn finish(&mut self) -> Result<(), EventError> {
+            self.finished = true;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn cancellation_stops_without_finishing_sink() {
+        let bundle = OkfBundle::from_documents([("concept.md", "---\ntype: Concept\n---\nbody\n")])
+            .expect("bundle");
+        let mut sink = CancellingSink::default();
+        let outcome = lift_okf_bundle(&bundle, &config(), &mut sink).expect("cancelled lift");
+        assert!(outcome.cancelled);
+        assert!(!sink.finished);
+    }
+
+    #[test]
+    fn configuration_and_paths_reject_implicit_or_unsafe_values() {
+        assert!(OkfConfig::new("relative#", "https://example.org/doc/", ["type"]).is_err());
+        assert!(
+            OkfConfig::new(
+                "https://example.org/okf#",
+                "https://example.org/doc/",
+                ["title"]
+            )
+            .is_err()
+        );
+        assert!(
+            OkfConfig::new(
+                "https://example.org/okf#",
+                "https://example.org/doc/",
+                ["type", "body"]
+            )
+            .is_err()
+        );
+        assert!(OkfBundle::from_documents([("../escape.md", "x")]).is_err());
+        assert!(OkfBundle::from_documents([("not-markdown.txt", "x")]).is_err());
+    }
+}

--- a/crates/rdf/src/native_codecs/okf/reader.rs
+++ b/crates/rdf/src/native_codecs/okf/reader.rs
@@ -775,14 +775,14 @@ fn find_unescaped(bytes: &[u8], mut cursor: usize, needle: u8) -> Option<usize> 
 fn find_closing_paren(bytes: &[u8], mut cursor: usize) -> Option<usize> {
     let mut depth = 1usize;
     while cursor < bytes.len() {
-        if escaped(bytes, cursor) {
-            cursor += 1;
-        } else if bytes[cursor] == b'(' {
-            depth += 1;
-        } else if bytes[cursor] == b')' {
-            depth -= 1;
-            if depth == 0 {
-                return Some(cursor);
+        if !escaped(bytes, cursor) {
+            if bytes[cursor] == b'(' {
+                depth += 1;
+            } else if bytes[cursor] == b')' {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(cursor);
+                }
             }
         }
         cursor += 1;
@@ -981,6 +981,14 @@ mod tests {
             lift_okf_bundle(&bundle, &config(), &mut sink).expect_err("dangling link must fail");
         assert!(error.to_string().contains("dangling Markdown link"));
         assert!(sink.dataset().is_none());
+    }
+
+    #[test]
+    fn escaped_destination_character_does_not_hide_closing_parenthesis() {
+        let links = extract_markdown_links("See [literal](schema.md\\)).\n", "concept.md")
+            .expect("escaped destination character");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "schema.md)");
     }
 
     #[test]

--- a/crates/rdf/src/native_codecs/okf/writer.rs
+++ b/crates/rdf/src/native_codecs/okf/writer.rs
@@ -1,0 +1,1273 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_yaml::Value as YamlValue;
+
+use super::reader::{extract_markdown_links, resolve_link_path};
+use super::{OkfBundle, OkfConfig, OkfError, minted_document_iri};
+use crate::{
+    BlankScope, LossEntry, LossLedger, QuadIds, RdfDataset, RdfDatasetVisitor, RdfLocation,
+    RdfTextDirection, TermId, TermRef,
+};
+
+const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
+const XSD_BOOLEAN: &str = "http://www.w3.org/2001/XMLSchema#boolean";
+const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+const XSD_DECIMAL: &str = "http://www.w3.org/2001/XMLSchema#decimal";
+const XSD_DATETIME: &str = "http://www.w3.org/2001/XMLSchema#dateTime";
+
+/// Result of projecting an RDF 1.2 dataset into an OKF Markdown bundle.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OkfWriteOutcome {
+    /// Deterministic in-memory Markdown bundle.
+    pub bundle: OkfBundle,
+    /// Always-computed runtime loss ledger.
+    pub losses: LossLedger,
+    /// Number of concept documents written.
+    pub documents: usize,
+}
+
+#[derive(Clone, Debug)]
+enum OwnedTerm {
+    Iri(String),
+    Blank {
+        label: String,
+        scope: BlankScope,
+    },
+    Literal {
+        lexical: String,
+        datatype: TermId,
+        language: Option<String>,
+        direction: Option<RdfTextDirection>,
+    },
+    Triple {
+        s: TermId,
+        p: TermId,
+        o: TermId,
+    },
+}
+
+impl OwnedTerm {
+    fn from_ref(term: TermRef<'_>) -> Self {
+        match term {
+            TermRef::Iri(iri) => Self::Iri(iri.to_owned()),
+            TermRef::Blank { label, scope } => Self::Blank {
+                label: label.to_owned(),
+                scope,
+            },
+            TermRef::Literal {
+                lexical,
+                datatype,
+                language,
+                direction,
+            } => Self::Literal {
+                lexical: lexical.to_owned(),
+                datatype,
+                language: language.map(str::to_owned),
+                direction,
+            },
+            TermRef::Triple { s, p, o } => Self::Triple { s, p, o },
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ReifierEvent {
+    ordinal: usize,
+    reifier: TermId,
+    triple: TermId,
+    graph: Option<TermId>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct AnnotationEvent {
+    ordinal: usize,
+    reifier: TermId,
+    predicate: TermId,
+    object: TermId,
+    graph: Option<TermId>,
+}
+
+/// Event receiver for the RDF-dataset → OKF projection.
+///
+/// Drive it with [`RdfDataset::emit`], then call [`finish`](Self::finish). Term
+/// declarations must be dense and ascending, exactly as the frozen-dataset driver
+/// guarantees. The writer retains owned term values because frontmatter grouping and
+/// link-layer verification happen after the visitor has seen the complete dataset.
+#[derive(Debug)]
+pub struct OkfWriter<'a> {
+    config: &'a OkfConfig,
+    terms: Vec<OwnedTerm>,
+    quads: Vec<(usize, QuadIds)>,
+    reifiers: Vec<ReifierEvent>,
+    annotations: Vec<AnnotationEvent>,
+    stream_error: Option<OkfError>,
+}
+
+impl<'a> OkfWriter<'a> {
+    /// Construct a writer using mandatory caller-owned configuration.
+    pub fn new(config: &'a OkfConfig) -> Self {
+        Self {
+            config,
+            terms: Vec::new(),
+            quads: Vec::new(),
+            reifiers: Vec::new(),
+            annotations: Vec::new(),
+            stream_error: None,
+        }
+    }
+
+    /// Finish grouping, verify the exact OKF link layer, render the bundle, and
+    /// return its runtime loss ledger.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OkfError`] when the visitor stream is malformed, configured OKF
+    /// profile data is ambiguous/inconsistent, a link target/layer is incomplete,
+    /// a YAML value cannot round-trip without value loss, or bundle limits are hit.
+    pub fn finish(mut self) -> Result<OkfWriteOutcome, OkfError> {
+        if let Some(error) = self.stream_error.take() {
+            return Err(error);
+        }
+        Projector::new(
+            self.config,
+            self.terms,
+            self.quads,
+            self.reifiers,
+            self.annotations,
+        )
+        .project()
+    }
+
+    fn remember_error(&mut self, detail: impl Into<String>) {
+        if self.stream_error.is_none() {
+            self.stream_error = Some(OkfError::new(detail));
+        }
+    }
+
+    fn push_reifier(&mut self, reifier: TermId, triple: TermId, graph: Option<TermId>) {
+        let ordinal = self.reifiers.len();
+        self.reifiers.push(ReifierEvent {
+            ordinal,
+            reifier,
+            triple,
+            graph,
+        });
+    }
+
+    fn push_annotation(
+        &mut self,
+        reifier: TermId,
+        predicate: TermId,
+        object: TermId,
+        graph: Option<TermId>,
+    ) {
+        let ordinal = self.annotations.len();
+        self.annotations.push(AnnotationEvent {
+            ordinal,
+            reifier,
+            predicate,
+            object,
+            graph,
+        });
+    }
+}
+
+impl RdfDatasetVisitor for OkfWriter<'_> {
+    fn term(&mut self, id: TermId, term: TermRef<'_>) {
+        if self.stream_error.is_some() {
+            return;
+        }
+        if id.index() != self.terms.len() {
+            self.remember_error(format!(
+                "OKF writer requires dense ascending term declarations: expected index {}, got {}",
+                self.terms.len(),
+                id.index()
+            ));
+            return;
+        }
+        self.terms.push(OwnedTerm::from_ref(term));
+    }
+
+    fn quad(&mut self, quad: QuadIds) {
+        if self.stream_error.is_none() {
+            let ordinal = self.quads.len();
+            self.quads.push((ordinal, quad));
+        }
+    }
+
+    fn reifier(&mut self, reifier: TermId, triple: TermId) {
+        if self.stream_error.is_none() {
+            self.push_reifier(reifier, triple, None);
+        }
+    }
+
+    fn reifier_in_graph(&mut self, reifier: TermId, triple: TermId, graph: Option<TermId>) {
+        if self.stream_error.is_none() {
+            self.push_reifier(reifier, triple, graph);
+        }
+    }
+
+    fn annotation(&mut self, reifier: TermId, predicate: TermId, object: TermId) {
+        if self.stream_error.is_none() {
+            self.push_annotation(reifier, predicate, object, None);
+        }
+    }
+
+    fn annotation_in_graph(
+        &mut self,
+        reifier: TermId,
+        predicate: TermId,
+        object: TermId,
+        graph: Option<TermId>,
+    ) {
+        if self.stream_error.is_none() {
+            self.push_annotation(reifier, predicate, object, graph);
+        }
+    }
+}
+
+/// Project a frozen RDF 1.2 dataset through [`OkfWriter`].
+///
+/// # Errors
+///
+/// Returns the same [`OkfError`] conditions as [`OkfWriter::finish`].
+pub fn write_okf_bundle(
+    dataset: &RdfDataset,
+    config: &OkfConfig,
+) -> Result<OkfWriteOutcome, OkfError> {
+    let mut writer = OkfWriter::new(config);
+    dataset.emit(&mut writer);
+    writer.finish()
+}
+
+#[derive(Debug)]
+struct DocumentAccumulator {
+    subject: TermId,
+    path: Option<String>,
+    fields: BTreeMap<String, YamlValue>,
+    tags: BTreeSet<String>,
+    body: Option<String>,
+}
+
+impl DocumentAccumulator {
+    fn new(subject: TermId) -> Self {
+        Self {
+            subject,
+            path: None,
+            fields: BTreeMap::new(),
+            tags: BTreeSet::new(),
+            body: None,
+        }
+    }
+
+    fn set_path(&mut self, path: String) -> Result<(), OkfError> {
+        if self.path.replace(path).is_some() {
+            return Err(OkfError::new(format!(
+                "OKF subject term#{} has more than one path",
+                self.subject.index()
+            )));
+        }
+        Ok(())
+    }
+
+    fn set_body(&mut self, body: String) -> Result<(), OkfError> {
+        if self.body.replace(body).is_some() {
+            return Err(OkfError::new(format!(
+                "OKF subject term#{} has more than one body",
+                self.subject.index()
+            )));
+        }
+        Ok(())
+    }
+
+    fn set_field(&mut self, key: &str, value: YamlValue) -> Result<(), OkfError> {
+        if self.fields.insert(key.to_owned(), value).is_some() {
+            return Err(OkfError::new(format!(
+                "OKF subject term#{} has more than one `{key}` value",
+                self.subject.index()
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct FinalDocument {
+    subject: TermId,
+    fields: BTreeMap<String, YamlValue>,
+    body: String,
+}
+
+type CollectedDocuments = (BTreeMap<TermId, DocumentAccumulator>, Vec<(usize, QuadIds)>);
+
+#[derive(Clone, Debug)]
+struct ExpectedLink {
+    source: TermId,
+    target: TermId,
+    document_index: usize,
+    ordinal: usize,
+    text: String,
+}
+
+impl ExpectedLink {
+    fn reifier_label(&self) -> String {
+        format!("okf_link_{}_{}", self.document_index, self.ordinal)
+    }
+}
+
+struct Projector<'a> {
+    config: &'a OkfConfig,
+    terms: Vec<OwnedTerm>,
+    quads: Vec<(usize, QuadIds)>,
+    reifiers: Vec<ReifierEvent>,
+    annotations: Vec<AnnotationEvent>,
+    losses: LossLedger,
+}
+
+impl<'a> Projector<'a> {
+    fn new(
+        config: &'a OkfConfig,
+        terms: Vec<OwnedTerm>,
+        quads: Vec<(usize, QuadIds)>,
+        reifiers: Vec<ReifierEvent>,
+        annotations: Vec<AnnotationEvent>,
+    ) -> Self {
+        Self {
+            config,
+            terms,
+            quads,
+            reifiers,
+            annotations,
+            losses: LossLedger::new(),
+        }
+    }
+
+    fn project(mut self) -> Result<OkfWriteOutcome, OkfError> {
+        let (documents, link_quads) = self.collect_documents()?;
+        let documents = self.finalize_documents(documents)?;
+        let expected_links = self.expected_links(&documents)?;
+        self.reconcile_link_quads(&link_quads, &expected_links)?;
+        self.reconcile_statement_layer(&expected_links)?;
+        let bundle = self.render_bundle(documents)?;
+        let documents = bundle.len();
+        Ok(OkfWriteOutcome {
+            bundle,
+            losses: self.losses,
+            documents,
+        })
+    }
+
+    fn collect_documents(&mut self) -> Result<CollectedDocuments, OkfError> {
+        let mut documents = BTreeMap::new();
+        let mut link_quads = Vec::new();
+
+        for &(ordinal, quad) in &self.quads {
+            self.require_term(quad.s)?;
+            self.require_term(quad.p)?;
+            self.require_term(quad.o)?;
+            if let Some(graph) = quad.g {
+                self.require_term(graph)?;
+                record_quad_loss(
+                    &mut self.losses,
+                    &self.terms,
+                    ordinal,
+                    quad.s,
+                    "named-graph-dropped",
+                    "OKF cannot represent named-graph placement.",
+                );
+                continue;
+            }
+
+            let predicate = self.iri(quad.p)?.to_owned();
+            if predicate == self.config.path_predicate() {
+                let path = self
+                    .plain_literal(quad.o, XSD_STRING, "okf:path")?
+                    .to_owned();
+                super::validate_relative_markdown_path(&path)?;
+                documents
+                    .entry(quad.s)
+                    .or_insert_with(|| DocumentAccumulator::new(quad.s))
+                    .set_path(path)?;
+            } else if predicate == self.config.body_predicate() {
+                let body = self
+                    .plain_literal(quad.o, XSD_STRING, "okf:body")?
+                    .to_owned();
+                documents
+                    .entry(quad.s)
+                    .or_insert_with(|| DocumentAccumulator::new(quad.s))
+                    .set_body(body)?;
+            } else if predicate == self.config.links_predicate() {
+                let _ = self.iri(quad.o).map_err(|_| {
+                    OkfError::new(format!(
+                        "OKF link object term#{} must be an IRI",
+                        quad.o.index()
+                    ))
+                })?;
+                link_quads.push((ordinal, quad));
+            } else if let Some(key) = self.config.key_for_predicate(&predicate) {
+                let key = key.to_owned();
+                match key.as_str() {
+                    "resource" => {
+                        let resource = self.iri(quad.o)?.to_owned();
+                        documents
+                            .entry(quad.s)
+                            .or_insert_with(|| DocumentAccumulator::new(quad.s))
+                            .set_field(&key, YamlValue::String(resource))?;
+                    }
+                    "tags" => {
+                        let tag = self
+                            .plain_literal(quad.o, XSD_STRING, "OKF tag")?
+                            .to_owned();
+                        documents
+                            .entry(quad.s)
+                            .or_insert_with(|| DocumentAccumulator::new(quad.s))
+                            .tags
+                            .insert(tag);
+                    }
+                    "timestamp" => {
+                        let timestamp = self
+                            .plain_literal(quad.o, XSD_DATETIME, "OKF timestamp")?
+                            .to_owned();
+                        parse_known_xsd(&timestamp, XSD_DATETIME).map_err(|error| {
+                            OkfError::new(format!("invalid OKF timestamp `{timestamp}`: {error}"))
+                        })?;
+                        documents
+                            .entry(quad.s)
+                            .or_insert_with(|| DocumentAccumulator::new(quad.s))
+                            .set_field(&key, YamlValue::String(timestamp))?;
+                    }
+                    "type" | "title" | "description" => {
+                        let value = self
+                            .plain_literal(quad.o, XSD_STRING, &format!("OKF `{key}`"))?
+                            .to_owned();
+                        documents
+                            .entry(quad.s)
+                            .or_insert_with(|| DocumentAccumulator::new(quad.s))
+                            .set_field(&key, YamlValue::String(value))?;
+                    }
+                    _ => {
+                        let value = self.extension_value(quad.o)?;
+                        documents
+                            .entry(quad.s)
+                            .or_insert_with(|| DocumentAccumulator::new(quad.s))
+                            .set_field(&key, value)?;
+                    }
+                }
+            } else {
+                record_quad_loss(
+                    &mut self.losses,
+                    &self.terms,
+                    ordinal,
+                    quad.s,
+                    "okf-non-profile-quad-dropped",
+                    "RDF statement is outside the caller-configured OKF profile.",
+                );
+            }
+        }
+        Ok((documents, link_quads))
+    }
+
+    fn finalize_documents(
+        &self,
+        documents: BTreeMap<TermId, DocumentAccumulator>,
+    ) -> Result<BTreeMap<String, FinalDocument>, OkfError> {
+        let mut by_path = BTreeMap::new();
+        for (_, mut document) in documents {
+            let subject_iri = self.iri(document.subject)?;
+            super::validate_absolute_iri("OKF document subject", subject_iri)?;
+            let path = document.path.take().ok_or_else(|| {
+                OkfError::new(format!(
+                    "OKF subject `{subject_iri}` has profile fields but no okf:path"
+                ))
+            })?;
+            if !document.fields.contains_key("type") {
+                return Err(OkfError::new(format!(
+                    "OKF document `{path}` is missing the required `type` field"
+                )));
+            }
+            if matches!(document.fields.get("type"), Some(YamlValue::String(value)) if value.is_empty())
+            {
+                return Err(OkfError::new(format!(
+                    "OKF document `{path}` has an empty required `type` field"
+                )));
+            }
+            let body = document.body.take().ok_or_else(|| {
+                OkfError::new(format!("OKF document `{path}` is missing okf:body"))
+            })?;
+
+            match document.fields.get("resource") {
+                Some(YamlValue::String(resource)) if resource == subject_iri => {}
+                Some(YamlValue::String(resource)) => {
+                    return Err(OkfError::new(format!(
+                        "OKF document `{path}` resource `{resource}` does not equal its subject `{subject_iri}`"
+                    )));
+                }
+                Some(_) => unreachable!("resource fields are built as YAML strings"),
+                None => {
+                    let expected = minted_document_iri(self.config, &path)?;
+                    if expected != subject_iri {
+                        return Err(OkfError::new(format!(
+                            "OKF document `{path}` has subject `{subject_iri}` but no resource; expected caller-base IRI `{expected}`"
+                        )));
+                    }
+                }
+            }
+
+            if !document.tags.is_empty() {
+                document.fields.insert(
+                    "tags".to_owned(),
+                    YamlValue::Sequence(document.tags.into_iter().map(YamlValue::String).collect()),
+                );
+            }
+            if by_path
+                .insert(
+                    path.clone(),
+                    FinalDocument {
+                        subject: document.subject,
+                        fields: document.fields,
+                        body,
+                    },
+                )
+                .is_some()
+            {
+                return Err(OkfError::new(format!(
+                    "more than one OKF subject claims document path `{path}`"
+                )));
+            }
+        }
+        Ok(by_path)
+    }
+
+    fn expected_links(
+        &self,
+        documents: &BTreeMap<String, FinalDocument>,
+    ) -> Result<Vec<ExpectedLink>, OkfError> {
+        let subjects: BTreeMap<&str, TermId> = documents
+            .iter()
+            .map(|(path, document)| (path.as_str(), document.subject))
+            .collect();
+        let mut links = Vec::new();
+        for (document_index, (path, document)) in documents.iter().enumerate() {
+            for link in extract_markdown_links(&document.body, path)? {
+                let Some(target_path) = resolve_link_path(path, &link.target)? else {
+                    continue;
+                };
+                let Some(&target) = subjects.get(target_path.as_str()) else {
+                    return Err(OkfError::new(format!(
+                        "{path}: dangling Markdown link target `{}`",
+                        link.target
+                    )));
+                };
+                links.push(ExpectedLink {
+                    source: document.subject,
+                    target,
+                    document_index,
+                    ordinal: link.ordinal,
+                    text: link.text,
+                });
+            }
+        }
+        Ok(links)
+    }
+
+    fn reconcile_link_quads(
+        &mut self,
+        link_quads: &[(usize, QuadIds)],
+        expected_links: &[ExpectedLink],
+    ) -> Result<(), OkfError> {
+        let expected_pairs: BTreeSet<(TermId, TermId)> = expected_links
+            .iter()
+            .map(|link| (link.source, link.target))
+            .collect();
+        let mut actual_pairs = BTreeSet::new();
+        for &(ordinal, quad) in link_quads {
+            let pair = (quad.s, quad.o);
+            if expected_pairs.contains(&pair) && actual_pairs.insert(pair) {
+                continue;
+            }
+            record_quad_loss(
+                &mut self.losses,
+                &self.terms,
+                ordinal,
+                quad.s,
+                "okf-non-profile-quad-dropped",
+                "OKF link edge is not backed by exactly one relative Markdown-link target.",
+            );
+        }
+        let missing: Vec<String> = expected_pairs
+            .difference(&actual_pairs)
+            .map(|(source, target)| {
+                format!(
+                    "{} -> {}",
+                    self.term_label(*source),
+                    self.term_label(*target)
+                )
+            })
+            .collect();
+        if !missing.is_empty() {
+            return Err(OkfError::new(format!(
+                "Markdown body link(s) lack configured OKF link edge(s): {}",
+                missing.join(", ")
+            )));
+        }
+        Ok(())
+    }
+
+    fn reconcile_statement_layer(
+        &mut self,
+        expected_links: &[ExpectedLink],
+    ) -> Result<(), OkfError> {
+        let expected_by_label: BTreeMap<String, &ExpectedLink> = expected_links
+            .iter()
+            .map(|link| (link.reifier_label(), link))
+            .collect();
+        let mut annotations_by_reifier: BTreeMap<TermId, Vec<AnnotationEvent>> = BTreeMap::new();
+        for &annotation in &self.annotations {
+            annotations_by_reifier
+                .entry(annotation.reifier)
+                .or_default()
+                .push(annotation);
+        }
+
+        let mut matched_labels = BTreeSet::new();
+        let mut consumed_annotations = BTreeSet::new();
+        for reifier in &self.reifiers {
+            self.require_term(reifier.reifier)?;
+            self.require_term(reifier.triple)?;
+            if let Some(graph) = reifier.graph {
+                self.require_term(graph)?;
+            }
+            let exact = self.match_link_reifier(
+                reifier,
+                &expected_by_label,
+                &annotations_by_reifier,
+                &matched_labels,
+            )?;
+            if let Some((label, annotation_ordinals)) = exact {
+                matched_labels.insert(label);
+                consumed_annotations.extend(annotation_ordinals);
+            } else {
+                record_reifier_loss(
+                    &mut self.losses,
+                    &self.terms,
+                    reifier.ordinal,
+                    reifier.reifier,
+                );
+            }
+        }
+
+        let missing: Vec<&str> = expected_by_label
+            .keys()
+            .map(String::as_str)
+            .filter(|label| !matched_labels.contains(*label))
+            .collect();
+        if !missing.is_empty() {
+            return Err(OkfError::new(format!(
+                "Markdown link occurrence(s) lack exact OKF reifier metadata: {}",
+                missing.join(", ")
+            )));
+        }
+
+        for annotation in &self.annotations {
+            self.require_term(annotation.reifier)?;
+            self.require_term(annotation.predicate)?;
+            self.require_term(annotation.object)?;
+            if let Some(graph) = annotation.graph {
+                self.require_term(graph)?;
+            }
+            if !consumed_annotations.contains(&annotation.ordinal) {
+                record_annotation_loss(
+                    &mut self.losses,
+                    &self.terms,
+                    annotation.ordinal,
+                    annotation.reifier,
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn match_link_reifier(
+        &self,
+        reifier: &ReifierEvent,
+        expected_by_label: &BTreeMap<String, &ExpectedLink>,
+        annotations_by_reifier: &BTreeMap<TermId, Vec<AnnotationEvent>>,
+        matched_labels: &BTreeSet<String>,
+    ) -> Result<Option<(String, Vec<usize>)>, OkfError> {
+        if reifier.graph.is_some() {
+            return Ok(None);
+        }
+        let OwnedTerm::Blank { label, scope } = self.term(reifier.reifier)? else {
+            return Ok(None);
+        };
+        if *scope != BlankScope::DEFAULT || matched_labels.contains(label) {
+            return Ok(None);
+        }
+        let Some(expected) = expected_by_label.get(label) else {
+            return Ok(None);
+        };
+        let OwnedTerm::Triple { s, p, o } = self.term(reifier.triple)? else {
+            return Err(OkfError::new(format!(
+                "OKF reifier {} does not bind a triple term",
+                self.term_label(reifier.reifier)
+            )));
+        };
+        if *s != expected.source
+            || *o != expected.target
+            || self.iri(*p)? != self.config.links_predicate()
+        {
+            return Ok(None);
+        }
+        let Some(annotations) = annotations_by_reifier.get(&reifier.reifier) else {
+            return Ok(None);
+        };
+        let mut text_ordinal = None;
+        let mut occurrence_ordinal = None;
+        for annotation in annotations {
+            if annotation.graph.is_some() {
+                continue;
+            }
+            let Ok(predicate) = self.iri(annotation.predicate) else {
+                continue;
+            };
+            if predicate == self.config.link_text_predicate() {
+                if text_ordinal.is_none()
+                    && self.plain_literal_opt(annotation.object, XSD_STRING)
+                        == Some(expected.text.as_str())
+                {
+                    text_ordinal = Some(annotation.ordinal);
+                }
+            } else if predicate == self.config.link_occurrence_predicate() {
+                let occurrence = (expected.ordinal + 1).to_string();
+                if occurrence_ordinal.is_none()
+                    && self.plain_literal_opt(annotation.object, XSD_INTEGER)
+                        == Some(occurrence.as_str())
+                {
+                    occurrence_ordinal = Some(annotation.ordinal);
+                }
+            }
+        }
+        Ok(text_ordinal.zip(occurrence_ordinal).map(|ordinals| {
+            let (text, occurrence) = ordinals;
+            (label.clone(), vec![text, occurrence])
+        }))
+    }
+
+    fn render_bundle(
+        &self,
+        documents: BTreeMap<String, FinalDocument>,
+    ) -> Result<OkfBundle, OkfError> {
+        let mut bundle = OkfBundle::new();
+        for (path, document) in documents {
+            validate_yaml_fields(&document.fields, &path)?;
+            let yaml = serde_yaml::to_string(&document.fields).map_err(|error| {
+                OkfError::new(format!("cannot serialize `{path}` frontmatter: {error}"))
+            })?;
+            if yaml.len() > super::MAX_OKF_FRONTMATTER_BYTES {
+                return Err(OkfError::new(format!(
+                    "`{path}` YAML frontmatter is {} bytes; limit is {}",
+                    yaml.len(),
+                    super::MAX_OKF_FRONTMATTER_BYTES
+                )));
+            }
+            if yaml.starts_with("---") || yaml.trim_end().ends_with("...") {
+                return Err(OkfError::new(format!(
+                    "YAML serializer emitted a document marker for `{path}`"
+                )));
+            }
+            bundle.insert(path, format!("---\n{yaml}---\n{}", document.body))?;
+        }
+        Ok(bundle)
+    }
+
+    fn extension_value(&self, id: TermId) -> Result<YamlValue, OkfError> {
+        let OwnedTerm::Literal {
+            lexical,
+            datatype,
+            language,
+            direction,
+        } = self.term(id)?
+        else {
+            return Err(OkfError::new(format!(
+                "OKF extension object term#{} must be a literal",
+                id.index()
+            )));
+        };
+        if language.is_some() || direction.is_some() {
+            return Err(OkfError::new(format!(
+                "OKF extension literal term#{} cannot carry language or base direction",
+                id.index()
+            )));
+        }
+        let datatype = self.iri(*datatype)?;
+        match datatype {
+            XSD_STRING => Ok(YamlValue::String(lexical.clone())),
+            XSD_BOOLEAN => {
+                let parsed = canonical_xsd(lexical, datatype)?;
+                Ok(YamlValue::Bool(parsed == "true"))
+            }
+            XSD_INTEGER => {
+                let parsed = canonical_xsd(lexical, datatype)?;
+                if let Ok(value) = parsed.parse::<i64>() {
+                    serde_yaml::to_value(value).map_err(|error| yaml_value_error(&error))
+                } else if let Ok(value) = parsed.parse::<u64>() {
+                    serde_yaml::to_value(value).map_err(|error| yaml_value_error(&error))
+                } else {
+                    Err(OkfError::new(format!(
+                        "OKF integer `{parsed}` exceeds YAML's exact 64-bit numeric domain"
+                    )))
+                }
+            }
+            XSD_DECIMAL => {
+                let parsed = canonical_xsd(lexical, datatype)?;
+                let value = parsed.parse::<f64>().map_err(|error| {
+                    OkfError::new(format!(
+                        "OKF decimal `{parsed}` is not YAML-representable: {error}"
+                    ))
+                })?;
+                if !value.is_finite() {
+                    return Err(OkfError::new(format!(
+                        "OKF decimal `{parsed}` is not finite"
+                    )));
+                }
+                let round_trip =
+                    parse_known_xsd(&value.to_string(), XSD_DECIMAL).map_err(|error| {
+                        OkfError::new(format!(
+                            "OKF decimal `{parsed}` cannot round-trip through YAML: {error}"
+                        ))
+                    })?;
+                let original = parse_known_xsd(&parsed, XSD_DECIMAL)?;
+                if !purrdf_xsd::value_eq(&original, &round_trip) {
+                    return Err(OkfError::new(format!(
+                        "OKF decimal `{parsed}` would lose precision in YAML"
+                    )));
+                }
+                serde_yaml::to_value(value).map_err(|error| yaml_value_error(&error))
+            }
+            datatype if datatype == self.config.json_datatype() => {
+                let json: serde_json::Value = serde_json::from_str(lexical).map_err(|error| {
+                    OkfError::new(format!("invalid OKF JSON literal `{lexical}`: {error}"))
+                })?;
+                let canonical = serde_json::to_string(&json).map_err(|error| {
+                    OkfError::new(format!("cannot canonicalize OKF JSON: {error}"))
+                })?;
+                if canonical != lexical.as_str() {
+                    return Err(OkfError::new(format!(
+                        "OKF JSON literal must be canonical; expected `{canonical}`"
+                    )));
+                }
+                serde_yaml::to_value(json).map_err(|error| yaml_value_error(&error))
+            }
+            other => Err(OkfError::new(format!(
+                "OKF extension literal datatype `{other}` is not representable"
+            ))),
+        }
+    }
+
+    fn plain_literal(
+        &self,
+        id: TermId,
+        expected_datatype: &str,
+        label: &str,
+    ) -> Result<&str, OkfError> {
+        let OwnedTerm::Literal {
+            lexical,
+            datatype,
+            language,
+            direction,
+        } = self.term(id)?
+        else {
+            return Err(OkfError::new(format!(
+                "{label} object term#{} must be a literal",
+                id.index()
+            )));
+        };
+        if language.is_some() || direction.is_some() || self.iri(*datatype)? != expected_datatype {
+            return Err(OkfError::new(format!(
+                "{label} term#{} must be an undirected, language-free `{expected_datatype}` literal",
+                id.index()
+            )));
+        }
+        Ok(lexical)
+    }
+
+    fn plain_literal_opt(&self, id: TermId, expected_datatype: &str) -> Option<&str> {
+        let OwnedTerm::Literal {
+            lexical,
+            datatype,
+            language,
+            direction,
+        } = self.term(id).ok()?
+        else {
+            return None;
+        };
+        (language.is_none()
+            && direction.is_none()
+            && self.iri(*datatype).ok()? == expected_datatype)
+            .then_some(lexical.as_str())
+    }
+
+    fn term(&self, id: TermId) -> Result<&OwnedTerm, OkfError> {
+        self.terms.get(id.index()).ok_or_else(|| {
+            OkfError::new(format!(
+                "OKF writer event references undeclared term index {}",
+                id.index()
+            ))
+        })
+    }
+
+    fn require_term(&self, id: TermId) -> Result<(), OkfError> {
+        self.term(id).map(|_| ())
+    }
+
+    fn iri(&self, id: TermId) -> Result<&str, OkfError> {
+        let OwnedTerm::Iri(iri) = self.term(id)? else {
+            return Err(OkfError::new(format!(
+                "OKF writer expected term#{} to be an IRI",
+                id.index()
+            )));
+        };
+        Ok(iri)
+    }
+
+    fn term_label(&self, id: TermId) -> String {
+        match self.terms.get(id.index()) {
+            Some(OwnedTerm::Iri(iri)) => iri.clone(),
+            Some(OwnedTerm::Blank { label, scope }) => {
+                format!("_:{}@{}", label, scope.ordinal())
+            }
+            _ => format!("term#{}", id.index()),
+        }
+    }
+}
+
+fn canonical_xsd(lexical: &str, datatype: &str) -> Result<String, OkfError> {
+    let value = parse_known_xsd(lexical, datatype)?;
+    let canonical = value.canonical_lexical();
+    if canonical != lexical {
+        return Err(OkfError::new(format!(
+            "OKF numeric/boolean literal `{lexical}` must use canonical `{canonical}`"
+        )));
+    }
+    Ok(canonical)
+}
+
+fn parse_known_xsd(lexical: &str, datatype: &str) -> Result<purrdf_xsd::XsdValue, OkfError> {
+    purrdf_xsd::parse_by_iri(lexical, datatype)
+        .map_err(|error| {
+            OkfError::new(format!("invalid `{datatype}` literal `{lexical}`: {error}"))
+        })?
+        .ok_or_else(|| OkfError::new(format!("unrecognized internal XSD datatype `{datatype}`")))
+}
+
+fn yaml_value_error(error: &serde_yaml::Error) -> OkfError {
+    OkfError::new(format!("cannot encode OKF YAML value: {error}"))
+}
+
+fn validate_yaml_fields(fields: &BTreeMap<String, YamlValue>, path: &str) -> Result<(), OkfError> {
+    fn visit(
+        value: &YamlValue,
+        depth: usize,
+        nodes: &mut usize,
+        path: &str,
+    ) -> Result<(), OkfError> {
+        if depth > super::MAX_OKF_YAML_DEPTH {
+            return Err(OkfError::new(format!(
+                "`{path}` YAML nesting exceeds depth {}",
+                super::MAX_OKF_YAML_DEPTH
+            )));
+        }
+        *nodes = nodes
+            .checked_add(1)
+            .ok_or_else(|| OkfError::new(format!("`{path}` YAML node count overflow")))?;
+        if *nodes > super::MAX_OKF_YAML_NODES {
+            return Err(OkfError::new(format!(
+                "`{path}` YAML tree exceeds {} nodes",
+                super::MAX_OKF_YAML_NODES
+            )));
+        }
+        match value {
+            YamlValue::Sequence(values) => {
+                for child in values {
+                    visit(child, depth + 1, nodes, path)?;
+                }
+            }
+            YamlValue::Mapping(values) => {
+                for child in values.values() {
+                    visit(child, depth + 1, nodes, path)?;
+                }
+            }
+            YamlValue::Tagged(_) => {
+                return Err(OkfError::new(format!(
+                    "`{path}` cannot represent a tagged YAML value"
+                )));
+            }
+            YamlValue::Null | YamlValue::Bool(_) | YamlValue::Number(_) | YamlValue::String(_) => {}
+        }
+        Ok(())
+    }
+
+    let mut nodes = 1;
+    for value in fields.values() {
+        visit(value, 1, &mut nodes, path)?;
+    }
+    Ok(())
+}
+
+fn term_subject(terms: &[OwnedTerm], subject: TermId) -> String {
+    match terms.get(subject.index()) {
+        Some(OwnedTerm::Iri(iri)) => iri.clone(),
+        Some(OwnedTerm::Blank { label, scope }) => format!("_:{}@{}", label, scope.ordinal()),
+        _ => format!("term#{}", subject.index()),
+    }
+}
+
+fn record_quad_loss(
+    ledger: &mut LossLedger,
+    terms: &[OwnedTerm],
+    ordinal: usize,
+    subject: TermId,
+    code: &'static str,
+    note: &'static str,
+) {
+    ledger.record(LossEntry {
+        code: Cow::Borrowed(code),
+        from: Cow::Borrowed("rdf-1.2-dataset"),
+        to: Cow::Borrowed("okf"),
+        note: Cow::Borrowed(note),
+        location: Some(Box::new(
+            RdfLocation::logical(format!("okf-writer:quad:{ordinal}"))
+                .with_subject(term_subject(terms, subject)),
+        )),
+    });
+}
+
+fn record_reifier_loss(
+    ledger: &mut LossLedger,
+    terms: &[OwnedTerm],
+    ordinal: usize,
+    reifier: TermId,
+) {
+    ledger.record(LossEntry {
+        code: Cow::Borrowed("okf-reifier-dropped"),
+        from: Cow::Borrowed("rdf-1.2-dataset"),
+        to: Cow::Borrowed("okf"),
+        note: Cow::Borrowed("RDF 1.2 reifier is outside the exact OKF Markdown-link profile."),
+        location: Some(Box::new(
+            RdfLocation::logical(format!("okf-writer:reifier:{ordinal}"))
+                .with_subject(term_subject(terms, reifier)),
+        )),
+    });
+}
+
+fn record_annotation_loss(
+    ledger: &mut LossLedger,
+    terms: &[OwnedTerm],
+    ordinal: usize,
+    reifier: TermId,
+) {
+    ledger.record(LossEntry {
+        code: Cow::Borrowed("okf-annotation-dropped"),
+        from: Cow::Borrowed("rdf-1.2-dataset"),
+        to: Cow::Borrowed("okf"),
+        note: Cow::Borrowed("RDF 1.2 annotation is outside the exact OKF Markdown-link profile."),
+        location: Some(Box::new(
+            RdfLocation::logical(format!("okf-writer:annotation:{ordinal}"))
+                .with_subject(term_subject(terms, reifier)),
+        )),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        DatasetMut, DatasetSink, MutableDataset, QuadValues, RdfDatasetBuilder, RdfLiteral,
+        TermValue, assert_ledger_complete, assert_ledger_sound, datasets_isomorphic,
+    };
+
+    fn config() -> OkfConfig {
+        OkfConfig::new(
+            "https://example.org/okf#",
+            "https://example.org/doc/",
+            [
+                "type",
+                "title",
+                "description",
+                "resource",
+                "tags",
+                "timestamp",
+                "active",
+                "count",
+                "ratio",
+                "producer",
+            ],
+        )
+        .expect("valid config")
+    }
+
+    fn source_bundle() -> OkfBundle {
+        OkfBundle::from_documents([
+            (
+                "concepts/schema.md",
+                "---\ntype: Schema\ntitle: Event Schema\ndescription: Stable columns.\n---\nColumns: id.\n",
+            ),
+            (
+                "concepts/table.md",
+                "---\ntype: Table\ntitle: Events\nresource: https://example.org/data/events\ntags:\n- stable\n- analytics\ntimestamp: 2026-07-15T01:02:03Z\nactive: true\ncount: 7\nratio: 0.625\nproducer:\n  name: fixture\n  ranks: [1, 2]\n---\nSee [Schema](schema.md) and [Schema again](schema.md#columns). External [site](https://example.net/).\n",
+            ),
+        ])
+        .expect("valid bundle")
+    }
+
+    fn lift(bundle: &OkfBundle, config: &OkfConfig) -> std::sync::Arc<RdfDataset> {
+        let mut sink = DatasetSink::new();
+        let outcome = crate::native_codecs::okf::lift_okf_bundle(bundle, config, &mut sink)
+            .expect("lift bundle");
+        assert!(outcome.losses.is_empty());
+        assert!(!outcome.cancelled);
+        sink.into_dataset().expect("finished dataset sink")
+    }
+
+    #[test]
+    fn writer_is_deterministic_and_write_read_write_stable() {
+        let config = config();
+        let source = lift(&source_bundle(), &config);
+
+        let first = write_okf_bundle(&source, &config).expect("first write");
+        let repeated = write_okf_bundle(&source, &config).expect("repeated write");
+        assert_eq!(first, repeated, "same dataset must emit byte-identically");
+        assert_eq!(first.documents, 2);
+        assert!(first.losses.is_empty());
+
+        let reparsed = lift(&first.bundle, &config);
+        assert!(
+            datasets_isomorphic(&source, &reparsed),
+            "the complete OKF profile must round-trip isomorphically"
+        );
+        let second = write_okf_bundle(&reparsed, &config).expect("second write");
+        assert_eq!(
+            first.bundle, second.bundle,
+            "write-read-write must stabilize"
+        );
+        assert!(second.losses.is_empty());
+
+        let table = first
+            .bundle
+            .get("concepts/table.md")
+            .expect("table document");
+        assert!(table.contains("resource: https://example.org/data/events"));
+        assert!(table.contains("ratio: 0.625"));
+        assert!(table.contains("- analytics\n- stable"));
+    }
+
+    #[test]
+    fn exact_link_metadata_survives_while_extra_annotation_is_ledgered() {
+        let config = config();
+        let base = lift(&source_bundle(), &config);
+        let mut mutable = MutableDataset::new(base.clone());
+        assert!(mutable.insert(QuadValues::triple(
+            TermValue::blank("okf_link_1_0"),
+            TermValue::iri("https://example.org/meta#reviewer"),
+            TermValue::simple_literal("Ada"),
+        )));
+        let extended = mutable.freeze().expect("freeze extended dataset");
+
+        let outcome = write_okf_bundle(&extended, &config).expect("write extended dataset");
+        assert_ledger_complete(&outcome.losses, &["okf-annotation-dropped"]);
+        assert_ledger_sound(&outcome.losses, "rdf-1.2-dataset", "okf");
+
+        let reparsed = lift(&outcome.bundle, &config);
+        assert!(
+            datasets_isomorphic(&base, &reparsed),
+            "only the explicitly ledgered extra annotation may disappear"
+        );
+    }
+
+    #[test]
+    fn every_rdf_to_okf_loss_class_is_recorded_with_location() {
+        let config = config();
+        let mut builder = RdfDatasetBuilder::new();
+        let subject = builder.intern_iri("https://example.org/doc/concept.md");
+        let path_predicate = builder.intern_iri(config.path_predicate());
+        let body_predicate = builder.intern_iri(config.body_predicate());
+        let type_predicate = builder.intern_iri(config.predicate_iri("type").expect("type IRI"));
+        let path = builder.intern_literal(RdfLiteral::simple("concept.md"));
+        let body = builder.intern_literal(RdfLiteral::simple("Body.\n"));
+        let kind = builder.intern_literal(RdfLiteral::simple("Concept"));
+        builder.push_quad(subject, path_predicate, path, None);
+        builder.push_quad(subject, body_predicate, body, None);
+        builder.push_quad(subject, type_predicate, kind, None);
+
+        let owl_equivalent = builder.intern_iri("http://www.w3.org/2002/07/owl#equivalentClass");
+        let other = builder.intern_iri("https://example.org/Other");
+        let graph = builder.intern_iri("https://example.org/graph");
+        builder.push_quad(subject, owl_equivalent, other, None);
+        builder.push_quad(subject, owl_equivalent, other, Some(graph));
+
+        let triple = builder.intern_triple(subject, owl_equivalent, other);
+        let reifier = builder.intern_blank("unrelated", BlankScope::DEFAULT);
+        builder.push_reifier(reifier, triple);
+        let note_predicate = builder.intern_iri("https://example.org/note");
+        let note = builder.intern_literal(RdfLiteral::simple("not OKF metadata"));
+        builder.push_annotation(reifier, note_predicate, note);
+
+        let dataset = builder.freeze().expect("valid dataset");
+        let outcome = write_okf_bundle(&dataset, &config).expect("lossy write");
+        assert_ledger_complete(
+            &outcome.losses,
+            &[
+                "named-graph-dropped",
+                "okf-annotation-dropped",
+                "okf-non-profile-quad-dropped",
+                "okf-reifier-dropped",
+            ],
+        );
+        assert_ledger_sound(&outcome.losses, "rdf-1.2-dataset", "okf");
+        assert!(
+            outcome
+                .losses
+                .entries()
+                .iter()
+                .all(|entry| entry.location.is_some()),
+            "every runtime loss must identify its source row"
+        );
+        assert_eq!(outcome.documents, 1);
+        let reparsed = lift(&outcome.bundle, &config);
+        assert_eq!(reparsed.quad_count(), 3);
+    }
+
+    fn profile_dataset(types: &[&str]) -> std::sync::Arc<RdfDataset> {
+        let config = config();
+        let mut builder = RdfDatasetBuilder::new();
+        let subject = builder.intern_iri("https://example.org/doc/concept.md");
+        let path_predicate = builder.intern_iri(config.path_predicate());
+        let body_predicate = builder.intern_iri(config.body_predicate());
+        let type_predicate = builder.intern_iri(config.predicate_iri("type").expect("type IRI"));
+        let path = builder.intern_literal(RdfLiteral::simple("concept.md"));
+        let body = builder.intern_literal(RdfLiteral::simple("Body.\n"));
+        builder.push_quad(subject, path_predicate, path, None);
+        builder.push_quad(subject, body_predicate, body, None);
+        for value in types {
+            let value = builder.intern_literal(RdfLiteral::simple(*value));
+            builder.push_quad(subject, type_predicate, value, None);
+        }
+        builder.freeze().expect("valid dataset")
+    }
+
+    #[test]
+    fn ambiguous_and_empty_required_profile_values_hard_fail() {
+        let config = config();
+        let ambiguous = write_okf_bundle(&profile_dataset(&["A", "B"]), &config)
+            .expect_err("ambiguous type must fail");
+        assert!(ambiguous.detail().contains("more than one `type` value"));
+
+        let empty =
+            write_okf_bundle(&profile_dataset(&[""]), &config).expect_err("empty type must fail");
+        assert!(empty.detail().contains("empty required `type`"));
+    }
+}

--- a/crates/rdf/src/native_codecs/okf/writer.rs
+++ b/crates/rdf/src/native_codecs/okf/writer.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde_yaml::Value as YamlValue;
 
 use super::reader::{extract_markdown_links, resolve_link_path};
-use super::{OkfBundle, OkfConfig, OkfError, minted_document_iri};
+use super::{OkfBundle, OkfConfig, OkfError, decimal_lexical_from_f64, minted_document_iri};
 use crate::{
     BlankScope, LossEntry, LossLedger, QuadIds, RdfDataset, RdfDatasetVisitor, RdfLocation,
     RdfTextDirection, TermId, TermRef,
@@ -834,12 +834,12 @@ impl<'a> Projector<'a> {
                         "OKF decimal `{parsed}` is not finite"
                     )));
                 }
-                let round_trip =
-                    parse_known_xsd(&value.to_string(), XSD_DECIMAL).map_err(|error| {
-                        OkfError::new(format!(
-                            "OKF decimal `{parsed}` cannot round-trip through YAML: {error}"
-                        ))
-                    })?;
+                let yaml_lexical = decimal_lexical_from_f64(value)?;
+                let round_trip = parse_known_xsd(&yaml_lexical, XSD_DECIMAL).map_err(|error| {
+                    OkfError::new(format!(
+                        "OKF decimal `{parsed}` cannot round-trip through YAML: {error}"
+                    ))
+                })?;
                 let original = parse_known_xsd(&parsed, XSD_DECIMAL)?;
                 if !purrdf_xsd::value_eq(&original, &round_trip) {
                     return Err(OkfError::new(format!(
@@ -1104,6 +1104,8 @@ mod tests {
                 "active",
                 "count",
                 "ratio",
+                "small",
+                "large",
                 "producer",
             ],
         )
@@ -1118,7 +1120,7 @@ mod tests {
             ),
             (
                 "concepts/table.md",
-                "---\ntype: Table\ntitle: Events\nresource: https://example.org/data/events\ntags:\n- stable\n- analytics\ntimestamp: 2026-07-15T01:02:03Z\nactive: true\ncount: 7\nratio: 0.625\nproducer:\n  name: fixture\n  ranks: [1, 2]\n---\nSee [Schema](schema.md) and [Schema again](schema.md#columns). External [site](https://example.net/).\n",
+                "---\ntype: Table\ntitle: Events\nresource: https://example.org/data/events\ntags:\n- stable\n- analytics\ntimestamp: 2026-07-15T01:02:03Z\nactive: true\ncount: 7\nratio: 0.625\nsmall: 1e-5\nlarge: 1e20\nproducer:\n  name: fixture\n  ranks: [1, 2]\n---\nSee [Schema](schema.md) and [Schema again](schema.md#columns). External [site](https://example.net/).\n",
             ),
         ])
         .expect("valid bundle")
@@ -1162,6 +1164,8 @@ mod tests {
             .expect("table document");
         assert!(table.contains("resource: https://example.org/data/events"));
         assert!(table.contains("ratio: 0.625"));
+        assert!(table.contains("small: 0.00001"));
+        assert!(table.contains("large: 1e20"));
         assert!(table.contains("- analytics\n- stable"));
     }
 

--- a/crates/rdf/tests/okf_codec.rs
+++ b/crates/rdf/tests/okf_codec.rs
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Production-surface tests for the bidirectional native OKF codec.
+
+use purrdf_rdf::{
+    BlankScope, DatasetSink, OkfBundle, OkfConfig, OkfWriter, RdfDataset, RdfDatasetBuilder,
+    RdfLiteral, assert_ledger_complete, assert_ledger_sound, datasets_isomorphic, lift_okf_bundle,
+    write_okf_bundle,
+};
+
+fn config() -> OkfConfig {
+    OkfConfig::new(
+        "https://example.org/okf#",
+        "https://example.org/doc/",
+        ["type", "title", "resource", "tags", "active", "producer"],
+    )
+    .expect("valid caller profile")
+}
+
+fn lift(bundle: &OkfBundle, config: &OkfConfig) -> std::sync::Arc<RdfDataset> {
+    let mut sink = DatasetSink::new();
+    let outcome = lift_okf_bundle(bundle, config, &mut sink).expect("lift bundle");
+    assert!(outcome.losses.is_empty());
+    sink.into_dataset().expect("finished sink")
+}
+
+#[test]
+fn public_visitor_and_sink_surfaces_are_bidirectional_and_stable() {
+    let config = config();
+    let bundle = OkfBundle::from_documents([
+        (
+            "schema.md",
+            "---\ntype: Schema\ntitle: Events\n---\nColumns.\n",
+        ),
+        (
+            "table.md",
+            "---\ntype: Table\nresource: https://example.org/data/events\ntags: [stable, analytics]\nactive: true\nproducer:\n  name: fixture\n---\nSee [schema](schema.md).\n",
+        ),
+    ])
+    .expect("valid OKF bundle");
+    let dataset = lift(&bundle, &config);
+
+    let convenience = write_okf_bundle(&dataset, &config).expect("write bundle");
+    let mut visitor = OkfWriter::new(&config);
+    dataset.emit(&mut visitor);
+    let direct = visitor.finish().expect("finish visitor");
+    assert_eq!(direct, convenience);
+    assert!(direct.losses.is_empty());
+
+    let reparsed = lift(&direct.bundle, &config);
+    assert!(datasets_isomorphic(&dataset, &reparsed));
+    let stable = write_okf_bundle(&reparsed, &config).expect("rewrite bundle");
+    assert_eq!(direct.bundle, stable.bundle);
+}
+
+#[test]
+fn public_writer_reports_the_closed_loss_profile() {
+    let config = config();
+    let mut builder = RdfDatasetBuilder::new();
+    let subject = builder.intern_iri("https://example.org/doc/concept.md");
+    let path_predicate = builder.intern_iri(config.path_predicate());
+    let body_predicate = builder.intern_iri(config.body_predicate());
+    let type_predicate = builder.intern_iri(config.predicate_iri("type").expect("type IRI"));
+    let path = builder.intern_literal(RdfLiteral::simple("concept.md"));
+    let body = builder.intern_literal(RdfLiteral::simple("Body.\n"));
+    let kind = builder.intern_literal(RdfLiteral::simple("Concept"));
+    builder.push_quad(subject, path_predicate, path, None);
+    builder.push_quad(subject, body_predicate, body, None);
+    builder.push_quad(subject, type_predicate, kind, None);
+
+    let owl = builder.intern_iri("http://www.w3.org/2002/07/owl#equivalentClass");
+    let other = builder.intern_iri("https://example.org/Other");
+    let graph = builder.intern_iri("https://example.org/graph");
+    builder.push_quad(subject, owl, other, None);
+    builder.push_quad(subject, owl, other, Some(graph));
+    let triple = builder.intern_triple(subject, owl, other);
+    let reifier = builder.intern_blank("unrelated", BlankScope::DEFAULT);
+    builder.push_reifier(reifier, triple);
+    let note_predicate = builder.intern_iri("https://example.org/note");
+    let note = builder.intern_literal(RdfLiteral::simple("metadata"));
+    builder.push_annotation(reifier, note_predicate, note);
+
+    let dataset = builder.freeze().expect("valid RDF dataset");
+    let outcome = write_okf_bundle(&dataset, &config).expect("lossy projection");
+    assert_ledger_complete(
+        &outcome.losses,
+        &[
+            "named-graph-dropped",
+            "okf-annotation-dropped",
+            "okf-non-profile-quad-dropped",
+            "okf-reifier-dropped",
+        ],
+    );
+    assert_ledger_sound(&outcome.losses, "rdf-1.2-dataset", "okf");
+}

--- a/docs/book/src/concepts/codecs.md
+++ b/docs/book/src/concepts/codecs.md
@@ -38,6 +38,22 @@ let nq = serialize_dataset(&ds, "application/n-quads", SerializeGraph::Dataset)
     .expect("serializes");
 ```
 
+## Open Knowledge Format bundles
+
+The native OKF codec maps caller-profiled RDF 1.2 datasets to agent-facing
+Markdown files with YAML frontmatter and lifts them back through the RDF event
+seam. OKF is an in-memory bundle API rather than another media type: callers
+choose how to store the files, so the same code remains deterministic and
+wasm-clean.
+
+`OkfConfig::new` requires the vocabulary namespace, document base IRI, and
+recognized frontmatter keys. There is no built-in ontology or namespace. Use
+`lift_okf_bundle` to drive an `RdfEventSink`, or `write_okf_bundle` (backed by
+`OkfWriter`, an `RdfDatasetVisitor`) to project a frozen dataset. Both directions
+always return a loss ledger. A lossless profile yields an empty ledger; named
+graphs, non-profile/OWL rows, and unrelated reifier or annotation rows are
+pinpointed explicitly when writing.
+
 ## Byte determinism
 
 Every serializer is **byte-deterministic**: the same dataset always produces

--- a/generated/transcode-loss-matrix.json
+++ b/generated/transcode-loss-matrix.json
@@ -616,6 +616,13 @@
     "note": "RDF/XML has no triple-term (RDF-1.2 quoted triple) syntax; reifying triples and their annotations are dropped."
   },
   {
+    "code": "okf-navigation-page-dropped",
+    "from": "okf",
+    "to": "rdf-1.2-dataset",
+    "intentional": true,
+    "note": "A frontmatter-less index.md navigation page has no OKF concept subject and is omitted from the RDF profile; its path is recorded on the runtime loss entry."
+  },
+  {
     "code": "canonical-rdf12-projection",
     "from": "owl-rdf12",
     "to": "canonical-rdf12",
@@ -684,6 +691,34 @@
     "to": "gts",
     "intentional": true,
     "note": "Blob payloads are preserved as content-addressed references (the blob_id digest plus the origin file id), never materialized into the RDF IR, which must stay value-light for arbitrarily large payloads (e.g. multi-terabyte data dumps). A destination GTS carries the reference; the payload bytes are streamed origin->destination on demand (deferred materialization)."
+  },
+  {
+    "code": "named-graph-dropped",
+    "from": "rdf-1.2-dataset",
+    "to": "okf",
+    "intentional": true,
+    "note": "OKF documents have no named-graph placement; a quad asserted outside the default graph cannot be represented in Markdown frontmatter or body text."
+  },
+  {
+    "code": "okf-annotation-dropped",
+    "from": "rdf-1.2-dataset",
+    "to": "okf",
+    "intentional": true,
+    "note": "An RDF 1.2 annotation outside the exact caller-configured OKF Markdown-link profile has no OKF representation and is omitted from the bundle."
+  },
+  {
+    "code": "okf-non-profile-quad-dropped",
+    "from": "rdf-1.2-dataset",
+    "to": "okf",
+    "intentional": true,
+    "note": "An RDF statement outside the caller-configured OKF profile, including an OWL axiom, has no Markdown/frontmatter field and is omitted from the bundle."
+  },
+  {
+    "code": "okf-reifier-dropped",
+    "from": "rdf-1.2-dataset",
+    "to": "okf",
+    "intentional": true,
+    "note": "An RDF 1.2 reifier outside the exact caller-configured OKF Markdown-link profile has no OKF representation and is omitted from the bundle."
   },
   {
     "code": "canonical-rdf12-projection",


### PR DESCRIPTION
## Summary

- add a bounded, deterministic in-memory Open Knowledge Format Markdown bundle with mandatory caller-supplied namespace, document base, and recognized-key profile
- lift OKF YAML/frontmatter, body content, structured extensions, relative links, RDF 1.2 reifiers, and link annotations through any `RdfEventSink`
- project frozen RDF 1.2 datasets through `OkfWriter` / `RdfDatasetVisitor` into byte-stable YAML and Markdown
- preserve the exact body-derived link statement layer and record every named-graph, non-profile/OWL, unrelated reifier, and unrelated annotation loss with deterministic source locations
- expose the codec at the `purrdf-rdf` and umbrella roots and document the caller-owned filesystem boundary

## Acceptance

- Bidirectional production surfaces are covered by crate-root integration tests.
- Repeated writes are byte-identical and write-read-write stabilizes.
- Lossless configured profiles return an empty ledger.
- The four RDF-to-OKF loss classes and navigation-page loss are closed, generated contracts; runtime completeness and soundness are asserted.
- Malformed paths, duplicate or unknown fields, invalid timestamps, dangling links, incomplete link metadata, unsafe configuration, size limits, and ambiguous RDF profile values hard-fail.
- Library code contains no built-in OKF vocabulary or Blackcat/GMEOW namespace.

## Validation

- `make metadata`
- `make check`
- `make doc`
- `cargo test -p purrdf-rdf --locked`
- `cargo clippy -p purrdf-rdf --all-targets --locked -- -D warnings`
- `cargo check --target wasm32-unknown-unknown -p purrdf-rdf --lib --locked`
- `git -c core.whitespace=trailing-space,space-before-tab diff --check origin/main...HEAD`
- Stage 1 no-deferrals scan: clean

## Residual risk

No unresolved acceptance gaps or known regressions remain.

Closes #108