### PR TITLE
feat(shapes): emit deterministic TypeScript declarations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,6 +184,9 @@ jobs:
           npm ci --ignore-scripts --no-audit --no-fund
           npm run check
 
+      - name: TypeScript emitter schema oracle
+        run: node crates/shapes/tests/typescript_oracle.mjs
+
   benchmarks:
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,5 +138,7 @@ is single-sourced in `[workspace.package]`. `purrdf-capi` and
 ## 7. Provenance
 
 This repo was extracted from `gmeow-ontology` and `gmeow-gts` — see
-[`PROVENANCE.md`](./PROVENANCE.md) for source commits. The downstream
-`gmeow-ontology` cutover onto these crates is complete.
+[`PROVENANCE.md`](./PROVENANCE.md) for source commits. PurRDF's replacement
+surfaces are being completed here, but the downstream `gmeow-ontology` cutover
+is not yet complete. Its legacy models are migration evidence only and should
+be deleted as each PurRDF replacement is integrated.

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ help: ## Show this help.
 	@grep -E '^[a-zA-Z_-]+:.*## ' $(MAKEFILE_LIST) | awk -F':.*## ' '{printf "  %-18s %s\n", $$1, $$2}'
 
 metadata: ## Regenerate + verify workspace metadata and generated artifacts.
-	cargo metadata --no-deps
-	bash scripts/check-generated.sh
+	cargo metadata --no-deps --format-version 1 >/dev/null
+	bash scripts/check-generated.sh --write
 
 fmt: ## Auto-format the workspace.
 	cargo fmt --all

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 CARGO_TARGET_DIR ?= target
 CAPI_HEADER := crates/rdf-capi/include/purrdf.h
 
-.PHONY: help metadata fmt check book book-samples check-issue-refs changelog bump release-tags test doc bench bench-python columnar-oracle pydantic-oracle linkml-oracle pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-size wasm-pkg-test wasm-pkg-bench playground playground-smoke \
+.PHONY: help metadata fmt check book book-samples check-issue-refs changelog bump release-tags test doc bench bench-python columnar-oracle pydantic-oracle linkml-oracle typescript-oracle pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-size wasm-pkg-test wasm-pkg-bench playground playground-smoke \
 	capi-build capi-header capi-check capi-install
 
 # The changelog generator is pinned so the committed CHANGELOG.md and the notes
@@ -148,6 +148,10 @@ pydantic-oracle: ## Execute emitted Pydantic v2 models and compare model_json_sc
 linkml-oracle: ## Validate emitted LinkML through the locked official 1.11 toolchain.
 	uv sync --project bindings/python --locked --no-install-project
 	uv run --project bindings/python --no-sync python crates/shapes/tests/linkml_oracle.py
+
+typescript-oracle: ## Compile emitted declarations with TypeScript 7.0 and compare assignability with CompiledSchema.
+	npm --prefix crates/rdf-wasm/js ci --ignore-scripts --no-audit --no-fund
+	node crates/shapes/tests/typescript_oracle.mjs
 
 bench-python: ## Compare the rdflib compat shim vs. real rdflib (report-only; NOT a test gate). See docs/BENCHMARKS.md.
 	cd bindings/python && uv run maturin develop && uv run python benchmarks/bench_compat.py

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -37,8 +37,22 @@ Copied from `gmeow-ontology`:
   TypeScript/GraphQL model are not reused architecture. The replacement
   `purrdf-shapes::linkml` API consumes `CompiledSchema`, requires all identity
   and vocabulary from the caller, preserves a canonical LinkML 1.11 document,
-  and records projection gaps through the closed loss ledger; the legacy model
-  is intended for deletion after consumer rollover.
+  and records projection gaps through the closed loss ledger. The legacy model
+  is intended for deletion once this replacement is integrated, not
+  preservation as a downstream contract.
+- The legacy `render_typescript` path in
+  `crates/pipeline/src/stages/schemas.rs` at
+  `c91195e0c300cad9c9a32c8580c2910a6fd48fc1` was used only as evidence of the
+  consumer artifact to replace. Its LinkML-coupled private model, normalized
+  property identifiers, all-optional fields, local-name runtime enums, scalar
+  fallbacks, and fixed downstream identity are deliberately discarded. The
+  replacement `purrdf-shapes::typescript` projection consumes
+  `CompiledSchema`, preserves exact JSON property names and requiredness,
+  requires caller-owned package identity and prose, exposes a reversible type
+  map, and locates every non-projectable assertion on a closed loss ledger. The
+  old renderer and its shared private schema model are intended for deletion
+  once this replacement is integrated; no downstream type contract is being
+  preserved.
 
 Copied from `gmeow-gts`:
 

--- a/crates/rdf-core/src/loss.rs
+++ b/crates/rdf-core/src/loss.rs
@@ -25,6 +25,7 @@
 //! known across BOTH disciplines, including the non-syntax `shacl`→`json-schema`
 //! shapes projection, the `json-schema`→`pydantic-v2` code-generation profile,
 //! the `json-schema`→`linkml-1.11` schema projection,
+//! the `json-schema`→`typescript-7.0` declaration projection,
 //! and the bidirectional RDF 1.2 dataset↔OKF profile;
 //! [`loss_matrix_json`] renders that same enumerable registry.
 
@@ -733,6 +734,123 @@ const JSON_SCHEMA_LINKML_PROFILE: &[(&str, &str)] = &[
     ),
 ];
 
+/// The JSON Schema → TypeScript 7.0 declaration emitter's closed loss profile.
+/// The emitter targets the fixed `strict` + `exactOptionalPropertyTypes`
+/// assignability relation over JSON values. TypeScript declarations preserve
+/// the representable carrier graph, while every JSON Schema assertion without
+/// an exact structural type expression is widened or omitted explicitly at its
+/// JSON Pointer location.
+const JSON_SCHEMA_TYPESCRIPT_PROFILE: &[(&str, &str)] = &[
+    (
+        "additional-properties-validation-widened",
+        "TypeScript uses structural object compatibility and index signatures apply to every \
+         string key, so it cannot constrain only JSON object properties not named by the schema. \
+         Named properties retain their exact declarations while the extra-property policy or \
+         value schema is widened.",
+    ),
+    (
+        "array-cardinality-validation-widened",
+        "A JSON Schema minItems/maxItems assertion exceeds the declaration emitter's fixed \
+         tuple-expansion budget. Item and tuple-prefix carriers remain, while exact length \
+         validation is widened to keep declaration size bounded deterministically.",
+    ),
+    (
+        "array-contains-validation-dropped",
+        "JSON Schema contains/minContains/maxContains assertions quantify matching array \
+         elements and have no TypeScript assignability equivalent. Item and cardinality \
+         declarations remain while the contains predicate and match count are omitted.",
+    ),
+    (
+        "conditional-validation-dropped",
+        "JSON Schema if/then/else validates one branch according to runtime instance content; a \
+         general conditional relationship has no finite TypeScript declaration equivalent. \
+         Independently representable carrier constraints remain.",
+    ),
+    (
+        "dependency-validation-dropped",
+        "JSON Schema dependentRequired/dependentSchemas assertions impose cross-property runtime \
+         relationships that a general structural TypeScript declaration cannot enforce. \
+         Individual property declarations remain.",
+    ),
+    (
+        "integer-validation-widened",
+        "TypeScript has one number type and cannot distinguish all JSON integers from fractional \
+         numbers. The generated declaration retains the number carrier while integer-only \
+         validation is widened.",
+    ),
+    (
+        "keyword-validation-dropped",
+        "A JSON Schema assertion outside the emitter's closed TypeScript 7.0 capability table has \
+         no sound declaration projection. The assertion is omitted and recorded at its schema \
+         location rather than disappearing silently.",
+    ),
+    (
+        "negation-validation-dropped",
+        "General JSON Schema not is a set complement over instance validation. TypeScript's \
+         Exclude utility distributes over union members and cannot express that general \
+         complement, so the positive carrier remains while negation is omitted.",
+    ),
+    (
+        "numeric-validation-dropped",
+        "JSON Schema minimum/maximum/exclusive bounds and multipleOf are runtime numeric \
+         predicates with no exact TypeScript number-type expression. The numeric carrier remains \
+         while the predicate is omitted.",
+    ),
+    (
+        "object-literal-validation-widened",
+        "A JSON Schema object-valued const or enum member requires exact key membership. \
+         TypeScript can preserve every named literal field but structural compatibility still \
+         accepts values with additional fields outside fresh-object checks.",
+    ),
+    (
+        "one-of-validation-widened",
+        "A TypeScript union implements any-branch assignability and cannot generally enforce JSON \
+         Schema oneOf's exactly-one matching rule. Branch declarations remain as a union while \
+         overlap exclusivity is widened.",
+    ),
+    (
+        "pattern-properties-validation-dropped",
+        "Arbitrary JSON Schema patternProperties regular expressions have no equivalent key-space \
+         expression in TypeScript. Named and additional-property declarations remain while \
+         regex-selected property validation is omitted.",
+    ),
+    (
+        "property-count-validation-dropped",
+        "JSON Schema minProperties/maxProperties count runtime object keys; TypeScript structural \
+         declarations express named requiredness but cannot bound the total property count.",
+    ),
+    (
+        "property-name-validation-dropped",
+        "JSON Schema propertyNames validates every runtime object key with a schema, which a \
+         general TypeScript string-key declaration cannot express. Property value declarations \
+         remain while key validation is omitted.",
+    ),
+    (
+        "string-validation-dropped",
+        "JSON Schema minLength/maxLength, pattern, format, and content assertions are runtime \
+         predicates without a general TypeScript string-type equivalent. The string carrier \
+         remains while the predicate is omitted.",
+    ),
+    (
+        "tuple-array-validation-widened",
+        "A JSON Schema prefixItems tuple exceeds the declaration emitter's fixed tuple-expansion \
+         budget. The common item carrier remains while position-specific validation beyond the \
+         budget is widened deterministically.",
+    ),
+    (
+        "unevaluated-validation-dropped",
+        "JSON Schema unevaluatedProperties/unevaluatedItems depends on applicator evaluation state \
+         that TypeScript's structural type system does not expose. Representable local \
+         declarations remain while the unevaluated assertion is omitted.",
+    ),
+    (
+        "unique-items-validation-dropped",
+        "JSON Schema uniqueItems compares runtime array values for equality; TypeScript array and \
+         tuple declarations cannot require pairwise-distinct elements. Item and length \
+         declarations remain while uniqueness is omitted.",
+    ),
+];
+
 /// Build the runtime-shaped [`LossEntry`] rows for the
 /// `("shacl", "json-schema")` shapes profile from [`SHACL_JSON_SCHEMA_PROFILE`]
 /// — one contract entry per declared `(code, note)` pair, `location: None`
