### PR TITLE
feat(shapes): add canonical LinkML 1.11 projection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -272,6 +272,9 @@ jobs:
       - name: Pydantic emitter schema oracle
         run: make pydantic-oracle
 
+      - name: LinkML emitter schema oracle
+        run: make linkml-oracle
+
   # The single conformance matrix: runs the native Rust W3C
   # harnesses (RDFC-1.0, IRI, syntax codecs, SPARQL-eval subset, SHACL, shexTest)
   # AND the Python rdflib drop-in gate together, printing ONE scoreboard with

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,13 +1421,16 @@ dependencies = [
  "criterion",
  "proptest",
  "purrdf-gts",
+ "purrdf-iri",
  "purrdf-rdf",
  "purrdf-slice",
  "purrdf-sparql-algebra",
  "purrdf-sparql-eval",
  "purrdf-xsd",
  "regex",
+ "serde",
  "serde_json",
+ "serde_yaml_ng",
  "smallvec",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 CARGO_TARGET_DIR ?= target
 CAPI_HEADER := crates/rdf-capi/include/purrdf.h
 
-.PHONY: help metadata fmt check book book-samples check-issue-refs changelog bump release-tags test doc bench bench-python columnar-oracle pydantic-oracle pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-size wasm-pkg-test wasm-pkg-bench playground playground-smoke \
+.PHONY: help metadata fmt check book book-samples check-issue-refs changelog bump release-tags test doc bench bench-python columnar-oracle pydantic-oracle linkml-oracle pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-size wasm-pkg-test wasm-pkg-bench playground playground-smoke \
 	capi-build capi-header capi-check capi-install
 
 # The changelog generator is pinned so the committed CHANGELOG.md and the notes
@@ -144,6 +144,10 @@ columnar-oracle: ## Verify production Parquet files through the dev-only DuckDB 
 pydantic-oracle: ## Execute emitted Pydantic v2 models and compare model_json_schema() with CompiledSchema.
 	uv sync --project bindings/python --locked --no-install-project
 	uv run --project bindings/python --no-sync python crates/shapes/tests/pydantic_oracle.py
+
+linkml-oracle: ## Validate emitted LinkML through the locked official 1.11 toolchain.
+	uv sync --project bindings/python --locked --no-install-project
+	uv run --project bindings/python --no-sync python crates/shapes/tests/linkml_oracle.py
 
 bench-python: ## Compare the rdflib compat shim vs. real rdflib (report-only; NOT a test gate). See docs/BENCHMARKS.md.
 	cd bindings/python && uv run maturin develop && uv run python benchmarks/bench_compat.py

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -29,6 +29,16 @@ Copied from `gmeow-ontology`:
   namespace, slice-routing, and fixed-package coupling; the carrier API consumes
   `CompiledSchema` in memory, takes package prose from the caller, and records
   runtime projection gaps on the shared closed loss ledger.
+- The legacy LinkML YAML model in
+  `crates/pipeline/src/stages/schemas.rs` at
+  `c91195e0c300cad9c9a32c8580c2910a6fd48fc1` was used solely as migration
+  evidence for behavior that PurRDF must subsume and replace. Its private
+  OWL/FoldView structures, fixed identity, shallow range mapping, and coupled
+  TypeScript/GraphQL model are not reused architecture. The replacement
+  `purrdf-shapes::linkml` API consumes `CompiledSchema`, requires all identity
+  and vocabulary from the caller, preserves a canonical LinkML 1.11 document,
+  and records projection gaps through the closed loss ledger; the legacy model
+  is intended for deletion after consumer rollover.
 
 Copied from `gmeow-gts`:
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
   "SPARQLWrapper",
   "sssom",
   "jsonschema>=4,<5",
+  "linkml==1.11.1",
   "pydantic>=2,<3",
 ]
 

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -965,6 +965,7 @@ rdflib = [
 [package.dev-dependencies]
 dev = [
     { name = "jsonschema" },
+    { name = "linkml" },
     { name = "maturin" },
     { name = "mypy" },
     { name = "pydantic" },
@@ -982,6 +983,7 @@ provides-extras = ["rdflib"]
 [package.metadata.requires-dev]
 dev = [
     { name = "jsonschema", specifier = ">=4,<5" },
+    { name = "linkml", specifier = "==1.11.1" },
     { name = "maturin", specifier = ">=1.7,<2" },
     { name = "mypy", specifier = ">=1.10" },
     { name = "pydantic", specifier = ">=2,<3" },

--- a/crates/rdf-core/src/loss.rs
+++ b/crates/rdf-core/src/loss.rs
@@ -24,6 +24,7 @@
 //! [`profile_for`] enumerate the closed set of `(from, to)` pairs and loss codes
 //! known across BOTH disciplines, including the non-syntax `shacl`→`json-schema`
 //! shapes projection, the `json-schema`→`pydantic-v2` code-generation profile,
+//! the `json-schema`→`linkml-1.11` schema projection,
 //! and the bidirectional RDF 1.2 dataset↔OKF profile;
 //! [`loss_matrix_json`] renders that same enumerable registry.
 
@@ -648,6 +649,90 @@ const JSON_SCHEMA_PYDANTIC_PROFILE: &[(&str, &str)] = &[
     ),
 ];
 
+/// The JSON Schema → LinkML 1.11 emitter's closed loss profile. LinkML carries
+/// the representable schema structure directly, while each JSON Schema
+/// assertion without an exact LinkML 1.11 metamodel expression is widened or
+/// omitted explicitly at its JSON Pointer location.
+const JSON_SCHEMA_LINKML_PROFILE: &[(&str, &str)] = &[
+    (
+        "additional-properties-validation-widened",
+        "LinkML 1.11 has no per-class equivalent for JSON Schema's \
+         additionalProperties policy or schema. Named attributes retain their constraints, but \
+         acceptance of unlisted object keys is widened and recorded on the object schema.",
+    ),
+    (
+        "array-contains-validation-dropped",
+        "JSON Schema contains/minContains/maxContains assertions have no LinkML 1.11 slot \
+         expression. List item and cardinality constraints remain, while the contains predicate \
+         and its match-count bounds are omitted.",
+    ),
+    (
+        "conditional-validation-dropped",
+        "JSON Schema if/then/else conditional validation has no LinkML 1.11 expression. \
+         Independently representable carrier constraints remain, while the conditional \
+         relationship is omitted.",
+    ),
+    (
+        "dependency-validation-dropped",
+        "JSON Schema dependentRequired/dependentSchemas validation has no LinkML 1.11 \
+         expression. Attribute constraints remain, while cross-property dependencies are \
+         omitted.",
+    ),
+    (
+        "exclusive-bound-validation-widened",
+        "LinkML 1.11 exposes inclusive minimum_value/maximum_value bounds but no exclusive \
+         numeric bounds. An exclusive JSON Schema bound is projected as the corresponding \
+         inclusive bound, widening acceptance at the boundary value.",
+    ),
+    (
+        "format-validation-widened",
+        "A JSON Schema format does not have an exact, uniformly enforced LinkML 1.11 \
+         equivalent. The scalar carrier remains constrained and the format name is retained \
+         when representable, while validation semantics are widened.",
+    ),
+    (
+        "keyword-validation-dropped",
+        "A JSON Schema assertion outside the emitter's closed LinkML 1.11 capability table has \
+         no sound projection. The assertion is omitted and recorded at its schema location \
+         rather than disappearing silently.",
+    ),
+    (
+        "multiple-of-validation-dropped",
+        "JSON Schema multipleOf has no LinkML 1.11 numeric expression. The numeric carrier and \
+         other representable bounds remain, while divisibility validation is omitted.",
+    ),
+    (
+        "non-scalar-enum-validation-widened",
+        "LinkML 1.11 permissible values are scalar identifiers and cannot encode arbitrary JSON \
+         object or array enum members. The representable carrier remains, while non-scalar \
+         membership validation is widened.",
+    ),
+    (
+        "property-count-validation-dropped",
+        "JSON Schema minProperties/maxProperties assertions have no LinkML 1.11 class \
+         expression. Named attributes and their requiredness remain, while total property-count \
+         validation is omitted.",
+    ),
+    (
+        "string-length-validation-dropped",
+        "JSON Schema minLength/maxLength assertions have no LinkML 1.11 slot expression. The \
+         string carrier and representable pattern remain, while code-point length validation is \
+         omitted.",
+    ),
+    (
+        "tuple-array-validation-widened",
+        "LinkML 1.11 lists are homogeneous and cannot preserve JSON Schema prefixItems or \
+         position-specific item schemas. The list is projected to a sound common item carrier, \
+         widening position-specific validation.",
+    ),
+    (
+        "unevaluated-validation-dropped",
+        "JSON Schema unevaluatedProperties/unevaluatedItems assertions depend on applicator \
+         evaluation state that LinkML 1.11 does not expose. Representable local constraints \
+         remain, while the unevaluated assertion is omitted.",
+    ),
+];
+
 /// Build the runtime-shaped [`LossEntry`] rows for the
 /// `("shacl", "json-schema")` shapes profile from [`SHACL_JSON_SCHEMA_PROFILE`]
 /// — one contract entry per declared `(code, note)` pair, `location: None`
@@ -681,6 +766,21 @@ fn json_schema_pydantic_entries() -> Vec<LossEntry> {
         .collect()
 }
 
+/// Build the static contract rows for the
+/// `("json-schema", "linkml-1.11")` projection profile.
+fn json_schema_linkml_entries() -> Vec<LossEntry> {
+    JSON_SCHEMA_LINKML_PROFILE
+        .iter()
+        .map(|&(code, note)| LossEntry {
+            code: Cow::Borrowed(code),
+            from: Cow::Borrowed("json-schema"),
+            to: Cow::Borrowed("linkml-1.11"),
+            note: Cow::Borrowed(note),
+            location: None,
+        })
+        .collect()
+}
+
 /// Extract the `&'static str` payload of a **contract**-discipline
 /// [`LossEntry`] field (one built via [`Cow::Borrowed`]).
 ///
@@ -707,7 +807,8 @@ fn static_str(cow: &Cow<'static, str>) -> &'static str {
 /// ([`rdf_to_okf_loss_ledger`] / [`okf_to_rdf_loss_ledger`]), plus
 /// [`transcode_and_shapes_entries`] (the full
 /// syntax/projection transcode matrix over `SYNTAX_CODECS` × `(SYNTAX_CODECS ∪
-/// PROJECTION_CODECS)` AND the non-syntax shapes pair `("shacl", "json-schema")`).
+/// PROJECTION_CODECS)` and the non-syntax shapes pair `("shacl", "json-schema")`),
+/// and the standalone JSON Schema emitter profiles.
 ///
 /// [`loss_matrix_json`] renders these rows (with their `note` text intact) and
 /// [`registry`] folds them into a `(from, to) -> codes` lookup table — both
@@ -722,13 +823,15 @@ fn registry_entries() -> Vec<LossEntry> {
     entries.extend_from_slice(okf_to_rdf_loss_ledger().entries());
     entries.extend(transcode_and_shapes_entries());
     entries.extend(json_schema_pydantic_entries());
+    entries.extend(json_schema_linkml_entries());
     entries
 }
 
 /// The enumerable loss registry as deterministic JSON: every `(from, to)` pair
 /// [`registered_pairs`] reports — the RDF↔GTS directions, every non-identity
-/// syntax/projection transcode pair, and the `("shacl", "json-schema")` shapes
-/// projection — rendered from `registry_entries` sorted by `(from, to, code)`.
+/// syntax/projection transcode pair, the shapes projection, and schema-language
+/// emitter profiles — rendered from `registry_entries` sorted by
+/// `(from, to, code)`.
 /// Unlike a single [`LossLedger::contract`], codes are NOT assumed unique here
 /// — the same code recurs for different `(from, to)` pairs.
 ///
@@ -781,8 +884,8 @@ fn registry() -> &'static BTreeMap<(&'static str, &'static str), BTreeSet<&'stat
 }
 
 /// Every `(from, to)` pair with a registered loss profile: the RDF↔GTS
-/// directions, every non-identity syntax/projection transcode pair, and the
-/// `("shacl", "json-schema")` shapes projection.
+/// directions, every non-identity syntax/projection transcode pair, the shapes
+/// projection, and schema-language emitter profiles.
 pub fn registered_pairs() -> impl Iterator<Item = (&'static str, &'static str)> {
     registry().keys().copied()
 }
@@ -1244,6 +1347,19 @@ mod tests {
     }
 
     #[test]
+    fn transcode_matrix_includes_json_schema_linkml_pair() {
+        let json = loss_matrix_json();
+        assert!(json.contains("\"from\": \"json-schema\""));
+        assert!(json.contains("\"to\": \"linkml-1.11\""));
+        for (code, _) in JSON_SCHEMA_LINKML_PROFILE {
+            assert!(
+                json.contains(&format!("\"code\": \"{code}\"")),
+                "transcode-loss-matrix.json missing LinkML-profile code `{code}`"
+            );
+        }
+    }
+
+    #[test]
     fn pair_loss_identity_is_empty() {
         assert!(pair_loss_ledger("turtle", "turtle").is_empty());
         assert!(pair_loss_ledger("gts", "gts").is_empty());
@@ -1383,6 +1499,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn registered_pairs_includes_json_schema_linkml() {
+        assert!(
+            registered_pairs().any(|(from, to)| from == "json-schema" && to == "linkml-1.11"),
+            "registered_pairs() must include (\"json-schema\", \"linkml-1.11\")"
+        );
+    }
+
     /// `registered_pairs()` must yield the SAME ordered sequence across two
     /// independent calls (it is backed by a `BTreeMap`, so this is order, not
     /// merely set-equality) — callers rendering it directly (e.g. a diagnostic
@@ -1414,6 +1538,16 @@ mod tests {
     fn profile_for_json_schema_pydantic_is_closed() {
         let profile = profile_for("json-schema", "pydantic-v2");
         let expected: BTreeSet<&str> = JSON_SCHEMA_PYDANTIC_PROFILE
+            .iter()
+            .map(|(code, _)| *code)
+            .collect();
+        assert_eq!(profile, expected);
+    }
+
+    #[test]
+    fn profile_for_json_schema_linkml_is_closed() {
+        let profile = profile_for("json-schema", "linkml-1.11");
+        let expected: BTreeSet<&str> = JSON_SCHEMA_LINKML_PROFILE
             .iter()
             .map(|(code, _)| *code)
             .collect();

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -48,6 +48,13 @@ purrdf-xsd = { workspace = true }
 # serde_json's default BTreeMap-backed Map so object keys serialize sorted for
 # deterministic, byte-stable output.
 serde_json = { workspace = true }
+# Canonical LinkML 1.11 YAML codec. Both dependencies are always-on: the
+# reader/writer is one production behavior on native and wasm targets.
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+# Validate caller-supplied schema and prefix IRIs with the workspace's
+# zero-dependency RFC 3987 implementation.
+purrdf-iri = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.

--- a/crates/shapes/README.md
+++ b/crates/shapes/README.md
@@ -98,6 +98,87 @@ and alias round trips:
 make pydantic-oracle
 ```
 
+## LinkML 1.11 schemas
+
+The LinkML emitter projects `CompiledSchema` directly to one fixed LinkML
+metamodel dialect (`metamodel_version: 1.11.0`). It is an in-memory Rust API:
+PurRDF does not shell out, select behavior with a feature flag, read a repository,
+or invent a schema identity. The caller supplies the schema IRI, name,
+description, default prefix, and complete prefix map; there is deliberately no
+`Default` configuration.
+
+```rust,ignore
+use std::collections::BTreeMap;
+use purrdf_shapes::{LinkmlConfig, emit_linkml, parse_linkml, write_linkml};
+
+let config = LinkmlConfig::new(
+    "https://example.org/schema/linkml",
+    "Example-Schema",
+    "Schema documentation owned by the caller.",
+    "ex",
+    BTreeMap::from([
+        ("ex".into(), "https://example.org/".into()),
+        ("linkml".into(), "https://w3id.org/linkml/".into()),
+    ]),
+)?;
+let package = emit_linkml(&compiled_schema, &config)?;
+
+let parsed = parse_linkml(&package.yaml)?;
+assert_eq!(write_linkml(&parsed)?, package.yaml);
+assert_eq!(
+    package.element_names.get("Person").map(String::as_str),
+    Some("Person"),
+);
+```
+
+`LinkmlPackage` returns the validated document tree, canonical YAML, a
+reversible source-`$defs`-key to LinkML-element map, and the always-computed
+`json-schema` → `linkml-1.11` loss ledger. The YAML writer sorts every mapping
+and emits exactly one trailing newline. The reader preserves every
+JSON-compatible LinkML field, including metamodel extensions PurRDF does not
+author, while rejecting duplicate keys, YAML tags, non-string mapping keys,
+non-finite numbers, and resource-limit violations. Thus read → write and write
+→ read → write are stable without pretending YAML-only semantics can cross a
+language-neutral boundary.
+
+The projection grammar is:
+
+| JSON Schema input | LinkML 1.11 representation |
+|---|---|
+| object `$defs` | named `classes` with caller-prefix-derived `class_uri` |
+| scalar `$defs` | named `types` |
+| string and `{"@id": ...}` enum `$defs` | named `enums` and `permissible_values` |
+| `properties` | class-scoped `attributes`; the exact JSON key remains the attribute key and `alias` |
+| local `$ref` | class, type, or enum `range`; class aliases use `is_a` |
+| inline object | deterministic synthesized class with `inlined: true` |
+| `required` | attribute `required` |
+| homogeneous array | `multivalued`, item range, ordered/unique flags, and min/max cardinality |
+| `anyOf` / `allOf` / `oneOf` / `not` | `any_of` / `all_of` / `exactly_one_of` / `none_of` |
+| `pattern`, `minimum`, `maximum` | `pattern`, `minimum_value`, `maximum_value` |
+| `additionalProperties` | LinkML 1.11 `extra_slots`, including a typed `range_expression` |
+| titles and descriptions | the corresponding LinkML element fields |
+
+Every schema assertion passes through the same closed capability audit used by
+the renderer. A construct that LinkML cannot express is never silently ignored:
+it produces a stable code and JSON Pointer location. The profile covers
+conditional/dependency/contains/unevaluated rules, tuple widening, string and
+property counts, exclusive and multiple-of bounds, format differences,
+non-scalar enum carriers, and a closed catch-all. Malformed values,
+external/dynamic/dangling references, inconsistent `required` declarations,
+unknown caller prefixes, reserved names, and normalized-name collisions hard
+fail instead of entering the ledger. Source SHACL → JSON Schema losses remain
+separate on `CompiledSchema::losses`.
+
+The production emitter has no Python dependency and remains wasm-clean. The
+dev-only oracle pins the official `linkml` and `linkml-runtime` packages to
+1.11.1, loads the emitted YAML through `SchemaDefinition` and `SchemaView`,
+regenerates JSON Schema, compares the exact fixture's `$defs` and accept/reject
+corpus, and probes every lossy family:
+
+```bash
+make linkml-oracle
+```
+
 ---
 
 ## Python extension

--- a/crates/shapes/examples/linkml_oracle_fixture.rs
+++ b/crates/shapes/examples/linkml_oracle_fixture.rs
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Emit deterministic exact and lossy packages for the dev-only LinkML oracle.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+
+use purrdf::loss::{LossLedger, check_ledger_sound};
+use purrdf_shapes::json_schema::CompiledSchema;
+use purrdf_shapes::{LinkmlConfig, emit_linkml, parse_linkml, write_linkml};
+use serde_json::{Value, json};
+
+fn compiled(schema: &Value) -> Result<CompiledSchema, serde_json::Error> {
+    Ok(CompiledSchema {
+        schema_json: format!("{}\n", serde_json::to_string_pretty(schema)?),
+        openapi_json: "{}\n".to_owned(),
+        losses: LossLedger::new(),
+    })
+}
+
+fn config() -> Result<LinkmlConfig, Box<dyn Error>> {
+    Ok(LinkmlConfig::new(
+        "https://example.org/schema/linkml",
+        "Example-Schema",
+        "Caller-owned LinkML differential oracle fixture.",
+        "ex",
+        BTreeMap::from([
+            ("ex".to_owned(), "https://example.org/".to_owned()),
+            ("linkml".to_owned(), "https://w3id.org/linkml/".to_owned()),
+        ]),
+    )?)
+}
+
+fn exact_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://example.org/schema/exact.json",
+        "$defs": {
+            "Address": {
+                "type": "object",
+                "title": "Address",
+                "description": "A caller-described address.",
+                "additionalProperties": false,
+                "properties": {
+                    "ex:city": { "type": "string", "pattern": "^[A-Z]" },
+                    "ex:postalCode": { "type": "string", "pattern": "^[A-Z][0-9]$" }
+                },
+                "required": ["ex:city"]
+            },
+            "Color": {
+                "type": "string",
+                "title": "Color",
+                "description": "One allowed color identifier.",
+                "enum": ["ex:blue", "ex:red"]
+            },
+            "Person": {
+                "type": "object",
+                "title": "Person",
+                "description": "A caller-described person.",
+                "additionalProperties": false,
+                "properties": {
+                    "@id": { "type": "string" },
+                    "ex:active": { "type": "boolean" },
+                    "ex:address": { "$ref": "#/$defs/Address" },
+                    "ex:age": { "type": "integer", "minimum": 0, "maximum": 130 },
+                    "ex:color": { "$ref": "#/$defs/Color" },
+                    "ex:name": { "type": "string", "pattern": "^[A-Z]" },
+                    "ex:score": { "type": "number", "minimum": 0, "maximum": 1 },
+                    "ex:tags": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "minItems": 1,
+                        "maxItems": 3
+                    },
+                    "ex:value": {
+                        "anyOf": [
+                            { "type": "string" },
+                            { "type": "integer" }
+                        ]
+                    }
+                },
+                "required": ["ex:age", "ex:name"]
+            }
+        }
+    })
+}
+
+fn lossy_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "Lossy": {
+                "type": "object",
+                "title": "Lossy",
+                "description": "A fixture exercising the closed LinkML loss profile.",
+                "additionalProperties": { "type": "integer" },
+                "minProperties": 1,
+                "maxProperties": 8,
+                "dependentRequired": { "ex:a": ["ex:b"] },
+                "if": { "properties": { "ex:a": { "const": true } } },
+                "then": { "required": ["ex:b"], "properties": { "ex:b": true } },
+                "unevaluatedProperties": false,
+                "propertyNames": { "pattern": "^ex:" },
+                "properties": {
+                    "ex:array": {
+                        "type": "array",
+                        "prefixItems": [
+                            { "type": "string" },
+                            { "type": "integer" }
+                        ],
+                        "contains": { "const": 7 },
+                        "minContains": 1,
+                        "unevaluatedItems": false
+                    },
+                    "ex:choice": {
+                        "enum": [
+                            { "@id": "ex:open" },
+                            { "@id": "ex:closed" }
+                        ]
+                    },
+                    "ex:label": {
+                        "type": "string",
+                        "minLength": 2,
+                        "maxLength": 12,
+                        "format": "email"
+                    },
+                    "ex:number": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "exclusiveMaximum": 10,
+                        "multipleOf": 0.5
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let config = config()?;
+    let exact_schema = exact_schema();
+    let lossy_schema = lossy_schema();
+    let exact = emit_linkml(&compiled(&exact_schema)?, &config)?;
+    let lossy = emit_linkml(&compiled(&lossy_schema)?, &config)?;
+
+    if !exact.losses.is_empty() {
+        return Err(format!(
+            "exact LinkML fixture unexpectedly lost semantics: {}",
+            exact.losses.render_json()
+        )
+        .into());
+    }
+    check_ledger_sound(&lossy.losses, "json-schema", "linkml-1.11")?;
+    let observed_losses = lossy
+        .losses
+        .entries()
+        .iter()
+        .map(|entry| {
+            (
+                entry.code.as_ref(),
+                entry
+                    .location
+                    .as_ref()
+                    .and_then(|location| location.subject.as_deref())
+                    .unwrap_or("<missing>"),
+            )
+        })
+        .collect::<BTreeSet<_>>();
+    let expected_losses = BTreeSet::from([
+        (
+            "array-contains-validation-dropped",
+            "#/$defs/Lossy/properties/ex:array/contains",
+        ),
+        ("conditional-validation-dropped", "#/$defs/Lossy/if"),
+        (
+            "dependency-validation-dropped",
+            "#/$defs/Lossy/dependentRequired",
+        ),
+        (
+            "exclusive-bound-validation-widened",
+            "#/$defs/Lossy/properties/ex:number/exclusiveMaximum",
+        ),
+        (
+            "exclusive-bound-validation-widened",
+            "#/$defs/Lossy/properties/ex:number/exclusiveMinimum",
+        ),
+        (
+            "format-validation-widened",
+            "#/$defs/Lossy/properties/ex:label/format",
+        ),
+        (
+            "keyword-validation-dropped",
+            "#/$defs/Lossy/if/properties/ex:a/const",
+        ),
+        ("keyword-validation-dropped", "#/$defs/Lossy/propertyNames"),
+        (
+            "multiple-of-validation-dropped",
+            "#/$defs/Lossy/properties/ex:number/multipleOf",
+        ),
+        (
+            "non-scalar-enum-validation-widened",
+            "#/$defs/Lossy/properties/ex:choice/enum/0",
+        ),
+        (
+            "non-scalar-enum-validation-widened",
+            "#/$defs/Lossy/properties/ex:choice/enum/1",
+        ),
+        (
+            "property-count-validation-dropped",
+            "#/$defs/Lossy/maxProperties",
+        ),
+        (
+            "property-count-validation-dropped",
+            "#/$defs/Lossy/minProperties",
+        ),
+        (
+            "string-length-validation-dropped",
+            "#/$defs/Lossy/properties/ex:label/maxLength",
+        ),
+        (
+            "string-length-validation-dropped",
+            "#/$defs/Lossy/properties/ex:label/minLength",
+        ),
+        (
+            "tuple-array-validation-widened",
+            "#/$defs/Lossy/properties/ex:array/prefixItems",
+        ),
+        (
+            "unevaluated-validation-dropped",
+            "#/$defs/Lossy/properties/ex:array/unevaluatedItems",
+        ),
+        (
+            "unevaluated-validation-dropped",
+            "#/$defs/Lossy/unevaluatedProperties",
+        ),
+    ]);
+    if observed_losses != expected_losses {
+        return Err(format!(
+            "lossy LinkML fixture contract disagrees: {}",
+            lossy.losses.render_json()
+        )
+        .into());
+    }
+
+    for package in [&exact, &lossy] {
+        let reparsed = parse_linkml(&package.yaml)?;
+        if reparsed != package.document || write_linkml(&reparsed)? != package.yaml {
+            return Err("LinkML fixture did not survive canonical read/write".into());
+        }
+    }
+
+    let output = json!({
+        "exact": {
+            "element_names": exact.element_names,
+            "schema": exact_schema,
+            "yaml": exact.yaml,
+        },
+        "lossy": {
+            "element_names": lossy.element_names,
+            "losses": serde_json::from_str::<Value>(&lossy.losses.render_json())?,
+            "schema": lossy_schema,
+            "yaml": lossy.yaml,
+        }
+    });
+    println!("{}", serde_json::to_string(&output)?);
+    Ok(())
+}

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -24,6 +24,7 @@ pub mod engine;
 pub mod expression;
 pub mod instance;
 pub mod json_schema;
+pub mod linkml;
 pub mod model;
 pub mod path;
 pub(crate) mod prebinding;
@@ -38,6 +39,9 @@ pub mod term;
 pub mod text_ingest;
 
 pub use json_schema::{Namespaces, ValueVocab, ValueVocabProjection, compile_with_value_vocab};
+pub use linkml::{
+    LinkmlConfig, LinkmlDocument, LinkmlError, LinkmlPackage, parse_linkml, write_linkml,
+};
 pub use pydantic::{PydanticConfig, PydanticError, PydanticPackage, emit_pydantic};
 pub use rules::{apply_rules, entail_dataset};
 

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -30,6 +30,7 @@ pub(crate) mod prebinding;
 pub mod pydantic;
 pub mod report;
 pub mod rules;
+mod schema_catalog;
 pub mod shape_union;
 pub mod shapes;
 pub mod sparql;

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -40,7 +40,8 @@ pub mod text_ingest;
 
 pub use json_schema::{Namespaces, ValueVocab, ValueVocabProjection, compile_with_value_vocab};
 pub use linkml::{
-    LinkmlConfig, LinkmlDocument, LinkmlError, LinkmlPackage, parse_linkml, write_linkml,
+    LinkmlConfig, LinkmlDocument, LinkmlError, LinkmlPackage, emit_linkml, parse_linkml,
+    write_linkml,
 };
 pub use pydantic::{PydanticConfig, PydanticError, PydanticPackage, emit_pydantic};
 pub use rules::{apply_rules, entail_dataset};

--- a/crates/shapes/src/linkml.rs
+++ b/crates/shapes/src/linkml.rs
@@ -19,6 +19,10 @@ use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde_json::{Map, Number, Value};
 use serde_yaml::Value as YamlValue;
 
+use crate::json_schema::CompiledSchema;
+
+mod projection;
+
 /// The exact LinkML metamodel version carried by this codec.
 pub const LINKML_METAMODEL_VERSION: &str = "1.11.0";
 
@@ -242,6 +246,24 @@ pub fn write_linkml(document: &LinkmlDocument) -> Result<String, LinkmlError> {
     let mut canonical = serialized.trim_end_matches('\n').to_owned();
     canonical.push('\n');
     Ok(canonical)
+}
+
+/// Project one compiled SHACL-derived JSON Schema to deterministic LinkML 1.11.
+///
+/// Source-stage losses remain on [`CompiledSchema::losses`]. The returned
+/// ledger covers only this projection step, `json-schema` → `linkml-1.11`.
+/// Every emitted identity and vocabulary IRI comes from [`LinkmlConfig`].
+///
+/// # Errors
+///
+/// Returns [`LinkmlError`] when the compiled schema is malformed, a reference
+/// is external or dangling, a required-property declaration is inconsistent,
+/// or source names collide after deterministic LinkML normalization.
+pub fn emit_linkml(
+    compiled: &CompiledSchema,
+    config: &LinkmlConfig,
+) -> Result<LinkmlPackage, LinkmlError> {
+    projection::emit(compiled, config)
 }
 
 fn validate_document(value: &Value) -> Result<(), LinkmlError> {

--- a/crates/shapes/src/linkml.rs
+++ b/crates/shapes/src/linkml.rs
@@ -1,0 +1,871 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Canonical LinkML 1.11 document boundary and schema-emitter types.
+//!
+//! The reader accepts the fixed PurRDF LinkML 1.11 dialect into a
+//! JSON-compatible value tree. It rejects YAML-only semantics that cannot
+//! survive a language-neutral round trip: duplicate keys, tags, non-string
+//! mapping keys, and non-finite numbers. The writer emits one sorted,
+//! byte-stable YAML representation while preserving fields the emitter does
+//! not author.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+
+use ::purrdf::loss::LossLedger;
+use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
+use serde_json::{Map, Number, Value};
+use serde_yaml::Value as YamlValue;
+
+/// The exact LinkML metamodel version carried by this codec.
+pub const LINKML_METAMODEL_VERSION: &str = "1.11.0";
+
+const LINKML_PREFIX: &str = "linkml";
+const MAX_LINKML_YAML_BYTES: usize = 16 * 1024 * 1024;
+const MAX_LINKML_YAML_DEPTH: usize = 256;
+const MAX_LINKML_YAML_NODES: usize = 1_000_000;
+
+/// Caller-owned identity and vocabulary configuration for LinkML emission.
+///
+/// There is intentionally no Default implementation. The caller must supply
+/// the schema IRI, schema name, prose, default vocabulary prefix, and every
+/// prefix mapping. The reserved linkml prefix must also be supplied explicitly
+/// because the emitted schema imports linkml:types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkmlConfig {
+    schema_id: String,
+    schema_name: String,
+    description: String,
+    default_prefix: String,
+    prefixes: BTreeMap<String, String>,
+}
+
+impl LinkmlConfig {
+    /// Validate and construct LinkML emitter configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns LinkmlError when an identity or prefix is missing, malformed,
+    /// relative, or conflicts with the reserved linkml prefix.
+    pub fn new(
+        schema_id: impl Into<String>,
+        schema_name: impl Into<String>,
+        description: impl Into<String>,
+        default_prefix: impl Into<String>,
+        prefixes: BTreeMap<String, String>,
+    ) -> Result<Self, LinkmlError> {
+        let schema_id = schema_id.into();
+        let schema_name = schema_name.into();
+        let description = description.into();
+        let default_prefix = default_prefix.into();
+
+        validate_absolute_iri("LinkML schema id", &schema_id)?;
+        validate_identifier("LinkML schema name", &schema_name)?;
+        if description.trim().is_empty() {
+            return Err(LinkmlError::new(
+                "LinkML schema description must be caller-supplied non-whitespace text",
+            ));
+        }
+        validate_identifier("LinkML default prefix", &default_prefix)?;
+        validate_prefixes(&prefixes)?;
+        if !prefixes.contains_key(&default_prefix) {
+            return Err(LinkmlError::new(format!(
+                "LinkML default prefix {default_prefix:?} is absent from the caller prefix map"
+            )));
+        }
+        if default_prefix == LINKML_PREFIX {
+            return Err(LinkmlError::new(
+                "LinkML default prefix cannot reuse the reserved linkml metamodel prefix",
+            ));
+        }
+        if !prefixes.contains_key(LINKML_PREFIX) {
+            return Err(LinkmlError::new(
+                "LinkML prefix map must caller-supply the reserved linkml namespace",
+            ));
+        }
+
+        Ok(Self {
+            schema_id,
+            schema_name,
+            description,
+            default_prefix,
+            prefixes,
+        })
+    }
+
+    /// Caller-supplied absolute schema IRI.
+    #[must_use]
+    pub fn schema_id(&self) -> &str {
+        &self.schema_id
+    }
+
+    /// Caller-supplied LinkML schema name.
+    #[must_use]
+    pub fn schema_name(&self) -> &str {
+        &self.schema_name
+    }
+
+    /// Caller-supplied schema description.
+    #[must_use]
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    /// Prefix used to derive unqualified element URIs.
+    #[must_use]
+    pub fn default_prefix(&self) -> &str {
+        &self.default_prefix
+    }
+
+    /// Ordered caller-supplied prefix map.
+    #[must_use]
+    pub fn prefixes(&self) -> &BTreeMap<String, String> {
+        &self.prefixes
+    }
+}
+
+/// One validated LinkML 1.11 document, including unknown metamodel fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkmlDocument {
+    value: Value,
+}
+
+impl LinkmlDocument {
+    /// Validate a JSON-compatible LinkML 1.11 value tree.
+    ///
+    /// # Errors
+    ///
+    /// Returns LinkmlError when the fixed dialect envelope is malformed.
+    pub fn from_value(value: Value) -> Result<Self, LinkmlError> {
+        validate_document(&value)?;
+        Ok(Self { value })
+    }
+
+    /// Borrow the complete JSON-compatible document tree.
+    #[must_use]
+    pub fn as_value(&self) -> &Value {
+        &self.value
+    }
+
+    /// Consume this wrapper and return the complete document tree.
+    #[must_use]
+    pub fn into_value(self) -> Value {
+        self.value
+    }
+}
+
+impl TryFrom<Value> for LinkmlDocument {
+    type Error = LinkmlError;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        Self::from_value(value)
+    }
+}
+
+/// Deterministic emitted LinkML document, bytes, element map, and losses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkmlPackage {
+    /// Validated semantic document.
+    pub document: LinkmlDocument,
+    /// Canonical LinkML YAML with exactly one trailing newline.
+    pub yaml: String,
+    /// Source definition key to emitted LinkML element name, sorted by key.
+    pub element_names: BTreeMap<String, String>,
+    /// JSON Schema assertions not represented exactly in LinkML 1.11.
+    pub losses: LossLedger,
+}
+
+/// A malformed LinkML configuration, document, or projection input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkmlError {
+    detail: String,
+}
+
+impl LinkmlError {
+    fn new(detail: impl Into<String>) -> Self {
+        Self {
+            detail: detail.into(),
+        }
+    }
+
+    /// Stable human-readable error detail.
+    #[must_use]
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+}
+
+impl fmt::Display for LinkmlError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.detail)
+    }
+}
+
+impl Error for LinkmlError {}
+
+/// Parse a LinkML 1.11 YAML document without accepting lossy YAML semantics.
+///
+/// # Errors
+///
+/// Returns LinkmlError for invalid YAML, duplicate keys, tags, non-string
+/// mapping keys, non-finite numbers, resource-limit violations, or an invalid
+/// fixed-dialect envelope.
+pub fn parse_linkml(input: &str) -> Result<LinkmlDocument, LinkmlError> {
+    if input.len() > MAX_LINKML_YAML_BYTES {
+        return Err(LinkmlError::new(format!(
+            "LinkML YAML exceeds the {MAX_LINKML_YAML_BYTES}-byte input limit"
+        )));
+    }
+
+    let yaml_value: YamlValue = serde_yaml::from_str(input)
+        .map_err(|error| LinkmlError::new(format!("invalid LinkML YAML: {error}")))?;
+    let mut nodes = 0;
+    validate_yaml_value(&yaml_value, 0, &mut nodes, "$")?;
+
+    let strict_value: StrictValue = serde_yaml::from_str(input)
+        .map_err(|error| LinkmlError::new(format!("invalid LinkML YAML: {error}")))?;
+    LinkmlDocument::from_value(strict_value.into_json())
+}
+
+/// Serialize one validated LinkML document to canonical sorted block YAML.
+///
+/// # Errors
+///
+/// Returns LinkmlError when the document envelope is invalid or YAML
+/// serialization fails.
+pub fn write_linkml(document: &LinkmlDocument) -> Result<String, LinkmlError> {
+    validate_document(document.as_value())?;
+    let serialized = serde_yaml::to_string(document.as_value())
+        .map_err(|error| LinkmlError::new(format!("cannot serialize LinkML YAML: {error}")))?;
+    let mut canonical = serialized.trim_end_matches('\n').to_owned();
+    canonical.push('\n');
+    Ok(canonical)
+}
+
+fn validate_document(value: &Value) -> Result<(), LinkmlError> {
+    let root = value
+        .as_object()
+        .ok_or_else(|| LinkmlError::new("LinkML document root must be a mapping"))?;
+
+    let schema_id = required_string(root, "id")?;
+    validate_absolute_iri("LinkML document id", schema_id)?;
+    validate_identifier("LinkML document name", required_string(root, "name")?)?;
+
+    let metamodel_version = required_string(root, "metamodel_version")?;
+    if metamodel_version != LINKML_METAMODEL_VERSION {
+        return Err(LinkmlError::new(format!(
+            "LinkML metamodel_version must be {LINKML_METAMODEL_VERSION:?}, got {metamodel_version:?}"
+        )));
+    }
+
+    if let Some(description) = root.get("description") {
+        let description = description
+            .as_str()
+            .ok_or_else(|| LinkmlError::new("LinkML description must be a string"))?;
+        if description.trim().is_empty() {
+            return Err(LinkmlError::new(
+                "LinkML description must contain non-whitespace text when present",
+            ));
+        }
+    }
+
+    let prefixes = root
+        .get("prefixes")
+        .and_then(Value::as_object)
+        .ok_or_else(|| LinkmlError::new("LinkML prefixes must be a mapping"))?;
+    validate_document_prefixes(prefixes)?;
+
+    let default_prefix = required_string(root, "default_prefix")?;
+    validate_identifier("LinkML document default_prefix", default_prefix)?;
+    if !prefixes.contains_key(default_prefix) {
+        return Err(LinkmlError::new(format!(
+            "LinkML default_prefix {default_prefix:?} is absent from prefixes"
+        )));
+    }
+    if default_prefix == LINKML_PREFIX {
+        return Err(LinkmlError::new(
+            "LinkML default_prefix cannot reuse the reserved linkml metamodel prefix",
+        ));
+    }
+    if !prefixes.contains_key(LINKML_PREFIX) {
+        return Err(LinkmlError::new(
+            "LinkML prefixes must include the caller-supplied linkml namespace",
+        ));
+    }
+
+    for section in ["classes", "enums", "slots", "types"] {
+        if root.get(section).is_some_and(|value| !value.is_object()) {
+            return Err(LinkmlError::new(format!(
+                "LinkML {section} must be a mapping when present"
+            )));
+        }
+    }
+    if let Some(imports) = root.get("imports") {
+        match imports {
+            Value::String(_) => {}
+            Value::Array(values) if values.iter().all(Value::is_string) => {}
+            _ => {
+                return Err(LinkmlError::new(
+                    "LinkML imports must be a string or an array of strings",
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_prefixes(prefixes: &BTreeMap<String, String>) -> Result<(), LinkmlError> {
+    if prefixes.is_empty() {
+        return Err(LinkmlError::new("LinkML caller prefix map cannot be empty"));
+    }
+    for (prefix, namespace) in prefixes {
+        validate_identifier("LinkML prefix", prefix)?;
+        validate_absolute_iri(&format!("LinkML prefix {prefix:?} namespace"), namespace)?;
+    }
+    Ok(())
+}
+
+fn validate_document_prefixes(prefixes: &Map<String, Value>) -> Result<(), LinkmlError> {
+    if prefixes.is_empty() {
+        return Err(LinkmlError::new("LinkML prefixes cannot be empty"));
+    }
+    for (prefix, definition) in prefixes {
+        validate_identifier("LinkML prefix", prefix)?;
+        match definition {
+            Value::String(namespace) => {
+                validate_absolute_iri(&format!("LinkML prefix {prefix:?} namespace"), namespace)?;
+            }
+            Value::Object(object) => {
+                if let Some(declared_prefix) = object.get("prefix_prefix") {
+                    let declared_prefix = declared_prefix.as_str().ok_or_else(|| {
+                        LinkmlError::new(format!(
+                            "LinkML prefix {prefix:?} prefix_prefix must be a string"
+                        ))
+                    })?;
+                    if declared_prefix != prefix {
+                        return Err(LinkmlError::new(format!(
+                            "LinkML prefix {prefix:?} conflicts with prefix_prefix {declared_prefix:?}"
+                        )));
+                    }
+                }
+                let namespace = object
+                    .get("prefix_reference")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        LinkmlError::new(format!(
+                            "LinkML prefix {prefix:?} object requires string prefix_reference"
+                        ))
+                    })?;
+                validate_absolute_iri(
+                    &format!("LinkML prefix {prefix:?} prefix_reference"),
+                    namespace,
+                )?;
+            }
+            _ => {
+                return Err(LinkmlError::new(format!(
+                    "LinkML prefix {prefix:?} must be a namespace string or prefix object"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn required_string<'a>(object: &'a Map<String, Value>, key: &str) -> Result<&'a str, LinkmlError> {
+    object
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| LinkmlError::new(format!("LinkML {key} must be a string")))
+}
+
+fn validate_absolute_iri(label: &str, value: &str) -> Result<(), LinkmlError> {
+    let iri = purrdf_iri::parse(value)
+        .map_err(|error| LinkmlError::new(format!("{label} {value:?} is invalid: {error}")))?;
+    if !iri.has_scheme() {
+        return Err(LinkmlError::new(format!(
+            "{label} {value:?} must be absolute"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_identifier(label: &str, value: &str) -> Result<(), LinkmlError> {
+    if !is_linkml_identifier(value) {
+        return Err(LinkmlError::new(format!(
+            "{label} {value:?} is not a LinkML NCName"
+        )));
+    }
+    Ok(())
+}
+
+fn is_linkml_identifier(value: &str) -> bool {
+    let mut characters = value.chars();
+    let Some(first) = characters.next() else {
+        return false;
+    };
+    (first == '_' || first.is_alphabetic())
+        && characters.all(|character| {
+            character == '_'
+                || character == '-'
+                || character == '.'
+                || character.is_alphanumeric()
+                || matches!(
+                    character,
+                    '\u{300}'..='\u{36f}'
+                        | '\u{203f}'..='\u{2040}'
+                        | '\u{b7}'
+                )
+        })
+}
+
+fn validate_yaml_value(
+    value: &YamlValue,
+    depth: usize,
+    nodes: &mut usize,
+    path: &str,
+) -> Result<(), LinkmlError> {
+    if depth > MAX_LINKML_YAML_DEPTH {
+        return Err(LinkmlError::new(format!(
+            "LinkML YAML at {path} exceeds depth {MAX_LINKML_YAML_DEPTH}"
+        )));
+    }
+    *nodes = nodes
+        .checked_add(1)
+        .ok_or_else(|| LinkmlError::new("LinkML YAML node count overflow"))?;
+    if *nodes > MAX_LINKML_YAML_NODES {
+        return Err(LinkmlError::new(format!(
+            "LinkML YAML exceeds {MAX_LINKML_YAML_NODES} nodes"
+        )));
+    }
+
+    match value {
+        YamlValue::Sequence(values) => {
+            for (index, child) in values.iter().enumerate() {
+                validate_yaml_value(child, depth + 1, nodes, &format!("{path}/{index}"))?;
+            }
+        }
+        YamlValue::Mapping(values) => {
+            for (key, child) in values {
+                let key = key.as_str().ok_or_else(|| {
+                    LinkmlError::new(format!(
+                        "LinkML YAML mapping at {path} has a non-string key"
+                    ))
+                })?;
+                validate_yaml_value(child, depth + 1, nodes, &format!("{path}/{key}"))?;
+            }
+        }
+        YamlValue::Number(number) => {
+            if number.as_i64().is_none()
+                && number.as_u64().is_none()
+                && !number.as_f64().is_some_and(f64::is_finite)
+            {
+                return Err(LinkmlError::new(format!(
+                    "LinkML YAML number at {path} is not finite"
+                )));
+            }
+        }
+        YamlValue::Tagged(_) => {
+            return Err(LinkmlError::new(format!(
+                "LinkML YAML tag at {path} is not JSON-compatible"
+            )));
+        }
+        YamlValue::Null | YamlValue::Bool(_) | YamlValue::String(_) => {}
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StrictValue {
+    Null,
+    Bool(bool),
+    Number(Number),
+    String(String),
+    Sequence(Vec<Self>),
+    Mapping(BTreeMap<String, Self>),
+}
+
+impl StrictValue {
+    fn into_json(self) -> Value {
+        match self {
+            Self::Null => Value::Null,
+            Self::Bool(value) => Value::Bool(value),
+            Self::Number(value) => Value::Number(value),
+            Self::String(value) => Value::String(value),
+            Self::Sequence(values) => {
+                Value::Array(values.into_iter().map(Self::into_json).collect())
+            }
+            Self::Mapping(values) => Value::Object(
+                values
+                    .into_iter()
+                    .map(|(key, value)| (key, value.into_json()))
+                    .collect(),
+            ),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for StrictValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(StrictValueVisitor)
+    }
+}
+
+struct StrictValueVisitor;
+
+impl<'de> Visitor<'de> for StrictValueVisitor {
+    type Value = StrictValue;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a finite JSON-compatible YAML value")
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(StrictValue::Null)
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(StrictValue::Null)
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(StrictValue::Bool(value))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(StrictValue::Number(Number::from(value)))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(StrictValue::Number(Number::from(value)))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Number::from_f64(value)
+            .map(StrictValue::Number)
+            .ok_or_else(|| E::custom("non-finite YAML number is not JSON-compatible"))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(StrictValue::String(value.to_owned()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(StrictValue::String(value))
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::with_capacity(sequence.size_hint().unwrap_or(0).min(1_024));
+        while let Some(value) = sequence.next_element()? {
+            values.push(value);
+        }
+        Ok(StrictValue::Sequence(values))
+    }
+
+    fn visit_map<A>(self, mut mapping: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut values = BTreeMap::new();
+        while let Some((key, value)) = mapping.next_entry::<String, StrictValue>()? {
+            if values.insert(key.clone(), value).is_some() {
+                return Err(<A::Error as de::Error>::custom(format!(
+                    "duplicate YAML mapping key {key:?}"
+                )));
+            }
+        }
+        Ok(StrictValue::Mapping(values))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn prefixes() -> BTreeMap<String, String> {
+        BTreeMap::from([
+            ("ex".to_owned(), "https://example.org/".to_owned()),
+            (
+                "linkml".to_owned(),
+                "https://example.org/linkml/".to_owned(),
+            ),
+        ])
+    }
+
+    fn valid_value() -> Value {
+        json!({
+            "id": "https://example.org/schema",
+            "name": "Example-Schema",
+            "description": "Caller schema.",
+            "metamodel_version": LINKML_METAMODEL_VERSION,
+            "prefixes": {
+                "ex": "https://example.org/",
+                "linkml": "https://example.org/linkml/"
+            },
+            "default_prefix": "ex",
+            "classes": {}
+        })
+    }
+
+    #[test]
+    fn config_requires_caller_identity_vocabulary_and_docs() {
+        let config = LinkmlConfig::new(
+            "https://example.org/schema",
+            "Example-Schema",
+            "Caller schema.",
+            "ex",
+            prefixes(),
+        )
+        .expect("valid configuration");
+        assert_eq!(config.schema_id(), "https://example.org/schema");
+        assert_eq!(config.schema_name(), "Example-Schema");
+        assert_eq!(config.description(), "Caller schema.");
+        assert_eq!(config.default_prefix(), "ex");
+        assert_eq!(config.prefixes(), &prefixes());
+
+        assert!(LinkmlConfig::new("/relative", "Schema", "docs", "ex", prefixes()).is_err());
+        assert!(
+            LinkmlConfig::new(
+                "https://example.org/schema",
+                "9bad",
+                "docs",
+                "ex",
+                prefixes()
+            )
+            .is_err()
+        );
+        assert!(
+            LinkmlConfig::new(
+                "https://example.org/schema",
+                "Schema",
+                " ",
+                "ex",
+                prefixes()
+            )
+            .is_err()
+        );
+        assert!(
+            LinkmlConfig::new(
+                "https://example.org/schema",
+                "Schema",
+                "docs",
+                "missing",
+                prefixes()
+            )
+            .is_err()
+        );
+        assert!(
+            LinkmlConfig::new(
+                "https://example.org/schema",
+                "Schema",
+                "docs",
+                "linkml",
+                prefixes()
+            )
+            .is_err()
+        );
+
+        let mut missing_linkml = prefixes();
+        missing_linkml.remove("linkml");
+        assert!(
+            LinkmlConfig::new(
+                "https://example.org/schema",
+                "Schema",
+                "docs",
+                "ex",
+                missing_linkml,
+            )
+            .is_err()
+        );
+        let bad_namespace = BTreeMap::from([
+            ("ex".to_owned(), "relative".to_owned()),
+            (
+                "linkml".to_owned(),
+                "https://example.org/linkml/".to_owned(),
+            ),
+        ]);
+        assert!(
+            LinkmlConfig::new(
+                "https://example.org/schema",
+                "Schema",
+                "docs",
+                "ex",
+                bad_namespace,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn canonical_codec_preserves_unknown_fields_and_is_byte_stable() {
+        let source = r"
+x-extension:
+  nested:
+    - null
+    - answer: 42
+prefixes:
+  linkml:
+    prefix_reference: https://example.org/linkml/
+    prefix_prefix: linkml
+  ex: https://example.org/
+name: Example-Schema
+metamodel_version: 1.11.0
+id: https://example.org/schema
+description: Caller schema.
+default_prefix: ex
+classes:
+  Person:
+    attributes:
+      ex:name:
+        range: string
+";
+        let document = parse_linkml(source).expect("parse");
+        assert_eq!(
+            document.as_value()["x-extension"]["nested"][1]["answer"],
+            json!(42)
+        );
+
+        let first = write_linkml(&document).expect("write");
+        let reparsed = parse_linkml(&first).expect("reparse");
+        let second = write_linkml(&reparsed).expect("rewrite");
+        assert_eq!(reparsed, document);
+        assert_eq!(second, first);
+        assert!(first.ends_with('\n'));
+        assert!(!first.ends_with("\n\n"));
+        assert!(first.starts_with("classes:\n"));
+    }
+
+    #[test]
+    fn document_value_round_trips_through_canonical_yaml() {
+        let document = LinkmlDocument::from_value(valid_value()).expect("valid document");
+        let yaml = write_linkml(&document).expect("write");
+        let reparsed = parse_linkml(&yaml).expect("parse");
+        assert_eq!(reparsed, document);
+        assert_eq!(reparsed.into_value(), valid_value());
+    }
+
+    #[test]
+    fn parser_rejects_yaml_semantics_that_are_not_json_compatible() {
+        let duplicate = r"
+id: https://example.org/schema
+name: First
+name: Second
+metamodel_version: 1.11.0
+prefixes:
+  ex: https://example.org/
+  linkml: https://example.org/linkml/
+default_prefix: ex
+";
+        assert!(
+            parse_linkml(duplicate)
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate")
+        );
+
+        let tagged = r"
+id: https://example.org/schema
+name: Schema
+metamodel_version: 1.11.0
+prefixes:
+  ex: https://example.org/
+  linkml: https://example.org/linkml/
+default_prefix: ex
+x-value: !caller tagged
+";
+        assert!(
+            parse_linkml(tagged)
+                .unwrap_err()
+                .to_string()
+                .contains("tag")
+        );
+
+        let non_string_key = r"
+id: https://example.org/schema
+name: Schema
+metamodel_version: 1.11.0
+prefixes:
+  ex: https://example.org/
+  linkml: https://example.org/linkml/
+default_prefix: ex
+x-value:
+  7: seven
+";
+        assert!(
+            parse_linkml(non_string_key)
+                .unwrap_err()
+                .to_string()
+                .contains("non-string key")
+        );
+
+        let non_finite = r"
+id: https://example.org/schema
+name: Schema
+metamodel_version: 1.11.0
+prefixes:
+  ex: https://example.org/
+  linkml: https://example.org/linkml/
+default_prefix: ex
+x-value: .nan
+";
+        assert!(
+            parse_linkml(non_finite)
+                .unwrap_err()
+                .to_string()
+                .contains("not finite")
+        );
+    }
+
+    #[test]
+    fn parser_rejects_invalid_fixed_dialect_envelopes() {
+        let mut value = valid_value();
+        value["metamodel_version"] = json!("1.12.0");
+        assert!(LinkmlDocument::from_value(value).is_err());
+
+        let mut value = valid_value();
+        value["id"] = json!("/relative");
+        assert!(LinkmlDocument::from_value(value).is_err());
+
+        let mut value = valid_value();
+        value["name"] = json!("bad:name");
+        assert!(LinkmlDocument::from_value(value).is_err());
+
+        let mut value = valid_value();
+        value["prefixes"].as_object_mut().unwrap().remove("linkml");
+        assert!(LinkmlDocument::from_value(value).is_err());
+
+        let mut value = valid_value();
+        value["classes"] = json!([]);
+        assert!(LinkmlDocument::from_value(value).is_err());
+
+        let mut value = valid_value();
+        value["imports"] = json!([7]);
+        assert!(LinkmlDocument::from_value(value).is_err());
+    }
+
+    #[test]
+    fn parser_accepts_structured_prefixes_without_erasing_extensions() {
+        let mut value = valid_value();
+        value["prefixes"]["ex"] = json!({
+            "prefix_prefix": "ex",
+            "prefix_reference": "https://example.org/",
+            "x-prefix-extension": true
+        });
+        value["x-document-extension"] = json!({"kept": ["yes"]});
+        let document = LinkmlDocument::from_value(value.clone()).expect("valid document");
+        let reparsed = parse_linkml(&write_linkml(&document).unwrap()).unwrap();
+        assert_eq!(reparsed.into_value(), value);
+    }
+}

--- a/crates/shapes/src/linkml/projection.rs
+++ b/crates/shapes/src/linkml/projection.rs
@@ -1,0 +1,2194 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Capability-driven JSON Schema to LinkML 1.11 projection.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use ::purrdf::RdfLocation;
+use ::purrdf::loss::{LossEntry, LossLedger};
+use serde_json::{Map, Value};
+
+use super::{
+    LINKML_METAMODEL_VERSION, LinkmlConfig, LinkmlDocument, LinkmlError, LinkmlPackage,
+    is_linkml_identifier, write_linkml,
+};
+use crate::json_schema::CompiledSchema;
+use crate::schema_catalog::{
+    CompiledSchemaCatalog, definition_path, pointer_escape, reference_key, schema_array_keywords,
+    schema_map_keywords, schema_single_keywords,
+};
+
+const LOSS_FROM: &str = "json-schema";
+const LOSS_TO: &str = "linkml-1.11";
+const LOSS_CONTEXT: &str = "shapes:linkml";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ElementKind {
+    Class,
+    Enum,
+    Type,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ElementInfo {
+    name: String,
+    kind: ElementKind,
+}
+
+pub(super) fn emit(
+    compiled: &CompiledSchema,
+    config: &LinkmlConfig,
+) -> Result<LinkmlPackage, LinkmlError> {
+    let catalog = CompiledSchemaCatalog::parse(compiled)
+        .map_err(|error| LinkmlError::new(error.to_string()))?;
+    let definitions = catalog.definitions();
+    let elements = element_infos(definitions)?;
+    let element_names = elements
+        .iter()
+        .map(|(key, info)| (key.clone(), info.name.clone()))
+        .collect();
+
+    let mut renderer = Renderer::new(config, &elements);
+    for (key, definition) in definitions {
+        renderer.audit_schema(definition, &definition_path(key))?;
+    }
+    for (key, definition) in definitions {
+        let info = elements
+            .get(key)
+            .expect("element_infos covers every definition")
+            .clone();
+        renderer.render_definition(key, &info, definition)?;
+    }
+
+    let mut root = Map::new();
+    root.insert(
+        "id".to_owned(),
+        Value::String(config.schema_id().to_owned()),
+    );
+    root.insert(
+        "name".to_owned(),
+        Value::String(config.schema_name().to_owned()),
+    );
+    root.insert(
+        "description".to_owned(),
+        Value::String(config.description().to_owned()),
+    );
+    root.insert(
+        "metamodel_version".to_owned(),
+        Value::String(LINKML_METAMODEL_VERSION.to_owned()),
+    );
+    root.insert(
+        "prefixes".to_owned(),
+        Value::Object(
+            config
+                .prefixes()
+                .iter()
+                .map(|(prefix, namespace)| (prefix.clone(), Value::String(namespace.clone())))
+                .collect(),
+        ),
+    );
+    root.insert(
+        "default_prefix".to_owned(),
+        Value::String(config.default_prefix().to_owned()),
+    );
+    root.insert(
+        "imports".to_owned(),
+        Value::Array(vec![Value::String("linkml:types".to_owned())]),
+    );
+    if !renderer.types.is_empty() {
+        root.insert("types".to_owned(), Value::Object(renderer.types));
+    }
+    if !renderer.enums.is_empty() {
+        root.insert("enums".to_owned(), Value::Object(renderer.enums));
+    }
+    if !renderer.classes.is_empty() {
+        root.insert("classes".to_owned(), Value::Object(renderer.classes));
+    }
+
+    let document = LinkmlDocument::from_value(Value::Object(root))?;
+    let yaml = write_linkml(&document)?;
+    Ok(LinkmlPackage {
+        document,
+        yaml,
+        element_names,
+        losses: renderer.ledger,
+    })
+}
+
+fn element_infos(
+    definitions: &Map<String, Value>,
+) -> Result<BTreeMap<String, ElementInfo>, LinkmlError> {
+    let mut names = BTreeMap::new();
+    let mut reverse = BTreeMap::<String, String>::new();
+    for key in definitions.keys() {
+        let name = element_name(key);
+        if reserved_element_names().contains(name.as_str()) {
+            return Err(LinkmlError::new(format!(
+                "$defs key {key:?} normalizes to reserved LinkML element name {name:?}"
+            )));
+        }
+        if let Some(previous) = reverse.insert(name.clone(), key.clone()) {
+            return Err(LinkmlError::new(format!(
+                "$defs keys {previous:?} and {key:?} collide on LinkML element name {name:?}"
+            )));
+        }
+        names.insert(key.clone(), name);
+    }
+
+    let mut kinds = BTreeMap::new();
+    let mut visiting = BTreeSet::new();
+    for key in definitions.keys() {
+        resolve_element_kind(key, definitions, &mut kinds, &mut visiting)?;
+    }
+
+    Ok(names
+        .into_iter()
+        .map(|(key, name)| {
+            let kind = kinds
+                .get(&key)
+                .copied()
+                .expect("every definition kind is resolved");
+            (key, ElementInfo { name, kind })
+        })
+        .collect())
+}
+
+fn resolve_element_kind(
+    key: &str,
+    definitions: &Map<String, Value>,
+    resolved: &mut BTreeMap<String, ElementKind>,
+    visiting: &mut BTreeSet<String>,
+) -> Result<ElementKind, LinkmlError> {
+    if let Some(kind) = resolved.get(key) {
+        return Ok(*kind);
+    }
+    if !visiting.insert(key.to_owned()) {
+        return Err(LinkmlError::new(format!(
+            "cyclic alias-only $defs chain includes {key:?}"
+        )));
+    }
+
+    let definition = definitions
+        .get(key)
+        .expect("resolve_element_kind receives an existing key");
+    let kind = match definition {
+        Value::Object(object) if is_enum_definition(object) => ElementKind::Enum,
+        Value::Object(object) if is_object_schema(object) => ElementKind::Class,
+        Value::Object(object) if is_alias_only(object) => {
+            let reference = object
+                .get("$ref")
+                .and_then(Value::as_str)
+                .expect("is_alias_only requires a string reference");
+            let target = reference_key(reference).ok_or_else(|| {
+                LinkmlError::new(format!(
+                    "{} contains a non-local alias reference {reference:?}",
+                    definition_path(key)
+                ))
+            })?;
+            resolve_element_kind(&target, definitions, resolved, visiting)?
+        }
+        _ => ElementKind::Type,
+    };
+
+    visiting.remove(key);
+    resolved.insert(key.to_owned(), kind);
+    Ok(kind)
+}
+
+fn is_enum_definition(object: &Map<String, Value>) -> bool {
+    object
+        .get("enum")
+        .and_then(Value::as_array)
+        .is_some_and(|values| {
+            values.iter().all(|value| {
+                value.is_string()
+                    || value
+                        .as_object()
+                        .and_then(|member| member.get("@id"))
+                        .is_some_and(Value::is_string)
+            })
+        })
+}
+
+fn is_object_schema(object: &Map<String, Value>) -> bool {
+    matches!(object.get("type"), Some(Value::String(kind)) if kind == "object")
+        || [
+            "properties",
+            "required",
+            "additionalProperties",
+            "patternProperties",
+            "propertyNames",
+            "minProperties",
+            "maxProperties",
+            "dependentRequired",
+            "dependentSchemas",
+        ]
+        .iter()
+        .any(|keyword| object.contains_key(*keyword))
+}
+
+fn is_alias_only(object: &Map<String, Value>) -> bool {
+    object.get("$ref").is_some_and(Value::is_string)
+        && object
+            .keys()
+            .all(|key| key == "$ref" || is_annotation_keyword(key))
+}
+
+fn element_name(raw: &str) -> String {
+    let mut output = String::new();
+    let mut capitalize = true;
+    for character in raw.chars() {
+        if character.is_alphanumeric() || character == '_' {
+            if capitalize {
+                output.extend(character.to_uppercase());
+            } else {
+                output.push(character);
+            }
+            capitalize = false;
+        } else {
+            capitalize = true;
+        }
+    }
+    if output.is_empty() {
+        output.push_str("SchemaElement");
+    }
+    if output.chars().next().is_some_and(char::is_numeric) {
+        output.insert(0, 'N');
+    }
+    if output.len() > 120 {
+        output = format!("SchemaElement{:016x}", fnv1a(raw.as_bytes()));
+    }
+    debug_assert!(is_linkml_identifier(&output));
+    output
+}
+
+fn reserved_element_names() -> BTreeSet<&'static str> {
+    BTreeSet::from([
+        "Any",
+        "Boolean",
+        "Date",
+        "DateOrDatetime",
+        "Datetime",
+        "Decimal",
+        "Double",
+        "Float",
+        "Integer",
+        "Jsonpath",
+        "Jsonpointer",
+        "Ncname",
+        "Nodeidentifier",
+        "Objectidentifier",
+        "Sparqlpath",
+        "String",
+        "Time",
+        "Uri",
+        "Uriorcurie",
+    ])
+}
+
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+struct Renderer<'a> {
+    config: &'a LinkmlConfig,
+    elements: &'a BTreeMap<String, ElementInfo>,
+    classes: Map<String, Value>,
+    enums: Map<String, Value>,
+    types: Map<String, Value>,
+    ledger: LossLedger,
+    recorded_losses: BTreeSet<(String, String)>,
+    used_names: BTreeMap<String, String>,
+    inline_classes: BTreeMap<String, String>,
+    inline_enums: BTreeMap<String, String>,
+}
+
+impl<'a> Renderer<'a> {
+    fn new(config: &'a LinkmlConfig, elements: &'a BTreeMap<String, ElementInfo>) -> Self {
+        let mut used_names = BTreeMap::new();
+        for (key, info) in elements {
+            used_names.insert(info.name.clone(), definition_path(key));
+        }
+        for reserved in reserved_element_names() {
+            used_names.insert(reserved.to_owned(), "LinkML imported type".to_owned());
+        }
+        Self {
+            config,
+            elements,
+            classes: Map::new(),
+            enums: Map::new(),
+            types: Map::new(),
+            ledger: LossLedger::new(),
+            recorded_losses: BTreeSet::new(),
+            used_names,
+            inline_classes: BTreeMap::new(),
+            inline_enums: BTreeMap::new(),
+        }
+    }
+
+    fn render_definition(
+        &mut self,
+        key: &str,
+        info: &ElementInfo,
+        definition: &Value,
+    ) -> Result<(), LinkmlError> {
+        let path = definition_path(key);
+        match info.kind {
+            ElementKind::Class => {
+                let rendered = self.render_class(&info.name, Some(key), definition, &path)?;
+                self.classes
+                    .insert(info.name.clone(), Value::Object(rendered));
+            }
+            ElementKind::Enum => {
+                let rendered = self.render_enum(&info.name, definition, &path)?;
+                self.enums
+                    .insert(info.name.clone(), Value::Object(rendered));
+            }
+            ElementKind::Type => {
+                let rendered = self.render_type(&info.name, definition, &path)?;
+                self.types
+                    .insert(info.name.clone(), Value::Object(rendered));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Renderer<'_> {
+    fn render_enum(
+        &self,
+        name: &str,
+        schema: &Value,
+        path: &str,
+    ) -> Result<Map<String, Value>, LinkmlError> {
+        let object = schema
+            .as_object()
+            .ok_or_else(|| LinkmlError::new(format!("{path} enum must be an object schema")))?;
+        let values = object
+            .get("enum")
+            .and_then(Value::as_array)
+            .ok_or_else(|| LinkmlError::new(format!("{path}/enum must be an array")))?;
+
+        let mut enumeration = Map::new();
+        enumeration.insert(
+            "enum_uri".to_owned(),
+            Value::String(self.element_curie(name)),
+        );
+        self.copy_element_annotations(object, &mut enumeration, path)?;
+
+        let varnames = string_extension_array(object, "x-enum-varnames");
+        let descriptions = string_extension_array(object, "x-enum-descriptions");
+        let mut permissible_values = Map::new();
+        for (index, value) in values.iter().enumerate() {
+            let (text, meaning) = match value {
+                Value::String(text) => (text.clone(), None),
+                Value::Object(member) => {
+                    let identifier = member.get("@id").and_then(Value::as_str).ok_or_else(|| {
+                        LinkmlError::new(format!(
+                            "{path}/enum/{index} object member requires a string @id for LinkML enumeration"
+                        ))
+                    })?;
+                    (identifier.to_owned(), self.permissible_meaning(identifier))
+                }
+                _ => {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/enum/{index} is not a string or @id object and cannot form a named LinkML enum"
+                    )));
+                }
+            };
+            if permissible_values.contains_key(&text) {
+                return Err(LinkmlError::new(format!(
+                    "{path}/enum has duplicate LinkML permissible value {text:?}"
+                )));
+            }
+            let mut permissible = Map::new();
+            if let Some(meaning) = meaning {
+                permissible.insert("meaning".to_owned(), Value::String(meaning));
+            }
+            if let Some(title) = varnames.as_ref().and_then(|values| values.get(index)) {
+                permissible.insert("title".to_owned(), Value::String((*title).to_owned()));
+            }
+            if let Some(description) = descriptions.as_ref().and_then(|values| values.get(index))
+                && !description.trim().is_empty()
+            {
+                permissible.insert(
+                    "description".to_owned(),
+                    Value::String((*description).to_owned()),
+                );
+            }
+            permissible_values.insert(text, Value::Object(permissible));
+        }
+        enumeration.insert(
+            "permissible_values".to_owned(),
+            Value::Object(permissible_values),
+        );
+        Ok(enumeration)
+    }
+
+    fn render_type(
+        &mut self,
+        name: &str,
+        schema: &Value,
+        path: &str,
+    ) -> Result<Map<String, Value>, LinkmlError> {
+        let mut definition = Map::new();
+        definition.insert("uri".to_owned(), Value::String(self.element_curie(name)));
+
+        let Value::Object(object) = schema else {
+            self.record(
+                "keyword-validation-dropped",
+                path,
+                "A boolean JSON Schema has no exact LinkML type definition; string is retained as a deterministic carrier",
+            );
+            definition.insert("typeof".to_owned(), Value::String("string".to_owned()));
+            return Ok(definition);
+        };
+
+        self.copy_element_annotations(object, &mut definition, path)?;
+        let base = self.type_definition_base(object, path)?;
+        definition.insert("typeof".to_owned(), Value::String(base.clone()));
+        self.apply_scalar_constraints(object, &mut definition, path)?;
+
+        if let Some(values) = object.get("enum").and_then(Value::as_array) {
+            let mut expressions = Vec::new();
+            for (index, value) in values.iter().enumerate() {
+                if let Some(expression) =
+                    self.equality_expression(value, &format!("{path}/enum/{index}"), "enum member")
+                {
+                    expressions.push(Value::Object(expression));
+                }
+            }
+            if !expressions.is_empty() {
+                definition.insert("any_of".to_owned(), Value::Array(expressions));
+            }
+        }
+        if let Some(value) = object.get("const")
+            && let Some(expression) =
+                self.equality_expression(value, &format!("{path}/const"), "const value")
+        {
+            definition.extend(expression);
+        }
+
+        self.apply_type_compositions(object, &mut definition, &base, path)?;
+        Ok(definition)
+    }
+
+    fn type_definition_base(
+        &mut self,
+        object: &Map<String, Value>,
+        path: &str,
+    ) -> Result<String, LinkmlError> {
+        if let Some(reference) = object.get("$ref") {
+            let target = self
+                .reference_info(reference, &format!("{path}/$ref"))?
+                .clone();
+            if target.kind == ElementKind::Type {
+                return Ok(target.name);
+            }
+            self.record(
+                "keyword-validation-dropped",
+                &format!("{path}/$ref"),
+                "A LinkML type definition cannot alias a class or enum target; string is retained as its carrier",
+            );
+            return Ok("string".to_owned());
+        }
+
+        if let Some(format) = object.get("format") {
+            let format = format
+                .as_str()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/format must be a string")))?;
+            if let Some(range) = format_range(format) {
+                return Ok(range.to_owned());
+            }
+        }
+
+        match object.get("type") {
+            Some(Value::String(kind)) => {
+                let range = scalar_range(kind).ok_or_else(|| {
+                    LinkmlError::new(format!("{path}/type names unsupported type {kind:?}"))
+                })?;
+                if matches!(kind.as_str(), "array" | "object" | "null") {
+                    self.record(
+                        "keyword-validation-dropped",
+                        &format!("{path}/type"),
+                        "A standalone LinkML type cannot retain this JSON container or null carrier; string is used as the deterministic fallback",
+                    );
+                }
+                Ok(range.to_owned())
+            }
+            Some(Value::Array(kinds)) => {
+                let mut ranges = BTreeSet::new();
+                for (index, kind) in kinds.iter().enumerate() {
+                    let kind = kind.as_str().ok_or_else(|| {
+                        LinkmlError::new(format!("{path}/type/{index} must be a string"))
+                    })?;
+                    let range = scalar_range(kind).ok_or_else(|| {
+                        LinkmlError::new(format!(
+                            "{path}/type/{index} names unsupported type {kind:?}"
+                        ))
+                    })?;
+                    if kind != "null" {
+                        ranges.insert(range);
+                    }
+                }
+                if ranges.len() == 1 {
+                    Ok((*ranges.first().expect("length checked")).to_owned())
+                } else {
+                    self.record(
+                        "keyword-validation-dropped",
+                        &format!("{path}/type"),
+                        "A named LinkML type has one base carrier and cannot retain a heterogeneous JSON Schema type union",
+                    );
+                    Ok(ranges.first().copied().unwrap_or("string").to_owned())
+                }
+            }
+            Some(_) => Err(LinkmlError::new(format!(
+                "{path}/type must be a string or array of strings"
+            ))),
+            None => {
+                if object
+                    .get("enum")
+                    .and_then(Value::as_array)
+                    .is_some_and(|values| values.iter().all(Value::is_number))
+                    || object.contains_key("minimum")
+                    || object.contains_key("maximum")
+                    || object.contains_key("exclusiveMinimum")
+                    || object.contains_key("exclusiveMaximum")
+                {
+                    Ok("double".to_owned())
+                } else if object
+                    .get("enum")
+                    .and_then(Value::as_array)
+                    .is_some_and(|values| values.iter().all(Value::is_boolean))
+                {
+                    Ok("boolean".to_owned())
+                } else {
+                    self.record(
+                        "keyword-validation-dropped",
+                        path,
+                        "An unconstrained JSON Schema carrier has no LinkML Any type; string is used as the deterministic fallback",
+                    );
+                    Ok("string".to_owned())
+                }
+            }
+        }
+    }
+
+    fn apply_type_compositions(
+        &mut self,
+        object: &Map<String, Value>,
+        definition: &mut Map<String, Value>,
+        base: &str,
+        path: &str,
+    ) -> Result<(), LinkmlError> {
+        for (source, target) in [
+            ("anyOf", "any_of"),
+            ("oneOf", "exactly_one_of"),
+            ("allOf", "all_of"),
+        ] {
+            let Some(branches) = object.get(source) else {
+                continue;
+            };
+            let branches = branches
+                .as_array()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/{source} must be an array")))?;
+            let mut expressions = Vec::new();
+            for (index, branch) in branches.iter().enumerate() {
+                if let Some(expression) =
+                    self.render_type_expression(branch, base, &format!("{path}/{source}/{index}"))?
+                {
+                    expressions.push(Value::Object(expression));
+                }
+            }
+            if !expressions.is_empty() {
+                definition.insert(target.to_owned(), Value::Array(expressions));
+            }
+        }
+        if let Some(negated) = object.get("not")
+            && let Some(expression) =
+                self.render_type_expression(negated, base, &format!("{path}/not"))?
+        {
+            definition.insert(
+                "none_of".to_owned(),
+                Value::Array(vec![Value::Object(expression)]),
+            );
+        }
+        Ok(())
+    }
+
+    fn render_type_expression(
+        &mut self,
+        schema: &Value,
+        base: &str,
+        path: &str,
+    ) -> Result<Option<Map<String, Value>>, LinkmlError> {
+        let Value::Object(object) = schema else {
+            self.record(
+                "keyword-validation-dropped",
+                path,
+                "A boolean branch has no LinkML anonymous-type expression",
+            );
+            return Ok(None);
+        };
+        if let Some(kind) = object.get("type").and_then(Value::as_str) {
+            let branch_base = scalar_range(kind).ok_or_else(|| {
+                LinkmlError::new(format!("{path}/type names unsupported type {kind:?}"))
+            })?;
+            if branch_base != base {
+                self.record(
+                    "keyword-validation-dropped",
+                    &format!("{path}/type"),
+                    "A LinkML anonymous-type expression cannot change the named type's base carrier",
+                );
+                return Ok(None);
+            }
+        }
+        let mut expression = Map::new();
+        self.apply_scalar_constraints(object, &mut expression, path)?;
+        if let Some(value) = object.get("const")
+            && let Some(equality) =
+                self.equality_expression(value, &format!("{path}/const"), "const value")
+        {
+            expression.extend(equality);
+        }
+        if expression.is_empty() {
+            self.record(
+                "keyword-validation-dropped",
+                path,
+                "This JSON Schema branch has no LinkML anonymous-type constraint",
+            );
+            Ok(None)
+        } else {
+            Ok(Some(expression))
+        }
+    }
+
+    fn apply_scalar_constraints(
+        &self,
+        object: &Map<String, Value>,
+        target: &mut Map<String, Value>,
+        path: &str,
+    ) -> Result<(), LinkmlError> {
+        if let Some(pattern) = object.get("pattern") {
+            let pattern = pattern
+                .as_str()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/pattern must be a string")))?;
+            target.insert("pattern".to_owned(), Value::String(pattern.to_owned()));
+        }
+        for (source, output) in [
+            ("minimum", "minimum_value"),
+            ("maximum", "maximum_value"),
+            ("exclusiveMinimum", "minimum_value"),
+            ("exclusiveMaximum", "maximum_value"),
+        ] {
+            if let Some(value) = object.get(source) {
+                if !value.is_number() {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/{source} must be a number"
+                    )));
+                }
+                target.insert(output.to_owned(), value.clone());
+            }
+        }
+        Ok(())
+    }
+
+    fn equality_expression(
+        &mut self,
+        value: &Value,
+        path: &str,
+        label: &str,
+    ) -> Option<Map<String, Value>> {
+        let mut expression = Map::new();
+        match value {
+            Value::String(text) => {
+                expression.insert("equals_string".to_owned(), Value::String(text.clone()));
+            }
+            Value::Number(number) => {
+                expression.insert("equals_number".to_owned(), Value::Number(number.clone()));
+            }
+            _ => {
+                self.record(
+                    "keyword-validation-dropped",
+                    path,
+                    &format!("A JSON {label} of this carrier has no LinkML equality expression"),
+                );
+                return None;
+            }
+        }
+        Some(expression)
+    }
+
+    fn permissible_meaning(&self, value: &str) -> Option<String> {
+        if let Some((prefix, local)) = value.split_once(':')
+            && self.config.prefixes().contains_key(prefix)
+            && is_linkml_identifier(local)
+        {
+            return Some(value.to_owned());
+        }
+        if purrdf_iri::parse(value).is_ok_and(|iri| iri.has_scheme()) {
+            return Some(value.to_owned());
+        }
+        None
+    }
+
+    fn render_class(
+        &mut self,
+        name: &str,
+        source_key: Option<&str>,
+        schema: &Value,
+        path: &str,
+    ) -> Result<Map<String, Value>, LinkmlError> {
+        let mut class = Map::new();
+        class.insert(
+            "class_uri".to_owned(),
+            Value::String(self.element_curie(name)),
+        );
+        if let Some(source_key) = source_key
+            && source_key != name
+        {
+            class.insert("alias".to_owned(), Value::String(source_key.to_owned()));
+        }
+
+        let Value::Object(object) = schema else {
+            self.record(
+                "keyword-validation-dropped",
+                path,
+                "A boolean JSON Schema cannot be represented as a LinkML class; the emitted class retains only its caller-owned identity",
+            );
+            class.insert("extra_slots".to_owned(), extra_slots(true, None));
+            return Ok(class);
+        };
+
+        self.copy_element_annotations(object, &mut class, path)?;
+
+        if let Some(reference) = object.get("$ref") {
+            let target = self.reference_info(reference, &format!("{path}/$ref"))?;
+            if target.kind == ElementKind::Class {
+                class.insert("is_a".to_owned(), Value::String(target.name.clone()));
+            } else {
+                self.record(
+                    "keyword-validation-dropped",
+                    &format!("{path}/$ref"),
+                    "A LinkML class cannot inherit from a JSON Schema alias whose target is not a class",
+                );
+            }
+        }
+
+        if object
+            .get("type")
+            .is_some_and(|value| !matches!(value, Value::String(kind) if kind == "object"))
+        {
+            self.record(
+                "keyword-validation-dropped",
+                &format!("{path}/type"),
+                "An object-shaped definition also declares a non-object JSON carrier; LinkML retains the class structure but cannot preserve that carrier intersection",
+            );
+        }
+
+        let properties = object_map(object, "properties", path)?;
+        let required = required_names(object, properties, path)?;
+        if !properties.is_empty() {
+            let mut attributes = Map::new();
+            let mut slot_uris = BTreeMap::<String, String>::new();
+            for (property, property_schema) in properties {
+                let property_path = format!("{path}/properties/{}", pointer_escape(property));
+                let mut slot = self.render_slot_expression(property_schema, &property_path)?;
+                slot.insert("alias".to_owned(), Value::String(property.clone()));
+                if let Some(slot_uri) = self.slot_uri(property)? {
+                    if let Some(previous) = slot_uris.insert(slot_uri.clone(), property.clone()) {
+                        return Err(LinkmlError::new(format!(
+                            "{path}/properties keys {previous:?} and {property:?} derive the same caller-vocabulary slot URI {slot_uri:?}"
+                        )));
+                    }
+                    slot.insert("slot_uri".to_owned(), Value::String(slot_uri));
+                }
+                slot.insert(
+                    "required".to_owned(),
+                    Value::Bool(required.contains(property.as_str())),
+                );
+                attributes.insert(property.clone(), Value::Object(slot));
+            }
+            class.insert("attributes".to_owned(), Value::Object(attributes));
+        }
+
+        let extra = match object.get("additionalProperties") {
+            None | Some(Value::Bool(true)) => extra_slots(true, None),
+            Some(Value::Bool(false)) => extra_slots(false, None),
+            Some(schema @ Value::Object(_)) => {
+                let expression =
+                    self.render_slot_expression(schema, &format!("{path}/additionalProperties"))?;
+                extra_slots(true, Some(expression))
+            }
+            Some(_) => {
+                return Err(LinkmlError::new(format!(
+                    "{path}/additionalProperties must be a boolean or schema"
+                )));
+            }
+        };
+        class.insert("extra_slots".to_owned(), extra);
+
+        self.apply_class_compositions(object, &mut class, path)?;
+        Ok(class)
+    }
+
+    fn apply_class_compositions(
+        &mut self,
+        object: &Map<String, Value>,
+        class: &mut Map<String, Value>,
+        path: &str,
+    ) -> Result<(), LinkmlError> {
+        for (source, target) in [
+            ("anyOf", "any_of"),
+            ("oneOf", "exactly_one_of"),
+            ("allOf", "all_of"),
+        ] {
+            let Some(branches) = object.get(source) else {
+                continue;
+            };
+            let branches = branches
+                .as_array()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/{source} must be an array")))?;
+            let mut expressions = Vec::with_capacity(branches.len());
+            for (index, branch) in branches.iter().enumerate() {
+                let branch_path = format!("{path}/{source}/{index}");
+                if let Some(expression) = self.render_class_expression(branch, &branch_path)? {
+                    expressions.push(Value::Object(expression));
+                }
+            }
+            if !expressions.is_empty() {
+                class.insert(target.to_owned(), Value::Array(expressions));
+            }
+        }
+        if let Some(negated) = object.get("not")
+            && let Some(expression) =
+                self.render_class_expression(negated, &format!("{path}/not"))?
+        {
+            class.insert(
+                "none_of".to_owned(),
+                Value::Array(vec![Value::Object(expression)]),
+            );
+        }
+        Ok(())
+    }
+
+    fn render_class_expression(
+        &mut self,
+        schema: &Value,
+        path: &str,
+    ) -> Result<Option<Map<String, Value>>, LinkmlError> {
+        let Value::Object(object) = schema else {
+            self.record(
+                "keyword-validation-dropped",
+                path,
+                "A boolean JSON Schema branch has no LinkML anonymous-class expression",
+            );
+            return Ok(None);
+        };
+
+        if let Some(reference) = object.get("$ref") {
+            let target = self.reference_info(reference, &format!("{path}/$ref"))?;
+            if target.kind == ElementKind::Class {
+                let mut expression = Map::new();
+                expression.insert("is_a".to_owned(), Value::String(target.name.clone()));
+                return Ok(Some(expression));
+            }
+        }
+
+        if is_object_schema(object) {
+            let inline = self.ensure_inline_class(schema, path)?;
+            let mut expression = Map::new();
+            expression.insert("is_a".to_owned(), Value::String(inline));
+            return Ok(Some(expression));
+        }
+
+        let mut expression = Map::new();
+        for (source, target) in [
+            ("anyOf", "any_of"),
+            ("oneOf", "exactly_one_of"),
+            ("allOf", "all_of"),
+        ] {
+            let Some(branches) = object.get(source).and_then(Value::as_array) else {
+                continue;
+            };
+            let mut nested = Vec::new();
+            for (index, branch) in branches.iter().enumerate() {
+                if let Some(branch) =
+                    self.render_class_expression(branch, &format!("{path}/{source}/{index}"))?
+                {
+                    nested.push(Value::Object(branch));
+                }
+            }
+            if !nested.is_empty() {
+                expression.insert(target.to_owned(), Value::Array(nested));
+            }
+        }
+        if let Some(negated) = object.get("not")
+            && let Some(negated) = self.render_class_expression(negated, &format!("{path}/not"))?
+        {
+            expression.insert(
+                "none_of".to_owned(),
+                Value::Array(vec![Value::Object(negated)]),
+            );
+        }
+        if expression.is_empty() {
+            self.record(
+                "keyword-validation-dropped",
+                path,
+                "This JSON Schema branch has no LinkML anonymous-class expression and is omitted from the class composition",
+            );
+            Ok(None)
+        } else {
+            Ok(Some(expression))
+        }
+    }
+
+    fn ensure_inline_class(&mut self, schema: &Value, path: &str) -> Result<String, LinkmlError> {
+        if let Some(name) = self.inline_classes.get(path) {
+            return Ok(name.clone());
+        }
+        let name = self.allocate_inline_name(path, "Object")?;
+        self.inline_classes.insert(path.to_owned(), name.clone());
+        self.classes.insert(name.clone(), Value::Object(Map::new()));
+        let rendered = self.render_class(&name, None, schema, path)?;
+        self.classes.insert(name.clone(), Value::Object(rendered));
+        Ok(name)
+    }
+
+    fn slot_uri(&self, property: &str) -> Result<Option<String>, LinkmlError> {
+        if property.starts_with('@') {
+            return Ok(None);
+        }
+
+        if let Some((prefix, local)) = property.split_once(':')
+            && self.config.prefixes().contains_key(prefix)
+        {
+            if !is_linkml_identifier(local) {
+                return Err(LinkmlError::new(format!(
+                    "JSON property {property:?} has a non-NCName CURIE local part"
+                )));
+            }
+            return Ok(Some(property.to_owned()));
+        }
+
+        if purrdf_iri::parse(property).is_ok_and(|iri| iri.has_scheme()) {
+            let compacted = self
+                .config
+                .prefixes()
+                .iter()
+                .filter_map(|(prefix, namespace)| {
+                    property
+                        .strip_prefix(namespace)
+                        .filter(|local| is_linkml_identifier(local))
+                        .map(|local| (namespace.len(), format!("{prefix}:{local}")))
+                })
+                .max_by_key(|(length, _)| *length)
+                .map(|(_, curie)| curie)
+                .ok_or_else(|| {
+                    LinkmlError::new(format!(
+                        "absolute JSON property {property:?} is outside every caller-supplied LinkML prefix namespace"
+                    ))
+                })?;
+            return Ok(Some(compacted));
+        }
+
+        let local = if is_linkml_identifier(property) {
+            property.to_owned()
+        } else {
+            element_name(property)
+        };
+        Ok(Some(format!("{}:{local}", self.config.default_prefix())))
+    }
+
+    fn element_curie(&self, name: &str) -> String {
+        format!("{}:{name}", self.config.default_prefix())
+    }
+
+    fn allocate_inline_name(&mut self, path: &str, suffix: &str) -> Result<String, LinkmlError> {
+        let name = element_name(&format!("Inline {path} {suffix}"));
+        if let Some(previous) = self.used_names.get(&name) {
+            return Err(LinkmlError::new(format!(
+                "schema locations {previous:?} and {path:?} collide on synthesized LinkML element name {name:?}"
+            )));
+        }
+        self.used_names.insert(name.clone(), path.to_owned());
+        Ok(name)
+    }
+
+    fn reference_info(&self, value: &Value, path: &str) -> Result<&ElementInfo, LinkmlError> {
+        let reference = value
+            .as_str()
+            .ok_or_else(|| LinkmlError::new(format!("{path} must be a string")))?;
+        let key = reference_key(reference).ok_or_else(|| {
+            LinkmlError::new(format!(
+                "{path} is not a direct local #/$defs reference: {reference:?}"
+            ))
+        })?;
+        self.elements
+            .get(&key)
+            .ok_or_else(|| LinkmlError::new(format!("{path} targets missing $defs key {key:?}")))
+    }
+
+    fn render_slot_expression(
+        &mut self,
+        schema: &Value,
+        path: &str,
+    ) -> Result<Map<String, Value>, LinkmlError> {
+        let Value::Object(object) = schema else {
+            self.record(
+                "keyword-validation-dropped",
+                path,
+                if schema == &Value::Bool(false) {
+                    "The false JSON Schema rejects every value and has no inhabited LinkML slot expression; string is retained as a deterministic carrier"
+                } else {
+                    "The unconstrained true JSON Schema has no LinkML Any range; string is retained as a deterministic carrier"
+                },
+            );
+            return Ok(Map::from_iter([(
+                "range".to_owned(),
+                Value::String("string".to_owned()),
+            )]));
+        };
+
+        let mut slot = Map::new();
+        self.copy_element_annotations(object, &mut slot, path)?;
+        let mut has_carrier = if let Some(reference) = object.get("$ref") {
+            let target = self
+                .reference_info(reference, &format!("{path}/$ref"))?
+                .clone();
+            slot.insert("range".to_owned(), Value::String(target.name));
+            if target.kind == ElementKind::Class {
+                slot.insert("inlined".to_owned(), Value::Bool(true));
+            }
+            true
+        } else {
+            false
+        };
+
+        if let Some(values) = object.get("enum") {
+            let values = values
+                .as_array()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/enum must be an array")))?;
+            if values.iter().all(|value| {
+                value.is_string()
+                    || value
+                        .as_object()
+                        .and_then(|member| member.get("@id"))
+                        .is_some_and(Value::is_string)
+            }) {
+                let name = self.ensure_inline_enum(schema, path)?;
+                slot.insert("range".to_owned(), Value::String(name));
+                has_carrier = true;
+            } else {
+                let mut expressions = Vec::new();
+                for (index, value) in values.iter().enumerate() {
+                    if let Some(expression) = self.equality_expression(
+                        value,
+                        &format!("{path}/enum/{index}"),
+                        "enum member",
+                    ) {
+                        expressions.push(Value::Object(expression));
+                    }
+                }
+                if !expressions.is_empty() {
+                    conjoin_expression(&mut slot, "any_of", expressions);
+                    has_carrier = true;
+                }
+            }
+        }
+
+        if let Some(value) = object.get("const")
+            && let Some(expression) =
+                self.equality_expression(value, &format!("{path}/const"), "const value")
+        {
+            slot.extend(expression);
+            has_carrier = true;
+        }
+
+        if !has_carrier {
+            match object.get("type") {
+                Some(Value::String(kind)) => {
+                    self.apply_slot_type(kind, object, &mut slot, path)?;
+                    has_carrier = kind != "null";
+                }
+                Some(Value::Array(kinds)) => {
+                    let mut expressions = Vec::new();
+                    let mut seen = BTreeSet::new();
+                    for (index, kind) in kinds.iter().enumerate() {
+                        let kind = kind.as_str().ok_or_else(|| {
+                            LinkmlError::new(format!("{path}/type/{index} must be a string"))
+                        })?;
+                        if !seen.insert(kind) {
+                            return Err(LinkmlError::new(format!(
+                                "{path}/type repeats type {kind:?}"
+                            )));
+                        }
+                        let mut branch = object.clone();
+                        branch.insert("type".to_owned(), Value::String(kind.to_owned()));
+                        branch.remove("anyOf");
+                        branch.remove("oneOf");
+                        branch.remove("allOf");
+                        branch.remove("not");
+                        let branch_path = format!("{path}/type/{index}");
+                        if kind == "null" {
+                            self.record(
+                                "keyword-validation-dropped",
+                                &branch_path,
+                                "Explicit JSON null is not a LinkML scalar range; optionality remains distinct from accepting a null value",
+                            );
+                            continue;
+                        }
+                        expressions.push(Value::Object(
+                            self.render_slot_expression(&Value::Object(branch), &branch_path)?,
+                        ));
+                    }
+                    if !expressions.is_empty() {
+                        conjoin_expression(&mut slot, "any_of", expressions);
+                        has_carrier = true;
+                    }
+                }
+                Some(_) => {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/type must be a string or array of strings"
+                    )));
+                }
+                None if is_object_schema(object) => {
+                    let inline = self.ensure_inline_class(schema, path)?;
+                    slot.insert("range".to_owned(), Value::String(inline));
+                    slot.insert("inlined".to_owned(), Value::Bool(true));
+                    has_carrier = true;
+                }
+                None => {}
+            }
+        }
+
+        self.apply_scalar_constraints(object, &mut slot, path)?;
+        self.apply_slot_compositions(object, &mut slot, path)?;
+
+        if !has_carrier
+            && ![
+                "any_of",
+                "exactly_one_of",
+                "all_of",
+                "none_of",
+                "equals_string",
+                "equals_number",
+            ]
+            .iter()
+            .any(|key| slot.contains_key(*key))
+        {
+            self.record(
+                "keyword-validation-dropped",
+                path,
+                "An unconstrained JSON Schema carrier has no LinkML Any range; string is used as the deterministic fallback",
+            );
+            slot.insert("range".to_owned(), Value::String("string".to_owned()));
+        }
+        Ok(slot)
+    }
+
+    fn apply_slot_type(
+        &mut self,
+        kind: &str,
+        object: &Map<String, Value>,
+        slot: &mut Map<String, Value>,
+        path: &str,
+    ) -> Result<(), LinkmlError> {
+        match kind {
+            "null" => {
+                self.record(
+                    "keyword-validation-dropped",
+                    &format!("{path}/type"),
+                    "Explicit JSON null is not a LinkML scalar range; optionality remains distinct from accepting a null value",
+                );
+            }
+            "object" => {
+                let inline = self.ensure_inline_class(&Value::Object(object.clone()), path)?;
+                slot.insert("range".to_owned(), Value::String(inline));
+                slot.insert("inlined".to_owned(), Value::Bool(true));
+            }
+            "array" => self.apply_array(object, slot, path)?,
+            scalar => {
+                let mut range = scalar_range(scalar).ok_or_else(|| {
+                    LinkmlError::new(format!("{path}/type names unsupported type {scalar:?}"))
+                })?;
+                if scalar == "string"
+                    && let Some(format) = object.get("format")
+                {
+                    let format = format.as_str().ok_or_else(|| {
+                        LinkmlError::new(format!("{path}/format must be a string"))
+                    })?;
+                    if let Some(formatted) = format_range(format) {
+                        range = formatted;
+                    }
+                }
+                slot.insert("range".to_owned(), Value::String(range.to_owned()));
+            }
+        }
+        Ok(())
+    }
+
+    fn apply_array(
+        &mut self,
+        object: &Map<String, Value>,
+        slot: &mut Map<String, Value>,
+        path: &str,
+    ) -> Result<(), LinkmlError> {
+        let item_schema = if let Some(prefix_items) = object.get("prefixItems") {
+            let prefix_items = prefix_items
+                .as_array()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/prefixItems must be an array")))?;
+            let mut branches = prefix_items.clone();
+            branches.push(object.get("items").cloned().unwrap_or(Value::Bool(true)));
+            let mut synthetic = Map::new();
+            synthetic.insert("anyOf".to_owned(), Value::Array(branches));
+            Value::Object(synthetic)
+        } else {
+            object.get("items").cloned().unwrap_or(Value::Bool(true))
+        };
+        let item_path = if object.contains_key("prefixItems") {
+            format!("{path}/prefixItems")
+        } else {
+            format!("{path}/items")
+        };
+        let item = self.render_slot_expression(&item_schema, &item_path)?;
+        for (key, value) in item {
+            if !matches!(
+                key.as_str(),
+                "title"
+                    | "description"
+                    | "required"
+                    | "multivalued"
+                    | "minimum_cardinality"
+                    | "maximum_cardinality"
+                    | "list_elements_ordered"
+                    | "list_elements_unique"
+                    | "alias"
+                    | "slot_uri"
+            ) {
+                slot.insert(key, value);
+            }
+        }
+        slot.insert("multivalued".to_owned(), Value::Bool(true));
+        slot.insert("list_elements_ordered".to_owned(), Value::Bool(true));
+        if slot.get("inlined") == Some(&Value::Bool(true)) {
+            slot.insert("inlined_as_list".to_owned(), Value::Bool(true));
+        }
+        for (source, target) in [
+            ("minItems", "minimum_cardinality"),
+            ("maxItems", "maximum_cardinality"),
+        ] {
+            if let Some(value) = object.get(source) {
+                if value.as_u64().is_none() {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/{source} must be a non-negative integer"
+                    )));
+                }
+                slot.insert(target.to_owned(), value.clone());
+            }
+        }
+        if let Some(unique) = object.get("uniqueItems") {
+            let unique = unique
+                .as_bool()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/uniqueItems must be a boolean")))?;
+            slot.insert("list_elements_unique".to_owned(), Value::Bool(unique));
+        }
+        Ok(())
+    }
+
+    fn apply_slot_compositions(
+        &mut self,
+        object: &Map<String, Value>,
+        slot: &mut Map<String, Value>,
+        path: &str,
+    ) -> Result<(), LinkmlError> {
+        for (source, target) in [
+            ("anyOf", "any_of"),
+            ("oneOf", "exactly_one_of"),
+            ("allOf", "all_of"),
+        ] {
+            let Some(branches) = object.get(source) else {
+                continue;
+            };
+            let branches = branches
+                .as_array()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/{source} must be an array")))?;
+            let mut expressions = Vec::with_capacity(branches.len());
+            for (index, branch) in branches.iter().enumerate() {
+                expressions.push(Value::Object(
+                    self.render_slot_expression(branch, &format!("{path}/{source}/{index}"))?,
+                ));
+            }
+            conjoin_expression(slot, target, expressions);
+        }
+        if let Some(negated) = object.get("not") {
+            let expression = self.render_slot_expression(negated, &format!("{path}/not"))?;
+            conjoin_expression(slot, "none_of", vec![Value::Object(expression)]);
+        }
+        Ok(())
+    }
+
+    fn ensure_inline_enum(&mut self, schema: &Value, path: &str) -> Result<String, LinkmlError> {
+        if let Some(name) = self.inline_enums.get(path) {
+            return Ok(name.clone());
+        }
+        let name = self.allocate_inline_name(path, "Enum")?;
+        self.inline_enums.insert(path.to_owned(), name.clone());
+        let rendered = self.render_enum(&name, schema, path)?;
+        self.enums.insert(name.clone(), Value::Object(rendered));
+        Ok(name)
+    }
+
+    fn audit_schema(&mut self, schema: &Value, path: &str) -> Result<(), LinkmlError> {
+        let Value::Object(object) = schema else {
+            return if schema.is_boolean() {
+                Ok(())
+            } else {
+                Err(LinkmlError::new(format!(
+                    "{path} must be an object or boolean JSON Schema"
+                )))
+            };
+        };
+
+        self.validate_keyword_values(object, path)?;
+
+        if ["if", "then", "else"]
+            .iter()
+            .any(|keyword| object.contains_key(*keyword))
+        {
+            let keyword = ["if", "then", "else"]
+                .into_iter()
+                .find(|keyword| object.contains_key(*keyword))
+                .expect("presence checked");
+            self.record(
+                "conditional-validation-dropped",
+                &format!("{path}/{keyword}"),
+                "JSON Schema if/then/else dependent validation has no LinkML 1.11 expression",
+            );
+        }
+        if ["contains", "minContains", "maxContains"]
+            .iter()
+            .any(|keyword| object.contains_key(*keyword))
+        {
+            let keyword = ["contains", "minContains", "maxContains"]
+                .into_iter()
+                .find(|keyword| object.contains_key(*keyword))
+                .expect("presence checked");
+            self.record(
+                "array-contains-validation-dropped",
+                &format!("{path}/{keyword}"),
+                "LinkML list expressions retain item and list cardinality constraints but cannot enforce a contains predicate or its match count",
+            );
+        }
+        for keyword in ["dependentRequired", "dependentSchemas"] {
+            if object.contains_key(keyword) {
+                self.record(
+                    "dependency-validation-dropped",
+                    &format!("{path}/{keyword}"),
+                    "LinkML 1.11 has no cross-property dependency expression",
+                );
+            }
+        }
+        for keyword in ["exclusiveMinimum", "exclusiveMaximum"] {
+            if object.contains_key(keyword) {
+                self.record(
+                    "exclusive-bound-validation-widened",
+                    &format!("{path}/{keyword}"),
+                    "The exclusive JSON Schema bound is retained as LinkML's corresponding inclusive bound",
+                );
+            }
+        }
+        if let Some(format) = object.get("format") {
+            self.record(
+                "format-validation-widened",
+                &format!("{path}/format"),
+                &format!(
+                    "JSON Schema format {:?} does not have byte-identical validation semantics in LinkML 1.11",
+                    format.as_str().expect("validated string")
+                ),
+            );
+        }
+        if object.contains_key("multipleOf") {
+            self.record(
+                "multiple-of-validation-dropped",
+                &format!("{path}/multipleOf"),
+                "LinkML 1.11 has no numeric divisibility expression",
+            );
+        }
+        for keyword in ["minProperties", "maxProperties"] {
+            if object.contains_key(keyword) {
+                self.record(
+                    "property-count-validation-dropped",
+                    &format!("{path}/{keyword}"),
+                    "LinkML class structure cannot constrain the total number of JSON object properties",
+                );
+            }
+        }
+        for keyword in ["minLength", "maxLength"] {
+            if object.contains_key(keyword) {
+                self.record(
+                    "string-length-validation-dropped",
+                    &format!("{path}/{keyword}"),
+                    "LinkML 1.11 has no code-point string-length expression",
+                );
+            }
+        }
+        if object.contains_key("prefixItems") {
+            self.record(
+                "tuple-array-validation-widened",
+                &format!("{path}/prefixItems"),
+                "Position-specific tuple items are widened to a homogeneous LinkML list whose item expression is the union of tuple branches",
+            );
+        }
+        for keyword in ["unevaluatedProperties", "unevaluatedItems"] {
+            if object.contains_key(keyword) {
+                self.record(
+                    "unevaluated-validation-dropped",
+                    &format!("{path}/{keyword}"),
+                    "LinkML 1.11 does not expose JSON Schema applicator evaluation state",
+                );
+            }
+        }
+        if let Some(values) = object.get("enum").and_then(Value::as_array) {
+            for (index, value) in values.iter().enumerate() {
+                if matches!(value, Value::Array(_) | Value::Object(_)) {
+                    self.record(
+                        "non-scalar-enum-validation-widened",
+                        &format!("{path}/enum/{index}"),
+                        "A non-scalar JSON enum member is projected to a LinkML permissible-value identifier rather than its original JSON carrier",
+                    );
+                }
+            }
+        }
+        if let Some(value) = object.get("const")
+            && !matches!(value, Value::String(_) | Value::Number(_))
+        {
+            self.record(
+                "keyword-validation-dropped",
+                &format!("{path}/const"),
+                "This JSON const carrier has no LinkML equality expression",
+            );
+        }
+
+        for key in object.keys() {
+            if !known_schema_keyword(key) && !is_annotation_keyword(key) {
+                self.record(
+                    "keyword-validation-dropped",
+                    &format!("{path}/{}", pointer_escape(key)),
+                    &format!(
+                        "JSON Schema assertion keyword {key:?} is outside the closed LinkML 1.11 capability table"
+                    ),
+                );
+            }
+        }
+
+        for keyword in schema_map_keywords() {
+            if let Some(children) = object.get(*keyword).and_then(Value::as_object) {
+                for (key, child) in children {
+                    self.audit_schema(child, &format!("{path}/{keyword}/{}", pointer_escape(key)))?;
+                }
+            }
+        }
+        for keyword in schema_array_keywords() {
+            if let Some(children) = object.get(*keyword).and_then(Value::as_array) {
+                for (index, child) in children.iter().enumerate() {
+                    self.audit_schema(child, &format!("{path}/{keyword}/{index}"))?;
+                }
+            }
+        }
+        for keyword in schema_single_keywords() {
+            if let Some(child) = object.get(*keyword) {
+                self.audit_schema(child, &format!("{path}/{keyword}"))?;
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_keyword_values(
+        &self,
+        object: &Map<String, Value>,
+        path: &str,
+    ) -> Result<(), LinkmlError> {
+        if let Some(value) = object.get("type") {
+            let mut seen = BTreeSet::new();
+            match value {
+                Value::String(kind) => validate_json_type(kind, &format!("{path}/type"))?,
+                Value::Array(kinds) if !kinds.is_empty() => {
+                    for (index, kind) in kinds.iter().enumerate() {
+                        let kind = kind.as_str().ok_or_else(|| {
+                            LinkmlError::new(format!("{path}/type/{index} must be a string"))
+                        })?;
+                        validate_json_type(kind, &format!("{path}/type/{index}"))?;
+                        if !seen.insert(kind) {
+                            return Err(LinkmlError::new(format!(
+                                "{path}/type repeats type {kind:?}"
+                            )));
+                        }
+                    }
+                }
+                Value::Array(_) => {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/type array cannot be empty"
+                    )));
+                }
+                _ => {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/type must be a string or non-empty array of strings"
+                    )));
+                }
+            }
+        }
+        if object.get("enum").is_some_and(|value| !value.is_array()) {
+            return Err(LinkmlError::new(format!("{path}/enum must be an array")));
+        }
+        for keyword in ["title", "description", "pattern", "format"] {
+            if object.get(keyword).is_some_and(|value| !value.is_string()) {
+                return Err(LinkmlError::new(format!(
+                    "{path}/{keyword} must be a string"
+                )));
+            }
+        }
+        for keyword in [
+            "minimum",
+            "maximum",
+            "exclusiveMinimum",
+            "exclusiveMaximum",
+            "multipleOf",
+        ] {
+            if object.get(keyword).is_some_and(|value| !value.is_number()) {
+                return Err(LinkmlError::new(format!(
+                    "{path}/{keyword} must be a number"
+                )));
+            }
+        }
+        for keyword in [
+            "minLength",
+            "maxLength",
+            "minItems",
+            "maxItems",
+            "minContains",
+            "maxContains",
+            "minProperties",
+            "maxProperties",
+        ] {
+            if object
+                .get(keyword)
+                .is_some_and(|value| value.as_u64().is_none())
+            {
+                return Err(LinkmlError::new(format!(
+                    "{path}/{keyword} must be a non-negative integer"
+                )));
+            }
+        }
+        if object
+            .get("uniqueItems")
+            .is_some_and(|value| !value.is_boolean())
+        {
+            return Err(LinkmlError::new(format!(
+                "{path}/uniqueItems must be a boolean"
+            )));
+        }
+        if let Some(Value::Object(dependencies)) = object.get("dependentRequired") {
+            for (property, values) in dependencies {
+                let values = values.as_array().ok_or_else(|| {
+                    LinkmlError::new(format!(
+                        "{path}/dependentRequired/{} must be an array",
+                        pointer_escape(property)
+                    ))
+                })?;
+                if values.iter().any(|value| !value.is_string()) {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/dependentRequired/{} must contain only strings",
+                        pointer_escape(property)
+                    )));
+                }
+            }
+        } else if object.contains_key("dependentRequired") {
+            return Err(LinkmlError::new(format!(
+                "{path}/dependentRequired must be an object"
+            )));
+        }
+        Ok(())
+    }
+
+    fn record(&mut self, code: &str, path: &str, note: &str) {
+        if !self
+            .recorded_losses
+            .insert((code.to_owned(), path.to_owned()))
+        {
+            return;
+        }
+        self.ledger.record(LossEntry {
+            code: code.to_owned().into(),
+            from: LOSS_FROM.into(),
+            to: LOSS_TO.into(),
+            note: note.to_owned().into(),
+            location: Some(Box::new(
+                RdfLocation::logical(LOSS_CONTEXT).with_subject(path),
+            )),
+        });
+    }
+
+    fn copy_element_annotations(
+        &self,
+        source: &Map<String, Value>,
+        target: &mut Map<String, Value>,
+        path: &str,
+    ) -> Result<(), LinkmlError> {
+        for key in ["title", "description"] {
+            if let Some(value) = source.get(key) {
+                let text = value
+                    .as_str()
+                    .ok_or_else(|| LinkmlError::new(format!("{path}/{key} must be a string")))?;
+                if key != "description" || !text.trim().is_empty() {
+                    target.insert(key.to_owned(), Value::String(text.to_owned()));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn extra_slots(allowed: bool, range_expression: Option<Map<String, Value>>) -> Value {
+    let mut extra = Map::new();
+    extra.insert("allowed".to_owned(), Value::Bool(allowed));
+    if let Some(range_expression) = range_expression {
+        extra.insert(
+            "range_expression".to_owned(),
+            Value::Object(range_expression),
+        );
+    }
+    Value::Object(extra)
+}
+
+fn object_map<'a>(
+    object: &'a Map<String, Value>,
+    key: &str,
+    path: &str,
+) -> Result<&'a Map<String, Value>, LinkmlError> {
+    match object.get(key) {
+        Some(Value::Object(values)) => Ok(values),
+        Some(_) => Err(LinkmlError::new(format!("{path}/{key} must be an object"))),
+        None => {
+            static EMPTY: std::sync::OnceLock<Map<String, Value>> = std::sync::OnceLock::new();
+            Ok(EMPTY.get_or_init(Map::new))
+        }
+    }
+}
+
+fn required_names(
+    object: &Map<String, Value>,
+    properties: &Map<String, Value>,
+    path: &str,
+) -> Result<BTreeSet<String>, LinkmlError> {
+    let mut required = BTreeSet::new();
+    let Some(values) = object.get("required") else {
+        return Ok(required);
+    };
+    let values = values
+        .as_array()
+        .ok_or_else(|| LinkmlError::new(format!("{path}/required must be an array")))?;
+    for (index, value) in values.iter().enumerate() {
+        let property = value
+            .as_str()
+            .ok_or_else(|| LinkmlError::new(format!("{path}/required/{index} must be a string")))?;
+        if !properties.contains_key(property) {
+            return Err(LinkmlError::new(format!(
+                "{path}/required names {property:?}, absent from properties"
+            )));
+        }
+        if !required.insert(property.to_owned()) {
+            return Err(LinkmlError::new(format!(
+                "{path}/required repeats property {property:?}"
+            )));
+        }
+    }
+    Ok(required)
+}
+
+fn scalar_range(kind: &str) -> Option<&'static str> {
+    match kind {
+        "string" => Some("string"),
+        "boolean" => Some("boolean"),
+        "integer" => Some("integer"),
+        "number" => Some("double"),
+        "object" | "array" | "null" => Some("string"),
+        _ => None,
+    }
+}
+
+fn format_range(format: &str) -> Option<&'static str> {
+    match format {
+        "date-time" => Some("datetime"),
+        "date" => Some("date"),
+        "time" => Some("time"),
+        "uri" | "iri" | "uri-reference" | "iri-reference" => Some("uri"),
+        _ => None,
+    }
+}
+
+fn string_extension_array<'a>(object: &'a Map<String, Value>, key: &str) -> Option<Vec<&'a str>> {
+    let values = object.get(key)?.as_array()?;
+    values.iter().map(Value::as_str).collect()
+}
+
+fn validate_json_type(kind: &str, path: &str) -> Result<(), LinkmlError> {
+    if matches!(
+        kind,
+        "null" | "boolean" | "object" | "array" | "number" | "string" | "integer"
+    ) {
+        Ok(())
+    } else {
+        Err(LinkmlError::new(format!(
+            "{path} names unsupported JSON Schema type {kind:?}"
+        )))
+    }
+}
+
+fn known_schema_keyword(keyword: &str) -> bool {
+    matches!(
+        keyword,
+        "$ref"
+            | "$defs"
+            | "type"
+            | "enum"
+            | "const"
+            | "allOf"
+            | "anyOf"
+            | "oneOf"
+            | "not"
+            | "if"
+            | "then"
+            | "else"
+            | "properties"
+            | "required"
+            | "additionalProperties"
+            | "dependentRequired"
+            | "dependentSchemas"
+            | "items"
+            | "prefixItems"
+            | "contains"
+            | "minContains"
+            | "maxContains"
+            | "unevaluatedItems"
+            | "unevaluatedProperties"
+            | "minimum"
+            | "maximum"
+            | "exclusiveMinimum"
+            | "exclusiveMaximum"
+            | "multipleOf"
+            | "minLength"
+            | "maxLength"
+            | "pattern"
+            | "minItems"
+            | "maxItems"
+            | "uniqueItems"
+            | "minProperties"
+            | "maxProperties"
+            | "format"
+    )
+}
+
+fn is_annotation_keyword(keyword: &str) -> bool {
+    keyword.starts_with("x-")
+        || matches!(
+            keyword,
+            "$schema"
+                | "$id"
+                | "$anchor"
+                | "$dynamicAnchor"
+                | "$vocabulary"
+                | "$comment"
+                | "title"
+                | "description"
+                | "default"
+                | "examples"
+                | "deprecated"
+                | "readOnly"
+                | "writeOnly"
+        )
+}
+
+fn conjoin_expression(target: &mut Map<String, Value>, key: &str, values: Vec<Value>) {
+    if values.is_empty() {
+        return;
+    }
+    if key == "all_of" {
+        match target.get_mut("all_of") {
+            Some(Value::Array(existing)) => existing.extend(values),
+            _ => {
+                target.insert("all_of".to_owned(), Value::Array(values));
+            }
+        }
+        return;
+    }
+    let Some(existing) = target.remove(key) else {
+        target.insert(key.to_owned(), Value::Array(values));
+        return;
+    };
+
+    let mut all_of = match target.remove("all_of") {
+        Some(Value::Array(existing)) => existing,
+        _ => Vec::new(),
+    };
+    all_of.push(Value::Object(Map::from_iter([(key.to_owned(), existing)])));
+    all_of.push(Value::Object(Map::from_iter([(
+        key.to_owned(),
+        Value::Array(values),
+    )])));
+    target.insert("all_of".to_owned(), Value::Array(all_of));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::purrdf::loss::check_ledger_sound;
+    use serde_json::json;
+
+    fn compiled(schema: &Value) -> CompiledSchema {
+        CompiledSchema {
+            schema_json: format!(
+                "{}\n",
+                serde_json::to_string_pretty(schema).expect("fixture serializes")
+            ),
+            openapi_json: "{}\n".to_owned(),
+            losses: LossLedger::new(),
+        }
+    }
+
+    fn config() -> LinkmlConfig {
+        LinkmlConfig::new(
+            "https://example.org/schema",
+            "Example-Schema",
+            "Caller-owned exact projection fixture.",
+            "ex",
+            BTreeMap::from([
+                ("ex".to_owned(), "https://example.org/".to_owned()),
+                ("linkml".to_owned(), "https://w3id.org/linkml/".to_owned()),
+            ]),
+        )
+        .expect("valid config")
+    }
+
+    fn exact_schema() -> Value {
+        json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "Color": {
+                    "title": "Color",
+                    "description": "Allowed colors.",
+                    "type": "string",
+                    "enum": ["ex:blue", "ex:red"]
+                },
+                "Person": {
+                    "type": "object",
+                    "title": "Person",
+                    "description": "A represented person.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "@id": { "type": "string" },
+                        "ex:active": { "type": "boolean" },
+                        "ex:age": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 130
+                        },
+                        "ex:child": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "ex:label": { "type": "string" }
+                            },
+                            "required": ["ex:label"]
+                        },
+                        "ex:color": { "$ref": "#/$defs/Color" },
+                        "ex:name": {
+                            "type": "string",
+                            "pattern": "^[A-Z]"
+                        },
+                        "ex:score": { "type": "number", "maximum": 1.0 },
+                        "ex:tags": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "minItems": 1,
+                            "maxItems": 3,
+                            "uniqueItems": true
+                        },
+                        "ex:value": {
+                            "anyOf": [
+                                { "type": "string" },
+                                { "type": "integer" }
+                            ]
+                        }
+                    },
+                    "required": ["ex:age", "ex:name"]
+                },
+                "PersonAlias": {
+                    "$ref": "#/$defs/Person",
+                    "description": "A direct class alias."
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn exact_projection_is_deterministic_reversible_and_lossless() {
+        let compiled = compiled(&exact_schema());
+        let first = emit(&compiled, &config()).expect("emit");
+        let second = emit(&compiled, &config()).expect("emit again");
+        assert_eq!(first, second);
+        assert!(first.losses.is_empty(), "{}", first.losses.render_json());
+        check_ledger_sound(&first.losses, LOSS_FROM, LOSS_TO).expect("empty ledger is sound");
+        assert_eq!(
+            first.element_names,
+            BTreeMap::from([
+                ("Color".to_owned(), "Color".to_owned()),
+                ("Person".to_owned(), "Person".to_owned()),
+                ("PersonAlias".to_owned(), "PersonAlias".to_owned()),
+            ])
+        );
+
+        let root = first.document.as_value();
+        assert_eq!(root["classes"]["Person"]["class_uri"], "ex:Person");
+        assert_eq!(root["classes"]["Person"]["extra_slots"]["allowed"], false);
+        assert_eq!(
+            root["classes"]["Person"]["attributes"]["ex:name"]["alias"],
+            "ex:name"
+        );
+        assert_eq!(
+            root["classes"]["Person"]["attributes"]["ex:name"]["slot_uri"],
+            "ex:name"
+        );
+        assert_eq!(
+            root["classes"]["Person"]["attributes"]["ex:age"]["required"],
+            true
+        );
+        assert_eq!(
+            root["classes"]["Person"]["attributes"]["ex:tags"]["list_elements_unique"],
+            true
+        );
+        assert_eq!(
+            root["classes"]["PersonAlias"]["is_a"],
+            Value::String("Person".to_owned())
+        );
+        assert_eq!(root["enums"]["Color"]["enum_uri"], "ex:Color");
+        let classes = root["classes"].as_object().unwrap();
+        assert_eq!(classes.len(), 3);
+        assert!(classes.keys().any(|name| name.starts_with("Inline")));
+
+        let reparsed = super::super::parse_linkml(&first.yaml).expect("read emitted YAML");
+        assert_eq!(reparsed, first.document);
+        assert_eq!(write_linkml(&reparsed).expect("rewrite"), first.yaml);
+        assert!(!first.yaml.contains("gmeow"));
+        assert!(!first.yaml.contains("blackcatinformatics.ca"));
+    }
+
+    #[test]
+    fn lossy_projection_records_the_closed_profile_at_exact_locations() {
+        let schema = json!({
+            "$defs": {
+                "Lossy": {
+                    "type": "object",
+                    "additionalProperties": { "type": "integer" },
+                    "minProperties": 1,
+                    "maxProperties": 8,
+                    "dependentRequired": { "ex:a": ["ex:b"] },
+                    "if": { "properties": { "ex:a": { "const": true } } },
+                    "then": { "required": ["ex:b"], "properties": { "ex:b": true } },
+                    "unevaluatedProperties": false,
+                    "propertyNames": { "pattern": "^ex:" },
+                    "properties": {
+                        "ex:array": {
+                            "type": "array",
+                            "prefixItems": [
+                                { "type": "string" },
+                                { "type": "integer" }
+                            ],
+                            "contains": { "const": 7 },
+                            "minContains": 1,
+                            "unevaluatedItems": false
+                        },
+                        "ex:choice": {
+                            "enum": [
+                                { "@id": "ex:open" },
+                                { "@id": "ex:closed" }
+                            ]
+                        },
+                        "ex:label": {
+                            "type": "string",
+                            "minLength": 2,
+                            "maxLength": 12,
+                            "format": "email"
+                        },
+                        "ex:number": {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "exclusiveMaximum": 10,
+                            "multipleOf": 0.5
+                        }
+                    }
+                }
+            }
+        });
+        let output = emit(&compiled(&schema), &config()).expect("emit lossy schema");
+        check_ledger_sound(&output.losses, LOSS_FROM, LOSS_TO)
+            .expect("all losses belong to the profile");
+        let codes = output
+            .losses
+            .entries()
+            .iter()
+            .map(|entry| entry.code.as_ref())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            codes,
+            BTreeSet::from([
+                "array-contains-validation-dropped",
+                "conditional-validation-dropped",
+                "dependency-validation-dropped",
+                "exclusive-bound-validation-widened",
+                "format-validation-widened",
+                "keyword-validation-dropped",
+                "multiple-of-validation-dropped",
+                "non-scalar-enum-validation-widened",
+                "property-count-validation-dropped",
+                "string-length-validation-dropped",
+                "tuple-array-validation-widened",
+                "unevaluated-validation-dropped",
+            ])
+        );
+        let rendered = output.losses.render_json();
+        assert!(rendered.contains("#/$defs/Lossy/properties/ex:label/minLength"));
+        assert!(rendered.contains("#/$defs/Lossy/properties/ex:number/multipleOf"));
+        assert!(rendered.contains("#/$defs/Lossy/propertyNames"));
+        assert_eq!(
+            output.document.as_value()["classes"]["Lossy"]["extra_slots"]["range_expression"]["range"],
+            "integer"
+        );
+    }
+
+    #[test]
+    fn expressions_and_array_contract_are_carried_on_the_public_document() {
+        let schema = json!({
+            "$defs": {
+                "ExpressionHolder": {
+                    "type": "object",
+                    "properties": {
+                        "ex:any": {
+                            "anyOf": [
+                                { "type": "string" },
+                                { "type": "integer" }
+                            ]
+                        },
+                        "ex:all": {
+                            "allOf": [
+                                { "type": "string" },
+                                { "pattern": "^A" }
+                            ]
+                        },
+                        "ex:exact": {
+                            "oneOf": [
+                                { "const": "yes" },
+                                { "const": "no" }
+                            ]
+                        },
+                        "ex:not": { "not": { "const": "forbidden" } },
+                        "ex:list": {
+                            "type": "array",
+                            "items": { "$ref": "#/$defs/Target" },
+                            "minItems": 2,
+                            "maxItems": 4,
+                            "uniqueItems": false
+                        }
+                    }
+                },
+                "Target": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": { "ex:name": { "type": "string" } }
+                }
+            }
+        });
+        let output = emit(&compiled(&schema), &config()).expect("emit expressions");
+        let attributes = &output.document.as_value()["classes"]["ExpressionHolder"]["attributes"];
+        assert!(attributes["ex:any"]["any_of"].is_array());
+        assert!(attributes["ex:all"]["all_of"].is_array());
+        assert!(attributes["ex:exact"]["exactly_one_of"].is_array());
+        assert!(attributes["ex:not"]["none_of"].is_array());
+        assert_eq!(attributes["ex:list"]["range"], "Target");
+        assert_eq!(attributes["ex:list"]["multivalued"], true);
+        assert_eq!(attributes["ex:list"]["inlined_as_list"], true);
+        assert_eq!(attributes["ex:list"]["minimum_cardinality"], 2);
+        assert_eq!(attributes["ex:list"]["maximum_cardinality"], 4);
+        assert_eq!(attributes["ex:list"]["list_elements_ordered"], true);
+        assert_eq!(attributes["ex:list"]["list_elements_unique"], false);
+    }
+
+    #[test]
+    fn malformed_names_requiredness_and_vocabularies_fail_closed() {
+        let collision = json!({
+            "$defs": {
+                "a-b": { "type": "string" },
+                "a b": { "type": "string" }
+            }
+        });
+        assert!(
+            emit(&compiled(&collision), &config())
+                .unwrap_err()
+                .to_string()
+                .contains("collide")
+        );
+
+        let reserved = json!({ "$defs": { "string": { "type": "string" } } });
+        assert!(
+            emit(&compiled(&reserved), &config())
+                .unwrap_err()
+                .to_string()
+                .contains("reserved")
+        );
+
+        let missing_required = json!({
+            "$defs": {
+                "Broken": {
+                    "type": "object",
+                    "properties": {},
+                    "required": ["ex:missing"]
+                }
+            }
+        });
+        assert!(
+            emit(&compiled(&missing_required), &config())
+                .unwrap_err()
+                .to_string()
+                .contains("absent")
+        );
+
+        let unknown_prefix = json!({
+            "$defs": {
+                "Broken": {
+                    "type": "object",
+                    "properties": { "other:value": { "type": "string" } }
+                }
+            }
+        });
+        assert!(
+            emit(&compiled(&unknown_prefix), &config())
+                .unwrap_err()
+                .to_string()
+                .contains("prefix")
+        );
+
+        let malformed_type = json!({ "$defs": { "Broken": { "type": [] } } });
+        assert!(
+            emit(&compiled(&malformed_type), &config())
+                .unwrap_err()
+                .to_string()
+                .contains("cannot be empty")
+        );
+    }
+}

--- a/crates/shapes/src/linkml/projection.rs
+++ b/crates/shapes/src/linkml/projection.rs
@@ -123,7 +123,7 @@ fn element_infos(
     let mut reverse = BTreeMap::<String, String>::new();
     for key in definitions.keys() {
         let name = element_name(key);
-        if reserved_element_names().contains(name.as_str()) {
+        if reserved_element_names().contains(&name.as_str()) {
             return Err(LinkmlError::new(format!(
                 "$defs key {key:?} normalizes to reserved LinkML element name {name:?}"
             )));
@@ -263,8 +263,8 @@ fn element_name(raw: &str) -> String {
     output
 }
 
-fn reserved_element_names() -> BTreeSet<&'static str> {
-    BTreeSet::from([
+fn reserved_element_names() -> &'static [&'static str] {
+    &[
         "Any",
         "Boolean",
         "Date",
@@ -284,7 +284,7 @@ fn reserved_element_names() -> BTreeSet<&'static str> {
         "Time",
         "Uri",
         "Uriorcurie",
-    ])
+    ]
 }
 
 fn fnv1a(bytes: &[u8]) -> u64 {
@@ -316,7 +316,7 @@ impl<'a> Renderer<'a> {
             used_names.insert(info.name.clone(), definition_path(key));
         }
         for reserved in reserved_element_names() {
-            used_names.insert(reserved.to_owned(), "LinkML imported type".to_owned());
+            used_names.insert((*reserved).to_owned(), "LinkML imported type".to_owned());
         }
         Self {
             config,
@@ -986,10 +986,10 @@ impl Renderer<'_> {
                     property
                         .strip_prefix(namespace)
                         .filter(|local| is_linkml_identifier(local))
-                        .map(|local| (namespace.len(), format!("{prefix}:{local}")))
+                        .map(|local| (namespace.len(), prefix, local))
                 })
-                .max_by_key(|(length, _)| *length)
-                .map(|(_, curie)| curie)
+                .max_by_key(|(length, _, _)| *length)
+                .map(|(_, prefix, local)| format!("{prefix}:{local}"))
                 .ok_or_else(|| {
                     LinkmlError::new(format!(
                         "absolute JSON property {property:?} is outside every caller-supplied LinkML prefix namespace"
@@ -2191,6 +2191,42 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("cannot be empty")
+        );
+    }
+
+    #[test]
+    fn absolute_property_uses_the_longest_matching_caller_prefix() {
+        let config = LinkmlConfig::new(
+            "https://example.org/schema",
+            "Example-Schema",
+            "Caller-owned longest-prefix fixture.",
+            "ex",
+            BTreeMap::from([
+                ("ex".to_owned(), "https://example.org/".to_owned()),
+                (
+                    "people".to_owned(),
+                    "https://example.org/people/".to_owned(),
+                ),
+                ("linkml".to_owned(), "https://w3id.org/linkml/".to_owned()),
+            ]),
+        )
+        .expect("valid config");
+        let schema = json!({
+            "$defs": {
+                "Person": {
+                    "type": "object",
+                    "properties": {
+                        "https://example.org/people/name": { "type": "string" }
+                    }
+                }
+            }
+        });
+
+        let output = emit(&compiled(&schema), &config).expect("emit absolute property");
+        assert_eq!(
+            output.document.as_value()["classes"]["Person"]["attributes"]["https://example.org/people/name"]
+                ["slot_uri"],
+            "people:name"
         );
     }
 }

--- a/crates/shapes/src/linkml/projection.rs
+++ b/crates/shapes/src/linkml/projection.rs
@@ -1245,7 +1245,9 @@ impl Renderer<'_> {
                 .as_array()
                 .ok_or_else(|| LinkmlError::new(format!("{path}/prefixItems must be an array")))?;
             let mut branches = prefix_items.clone();
-            branches.push(object.get("items").cloned().unwrap_or(Value::Bool(true)));
+            if let Some(items) = object.get("items") {
+                branches.push(items.clone());
+            }
             let mut synthetic = Map::new();
             synthetic.insert("anyOf".to_owned(), Value::Array(branches));
             Value::Object(synthetic)

--- a/crates/shapes/src/pydantic.rs
+++ b/crates/shapes/src/pydantic.rs
@@ -31,6 +31,10 @@ use ::purrdf::loss::{LossEntry, LossLedger};
 use serde_json::{Map, Value};
 
 use crate::json_schema::CompiledSchema;
+use crate::schema_catalog::{
+    CompiledSchemaCatalog, definition_path, pointer_escape, reference_key, schema_array_keywords,
+    schema_map_keywords, schema_single_keywords,
+};
 
 const MODELS_MODULE: &str = "models";
 const BASE_MODULE: &str = "_base";
@@ -162,33 +166,15 @@ pub fn emit_pydantic(
     compiled: &CompiledSchema,
     config: &PydanticConfig,
 ) -> Result<PydanticPackage, PydanticError> {
-    let document: Value = serde_json::from_str(&compiled.schema_json).map_err(|error| {
-        PydanticError::new(format!(
-            "CompiledSchema.schema_json is not valid JSON: {error}"
-        ))
-    })?;
-    let root = document.as_object().ok_or_else(|| {
-        PydanticError::new("CompiledSchema.schema_json root must be a JSON object")
-    })?;
-    let defs = root
-        .get("$defs")
-        .and_then(Value::as_object)
-        .ok_or_else(|| {
-            PydanticError::new("CompiledSchema.schema_json must contain an object-valued `$defs`")
-        })?;
+    let catalog = CompiledSchemaCatalog::parse(compiled)
+        .map_err(|error| PydanticError::new(error.to_string()))?;
+    let defs = catalog.definitions();
 
     let names = definition_names(defs)?;
-    for (key, definition) in defs {
-        validate_references(
-            definition,
-            defs,
-            &format!("#/$defs/{}", pointer_escape(key)),
-        )?;
-    }
 
     let mut renderer = Renderer::new(&names);
     for (key, definition) in defs {
-        renderer.audit_schema(definition, &format!("#/$defs/{}", pointer_escape(key)));
+        renderer.audit_schema(definition, &definition_path(key));
     }
 
     let mut definitions = Vec::with_capacity(defs.len());
@@ -265,76 +251,6 @@ fn definition_names(defs: &Map<String, Value>) -> Result<BTreeMap<String, String
         names.insert(key.clone(), name);
     }
     Ok(names)
-}
-
-fn validate_references(
-    value: &Value,
-    defs: &Map<String, Value>,
-    path: &str,
-) -> Result<(), PydanticError> {
-    let Value::Object(object) = value else {
-        return if value.is_boolean() {
-            Ok(())
-        } else {
-            Err(PydanticError::new(format!(
-                "{path} must be an object or boolean JSON Schema"
-            )))
-        };
-    };
-
-    for keyword in ["$dynamicRef", "$recursiveRef"] {
-        if object.contains_key(keyword) {
-            return Err(PydanticError::new(format!(
-                "{path}/{keyword} cannot be translated to a closed generated package"
-            )));
-        }
-    }
-
-    if let Some(reference) = object.get("$ref") {
-        let reference = reference
-            .as_str()
-            .ok_or_else(|| PydanticError::new(format!("{path}/$ref must be a string")))?;
-        let key = reference_key(reference).ok_or_else(|| {
-            PydanticError::new(format!(
-                "{path}/$ref is external or not a direct #/$defs reference: {reference:?}"
-            ))
-        })?;
-        if !defs.contains_key(&key) {
-            return Err(PydanticError::new(format!(
-                "{path}/$ref targets missing $defs key {key:?}"
-            )));
-        }
-    }
-    for keyword in schema_map_keywords() {
-        if let Some(children) = object.get(*keyword) {
-            let children = children
-                .as_object()
-                .ok_or_else(|| PydanticError::new(format!("{path}/{keyword} must be an object")))?;
-            for (key, child) in children {
-                validate_references(
-                    child,
-                    defs,
-                    &format!("{path}/{keyword}/{}", pointer_escape(key)),
-                )?;
-            }
-        }
-    }
-    for keyword in schema_array_keywords() {
-        if let Some(children) = object.get(*keyword) {
-            let children = children
-                .as_array()
-                .ok_or_else(|| PydanticError::new(format!("{path}/{keyword} must be an array")))?;
-            for (index, child) in children.iter().enumerate() {
-                validate_references(child, defs, &format!("{path}/{keyword}/{index}"))?;
-            }
-        }
-    }
-    for keyword in schema_single_keywords() {
-        if let Some(child) = object.get(*keyword) {
-            validate_references(child, defs, &format!("{path}/{keyword}"))?;
-        }
-    }
-    Ok(())
 }
 
 struct Renderer<'a> {
@@ -1248,36 +1164,6 @@ fn runtime_constraint_keys() -> &'static [&'static str] {
     ]
 }
 
-fn schema_map_keywords() -> &'static [&'static str] {
-    &[
-        "$defs",
-        "properties",
-        "patternProperties",
-        "dependentSchemas",
-    ]
-}
-
-fn schema_array_keywords() -> &'static [&'static str] {
-    &["allOf", "anyOf", "oneOf", "prefixItems"]
-}
-
-fn schema_single_keywords() -> &'static [&'static str] {
-    &[
-        "items",
-        "additionalItems",
-        "unevaluatedItems",
-        "additionalProperties",
-        "unevaluatedProperties",
-        "propertyNames",
-        "contains",
-        "not",
-        "if",
-        "then",
-        "else",
-        "contentSchema",
-    ]
-}
-
 fn enum_object_schema(member: &Map<String, Value>) -> Value {
     let mut properties = Map::new();
     let mut required = Vec::new();
@@ -1406,35 +1292,6 @@ fn rewrite_references(
         }
     }
     Ok(Value::Object(rewritten))
-}
-
-fn reference_key(reference: &str) -> Option<String> {
-    let encoded = reference.strip_prefix("#/$defs/")?;
-    if encoded.contains('/') {
-        return None;
-    }
-    pointer_unescape(encoded)
-}
-
-fn pointer_escape(value: &str) -> String {
-    value.replace('~', "~0").replace('/', "~1")
-}
-
-fn pointer_unescape(value: &str) -> Option<String> {
-    let mut out = String::with_capacity(value.len());
-    let mut chars = value.chars();
-    while let Some(ch) = chars.next() {
-        if ch != '~' {
-            out.push(ch);
-            continue;
-        }
-        match chars.next()? {
-            '0' => out.push('~'),
-            '1' => out.push('/'),
-            _ => return None,
-        }
-    }
-    Some(out)
 }
 
 fn python_value(value: &Value) -> String {

--- a/crates/shapes/src/schema_catalog.rs
+++ b/crates/shapes/src/schema_catalog.rs
@@ -1,0 +1,320 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Validated, deterministic access to a compiled JSON Schema definition catalog.
+//!
+//! Schema-language projections share this crate-private boundary so parsing,
+//! direct-reference closure, and JSON Pointer locations cannot drift between
+//! emitters. It deliberately is not a second public schema algebra: the public
+//! carrier remains [`CompiledSchema`].
+
+use std::error::Error;
+use std::fmt;
+
+use serde_json::{Map, Value};
+
+use crate::json_schema::CompiledSchema;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SchemaCatalogError {
+    message: String,
+}
+
+impl SchemaCatalogError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for SchemaCatalogError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for SchemaCatalogError {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CompiledSchemaCatalog {
+    document: Value,
+}
+
+impl CompiledSchemaCatalog {
+    pub(crate) fn parse(compiled: &CompiledSchema) -> Result<Self, SchemaCatalogError> {
+        let document: Value = serde_json::from_str(&compiled.schema_json).map_err(|error| {
+            SchemaCatalogError::new(format!(
+                "CompiledSchema.schema_json is not valid JSON: {error}"
+            ))
+        })?;
+        let root = document.as_object().ok_or_else(|| {
+            SchemaCatalogError::new("CompiledSchema.schema_json root must be a JSON object")
+        })?;
+        let definitions = root
+            .get("$defs")
+            .and_then(Value::as_object)
+            .ok_or_else(|| {
+                SchemaCatalogError::new(
+                    "CompiledSchema.schema_json must contain an object-valued `$defs`",
+                )
+            })?;
+
+        for (key, definition) in definitions {
+            validate_schema(definition, definitions, &definition_path(key))?;
+        }
+
+        Ok(Self { document })
+    }
+
+    pub(crate) fn definitions(&self) -> &Map<String, Value> {
+        self.document
+            .as_object()
+            .and_then(|root| root.get("$defs"))
+            .and_then(Value::as_object)
+            .expect("a compiled schema catalog always has validated object-valued `$defs`")
+    }
+}
+
+pub(crate) fn definition_path(key: &str) -> String {
+    format!("#/$defs/{}", pointer_escape(key))
+}
+
+pub(crate) fn reference_key(reference: &str) -> Option<String> {
+    let encoded = reference.strip_prefix("#/$defs/")?;
+    if encoded.contains('/') {
+        return None;
+    }
+    pointer_unescape(encoded)
+}
+
+pub(crate) fn pointer_escape(value: &str) -> String {
+    value.replace('~', "~0").replace('/', "~1")
+}
+
+pub(crate) const fn schema_map_keywords() -> &'static [&'static str] {
+    &[
+        "$defs",
+        "properties",
+        "patternProperties",
+        "dependentSchemas",
+    ]
+}
+
+pub(crate) const fn schema_array_keywords() -> &'static [&'static str] {
+    &["allOf", "anyOf", "oneOf", "prefixItems"]
+}
+
+pub(crate) const fn schema_single_keywords() -> &'static [&'static str] {
+    &[
+        "items",
+        "additionalItems",
+        "unevaluatedItems",
+        "additionalProperties",
+        "unevaluatedProperties",
+        "propertyNames",
+        "contains",
+        "not",
+        "if",
+        "then",
+        "else",
+        "contentSchema",
+    ]
+}
+
+fn validate_schema(
+    value: &Value,
+    definitions: &Map<String, Value>,
+    path: &str,
+) -> Result<(), SchemaCatalogError> {
+    let Value::Object(object) = value else {
+        return if value.is_boolean() {
+            Ok(())
+        } else {
+            Err(SchemaCatalogError::new(format!(
+                "{path} must be an object or boolean JSON Schema"
+            )))
+        };
+    };
+
+    for keyword in ["$dynamicRef", "$recursiveRef"] {
+        if object.contains_key(keyword) {
+            return Err(SchemaCatalogError::new(format!(
+                "{path}/{keyword} cannot be translated to a closed generated package"
+            )));
+        }
+    }
+
+    if let Some(reference) = object.get("$ref") {
+        let reference = reference
+            .as_str()
+            .ok_or_else(|| SchemaCatalogError::new(format!("{path}/$ref must be a string")))?;
+        let key = reference_key(reference).ok_or_else(|| {
+            SchemaCatalogError::new(format!(
+                "{path}/$ref is external or not a direct #/$defs reference: {reference:?}"
+            ))
+        })?;
+        if !definitions.contains_key(&key) {
+            return Err(SchemaCatalogError::new(format!(
+                "{path}/$ref targets missing $defs key {key:?}"
+            )));
+        }
+    }
+
+    for keyword in schema_map_keywords() {
+        if let Some(children) = object.get(*keyword) {
+            let children = children.as_object().ok_or_else(|| {
+                SchemaCatalogError::new(format!("{path}/{keyword} must be an object"))
+            })?;
+            for (key, child) in children {
+                validate_schema(
+                    child,
+                    definitions,
+                    &format!("{path}/{keyword}/{}", pointer_escape(key)),
+                )?;
+            }
+        }
+    }
+    for keyword in schema_array_keywords() {
+        if let Some(children) = object.get(*keyword) {
+            let children = children.as_array().ok_or_else(|| {
+                SchemaCatalogError::new(format!("{path}/{keyword} must be an array"))
+            })?;
+            for (index, child) in children.iter().enumerate() {
+                validate_schema(child, definitions, &format!("{path}/{keyword}/{index}"))?;
+            }
+        }
+    }
+    for keyword in schema_single_keywords() {
+        if let Some(child) = object.get(*keyword) {
+            validate_schema(child, definitions, &format!("{path}/{keyword}"))?;
+        }
+    }
+    Ok(())
+}
+
+fn pointer_unescape(value: &str) -> Option<String> {
+    let mut output = String::with_capacity(value.len());
+    let mut characters = value.chars();
+    while let Some(character) = characters.next() {
+        if character != '~' {
+            output.push(character);
+            continue;
+        }
+        match characters.next()? {
+            '0' => output.push('~'),
+            '1' => output.push('/'),
+            _ => return None,
+        }
+    }
+    Some(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::purrdf::loss::LossLedger;
+    use serde_json::json;
+
+    fn compiled(schema: &Value) -> CompiledSchema {
+        CompiledSchema {
+            schema_json: serde_json::to_string(schema).expect("fixture serializes"),
+            openapi_json: "{}\n".to_owned(),
+            losses: LossLedger::new(),
+        }
+    }
+
+    #[test]
+    fn catalog_exposes_sorted_validated_definitions() {
+        let schema = json!({
+            "$defs": {
+                "Zulu": true,
+                "Alpha": {
+                    "properties": {
+                        "ex:target": { "$ref": "#/$defs/path~1with~0token" },
+                        "$ref": { "type": "string" },
+                        "ex:data": { "enum": [{ "$ref": "ordinary data" }] }
+                    }
+                },
+                "path/with~token": false
+            }
+        });
+        let catalog = CompiledSchemaCatalog::parse(&compiled(&schema)).expect("valid catalog");
+        assert_eq!(
+            catalog
+                .definitions()
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            ["Alpha", "Zulu", "path/with~token"]
+        );
+        assert_eq!(
+            reference_key("#/$defs/path~1with~0token").as_deref(),
+            Some("path/with~token")
+        );
+        assert_eq!(
+            definition_path("path/with~token"),
+            "#/$defs/path~1with~0token"
+        );
+    }
+
+    #[test]
+    fn catalog_rejects_malformed_documents_and_schema_values() {
+        for (schema_json, expected) in [
+            ("not json", "is not valid JSON"),
+            ("[]", "root must be a JSON object"),
+            ("{}", "must contain an object-valued `$defs`"),
+            (r#"{"$defs":[]}"#, "must contain an object-valued `$defs`"),
+            (
+                r#"{"$defs":{"Broken":7}}"#,
+                "#/$defs/Broken must be an object or boolean JSON Schema",
+            ),
+        ] {
+            let error = CompiledSchemaCatalog::parse(&CompiledSchema {
+                schema_json: schema_json.to_owned(),
+                openapi_json: "{}\n".to_owned(),
+                losses: LossLedger::new(),
+            })
+            .expect_err("fixture must fail");
+            assert!(error.to_string().contains(expected), "{error}");
+        }
+    }
+
+    #[test]
+    fn catalog_rejects_open_or_malformed_references_at_their_locations() {
+        for (reference, expected) in [
+            (json!("#/$defs/Missing"), "targets missing $defs key"),
+            (
+                json!("https://example.org/schema"),
+                "is external or not a direct",
+            ),
+            (json!("#/$defs/path/child"), "is external or not a direct"),
+            (json!("#/$defs/bad~2escape"), "is external or not a direct"),
+            (json!(7), "must be a string"),
+        ] {
+            let schema = json!({
+                "$defs": {
+                    "Holder": {
+                        "properties": { "ex:value": { "$ref": reference } }
+                    }
+                }
+            });
+            let error =
+                CompiledSchemaCatalog::parse(&compiled(&schema)).expect_err("reference must fail");
+            assert!(
+                error
+                    .to_string()
+                    .contains("#/$defs/Holder/properties/ex:value/$ref"),
+                "{error}"
+            );
+            assert!(error.to_string().contains(expected), "{error}");
+        }
+
+        for keyword in ["$dynamicRef", "$recursiveRef"] {
+            let schema = json!({ "$defs": { "Holder": { (keyword): "#/$defs/Holder" } } });
+            let error = CompiledSchemaCatalog::parse(&compiled(&schema))
+                .expect_err("open reference must fail");
+            assert!(error.to_string().contains(keyword), "{error}");
+        }
+    }
+}

--- a/crates/shapes/tests/linkml_oracle.py
+++ b/crates/shapes/tests/linkml_oracle.py
@@ -1,0 +1,304 @@
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""Validate emitted LinkML through the official locked 1.11 toolchain."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from jsonschema.validators import validator_for
+from linkml.generators.jsonschemagen import JsonSchemaGenerator
+from linkml_runtime.linkml_model.meta import SchemaDefinition
+from linkml_runtime.loaders import yaml_loader
+from linkml_runtime.utils.schemaview import SchemaView
+
+
+REPO = Path(__file__).resolve().parents[3]
+LINKML_PACKAGE_VERSION = "1.11.1"
+LINKML_METAMODEL_VERSION = "1.11.0"
+
+
+def _fixture() -> dict[str, Any]:
+    completed = subprocess.run(
+        [
+            "cargo",
+            "run",
+            "-p",
+            "purrdf-shapes",
+            "--example",
+            "linkml_oracle_fixture",
+            "--locked",
+            "--quiet",
+        ],
+        cwd=REPO,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def _load(text: str) -> SchemaDefinition:
+    schema = yaml_loader.loads(text, target_class=SchemaDefinition)
+    if schema.metamodel_version != LINKML_METAMODEL_VERSION:
+        raise AssertionError(
+            f"unexpected metamodel version: {schema.metamodel_version!r}"
+        )
+    return schema
+
+
+def _generate(schema: SchemaDefinition) -> dict[str, Any]:
+    generated = JsonSchemaGenerator(
+        schema,
+        not_closed=True,
+        preserve_names=True,
+        useuris=False,
+        include_null=False,
+        materialize_patterns=True,
+    ).serialize()
+    value = json.loads(generated)
+    if not isinstance(value, dict):
+        raise AssertionError("official LinkML JSON Schema generator returned a non-object")
+    return value
+
+
+def _rewrite_refs(value: Any, element_names: dict[str, str]) -> Any:
+    if isinstance(value, list):
+        return [_rewrite_refs(child, element_names) for child in value]
+    if not isinstance(value, dict):
+        return value
+    rewritten = {
+        key: _rewrite_refs(child, element_names) for key, child in value.items()
+    }
+    reference = value.get("$ref")
+    if isinstance(reference, str) and reference.startswith("#/$defs/"):
+        key = reference.removeprefix("#/$defs/").replace("~1", "/").replace(
+            "~0", "~"
+        )
+        rewritten["$ref"] = f"#/$defs/{element_names[key]}"
+    return rewritten
+
+
+def _definition_wrapper(document: dict[str, Any], name: str) -> dict[str, Any]:
+    return {
+        "$schema": document["$schema"],
+        "$defs": document["$defs"],
+        "$ref": f"#/$defs/{name}",
+    }
+
+
+def _is_valid(document: dict[str, Any], name: str, instance: Any) -> bool:
+    wrapper = _definition_wrapper(document, name)
+    validator_class = validator_for(wrapper)
+    validator_class.check_schema(wrapper)
+    return validator_class(wrapper).is_valid(instance)
+
+
+def _assert_acceptance_agrees(
+    source: dict[str, Any],
+    generated: dict[str, Any],
+    probes: dict[str, list[Any]],
+) -> None:
+    for name, instances in probes.items():
+        for instance in instances:
+            expected = _is_valid(source, name, instance)
+            actual = _is_valid(generated, name, instance)
+            if actual != expected:
+                raise AssertionError(
+                    f"{name} acceptance differs for {instance!r}: "
+                    f"source={expected}, generated={actual}"
+                )
+
+
+def _assert_reference_closure(document: dict[str, Any]) -> None:
+    definitions = document.get("$defs")
+    if not isinstance(definitions, dict):
+        raise AssertionError("generated JSON Schema has no $defs object")
+
+    def walk(value: Any) -> None:
+        if isinstance(value, list):
+            for child in value:
+                walk(child)
+            return
+        if not isinstance(value, dict):
+            return
+        reference = value.get("$ref")
+        if isinstance(reference, str) and reference.startswith("#/$defs/"):
+            target = reference.removeprefix("#/$defs/")
+            if target not in definitions:
+                raise AssertionError(f"dangling generated reference: {reference!r}")
+        for child in value.values():
+            walk(child)
+
+    walk(definitions)
+
+
+def _assert_exact(payload: dict[str, Any]) -> None:
+    source = payload["schema"]
+    element_names = payload["element_names"]
+    schema = _load(payload["yaml"])
+    view = SchemaView(schema)
+    if sorted(view.all_classes()) != ["Address", "Person"]:
+        raise AssertionError(f"unexpected classes: {sorted(view.all_classes())}")
+    if sorted(view.all_enums()) != ["Color"]:
+        raise AssertionError(f"unexpected enums: {sorted(view.all_enums())}")
+
+    age = view.induced_slot("ex:age", "Person")
+    tags = view.induced_slot("ex:tags", "Person")
+    address = view.induced_slot("ex:address", "Person")
+    if str(age.range) != "integer" or not age.required:
+        raise AssertionError(f"age slot drifted: {age!r}")
+    if age.minimum_value != 0 or age.maximum_value != 130:
+        raise AssertionError(f"age bounds drifted: {age!r}")
+    if not tags.multivalued or tags.minimum_cardinality != 1:
+        raise AssertionError(f"tags list contract drifted: {tags!r}")
+    if str(address.range) != "Address" or not address.inlined:
+        raise AssertionError(f"address reference drifted: {address!r}")
+    if schema.classes["Person"].extra_slots.allowed:
+        raise AssertionError("closed Person class became open")
+
+    generated = _generate(schema)
+    expected_defs = {
+        element_names[key]: _rewrite_refs(definition, element_names)
+        for key, definition in source["$defs"].items()
+    }
+    if generated.get("$defs") != expected_defs:
+        raise AssertionError(
+            "official LinkML generator disagrees with the exact CompiledSchema:\n"
+            f"expected={json.dumps(expected_defs, indent=2, sort_keys=True)}\n"
+            f"actual={json.dumps(generated.get('$defs'), indent=2, sort_keys=True)}"
+        )
+    _assert_reference_closure(generated)
+
+    valid_person = {
+        "@id": "ex:alice",
+        "ex:active": True,
+        "ex:address": {"ex:city": "Edmonton", "ex:postalCode": "A1"},
+        "ex:age": 42,
+        "ex:color": "ex:red",
+        "ex:name": "Alice",
+        "ex:score": 0.75,
+        "ex:tags": ["one", "two"],
+        "ex:value": "text",
+    }
+    probes = {
+        "Address": [
+            {"ex:city": "Edmonton"},
+            {},
+            {"ex:city": "edmonton"},
+            {"ex:city": "Edmonton", "ex:unexpected": True},
+        ],
+        "Color": ["ex:red", "ex:blue", "ex:green", 7],
+        "Person": [
+            valid_person,
+            {"ex:age": 42},
+            {"ex:age": -1, "ex:name": "Alice"},
+            {"ex:age": 42, "ex:name": "alice"},
+            {"ex:age": 42, "ex:name": "Alice", "ex:color": "ex:green"},
+            {"ex:age": 42, "ex:name": "Alice", "ex:tags": []},
+            {"ex:age": 42, "ex:name": "Alice", "ex:value": False},
+            {"ex:age": 42, "ex:name": "Alice", "ex:unexpected": True},
+        ],
+    }
+    _assert_acceptance_agrees(
+        {
+            "$schema": source["$schema"],
+            "$defs": expected_defs,
+        },
+        generated,
+        probes,
+    )
+
+
+def _assert_lossy(payload: dict[str, Any]) -> None:
+    losses = payload["losses"]["losses"]
+    if len(losses) != 18:
+        raise AssertionError(f"unexpected lossy-ledger size: {len(losses)}")
+    codes = {entry["code"] for entry in losses}
+    expected_codes = {
+        "array-contains-validation-dropped",
+        "conditional-validation-dropped",
+        "dependency-validation-dropped",
+        "exclusive-bound-validation-widened",
+        "format-validation-widened",
+        "keyword-validation-dropped",
+        "multiple-of-validation-dropped",
+        "non-scalar-enum-validation-widened",
+        "property-count-validation-dropped",
+        "string-length-validation-dropped",
+        "tuple-array-validation-widened",
+        "unevaluated-validation-dropped",
+    }
+    if codes != expected_codes:
+        raise AssertionError(f"loss code drift: {sorted(codes)}")
+    if not all(entry["intentional"] for entry in losses):
+        raise AssertionError("lossy fixture contains an unregistered loss")
+
+    schema = _load(payload["yaml"])
+    view = SchemaView(schema)
+    if sorted(view.all_classes()) != ["Lossy"]:
+        raise AssertionError(f"unexpected lossy classes: {sorted(view.all_classes())}")
+    if sorted(view.all_enums()) != ["InlineDefsLossyPropertiesExChoiceEnum"]:
+        raise AssertionError(f"unexpected lossy enums: {sorted(view.all_enums())}")
+    extra = schema.classes["Lossy"].extra_slots
+    if not extra.allowed or str(extra.range_expression.range) != "integer":
+        raise AssertionError(f"typed extra-slot contract drifted: {extra!r}")
+
+    number = view.induced_slot("ex:number", "Lossy")
+    array = view.induced_slot("ex:array", "Lossy")
+    choice = view.induced_slot("ex:choice", "Lossy")
+    if number.minimum_value != 0 or number.maximum_value != 10:
+        raise AssertionError(f"inclusive bound widening drifted: {number!r}")
+    if not array.multivalued or len(array.any_of) != 2:
+        raise AssertionError(f"tuple widening drifted: {array!r}")
+    if str(choice.range) != "InlineDefsLossyPropertiesExChoiceEnum":
+        raise AssertionError(f"enum carrier drifted: {choice!r}")
+
+    generated = _generate(schema)
+    _assert_reference_closure(generated)
+    if not _is_valid(generated, "Lossy", {"ex:number": 5}):
+        raise AssertionError("representable numeric interior was rejected")
+    if _is_valid(generated, "Lossy", {"ex:number": "five"}):
+        raise AssertionError("representable numeric carrier was widened unexpectedly")
+    if not _is_valid(generated, "Lossy", {"ex:array": ["text", 7]}):
+        raise AssertionError("representable homogeneous tuple union was rejected")
+    if _is_valid(generated, "Lossy", {"ex:array": [{"bad": True}]}):
+        raise AssertionError("representable tuple item union accepted an object")
+    if not _is_valid(generated, "Lossy", {"ex:choice": "ex:open"}):
+        raise AssertionError("projected permissible value was rejected")
+    if _is_valid(generated, "Lossy", {"ex:choice": "ex:unknown"}):
+        raise AssertionError("projected permissible value set widened unexpectedly")
+
+    source = payload["schema"]
+    if _is_valid(source, "Lossy", {"ex:number": 0}):
+        raise AssertionError("source exclusive minimum unexpectedly accepted its boundary")
+    if not _is_valid(generated, "Lossy", {"ex:number": 0}):
+        raise AssertionError("recorded inclusive-bound widening is not observable")
+    if _is_valid(source, "Lossy", {"ex:label": "x"}):
+        raise AssertionError("source string length unexpectedly accepted a short label")
+    if not _is_valid(generated, "Lossy", {"ex:label": "x"}):
+        raise AssertionError("recorded string-length drop is not observable")
+
+
+def main() -> None:
+    if importlib.metadata.version("linkml") != LINKML_PACKAGE_VERSION:
+        raise AssertionError("linkml package version is not locked to 1.11.1")
+    if importlib.metadata.version("linkml-runtime") != LINKML_PACKAGE_VERSION:
+        raise AssertionError("linkml-runtime package version is not locked to 1.11.1")
+
+    payload = _fixture()
+    _assert_exact(payload["exact"])
+    _assert_lossy(payload["lossy"])
+    print(
+        "LinkML oracle: exact $defs and 16 instance probes agree; "
+        "18 located losses and representable widening probes pass"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/book/src/validation/shacl.md
+++ b/docs/book/src/validation/shacl.md
@@ -62,6 +62,32 @@ located entry in the always-computed `json-schema` → `pydantic-v2`
 Python dependency and stays wasm-clean. A dev-only Python oracle executes the
 generated code and checks the live reverse/schema surface.
 
+## LinkML 1.11 projection
+
+The same `CompiledSchema` carrier can be projected to canonical LinkML 1.11
+with `emit_linkml`. `LinkmlConfig` requires the caller's schema IRI, name,
+description, default prefix, and complete prefix map, so PurRDF never mints a
+consumer vocabulary or identity. The returned `LinkmlPackage` includes the
+typed document, deterministic YAML, a reversible `$defs`-key mapping, and a
+located `json-schema` → `linkml-1.11` loss ledger.
+
+Classes and exact property aliases, types, enums, local references, inline
+objects, requiredness, homogeneous arrays, patterns, inclusive bounds, and
+LinkML boolean expressions are represented directly. Every unsupported
+assertion is classified by a closed capability table; malformed inputs,
+external/dynamic/dangling references, prefix mistakes, and deterministic-name
+collisions fail closed. `parse_linkml` and `write_linkml` preserve all
+JSON-compatible metamodel fields and provide byte-stable read/write round trips
+while rejecting YAML-only tags, duplicate keys, non-string keys, and non-finite
+numbers.
+
+The Rust production path has no LinkML-toolkit dependency. CI uses the locked
+official LinkML 1.11.1 Python packages only as a differential oracle:
+
+```bash
+make linkml-oracle
+```
+
 ## From Python
 
 ```python

--- a/generated/transcode-loss-matrix.json
+++ b/generated/transcode-loss-matrix.json
@@ -147,6 +147,97 @@
     "note": "The target syntax has no named-graph construct; quads are folded into the default graph and graph names are dropped."
   },
   {
+    "code": "additional-properties-validation-widened",
+    "from": "json-schema",
+    "to": "linkml-1.11",
+    "intentional": true,
+    "note": "LinkML 1.11 has no per-class equivalent for JSON Schema's additionalProperties policy or schema. Named attributes retain their constraints, but acceptance of unlisted object keys is widened and recorded on the object schema."
+  },
+  {
+    "code": "array-contains-validation-dropped",
+    "from": "json-schema",
+    "to": "linkml-1.11",
+    "intentional": true,
+    "note": "JSON Schema contains/minContains/maxContains assertions have no LinkML 1.11 slot expression. List item and cardinality constraints remain, while the contains predicate and its match-count bounds are omitted."
+  },
+  {
+    "code": "conditional-validation-dropped",
+    "from": "json-schema",
+    "to": "linkml-1.11",
+    "intentional": true,
+    "note": "JSON Schema if/then/else conditional validation has no LinkML 1.11 expression. Independently representable carrier constraints remain, while the conditional relationship is omitted."
+  },
+  {
+    "code": "dependency-validation-dropped",
+    "from": "json-schema",
+    "to": "linkml-1.11",
+    "intentional": true,
+    "note": "JSON Schema dependentRequired/dependentSchemas validation has no LinkML 1.11 expression. Attribute constraints remain, while cross-property dependencies are omitted."
+  },
+  {
+    "code": "exclusive-bound-validation-widened",
+    "from": "json-schema",
+    "to": "linkml-1.11",
+    "intentional": true,
+    "note": "LinkML 1.11 exposes inclusive minimum_value/maximum_value bounds but no exclusive numeric bounds. An exclusive JSON Schema bound is projected as the corresponding inclusive bound, widening acceptance at the boundary value."
+  },
+  {
+    "code": "format-validation-widened",
+    "from": "json-schema",
+    "to": "linkml-1.11",
+    "intentional": true,
+    "note": "A JSON Schema format does not have an exact, uniformly enforced LinkML 1.11 equivalent. The scalar carrier remains constrained and the format name is retained when representable, while validation semantics are widened."
+  },
+  {
+    "code": "keyword-validation-dropped",
+    "from": "json-schema",
+    "to": "linkml-1.11",
+    "intentional": true,
+    "note": "A JSON Schema assertion outside the emitter's closed LinkML 1.11 capability table has no sound projection. The assertion is omitted and recorded at its schema location rather than disappearing silently."
+  },
+  {
+    "code": "multiple-of-validation-dropped",
+    "from": "json-schema",
+    "to": "linkml-1.11",
+    "intentional": true,
+    "note": "JSON Schema multipleOf has no LinkML 1.11 numeric expression. The numeric carrier and other representable bounds remain, while divisibility validation is omitted."
+  },
+  {
+    "code": "non-scalar-enum-validation-widened",
+    "from": "json-schema",
+    "to": "linkml-1.11",
+    "intentional": true,
+    "note": "LinkML 1.11 permissible values are scalar identifiers and cannot encode arbitrary JSON object or array enum members. The representable carrier remains, while non-scalar membership validation is widened."
+  },
+  {
+    "code": "property-count-validation-dropped",
+    "from": "json-schema",
+    "to": "linkml-1.11",
+    "intentional": true,
+    "note": "JSON Schema minProperties/maxProperties assertions have no LinkML 1.11 class expression. Named attributes and their requiredness remain, while total property-count validation is omitted."
+  },
+  {
+    "code": "string-length-validation-dropped",
+    "from": "json-schema",
+    "to": "linkml-1.11",
+    "intentional": true,
+    "note": "JSON Schema minLength/maxLength assertions have no LinkML 1.11 slot expression. The string carrier and representable pattern remain, while code-point length validation is omitted."
+  },
+  {
+    "code": "tuple-array-validation-widened",
+    "from": "json-schema",
+    "to": "linkml-1.11",
+    "intentional": true,
+    "note": "LinkML 1.11 lists are homogeneous and cannot preserve JSON Schema prefixItems or position-specific item schemas. The list is projected to a sound common item carrier, widening position-specific validation."
+  },
+  {
+    "code": "unevaluated-validation-dropped",
+    "from": "json-schema",
+    "to": "linkml-1.11",
+    "intentional": true,
+    "note": "JSON Schema unevaluatedProperties/unevaluatedItems assertions depend on applicator evaluation state that LinkML 1.11 does not expose. Representable local constraints remain, while the unevaluated assertion is omitted."
+  },
+  {
     "code": "array-contains-validation-dropped",
     "from": "json-schema",
     "to": "pydantic-v2",


### PR DESCRIPTION
Part of #109. This PR delivers only the LinkML subtask; it intentionally does not close the emitter epic.

## Outcome

PurRDF can now project any `CompiledSchema` into one canonical LinkML 1.11 document without importing gmeow's legacy schema model or minting consumer identity. The production path is native Rust, deterministic, wasm-clean, and always computes a located `json-schema` → `linkml-1.11` loss ledger.

## Public surface

- adds `LinkmlConfig` with mandatory caller-supplied schema IRI, schema name, description, default prefix, and complete prefix map; there is deliberately no `Default`
- adds `emit_linkml`, returning a validated `LinkmlPackage` with the typed document, canonical YAML, reversible source-name mapping, and loss ledger
- adds `parse_linkml` / `write_linkml` for byte-stable read→write and write→read→write behavior
- fixes the authored dialect at LinkML metamodel 1.11.0 while locking the dev-only official toolkit/runtime oracle to 1.11.1

## Projection behavior

- directly represents classes, scalar types, enums, exact property aliases, local references, inline objects, requiredness, homogeneous arrays, patterns, inclusive bounds, LinkML boolean expressions, and LinkML 1.11 `extra_slots`
- derives every class/slot URI from caller configuration and preserves exact source `$defs` and property-key aliases through a deterministic reversible map
- rejects malformed values, external/dynamic/dangling references, inconsistent `required`, unknown prefixes, reserved names, and normalized-name collisions
- audits every schema assertion through a shared closed capability table; the 13-code profile covers conditional/dependency/contains/unevaluated rules, tuple widening, count constraints, exclusive and multiple-of bounds, format differences, non-scalar enum carriers, and a closed catch-all
- preserves unknown JSON-compatible LinkML fields while rejecting duplicate YAML keys, tags, non-string keys, non-finite numbers, and configured resource-limit violations

## Agreement and regression evidence

- factors the Pydantic and LinkML emitters onto one immutable `CompiledSchema` catalog, with a regression proving Pydantic output bytes remain unchanged
- adds a live official LinkML oracle that loads emitted YAML through `SchemaDefinition` and `SchemaView`, regenerates JSON Schema, compares the supported fixture's exact `$defs`, checks 16 accept/reject probes, and exercises all lossy families
- wires the oracle into the Python CI lane and locks its dependency graph
- registers the closed LinkML loss profile and regenerates the canonical transcode-loss matrix

## Acceptance map

| Criterion | Evidence |
|---|---|
| Output agrees with `CompiledSchema` by construction | direct shared-catalog projection plus exact `$defs` and 16-behavior official oracle |
| Every unprojectable construct is recorded | closed capability audit, located 13-code loss profile, exhaustive ledger-completeness tests |
| Bidirectional by default | canonical parser/writer preserve JSON-compatible LinkML documents; writer stability and hostile-input tests included |
| Caller owns vocabulary | mandatory config, no fabricated default, unknown-prefix failures, negative consumer-namespace assertions |
| Byte deterministic | sorted mappings, deterministic synthesized names, one trailing newline, repeated-emission equality tests |
| wasm32-clean / no features | production crate has no Python dependency; full published-crate wasm gate passes |

## Validation

- `make check`
- `make doc` with warnings denied
- `make metadata`
- `make linkml-oracle` — exact `$defs` and 16 probes agree; 18 located losses and representable-widening probes pass
- `make pydantic-oracle`
- `make wasm-pkg-size` — 4,074,341 / 4,444,391 bytes (91%); gzip -9 1,435,562 bytes
- branch-wide whitespace, issue-reference, generated-drift, deferral-marker, and consumer-vocabulary scans

## Migration boundary

The old gmeow YAML structures were read only as migration evidence. Their private OWL/FoldView types, fixed identity, shallow range mapping, and coupled TypeScript/GraphQL model are not reused. `PROVENANCE.md` records that distinction and the intent to delete the legacy model after gmeow rolls over to PurRDF's replacement.