@@ -775,6 +893,21 @@ fn json_schema_linkml_entries() -> Vec<LossEntry> {
             code: Cow::Borrowed(code),
             from: Cow::Borrowed("json-schema"),
             to: Cow::Borrowed("linkml-1.11"),
+            note: Cow::Borrowed(note),
+            location: None,
+        })
+        .collect()
+}
+
+/// Build the static contract rows for the
+/// `("json-schema", "typescript-7.0")` projection profile.
+fn json_schema_typescript_entries() -> Vec<LossEntry> {
+    JSON_SCHEMA_TYPESCRIPT_PROFILE
+        .iter()
+        .map(|&(code, note)| LossEntry {
+            code: Cow::Borrowed(code),
+            from: Cow::Borrowed("json-schema"),
+            to: Cow::Borrowed("typescript-7.0"),
             note: Cow::Borrowed(note),
             location: None,
         })
@@ -824,6 +957,7 @@ fn registry_entries() -> Vec<LossEntry> {
     entries.extend(transcode_and_shapes_entries());
     entries.extend(json_schema_pydantic_entries());
     entries.extend(json_schema_linkml_entries());
+    entries.extend(json_schema_typescript_entries());
     entries
 }
 
@@ -1360,6 +1494,19 @@ mod tests {
     }
 
     #[test]
+    fn transcode_matrix_includes_json_schema_typescript_pair() {
+        let json = loss_matrix_json();
+        assert!(json.contains("\"from\": \"json-schema\""));
+        assert!(json.contains("\"to\": \"typescript-7.0\""));
+        for (code, _) in JSON_SCHEMA_TYPESCRIPT_PROFILE {
+            assert!(
+                json.contains(&format!("\"code\": \"{code}\"")),
+                "transcode-loss-matrix.json missing TypeScript-profile code `{code}`"
+            );
+        }
+    }
+
+    #[test]
     fn pair_loss_identity_is_empty() {
         assert!(pair_loss_ledger("turtle", "turtle").is_empty());
         assert!(pair_loss_ledger("gts", "gts").is_empty());
@@ -1507,6 +1654,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn registered_pairs_includes_json_schema_typescript() {
+        assert!(
+            registered_pairs().any(|(from, to)| from == "json-schema" && to == "typescript-7.0"),
+            "registered_pairs() must include (\"json-schema\", \"typescript-7.0\")"
+        );
+    }
+
     /// `registered_pairs()` must yield the SAME ordered sequence across two
     /// independent calls (it is backed by a `BTreeMap`, so this is order, not
     /// merely set-equality) — callers rendering it directly (e.g. a diagnostic
@@ -1548,6 +1703,16 @@ mod tests {
     fn profile_for_json_schema_linkml_is_closed() {
         let profile = profile_for("json-schema", "linkml-1.11");
         let expected: BTreeSet<&str> = JSON_SCHEMA_LINKML_PROFILE
+            .iter()
+            .map(|(code, _)| *code)
+            .collect();
+        assert_eq!(profile, expected);
+    }
+
+    #[test]
+    fn profile_for_json_schema_typescript_is_closed() {
+        let profile = profile_for("json-schema", "typescript-7.0");
+        let expected: BTreeSet<&str> = JSON_SCHEMA_TYPESCRIPT_PROFILE
             .iter()
             .map(|(code, _)| *code)
             .collect();

--- a/crates/rdf-core/src/loss.rs
+++ b/crates/rdf-core/src/loss.rs
@@ -793,8 +793,10 @@ const JSON_SCHEMA_TYPESCRIPT_PROFILE: &[(&str, &str)] = &[
     (
         "numeric-validation-dropped",
         "JSON Schema minimum/maximum/exclusive bounds and multipleOf are runtime numeric \
-         predicates with no exact TypeScript number-type expression. The numeric carrier remains \
-         while the predicate is omitted.",
+         predicates with no exact TypeScript number-type expression; integer const/enum values \
+         outside the IEEE-754 safe range also have no exact TypeScript number literal. The \
+         numeric carrier or closest literal remains while the predicate or excess precision is \
+         omitted.",
     ),
     (
         "object-literal-validation-widened",

--- a/crates/shapes/README.md
+++ b/crates/shapes/README.md
@@ -179,6 +179,63 @@ corpus, and probes every lossy family:
 make linkml-oracle
 ```
 
+## TypeScript 7.0 declarations
+
+`emit_typescript` projects `CompiledSchema` directly into one deterministic
+`index.d.ts` artifact. `TypeScriptConfig` requires the caller's package name and
+package/module prose; no downstream identity or vocabulary is fabricated. The
+result includes the declaration bytes, an exact source-`$defs`-key to exported
+type-name map, and the always-computed `json-schema` → `typescript-7.0` loss
+ledger.
+
+```rust,ignore
+use purrdf_shapes::{
+    TYPESCRIPT_DECLARATION_PATH, TypeScriptConfig, emit_typescript,
+};
+
+let config = TypeScriptConfig::new(
+    "example-schema-types",
+    "Types published by the caller.",
+    "Declarations generated from the caller's compiled schema.",
+)?;
+let package = emit_typescript(&compiled_schema, &config)?;
+let declaration = std::str::from_utf8(
+    &package.artifacts[TYPESCRIPT_DECLARATION_PATH],
+)?;
+
+assert!(declaration.contains("export type Person"));
+assert_eq!(package.type_names.get("Person").map(String::as_str), Some("Person"));
+```
+
+The closed dialect is TypeScript 7.0 under `strict` and
+`exactOptionalPropertyTypes`. It represents JSON primitives and literals, exact
+required-versus-optional fields, explicit JSON `null`, local recursive
+references, `anyOf` unions, `allOf` intersections, homogeneous arrays, and
+bounded tuples. It emits type aliases rather than runtime enums or mergeable
+interfaces and never uses `any`. Malformed keyword values, external/dynamic or
+dangling references, reserved names, and normalized-name collisions fail
+closed.
+
+TypeScript's structural assignability cannot encode every runtime JSON Schema
+assertion. Integer subsets, numeric/string predicates, object closure with
+named fields, regex-selected properties, dependencies, conditionals,
+negation, contains/uniqueness, evaluation state, and expansion-budget
+widenings are therefore classified at their JSON Pointer locations by the
+closed loss profile. The compiler oracle checks both fresh literals and values
+passed through variables, so excess-property checks cannot hide structural
+widening:
+
+```bash
+make typescript-oracle
+```
+
+There is deliberately no general TypeScript → JSON Schema reader. Arbitrary
+TypeScript declarations have no unique runtime acceptance relation, and many
+different schemas project to the same declaration. The retained
+`CompiledSchema`, paired with `type_names`, is the authoritative reverse
+surface. The production emitter has no JavaScript dependency, performs no
+filesystem I/O, and remains wasm-clean; TypeScript is dev-only oracle tooling.
+
 ---
 
 ## Python extension

--- a/crates/shapes/examples/typescript_oracle_fixture.rs
+++ b/crates/shapes/examples/typescript_oracle_fixture.rs
@@ -1,0 +1,940 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Emit exact and lossy packages for the dev-only TypeScript compiler oracle.
+
+use std::collections::BTreeSet;
+use std::error::Error;
+
+use boon::{Compiler, Schemas};
+use purrdf::loss::{LossLedger, check_ledger_complete, check_ledger_sound};
+use purrdf_shapes::json_schema::CompiledSchema;
+use purrdf_shapes::{
+    TYPESCRIPT_DECLARATION_PATH, TypeScriptConfig, TypeScriptPackage, emit_typescript,
+};
+use serde::Serialize;
+use serde_json::{Value, json};
+
+const CLOSED_PROFILE: [&str; 18] = [
+    "additional-properties-validation-widened",
+    "array-cardinality-validation-widened",
+    "array-contains-validation-dropped",
+    "conditional-validation-dropped",
+    "dependency-validation-dropped",
+    "integer-validation-widened",
+    "keyword-validation-dropped",
+    "negation-validation-dropped",
+    "numeric-validation-dropped",
+    "object-literal-validation-widened",
+    "one-of-validation-widened",
+    "pattern-properties-validation-dropped",
+    "property-count-validation-dropped",
+    "property-name-validation-dropped",
+    "string-validation-dropped",
+    "tuple-array-validation-widened",
+    "unevaluated-validation-dropped",
+    "unique-items-validation-dropped",
+];
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ExpectedLoss {
+    code: String,
+    location: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Probe {
+    label: String,
+    type_name: String,
+    value: Value,
+    mode: String,
+    source_valid: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expected_loss: Option<ExpectedLoss>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CompilerProbe {
+    label: String,
+    type_name: String,
+    expression: String,
+    expected_typescript_valid: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Fixture {
+    declaration: String,
+    type_names: std::collections::BTreeMap<String, String>,
+    losses: Value,
+    probes: Vec<Probe>,
+    compiler_probes: Vec<CompilerProbe>,
+}
+
+fn compiled(schema: &Value) -> Result<CompiledSchema, serde_json::Error> {
+    Ok(CompiledSchema {
+        schema_json: format!("{}\n", serde_json::to_string_pretty(schema)?),
+        openapi_json: "{}\n".to_owned(),
+        losses: LossLedger::new(),
+    })
+}
+
+fn config() -> Result<TypeScriptConfig, Box<dyn Error>> {
+    Ok(TypeScriptConfig::new(
+        "@example/typescript-oracle",
+        "Caller-owned TypeScript differential-oracle fixture.",
+        "Declarations checked against the source JSON Schema acceptance relation.",
+    )?)
+}
+
+fn exact_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://example.org/schema/typescript-exact.json",
+        "$defs": {
+            "Alias": { "$ref": "#/$defs/Person" },
+            "Choice": {
+                "anyOf": [
+                    { "const": "ex:open" },
+                    { "const": true }
+                ]
+            },
+            "ClosedEmpty": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "Empty": { "enum": [] },
+            "Extended": {
+                "allOf": [
+                    { "$ref": "#/$defs/Person" },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "ex:score": { "type": "number" }
+                        },
+                        "required": ["ex:score"]
+                    }
+                ]
+            },
+            "JsonAny": true,
+            "Nothing": false,
+            "Person": {
+                "type": "object",
+                "properties": {
+                    "@id": { "type": "string" },
+                    "ex:choice": { "$ref": "#/$defs/Choice" },
+                    "ex:friend": { "$ref": "#/$defs/Person" },
+                    "ex:nullable": { "type": ["string", "null"] },
+                    "ex:tags": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "minItems": 1,
+                        "maxItems": 2
+                    },
+                    "ex:tuple": {
+                        "type": "array",
+                        "prefixItems": [
+                            { "type": "string" },
+                            { "type": "number" }
+                        ],
+                        "items": false
+                    }
+                },
+                "required": ["@id"]
+            },
+            "Tree": {
+                "type": "object",
+                "properties": {
+                    "children": {
+                        "type": "array",
+                        "items": { "$ref": "#/$defs/Tree" }
+                    },
+                    "value": { "type": "string" }
+                },
+                "required": ["value"]
+            },
+            "path/with~token": { "enum": [null, 7, "mapped"] }
+        }
+    })
+}
+
+fn lossy_schema() -> Value {
+    let long_prefix = (0..33)
+        .map(|index| {
+            if index % 2 == 0 {
+                json!({ "type": "string" })
+            } else {
+                json!({ "type": "number" })
+            }
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://example.org/schema/typescript-lossy.json",
+        "$defs": {
+            "Cardinality": {
+                "type": "array",
+                "items": { "type": "string" },
+                "minItems": 40
+            },
+            "ClosedNamed": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": { "known": { "type": "string" } },
+                "required": ["known"]
+            },
+            "Conditional": {
+                "type": "object",
+                "properties": {
+                    "flag": { "type": "boolean" },
+                    "value": { "type": "string" }
+                },
+                "if": {
+                    "properties": { "flag": { "const": true } },
+                    "required": ["flag"]
+                },
+                "then": { "required": ["value"] }
+            },
+            "Contains": {
+                "type": "array",
+                "items": { "type": "string" },
+                "contains": { "const": "match" }
+            },
+            "Dependency": {
+                "type": "object",
+                "properties": {
+                    "a": { "type": "boolean" },
+                    "b": { "type": "string" }
+                },
+                "dependentRequired": { "a": ["b"] }
+            },
+            "IntegerRule": { "type": "integer" },
+            "LongTuple": {
+                "type": "array",
+                "prefixItems": long_prefix,
+                "items": false
+            },
+            "Negated": { "not": { "type": "boolean" } },
+            "NumericRule": { "type": "number", "minimum": 0 },
+            "ObjectLiteral": { "enum": [{ "state": "open" }] },
+            "OneOfExclusive": {
+                "oneOf": [
+                    { "type": "string" },
+                    { "const": "overlap" }
+                ]
+            },
+            "Patterned": {
+                "type": "object",
+                "patternProperties": {
+                    "^ex:": { "type": "string" }
+                },
+                "additionalProperties": false
+            },
+            "PropertyCount": {
+                "type": "object",
+                "minProperties": 1
+            },
+            "PropertyNames": {
+                "type": "object",
+                "propertyNames": { "pattern": "^ex:" }
+            },
+            "StringRule": { "type": "string", "pattern": "^[A-Z]" },
+            "UnevaluatedArray": {
+                "type": "array",
+                "prefixItems": [{ "type": "string" }],
+                "unevaluatedItems": false
+            },
+            "UnevaluatedObject": {
+                "allOf": [{
+                    "type": "object",
+                    "properties": { "known": { "type": "string" } }
+                }],
+                "unevaluatedProperties": false
+            },
+            "UniqueItems": {
+                "type": "array",
+                "items": { "type": "string" },
+                "uniqueItems": true
+            },
+            "UnknownRule": { "unsupportedAssertion": true }
+        }
+    })
+}
+
+fn validates(schema: &Value, definition: &str, instance: &Value) -> Result<bool, Box<dyn Error>> {
+    let escaped = definition.replace('~', "~0").replace('/', "~1");
+    let wrapper = json!({
+        "$schema": schema["$schema"],
+        "$defs": schema["$defs"],
+        "$ref": format!("#/$defs/{escaped}")
+    });
+    let location = "mem:///typescript-oracle.schema.json";
+    let mut schemas = Schemas::new();
+    let mut compiler = Compiler::new();
+    compiler.add_resource(location, wrapper)?;
+    let compiled = compiler.compile(location, &mut schemas)?;
+    Ok(schemas.validate(instance, compiled).is_ok())
+}
+
+fn has_loss(package: &TypeScriptPackage, code: &str, location: &str) -> bool {
+    package.losses.entries().iter().any(|entry| {
+        entry.code == code
+            && entry
+                .location
+                .as_ref()
+                .and_then(|value| value.subject.as_deref())
+                == Some(location)
+    })
+}
+
+// Keep each fixture row explicit: schema, projection, compiler mode, independent
+// source classification, and located-loss expectation are separate oracle inputs.
+#[allow(clippy::too_many_arguments)]
+fn probe(
+    schema: &Value,
+    package: &TypeScriptPackage,
+    label: &str,
+    definition: &str,
+    value: Value,
+    mode: &str,
+    expected_source_valid: bool,
+    expected_loss: Option<(&str, &str)>,
+) -> Result<Probe, Box<dyn Error>> {
+    let source_valid = validates(schema, definition, &value)?;
+    if source_valid != expected_source_valid {
+        return Err(format!(
+            "source fixture probe {label:?} classified as {source_valid}, expected \
+             {expected_source_valid}"
+        )
+        .into());
+    }
+    let expected_loss = expected_loss.map(|(code, location)| ExpectedLoss {
+        code: code.to_owned(),
+        location: location.to_owned(),
+    });
+    if let Some(loss) = &expected_loss
+        && !has_loss(package, &loss.code, &loss.location)
+    {
+        return Err(format!(
+            "probe {label:?} names absent loss {} at {}",
+            loss.code, loss.location
+        )
+        .into());
+    }
+    let type_name = package
+        .type_names
+        .get(definition)
+        .ok_or_else(|| format!("fixture definition {definition:?} has no generated type"))?
+        .clone();
+    Ok(Probe {
+        label: label.to_owned(),
+        type_name,
+        value,
+        mode: mode.to_owned(),
+        source_valid,
+        expected_loss,
+    })
+}
+
+fn declaration(package: &TypeScriptPackage) -> Result<String, Box<dyn Error>> {
+    let bytes = package
+        .artifacts
+        .get(TYPESCRIPT_DECLARATION_PATH)
+        .ok_or("TypeScript package has no declaration artifact")?;
+    Ok(std::str::from_utf8(bytes)?.to_owned())
+}
+
+fn ledger_json(package: &TypeScriptPackage) -> Result<Value, Box<dyn Error>> {
+    Ok(serde_json::from_str(&package.losses.render_json())?)
+}
+
+fn exact_fixture(schema: &Value, package: TypeScriptPackage) -> Result<Fixture, Box<dyn Error>> {
+    if !package.losses.is_empty() {
+        return Err(format!(
+            "exact TypeScript fixture unexpectedly lost semantics: {}",
+            package.losses.render_json()
+        )
+        .into());
+    }
+    let probes = vec![
+        probe(
+            schema,
+            &package,
+            "alias-valid",
+            "Alias",
+            json!({"@id": "ex:a"}),
+            "fresh",
+            true,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "choice-string",
+            "Choice",
+            json!("ex:open"),
+            "fresh",
+            true,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "choice-boolean",
+            "Choice",
+            json!(true),
+            "fresh",
+            true,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "choice-reject",
+            "Choice",
+            json!("closed"),
+            "fresh",
+            false,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "closed-empty",
+            "ClosedEmpty",
+            json!({}),
+            "variable",
+            true,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "closed-empty-rejects-key",
+            "ClosedEmpty",
+            json!({"extra": 1}),
+            "variable",
+            false,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "empty-enum",
+            "Empty",
+            json!(null),
+            "fresh",
+            false,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "extended-valid",
+            "Extended",
+            json!({"@id": "ex:a", "ex:score": 0.5}),
+            "variable",
+            true,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "extended-missing-score",
+            "Extended",
+            json!({"@id": "ex:a"}),
+            "variable",
+            false,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "json-any",
+            "JsonAny",
+            json!({"nested": [true, null, 3]}),
+            "variable",
+            true,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "false-schema",
+            "Nothing",
+            json!(false),
+            "fresh",
+            false,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "person-minimal",
+            "Person",
+            json!({"@id": "ex:a"}),
+            "fresh",
+            true,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "person-required",
+            "Person",
+            json!({}),
+            "variable",
+            false,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "person-null",
+            "Person",
+            json!({"@id": "ex:a", "ex:nullable": null}),
+            "fresh",
+            true,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "person-nullable-rejects-number",
+            "Person",
+            json!({"@id": "ex:a", "ex:nullable": 3}),
+            "fresh",
+            false,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "person-open",
+            "Person",
+            json!({"@id": "ex:a", "extra": {"ok": true}}),
+            "variable",
+            true,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "person-tags-min",
+            "Person",
+            json!({"@id": "ex:a", "ex:tags": []}),
+            "fresh",
+            false,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "person-tags-max",
+            "Person",
+            json!({"@id": "ex:a", "ex:tags": ["a", "b", "c"]}),
+            "fresh",
+            false,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "person-tuple-prefix",
+            "Person",
+            json!({"@id": "ex:a", "ex:tuple": ["a", 1]}),
+            "variable",
+            true,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "person-tuple-short",
+            "Person",
+            json!({"@id": "ex:a", "ex:tuple": ["a"]}),
+            "variable",
+            true,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "person-tuple-order",
+            "Person",
+            json!({"@id": "ex:a", "ex:tuple": [1, "a"]}),
+            "variable",
+            false,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "recursive-valid",
+            "Tree",
+            json!({"value": "root", "children": [{"value": "leaf"}]}),
+            "variable",
+            true,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "recursive-required",
+            "Tree",
+            json!({"value": "root", "children": [{}]}),
+            "variable",
+            false,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "escaped-name",
+            "path/with~token",
+            json!("mapped"),
+            "fresh",
+            true,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "escaped-name-reject",
+            "path/with~token",
+            json!(8),
+            "fresh",
+            false,
+            None,
+        )?,
+    ];
+    let person = package.type_names["Person"].clone();
+    let compiler_probes = vec![
+        CompilerProbe {
+            label: "optional-property-may-be-absent".to_owned(),
+            type_name: person.clone(),
+            expression: r#"{ "@id": "ex:a" }"#.to_owned(),
+            expected_typescript_valid: true,
+        },
+        CompilerProbe {
+            label: "json-null-is-explicitly-represented".to_owned(),
+            type_name: person.clone(),
+            expression: r#"{ "@id": "ex:a", "ex:nullable": null }"#.to_owned(),
+            expected_typescript_valid: true,
+        },
+        CompilerProbe {
+            label: "undefined-is-not-json-null-or-absence".to_owned(),
+            type_name: person,
+            expression: r#"{ "@id": "ex:a", "ex:nullable": undefined }"#.to_owned(),
+            expected_typescript_valid: false,
+        },
+    ];
+    let declaration = declaration(&package)?;
+    let losses = ledger_json(&package)?;
+    Ok(Fixture {
+        declaration,
+        type_names: package.type_names,
+        losses,
+        probes,
+        compiler_probes,
+    })
+}
+
+fn lossy_fixture(schema: &Value, package: TypeScriptPackage) -> Result<Fixture, Box<dyn Error>> {
+    check_ledger_sound(&package.losses, "json-schema", "typescript-7.0")?;
+    check_ledger_complete(&package.losses, &CLOSED_PROFILE)?;
+    let observed_codes = package
+        .losses
+        .entries()
+        .iter()
+        .map(|entry| entry.code.as_ref())
+        .collect::<BTreeSet<_>>();
+    let expected_codes = CLOSED_PROFILE.into_iter().collect::<BTreeSet<_>>();
+    if observed_codes != expected_codes {
+        return Err(format!("lossy TypeScript fixture code drift: {observed_codes:?}").into());
+    }
+    let probes = vec![
+        probe(
+            schema,
+            &package,
+            "closed-named-baseline",
+            "ClosedNamed",
+            json!({"known": "yes"}),
+            "fresh",
+            true,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "closed-named-fresh-extra",
+            "ClosedNamed",
+            json!({"known": "yes", "extra": true}),
+            "fresh",
+            false,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "closed-named-variable-extra",
+            "ClosedNamed",
+            json!({"known": "yes", "extra": true}),
+            "variable",
+            false,
+            Some((
+                "additional-properties-validation-widened",
+                "#/$defs/ClosedNamed/additionalProperties",
+            )),
+        )?,
+        probe(
+            schema,
+            &package,
+            "cardinality-minimum",
+            "Cardinality",
+            json!([]),
+            "variable",
+            false,
+            Some((
+                "array-cardinality-validation-widened",
+                "#/$defs/Cardinality/minItems",
+            )),
+        )?,
+        probe(
+            schema,
+            &package,
+            "contains-match",
+            "Contains",
+            json!(["other"]),
+            "variable",
+            false,
+            Some((
+                "array-contains-validation-dropped",
+                "#/$defs/Contains/contains",
+            )),
+        )?,
+        probe(
+            schema,
+            &package,
+            "conditional-then",
+            "Conditional",
+            json!({"flag": true}),
+            "variable",
+            false,
+            Some(("conditional-validation-dropped", "#/$defs/Conditional/then")),
+        )?,
+        probe(
+            schema,
+            &package,
+            "dependent-required",
+            "Dependency",
+            json!({"a": true}),
+            "variable",
+            false,
+            Some((
+                "dependency-validation-dropped",
+                "#/$defs/Dependency/dependentRequired",
+            )),
+        )?,
+        probe(
+            schema,
+            &package,
+            "integer-fraction",
+            "IntegerRule",
+            json!(1.5),
+            "fresh",
+            false,
+            Some(("integer-validation-widened", "#/$defs/IntegerRule/type")),
+        )?,
+        probe(
+            schema,
+            &package,
+            "negation",
+            "Negated",
+            json!(true),
+            "fresh",
+            false,
+            Some(("negation-validation-dropped", "#/$defs/Negated/not")),
+        )?,
+        probe(
+            schema,
+            &package,
+            "numeric-minimum",
+            "NumericRule",
+            json!(-1),
+            "fresh",
+            false,
+            Some(("numeric-validation-dropped", "#/$defs/NumericRule/minimum")),
+        )?,
+        probe(
+            schema,
+            &package,
+            "object-literal-variable-extra",
+            "ObjectLiteral",
+            json!({"state": "open", "extra": true}),
+            "variable",
+            false,
+            Some((
+                "object-literal-validation-widened",
+                "#/$defs/ObjectLiteral/enum/0",
+            )),
+        )?,
+        probe(
+            schema,
+            &package,
+            "one-of-overlap",
+            "OneOfExclusive",
+            json!("overlap"),
+            "fresh",
+            false,
+            Some(("one-of-validation-widened", "#/$defs/OneOfExclusive/oneOf")),
+        )?,
+        probe(
+            schema,
+            &package,
+            "patterned-baseline",
+            "Patterned",
+            json!({"ex:name": "Alice"}),
+            "variable",
+            true,
+            None,
+        )?,
+        probe(
+            schema,
+            &package,
+            "pattern-key-selection",
+            "Patterned",
+            json!({"wrong": "Alice"}),
+            "variable",
+            false,
+            Some((
+                "pattern-properties-validation-dropped",
+                "#/$defs/Patterned/patternProperties/^ex:",
+            )),
+        )?,
+        probe(
+            schema,
+            &package,
+            "property-count",
+            "PropertyCount",
+            json!({}),
+            "variable",
+            false,
+            Some((
+                "property-count-validation-dropped",
+                "#/$defs/PropertyCount/minProperties",
+            )),
+        )?,
+        probe(
+            schema,
+            &package,
+            "property-name",
+            "PropertyNames",
+            json!({"wrong": 1}),
+            "variable",
+            false,
+            Some((
+                "property-name-validation-dropped",
+                "#/$defs/PropertyNames/propertyNames",
+            )),
+        )?,
+        probe(
+            schema,
+            &package,
+            "string-pattern",
+            "StringRule",
+            json!("lower"),
+            "fresh",
+            false,
+            Some(("string-validation-dropped", "#/$defs/StringRule/pattern")),
+        )?,
+        probe(
+            schema,
+            &package,
+            "long-tuple-position",
+            "LongTuple",
+            json!([7]),
+            "variable",
+            false,
+            Some((
+                "tuple-array-validation-widened",
+                "#/$defs/LongTuple/prefixItems",
+            )),
+        )?,
+        probe(
+            schema,
+            &package,
+            "unevaluated-array",
+            "UnevaluatedArray",
+            json!(["first", 2]),
+            "variable",
+            false,
+            Some((
+                "unevaluated-validation-dropped",
+                "#/$defs/UnevaluatedArray/unevaluatedItems",
+            )),
+        )?,
+        probe(
+            schema,
+            &package,
+            "unevaluated-object",
+            "UnevaluatedObject",
+            json!({"known": "yes", "extra": true}),
+            "variable",
+            false,
+            Some((
+                "unevaluated-validation-dropped",
+                "#/$defs/UnevaluatedObject/unevaluatedProperties",
+            )),
+        )?,
+        probe(
+            schema,
+            &package,
+            "unique-items",
+            "UniqueItems",
+            json!(["same", "same"]),
+            "variable",
+            false,
+            Some((
+                "unique-items-validation-dropped",
+                "#/$defs/UniqueItems/uniqueItems",
+            )),
+        )?,
+        probe(
+            schema,
+            &package,
+            "unknown-keyword-is-conservatively-ledgered",
+            "UnknownRule",
+            json!({"still": "json"}),
+            "variable",
+            true,
+            None,
+        )?,
+    ];
+    let declaration = declaration(&package)?;
+    let losses = ledger_json(&package)?;
+    Ok(Fixture {
+        declaration,
+        type_names: package.type_names,
+        losses,
+        probes,
+        compiler_probes: Vec::new(),
+    })
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let config = config()?;
+    let exact_schema = exact_schema();
+    let lossy_schema = lossy_schema();
+    let exact_package = emit_typescript(&compiled(&exact_schema)?, &config)?;
+    let lossy_package = emit_typescript(&compiled(&lossy_schema)?, &config)?;
+    let output = json!({
+        "exact": exact_fixture(&exact_schema, exact_package)?,
+        "lossy": lossy_fixture(&lossy_schema, lossy_package)?,
+    });
+    println!("{}", serde_json::to_string(&output)?);
+    Ok(())
+}

--- a/crates/shapes/examples/typescript_oracle_fixture.rs
+++ b/crates/shapes/examples/typescript_oracle_fixture.rs
@@ -218,6 +218,9 @@ fn lossy_schema() -> Value {
                 "items": false
             },
             "Negated": { "not": { "type": "boolean" } },
+            "NestedObjectLiteral": {
+                "const": [{ "state": "open" }]
+            },
             "NumericRule": { "type": "number", "minimum": 0 },
             "ObjectLiteral": { "enum": [{ "state": "open" }] },
             "OneOfExclusive": {
@@ -258,6 +261,9 @@ fn lossy_schema() -> Value {
                 "type": "array",
                 "items": { "type": "string" },
                 "uniqueItems": true
+            },
+            "UnsafeIntegerLiteral": {
+                "const": 9_007_199_254_740_993_u64
             },
             "UnknownRule": { "unsupportedAssertion": true }
         }
@@ -762,6 +768,19 @@ fn lossy_fixture(schema: &Value, package: TypeScriptPackage) -> Result<Fixture, 
         probe(
             schema,
             &package,
+            "nested-object-literal-variable-extra",
+            "NestedObjectLiteral",
+            json!([{"state": "open", "extra": true}]),
+            "variable",
+            false,
+            Some((
+                "object-literal-validation-widened",
+                "#/$defs/NestedObjectLiteral/const/0",
+            )),
+        )?,
+        probe(
+            schema,
+            &package,
             "numeric-minimum",
             "NumericRule",
             json!(-1),
@@ -901,6 +920,19 @@ fn lossy_fixture(schema: &Value, package: TypeScriptPackage) -> Result<Fixture, 
             Some((
                 "unique-items-validation-dropped",
                 "#/$defs/UniqueItems/uniqueItems",
+            )),
+        )?,
+        probe(
+            schema,
+            &package,
+            "unsafe-integer-literal",
+            "UnsafeIntegerLiteral",
+            json!(9_007_199_254_740_992_u64),
+            "fresh",
+            false,
+            Some((
+                "numeric-validation-dropped",
+                "#/$defs/UnsafeIntegerLiteral/const",
             )),
         )?,
         probe(

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -37,6 +37,7 @@ pub mod shapes;
 pub mod sparql;
 pub mod term;
 pub mod text_ingest;
+pub mod typescript;
 
 pub use json_schema::{Namespaces, ValueVocab, ValueVocabProjection, compile_with_value_vocab};
 pub use linkml::{
@@ -45,6 +46,10 @@ pub use linkml::{
 };
 pub use pydantic::{PydanticConfig, PydanticError, PydanticPackage, emit_pydantic};
 pub use rules::{apply_rules, entail_dataset};
+pub use typescript::{
+    TYPESCRIPT_DECLARATION_PATH, TYPESCRIPT_DIALECT, TypeScriptConfig, TypeScriptError,
+    TypeScriptPackage, emit_typescript,
+};
 
 /// Crate version string for cache/toolchain salt parity with Python package
 /// versions (`metadata.version("purrdf-shapes")`).

--- a/crates/shapes/src/schema_catalog.rs
+++ b/crates/shapes/src/schema_catalog.rs
@@ -145,6 +145,12 @@ fn validate_schema(
         }
     }
 
+    if object.contains_key("$id") {
+        return Err(SchemaCatalogError::new(format!(
+            "{path}/$id cannot rebase a closed generated package"
+        )));
+    }
+
     if let Some(reference) = object.get("$ref") {
         let reference = reference
             .as_str()
@@ -315,6 +321,40 @@ mod tests {
             let error = CompiledSchemaCatalog::parse(&compiled(&schema))
                 .expect_err("open reference must fail");
             assert!(error.to_string().contains(keyword), "{error}");
+        }
+
+        for schema in [
+            json!({
+                "$defs": {
+                    "Holder": {
+                        "$id": "nested.json",
+                        "$ref": "#/$defs/Target"
+                    },
+                    "Target": true
+                }
+            }),
+            json!({
+                "$defs": {
+                    "Holder": {
+                        "properties": {
+                            "nested": {
+                                "$id": "nested.json",
+                                "$ref": "#/$defs/Target"
+                            }
+                        }
+                    },
+                    "Target": true
+                }
+            }),
+        ] {
+            let error = CompiledSchemaCatalog::parse(&compiled(&schema))
+                .expect_err("resource rebasing must fail");
+            assert!(
+                error
+                    .to_string()
+                    .contains("$id cannot rebase a closed generated package"),
+                "{error}"
+            );
         }
     }
 }

--- a/crates/shapes/src/typescript.rs
+++ b/crates/shapes/src/typescript.rs
@@ -294,10 +294,44 @@ fn validate_unguarded_reference_cycles(
             (key.clone(), references)
         })
         .collect::<BTreeMap<_, _>>();
-    let mut active = Vec::new();
     let mut complete = BTreeSet::new();
     for key in definitions.keys() {
-        visit_unguarded_references(key, &graph, &mut active, &mut complete)?;
+        if complete.contains(key) {
+            continue;
+        }
+        let mut active = Vec::new();
+        let mut active_positions = BTreeMap::new();
+        let mut stack = vec![(key.clone(), false)];
+        while let Some((current, exiting)) = stack.pop() {
+            if exiting {
+                let removed_position = active_positions.remove(&current);
+                debug_assert_eq!(removed_position, Some(active.len().saturating_sub(1)));
+                let removed = active.pop();
+                debug_assert_eq!(removed.as_deref(), Some(current.as_str()));
+                complete.insert(current);
+                continue;
+            }
+            if complete.contains(&current) {
+                continue;
+            }
+            if let Some(start) = active_positions.get(&current).copied() {
+                let mut cycle = active[start..].to_vec();
+                cycle.push(current);
+                return Err(TypeScriptError::new(format!(
+                    "CompiledSchema contains an unguarded recursive TypeScript alias cycle: {}",
+                    cycle.join(" -> ")
+                )));
+            }
+
+            active_positions.insert(current.clone(), active.len());
+            active.push(current.clone());
+            stack.push((current.clone(), true));
+            if let Some(references) = graph.get(&current) {
+                for reference in references.iter().rev() {
+                    stack.push((reference.clone(), false));
+                }
+            }
+        }
     }
     Ok(())
 }
@@ -395,36 +429,6 @@ fn join_unguarded_intersection(
     } else {
         UnguardedRelation::Universal
     }
-}
-
-fn visit_unguarded_references(
-    key: &str,
-    graph: &BTreeMap<String, BTreeSet<String>>,
-    active: &mut Vec<String>,
-    complete: &mut BTreeSet<String>,
-) -> Result<(), TypeScriptError> {
-    if complete.contains(key) {
-        return Ok(());
-    }
-    if let Some(start) = active.iter().position(|candidate| candidate == key) {
-        let mut cycle = active[start..].to_vec();
-        cycle.push(key.to_owned());
-        return Err(TypeScriptError::new(format!(
-            "CompiledSchema contains an unguarded recursive TypeScript alias cycle: {}",
-            cycle.join(" -> ")
-        )));
-    }
-
-    active.push(key.to_owned());
-    if let Some(references) = graph.get(key) {
-        for reference in references {
-            visit_unguarded_references(reference, graph, active, complete)?;
-        }
-    }
-    let removed = active.pop();
-    debug_assert_eq!(removed.as_deref(), Some(key));
-    complete.insert(key.to_owned());
-    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -2220,6 +2224,21 @@ mod tests {
         assert!(source.contains("export type Always = JsonValue;"));
         assert!(source.contains("readonly \"children\"?: readonly (Alias)[];"));
         assert!(source.contains("export type Bottom = never;"));
+    }
+
+    #[test]
+    fn long_unguarded_alias_chains_are_checked_without_recursion() {
+        const DEFINITION_COUNT: usize = 8_192;
+        let mut definitions = Map::new();
+        for index in 0..DEFINITION_COUNT {
+            let definition = if index + 1 == DEFINITION_COUNT {
+                Value::Bool(true)
+            } else {
+                json!({ "$ref": format!("#/$defs/Node{}", index + 1) })
+            };
+            definitions.insert(format!("Node{index}"), definition);
+        }
+        validate_unguarded_reference_cycles(&definitions).expect("long alias chain is acyclic");
     }
 
     #[test]

--- a/crates/shapes/src/typescript.rs
+++ b/crates/shapes/src/typescript.rs
@@ -925,13 +925,15 @@ impl<'a> Renderer<'a> {
             }
         }
         if has_kind(JsonKind::Array) {
-            for keyword in ["contains", "minContains", "maxContains"] {
-                if object.contains_key(keyword) {
-                    self.record(
-                        "array-contains-validation-dropped",
-                        &format!("{path}/{keyword}"),
-                        "TypeScript cannot quantify elements matching an array predicate",
-                    );
+            if object.contains_key("contains") {
+                for keyword in ["contains", "minContains", "maxContains"] {
+                    if object.contains_key(keyword) {
+                        self.record(
+                            "array-contains-validation-dropped",
+                            &format!("{path}/{keyword}"),
+                            "TypeScript cannot quantify elements matching an array predicate",
+                        );
+                    }
                 }
             }
             if object.get("uniqueItems") == Some(&Value::Bool(true)) {
@@ -992,7 +994,9 @@ impl<'a> Renderer<'a> {
                 "TypeScript has no general JSON value-set complement",
             );
         }
-        if object.contains_key("if") {
+        let has_active_conditional = object.contains_key("if")
+            && (object.contains_key("then") || object.contains_key("else"));
+        if has_active_conditional {
             for keyword in ["if", "then", "else"] {
                 if object.contains_key(keyword) {
                     self.record(
@@ -1012,22 +1016,12 @@ impl<'a> Renderer<'a> {
                 );
             }
         }
-        if object.get("const").is_some_and(Value::is_object) {
-            self.record(
-                "object-literal-validation-widened",
-                &format!("{path}/const"),
-                "TypeScript object literal types cannot close structural compatibility",
-            );
+        if let Some(value) = object.get("const") {
+            self.audit_literal(value, &format!("{path}/const"), depth + 1)?;
         }
         if let Some(values) = object.get("enum").and_then(Value::as_array) {
             for (index, value) in values.iter().enumerate() {
-                if value.is_object() {
-                    self.record(
-                        "object-literal-validation-widened",
-                        &format!("{path}/enum/{index}"),
-                        "TypeScript object literal types cannot close structural compatibility",
-                    );
-                }
+                self.audit_literal(value, &format!("{path}/enum/{index}"), depth + 1)?;
             }
         }
         if object.contains_key("additionalItems") {
@@ -1051,6 +1045,9 @@ impl<'a> Renderer<'a> {
         }
 
         for keyword in schema_map_keywords() {
+            if *keyword == "$defs" {
+                continue;
+            }
             if let Some(children) = object.get(*keyword).and_then(Value::as_object) {
                 for (key, child) in children {
                     self.audit_schema(
@@ -1069,9 +1066,51 @@ impl<'a> Renderer<'a> {
             }
         }
         for keyword in schema_single_keywords() {
+            if matches!(*keyword, "if" | "then" | "else") && !has_active_conditional {
+                continue;
+            }
             if let Some(child) = object.get(*keyword) {
                 self.audit_schema(child, &format!("{path}/{keyword}"), depth + 1)?;
             }
+        }
+        Ok(())
+    }
+
+    fn audit_literal(
+        &mut self,
+        value: &Value,
+        path: &str,
+        depth: usize,
+    ) -> Result<(), TypeScriptError> {
+        ensure_depth(depth, path)?;
+        match value {
+            Value::Number(number) if integer_exceeds_typescript_exact_range(number) => {
+                self.record(
+                    "numeric-validation-dropped",
+                    path,
+                    "TypeScript number literals cannot preserve this exact JSON integer",
+                );
+            }
+            Value::Array(values) => {
+                for (index, value) in values.iter().enumerate() {
+                    self.audit_literal(value, &format!("{path}/{index}"), depth + 1)?;
+                }
+            }
+            Value::Object(object) => {
+                self.record(
+                    "object-literal-validation-widened",
+                    path,
+                    "TypeScript object literal types cannot close structural compatibility",
+                );
+                for (key, value) in object {
+                    self.audit_literal(
+                        value,
+                        &format!("{path}/{}", pointer_escape(key)),
+                        depth + 1,
+                    )?;
+                }
+            }
+            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
         }
         Ok(())
     }
@@ -1360,14 +1399,40 @@ fn nonnegative_usize(
     keyword: &str,
     path: &str,
 ) -> Result<usize, TypeScriptError> {
-    let value = object.get(keyword).and_then(Value::as_u64).ok_or_else(|| {
-        TypeScriptError::new(format!("{path}/{keyword} must be a non-negative integer"))
-    })?;
-    usize::try_from(value).map_err(|_| {
-        TypeScriptError::new(format!(
-            "{path}/{keyword} exceeds this platform's index range"
-        ))
-    })
+    let value = object
+        .get(keyword)
+        .expect("nonnegative_usize is called only for a present keyword");
+    // Only values through the fixed tuple budget affect emitted structure.
+    // Saturating larger integers keeps native and wasm32 behavior identical.
+    let over_budget = MAX_TUPLE_EXPANSION + 1;
+    if let Some(value) = value.as_u64() {
+        return Ok(usize::try_from(value.min(over_budget as u64))
+            .expect("the fixed expansion-budget sentinel fits every supported usize"));
+    }
+    if let Some(value) = value.as_f64()
+        && value >= 0.0
+        && value.fract() == 0.0
+    {
+        return Ok(if value > over_budget as f64 {
+            over_budget
+        } else {
+            value as usize
+        });
+    }
+    Err(TypeScriptError::new(format!(
+        "{path}/{keyword} must be a non-negative integer"
+    )))
+}
+
+fn integer_exceeds_typescript_exact_range(number: &serde_json::Number) -> bool {
+    const MAX_SAFE_INTEGER: i64 = 9_007_199_254_740_991;
+    if let Some(value) = number.as_i64() {
+        !(-MAX_SAFE_INTEGER..=MAX_SAFE_INTEGER).contains(&value)
+    } else {
+        number
+            .as_u64()
+            .is_some_and(|value| value > MAX_SAFE_INTEGER as u64)
+    }
 }
 
 fn render_array_relation(
@@ -2176,22 +2241,85 @@ mod tests {
     }
 
     #[test]
-    fn then_and_else_without_if_do_not_claim_a_conditional_loss() {
+    fn inactive_schema_keywords_do_not_claim_losses() {
         let schema = json!({
             "$defs": {
+                "ContainsBoundsOnly": {
+                    "type": "array",
+                    "minContains": 1,
+                    "maxContains": 2
+                },
+                "IfOnly": {
+                    "if": { "type": "integer", "minimum": 2 }
+                },
                 "IgnoredBranches": {
                     "then": { "type": "integer" },
                     "else": { "pattern": "x" }
+                },
+                "NestedDefinitions": {
+                    "$defs": {
+                        "Inert": { "type": "string", "pattern": "x" }
+                    }
                 }
             }
         });
         let package = emit_typescript(&compiled(&schema), &config()).expect("emits");
         assert!(
-            !package
-                .losses
-                .entries()
-                .iter()
-                .any(|entry| entry.code == "conditional-validation-dropped")
+            package.losses.is_empty(),
+            "{}",
+            package.losses.render_json()
         );
+    }
+
+    #[test]
+    fn literal_trees_and_portable_array_bounds_are_audited_exactly() {
+        let schema = json!({
+            "$defs": {
+                "IntegralFloatBounds": {
+                    "type": "array",
+                    "minItems": 1.0,
+                    "maxItems": 2.0
+                },
+                "LargeBound": {
+                    "type": "array",
+                    "minItems": 4_294_967_296_u64
+                },
+                "NestedLiterals": {
+                    "enum": [[{
+                        "state": "open",
+                        "sequence": [9_007_199_254_740_993_u64]
+                    }]]
+                }
+            }
+        });
+        let package = emit_typescript(&compiled(&schema), &config()).expect("emits");
+        let source = declaration(&package);
+        assert!(source.contains(
+            "export type IntegralFloatBounds = (readonly [JsonValue] | readonly [JsonValue, \
+             JsonValue]);"
+        ));
+        for (code, location) in [
+            (
+                "array-cardinality-validation-widened",
+                "#/$defs/LargeBound/minItems",
+            ),
+            (
+                "object-literal-validation-widened",
+                "#/$defs/NestedLiterals/enum/0/0",
+            ),
+            (
+                "numeric-validation-dropped",
+                "#/$defs/NestedLiterals/enum/0/0/sequence/0",
+            ),
+        ] {
+            assert!(package.losses.entries().iter().any(|entry| {
+                entry.code == code
+                    && entry
+                        .location
+                        .as_ref()
+                        .and_then(|value| value.subject.as_deref())
+                        == Some(location)
+            }));
+        }
     }
 }

--- a/crates/shapes/src/typescript.rs
+++ b/crates/shapes/src/typescript.rs
@@ -251,6 +251,7 @@ pub fn emit_typescript(
     }
 
     let type_names = definition_names(definitions)?;
+    validate_unguarded_reference_cycles(definitions)?;
     let (declaration, losses) = {
         let mut renderer = Renderer::new(&type_names);
         for (key, definition) in definitions {
@@ -277,6 +278,152 @@ pub fn emit_typescript(
         type_names,
         losses,
     })
+}
+
+fn validate_unguarded_reference_cycles(
+    definitions: &Map<String, Value>,
+) -> Result<(), TypeScriptError> {
+    let graph = definitions
+        .iter()
+        .map(|(key, definition)| {
+            let references = match unguarded_relation(definition) {
+                UnguardedRelation::Never | UnguardedRelation::Universal => BTreeSet::new(),
+                UnguardedRelation::Specific(references) => references,
+            };
+            (key.clone(), references)
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut active = Vec::new();
+    let mut complete = BTreeSet::new();
+    for key in definitions.keys() {
+        visit_unguarded_references(key, &graph, &mut active, &mut complete)?;
+    }
+    Ok(())
+}
+
+enum UnguardedRelation {
+    Never,
+    Universal,
+    Specific(BTreeSet<String>),
+}
+
+fn unguarded_relation(schema: &Value) -> UnguardedRelation {
+    let Value::Object(object) = schema else {
+        return if schema == &Value::Bool(false) {
+            UnguardedRelation::Never
+        } else {
+            UnguardedRelation::Universal
+        };
+    };
+
+    let mut conjuncts = Vec::new();
+    if object.contains_key("type") || has_object_shape(object) || has_array_shape(object) {
+        conjuncts.push(UnguardedRelation::Specific(BTreeSet::new()));
+    }
+    if let Some(reference) = object
+        .get("$ref")
+        .and_then(Value::as_str)
+        .and_then(reference_key)
+    {
+        conjuncts.push(UnguardedRelation::Specific(BTreeSet::from([reference])));
+    }
+    if let Some(values) = object.get("enum").and_then(Value::as_array) {
+        if values.is_empty() {
+            conjuncts.push(UnguardedRelation::Never);
+        } else {
+            conjuncts.push(UnguardedRelation::Specific(BTreeSet::new()));
+        }
+    }
+    if object.contains_key("const") {
+        conjuncts.push(UnguardedRelation::Specific(BTreeSet::new()));
+    }
+    if let Some(branches) = object.get("allOf").and_then(Value::as_array) {
+        conjuncts.push(join_unguarded_intersection(
+            branches.iter().map(unguarded_relation),
+        ));
+    }
+    for keyword in ["anyOf", "oneOf"] {
+        if let Some(branches) = object.get(keyword).and_then(Value::as_array) {
+            conjuncts.push(join_unguarded_union(
+                branches.iter().map(unguarded_relation),
+            ));
+        }
+    }
+    join_unguarded_intersection(conjuncts)
+}
+
+fn join_unguarded_union(
+    relations: impl IntoIterator<Item = UnguardedRelation>,
+) -> UnguardedRelation {
+    let mut references = BTreeSet::new();
+    let mut has_specific = false;
+    for relation in relations {
+        match relation {
+            UnguardedRelation::Never => {}
+            UnguardedRelation::Universal => return UnguardedRelation::Universal,
+            UnguardedRelation::Specific(current) => {
+                has_specific = true;
+                references.extend(current);
+            }
+        }
+    }
+    if has_specific {
+        UnguardedRelation::Specific(references)
+    } else {
+        UnguardedRelation::Never
+    }
+}
+
+fn join_unguarded_intersection(
+    relations: impl IntoIterator<Item = UnguardedRelation>,
+) -> UnguardedRelation {
+    let mut references = BTreeSet::new();
+    let mut has_specific = false;
+    for relation in relations {
+        match relation {
+            UnguardedRelation::Never => return UnguardedRelation::Never,
+            UnguardedRelation::Universal => {}
+            UnguardedRelation::Specific(current) => {
+                has_specific = true;
+                references.extend(current);
+            }
+        }
+    }
+    if has_specific {
+        UnguardedRelation::Specific(references)
+    } else {
+        UnguardedRelation::Universal
+    }
+}
+
+fn visit_unguarded_references(
+    key: &str,
+    graph: &BTreeMap<String, BTreeSet<String>>,
+    active: &mut Vec<String>,
+    complete: &mut BTreeSet<String>,
+) -> Result<(), TypeScriptError> {
+    if complete.contains(key) {
+        return Ok(());
+    }
+    if let Some(start) = active.iter().position(|candidate| candidate == key) {
+        let mut cycle = active[start..].to_vec();
+        cycle.push(key.to_owned());
+        return Err(TypeScriptError::new(format!(
+            "CompiledSchema contains an unguarded recursive TypeScript alias cycle: {}",
+            cycle.join(" -> ")
+        )));
+    }
+
+    active.push(key.to_owned());
+    if let Some(references) = graph.get(key) {
+        for reference in references {
+            visit_unguarded_references(reference, graph, active, complete)?;
+        }
+    }
+    let removed = active.pop();
+    debug_assert_eq!(removed.as_deref(), Some(key));
+    complete.insert(key.to_owned());
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -1935,11 +2082,66 @@ mod tests {
                 json!({ "$defs": { "Broken": { "$dynamicRef": "#/$defs/Broken" } } }),
                 "cannot be translated to a closed generated package",
             ),
+            (
+                json!({
+                    "$defs": {
+                        "Broken": {
+                            "$id": "nested.json",
+                            "$ref": "#/$defs/Target"
+                        },
+                        "Target": true
+                    }
+                }),
+                "$id cannot rebase a closed generated package",
+            ),
+            (
+                json!({ "$defs": { "Broken": { "$ref": "#/$defs/Broken" } } }),
+                "unguarded recursive TypeScript alias cycle: Broken -> Broken",
+            ),
+            (
+                json!({
+                    "$defs": {
+                        "Alpha": { "anyOf": [{ "$ref": "#/$defs/Beta" }] },
+                        "Beta": { "allOf": [{ "$ref": "#/$defs/Alpha" }] }
+                    }
+                }),
+                "unguarded recursive TypeScript alias cycle: Alpha -> Beta -> Alpha",
+            ),
         ] {
             let error = emit_typescript(&compiled(&schema), &config())
                 .expect_err("malformed schema must fail");
             assert!(error.to_string().contains(expected), "{error}");
         }
+    }
+
+    #[test]
+    fn reference_cycles_guarded_by_carriers_remain_supported() {
+        let schema = json!({
+            "$defs": {
+                "Alias": { "$ref": "#/$defs/Node" },
+                "Always": {
+                    "anyOf": [{ "$ref": "#/$defs/Always" }, true]
+                },
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "children": {
+                            "type": "array",
+                            "items": { "$ref": "#/$defs/Alias" }
+                        }
+                    }
+                },
+                "Bottom": {
+                    "allOf": [{ "$ref": "#/$defs/Bottom" }, false]
+                }
+            }
+        });
+        let package = emit_typescript(&compiled(&schema), &config()).expect("guarded cycle emits");
+        let source = declaration(&package);
+        assert!(source.contains("export type Alias = Node;"));
+        assert!(source.contains("export type Always = JsonValue;"));
+        assert!(source.contains("readonly \"children\"?: readonly (Alias)[];"));
+        assert!(source.contains("export type Bottom = never;"));
     }
 
     #[test]

--- a/crates/shapes/src/typescript.rs
+++ b/crates/shapes/src/typescript.rs
@@ -23,6 +23,7 @@
 //! source [`CompiledSchema`], retained by the caller alongside the reversible
 //! `$defs` key → exported type-name map.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt::{self, Write as _};
@@ -606,20 +607,19 @@ impl<'a> Renderer<'a> {
         depth: usize,
     ) -> Result<String, TypeScriptError> {
         ensure_depth(depth, path)?;
+        let empty = Map::new();
         let properties = object
             .get("properties")
             .and_then(Value::as_object)
-            .cloned()
-            .unwrap_or_default();
+            .unwrap_or(&empty);
         let required = required_names(object, path)?;
         let pattern_properties = object
             .get("patternProperties")
             .and_then(Value::as_object)
-            .cloned()
-            .unwrap_or_default();
+            .unwrap_or(&empty);
 
         let mut field_types = BTreeMap::new();
-        for (property, schema) in &properties {
+        for (property, schema) in properties {
             let property_path = format!("{path}/properties/{}", pointer_escape(property));
             field_types.insert(
                 property.clone(),
@@ -630,7 +630,7 @@ impl<'a> Renderer<'a> {
         for property in required.difference(&property_names) {
             field_types.insert(
                 property.clone(),
-                self.render_required_only_property(object, &pattern_properties, path, depth + 1)?,
+                self.render_required_only_property(object, pattern_properties, path, depth + 1)?,
             );
         }
 
@@ -652,7 +652,7 @@ impl<'a> Renderer<'a> {
         }
 
         let mut index_types = Vec::new();
-        for (pattern, schema) in &pattern_properties {
+        for (pattern, schema) in pattern_properties {
             index_types.push(self.render_schema(
                 schema,
                 &format!("{path}/patternProperties/{}", pointer_escape(pattern)),
@@ -1251,7 +1251,7 @@ fn validate_keyword_values(object: &Map<String, Value>, path: &str) -> Result<()
         for (property, names) in dependencies {
             let names = names.as_array().ok_or_else(|| {
                 TypeScriptError::new(format!(
-                    "{path}/dependentRequired/{}/ must be an array",
+                    "{path}/dependentRequired/{} must be an array",
                     pointer_escape(property)
                 ))
             })?;
@@ -1683,7 +1683,12 @@ fn normalize_prose(label: &str, value: &str) -> Result<String, TypeScriptError> 
 fn write_doc_comment(output: &mut String, depth: usize, text: &str, tag: Option<&str>) {
     let pad = indentation(depth);
     writeln!(output, "{pad}/**").expect("writing TypeScript to a String cannot fail");
-    for line in text.replace("*/", "* /").lines() {
+    let sanitized = if text.contains("*/") {
+        Cow::Owned(text.replace("*/", "* /"))
+    } else {
+        Cow::Borrowed(text)
+    };
+    for line in sanitized.lines() {
         if line.is_empty() {
             writeln!(output, "{pad} *").expect("writing TypeScript to a String cannot fail");
         } else {
@@ -2126,6 +2131,14 @@ mod tests {
             (
                 json!({ "$defs": { "Broken": { "required": [7] } } }),
                 "required/0 must be a string",
+            ),
+            (
+                json!({
+                    "$defs": {
+                        "Broken": { "dependentRequired": { "ex:value": true } }
+                    }
+                }),
+                "dependentRequired/ex:value must be an array",
             ),
             (
                 json!({ "$defs": { "Broken": { "anyOf": [] } } }),

--- a/crates/shapes/src/typescript.rs
+++ b/crates/shapes/src/typescript.rs
@@ -1,0 +1,1955 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Deterministic [`CompiledSchema`] → TypeScript 7.0 declaration emitter.
+//!
+//! This is a filesystem-free code generator. It consumes the validated JSON
+//! Schema `$defs` carried by [`CompiledSchema`] and returns one in-memory
+//! declaration package. Package identity and all human-facing package/module
+//! prose are caller configuration; PurRDF neither mints vocabulary nor embeds a
+//! downstream brand.
+//!
+//! The emitted dialect is interpreted under TypeScript 7.0 with `strict` and
+//! `exactOptionalPropertyTypes`. It uses type aliases because aliases preserve
+//! unions, intersections, tuples, literal values, and recursive JSON object
+//! compatibility without declaration merging. JSON Schema assertions outside
+//! that structural assignability relation are recorded at their JSON Pointer
+//! locations on [`TypeScriptPackage::losses`]. No output path uses `any`.
+//!
+//! An arbitrary TypeScript → JSON Schema reader is semantically undefined:
+//! conditional/generic/ambient TypeScript declarations have no unique runtime
+//! acceptance relation, and many distinct JSON Schemas intentionally project to
+//! the same declaration. The authoritative reverse surface is therefore the
+//! source [`CompiledSchema`], retained by the caller alongside the reversible
+//! `$defs` key → exported type-name map.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt::{self, Write as _};
+
+use ::purrdf::RdfLocation;
+use ::purrdf::loss::{LossEntry, LossLedger};
+use serde_json::{Map, Value};
+
+use crate::json_schema::CompiledSchema;
+use crate::schema_catalog::{
+    CompiledSchemaCatalog, definition_path, pointer_escape, reference_key, schema_array_keywords,
+    schema_map_keywords, schema_single_keywords,
+};
+
+/// Fixed loss-registry target and compiler-dialect identifier.
+pub const TYPESCRIPT_DIALECT: &str = "typescript-7.0";
+
+/// Relative path of the generated declaration artifact.
+pub const TYPESCRIPT_DECLARATION_PATH: &str = "index.d.ts";
+
+const LOSS_FROM: &str = "json-schema";
+const LOSS_CONTEXT: &str = "typescript-emitter";
+const MAX_SCHEMA_JSON_BYTES: usize = 16 * 1024 * 1024;
+const MAX_DECLARATION_BYTES: usize = 16 * 1024 * 1024;
+const MAX_DEFINITIONS: usize = 65_536;
+const MAX_SCHEMA_DEPTH: usize = 128;
+const MAX_TUPLE_EXPANSION: usize = 32;
+const RESERVED_TYPE_NAMES: &[&str] = &[
+    "Any",
+    "Array",
+    "BigInt",
+    "Boolean",
+    "Date",
+    "Function",
+    "JsonObject",
+    "JsonPrimitive",
+    "JsonValue",
+    "Map",
+    "Never",
+    "Null",
+    "Number",
+    "Object",
+    "Promise",
+    "ReadonlyArray",
+    "Record",
+    "Set",
+    "String",
+    "Symbol",
+    "Undefined",
+    "Unknown",
+];
+
+/// Caller-owned identity and prose for a generated TypeScript declaration
+/// package.
+///
+/// There is intentionally no [`Default`] implementation: package identity and
+/// documentation must be supplied by the caller.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeScriptConfig {
+    package_name: String,
+    package_docstring: String,
+    module_docstring: String,
+}
+
+impl TypeScriptConfig {
+    /// Validate and construct TypeScript emitter configuration.
+    ///
+    /// `package_name` accepts a conservative npm-compatible lowercase package
+    /// name, either unscoped (`example-types`) or scoped
+    /// (`@example/schema-types`). Both prose values must contain non-whitespace
+    /// caller text. CRLF and CR line endings are canonicalized to LF.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TypeScriptError`] for an invalid package name, blank prose, or
+    /// unsupported control characters.
+    pub fn new(
+        package_name: impl Into<String>,
+        package_docstring: impl Into<String>,
+        module_docstring: impl Into<String>,
+    ) -> Result<Self, TypeScriptError> {
+        let package_name = package_name.into();
+        if !is_package_name(&package_name) {
+            return Err(TypeScriptError::new(format!(
+                "TypeScript package name {package_name:?} is not a conservative lowercase npm \
+                 package name"
+            )));
+        }
+        let package_docstring = package_docstring.into();
+        let module_docstring = module_docstring.into();
+        let package_docstring = normalize_prose("package docstring", &package_docstring)?;
+        let module_docstring = normalize_prose("module docstring", &module_docstring)?;
+        Ok(Self {
+            package_name,
+            package_docstring,
+            module_docstring,
+        })
+    }
+
+    /// Caller-supplied package identifier.
+    #[must_use]
+    pub fn package_name(&self) -> &str {
+        &self.package_name
+    }
+
+    /// Caller-supplied package documentation.
+    #[must_use]
+    pub fn package_docstring(&self) -> &str {
+        &self.package_docstring
+    }
+
+    /// Caller-supplied declaration-module documentation.
+    #[must_use]
+    pub fn module_docstring(&self) -> &str {
+        &self.module_docstring
+    }
+}
+
+/// Deterministic generated declaration package and its projection losses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeScriptPackage {
+    /// Caller-owned package identifier copied from [`TypeScriptConfig`].
+    pub package_name: String,
+    /// Relative package paths → exact file bytes, sorted by path.
+    pub artifacts: BTreeMap<String, Vec<u8>>,
+    /// Source `$defs` key → exported TypeScript type name, sorted by key.
+    pub type_names: BTreeMap<String, String>,
+    /// JSON Schema assertions not represented exactly by TypeScript 7.0
+    /// assignability.
+    pub losses: LossLedger,
+}
+
+/// A malformed TypeScript configuration, input schema, or declaration graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeScriptError {
+    message: String,
+}
+
+impl TypeScriptError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for TypeScriptError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for TypeScriptError {}
+
+/// Emit deterministic TypeScript 7.0 declarations from one compiled
+/// SHACL-derived JSON Schema.
+///
+/// Source-stage losses remain on [`CompiledSchema::losses`]. The returned
+/// ledger describes only the `json-schema` → `typescript-7.0` projection.
+///
+/// # Errors
+///
+/// Returns [`TypeScriptError`] when the schema is malformed or too large, lacks
+/// a valid `$defs` catalog, contains an open/dangling reference, uses malformed
+/// keyword values, or has source keys that collide on a reserved/exported
+/// TypeScript name.
+pub fn emit_typescript(
+    compiled: &CompiledSchema,
+    config: &TypeScriptConfig,
+) -> Result<TypeScriptPackage, TypeScriptError> {
+    if compiled.schema_json.len() > MAX_SCHEMA_JSON_BYTES {
+        return Err(TypeScriptError::new(format!(
+            "CompiledSchema.schema_json exceeds the {MAX_SCHEMA_JSON_BYTES}-byte TypeScript \
+             emitter input limit"
+        )));
+    }
+    let catalog = CompiledSchemaCatalog::parse(compiled)
+        .map_err(|error| TypeScriptError::new(error.to_string()))?;
+    let definitions = catalog.definitions();
+    if definitions.len() > MAX_DEFINITIONS {
+        return Err(TypeScriptError::new(format!(
+            "CompiledSchema contains {} definitions; TypeScript emission is limited to \
+             {MAX_DEFINITIONS}",
+            definitions.len()
+        )));
+    }
+
+    let type_names = definition_names(definitions)?;
+    let (declaration, losses) = {
+        let mut renderer = Renderer::new(&type_names);
+        for (key, definition) in definitions {
+            renderer.audit_schema(definition, &definition_path(key), 0)?;
+        }
+        let declaration = renderer.render_document(config, definitions)?;
+        (declaration, renderer.ledger)
+    };
+    if declaration.len() > MAX_DECLARATION_BYTES {
+        return Err(TypeScriptError::new(format!(
+            "generated TypeScript declaration exceeds the {MAX_DECLARATION_BYTES}-byte output \
+             limit"
+        )));
+    }
+
+    let mut artifacts = BTreeMap::new();
+    artifacts.insert(
+        TYPESCRIPT_DECLARATION_PATH.to_owned(),
+        declaration.into_bytes(),
+    );
+    Ok(TypeScriptPackage {
+        package_name: config.package_name.clone(),
+        artifacts,
+        type_names,
+        losses,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum JsonKind {
+    Null,
+    Boolean,
+    Number,
+    String,
+    Array,
+    Object,
+}
+
+struct Renderer<'a> {
+    names: &'a BTreeMap<String, String>,
+    ledger: LossLedger,
+    recorded_losses: BTreeSet<(String, String)>,
+}
+
+impl<'a> Renderer<'a> {
+    fn new(names: &'a BTreeMap<String, String>) -> Self {
+        Self {
+            names,
+            ledger: LossLedger::new(),
+            recorded_losses: BTreeSet::new(),
+        }
+    }
+
+    fn render_document(
+        &mut self,
+        config: &TypeScriptConfig,
+        definitions: &Map<String, Value>,
+    ) -> Result<String, TypeScriptError> {
+        let mut output = String::new();
+        let header = format!(
+            "{}\n\n{}\n\nPackage: {}",
+            config.package_docstring, config.module_docstring, config.package_name
+        );
+        write_doc_comment(&mut output, 0, &header, Some("@packageDocumentation"));
+        output.push_str("export type JsonPrimitive = string | number | boolean | null;\n");
+        output.push_str("export type JsonObject = { readonly [key: string]: JsonValue };\n");
+        output.push_str(
+            "export type JsonValue = JsonPrimitive | JsonObject | readonly JsonValue[];\n\n",
+        );
+
+        for (key, definition) in definitions {
+            let name = self
+                .names
+                .get(key)
+                .expect("definition_names covers every validated definition");
+            if let Some(description) = schema_doc(definition)? {
+                write_doc_comment(&mut output, 0, description, None);
+            }
+            let expression = self.render_schema(definition, &definition_path(key), 0)?;
+            writeln!(output, "export type {name} = {expression};\n")
+                .expect("writing TypeScript to a String cannot fail");
+        }
+        Ok(finish_text(output))
+    }
+
+    fn render_schema(
+        &mut self,
+        schema: &Value,
+        path: &str,
+        depth: usize,
+    ) -> Result<String, TypeScriptError> {
+        ensure_depth(depth, path)?;
+        match schema {
+            Value::Bool(true) => Ok("JsonValue".to_owned()),
+            Value::Bool(false) => Ok("never".to_owned()),
+            Value::Object(object) => {
+                let mut conjuncts = Vec::new();
+                if let Some(carrier) = self.render_carrier_relation(object, path, depth)? {
+                    conjuncts.push(carrier);
+                }
+                if let Some(reference) = object.get("$ref") {
+                    let reference = reference.as_str().ok_or_else(|| {
+                        TypeScriptError::new(format!("{path}/$ref must be a string"))
+                    })?;
+                    let key = reference_key(reference).ok_or_else(|| {
+                        TypeScriptError::new(format!(
+                            "{path}/$ref is not a direct #/$defs reference"
+                        ))
+                    })?;
+                    let name = self.names.get(&key).ok_or_else(|| {
+                        TypeScriptError::new(format!(
+                            "{path}/$ref targets missing $defs key {key:?}"
+                        ))
+                    })?;
+                    conjuncts.push(name.clone());
+                }
+                if let Some(values) = object.get("enum").and_then(Value::as_array) {
+                    let mut variants = Vec::with_capacity(values.len());
+                    for (index, value) in values.iter().enumerate() {
+                        variants.push(Self::render_literal(
+                            value,
+                            &format!("{path}/enum/{index}"),
+                            depth + 1,
+                        )?);
+                    }
+                    conjuncts.push(join_union(variants));
+                }
+                if let Some(value) = object.get("const") {
+                    conjuncts.push(Self::render_literal(
+                        value,
+                        &format!("{path}/const"),
+                        depth + 1,
+                    )?);
+                }
+                if let Some(branches) = object.get("allOf").and_then(Value::as_array) {
+                    let mut expressions = Vec::with_capacity(branches.len());
+                    for (index, branch) in branches.iter().enumerate() {
+                        expressions.push(self.render_schema(
+                            branch,
+                            &format!("{path}/allOf/{index}"),
+                            depth + 1,
+                        )?);
+                    }
+                    conjuncts.push(join_intersection(expressions));
+                }
+                for keyword in ["anyOf", "oneOf"] {
+                    if let Some(branches) = object.get(keyword).and_then(Value::as_array) {
+                        let mut expressions = Vec::with_capacity(branches.len());
+                        for (index, branch) in branches.iter().enumerate() {
+                            expressions.push(self.render_schema(
+                                branch,
+                                &format!("{path}/{keyword}/{index}"),
+                                depth + 1,
+                            )?);
+                        }
+                        conjuncts.push(join_union(expressions));
+                    }
+                }
+                Ok(join_intersection(conjuncts))
+            }
+            _ => Err(TypeScriptError::new(format!(
+                "{path} must be a JSON Schema object or boolean"
+            ))),
+        }
+    }
+
+    fn render_carrier_relation(
+        &mut self,
+        object: &Map<String, Value>,
+        path: &str,
+        depth: usize,
+    ) -> Result<Option<String>, TypeScriptError> {
+        let explicit_type = object.contains_key("type");
+        let object_shape = has_object_shape(object);
+        let array_shape = has_array_shape(object);
+        if !explicit_type && !object_shape && !array_shape {
+            return Ok(None);
+        }
+
+        let (kinds, _, _) = declared_kinds(object, path)?;
+        let mut variants = Vec::with_capacity(kinds.len());
+        for kind in kinds {
+            let expression = match kind {
+                JsonKind::Null => "null".to_owned(),
+                JsonKind::Boolean => "boolean".to_owned(),
+                JsonKind::Number => "number".to_owned(),
+                JsonKind::String => "string".to_owned(),
+                JsonKind::Array if explicit_type || array_shape => {
+                    self.render_array(object, path, depth + 1)?
+                }
+                JsonKind::Array => "readonly JsonValue[]".to_owned(),
+                JsonKind::Object if explicit_type || object_shape => {
+                    self.render_object(object, path, depth + 1)?
+                }
+                JsonKind::Object => "JsonObject".to_owned(),
+            };
+            variants.push(expression);
+        }
+        Ok(Some(join_union(variants)))
+    }
+
+    fn render_object(
+        &mut self,
+        object: &Map<String, Value>,
+        path: &str,
+        depth: usize,
+    ) -> Result<String, TypeScriptError> {
+        ensure_depth(depth, path)?;
+        let properties = object
+            .get("properties")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        let required = required_names(object, path)?;
+        let pattern_properties = object
+            .get("patternProperties")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+
+        let mut field_types = BTreeMap::new();
+        for (property, schema) in &properties {
+            let property_path = format!("{path}/properties/{}", pointer_escape(property));
+            field_types.insert(
+                property.clone(),
+                self.render_schema(schema, &property_path, depth + 1)?,
+            );
+        }
+        let property_names: BTreeSet<String> = properties.keys().cloned().collect();
+        for property in required.difference(&property_names) {
+            field_types.insert(
+                property.clone(),
+                self.render_required_only_property(object, &pattern_properties, path, depth + 1)?,
+            );
+        }
+
+        let mut output = String::from("{\n");
+        let field_indent = indentation(depth);
+        for (property, field_type) in &field_types {
+            if let Some(schema) = properties.get(property)
+                && let Some(description) = schema_doc(schema)?
+            {
+                write_doc_comment(&mut output, depth, description, None);
+            }
+            let optional = if required.contains(property) { "" } else { "?" };
+            writeln!(
+                output,
+                "{field_indent}readonly {}{optional}: {field_type};",
+                json_string(property)
+            )
+            .expect("writing TypeScript to a String cannot fail");
+        }
+
+        let mut index_types = Vec::new();
+        for (pattern, schema) in &pattern_properties {
+            index_types.push(self.render_schema(
+                schema,
+                &format!("{path}/patternProperties/{}", pointer_escape(pattern)),
+                depth + 1,
+            )?);
+        }
+        match object.get("additionalProperties") {
+            None | Some(Value::Bool(true)) => index_types.push("JsonValue".to_owned()),
+            Some(Value::Bool(false)) => {}
+            Some(schema @ Value::Object(_)) => index_types.push(self.render_schema(
+                schema,
+                &format!("{path}/additionalProperties"),
+                depth + 1,
+            )?),
+            Some(_) => unreachable!("schema catalog validates additionalProperties schemas"),
+        }
+        if !index_types.is_empty() {
+            index_types.extend(field_types.values().cloned());
+            writeln!(
+                output,
+                "{field_indent}readonly [key: string]: {};",
+                join_union(index_types)
+            )
+            .expect("writing TypeScript to a String cannot fail");
+        } else if field_types.is_empty() {
+            writeln!(output, "{field_indent}readonly [key: string]: never;")
+                .expect("writing TypeScript to a String cannot fail");
+        }
+        write!(output, "{}}}", indentation(depth.saturating_sub(1)))
+            .expect("writing TypeScript to a String cannot fail");
+        Ok(output)
+    }
+
+    fn render_required_only_property(
+        &mut self,
+        object: &Map<String, Value>,
+        patterns: &Map<String, Value>,
+        path: &str,
+        depth: usize,
+    ) -> Result<String, TypeScriptError> {
+        let mut variants = Vec::new();
+        for (pattern, schema) in patterns {
+            variants.push(self.render_schema(
+                schema,
+                &format!("{path}/patternProperties/{}", pointer_escape(pattern)),
+                depth + 1,
+            )?);
+        }
+        match object.get("additionalProperties") {
+            None | Some(Value::Bool(true)) => variants.push("JsonValue".to_owned()),
+            Some(Value::Bool(false)) => {}
+            Some(schema @ Value::Object(_)) => variants.push(self.render_schema(
+                schema,
+                &format!("{path}/additionalProperties"),
+                depth + 1,
+            )?),
+            Some(_) => unreachable!("schema catalog validates additionalProperties schemas"),
+        }
+        if variants.is_empty() {
+            Ok("never".to_owned())
+        } else {
+            Ok(join_union(variants))
+        }
+    }
+
+    fn render_array(
+        &mut self,
+        object: &Map<String, Value>,
+        path: &str,
+        depth: usize,
+    ) -> Result<String, TypeScriptError> {
+        ensure_depth(depth, path)?;
+        let mut prefix = Vec::new();
+        if let Some(items) = object.get("prefixItems").and_then(Value::as_array) {
+            prefix.reserve(items.len());
+            for (index, item) in items.iter().enumerate() {
+                prefix.push(self.render_schema(
+                    item,
+                    &format!("{path}/prefixItems/{index}"),
+                    depth + 1,
+                )?);
+            }
+        }
+        let mut rest = match object.get("items") {
+            None | Some(Value::Bool(true)) => "JsonValue".to_owned(),
+            Some(Value::Bool(false)) => "never".to_owned(),
+            Some(schema @ Value::Object(_)) => {
+                self.render_schema(schema, &format!("{path}/items"), depth + 1)?
+            }
+            Some(_) => unreachable!("schema catalog validates items schemas"),
+        };
+        let mut min_items = array_bound(object, "minItems", path)?.unwrap_or(0);
+        let mut max_items = array_bound(object, "maxItems", path)?;
+        let has_explicit_max = max_items.is_some();
+
+        if rest == "never" {
+            max_items = Some(max_items.map_or(prefix.len(), |value| value.min(prefix.len())));
+        }
+        if prefix.len().saturating_add(1) > MAX_TUPLE_EXPANSION {
+            self.record(
+                "tuple-array-validation-widened",
+                &format!("{path}/prefixItems"),
+                "The prefixItems tuple exceeds the fixed TypeScript declaration expansion budget",
+            );
+            let mut common = prefix;
+            if rest != "never" {
+                common.push(rest);
+            }
+            rest = join_union(common);
+            prefix = Vec::new();
+            if !has_explicit_max {
+                max_items = None;
+            }
+        }
+        if min_items > MAX_TUPLE_EXPANSION {
+            self.record(
+                "array-cardinality-validation-widened",
+                &format!("{path}/minItems"),
+                "minItems exceeds the fixed TypeScript tuple expansion budget",
+            );
+            min_items = 0;
+        }
+        if max_items.is_some_and(|maximum| maximum > MAX_TUPLE_EXPANSION) {
+            self.record(
+                "array-cardinality-validation-widened",
+                &format!("{path}/maxItems"),
+                "maxItems exceeds the fixed TypeScript tuple expansion budget",
+            );
+            max_items = None;
+        }
+        if let Some(maximum) = max_items
+            && maximum >= min_items
+            && maximum - min_items + 1 > MAX_TUPLE_EXPANSION
+        {
+            self.record(
+                "array-cardinality-validation-widened",
+                &format!("{path}/maxItems"),
+                "the minItems/maxItems interval exceeds the fixed TypeScript tuple union budget",
+            );
+            max_items = None;
+        }
+
+        render_array_relation(&prefix, &rest, min_items, max_items)
+    }
+
+    fn render_literal(value: &Value, path: &str, depth: usize) -> Result<String, TypeScriptError> {
+        ensure_depth(depth, path)?;
+        match value {
+            Value::Null => Ok("null".to_owned()),
+            Value::Bool(value) => Ok(value.to_string()),
+            Value::Number(value) => Ok(value.to_string()),
+            Value::String(value) => Ok(json_string(value)),
+            Value::Array(values) => {
+                let mut items = Vec::with_capacity(values.len());
+                for (index, value) in values.iter().enumerate() {
+                    items.push(Self::render_literal(
+                        value,
+                        &format!("{path}/{index}"),
+                        depth + 1,
+                    )?);
+                }
+                Ok(render_tuple(&items))
+            }
+            Value::Object(object) => {
+                let mut output = String::from("{\n");
+                let field_indent = indentation(depth + 1);
+                for (key, value) in object {
+                    let value = Self::render_literal(
+                        value,
+                        &format!("{path}/{}", pointer_escape(key)),
+                        depth + 1,
+                    )?;
+                    writeln!(
+                        output,
+                        "{field_indent}readonly {}: {value};",
+                        json_string(key)
+                    )
+                    .expect("writing TypeScript to a String cannot fail");
+                }
+                write!(output, "{}}}", indentation(depth))
+                    .expect("writing TypeScript to a String cannot fail");
+                Ok(output)
+            }
+        }
+    }
+
+    fn audit_schema(
+        &mut self,
+        schema: &Value,
+        path: &str,
+        depth: usize,
+    ) -> Result<(), TypeScriptError> {
+        ensure_depth(depth, path)?;
+        let Value::Object(object) = schema else {
+            return if schema.is_boolean() {
+                Ok(())
+            } else {
+                Err(TypeScriptError::new(format!(
+                    "{path} must be a JSON Schema object or boolean"
+                )))
+            };
+        };
+        validate_keyword_values(object, path)?;
+        let (kinds, has_integer, has_number) = declared_kinds(object, path)?;
+        let has_kind = |kind| kinds.contains(&kind);
+
+        if has_integer && !has_number {
+            self.record(
+                "integer-validation-widened",
+                &format!("{path}/type"),
+                "TypeScript number cannot enforce the JSON integer subset",
+            );
+        }
+        if has_kind(JsonKind::Object) {
+            let properties = object
+                .get("properties")
+                .and_then(Value::as_object)
+                .map_or(0, Map::len);
+            let required = required_names(object, path)?.len();
+            if matches!(object.get("additionalProperties"), Some(Value::Bool(false)))
+                && properties + required > 0
+            {
+                self.record(
+                    "additional-properties-validation-widened",
+                    &format!("{path}/additionalProperties"),
+                    "TypeScript structural compatibility cannot close an object with named fields",
+                );
+            } else if matches!(object.get("additionalProperties"), Some(Value::Object(_)))
+                && properties + required > 0
+            {
+                self.record(
+                    "additional-properties-validation-widened",
+                    &format!("{path}/additionalProperties"),
+                    "a TypeScript string index signature also constrains named fields",
+                );
+            }
+            if let Some(patterns) = object.get("patternProperties").and_then(Value::as_object) {
+                for pattern in patterns.keys() {
+                    self.record(
+                        "pattern-properties-validation-dropped",
+                        &format!("{path}/patternProperties/{}", pointer_escape(pattern)),
+                        "TypeScript cannot select arbitrary string keys with a JSON Schema regex",
+                    );
+                }
+            }
+            for keyword in ["minProperties", "maxProperties"] {
+                if object.contains_key(keyword) {
+                    self.record(
+                        "property-count-validation-dropped",
+                        &format!("{path}/{keyword}"),
+                        "TypeScript cannot count runtime object properties",
+                    );
+                }
+            }
+            if object.contains_key("propertyNames") {
+                self.record(
+                    "property-name-validation-dropped",
+                    &format!("{path}/propertyNames"),
+                    "TypeScript cannot apply a schema to every runtime property name",
+                );
+            }
+            for keyword in ["dependentRequired", "dependentSchemas"] {
+                if object.contains_key(keyword) {
+                    self.record(
+                        "dependency-validation-dropped",
+                        &format!("{path}/{keyword}"),
+                        "TypeScript cannot enforce a general cross-property dependency",
+                    );
+                }
+            }
+        }
+        if has_kind(JsonKind::Array) {
+            for keyword in ["contains", "minContains", "maxContains"] {
+                if object.contains_key(keyword) {
+                    self.record(
+                        "array-contains-validation-dropped",
+                        &format!("{path}/{keyword}"),
+                        "TypeScript cannot quantify elements matching an array predicate",
+                    );
+                }
+            }
+            if object.get("uniqueItems") == Some(&Value::Bool(true)) {
+                self.record(
+                    "unique-items-validation-dropped",
+                    &format!("{path}/uniqueItems"),
+                    "TypeScript cannot require pairwise-distinct runtime array values",
+                );
+            }
+        }
+        if has_kind(JsonKind::Number) {
+            for keyword in [
+                "minimum",
+                "maximum",
+                "exclusiveMinimum",
+                "exclusiveMaximum",
+                "multipleOf",
+            ] {
+                if object.contains_key(keyword) {
+                    self.record(
+                        "numeric-validation-dropped",
+                        &format!("{path}/{keyword}"),
+                        "TypeScript number types do not express runtime numeric predicates",
+                    );
+                }
+            }
+        }
+        if has_kind(JsonKind::String) {
+            for keyword in [
+                "minLength",
+                "maxLength",
+                "pattern",
+                "format",
+                "contentEncoding",
+                "contentMediaType",
+                "contentSchema",
+            ] {
+                if object.contains_key(keyword) {
+                    self.record(
+                        "string-validation-dropped",
+                        &format!("{path}/{keyword}"),
+                        "TypeScript string types do not express this runtime string predicate",
+                    );
+                }
+            }
+        }
+        if object.contains_key("oneOf") {
+            self.record(
+                "one-of-validation-widened",
+                &format!("{path}/oneOf"),
+                "TypeScript unions cannot enforce exactly-one matching branch",
+            );
+        }
+        if object.contains_key("not") {
+            self.record(
+                "negation-validation-dropped",
+                &format!("{path}/not"),
+                "TypeScript has no general JSON value-set complement",
+            );
+        }
+        if object.contains_key("if") {
+            for keyword in ["if", "then", "else"] {
+                if object.contains_key(keyword) {
+                    self.record(
+                        "conditional-validation-dropped",
+                        &format!("{path}/{keyword}"),
+                        "TypeScript cannot apply a schema branch conditionally to runtime content",
+                    );
+                }
+            }
+        }
+        for keyword in ["unevaluatedItems", "unevaluatedProperties"] {
+            if object.contains_key(keyword) {
+                self.record(
+                    "unevaluated-validation-dropped",
+                    &format!("{path}/{keyword}"),
+                    "TypeScript does not expose JSON Schema applicator evaluation state",
+                );
+            }
+        }
+        if object.get("const").is_some_and(Value::is_object) {
+            self.record(
+                "object-literal-validation-widened",
+                &format!("{path}/const"),
+                "TypeScript object literal types cannot close structural compatibility",
+            );
+        }
+        if let Some(values) = object.get("enum").and_then(Value::as_array) {
+            for (index, value) in values.iter().enumerate() {
+                if value.is_object() {
+                    self.record(
+                        "object-literal-validation-widened",
+                        &format!("{path}/enum/{index}"),
+                        "TypeScript object literal types cannot close structural compatibility",
+                    );
+                }
+            }
+        }
+        if object.contains_key("additionalItems") {
+            self.record(
+                "keyword-validation-dropped",
+                &format!("{path}/additionalItems"),
+                "additionalItems is outside the closed draft 2020-12 TypeScript capability table",
+            );
+        }
+        for key in object.keys() {
+            if !known_schema_keyword(key) && !is_annotation_keyword(key) {
+                self.record(
+                    "keyword-validation-dropped",
+                    &format!("{path}/{}", pointer_escape(key)),
+                    &format!(
+                        "JSON Schema assertion keyword {key:?} is outside the closed TypeScript \
+                         7.0 capability table"
+                    ),
+                );
+            }
+        }
+
+        for keyword in schema_map_keywords() {
+            if let Some(children) = object.get(*keyword).and_then(Value::as_object) {
+                for (key, child) in children {
+                    self.audit_schema(
+                        child,
+                        &format!("{path}/{keyword}/{}", pointer_escape(key)),
+                        depth + 1,
+                    )?;
+                }
+            }
+        }
+        for keyword in schema_array_keywords() {
+            if let Some(children) = object.get(*keyword).and_then(Value::as_array) {
+                for (index, child) in children.iter().enumerate() {
+                    self.audit_schema(child, &format!("{path}/{keyword}/{index}"), depth + 1)?;
+                }
+            }
+        }
+        for keyword in schema_single_keywords() {
+            if let Some(child) = object.get(*keyword) {
+                self.audit_schema(child, &format!("{path}/{keyword}"), depth + 1)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn record(&mut self, code: &str, path: &str, note: &str) {
+        if !self
+            .recorded_losses
+            .insert((code.to_owned(), path.to_owned()))
+        {
+            return;
+        }
+        self.ledger.record(LossEntry {
+            code: code.to_owned().into(),
+            from: LOSS_FROM.into(),
+            to: TYPESCRIPT_DIALECT.into(),
+            note: note.to_owned().into(),
+            location: Some(Box::new(
+                RdfLocation::logical(LOSS_CONTEXT).with_subject(path),
+            )),
+        });
+    }
+}
+
+fn definition_names(
+    definitions: &Map<String, Value>,
+) -> Result<BTreeMap<String, String>, TypeScriptError> {
+    let mut names = BTreeMap::new();
+    let mut reverse = BTreeMap::<String, String>::new();
+    for key in definitions.keys() {
+        let name = typescript_type_name(key, "SchemaType");
+        if RESERVED_TYPE_NAMES.binary_search(&name.as_str()).is_ok() || is_typescript_keyword(&name)
+        {
+            return Err(TypeScriptError::new(format!(
+                "$defs key {key:?} normalizes to reserved TypeScript type name {name:?}"
+            )));
+        }
+        if let Some(previous) = reverse.insert(name.clone(), key.clone()) {
+            return Err(TypeScriptError::new(format!(
+                "$defs keys {previous:?} and {key:?} collide on TypeScript type name {name:?}"
+            )));
+        }
+        names.insert(key.clone(), name);
+    }
+    Ok(names)
+}
+
+fn validate_keyword_values(object: &Map<String, Value>, path: &str) -> Result<(), TypeScriptError> {
+    let _ = declared_kinds(object, path)?;
+    if let Some(value) = object.get("enum") {
+        let values = value
+            .as_array()
+            .ok_or_else(|| TypeScriptError::new(format!("{path}/enum must be an array")))?;
+        let mut seen = BTreeSet::new();
+        for (index, value) in values.iter().enumerate() {
+            let key = serde_json::to_string(value).map_err(|error| {
+                TypeScriptError::new(format!("cannot inspect {path}/enum/{index}: {error}"))
+            })?;
+            if !seen.insert(key) {
+                return Err(TypeScriptError::new(format!(
+                    "{path}/enum repeats value at index {index}"
+                )));
+            }
+        }
+    }
+    for keyword in ["allOf", "anyOf", "oneOf"] {
+        if object
+            .get(keyword)
+            .and_then(Value::as_array)
+            .is_some_and(Vec::is_empty)
+        {
+            return Err(TypeScriptError::new(format!(
+                "{path}/{keyword} cannot be empty"
+            )));
+        }
+    }
+    for keyword in [
+        "title",
+        "description",
+        "pattern",
+        "format",
+        "contentEncoding",
+        "contentMediaType",
+    ] {
+        if object.get(keyword).is_some_and(|value| !value.is_string()) {
+            return Err(TypeScriptError::new(format!(
+                "{path}/{keyword} must be a string"
+            )));
+        }
+    }
+    for keyword in [
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+    ] {
+        if object.get(keyword).is_some_and(|value| !value.is_number()) {
+            return Err(TypeScriptError::new(format!(
+                "{path}/{keyword} must be a number"
+            )));
+        }
+    }
+    if object
+        .get("multipleOf")
+        .and_then(Value::as_f64)
+        .is_some_and(|value| value <= 0.0)
+    {
+        return Err(TypeScriptError::new(format!(
+            "{path}/multipleOf must be greater than zero"
+        )));
+    }
+    for keyword in [
+        "minLength",
+        "maxLength",
+        "minItems",
+        "maxItems",
+        "minContains",
+        "maxContains",
+        "minProperties",
+        "maxProperties",
+    ] {
+        if object.contains_key(keyword) {
+            let _ = nonnegative_usize(object, keyword, path)?;
+        }
+    }
+    for keyword in ["uniqueItems", "deprecated", "readOnly", "writeOnly"] {
+        if object.get(keyword).is_some_and(|value| !value.is_boolean()) {
+            return Err(TypeScriptError::new(format!(
+                "{path}/{keyword} must be a boolean"
+            )));
+        }
+    }
+    let _ = required_names(object, path)?;
+    if let Some(dependencies) = object.get("dependentRequired") {
+        let dependencies = dependencies.as_object().ok_or_else(|| {
+            TypeScriptError::new(format!("{path}/dependentRequired must be an object"))
+        })?;
+        for (property, names) in dependencies {
+            let names = names.as_array().ok_or_else(|| {
+                TypeScriptError::new(format!(
+                    "{path}/dependentRequired/{}/ must be an array",
+                    pointer_escape(property)
+                ))
+            })?;
+            let mut seen = BTreeSet::new();
+            for (index, name) in names.iter().enumerate() {
+                let name = name.as_str().ok_or_else(|| {
+                    TypeScriptError::new(format!(
+                        "{path}/dependentRequired/{}/{index} must be a string",
+                        pointer_escape(property)
+                    ))
+                })?;
+                if !seen.insert(name) {
+                    return Err(TypeScriptError::new(format!(
+                        "{path}/dependentRequired/{} repeats property {name:?}",
+                        pointer_escape(property)
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn declared_kinds(
+    object: &Map<String, Value>,
+    path: &str,
+) -> Result<(BTreeSet<JsonKind>, bool, bool), TypeScriptError> {
+    let mut kinds = BTreeSet::new();
+    let mut has_integer = false;
+    let mut has_number = false;
+    let values: Vec<(&str, String)> = match object.get("type") {
+        None => {
+            kinds.extend([
+                JsonKind::Null,
+                JsonKind::Boolean,
+                JsonKind::Number,
+                JsonKind::String,
+                JsonKind::Array,
+                JsonKind::Object,
+            ]);
+            return Ok((kinds, false, true));
+        }
+        Some(Value::String(kind)) => vec![(kind, format!("{path}/type"))],
+        Some(Value::Array(values)) if !values.is_empty() => values
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                value
+                    .as_str()
+                    .map(|kind| (kind, format!("{path}/type/{index}")))
+                    .ok_or_else(|| {
+                        TypeScriptError::new(format!("{path}/type/{index} must be a string"))
+                    })
+            })
+            .collect::<Result<_, _>>()?,
+        Some(Value::Array(_)) => {
+            return Err(TypeScriptError::new(format!(
+                "{path}/type array cannot be empty"
+            )));
+        }
+        Some(_) => {
+            return Err(TypeScriptError::new(format!(
+                "{path}/type must be a string or non-empty array of strings"
+            )));
+        }
+    };
+    let mut seen = BTreeSet::new();
+    for (kind, kind_path) in values {
+        if !seen.insert(kind) {
+            return Err(TypeScriptError::new(format!(
+                "{path}/type repeats type {kind:?}"
+            )));
+        }
+        match kind {
+            "null" => {
+                kinds.insert(JsonKind::Null);
+            }
+            "boolean" => {
+                kinds.insert(JsonKind::Boolean);
+            }
+            "number" => {
+                has_number = true;
+                kinds.insert(JsonKind::Number);
+            }
+            "integer" => {
+                has_integer = true;
+                kinds.insert(JsonKind::Number);
+            }
+            "string" => {
+                kinds.insert(JsonKind::String);
+            }
+            "array" => {
+                kinds.insert(JsonKind::Array);
+            }
+            "object" => {
+                kinds.insert(JsonKind::Object);
+            }
+            _ => {
+                return Err(TypeScriptError::new(format!(
+                    "{kind_path} names unsupported JSON Schema type {kind:?}"
+                )));
+            }
+        }
+    }
+    Ok((kinds, has_integer, has_number))
+}
+
+fn required_names(
+    object: &Map<String, Value>,
+    path: &str,
+) -> Result<BTreeSet<String>, TypeScriptError> {
+    let Some(value) = object.get("required") else {
+        return Ok(BTreeSet::new());
+    };
+    let values = value
+        .as_array()
+        .ok_or_else(|| TypeScriptError::new(format!("{path}/required must be an array")))?;
+    let mut required = BTreeSet::new();
+    for (index, value) in values.iter().enumerate() {
+        let name = value.as_str().ok_or_else(|| {
+            TypeScriptError::new(format!("{path}/required/{index} must be a string"))
+        })?;
+        if !required.insert(name.to_owned()) {
+            return Err(TypeScriptError::new(format!(
+                "{path}/required repeats property {name:?}"
+            )));
+        }
+    }
+    Ok(required)
+}
+
+fn array_bound(
+    object: &Map<String, Value>,
+    keyword: &str,
+    path: &str,
+) -> Result<Option<usize>, TypeScriptError> {
+    object
+        .contains_key(keyword)
+        .then(|| nonnegative_usize(object, keyword, path))
+        .transpose()
+}
+
+fn nonnegative_usize(
+    object: &Map<String, Value>,
+    keyword: &str,
+    path: &str,
+) -> Result<usize, TypeScriptError> {
+    let value = object.get(keyword).and_then(Value::as_u64).ok_or_else(|| {
+        TypeScriptError::new(format!("{path}/{keyword} must be a non-negative integer"))
+    })?;
+    usize::try_from(value).map_err(|_| {
+        TypeScriptError::new(format!(
+            "{path}/{keyword} exceeds this platform's index range"
+        ))
+    })
+}
+
+fn render_array_relation(
+    prefix: &[String],
+    rest: &str,
+    min_items: usize,
+    max_items: Option<usize>,
+) -> Result<String, TypeScriptError> {
+    if max_items.is_some_and(|maximum| maximum < min_items) {
+        return Ok("never".to_owned());
+    }
+    if let Some(maximum) = max_items {
+        let mut variants = Vec::with_capacity(maximum - min_items + 1);
+        for length in min_items..=maximum {
+            if length > prefix.len() && rest == "never" {
+                continue;
+            }
+            variants.push(render_tuple_for_length(prefix, rest, length));
+        }
+        return Ok(join_union(variants));
+    }
+    if prefix.is_empty() && min_items == 0 {
+        return Ok(format!("readonly ({rest})[]"));
+    }
+    if rest == "never" {
+        let mut variants = Vec::new();
+        for length in min_items..=prefix.len() {
+            variants.push(render_tuple_for_length(prefix, rest, length));
+        }
+        return Ok(join_union(variants));
+    }
+
+    let threshold = prefix.len().max(min_items);
+    let mut variants = Vec::new();
+    for length in min_items..threshold {
+        variants.push(render_tuple_for_length(prefix, rest, length));
+    }
+    if threshold == 0 {
+        variants.push(format!("readonly ({rest})[]"));
+    } else {
+        let mut head = Vec::with_capacity(threshold);
+        for index in 0..threshold {
+            head.push(
+                prefix
+                    .get(index)
+                    .cloned()
+                    .unwrap_or_else(|| rest.to_owned()),
+            );
+        }
+        variants.push(render_tuple_with_rest(&head, rest));
+    }
+    Ok(join_union(variants))
+}
+
+fn render_tuple_for_length(prefix: &[String], rest: &str, length: usize) -> String {
+    let mut items = Vec::with_capacity(length);
+    for index in 0..length {
+        items.push(
+            prefix
+                .get(index)
+                .cloned()
+                .unwrap_or_else(|| rest.to_owned()),
+        );
+    }
+    render_tuple(&items)
+}
+
+fn render_tuple(items: &[String]) -> String {
+    if items.is_empty() {
+        "readonly []".to_owned()
+    } else {
+        format!("readonly [{}]", items.join(", "))
+    }
+}
+
+fn render_tuple_with_rest(head: &[String], rest: &str) -> String {
+    let mut parts = head.to_vec();
+    parts.push(format!("...Array<{rest}>"));
+    format!("readonly [{}]", parts.join(", "))
+}
+
+fn join_union(expressions: Vec<String>) -> String {
+    let mut unique = Vec::new();
+    let mut seen = BTreeSet::new();
+    for expression in expressions {
+        if expression == "never" {
+            continue;
+        }
+        if expression == "JsonValue" {
+            return "JsonValue".to_owned();
+        }
+        if seen.insert(expression.clone()) {
+            unique.push(expression);
+        }
+    }
+    match unique.len() {
+        0 => "never".to_owned(),
+        1 => unique.pop().expect("length checked"),
+        _ => format!("({})", unique.join(" | ")),
+    }
+}
+
+fn join_intersection(expressions: Vec<String>) -> String {
+    let mut unique = Vec::new();
+    let mut seen = BTreeSet::new();
+    for expression in expressions {
+        if expression == "never" {
+            return "never".to_owned();
+        }
+        if expression == "JsonValue" {
+            continue;
+        }
+        if seen.insert(expression.clone()) {
+            unique.push(expression);
+        }
+    }
+    match unique.len() {
+        0 => "JsonValue".to_owned(),
+        1 => unique.pop().expect("length checked"),
+        _ => format!("({})", unique.join(" & ")),
+    }
+}
+
+fn has_object_shape(object: &Map<String, Value>) -> bool {
+    [
+        "properties",
+        "required",
+        "patternProperties",
+        "additionalProperties",
+    ]
+    .iter()
+    .any(|keyword| object.contains_key(*keyword))
+}
+
+fn has_array_shape(object: &Map<String, Value>) -> bool {
+    ["items", "prefixItems", "minItems", "maxItems"]
+        .iter()
+        .any(|keyword| object.contains_key(*keyword))
+}
+
+fn known_schema_keyword(keyword: &str) -> bool {
+    matches!(
+        keyword,
+        "$ref"
+            | "$defs"
+            | "type"
+            | "enum"
+            | "const"
+            | "allOf"
+            | "anyOf"
+            | "oneOf"
+            | "not"
+            | "if"
+            | "then"
+            | "else"
+            | "properties"
+            | "required"
+            | "patternProperties"
+            | "additionalProperties"
+            | "dependentRequired"
+            | "dependentSchemas"
+            | "propertyNames"
+            | "minProperties"
+            | "maxProperties"
+            | "items"
+            | "prefixItems"
+            | "additionalItems"
+            | "contains"
+            | "minContains"
+            | "maxContains"
+            | "uniqueItems"
+            | "minItems"
+            | "maxItems"
+            | "unevaluatedItems"
+            | "unevaluatedProperties"
+            | "minimum"
+            | "maximum"
+            | "exclusiveMinimum"
+            | "exclusiveMaximum"
+            | "multipleOf"
+            | "minLength"
+            | "maxLength"
+            | "pattern"
+            | "format"
+            | "contentEncoding"
+            | "contentMediaType"
+            | "contentSchema"
+    )
+}
+
+fn is_annotation_keyword(keyword: &str) -> bool {
+    keyword.starts_with("x-")
+        || matches!(
+            keyword,
+            "$schema"
+                | "$id"
+                | "$anchor"
+                | "$dynamicAnchor"
+                | "$vocabulary"
+                | "$comment"
+                | "title"
+                | "description"
+                | "default"
+                | "examples"
+                | "deprecated"
+                | "readOnly"
+                | "writeOnly"
+        )
+}
+
+fn schema_doc(schema: &Value) -> Result<Option<&str>, TypeScriptError> {
+    let Some(object) = schema.as_object() else {
+        return Ok(None);
+    };
+    if let Some(description) = object.get("description") {
+        return description
+            .as_str()
+            .map(Some)
+            .ok_or_else(|| TypeScriptError::new("JSON Schema description must be a string"));
+    }
+    if let Some(title) = object.get("title") {
+        return title
+            .as_str()
+            .map(Some)
+            .ok_or_else(|| TypeScriptError::new("JSON Schema title must be a string"));
+    }
+    Ok(None)
+}
+
+fn normalize_prose(label: &str, value: &str) -> Result<String, TypeScriptError> {
+    let normalized = value.replace("\r\n", "\n").replace('\r', "\n");
+    if normalized.trim().is_empty() {
+        return Err(TypeScriptError::new(format!(
+            "TypeScript {label} must be caller-supplied non-whitespace text"
+        )));
+    }
+    if normalized
+        .chars()
+        .any(|character| character.is_control() && character != '\n' && character != '\t')
+    {
+        return Err(TypeScriptError::new(format!(
+            "TypeScript {label} contains an unsupported control character"
+        )));
+    }
+    Ok(normalized)
+}
+
+fn write_doc_comment(output: &mut String, depth: usize, text: &str, tag: Option<&str>) {
+    let pad = indentation(depth);
+    writeln!(output, "{pad}/**").expect("writing TypeScript to a String cannot fail");
+    for line in text.replace("*/", "* /").lines() {
+        if line.is_empty() {
+            writeln!(output, "{pad} *").expect("writing TypeScript to a String cannot fail");
+        } else {
+            writeln!(output, "{pad} * {line}").expect("writing TypeScript to a String cannot fail");
+        }
+    }
+    if let Some(tag) = tag {
+        writeln!(output, "{pad} * {tag}").expect("writing TypeScript to a String cannot fail");
+    }
+    writeln!(output, "{pad} */").expect("writing TypeScript to a String cannot fail");
+}
+
+fn indentation(depth: usize) -> String {
+    "  ".repeat(depth)
+}
+
+fn ensure_depth(depth: usize, path: &str) -> Result<(), TypeScriptError> {
+    if depth > MAX_SCHEMA_DEPTH {
+        Err(TypeScriptError::new(format!(
+            "TypeScript schema expression at {path} exceeds depth {MAX_SCHEMA_DEPTH}"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn json_string(value: &str) -> String {
+    serde_json::to_string(value).expect("serializing a Rust string to JSON cannot fail")
+}
+
+fn typescript_type_name(raw: &str, fallback: &str) -> String {
+    let mut output = String::new();
+    let mut capitalize = true;
+    for character in raw.chars() {
+        if character.is_ascii_alphanumeric() {
+            if capitalize && character.is_ascii_alphabetic() {
+                output.push(character.to_ascii_uppercase());
+            } else {
+                output.push(character);
+            }
+            capitalize = false;
+        } else {
+            capitalize = true;
+        }
+    }
+    if output.is_empty() {
+        output.push_str(fallback);
+    }
+    if output
+        .chars()
+        .next()
+        .is_some_and(|first| first.is_ascii_digit())
+    {
+        output.insert(0, 'N');
+    }
+    output
+}
+
+fn is_typescript_keyword(value: &str) -> bool {
+    matches!(
+        value,
+        "Abstract"
+            | "Any"
+            | "As"
+            | "Asserts"
+            | "Async"
+            | "Await"
+            | "Bigint"
+            | "Boolean"
+            | "Break"
+            | "Case"
+            | "Catch"
+            | "Class"
+            | "Const"
+            | "Constructor"
+            | "Continue"
+            | "Debugger"
+            | "Declare"
+            | "Default"
+            | "Delete"
+            | "Do"
+            | "Else"
+            | "Enum"
+            | "Export"
+            | "Extends"
+            | "False"
+            | "Finally"
+            | "For"
+            | "From"
+            | "Function"
+            | "Get"
+            | "If"
+            | "Implements"
+            | "Import"
+            | "In"
+            | "Infer"
+            | "Instanceof"
+            | "Interface"
+            | "Is"
+            | "Keyof"
+            | "Let"
+            | "Module"
+            | "Namespace"
+            | "Never"
+            | "New"
+            | "Null"
+            | "Number"
+            | "Object"
+            | "Of"
+            | "Package"
+            | "Private"
+            | "Protected"
+            | "Public"
+            | "Readonly"
+            | "Require"
+            | "Return"
+            | "Set"
+            | "Static"
+            | "String"
+            | "Super"
+            | "Switch"
+            | "Symbol"
+            | "This"
+            | "Throw"
+            | "True"
+            | "Try"
+            | "Type"
+            | "Typeof"
+            | "Undefined"
+            | "Unique"
+            | "Unknown"
+            | "Var"
+            | "Void"
+            | "While"
+            | "With"
+            | "Yield"
+    )
+}
+
+fn is_package_name(value: &str) -> bool {
+    if value.is_empty() || value.len() > 214 || value == "." || value == ".." {
+        return false;
+    }
+    let valid_part = |part: &str| {
+        !part.is_empty()
+            && !part.starts_with(['.', '_'])
+            && part.chars().all(|character| {
+                character.is_ascii_lowercase()
+                    || character.is_ascii_digit()
+                    || matches!(character, '-' | '_' | '.')
+            })
+    };
+    if let Some(scoped) = value.strip_prefix('@') {
+        let Some((scope, name)) = scoped.split_once('/') else {
+            return false;
+        };
+        !name.contains('/') && valid_part(scope) && valid_part(name)
+    } else {
+        !value.contains('/') && valid_part(value)
+    }
+}
+
+fn finish_text(mut text: String) -> String {
+    while text.ends_with("\n\n") {
+        text.pop();
+    }
+    if !text.ends_with('\n') {
+        text.push('\n');
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::purrdf::loss::{check_ledger_complete, check_ledger_sound};
+    use serde_json::json;
+
+    fn compiled(schema: &Value) -> CompiledSchema {
+        CompiledSchema {
+            schema_json: format!(
+                "{}\n",
+                serde_json::to_string_pretty(schema).expect("fixture serializes")
+            ),
+            openapi_json: "{}\n".to_owned(),
+            losses: LossLedger::new(),
+        }
+    }
+
+    fn config() -> TypeScriptConfig {
+        TypeScriptConfig::new(
+            "@example/schema-types",
+            "Caller-owned package documentation.",
+            "Caller-owned module documentation.",
+        )
+        .expect("valid config")
+    }
+
+    fn declaration(package: &TypeScriptPackage) -> &str {
+        std::str::from_utf8(
+            package
+                .artifacts
+                .get(TYPESCRIPT_DECLARATION_PATH)
+                .expect("declaration artifact exists"),
+        )
+        .expect("declaration is UTF-8")
+    }
+
+    fn exact_schema() -> Value {
+        json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.org/schema/types.json",
+            "$defs": {
+                "Alias": { "$ref": "#/$defs/Person" },
+                "Choice": {
+                    "anyOf": [
+                        { "const": "ex:open" },
+                        { "const": true }
+                    ]
+                },
+                "ClosedEmpty": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "Person": {
+                    "type": "object",
+                    "title": "Person",
+                    "description": "A caller-described person.",
+                    "properties": {
+                        "@id": { "type": "string" },
+                        "ex:choice": { "$ref": "#/$defs/Choice" },
+                        "ex:nullable": { "type": ["string", "null"] },
+                        "ex:tags": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "minItems": 1,
+                            "maxItems": 2
+                        },
+                        "ex:tuple": {
+                            "type": "array",
+                            "prefixItems": [
+                                { "type": "string" },
+                                { "type": "number" }
+                            ],
+                            "items": false
+                        }
+                    },
+                    "required": ["@id"]
+                },
+                "path/with~token": { "enum": [null, 7, "mapped"] }
+            }
+        })
+    }
+
+    #[test]
+    fn exact_projection_is_deterministic_reversible_and_lossless() {
+        let schema = exact_schema();
+        let first = emit_typescript(&compiled(&schema), &config()).expect("emits");
+        let second = emit_typescript(&compiled(&schema), &config()).expect("emits");
+        assert_eq!(first, second);
+        assert!(first.losses.is_empty(), "{}", first.losses.render_json());
+        assert_eq!(first.package_name, "@example/schema-types");
+        assert_eq!(first.artifacts.len(), 1);
+        assert_eq!(
+            first.type_names,
+            BTreeMap::from([
+                ("Alias".to_owned(), "Alias".to_owned()),
+                ("Choice".to_owned(), "Choice".to_owned()),
+                ("ClosedEmpty".to_owned(), "ClosedEmpty".to_owned()),
+                ("Person".to_owned(), "Person".to_owned()),
+                ("path/with~token".to_owned(), "PathWithToken".to_owned()),
+            ])
+        );
+
+        let source = declaration(&first);
+        assert!(source.ends_with('\n'));
+        assert!(source.contains("@packageDocumentation"));
+        assert!(source.contains("export type Alias = Person;"));
+        assert!(source.contains("export type Choice = (\"ex:open\" | true);"));
+        assert!(source.contains("readonly \"@id\": string;"));
+        assert!(source.contains("readonly \"ex:choice\"?: Choice;"));
+        assert!(
+            source.contains(
+                "readonly \"ex:tags\"?: (readonly [string] | readonly [string, string]);"
+            )
+        );
+        assert!(source.contains(
+            "readonly \"ex:tuple\"?: (readonly [] | readonly [string] | readonly [string, number]);"
+        ));
+        assert!(source.contains("readonly [key: string]: never;"));
+        assert!(source.contains("export type PathWithToken = (null | 7 | \"mapped\");"));
+        assert!(!source.contains("gmeow"));
+        assert!(!source.contains("blackcatinformatics.ca"));
+        assert!(
+            !source
+                .split(|character: char| !character.is_ascii_alphanumeric())
+                .any(|token| token == "any")
+        );
+    }
+
+    #[test]
+    fn lossy_projection_exercises_the_entire_closed_profile() {
+        let prefix_items = (0..=MAX_TUPLE_EXPANSION)
+            .map(|index| {
+                if index % 2 == 0 {
+                    json!({ "type": "string" })
+                } else {
+                    json!({ "type": "number" })
+                }
+            })
+            .collect::<Vec<_>>();
+        let mut schema = json!({
+            "$defs": {
+                "Lossy": {
+                    "type": "object",
+                    "additionalProperties": { "type": "integer" },
+                    "patternProperties": {
+                        "^ex:": { "type": "string", "pattern": "^[A-Z]" }
+                    },
+                    "minProperties": 1,
+                    "maxProperties": 20,
+                    "propertyNames": { "pattern": "^ex:" },
+                    "dependentRequired": { "ex:a": ["ex:b"] },
+                    "dependentSchemas": { "ex:a": { "required": ["ex:b"] } },
+                    "if": { "properties": { "ex:a": { "const": true } } },
+                    "then": { "required": ["ex:b"] },
+                    "else": { "required": ["ex:c"] },
+                    "unevaluatedProperties": false,
+                    "properties": {
+                        "ex:array": {
+                            "type": "array",
+                            "prefixItems": [],
+                            "items": { "type": "string" },
+                            "additionalItems": false,
+                            "minItems": 40,
+                            "maxItems": 100,
+                            "contains": { "const": "match" },
+                            "minContains": 1,
+                            "maxContains": 2,
+                            "uniqueItems": true,
+                            "unevaluatedItems": false
+                        },
+                        "ex:literal": { "enum": [{ "state": "open" }] },
+                        "ex:negated": { "not": { "type": "boolean" } },
+                        "ex:number": {
+                            "type": "number",
+                            "minimum": 0,
+                            "exclusiveMaximum": 10,
+                            "multipleOf": 0.5
+                        },
+                        "ex:choice": {
+                            "oneOf": [{ "type": "string" }, { "const": "overlap" }]
+                        },
+                        "ex:unsupported": {
+                            "unsupportedAssertion": true
+                        }
+                    }
+                }
+            }
+        });
+        schema["$defs"]["Lossy"]["properties"]["ex:array"]["prefixItems"] =
+            Value::Array(prefix_items);
+
+        let package = emit_typescript(&compiled(&schema), &config()).expect("lossy schema emits");
+        let expected = [
+            "additional-properties-validation-widened",
+            "array-cardinality-validation-widened",
+            "array-contains-validation-dropped",
+            "conditional-validation-dropped",
+            "dependency-validation-dropped",
+            "integer-validation-widened",
+            "keyword-validation-dropped",
+            "negation-validation-dropped",
+            "numeric-validation-dropped",
+            "object-literal-validation-widened",
+            "one-of-validation-widened",
+            "pattern-properties-validation-dropped",
+            "property-count-validation-dropped",
+            "property-name-validation-dropped",
+            "string-validation-dropped",
+            "tuple-array-validation-widened",
+            "unevaluated-validation-dropped",
+            "unique-items-validation-dropped",
+        ];
+        check_ledger_sound(&package.losses, LOSS_FROM, TYPESCRIPT_DIALECT)
+            .expect("all losses are registered");
+        check_ledger_complete(&package.losses, &expected).expect("profile is fully exercised");
+        assert!(package.losses.entries().iter().all(|entry| {
+            entry
+                .location
+                .as_ref()
+                .and_then(|location| location.subject.as_deref())
+                .is_some_and(|subject| subject.starts_with("#/$defs/Lossy"))
+        }));
+        let source = declaration(&package);
+        assert!(source.contains("export type Lossy ="));
+        assert!(!source.contains("any"));
+    }
+
+    #[test]
+    fn config_is_caller_owned_canonical_and_comment_safe() {
+        let config = TypeScriptConfig::new(
+            "@caller/schema.types",
+            "Package */ prose.\r\nSecond line.",
+            "Module prose.",
+        )
+        .expect("valid config");
+        assert_eq!(config.package_name(), "@caller/schema.types");
+        assert_eq!(
+            config.package_docstring(),
+            "Package */ prose.\nSecond line."
+        );
+        assert_eq!(config.module_docstring(), "Module prose.");
+        let package = emit_typescript(&compiled(&json!({ "$defs": {} })), &config)
+            .expect("empty package emits");
+        assert!(declaration(&package).contains("Package * / prose.\n * Second line."));
+
+        for package_name in ["", "UPPER", "../escape", "@scope", "@scope/name/extra"] {
+            assert!(TypeScriptConfig::new(package_name, "package", "module").is_err());
+        }
+        assert!(TypeScriptConfig::new("valid-name", " ", "module").is_err());
+        assert!(TypeScriptConfig::new("valid-name", "package", "\0module").is_err());
+    }
+
+    #[test]
+    fn name_reference_and_keyword_failures_are_hard_errors() {
+        for (schema, expected) in [
+            (
+                json!({ "$defs": { "a-b": true, "a_b": true } }),
+                "collide on TypeScript type name",
+            ),
+            (
+                json!({ "$defs": { "JsonValue": true } }),
+                "reserved TypeScript type name",
+            ),
+            (
+                json!({ "$defs": { "Broken": { "type": [] } } }),
+                "type array cannot be empty",
+            ),
+            (
+                json!({ "$defs": { "Broken": { "required": [7] } } }),
+                "required/0 must be a string",
+            ),
+            (
+                json!({ "$defs": { "Broken": { "anyOf": [] } } }),
+                "anyOf cannot be empty",
+            ),
+            (
+                json!({ "$defs": { "Broken": { "multipleOf": 0 } } }),
+                "multipleOf must be greater than zero",
+            ),
+            (
+                json!({ "$defs": { "Broken": { "$ref": "#/$defs/Missing" } } }),
+                "targets missing $defs key",
+            ),
+            (
+                json!({ "$defs": { "Broken": { "$ref": "https://example.org/open" } } }),
+                "external or not a direct",
+            ),
+            (
+                json!({ "$defs": { "Broken": { "$dynamicRef": "#/$defs/Broken" } } }),
+                "cannot be translated to a closed generated package",
+            ),
+        ] {
+            let error = emit_typescript(&compiled(&schema), &config())
+                .expect_err("malformed schema must fail");
+            assert!(error.to_string().contains(expected), "{error}");
+        }
+    }
+
+    #[test]
+    fn required_only_closed_property_and_contradictory_arrays_are_uninhabited() {
+        let schema = json!({
+            "$defs": {
+                "ImpossibleObject": {
+                    "type": "object",
+                    "required": ["ex:missing"],
+                    "additionalProperties": false
+                },
+                "ImpossibleArray": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "minItems": 3,
+                    "maxItems": 2
+                }
+            }
+        });
+        let package = emit_typescript(&compiled(&schema), &config()).expect("emits");
+        let source = declaration(&package);
+        assert!(source.contains("readonly \"ex:missing\": never;"));
+        assert!(source.contains("export type ImpossibleArray = never;"));
+        assert!(package.losses.entries().iter().any(|entry| {
+            entry.code == "additional-properties-validation-widened"
+                && entry
+                    .location
+                    .as_ref()
+                    .and_then(|location| location.subject.as_deref())
+                    == Some("#/$defs/ImpossibleObject/additionalProperties")
+        }));
+    }
+
+    #[test]
+    fn then_and_else_without_if_do_not_claim_a_conditional_loss() {
+        let schema = json!({
+            "$defs": {
+                "IgnoredBranches": {
+                    "then": { "type": "integer" },
+                    "else": { "pattern": "x" }
+                }
+            }
+        });
+        let package = emit_typescript(&compiled(&schema), &config()).expect("emits");
+        assert!(
+            !package
+                .losses
+                .entries()
+                .iter()
+                .any(|entry| entry.code == "conditional-validation-dropped")
+        );
+    }
+}

--- a/crates/shapes/src/typescript.rs
+++ b/crates/shapes/src/typescript.rs
@@ -183,6 +183,46 @@ impl Error for TypeScriptError {}
 /// Source-stage losses remain on [`CompiledSchema::losses`]. The returned
 /// ledger describes only the `json-schema` → `typescript-7.0` projection.
 ///
+/// # Example
+///
+/// ```
+/// use purrdf::loss::LossLedger;
+/// use purrdf_shapes::json_schema::CompiledSchema;
+/// use purrdf_shapes::{
+///     TYPESCRIPT_DECLARATION_PATH, TypeScriptConfig, emit_typescript,
+/// };
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let compiled = CompiledSchema {
+///     schema_json: r#"{
+///       "$defs": {
+///         "Person": {
+///           "type": "object",
+///           "properties": { "name": { "type": "string" } },
+///           "required": ["name"]
+///         }
+///       }
+///     }"#.to_owned(),
+///     openapi_json: "{}\n".to_owned(),
+///     losses: LossLedger::new(),
+/// };
+/// let config = TypeScriptConfig::new(
+///     "example-schema-types",
+///     "Schema types published by the caller.",
+///     "Declarations generated from the caller's compiled schema.",
+/// )?;
+/// let package = emit_typescript(&compiled, &config)?;
+/// let declaration = std::str::from_utf8(
+///     &package.artifacts[TYPESCRIPT_DECLARATION_PATH],
+/// )?;
+///
+/// assert!(declaration.contains("export type Person"));
+/// assert_eq!(package.type_names["Person"], "Person");
+/// assert!(package.losses.is_empty());
+/// # Ok(())
+/// # }
+/// ```
+///
 /// # Errors
 ///
 /// Returns [`TypeScriptError`] when the schema is malformed or too large, lacks

--- a/crates/shapes/tests/typescript_oracle.mjs
+++ b/crates/shapes/tests/typescript_oracle.mjs
@@ -1,0 +1,367 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/**
+ * Compile emitted declarations with the locked TypeScript 7.0 compiler and
+ * compare their JSON-literal acceptance with dev-only boon classifications.
+ */
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const REPO = fileURLToPath(new URL("../../..", import.meta.url));
+const TYPESCRIPT_PROJECT = path.join(REPO, "crates", "rdf-wasm", "js");
+const TYPESCRIPT_VERSION = "7.0.2";
+const CLOSED_PROFILE = new Set([
+  "additional-properties-validation-widened",
+  "array-cardinality-validation-widened",
+  "array-contains-validation-dropped",
+  "conditional-validation-dropped",
+  "dependency-validation-dropped",
+  "integer-validation-widened",
+  "keyword-validation-dropped",
+  "negation-validation-dropped",
+  "numeric-validation-dropped",
+  "object-literal-validation-widened",
+  "one-of-validation-widened",
+  "pattern-properties-validation-dropped",
+  "property-count-validation-dropped",
+  "property-name-validation-dropped",
+  "string-validation-dropped",
+  "tuple-array-validation-widened",
+  "unevaluated-validation-dropped",
+  "unique-items-validation-dropped",
+]);
+
+const requireFromToolchain = createRequire(
+  path.join(TYPESCRIPT_PROJECT, "package.json"),
+);
+const compilerApiUrl = pathToFileURL(
+  requireFromToolchain.resolve("typescript/unstable/sync"),
+).href;
+const versionUrl = pathToFileURL(
+  requireFromToolchain.resolve("typescript"),
+).href;
+const { API } = await import(compilerApiUrl);
+const versionModule = await import(versionUrl);
+const compilerVersion =
+  versionModule.version ?? versionModule.default?.version ?? versionModule.default;
+
+function fixtureManifest() {
+  const completed = spawnSync(
+    "cargo",
+    [
+      "run",
+      "-p",
+      "purrdf-shapes",
+      "--example",
+      "typescript_oracle_fixture",
+      "--locked",
+      "--quiet",
+    ],
+    {
+      cwd: REPO,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  );
+  if (completed.status !== 0) {
+    throw new Error(
+      `TypeScript oracle fixture failed (${completed.status}):\n${completed.stderr}`,
+    );
+  }
+  return JSON.parse(completed.stdout);
+}
+
+function sourceExpression(probe) {
+  const literal = JSON.stringify(probe.value);
+  if (
+    probe.mode === "variable" &&
+    probe.value !== null &&
+    typeof probe.value === "object"
+  ) {
+    return [
+      `const candidate = ${literal} as const;`,
+      "const value: Target = candidate;",
+      "void value;",
+    ].join("\n");
+  }
+  if (probe.mode === "variable") {
+    return [
+      `const candidate = ${literal};`,
+      "const value: Target = candidate;",
+      "void value;",
+    ].join("\n");
+  }
+  if (probe.mode !== "fresh") {
+    throw new Error(`unknown probe mode ${JSON.stringify(probe.mode)}`);
+  }
+  return [`const value: Target = ${literal};`, "void value;"].join("\n");
+}
+
+function probeSource(probe, compilerOnly = false) {
+  const assignment = compilerOnly
+    ? [`const value: Target = (${probe.expression});`, "void value;"].join("\n")
+    : sourceExpression(probe);
+  return [
+    `import type { ${probe.typeName} as Target } from "./index.js";`,
+    assignment,
+    "export {};",
+    "",
+  ].join("\n");
+}
+
+function diagnosticsText(diagnostics) {
+  return diagnostics
+    .map((diagnostic) => {
+      const file = diagnostic.fileName ? path.basename(diagnostic.fileName) : "<project>";
+      return `${file}: TS${diagnostic.code}: ${diagnostic.text}`;
+    })
+    .join("\n");
+}
+
+function compileFixture(name, fixture, directory) {
+  const root = path.join(directory, name);
+  const files = ["index.d.ts"];
+  mkdirSync(root, { recursive: true });
+  writeFileSync(path.join(root, "index.d.ts"), fixture.declaration, "utf8");
+  writeFileSync(path.join(root, "package.json"), '{"type":"module"}\n', "utf8");
+
+  const probes = [];
+  fixture.probes.forEach((probe, index) => {
+    const file = `probe-${String(index).padStart(3, "0")}.ts`;
+    files.push(file);
+    probes.push({ file, probe, compilerOnly: false });
+    writeFileSync(path.join(root, file), probeSource(probe), "utf8");
+  });
+  fixture.compilerProbes.forEach((probe, index) => {
+    const file = `compiler-${String(index).padStart(3, "0")}.ts`;
+    files.push(file);
+    probes.push({ file, probe, compilerOnly: true });
+    writeFileSync(path.join(root, file), probeSource(probe, true), "utf8");
+  });
+
+  const configPath = path.join(root, "tsconfig.json");
+  writeFileSync(
+    configPath,
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          strict: true,
+          exactOptionalPropertyTypes: true,
+          noUncheckedIndexedAccess: true,
+          noEmit: true,
+          skipLibCheck: false,
+          forceConsistentCasingInFileNames: true,
+          types: [],
+        },
+        files,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+
+  const api = new API({ cwd: root });
+  let snapshot;
+  try {
+    snapshot = api.updateSnapshot({ openProjects: [configPath] });
+    const projects = snapshot.getProjects();
+    const project = snapshot.getProject(configPath) ?? projects[0];
+    if (project === undefined || projects.length !== 1) {
+      throw new Error(
+        `${name} compiler oracle expected one project, found ${projects.length}`,
+      );
+    }
+    const program = project.program;
+    const baselineDiagnostics = [
+      ...program.getConfigFileParsingDiagnostics(),
+      ...program.getProgramDiagnostics(),
+      ...program.getGlobalDiagnostics(),
+      ...program.getSyntacticDiagnostics(path.join(root, "index.d.ts")),
+      ...program.getBindDiagnostics(path.join(root, "index.d.ts")),
+      ...program.getSemanticDiagnostics(path.join(root, "index.d.ts")),
+    ];
+    if (baselineDiagnostics.length !== 0) {
+      throw new Error(
+        `${name} declaration or compiler configuration is invalid:\n${diagnosticsText(
+          baselineDiagnostics,
+        )}`,
+      );
+    }
+
+    return probes.map(({ file, probe, compilerOnly }) => {
+      const filePath = path.join(root, file);
+      const diagnostics = [
+        ...program.getSyntacticDiagnostics(filePath),
+        ...program.getBindDiagnostics(filePath),
+        ...program.getSemanticDiagnostics(filePath),
+      ];
+      return {
+        probe,
+        compilerOnly,
+        valid: diagnostics.length === 0,
+        diagnostics,
+      };
+    });
+  } finally {
+    snapshot?.dispose();
+    api.close();
+  }
+}
+
+function lossSubject(entry) {
+  const marker = " subject=";
+  const start = entry.location?.indexOf(marker);
+  if (start === undefined || start < 0) {
+    throw new Error(`loss ${entry.code} has no logical subject: ${entry.location}`);
+  }
+  return entry.location.slice(start + marker.length);
+}
+
+function lossKey(loss) {
+  return `${loss.code}\u0000${loss.location}`;
+}
+
+function compareProbe(fixtureName, probe, actual, locatedLosses) {
+  if (probe.expectedLoss === undefined) {
+    if (actual !== probe.sourceValid) {
+      throw new Error(
+        `${fixtureName}/${probe.label} has an unlocated acceptance divergence: ` +
+          `boon=${probe.sourceValid}, TypeScript=${actual}`,
+      );
+    }
+    return;
+  }
+  if (!locatedLosses.has(lossKey(probe.expectedLoss))) {
+    throw new Error(
+      `${fixtureName}/${probe.label} names a missing ledger entry ` +
+        `${probe.expectedLoss.code} at ${probe.expectedLoss.location}`,
+    );
+  }
+  if (actual === probe.sourceValid) {
+    throw new Error(
+      `${fixtureName}/${probe.label} was expected to expose ` +
+        `${probe.expectedLoss.code}, but boon and TypeScript both classified it as ${actual}`,
+    );
+  }
+}
+
+function assertSelfTest() {
+  assert.throws(
+    () =>
+      compareProbe(
+        "self-test",
+        { label: "flipped", sourceValid: true },
+        false,
+        new Set(),
+      ),
+    /unlocated acceptance divergence/,
+  );
+  assert.throws(
+    () =>
+      compareProbe(
+        "self-test",
+        {
+          label: "missing-loss",
+          sourceValid: false,
+          expectedLoss: { code: "absent", location: "#/absent" },
+        },
+        true,
+        new Set(),
+      ),
+    /missing ledger entry/,
+  );
+  assert.throws(
+    () =>
+      compareProbe(
+        "self-test",
+        {
+          label: "hidden-divergence",
+          sourceValid: false,
+          expectedLoss: { code: "present", location: "#/present" },
+        },
+        false,
+        new Set(["present\u0000#/present"]),
+      ),
+    /expected to expose/,
+  );
+}
+
+function assertFixture(name, fixture, results) {
+  const losses = fixture.losses.losses;
+  if (!Array.isArray(losses) || !losses.every((entry) => entry.intentional === true)) {
+    throw new Error(`${name} fixture has a malformed or unregistered loss ledger`);
+  }
+  const locatedLosses = new Set(
+    losses.map((entry) => lossKey({ code: entry.code, location: lossSubject(entry) })),
+  );
+  for (const result of results) {
+    if (result.compilerOnly) {
+      if (result.valid !== result.probe.expectedTypescriptValid) {
+        throw new Error(
+          `${name}/${result.probe.label} compiler-only expectation differs: ` +
+            `expected=${result.probe.expectedTypescriptValid}, actual=${result.valid}\n` +
+            diagnosticsText(result.diagnostics),
+        );
+      }
+    } else {
+      try {
+        compareProbe(name, result.probe, result.valid, locatedLosses);
+      } catch (error) {
+        error.message += `\n${diagnosticsText(result.diagnostics)}`;
+        throw error;
+      }
+    }
+  }
+}
+
+if (compilerVersion !== TYPESCRIPT_VERSION) {
+  throw new Error(
+    `TypeScript compiler version drift: expected ${TYPESCRIPT_VERSION}, found ${compilerVersion}`,
+  );
+}
+assertSelfTest();
+if (process.argv.includes("--self-test")) {
+  console.log(
+    "TypeScript oracle self-test: flipped, unlocated, and hidden divergences were rejected",
+  );
+  process.exit(0);
+}
+const manifest = fixtureManifest();
+if (manifest.exact.losses.losses.length !== 0) {
+  throw new Error("exact TypeScript oracle fixture has a non-empty loss ledger");
+}
+const lossyCodes = new Set(manifest.lossy.losses.losses.map((entry) => entry.code));
+assert.deepEqual(lossyCodes, CLOSED_PROFILE, "lossy fixture no longer covers the closed profile");
+
+const directory = mkdtempSync(path.join(tmpdir(), "purrdf-typescript-oracle-"));
+try {
+  const exactResults = compileFixture("exact", manifest.exact, directory);
+  const lossyResults = compileFixture("lossy", manifest.lossy, directory);
+  assertFixture("exact", manifest.exact, exactResults);
+  assertFixture("lossy", manifest.lossy, lossyResults);
+  const divergenceCount = lossyResults.filter(
+    ({ probe, compilerOnly, valid }) => !compilerOnly && valid !== probe.sourceValid,
+  ).length;
+  if (divergenceCount < 16) {
+    throw new Error(`lossy fixture exposed only ${divergenceCount} located divergences`);
+  }
+  console.log(
+    `TypeScript oracle: compiler ${compilerVersion}; ` +
+      `${manifest.exact.probes.length} exact boon probes and ` +
+      `${manifest.exact.compilerProbes.length} optional/null/undefined probes agree; ` +
+      `${divergenceCount} divergences map to the complete 18-code loss profile`,
+  );
+} finally {
+  rmSync(directory, { recursive: true, force: true });
+}

--- a/docs/book/src/validation/shacl.md
+++ b/docs/book/src/validation/shacl.md
@@ -88,6 +88,41 @@ official LinkML 1.11.1 Python packages only as a differential oracle:
 make linkml-oracle
 ```
 
+## TypeScript 7.0 projection
+
+`emit_typescript` projects the same `CompiledSchema` into deterministic
+TypeScript 7.0 declarations. The caller supplies the package name and all
+package/module prose through `TypeScriptConfig`. The returned package contains
+one `index.d.ts`, a reversible `$defs`-key to exported-type map, and a located
+`json-schema` → `typescript-7.0` loss ledger; PurRDF invents no consumer
+identity or vocabulary.
+
+The fixed declaration dialect uses `strict` plus
+`exactOptionalPropertyTypes`. Type aliases preserve JSON primitives and
+literals, required versus optional fields, explicit `null`, local recursive
+references, unions, intersections, homogeneous arrays, and bounded tuples.
+There are no runtime enums, mergeable interfaces, branded pseudo-validators,
+or `any` escape hatches. Invalid keywords, open/dangling references, and name
+collisions fail before bytes are emitted.
+
+Runtime assertions outside TypeScript structural assignability are never
+silently erased: integer, numeric/string predicate, closure, pattern-property,
+dependency, conditional, negation, contains/unique, evaluation-state, and
+bounded-expansion gaps receive stable codes and JSON Pointer locations. CI
+classifies instances independently with a draft 2020-12 validator and compiles
+the generated declarations with the locked TypeScript 7.0.2 compiler, including
+fresh-literal and through-variable probes:
+
+```bash
+make typescript-oracle
+```
+
+The projection intentionally has no arbitrary TypeScript reader. TypeScript
+declarations do not define a unique runtime JSON acceptance relation, and the
+projection is many-to-one. The retained `CompiledSchema` plus the reversible
+name map remains the authoritative reverse surface. TypeScript is only a
+dev-time oracle dependency; the Rust emitter is filesystem-free and wasm-clean.
+
 ## From Python
 
 ```python

--- a/generated/transcode-loss-matrix.json
+++ b/generated/transcode-loss-matrix.json
@@ -294,6 +294,132 @@
     "note": "Pydantic v2 unions implement any-branch semantics and cannot enforce JSON Schema oneOf's exactly-one matching rule; runtime validation uses a union while model_json_schema() retains oneOf."
   },
   {
+    "code": "additional-properties-validation-widened",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "TypeScript uses structural object compatibility and index signatures apply to every string key, so it cannot constrain only JSON object properties not named by the schema. Named properties retain their exact declarations while the extra-property policy or value schema is widened."
+  },
+  {
+    "code": "array-cardinality-validation-widened",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "A JSON Schema minItems/maxItems assertion exceeds the declaration emitter's fixed tuple-expansion budget. Item and tuple-prefix carriers remain, while exact length validation is widened to keep declaration size bounded deterministically."
+  },
+  {
+    "code": "array-contains-validation-dropped",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "JSON Schema contains/minContains/maxContains assertions quantify matching array elements and have no TypeScript assignability equivalent. Item and cardinality declarations remain while the contains predicate and match count are omitted."
+  },
+  {
+    "code": "conditional-validation-dropped",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "JSON Schema if/then/else validates one branch according to runtime instance content; a general conditional relationship has no finite TypeScript declaration equivalent. Independently representable carrier constraints remain."
+  },
+  {
+    "code": "dependency-validation-dropped",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "JSON Schema dependentRequired/dependentSchemas assertions impose cross-property runtime relationships that a general structural TypeScript declaration cannot enforce. Individual property declarations remain."
+  },
+  {
+    "code": "integer-validation-widened",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "TypeScript has one number type and cannot distinguish all JSON integers from fractional numbers. The generated declaration retains the number carrier while integer-only validation is widened."
+  },
+  {
+    "code": "keyword-validation-dropped",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "A JSON Schema assertion outside the emitter's closed TypeScript 7.0 capability table has no sound declaration projection. The assertion is omitted and recorded at its schema location rather than disappearing silently."
+  },
+  {
+    "code": "negation-validation-dropped",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "General JSON Schema not is a set complement over instance validation. TypeScript's Exclude utility distributes over union members and cannot express that general complement, so the positive carrier remains while negation is omitted."
+  },
+  {
+    "code": "numeric-validation-dropped",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "JSON Schema minimum/maximum/exclusive bounds and multipleOf are runtime numeric predicates with no exact TypeScript number-type expression. The numeric carrier remains while the predicate is omitted."
+  },
+  {
+    "code": "object-literal-validation-widened",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "A JSON Schema object-valued const or enum member requires exact key membership. TypeScript can preserve every named literal field but structural compatibility still accepts values with additional fields outside fresh-object checks."
+  },
+  {
+    "code": "one-of-validation-widened",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "A TypeScript union implements any-branch assignability and cannot generally enforce JSON Schema oneOf's exactly-one matching rule. Branch declarations remain as a union while overlap exclusivity is widened."
+  },
+  {
+    "code": "pattern-properties-validation-dropped",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "Arbitrary JSON Schema patternProperties regular expressions have no equivalent key-space expression in TypeScript. Named and additional-property declarations remain while regex-selected property validation is omitted."
+  },
+  {
+    "code": "property-count-validation-dropped",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "JSON Schema minProperties/maxProperties count runtime object keys; TypeScript structural declarations express named requiredness but cannot bound the total property count."
+  },
+  {
+    "code": "property-name-validation-dropped",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "JSON Schema propertyNames validates every runtime object key with a schema, which a general TypeScript string-key declaration cannot express. Property value declarations remain while key validation is omitted."
+  },
+  {
+    "code": "string-validation-dropped",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "JSON Schema minLength/maxLength, pattern, format, and content assertions are runtime predicates without a general TypeScript string-type equivalent. The string carrier remains while the predicate is omitted."
+  },
+  {
+    "code": "tuple-array-validation-widened",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "A JSON Schema prefixItems tuple exceeds the declaration emitter's fixed tuple-expansion budget. The common item carrier remains while position-specific validation beyond the budget is widened deterministically."
+  },
+  {
+    "code": "unevaluated-validation-dropped",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "JSON Schema unevaluatedProperties/unevaluatedItems depends on applicator evaluation state that TypeScript's structural type system does not expose. Representable local declarations remain while the unevaluated assertion is omitted."
+  },
+  {
+    "code": "unique-items-validation-dropped",
+    "from": "json-schema",
+    "to": "typescript-7.0",
+    "intentional": true,
+    "note": "JSON Schema uniqueItems compares runtime array values for equality; TypeScript array and tuple declarations cannot require pairwise-distinct elements. Item and length declarations remain while uniqueness is omitted."
+  },
+  {
     "code": "canonical-rdf12-projection",
     "from": "jsonld",
     "to": "canonical-rdf12",

--- a/generated/transcode-loss-matrix.json
+++ b/generated/transcode-loss-matrix.json
@@ -354,7 +354,7 @@
     "from": "json-schema",
     "to": "typescript-7.0",
     "intentional": true,
-    "note": "JSON Schema minimum/maximum/exclusive bounds and multipleOf are runtime numeric predicates with no exact TypeScript number-type expression. The numeric carrier remains while the predicate is omitted."
+    "note": "JSON Schema minimum/maximum/exclusive bounds and multipleOf are runtime numeric predicates with no exact TypeScript number-type expression; integer const/enum values outside the IEEE-754 safe range also have no exact TypeScript number literal. The numeric carrier or closest literal remains while the predicate or excess precision is omitted."
   },
   {
     "code": "object-literal-validation-widened",

--- a/scripts/check-generated.sh
+++ b/scripts/check-generated.sh
@@ -4,6 +4,19 @@
 
 set -euo pipefail
 
+mode="${1:---check}"
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [--check|--write]" >&2
+  exit 2
+fi
+case "$mode" in
+  --check | --write) ;;
+  *)
+    echo "usage: $0 [--check|--write]" >&2
+    exit 2
+    ;;
+esac
+
 repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
@@ -25,8 +38,17 @@ check_file() {
   fi
 }
 
-check_file "$tmp/rdf-loss-matrix.json" generated/rdf-loss-matrix.json
-check_file "$tmp/transcode-loss-matrix.json" generated/transcode-loss-matrix.json
+sync_file() {
+  local generated="$1"
+  local committed="$2"
+  if [ "$mode" = "--write" ]; then
+    cp -- "$generated" "$committed"
+  fi
+  check_file "$generated" "$committed"
+}
+
+sync_file "$tmp/rdf-loss-matrix.json" generated/rdf-loss-matrix.json
+sync_file "$tmp/transcode-loss-matrix.json" generated/transcode-loss-matrix.json
 
 viz_tmp="$tmp/visualization"
 viz_committed="docs/book/src/assets/visualization"
@@ -36,8 +58,16 @@ cargo run -p purrdf-rdf --example viz_samples --locked -- \
 generated_count=0
 for generated_svg in "$viz_tmp"/*.svg; do
   generated_count=$((generated_count + 1))
-  check_file "$generated_svg" "$viz_committed/$(basename "$generated_svg")"
+  sync_file "$generated_svg" "$viz_committed/$(basename "$generated_svg")"
 done
+if [ "$mode" = "--write" ]; then
+  for committed_svg in "$viz_committed"/*.svg; do
+    [ -e "$committed_svg" ] || continue
+    if [ ! -e "$viz_tmp/$(basename "$committed_svg")" ]; then
+      rm -- "$committed_svg"
+    fi
+  done
+fi
 committed_count=$(find "$viz_committed" -maxdepth 1 -type f -name '*.svg' | wc -l)
 if [ "$generated_count" -ne "$committed_count" ]; then
   echo "$viz_committed contains stale or missing SVG samples" >&2


### PR DESCRIPTION
Part of #109.

## Outcome

Adds the TypeScript partition of the schema-language emitter epic as a production `purrdf-shapes` API. `emit_typescript` projects validated `CompiledSchema` `$defs` into one deterministic TypeScript 7.0 declaration package, with caller-owned package identity/prose, a reversible definition-name map, and an always-computed closed loss ledger.

The gmeow TypeScript/LinkML model is migration evidence only. Its all-optional fields, normalized property identifiers, local-name runtime enums, scalar fallbacks, fixed identity, and private LinkML coupling are deliberately replaced; no downstream type contract is preserved. PurRDF now supplies the replacement surface, but the gmeow-ontology consumer cutover is not yet complete and the legacy model remains deletion-bound migration material.

## Acceptance mapping

| Requirement | Delivery |
|---|---|
| Production TypeScript module consuming `CompiledSchema` | `crates/shapes/src/typescript.rs`, re-exported from `purrdf-shapes` and the umbrella facade |
| Caller-supplied package identity/docstrings | Validated `TypeScriptConfig` with no `Default` or fabricated identity |
| Deterministic output | Ordered collections, fixed declaration grammar, one LF-terminated `index.d.ts`, repeated-emission equality tests |
| Agreement with JSON Schema by construction | Exact capability grammar plus independent draft 2020-12 validator classifications compiled by TypeScript 7.0.2 |
| Always-on loss accounting | Closed 18-code `json-schema` → `typescript-7.0` profile; every intentional divergence receives a JSON Pointer location |
| Required/optional/null fidelity | Quoted exact JSON keys, `exactOptionalPropertyTypes`, and separate absence/`null`/`undefined` compiler probes |
| Local graph closure | Guarded recursive/local refs supported; malformed, external, dynamic, rebased, dangling, unguarded-cyclic, reserved, and colliding graphs hard-fail |
| Reverse-direction decision | Arbitrary TypeScript → JSON Schema is documented as semantically undefined and many-to-one; retained `CompiledSchema` plus `type_names` is authoritative |
| Production-surface validation | Public API fixture emits real packages; dev-only `boon` and the pinned TypeScript compiler compare acceptance |
| Portability and vocabulary boundary | Filesystem-free Rust emitter, no production JavaScript dependency, no Cargo features, wasm32-clean, no minted IRIs |

## Declaration model

- Emits type aliases rather than runtime enums or mergeable interfaces.
- Defines a recursive JSON domain without `any`.
- Preserves primitive and compound literals, boolean schemas, empty schemas/enums, local guarded recursion, declared type unions, `anyOf`, `allOf`, objects, required fields, homogeneous arrays, and bounded tuple/cardinality forms.
- Preserves exact JSON property spelling with quoted keys.
- Uses deterministic hard budgets for schema size/depth, definition count, declaration size, and tuple expansion.
- Records structural closure, integer/numeric precision, runtime numeric/string predicates, pattern-property, dependency, conditional, negation, one-of, contains/unique, evaluation-state, literal-object, unknown-keyword, and expansion widenings rather than hiding them behind brands or assertions.

No runtime validator is generated. Consumers validate with the retained source schema; the TypeScript artifact is a checked static carrier projection.

## Independent oracle

The Rust fixture classifies JSON instances with dev-only `boon` against draft 2020-12 wrappers. The Node oracle invokes the repository-locked TypeScript 7.0.2 compiler API under `strict`, `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `noEmit`, and NodeNext semantics.

It compiles fresh literals and values passed through variables, preventing excess-property checks from masking structural widening. Its built-in corruption test proves flipped, unlocated, missing-ledger, and hidden divergences fail the oracle. Final result:

```text
TypeScript oracle: compiler 7.0.2; 25 exact boon probes and 3 optional/null/undefined probes agree; 20 divergences map to the complete 18-code loss profile
TypeScript oracle self-test: flipped, unlocated, and hidden divergences were rejected
```

The additional Stage 2 probes expose nested object-literal structural widening and integer-literal precision loss beyond the IEEE-754 safe range.

## Stage 2 hardening

The adversarial issue/PR review found and remediated all actionable gaps:

- reject nested `$id` resource rebasing before direct root-catalog refs can be misresolved;
- reject unguarded TypeScript alias cycles while preserving guarded object/array recursion and boolean compositions that simplify to `JsonValue`/`never`;
- walk the definition graph iteratively, with an 8,192-alias regression, so large shallow catalogs cannot exhaust the process stack;
- recursively audit `const`/`enum` literal trees for nested structural widening and unsafe integer precision;
- suppress false losses from inert `if`/`then`/`else`, contains bounds without `contains`, and nested `$defs` declarations;
- normalize non-negative integer keywords through the fixed tuple budget so integral `1.0` values are accepted and large bounds behave identically on native and wasm32;
- borrow schema maps during object rendering and avoid JSDoc sanitization allocation when no terminator is present;
- correct the stale repository claim that the downstream gmeow cutover was already complete.

Gemini's one allocation finding was fixed in `ec7cd11`, answered with commit-specific evidence, and its thread is resolved. The final thread-aware scan has no unresolved actionable review thread.

## Canonical metadata repair

While registering the profile, the documented `make metadata` target was found to check drift without regenerating it. This branch makes `make metadata` invoke the canonical generator in explicit write mode, retains check mode for CI, removes stale generated SVGs during regeneration, and regenerates `generated/transcode-loss-matrix.json` from the Rust registry.

## Validation

The final pushed head `e8c58426f3b875ec5c01dd6acfcac57b93b53bb2` passed:

```text
cargo fmt --all --check
cargo clippy --workspace --all-targets --locked -- -D warnings
make check
make test
make metadata
make wasm
make doc
make typescript-oracle
UV_CACHE_DIR=/tmp/purrdf-109-typescript-uv make pydantic-oracle
UV_CACHE_DIR=/tmp/purrdf-109-typescript-uv make linkml-oracle
npm --prefix crates/rdf-wasm/js run check
python3 scripts/check-no-features.py
python3 scripts/check-issue-refs.py
bash scripts/check-generated.sh
git -c core.whitespace=trailing-space,space-before-tab diff --check origin/main...HEAD
```

Additional evidence:

- npm TypeScript package typecheck, 50 Node tests, and packed-tarball entry/size budgets pass;
- Pydantic oracle: 6 live schemas plus validation/alias probes pass;
- LinkML oracle: exact `$defs`, 16 instances, 18 located losses, and widening probes pass;
- canonical metadata regeneration is clean and generated drift verification passes;
- mechanical placeholder/deferral scans over the complete diff and commit messages have no matches;
- every branch commit has a good EdDSA signature;
- the worktree is clean, based exactly on current `origin/main`, and byte-identical to the remote head.

## Commits

- `5a64592` — register the closed TypeScript loss profile and repair canonical metadata regeneration;
- `18d8bba` — implement and export the production declaration emitter;
- `3719718` — add the `boon`/TypeScript compiler oracle, Make target, and CI gate;
- `1452ed2` — document the public contract, reverse rationale, and disposable legacy-model provenance;
- `94979a8` — harden closed reference handling and recursive-alias validity;
- `0c7ef39` — close literal, loss-audit, and cross-target bound gaps;
- `ec7cd11` — remove hot-path copies, address review feedback, and correct cutover status;
- `e8c5842` — make alias-cycle analysis iterative and long-chain safe.

## Residual semantics

The residual gap is intentional and fully represented by the returned ledger: TypeScript structural assignability cannot enforce general runtime JSON Schema predicates or exact object closure through variables. No unlocated divergence is observed by the independent oracle, and no reverse transform is claimed.
