### PR TITLE
feat(shapes): emit deterministic GraphQL SDL

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -187,6 +187,9 @@ jobs:
       - name: TypeScript emitter schema oracle
         run: node crates/shapes/tests/typescript_oracle.mjs
 
+      - name: GraphQL emitter schema oracle
+        run: node crates/shapes/tests/graphql_oracle.mjs
+
   benchmarks:
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 CARGO_TARGET_DIR ?= target
 CAPI_HEADER := crates/rdf-capi/include/purrdf.h
 
-.PHONY: help metadata fmt check book book-samples check-issue-refs changelog bump release-tags test doc bench bench-python columnar-oracle pydantic-oracle linkml-oracle typescript-oracle pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-size wasm-pkg-test wasm-pkg-bench playground playground-smoke \
+.PHONY: help metadata fmt check book book-samples check-issue-refs changelog bump release-tags test doc bench bench-python columnar-oracle pydantic-oracle linkml-oracle typescript-oracle graphql-oracle pytest conformance rdf-core-hygiene wasm wasm-pkg wasm-pkg-size wasm-pkg-test wasm-pkg-bench playground playground-smoke \
 	capi-build capi-header capi-check capi-install
 
 # The changelog generator is pinned so the committed CHANGELOG.md and the notes
@@ -152,6 +152,10 @@ linkml-oracle: ## Validate emitted LinkML through the locked official 1.11 toolc
 typescript-oracle: ## Compile emitted declarations with TypeScript 7.0 and compare assignability with CompiledSchema.
 	npm --prefix crates/rdf-wasm/js ci --ignore-scripts --no-audit --no-fund
 	node crates/shapes/tests/typescript_oracle.mjs
+
+graphql-oracle: ## Validate emitted SDL and variable coercion with locked GraphQL.js and boon.
+	npm --prefix crates/rdf-wasm/js ci --ignore-scripts --no-audit --no-fund
+	node crates/shapes/tests/graphql_oracle.mjs
 
 bench-python: ## Compare the rdflib compat shim vs. real rdflib (report-only; NOT a test gate). See docs/BENCHMARKS.md.
 	cd bindings/python && uv run maturin develop && uv run python benchmarks/bench_compat.py

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -53,6 +53,21 @@ Copied from `gmeow-ontology`:
   old renderer and its shared private schema model are intended for deletion
   once this replacement is integrated; no downstream type contract is being
   preserved.
+- The legacy `render_graphql` path in
+  `crates/pipeline/src/stages/schemas.rs` at
+  `c91195e0c300cad9c9a32c8580c2910a6fd48fc1` was likewise used only as
+  migration evidence for a consumer artifact that PurRDF must subsume and
+  replace. Its output-only, LinkML-coupled private model, fabricated `id`/`iri`
+  fields, normalized names without a reverse map, all-nullable fields, broad
+  scalar collapse, and fixed GMEOW identity are deliberately discarded. The
+  replacement `purrdf-shapes::graphql` projection consumes `CompiledSchema`,
+  requires caller-owned identity, prose, and fallback-scalar name, emits paired
+  output/input GraphQL September 2025 SDL, retains a canonical reversible name
+  map and value codec, and locates every coercion difference on a closed loss
+  ledger verified against GraphQL.js. The old renderer and shared legacy model
+  are intended for deletion when gmeow integrates this replacement; that
+  consumer cutover is not yet complete and no downstream type contract is being
+  preserved.
 
 Copied from `gmeow-gts`:
 
@@ -82,5 +97,8 @@ Cutover staging:
 
 - `../gmeow-ontology/.worktrees/purrdf-cutover` exists on branch
   `paudley/purrdf-cutover`.
+- The downstream cutover is still in progress. Legacy consumer models and
+  renderers are migration evidence to delete as their PurRDF replacements are
+  integrated, not compatibility surfaces to preserve.
 - See `docs/CUTOVER.md` for the publish order, local gates, and dependency
   replacement rules.

--- a/crates/purrdf/src/lib.rs
+++ b/crates/purrdf/src/lib.rs
@@ -180,6 +180,30 @@ mod tests {
     }
 
     #[test]
+    fn facade_exposes_graphql_package_and_value_codec() {
+        let compiled = shapes::json_schema::CompiledSchema {
+            schema_json: "{\"$defs\":{\"Note\":{\"type\":\"string\"}}}\n".to_owned(),
+            openapi_json: "{}\n".to_owned(),
+            losses: LossLedger::new(),
+        };
+        let config = shapes::GraphqlConfig::new(
+            "FacadeSchema",
+            "Caller-owned package documentation.",
+            "Caller-owned module documentation.",
+            "JsonCarrier",
+        )
+        .expect("valid GraphQL configuration");
+        let package = shapes::emit_graphql(&compiled, &config).expect("GraphQL package emits");
+        assert!(package.losses.is_empty());
+        assert!(package.artifacts.contains_key(shapes::GRAPHQL_SCHEMA_PATH));
+        assert!(
+            package
+                .artifacts
+                .contains_key(shapes::GRAPHQL_NAME_MAP_PATH)
+        );
+    }
+
+    #[test]
     fn facade_exposes_the_completed_umbrella() {
         assert_eq!(columnar::Table::ALL.len(), 5);
 

--- a/crates/rdf-core/src/loss.rs
+++ b/crates/rdf-core/src/loss.rs
@@ -26,6 +26,7 @@
 //! shapes projection, the `json-schema`→`pydantic-v2` code-generation profile,
 //! the `json-schema`→`linkml-1.11` schema projection,
 //! the `json-schema`→`typescript-7.0` declaration projection,
+//! the `json-schema`→`graphql-september-2025` type-system projection,
 //! and the bidirectional RDF 1.2 dataset↔OKF profile;
 //! [`loss_matrix_json`] renders that same enumerable registry.
 
@@ -853,6 +854,152 @@ const JSON_SCHEMA_TYPESCRIPT_PROFILE: &[(&str, &str)] = &[
     ),
 ];
 
+/// The JSON Schema → GraphQL September 2025 type-system emitter's closed loss
+/// profile. GraphQL separates input and output types and defines variable
+/// coercion independently of JSON Schema validation. The emitter preserves the
+/// representable carrier graph and records every remaining difference at its
+/// JSON Pointer location; custom scalars are caller-owned behavior and are
+/// never treated as an implicit exact validator.
+const JSON_SCHEMA_GRAPHQL_PROFILE: &[(&str, &str)] = &[
+    (
+        "additional-properties-validation-narrowed",
+        "GraphQL input objects reject every field not declared by the input type before resolver \
+         execution. A JSON Schema object that permits additional properties therefore accepts \
+         source keys that the generated GraphQL input type rejects; named fields remain \
+         available and the narrowing is recorded on the object schema.",
+    ),
+    (
+        "array-cardinality-validation-dropped",
+        "GraphQL list types have no minimum- or maximum-length expression. The generated list \
+         retains its item carrier while JSON Schema minItems/maxItems validation is omitted.",
+    ),
+    (
+        "array-contains-validation-dropped",
+        "JSON Schema contains/minContains/maxContains quantifies matching array elements. \
+         GraphQL list input coercion has no corresponding predicate, so the item carrier remains \
+         while contains validation is omitted.",
+    ),
+    (
+        "conditional-validation-dropped",
+        "JSON Schema if/then/else chooses validation constraints from runtime instance content. \
+         GraphQL input object definitions cannot express that conditional relationship; \
+         independently representable fields remain while the conditional is omitted.",
+    ),
+    (
+        "custom-scalar-validation-delegated",
+        "GraphQL SDL declares a custom scalar name but does not define its parseValue, \
+         parseLiteral, or serialization behavior. Validation carried by the caller-named \
+         fallback scalar is therefore delegated to application code and is not an exact \
+         self-contained SDL projection.",
+    ),
+    (
+        "dependency-validation-dropped",
+        "JSON Schema dependentRequired/dependentSchemas imposes cross-field validation. GraphQL \
+         input object definitions express each field independently and cannot enforce those \
+         dependencies, so the relationship is omitted.",
+    ),
+    (
+        "integer-domain-validation-delegated",
+        "GraphQL Int accepts only signed 32-bit integers. A JSON Schema integer domain that is \
+         not exactly that domain is carried through the caller-named fallback scalar, whose \
+         integer acceptance behavior is application-defined.",
+    ),
+    (
+        "intersection-validation-delegated",
+        "General JSON Schema allOf is an intersection of validation sets. GraphQL has no input \
+         intersection type, so a non-mergeable intersection is carried through the \
+         caller-named fallback scalar and its validation is delegated.",
+    ),
+    (
+        "keyword-validation-delegated",
+        "A JSON Schema assertion outside the emitter's closed GraphQL capability table has no \
+         sound SDL expression. Its value is carried through the caller-named fallback scalar \
+         and the assertion is recorded rather than silently treated as enforced.",
+    ),
+    (
+        "negation-validation-delegated",
+        "JSON Schema not is a complement of an instance-validation set. GraphQL input types have \
+         no complement operator, so the value is carried through the caller-named fallback \
+         scalar and negation validation is delegated.",
+    ),
+    (
+        "nullable-presence-validation-widened",
+        "GraphQL uses one nullable field form for both omission and an explicit null. JSON Schema \
+         can distinguish required nullable properties from optional non-null properties; either \
+         source distinction must be widened when represented by a nullable GraphQL input field.",
+    ),
+    (
+        "numeric-validation-dropped",
+        "GraphQL Int and Float types do not express JSON Schema bounds, exclusive bounds, or \
+         multipleOf. The built-in numeric carrier remains while those runtime predicates are \
+         omitted.",
+    ),
+    (
+        "one-of-validation-delegated",
+        "JSON Schema oneOf requires exactly one branch to validate. GraphQL has no input union \
+         with exactly-one validation semantics, so a non-finite oneOf is carried through the \
+         caller-named fallback scalar and exclusivity is delegated.",
+    ),
+    (
+        "pattern-properties-validation-narrowed",
+        "JSON Schema patternProperties can admit runtime keys selected by a regular expression. \
+         GraphQL input object fields are a fixed finite name set and reject those dynamic keys, \
+         so the accepted object key space is narrowed.",
+    ),
+    (
+        "property-count-validation-dropped",
+        "JSON Schema minProperties/maxProperties counts runtime object keys. GraphQL input object \
+         definitions express field requiredness but cannot bound the total supplied-field count.",
+    ),
+    (
+        "property-name-validation-narrowed",
+        "JSON Schema propertyNames can validate an open runtime key space. GraphQL input objects \
+         expose only their declared finite field set and reject all other names, narrowing any \
+         source key space that remains open after the property-name assertion.",
+    ),
+    (
+        "recursive-input-nullability-relaxed",
+        "GraphQL forbids an unbroken cycle of singular non-null input-object fields because no \
+         finite value can satisfy it. The emitter makes one deterministic cycle edge nullable \
+         and records that required/non-null source constraint at the field location.",
+    ),
+    (
+        "singleton-list-coercion-widened",
+        "GraphQL variable coercion accepts a non-list value for list input and wraps it as a \
+         single-element list. JSON Schema array validation rejects that same non-array value, so \
+         every generated list input has this explicit coercion widening.",
+    ),
+    (
+        "string-validation-dropped",
+        "GraphQL String has no length, regular-expression, format, or content assertion. The \
+         string carrier remains while JSON Schema string predicates are omitted.",
+    ),
+    (
+        "tuple-array-validation-delegated",
+        "JSON Schema prefixItems and closed tuple tails assign schemas by array position. GraphQL \
+         lists are homogeneous, so a non-homogeneous tuple is carried through the caller-named \
+         fallback scalar and position-specific validation is delegated.",
+    ),
+    (
+        "unevaluated-validation-dropped",
+        "JSON Schema unevaluatedProperties/unevaluatedItems depends on applicator evaluation \
+         state that GraphQL input coercion does not expose. Representable local fields and items \
+         remain while the unevaluated assertion is omitted.",
+    ),
+    (
+        "union-validation-delegated",
+        "General JSON Schema anyOf and type unions define input-value unions. GraphQL has no \
+         input union type, so a non-finite union is carried through the caller-named fallback \
+         scalar and branch validation is delegated.",
+    ),
+    (
+        "unique-items-validation-dropped",
+        "JSON Schema uniqueItems compares runtime array values for equality. GraphQL list input \
+         coercion cannot require pairwise-distinct elements, so item validation remains while \
+         uniqueness is omitted.",
+    ),
+];
+
 /// Build the runtime-shaped [`LossEntry`] rows for the
 /// `("shacl", "json-schema")` shapes profile from [`SHACL_JSON_SCHEMA_PROFILE`]
 /// — one contract entry per declared `(code, note)` pair, `location: None`
@@ -916,6 +1063,21 @@ fn json_schema_typescript_entries() -> Vec<LossEntry> {
         .collect()
 }
 
+/// Build the static contract rows for the
+/// `("json-schema", "graphql-september-2025")` projection profile.
+fn json_schema_graphql_entries() -> Vec<LossEntry> {
+    JSON_SCHEMA_GRAPHQL_PROFILE
+        .iter()
+        .map(|&(code, note)| LossEntry {
+            code: Cow::Borrowed(code),
+            from: Cow::Borrowed("json-schema"),
+            to: Cow::Borrowed("graphql-september-2025"),
+            note: Cow::Borrowed(note),
+            location: None,
+        })
+        .collect()
+}
+
 /// Extract the `&'static str` payload of a **contract**-discipline
 /// [`LossEntry`] field (one built via [`Cow::Borrowed`]).
 ///
@@ -960,6 +1122,7 @@ fn registry_entries() -> Vec<LossEntry> {
     entries.extend(json_schema_pydantic_entries());
     entries.extend(json_schema_linkml_entries());
     entries.extend(json_schema_typescript_entries());
+    entries.extend(json_schema_graphql_entries());
     entries
 }
 
@@ -1509,6 +1672,19 @@ mod tests {
     }
 
     #[test]
+    fn transcode_matrix_includes_json_schema_graphql_pair() {
+        let json = loss_matrix_json();
+        assert!(json.contains("\"from\": \"json-schema\""));
+        assert!(json.contains("\"to\": \"graphql-september-2025\""));
+        for (code, _) in JSON_SCHEMA_GRAPHQL_PROFILE {
+            assert!(
+                json.contains(&format!("\"code\": \"{code}\"")),
+                "transcode-loss-matrix.json missing GraphQL-profile code `{code}`"
+            );
+        }
+    }
+
+    #[test]
     fn pair_loss_identity_is_empty() {
         assert!(pair_loss_ledger("turtle", "turtle").is_empty());
         assert!(pair_loss_ledger("gts", "gts").is_empty());
@@ -1664,6 +1840,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn registered_pairs_includes_json_schema_graphql() {
+        assert!(
+            registered_pairs()
+                .any(|(from, to)| { from == "json-schema" && to == "graphql-september-2025" })
+        );
+    }
+
     /// `registered_pairs()` must yield the SAME ordered sequence across two
     /// independent calls (it is backed by a `BTreeMap`, so this is order, not
     /// merely set-equality) — callers rendering it directly (e.g. a diagnostic
@@ -1715,6 +1899,16 @@ mod tests {
     fn profile_for_json_schema_typescript_is_closed() {
         let profile = profile_for("json-schema", "typescript-7.0");
         let expected: BTreeSet<&str> = JSON_SCHEMA_TYPESCRIPT_PROFILE
+            .iter()
+            .map(|(code, _)| *code)
+            .collect();
+        assert_eq!(profile, expected);
+    }
+
+    #[test]
+    fn profile_for_json_schema_graphql_is_closed() {
+        let profile = profile_for("json-schema", "graphql-september-2025");
+        let expected: BTreeSet<&str> = JSON_SCHEMA_GRAPHQL_PROFILE
             .iter()
             .map(|(code, _)| *code)
             .collect();

--- a/crates/rdf-core/src/loss.rs
+++ b/crates/rdf-core/src/loss.rs
@@ -941,10 +941,11 @@ const JSON_SCHEMA_GRAPHQL_PROFILE: &[(&str, &str)] = &[
          caller-named fallback scalar and exclusivity is delegated.",
     ),
     (
-        "pattern-properties-validation-narrowed",
-        "JSON Schema patternProperties can admit runtime keys selected by a regular expression. \
-         GraphQL input object fields are a fixed finite name set and reject those dynamic keys, \
-         so the accepted object key space is narrowed.",
+        "pattern-properties-validation-changed",
+        "JSON Schema patternProperties can admit dynamic regex-selected keys and can add \
+         conjunctive validation to declared keys. GraphQL input objects instead expose a fixed \
+         field set with one type per field, so dynamic keys are narrowed while overlapping \
+         declared-field validation may be widened.",
     ),
     (
         "property-count-validation-dropped",
@@ -952,10 +953,11 @@ const JSON_SCHEMA_GRAPHQL_PROFILE: &[(&str, &str)] = &[
          definitions express field requiredness but cannot bound the total supplied-field count.",
     ),
     (
-        "property-name-validation-narrowed",
-        "JSON Schema propertyNames can validate an open runtime key space. GraphQL input objects \
-         expose only their declared finite field set and reject all other names, narrowing any \
-         source key space that remains open after the property-name assertion.",
+        "property-name-validation-changed",
+        "JSON Schema propertyNames validates every runtime key, including declared properties. \
+         GraphQL input objects expose only a fixed declared field set: unknown names are narrowed, \
+         while a source property-name rule that rejects a generated declared field is not \
+         enforced and may widen acceptance.",
     ),
     (
         "recursive-input-nullability-relaxed",

--- a/crates/rdf-wasm/js/package-lock.json
+++ b/crates/rdf-wasm/js/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.4.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blackcatinformatics/purrdf",
-      "version": "0.4.1",
+      "version": "0.6.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
+        "graphql": "16.14.0",
         "typescript": "7.0.2"
       },
       "engines": {
@@ -353,6 +354,16 @@
       ],
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/typescript": {

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -43,6 +43,7 @@
     "typecheck": "tsc -p tsconfig.types.json"
   },
   "devDependencies": {
+    "graphql": "16.14.0",
     "typescript": "7.0.2"
   },
   "engines": {

--- a/crates/shapes/README.md
+++ b/crates/shapes/README.md
@@ -236,6 +236,105 @@ different schemas project to the same declaration. The retained
 surface. The production emitter has no JavaScript dependency, performs no
 filesystem I/O, and remains wasm-clean; TypeScript is dev-only oracle tooling.
 
+## GraphQL September 2025 SDL
+
+`emit_graphql` projects `CompiledSchema` into the fixed
+`graphql-september-2025` dialect. `GraphqlConfig` requires the caller's schema
+name, package and module prose, and non-built-in fallback-scalar name; it has no
+`Default` implementation. The output is a deterministic type-system fragment,
+not an executable GraphQL service: PurRDF emits no operation roots, resolvers,
+pagination, authorization, federation, or application directives.
+
+The compiling [`graphql_package` example](./examples/graphql_package.rs) shows
+configuration, artifact access, the typed name map, and the value codec:
+
+```rust,ignore
+use purrdf_shapes::{
+    GRAPHQL_NAME_MAP_PATH, GRAPHQL_SCHEMA_PATH, GraphqlConfig, emit_graphql,
+};
+
+let config = GraphqlConfig::new(
+    "ExampleSchema",
+    "GraphQL schema package owned by the caller.",
+    "Types generated from the caller's compiled schema.",
+    "JsonCarrier",
+)?;
+let package = emit_graphql(&compiled_schema, &config)?;
+let graphql_value = package.encode_input("Person", &source_json)?;
+let source_value = package.decode_output("Person", &graphql_value)?;
+
+let sdl = &package.artifacts[GRAPHQL_SCHEMA_PATH];
+let name_map = &package.artifacts[GRAPHQL_NAME_MAP_PATH];
+assert_eq!(package.names.definitions["Person"].input_type, "PersonInput");
+```
+
+Each structural object has a paired output `type` and input `input` object.
+The emitter directly represents booleans, strings, numbers, the exact signed
+32-bit `Int` domain, explicit nullability, finite `const`/`enum` value sets,
+closed named fields, required fields, homogeneous lists, local direct
+`#/$defs/...` references, aliases, descriptions, and deterministic inline
+object helpers. Types, helpers, and the fallback scalar share one global
+collision-checked namespace; fields and enum symbols are collision-checked in
+their GraphQL-local namespaces. The canonical `name-map.json` and identical
+typed `GraphqlNameMap` retain every source definition key, JSON property key,
+and finite JSON value alongside its GraphQL representation.
+
+`GraphqlPackage::encode_input` translates source JSON property names and
+finite values into GraphQL input names and enum symbols.
+`GraphqlPackage::decode_output` reverses present response fields and symbols;
+it permits GraphQL's normal partial field selection and does not invent omitted
+fields. Unknown definitions, keys, values, symbols, or incompatible carriers
+fail. This generated codec is the bidirectional boundary. Arbitrary GraphQL SDL
+does not define one unique JSON Schema acceptance relation, so PurRDF does not
+claim or provide a general SDL-to-JSON-Schema reader.
+
+GraphQL coercion cannot represent every JSON Schema assertion. Every semantic
+difference is intentional, stable-coded, and located at its source JSON
+Pointer on the closed `json-schema` → `graphql-september-2025` loss ledger:
+
+| Boundary | Closed loss codes |
+|---|---|
+| fixed input fields and object-key rules | `additional-properties-validation-narrowed`, `pattern-properties-validation-changed`, `property-name-validation-changed`, `property-count-validation-dropped` |
+| requiredness, null, and recursive inputs | `nullable-presence-validation-widened`, `recursive-input-nullability-relaxed` |
+| lists and positional/evaluation rules | `singleton-list-coercion-widened`, `array-cardinality-validation-dropped`, `array-contains-validation-dropped`, `unique-items-validation-dropped`, `tuple-array-validation-delegated`, `unevaluated-validation-dropped` |
+| scalar domains and predicates | `integer-domain-validation-delegated`, `numeric-validation-dropped`, `string-validation-dropped` |
+| applicators and cross-field rules | `conditional-validation-dropped`, `dependency-validation-dropped`, `intersection-validation-delegated`, `union-validation-delegated`, `one-of-validation-delegated`, `negation-validation-delegated` |
+| caller/runtime validation boundary | `custom-scalar-validation-delegated`, `keyword-validation-delegated` |
+
+The fallback scalar is only declared in SDL. Its `parseValue`, `parseLiteral`,
+and serialization behavior belongs to the caller, and every use that delegates
+source validation is ledgered. A package with an empty ledger is exact for the
+represented source acceptance relation; a non-empty ledger is never silently
+treated as validation.
+
+Emission hard-fails invalid caller names or prose, built-in fallback-scalar
+names, malformed keyword values, `$id` rebasing, external, indirect, or
+dangling `$ref`, `$dynamicRef`/`$recursiveRef`, pure-alias cycles,
+unsatisfiable closed required fields, and any generated type, field, helper,
+scalar, or enum name collision. The value codec likewise rejects unmapped or
+structurally incompatible values. Fixed platform-independent limits make
+resource behavior deterministic:
+
+| Resource | Limit |
+|---|---:|
+| input `schema_json`, each emitted artifact, or one codec JSON value | 16 MiB |
+| definitions, fields in one object, or values in one finite set | 65,536 |
+| schema-expression or codec-value depth | 128 |
+| generated or caller-supplied GraphQL name | 255 bytes |
+
+The dev-only oracle uses `boon` as the draft 2020-12 source classifier and the
+locked official GraphQL.js 16.14.0 implementation to build the generated SDL
+and execute real variable coercion. It checks lossless agreement, every closed
+loss family and location, codec/name-map agreement, and deliberate corruption
+failures:
+
+```bash
+make graphql-oracle
+```
+
+GraphQL.js is not a release dependency. The production emitter and codec are
+filesystem-free Rust and remain wasm-clean.
+
 ---
 
 ## Python extension

--- a/crates/shapes/examples/graphql_oracle_fixture.rs
+++ b/crates/shapes/examples/graphql_oracle_fixture.rs
@@ -1,0 +1,738 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Emit exact and lossy packages for the dev-only GraphQL.js coercion oracle.
+
+use std::collections::BTreeSet;
+use std::error::Error;
+
+use boon::{Compiler, Schemas};
+use purrdf::loss::{LossLedger, check_ledger_complete, check_ledger_sound};
+use purrdf_shapes::json_schema::CompiledSchema;
+use purrdf_shapes::{
+    GRAPHQL_DIALECT, GRAPHQL_NAME_MAP_PATH, GRAPHQL_SCHEMA_PATH, GraphqlConfig, GraphqlPackage,
+    emit_graphql,
+};
+use serde::Serialize;
+use serde_json::{Value, json};
+
+const CLOSED_PROFILE: [&str; 23] = [
+    "additional-properties-validation-narrowed",
+    "array-cardinality-validation-dropped",
+    "array-contains-validation-dropped",
+    "conditional-validation-dropped",
+    "custom-scalar-validation-delegated",
+    "dependency-validation-dropped",
+    "integer-domain-validation-delegated",
+    "intersection-validation-delegated",
+    "keyword-validation-delegated",
+    "negation-validation-delegated",
+    "nullable-presence-validation-widened",
+    "numeric-validation-dropped",
+    "one-of-validation-delegated",
+    "pattern-properties-validation-changed",
+    "property-count-validation-dropped",
+    "property-name-validation-changed",
+    "recursive-input-nullability-relaxed",
+    "singleton-list-coercion-widened",
+    "string-validation-dropped",
+    "tuple-array-validation-delegated",
+    "unevaluated-validation-dropped",
+    "union-validation-delegated",
+    "unique-items-validation-dropped",
+];
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ExpectedLoss {
+    code: String,
+    location: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Probe {
+    label: String,
+    definition: String,
+    graphql_type: String,
+    source_value: Value,
+    graphql_value: Value,
+    source_valid: bool,
+    used_codec: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expected_loss: Option<ExpectedLoss>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Fixture {
+    sdl: String,
+    fallback_scalar: String,
+    name_map: Value,
+    name_map_artifact: String,
+    losses: Value,
+    probes: Vec<Probe>,
+}
+
+fn compiled(schema: &Value) -> Result<CompiledSchema, serde_json::Error> {
+    Ok(CompiledSchema {
+        schema_json: format!("{}\n", serde_json::to_string_pretty(schema)?),
+        openapi_json: "{}\n".to_owned(),
+        losses: LossLedger::new(),
+    })
+}
+
+fn config() -> Result<GraphqlConfig, Box<dyn Error>> {
+    Ok(GraphqlConfig::new(
+        "GraphqlOracle",
+        "Caller-owned GraphQL differential-oracle fixture.",
+        "Type-system definitions checked against source JSON Schema acceptance.",
+        "JsonCarrier",
+    )?)
+}
+
+fn exact_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "Alias": { "$ref": "#/$defs/Person" },
+            "Choice": { "enum": [true, { "state": "open" }] },
+            "Int32": {
+                "type": "integer",
+                "minimum": -2_147_483_648_i64,
+                "maximum": 2_147_483_647_i64
+            },
+            "Person": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "@id": { "type": "string" },
+                    "ex:choice": { "$ref": "#/$defs/Choice" },
+                    "ex:count": { "$ref": "#/$defs/Int32" },
+                    "ex:maybe": { "type": ["string", "null"] }
+                },
+                "required": ["@id", "ex:choice", "ex:count"]
+            }
+        }
+    })
+}
+
+fn lossy_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "A": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": { "b": { "$ref": "#/$defs/B" } },
+                "required": ["b"]
+            },
+            "B": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": { "a": { "$ref": "#/$defs/A" } },
+                "required": ["a"]
+            },
+            "Cardinality": {
+                "type": "array",
+                "items": { "type": "string" },
+                "minItems": 2
+            },
+            "Conditional": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "flag": { "type": ["boolean", "null"] },
+                    "value": { "type": ["string", "null"] }
+                },
+                "if": { "properties": { "flag": { "const": true } }, "required": ["flag"] },
+                "then": { "required": ["value"] }
+            },
+            "Contains": {
+                "type": "array",
+                "items": { "type": "string" },
+                "contains": { "const": "match" }
+            },
+            "Dependency": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "a": { "type": ["boolean", "null"] },
+                    "b": { "type": ["string", "null"] }
+                },
+                "dependentRequired": { "a": ["b"] }
+            },
+            "FalseRule": false,
+            "GenericInteger": { "type": "integer" },
+            "IntPredicate": {
+                "type": "integer",
+                "minimum": -2_147_483_648_i64,
+                "maximum": 2_147_483_647_i64,
+                "multipleOf": 2
+            },
+            "Intersection": {
+                "allOf": [{ "type": "string" }, { "type": "string", "minLength": 2 }]
+            },
+            "Negated": { "type": "string", "not": { "const": "forbidden" } },
+            "OneOf": {
+                "oneOf": [{ "type": "string" }, { "const": "overlap" }]
+            },
+            "OpenObject": {
+                "type": "object",
+                "properties": { "known": { "type": ["string", "null"] } }
+            },
+            "OptionalNonNull": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": { "value": { "type": "string" } }
+            },
+            "Patterned": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": { "ex:value": { "type": "string" } },
+                "required": ["ex:value"],
+                "patternProperties": { "^ex:": { "type": "boolean" } }
+            },
+            "PropertyCount": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": { "known": { "type": ["string", "null"] } },
+                "minProperties": 1
+            },
+            "PropertyNames": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": { "bad-key": { "type": "string" } },
+                "required": ["bad-key"],
+                "propertyNames": { "pattern": "^[a-z]+$" }
+            },
+            "Singleton": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "StringRule": { "type": "string", "pattern": "^[A-Z]+$" },
+            "Tuple": {
+                "type": "array",
+                "prefixItems": [{ "type": "string" }, { "type": "boolean" }],
+                "items": false
+            },
+            "Unevaluated": {
+                "type": "array",
+                "contains": { "const": "match" },
+                "unevaluatedItems": false
+            },
+            "Union": { "anyOf": [{ "type": "string" }, { "type": "boolean" }] },
+            "Unique": {
+                "type": "array",
+                "items": { "type": "string" },
+                "uniqueItems": true
+            },
+            "Unknown": { "type": "string", "unsupportedAssertion": true }
+        }
+    })
+}
+
+fn validates(schema: &Value, definition: &str, instance: &Value) -> Result<bool, Box<dyn Error>> {
+    let escaped = definition.replace('~', "~0").replace('/', "~1");
+    let wrapper = json!({
+        "$schema": schema["$schema"],
+        "$defs": schema["$defs"],
+        "$ref": format!("#/$defs/{escaped}")
+    });
+    let location = "mem:///graphql-oracle.schema.json";
+    let mut schemas = Schemas::new();
+    let mut compiler = Compiler::new();
+    compiler.add_resource(location, wrapper)?;
+    let compiled = compiler.compile(location, &mut schemas)?;
+    Ok(schemas.validate(instance, compiled).is_ok())
+}
+
+fn has_loss(package: &GraphqlPackage, code: &str, location: &str) -> bool {
+    package.losses.entries().iter().any(|entry| {
+        entry.code == code
+            && entry
+                .location
+                .as_ref()
+                .and_then(|value| value.subject.as_deref())
+                == Some(location)
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn probe(
+    schema: &Value,
+    package: &GraphqlPackage,
+    label: &str,
+    definition: &str,
+    source_value: Value,
+    expected_source_valid: bool,
+    graphql_override: Option<Value>,
+    expected_loss: Option<(&str, &str)>,
+) -> Result<Probe, Box<dyn Error>> {
+    let source_valid = validates(schema, definition, &source_value)?;
+    if source_valid != expected_source_valid {
+        return Err(format!(
+            "source fixture probe {label:?} classified as {source_valid}, expected \
+             {expected_source_valid}"
+        )
+        .into());
+    }
+    let expected_loss = expected_loss.map(|(code, location)| ExpectedLoss {
+        code: code.to_owned(),
+        location: location.to_owned(),
+    });
+    if let Some(loss) = &expected_loss
+        && !has_loss(package, &loss.code, &loss.location)
+    {
+        return Err(format!(
+            "probe {label:?} names absent loss {} at {}",
+            loss.code, loss.location
+        )
+        .into());
+    }
+    let (graphql_value, used_codec) = if let Some(value) = graphql_override {
+        (value, false)
+    } else {
+        let encoded = package.encode_input(definition, &source_value)?;
+        if source_valid {
+            let decoded = package.decode_output(definition, &encoded)?;
+            if decoded != source_value {
+                return Err(
+                    format!("production GraphQL codec did not round-trip probe {label:?}").into(),
+                );
+            }
+        }
+        (encoded, true)
+    };
+    let input_type = &package
+        .names
+        .definitions
+        .get(definition)
+        .ok_or_else(|| format!("fixture definition {definition:?} has no generated type"))?
+        .input_type;
+    Ok(Probe {
+        label: label.to_owned(),
+        definition: definition.to_owned(),
+        graphql_type: format!("{input_type}!"),
+        source_value,
+        graphql_value,
+        source_valid,
+        used_codec,
+        expected_loss,
+    })
+}
+
+fn artifact(package: &GraphqlPackage, path: &str) -> Result<String, Box<dyn Error>> {
+    Ok(std::str::from_utf8(
+        package
+            .artifacts
+            .get(path)
+            .ok_or_else(|| format!("GraphQL package has no {path} artifact"))?,
+    )?
+    .to_owned())
+}
+
+fn fixture(package: &GraphqlPackage, probes: Vec<Probe>) -> Result<Fixture, Box<dyn Error>> {
+    Ok(Fixture {
+        sdl: artifact(package, GRAPHQL_SCHEMA_PATH)?,
+        fallback_scalar: "JsonCarrier".to_owned(),
+        name_map: serde_json::to_value(&package.names)?,
+        name_map_artifact: artifact(package, GRAPHQL_NAME_MAP_PATH)?,
+        losses: serde_json::from_str(&package.losses.render_json())?,
+        probes,
+    })
+}
+
+fn exact_fixture(schema: &Value, package: &GraphqlPackage) -> Result<Fixture, Box<dyn Error>> {
+    if !package.losses.is_empty() {
+        return Err(format!(
+            "exact GraphQL fixture has losses: {}",
+            package.losses.render_json()
+        )
+        .into());
+    }
+    let valid_person = json!({
+        "@id": "ex:person",
+        "ex:choice": { "state": "open" },
+        "ex:count": 7,
+        "ex:maybe": null
+    });
+    let probes = vec![
+        probe(
+            schema,
+            package,
+            "person-valid",
+            "Person",
+            valid_person,
+            true,
+            None,
+            None,
+        )?,
+        probe(
+            schema,
+            package,
+            "person-missing-required",
+            "Person",
+            json!({ "ex:choice": true, "ex:count": 7 }),
+            false,
+            None,
+            None,
+        )?,
+        probe(
+            schema,
+            package,
+            "person-wrong-scalar",
+            "Person",
+            json!({ "@id": true, "ex:choice": true, "ex:count": 7 }),
+            false,
+            Some(json!({ "id": true, "exChoice": "VALUE_0", "exCount": 7 })),
+            None,
+        )?,
+        probe(
+            schema,
+            package,
+            "person-unknown-field",
+            "Person",
+            json!({ "@id": "ex:p", "ex:choice": true, "ex:count": 7, "extra": true }),
+            false,
+            Some(json!({ "id": "ex:p", "exChoice": "VALUE_0", "exCount": 7, "extra": true })),
+            None,
+        )?,
+        probe(
+            schema,
+            package,
+            "choice-object",
+            "Choice",
+            json!({ "state": "open" }),
+            true,
+            None,
+            None,
+        )?,
+        probe(
+            schema,
+            package,
+            "choice-invalid",
+            "Choice",
+            json!("missing"),
+            false,
+            Some(json!("NOT_A_SYMBOL")),
+            None,
+        )?,
+        probe(
+            schema,
+            package,
+            "int32-maximum",
+            "Int32",
+            json!(2_147_483_647_i64),
+            true,
+            None,
+            None,
+        )?,
+        probe(
+            schema,
+            package,
+            "int32-overflow",
+            "Int32",
+            json!(2_147_483_648_i64),
+            false,
+            Some(json!(2_147_483_648_i64)),
+            None,
+        )?,
+    ];
+    fixture(package, probes)
+}
+
+fn lossy_fixture(schema: &Value, package: &GraphqlPackage) -> Result<Fixture, Box<dyn Error>> {
+    check_ledger_sound(&package.losses, "json-schema", GRAPHQL_DIALECT)?;
+    check_ledger_complete(&package.losses, &CLOSED_PROFILE)?;
+    let rows = [
+        (
+            "open-object",
+            "OpenObject",
+            json!({"known": "ok", "extra": "x"}),
+            false,
+            Some(json!({"known": "ok", "extra": "x"})),
+            true,
+            Some((
+                "additional-properties-validation-narrowed",
+                "#/$defs/OpenObject",
+            )),
+        ),
+        (
+            "array-cardinality",
+            "Cardinality",
+            json!(["one"]),
+            true,
+            None,
+            false,
+            Some((
+                "array-cardinality-validation-dropped",
+                "#/$defs/Cardinality/minItems",
+            )),
+        ),
+        (
+            "array-contains",
+            "Contains",
+            json!(["other"]),
+            true,
+            None,
+            false,
+            Some((
+                "array-contains-validation-dropped",
+                "#/$defs/Contains/contains",
+            )),
+        ),
+        (
+            "conditional",
+            "Conditional",
+            json!({"flag": true}),
+            true,
+            None,
+            false,
+            Some(("conditional-validation-dropped", "#/$defs/Conditional/then")),
+        ),
+        (
+            "custom-scalar",
+            "FalseRule",
+            json!("carried"),
+            true,
+            None,
+            false,
+            Some(("custom-scalar-validation-delegated", "#/$defs/FalseRule")),
+        ),
+        (
+            "dependency",
+            "Dependency",
+            json!({"a": true}),
+            true,
+            None,
+            false,
+            Some((
+                "dependency-validation-dropped",
+                "#/$defs/Dependency/dependentRequired",
+            )),
+        ),
+        (
+            "integer-domain",
+            "GenericInteger",
+            json!(1.5),
+            true,
+            None,
+            false,
+            Some((
+                "integer-domain-validation-delegated",
+                "#/$defs/GenericInteger/type",
+            )),
+        ),
+        (
+            "intersection",
+            "Intersection",
+            json!("x"),
+            true,
+            None,
+            false,
+            Some((
+                "intersection-validation-delegated",
+                "#/$defs/Intersection/allOf",
+            )),
+        ),
+        (
+            "negation",
+            "Negated",
+            json!("forbidden"),
+            true,
+            None,
+            false,
+            Some(("negation-validation-delegated", "#/$defs/Negated/not")),
+        ),
+        (
+            "nullable-presence",
+            "OptionalNonNull",
+            json!({"value": null}),
+            true,
+            None,
+            false,
+            Some((
+                "nullable-presence-validation-widened",
+                "#/$defs/OptionalNonNull/properties/value",
+            )),
+        ),
+        (
+            "numeric-predicate",
+            "IntPredicate",
+            json!(3),
+            true,
+            None,
+            false,
+            Some((
+                "numeric-validation-dropped",
+                "#/$defs/IntPredicate/multipleOf",
+            )),
+        ),
+        (
+            "one-of",
+            "OneOf",
+            json!("overlap"),
+            true,
+            None,
+            false,
+            Some(("one-of-validation-delegated", "#/$defs/OneOf/oneOf")),
+        ),
+        (
+            "pattern-properties",
+            "Patterned",
+            json!({"ex:value": "text"}),
+            true,
+            None,
+            false,
+            Some((
+                "pattern-properties-validation-changed",
+                "#/$defs/Patterned/patternProperties/^ex:",
+            )),
+        ),
+        (
+            "property-count",
+            "PropertyCount",
+            json!({}),
+            true,
+            None,
+            false,
+            Some((
+                "property-count-validation-dropped",
+                "#/$defs/PropertyCount/minProperties",
+            )),
+        ),
+        (
+            "property-name",
+            "PropertyNames",
+            json!({"bad-key": "x"}),
+            true,
+            None,
+            false,
+            Some((
+                "property-name-validation-changed",
+                "#/$defs/PropertyNames/propertyNames",
+            )),
+        ),
+        (
+            "recursive-input",
+            "A",
+            json!({"b": {}}),
+            true,
+            None,
+            false,
+            Some((
+                "recursive-input-nullability-relaxed",
+                "#/$defs/B/properties/a",
+            )),
+        ),
+        (
+            "singleton-list",
+            "Singleton",
+            json!("one"),
+            true,
+            Some(json!("one")),
+            false,
+            Some(("singleton-list-coercion-widened", "#/$defs/Singleton")),
+        ),
+        (
+            "string-rule",
+            "StringRule",
+            json!("lower"),
+            true,
+            None,
+            false,
+            Some(("string-validation-dropped", "#/$defs/StringRule/pattern")),
+        ),
+        (
+            "tuple",
+            "Tuple",
+            json!([true, false]),
+            true,
+            None,
+            false,
+            Some((
+                "tuple-array-validation-delegated",
+                "#/$defs/Tuple/prefixItems",
+            )),
+        ),
+        (
+            "unevaluated",
+            "Unevaluated",
+            json!(["match", "other"]),
+            true,
+            None,
+            false,
+            Some((
+                "unevaluated-validation-dropped",
+                "#/$defs/Unevaluated/unevaluatedItems",
+            )),
+        ),
+        (
+            "union",
+            "Union",
+            json!(7),
+            true,
+            None,
+            false,
+            Some(("union-validation-delegated", "#/$defs/Union/anyOf")),
+        ),
+        (
+            "unique",
+            "Unique",
+            json!(["x", "x"]),
+            true,
+            None,
+            false,
+            Some((
+                "unique-items-validation-dropped",
+                "#/$defs/Unique/uniqueItems",
+            )),
+        ),
+    ];
+    let mut probes = Vec::with_capacity(rows.len());
+    for (label, definition, value, expected_graphql_valid, override_value, source_valid, loss) in
+        rows
+    {
+        if expected_graphql_valid == source_valid {
+            return Err(format!("lossy fixture row {label:?} must declare a divergence").into());
+        }
+        probes.push(probe(
+            schema,
+            package,
+            label,
+            definition,
+            value,
+            source_valid,
+            override_value,
+            loss,
+        )?);
+    }
+    fixture(package, probes)
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let config = config()?;
+    let exact_schema = exact_schema();
+    let lossy_schema = lossy_schema();
+    let exact_package = emit_graphql(&compiled(&exact_schema)?, &config)?;
+    let lossy_package = emit_graphql(&compiled(&lossy_schema)?, &config)?;
+    let observed: BTreeSet<&str> = lossy_package
+        .losses
+        .entries()
+        .iter()
+        .map(|entry| entry.code.as_ref())
+        .collect();
+    let expected: BTreeSet<&str> = CLOSED_PROFILE.into_iter().collect();
+    if observed != expected {
+        return Err(format!("GraphQL oracle loss profile drift: {observed:?}").into());
+    }
+    let output = json!({
+        "dialect": GRAPHQL_DIALECT,
+        "closedProfile": CLOSED_PROFILE,
+        "exact": exact_fixture(&exact_schema, &exact_package)?,
+        "lossy": lossy_fixture(&lossy_schema, &lossy_package)?,
+    });
+    println!("{}", serde_json::to_string(&output)?);
+    Ok(())
+}

--- a/crates/shapes/examples/graphql_oracle_fixture.rs
+++ b/crates/shapes/examples/graphql_oracle_fixture.rs
@@ -3,6 +3,7 @@
 
 //! Emit exact and lossy packages for the dev-only GraphQL.js coercion oracle.
 
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::error::Error;
 
@@ -233,7 +234,11 @@ fn lossy_schema() -> Value {
 }
 
 fn validates(schema: &Value, definition: &str, instance: &Value) -> Result<bool, Box<dyn Error>> {
-    let escaped = definition.replace('~', "~0").replace('/', "~1");
+    let escaped = if definition.contains('~') || definition.contains('/') {
+        Cow::Owned(definition.replace('~', "~0").replace('/', "~1"))
+    } else {
+        Cow::Borrowed(definition)
+    };
     let wrapper = json!({
         "$schema": schema["$schema"],
         "$defs": schema["$defs"],

--- a/crates/shapes/examples/graphql_package.rs
+++ b/crates/shapes/examples/graphql_package.rs
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Emit a deterministic GraphQL package and use its reversible value codec.
+
+use std::error::Error;
+
+use purrdf::loss::LossLedger;
+use purrdf_shapes::json_schema::CompiledSchema;
+use purrdf_shapes::{GRAPHQL_NAME_MAP_PATH, GRAPHQL_SCHEMA_PATH, GraphqlConfig, emit_graphql};
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let source_schema = json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "Status": { "enum": ["active", "paused"] },
+            "Person": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "@id": { "type": "string" },
+                    "ex:status": { "$ref": "#/$defs/Status" }
+                },
+                "required": ["@id", "ex:status"]
+            }
+        }
+    });
+    let compiled = CompiledSchema {
+        schema_json: format!("{}\n", serde_json::to_string_pretty(&source_schema)?),
+        openapi_json: "{}\n".to_owned(),
+        losses: LossLedger::new(),
+    };
+    let config = GraphqlConfig::new(
+        "ExampleSchema",
+        "GraphQL schema package owned by the caller.",
+        "Types generated from the caller's compiled schema.",
+        "JsonCarrier",
+    )?;
+    let package = emit_graphql(&compiled, &config)?;
+
+    assert!(package.losses.is_empty());
+    assert_eq!(package.names.definitions["Person"].output_type, "Person");
+    assert_eq!(package.names.fields["#/$defs/Person"]["@id"], "id");
+
+    let source_value = json!({
+        "@id": "https://example.org/alice",
+        "ex:status": "active"
+    });
+    let graphql_value = package.encode_input("Person", &source_value)?;
+    assert_eq!(
+        package.decode_output("Person", &graphql_value)?,
+        source_value
+    );
+
+    let sdl = std::str::from_utf8(&package.artifacts[GRAPHQL_SCHEMA_PATH])?;
+    let name_map = std::str::from_utf8(&package.artifacts[GRAPHQL_NAME_MAP_PATH])?;
+    assert!(sdl.contains("type Person"));
+    assert!(sdl.contains("input PersonInput"));
+    assert!(name_map.ends_with('\n'));
+    Ok(())
+}

--- a/crates/shapes/src/graphql.rs
+++ b/crates/shapes/src/graphql.rs
@@ -785,17 +785,17 @@ impl<'a> Planner<'a> {
         if let Some(patterns) = object.get("patternProperties").and_then(Value::as_object) {
             for pattern in patterns.keys() {
                 self.record(
-                    "pattern-properties-validation-narrowed",
+                    "pattern-properties-validation-changed",
                     &format!("{path}/patternProperties/{}", pointer_escape(pattern)),
-                    "GraphQL input object fields cannot be selected by a runtime key regex",
+                    "GraphQL fixed fields cannot preserve regex-selected dynamic or overlapping keys",
                 );
             }
         }
         if object.contains_key("propertyNames") {
             self.record(
-                "property-name-validation-narrowed",
+                "property-name-validation-changed",
                 &format!("{path}/propertyNames"),
-                "GraphQL input objects expose a fixed finite property-name set",
+                "GraphQL fixed fields do not apply the source schema to each runtime key name",
             );
         }
         for keyword in ["minProperties", "maxProperties"] {
@@ -2403,9 +2403,9 @@ mod tests {
             "nullable-presence-validation-widened",
             "numeric-validation-dropped",
             "one-of-validation-delegated",
-            "pattern-properties-validation-narrowed",
+            "pattern-properties-validation-changed",
             "property-count-validation-dropped",
-            "property-name-validation-narrowed",
+            "property-name-validation-changed",
             "recursive-input-nullability-relaxed",
             "singleton-list-coercion-widened",
             "string-validation-dropped",

--- a/crates/shapes/src/graphql.rs
+++ b/crates/shapes/src/graphql.rs
@@ -1,0 +1,2706 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Deterministic [`CompiledSchema`] → GraphQL September 2025 type-system emitter.
+//!
+//! The generated SDL is a type-system fragment, not an executable service:
+//! operation roots, resolvers, authorization, and pagination are caller-owned.
+//! Every structural object is emitted as paired output and input types. A
+//! canonical name map and the package's value codec translate JSON property
+//! names and finite JSON values without inventing a vocabulary.
+//!
+//! GraphQL variable coercion is not JSON Schema validation. Differences such
+//! as singleton-list coercion, fixed input-field sets, custom-scalar behavior,
+//! and required/null presence are recorded on [`GraphqlPackage::losses`] at
+//! their source JSON Pointer locations.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt::{self, Write as _};
+
+use ::purrdf::RdfLocation;
+use ::purrdf::loss::{LossEntry, LossLedger};
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::json_schema::CompiledSchema;
+use crate::schema_catalog::{
+    CompiledSchemaCatalog, definition_path, pointer_escape, reference_key, schema_array_keywords,
+    schema_map_keywords, schema_single_keywords,
+};
+
+/// Fixed GraphQL language revision used by the emitter and loss registry.
+pub const GRAPHQL_DIALECT: &str = "graphql-september-2025";
+
+/// Relative path of the generated GraphQL type-system SDL artifact.
+pub const GRAPHQL_SCHEMA_PATH: &str = "schema.graphql";
+
+/// Relative path of the generated canonical JSON name-map artifact.
+pub const GRAPHQL_NAME_MAP_PATH: &str = "name-map.json";
+
+const LOSS_FROM: &str = "json-schema";
+const LOSS_CONTEXT: &str = "graphql-emitter";
+const MAX_SCHEMA_JSON_BYTES: usize = 16 * 1024 * 1024;
+const MAX_ARTIFACT_BYTES: usize = 16 * 1024 * 1024;
+const MAX_VALUE_JSON_BYTES: usize = 16 * 1024 * 1024;
+const MAX_DEFINITIONS: usize = 65_536;
+const MAX_FIELDS: usize = 65_536;
+const MAX_ENUM_VALUES: usize = 65_536;
+const MAX_SCHEMA_DEPTH: usize = 128;
+const MAX_GRAPHQL_NAME_BYTES: usize = 255;
+
+/// Caller-owned identity and prose for a generated GraphQL schema package.
+///
+/// There is intentionally no [`Default`] implementation. PurRDF does not
+/// fabricate package identity, documentation, or scalar semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphqlConfig {
+    schema_name: String,
+    package_docstring: String,
+    module_docstring: String,
+    fallback_scalar_name: String,
+}
+
+impl GraphqlConfig {
+    /// Validate and construct GraphQL emitter configuration.
+    ///
+    /// `schema_name` and `fallback_scalar_name` must be non-introspection
+    /// GraphQL Names. The fallback scalar must not be a built-in scalar. Prose
+    /// values must be caller-supplied, non-whitespace text; line endings are
+    /// canonicalized to LF.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GraphqlError`] for invalid names, blank prose, or unsupported
+    /// control characters.
+    pub fn new(
+        schema_name: impl Into<String>,
+        package_docstring: impl Into<String>,
+        module_docstring: impl Into<String>,
+        fallback_scalar_name: impl Into<String>,
+    ) -> Result<Self, GraphqlError> {
+        let schema_name = schema_name.into();
+        validate_graphql_name("schema name", &schema_name)?;
+        let fallback_scalar_name = fallback_scalar_name.into();
+        validate_graphql_name("fallback scalar name", &fallback_scalar_name)?;
+        if is_builtin_type(&fallback_scalar_name) {
+            return Err(GraphqlError::new(format!(
+                "GraphQL fallback scalar name {fallback_scalar_name:?} collides with a built-in \
+                 GraphQL type"
+            )));
+        }
+        Ok(Self {
+            schema_name,
+            package_docstring: normalize_prose("package docstring", &package_docstring.into())?,
+            module_docstring: normalize_prose("module docstring", &module_docstring.into())?,
+            fallback_scalar_name,
+        })
+    }
+
+    /// Caller-supplied package/schema identifier.
+    #[must_use]
+    pub fn schema_name(&self) -> &str {
+        &self.schema_name
+    }
+
+    /// Caller-supplied package documentation.
+    #[must_use]
+    pub fn package_docstring(&self) -> &str {
+        &self.package_docstring
+    }
+
+    /// Caller-supplied module documentation.
+    #[must_use]
+    pub fn module_docstring(&self) -> &str {
+        &self.module_docstring
+    }
+
+    /// Caller-supplied custom scalar used for values without an exact built-in
+    /// GraphQL carrier.
+    #[must_use]
+    pub fn fallback_scalar_name(&self) -> &str {
+        &self.fallback_scalar_name
+    }
+}
+
+/// Output/input GraphQL type expressions for one source `$defs` key.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GraphqlDefinitionMap {
+    /// Type expression used at GraphQL output position.
+    pub output_type: String,
+    /// Type expression used at GraphQL input position.
+    pub input_type: String,
+}
+
+/// One finite source JSON value and its generated GraphQL enum symbol.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GraphqlEnumValueMap {
+    /// Exact source JSON value.
+    pub source_value: Value,
+    /// Generated GraphQL enum symbol.
+    pub graphql_name: String,
+}
+
+/// Typed, deterministic source-name/value → GraphQL-name map.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GraphqlNameMap {
+    /// Fixed emitter dialect.
+    pub dialect: String,
+    /// Caller-owned schema/package identifier.
+    pub schema_name: String,
+    /// Source `$defs` key → output/input type expressions.
+    pub definitions: BTreeMap<String, GraphqlDefinitionMap>,
+    /// Object-schema JSON Pointer → source property → GraphQL field.
+    pub fields: BTreeMap<String, BTreeMap<String, String>>,
+    /// Finite-schema JSON Pointer → exact values and GraphQL enum symbols.
+    pub enum_values: BTreeMap<String, Vec<GraphqlEnumValueMap>>,
+}
+
+/// Deterministic generated GraphQL package and its projection losses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphqlPackage {
+    /// Caller-owned schema/package identifier copied from [`GraphqlConfig`].
+    pub schema_name: String,
+    /// Relative package paths → exact file bytes, sorted by path.
+    pub artifacts: BTreeMap<String, Vec<u8>>,
+    /// Typed copy of the canonical `name-map.json` contract.
+    pub names: GraphqlNameMap,
+    /// JSON Schema assertions not represented exactly by GraphQL coercion.
+    pub losses: LossLedger,
+    source_definitions: BTreeMap<String, Value>,
+    representations: BTreeMap<String, Representation>,
+    reference_targets: BTreeMap<String, String>,
+}
+
+impl GraphqlPackage {
+    /// Translate one source JSON value into the generated GraphQL input naming
+    /// and finite-enum transport representation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GraphqlError`] for an unknown definition, an unmapped field or
+    /// enum value, a structurally incompatible carrier, excessive nesting, or
+    /// a value beyond the fixed byte limit.
+    pub fn encode_input(&self, definition: &str, value: &Value) -> Result<Value, GraphqlError> {
+        self.translate_definition(definition, value, CodecDirection::EncodeInput)
+    }
+
+    /// Translate one generated GraphQL output value back to source JSON field
+    /// names and exact finite JSON values.
+    ///
+    /// GraphQL responses may contain a selected subset of output fields; this
+    /// method translates present fields and does not invent omitted values.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GraphqlError`] for an unknown definition, field, or enum symbol,
+    /// a structurally incompatible carrier, excessive nesting, or a value beyond
+    /// the fixed byte limit.
+    pub fn decode_output(&self, definition: &str, value: &Value) -> Result<Value, GraphqlError> {
+        self.translate_definition(definition, value, CodecDirection::DecodeOutput)
+    }
+
+    fn translate_definition(
+        &self,
+        definition: &str,
+        value: &Value,
+        direction: CodecDirection,
+    ) -> Result<Value, GraphqlError> {
+        ensure_value_size(value)?;
+        let schema = self.source_definitions.get(definition).ok_or_else(|| {
+            GraphqlError::new(format!("unknown GraphQL source definition {definition:?}"))
+        })?;
+        let translated =
+            self.translate_value(schema, &definition_path(definition), value, direction, 0)?;
+        ensure_value_size(&translated)?;
+        Ok(translated)
+    }
+}
+
+/// A malformed GraphQL configuration, input schema, generated name graph, or
+/// value-codec request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphqlError {
+    message: String,
+}
+
+impl GraphqlError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for GraphqlError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for GraphqlError {}
+
+/// Emit deterministic paired GraphQL output/input SDL and a canonical name map
+/// from one compiled SHACL-derived JSON Schema.
+///
+/// Source-stage losses remain on [`CompiledSchema::losses`]. The returned
+/// ledger describes only the `json-schema` → `graphql-september-2025`
+/// projection.
+///
+/// # Errors
+///
+/// Returns [`GraphqlError`] when configuration or schema input is malformed or
+/// too large, a reference is open/dangling, generated names collide, a schema
+/// value exceeds a fixed resource limit, or the resulting artifacts exceed
+/// their fixed byte limits.
+pub fn emit_graphql(
+    compiled: &CompiledSchema,
+    config: &GraphqlConfig,
+) -> Result<GraphqlPackage, GraphqlError> {
+    if compiled.schema_json.len() > MAX_SCHEMA_JSON_BYTES {
+        return Err(GraphqlError::new(format!(
+            "CompiledSchema.schema_json exceeds the {MAX_SCHEMA_JSON_BYTES}-byte GraphQL emitter \
+             input limit"
+        )));
+    }
+    let catalog = CompiledSchemaCatalog::parse(compiled)
+        .map_err(|error| GraphqlError::new(error.to_string()))?;
+    let definitions = catalog.definitions();
+    if definitions.len() > MAX_DEFINITIONS {
+        return Err(GraphqlError::new(format!(
+            "CompiledSchema contains {} definitions; GraphQL emission is limited to \
+             {MAX_DEFINITIONS}",
+            definitions.len()
+        )));
+    }
+    for (key, definition) in definitions {
+        validate_schema_keywords(definition, &definition_path(key), 0)?;
+    }
+
+    let mut planner = Planner::new(definitions, config)?;
+    planner.plan()?;
+    planner.audit()?;
+    planner.relax_invalid_input_cycles()?;
+    let definition_maps = planner.definition_maps()?;
+    let sdl = planner.render_sdl()?;
+    if sdl.len() > MAX_ARTIFACT_BYTES {
+        return Err(GraphqlError::new(format!(
+            "generated GraphQL SDL exceeds the {MAX_ARTIFACT_BYTES}-byte output limit"
+        )));
+    }
+    let names = GraphqlNameMap {
+        dialect: GRAPHQL_DIALECT.to_owned(),
+        schema_name: config.schema_name.clone(),
+        definitions: definition_maps,
+        fields: planner.fields.clone(),
+        enum_values: planner.enum_values.clone(),
+    };
+    let mut name_map_json = serde_json::to_string_pretty(&names).map_err(|error| {
+        GraphqlError::new(format!("cannot serialize GraphQL name map: {error}"))
+    })?;
+    name_map_json.push('\n');
+    if name_map_json.len() > MAX_ARTIFACT_BYTES {
+        return Err(GraphqlError::new(format!(
+            "generated GraphQL name map exceeds the {MAX_ARTIFACT_BYTES}-byte output limit"
+        )));
+    }
+
+    let mut artifacts = BTreeMap::new();
+    artifacts.insert(GRAPHQL_NAME_MAP_PATH.to_owned(), name_map_json.into_bytes());
+    artifacts.insert(GRAPHQL_SCHEMA_PATH.to_owned(), sdl.into_bytes());
+    Ok(GraphqlPackage {
+        schema_name: config.schema_name.clone(),
+        artifacts,
+        names,
+        losses: planner.ledger,
+        source_definitions: definitions
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
+        representations: planner.representations,
+        reference_targets: planner.reference_targets,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Representation {
+    Enum,
+    Object,
+    Array,
+    Reference(String),
+    String,
+    Boolean,
+    Int,
+    Fallback,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ObjectNames {
+    output: String,
+    input: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TypePosition {
+    Output,
+    Input,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodecDirection {
+    EncodeInput,
+    DecodeOutput,
+}
+
+struct Planner<'a> {
+    definitions: &'a Map<String, Value>,
+    config: &'a GraphqlConfig,
+    representations: BTreeMap<String, Representation>,
+    schemas: BTreeMap<String, Value>,
+    objects: BTreeMap<String, ObjectNames>,
+    enums: BTreeMap<String, String>,
+    fields: BTreeMap<String, BTreeMap<String, String>>,
+    enum_values: BTreeMap<String, Vec<GraphqlEnumValueMap>>,
+    used_type_names: BTreeMap<String, String>,
+    reference_targets: BTreeMap<String, String>,
+    ledger: LossLedger,
+    recorded_losses: BTreeSet<(String, String)>,
+    relaxed_fields: BTreeSet<String>,
+}
+
+impl<'a> Planner<'a> {
+    fn new(
+        definitions: &'a Map<String, Value>,
+        config: &'a GraphqlConfig,
+    ) -> Result<Self, GraphqlError> {
+        let mut used_type_names = BTreeMap::new();
+        used_type_names.insert(
+            config.fallback_scalar_name.clone(),
+            "caller-supplied fallback scalar".to_owned(),
+        );
+        Ok(Self {
+            definitions,
+            config,
+            representations: BTreeMap::new(),
+            schemas: BTreeMap::new(),
+            objects: BTreeMap::new(),
+            enums: BTreeMap::new(),
+            fields: BTreeMap::new(),
+            enum_values: BTreeMap::new(),
+            used_type_names,
+            reference_targets: BTreeMap::new(),
+            ledger: LossLedger::new(),
+            recorded_losses: BTreeSet::new(),
+            relaxed_fields: BTreeSet::new(),
+        })
+    }
+
+    fn plan(&mut self) -> Result<(), GraphqlError> {
+        for (key, schema) in self.definitions {
+            let path = definition_path(key);
+            let base = graphql_type_name(key, "SchemaType");
+            self.plan_schema(schema, &path, &base, 0)?;
+        }
+        self.resolve_reference_targets()?;
+        Ok(())
+    }
+
+    fn resolve_reference_targets(&mut self) -> Result<(), GraphqlError> {
+        for start in self.definitions.keys() {
+            if self.reference_targets.contains_key(start) {
+                continue;
+            }
+            let mut chain = Vec::<String>::new();
+            let mut positions = BTreeMap::<String, usize>::new();
+            let mut current = start.clone();
+            let endpoint = loop {
+                if let Some(endpoint) = self.reference_targets.get(&current) {
+                    break endpoint.clone();
+                }
+                if let Some(index) = positions.insert(current.clone(), chain.len()) {
+                    let mut cycle = chain[index..].to_vec();
+                    cycle.push(current);
+                    return Err(GraphqlError::new(format!(
+                        "CompiledSchema contains an unguarded GraphQL alias cycle: {}",
+                        cycle.join(" -> ")
+                    )));
+                }
+                chain.push(current.clone());
+                match self.representations.get(&definition_path(&current)) {
+                    Some(Representation::Reference(next)) => current.clone_from(next),
+                    Some(_) => break current,
+                    None => {
+                        return Err(GraphqlError::new(format!(
+                            "missing planned GraphQL representation for definition {current:?}"
+                        )));
+                    }
+                }
+            };
+            for key in chain {
+                self.reference_targets.insert(key, endpoint.clone());
+            }
+        }
+        Ok(())
+    }
+
+    fn plan_schema(
+        &mut self,
+        schema: &Value,
+        path: &str,
+        base: &str,
+        depth: usize,
+    ) -> Result<(), GraphqlError> {
+        ensure_depth(depth, path)?;
+        if self.representations.contains_key(path) {
+            return Ok(());
+        }
+        let representation = classify_schema(schema, path)?;
+        self.schemas.insert(path.to_owned(), schema.clone());
+        self.representations
+            .insert(path.to_owned(), representation.clone());
+
+        match representation {
+            Representation::Enum => {
+                self.reserve_type_name(base, path)?;
+                let values = finite_values(schema, path)?.ok_or_else(|| {
+                    GraphqlError::new(format!("{path} was classified as a finite GraphQL enum"))
+                })?;
+                if values.len() > MAX_ENUM_VALUES {
+                    return Err(GraphqlError::new(format!(
+                        "{path} contains {} enum values; GraphQL emission is limited to \
+                         {MAX_ENUM_VALUES}",
+                        values.len()
+                    )));
+                }
+                let mappings = values
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, source_value)| GraphqlEnumValueMap {
+                        source_value,
+                        graphql_name: format!("VALUE_{index}"),
+                    })
+                    .collect();
+                self.enums.insert(path.to_owned(), base.to_owned());
+                self.enum_values.insert(path.to_owned(), mappings);
+            }
+            Representation::Object => {
+                let object = schema
+                    .as_object()
+                    .expect("object representation comes from an object schema");
+                let properties = object
+                    .get("properties")
+                    .and_then(Value::as_object)
+                    .cloned()
+                    .unwrap_or_default();
+                let required = required_names(object, path)?;
+                if matches!(object.get("additionalProperties"), Some(Value::Bool(false))) {
+                    let property_names = properties.keys().cloned().collect::<BTreeSet<_>>();
+                    if let Some(name) = required.difference(&property_names).next() {
+                        return Err(GraphqlError::new(format!(
+                            "{path}/required names {name:?}, but the closed object has no matching \
+                             property schema"
+                        )));
+                    }
+                }
+                let source_fields: BTreeSet<String> = properties
+                    .keys()
+                    .cloned()
+                    .chain(required.iter().cloned())
+                    .collect();
+                if source_fields.len() > MAX_FIELDS {
+                    return Err(GraphqlError::new(format!(
+                        "{path} contains {} fields; GraphQL emission is limited to {MAX_FIELDS}",
+                        source_fields.len()
+                    )));
+                }
+                let mut field_map = BTreeMap::new();
+                let mut reverse = BTreeMap::<String, String>::new();
+                for source in source_fields {
+                    let graphql = graphql_field_name(&source, "field");
+                    validate_graphql_name("generated field name", &graphql)?;
+                    if let Some(previous) = reverse.insert(graphql.clone(), source.clone()) {
+                        return Err(GraphqlError::new(format!(
+                            "{path} properties {previous:?} and {source:?} collide on GraphQL field \
+                             name {graphql:?}"
+                        )));
+                    }
+                    field_map.insert(source, graphql);
+                }
+                let output = base.to_owned();
+                let input = checked_graphql_name(&format!("{base}Input"), "generated input type")?;
+                self.reserve_type_name(&output, path)?;
+                self.reserve_type_name(&input, path)?;
+                self.objects
+                    .insert(path.to_owned(), ObjectNames { output, input });
+                self.fields.insert(path.to_owned(), field_map.clone());
+
+                for (source, child) in properties {
+                    let child_path = format!("{path}/properties/{}", pointer_escape(&source));
+                    let graphql = field_map
+                        .get(&source)
+                        .expect("field map covers every property");
+                    let child_base = graphql_type_name(&format!("{base} {graphql}"), "InlineValue");
+                    self.plan_schema(&child, &child_path, &child_base, depth + 1)?;
+                }
+            }
+            Representation::Array => {
+                let object = schema
+                    .as_object()
+                    .expect("array representation comes from an object schema");
+                if let Some(items) = object.get("items") {
+                    let child_base = graphql_type_name(&format!("{base} item"), "ArrayItem");
+                    self.plan_schema(items, &format!("{path}/items"), &child_base, depth + 1)?;
+                }
+            }
+            Representation::Reference(_)
+            | Representation::String
+            | Representation::Boolean
+            | Representation::Int
+            | Representation::Fallback => {}
+        }
+        Ok(())
+    }
+
+    fn reserve_type_name(&mut self, name: &str, path: &str) -> Result<(), GraphqlError> {
+        validate_graphql_name("generated type name", name)?;
+        if is_builtin_type(name) {
+            return Err(GraphqlError::new(format!(
+                "{path} normalizes to built-in GraphQL type name {name:?}"
+            )));
+        }
+        if let Some(previous) = self
+            .used_type_names
+            .insert(name.to_owned(), path.to_owned())
+        {
+            return Err(GraphqlError::new(format!(
+                "GraphQL type name {name:?} collides between {previous} and {path}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn audit(&mut self) -> Result<(), GraphqlError> {
+        for (key, schema) in self.definitions {
+            self.audit_schema(schema, &definition_path(key), 0)?;
+        }
+        Ok(())
+    }
+
+    fn audit_schema(
+        &mut self,
+        schema: &Value,
+        path: &str,
+        depth: usize,
+    ) -> Result<(), GraphqlError> {
+        ensure_depth(depth, path)?;
+        let representation = self
+            .representations
+            .get(path)
+            .cloned()
+            .unwrap_or(Representation::Fallback);
+        let Value::Object(object) = schema else {
+            if representation == Representation::Fallback {
+                self.record(
+                    "custom-scalar-validation-delegated",
+                    path,
+                    "a boolean JSON Schema is carried by the caller-owned fallback scalar",
+                );
+            }
+            return Ok(());
+        };
+
+        if representation == Representation::Fallback {
+            self.record(
+                "custom-scalar-validation-delegated",
+                path,
+                "this schema has no exact built-in GraphQL carrier",
+            );
+        }
+        if object.contains_key("allOf") {
+            self.record(
+                "intersection-validation-delegated",
+                &format!("{path}/allOf"),
+                "GraphQL has no input intersection type",
+            );
+        }
+        if object.contains_key("anyOf") && representation != Representation::Enum {
+            self.record(
+                "union-validation-delegated",
+                &format!("{path}/anyOf"),
+                "GraphQL has no general input union type",
+            );
+        }
+        if object.contains_key("oneOf") && representation != Representation::Enum {
+            self.record(
+                "one-of-validation-delegated",
+                &format!("{path}/oneOf"),
+                "GraphQL has no exactly-one input union validation",
+            );
+        }
+        if object.contains_key("not") {
+            self.record(
+                "negation-validation-delegated",
+                &format!("{path}/not"),
+                "GraphQL has no input value-set complement",
+            );
+        }
+        if object
+            .get("prefixItems")
+            .and_then(Value::as_array)
+            .is_some_and(|values| !values.is_empty())
+        {
+            self.record(
+                "tuple-array-validation-delegated",
+                &format!("{path}/prefixItems"),
+                "GraphQL lists cannot express position-specific tuple item schemas",
+            );
+        }
+        let type_kinds = declared_types(object, path)?;
+        if type_kinds
+            .as_ref()
+            .is_some_and(|kinds| kinds.iter().filter(|kind| **kind != JsonKind::Null).count() > 1)
+        {
+            self.record(
+                "union-validation-delegated",
+                &format!("{path}/type"),
+                "GraphQL has no general input union for a JSON Schema type array",
+            );
+        }
+        if type_kinds.as_ref().is_some_and(|kinds| {
+            kinds.contains(&JsonKind::Integer) && representation != Representation::Int
+        }) {
+            self.record(
+                "integer-domain-validation-delegated",
+                &format!("{path}/type"),
+                "the JSON integer domain is not exactly GraphQL's signed 32-bit Int domain",
+            );
+        }
+
+        let active_conditional = object.contains_key("if")
+            && (object.contains_key("then") || object.contains_key("else"));
+        if active_conditional {
+            for keyword in ["if", "then", "else"] {
+                if object.contains_key(keyword) {
+                    self.record(
+                        "conditional-validation-dropped",
+                        &format!("{path}/{keyword}"),
+                        "GraphQL input fields cannot express content-dependent branches",
+                    );
+                }
+            }
+        }
+        for keyword in ["unevaluatedItems", "unevaluatedProperties"] {
+            if object.contains_key(keyword) {
+                self.record(
+                    "unevaluated-validation-dropped",
+                    &format!("{path}/{keyword}"),
+                    "GraphQL coercion does not expose JSON Schema applicator evaluation state",
+                );
+            }
+        }
+        for key in object.keys() {
+            if !known_schema_keyword(key) && !is_annotation_keyword(key) {
+                self.record(
+                    "keyword-validation-delegated",
+                    &format!("{path}/{}", pointer_escape(key)),
+                    &format!(
+                        "JSON Schema assertion keyword {key:?} is outside the closed GraphQL \
+                         capability table"
+                    ),
+                );
+            }
+        }
+        if object.contains_key("additionalItems") {
+            self.record(
+                "keyword-validation-delegated",
+                &format!("{path}/additionalItems"),
+                "additionalItems is outside the draft 2020-12 GraphQL capability table",
+            );
+        }
+
+        match representation {
+            Representation::Object => self.audit_object(object, path, depth)?,
+            Representation::Array => self.audit_array(object, path, depth)?,
+            Representation::String => {
+                for keyword in [
+                    "minLength",
+                    "maxLength",
+                    "pattern",
+                    "format",
+                    "contentEncoding",
+                    "contentMediaType",
+                    "contentSchema",
+                ] {
+                    if object.contains_key(keyword) {
+                        self.record(
+                            "string-validation-dropped",
+                            &format!("{path}/{keyword}"),
+                            "GraphQL String does not express this runtime string predicate",
+                        );
+                    }
+                }
+            }
+            Representation::Int => {
+                for keyword in [
+                    "minimum",
+                    "maximum",
+                    "exclusiveMinimum",
+                    "exclusiveMaximum",
+                    "multipleOf",
+                ] {
+                    if object.contains_key(keyword) && !matches!(keyword, "minimum" | "maximum") {
+                        self.record(
+                            "numeric-validation-dropped",
+                            &format!("{path}/{keyword}"),
+                            "GraphQL Int does not express this runtime numeric predicate",
+                        );
+                    }
+                }
+            }
+            Representation::Enum
+            | Representation::Reference(_)
+            | Representation::Boolean
+            | Representation::Fallback => {}
+        }
+        Ok(())
+    }
+
+    fn audit_object(
+        &mut self,
+        object: &Map<String, Value>,
+        path: &str,
+        depth: usize,
+    ) -> Result<(), GraphqlError> {
+        if !matches!(object.get("additionalProperties"), Some(Value::Bool(false))) {
+            self.record(
+                "additional-properties-validation-narrowed",
+                object
+                    .contains_key("additionalProperties")
+                    .then(|| format!("{path}/additionalProperties"))
+                    .as_deref()
+                    .unwrap_or(path),
+                "GraphQL input objects reject source keys outside the declared field set",
+            );
+        }
+        if let Some(patterns) = object.get("patternProperties").and_then(Value::as_object) {
+            for pattern in patterns.keys() {
+                self.record(
+                    "pattern-properties-validation-narrowed",
+                    &format!("{path}/patternProperties/{}", pointer_escape(pattern)),
+                    "GraphQL input object fields cannot be selected by a runtime key regex",
+                );
+            }
+        }
+        if object.contains_key("propertyNames") {
+            self.record(
+                "property-name-validation-narrowed",
+                &format!("{path}/propertyNames"),
+                "GraphQL input objects expose a fixed finite property-name set",
+            );
+        }
+        for keyword in ["minProperties", "maxProperties"] {
+            if object.contains_key(keyword) {
+                self.record(
+                    "property-count-validation-dropped",
+                    &format!("{path}/{keyword}"),
+                    "GraphQL cannot count supplied input object fields",
+                );
+            }
+        }
+        for keyword in ["dependentRequired", "dependentSchemas"] {
+            if object.contains_key(keyword) {
+                self.record(
+                    "dependency-validation-dropped",
+                    &format!("{path}/{keyword}"),
+                    "GraphQL input object definitions cannot enforce cross-field dependencies",
+                );
+            }
+        }
+
+        let empty = Map::new();
+        let properties = object
+            .get("properties")
+            .and_then(Value::as_object)
+            .unwrap_or(&empty);
+        let required = required_names(object, path)?;
+        for (source, child) in properties {
+            let child_path = format!("{path}/properties/{}", pointer_escape(source));
+            let nullable = schema_allows_null(child, self.definitions, &mut BTreeSet::new())?;
+            if (required.contains(source) && nullable) || (!required.contains(source) && !nullable)
+            {
+                self.record(
+                    "nullable-presence-validation-widened",
+                    &child_path,
+                    "GraphQL nullable fields cannot preserve this source presence/null distinction",
+                );
+            }
+            self.audit_schema(child, &child_path, depth + 1)?;
+        }
+        let property_names = properties.keys().cloned().collect::<BTreeSet<_>>();
+        for source in required.difference(&property_names) {
+            let required_path = format!("{path}/required/{}", pointer_escape(source));
+            self.record(
+                "custom-scalar-validation-delegated",
+                &required_path,
+                "a required property without a named schema uses the caller-owned fallback scalar",
+            );
+            self.record(
+                "nullable-presence-validation-widened",
+                &required_path,
+                "GraphQL cannot require presence while allowing null for an unconstrained value",
+            );
+        }
+        Ok(())
+    }
+
+    fn audit_array(
+        &mut self,
+        object: &Map<String, Value>,
+        path: &str,
+        depth: usize,
+    ) -> Result<(), GraphqlError> {
+        self.record(
+            "singleton-list-coercion-widened",
+            path,
+            "GraphQL variable coercion wraps a non-list input as a singleton list",
+        );
+        for keyword in ["minItems", "maxItems"] {
+            if object.contains_key(keyword) {
+                self.record(
+                    "array-cardinality-validation-dropped",
+                    &format!("{path}/{keyword}"),
+                    "GraphQL list types cannot constrain list length",
+                );
+            }
+        }
+        if object.contains_key("contains") {
+            for keyword in ["contains", "minContains", "maxContains"] {
+                if object.contains_key(keyword) {
+                    self.record(
+                        "array-contains-validation-dropped",
+                        &format!("{path}/{keyword}"),
+                        "GraphQL list coercion cannot quantify matching elements",
+                    );
+                }
+            }
+        }
+        if object.get("uniqueItems") == Some(&Value::Bool(true)) {
+            self.record(
+                "unique-items-validation-dropped",
+                &format!("{path}/uniqueItems"),
+                "GraphQL list coercion cannot enforce pairwise-distinct values",
+            );
+        }
+        if let Some(items) = object.get("items") {
+            self.audit_schema(items, &format!("{path}/items"), depth + 1)?;
+        } else {
+            self.record(
+                "custom-scalar-validation-delegated",
+                &format!("{path}/items"),
+                "an unconstrained list item uses the caller-owned fallback scalar",
+            );
+        }
+        Ok(())
+    }
+
+    fn record(&mut self, code: &str, path: &str, note: &str) {
+        if !self
+            .recorded_losses
+            .insert((code.to_owned(), path.to_owned()))
+        {
+            return;
+        }
+        self.ledger.record(LossEntry {
+            code: code.to_owned().into(),
+            from: LOSS_FROM.into(),
+            to: GRAPHQL_DIALECT.into(),
+            note: note.to_owned().into(),
+            location: Some(Box::new(
+                RdfLocation::logical(LOSS_CONTEXT).with_subject(path),
+            )),
+        });
+    }
+
+    fn definition_maps(&self) -> Result<BTreeMap<String, GraphqlDefinitionMap>, GraphqlError> {
+        let mut maps = BTreeMap::new();
+        for (key, schema) in self.definitions {
+            let path = definition_path(key);
+            maps.insert(
+                key.clone(),
+                GraphqlDefinitionMap {
+                    output_type: self.type_expression(schema, &path, TypePosition::Output)?,
+                    input_type: self.type_expression(schema, &path, TypePosition::Input)?,
+                },
+            );
+        }
+        Ok(maps)
+    }
+
+    fn type_expression(
+        &self,
+        schema: &Value,
+        path: &str,
+        position: TypePosition,
+    ) -> Result<String, GraphqlError> {
+        let representation = self
+            .representations
+            .get(path)
+            .cloned()
+            .unwrap_or(Representation::Fallback);
+        match representation {
+            Representation::Enum => self.enums.get(path).cloned().ok_or_else(|| {
+                GraphqlError::new(format!("missing generated enum name for {path}"))
+            }),
+            Representation::Object => {
+                let names = self.objects.get(path).ok_or_else(|| {
+                    GraphqlError::new(format!("missing generated object names for {path}"))
+                })?;
+                Ok(match position {
+                    TypePosition::Output => names.output.clone(),
+                    TypePosition::Input => names.input.clone(),
+                })
+            }
+            Representation::Array => {
+                let object = schema
+                    .as_object()
+                    .expect("array representation comes from an object schema");
+                let (item_schema, item_path) = object.get("items").map_or_else(
+                    || (None, format!("{path}/items")),
+                    |items| (Some(items), format!("{path}/items")),
+                );
+                let item_type = if let Some(items) = item_schema {
+                    self.type_expression(items, &item_path, position)?
+                } else {
+                    self.config.fallback_scalar_name.clone()
+                };
+                let nullable = item_schema.is_none_or(|items| {
+                    schema_allows_null(items, self.definitions, &mut BTreeSet::new())
+                        .unwrap_or(true)
+                });
+                Ok(if nullable {
+                    format!("[{item_type}]")
+                } else {
+                    format!("[{item_type}!]")
+                })
+            }
+            Representation::Reference(key) => {
+                let endpoint = self.reference_targets.get(&key).ok_or_else(|| {
+                    GraphqlError::new(format!("missing resolved GraphQL reference for {key:?}"))
+                })?;
+                let target = self.definitions.get(endpoint).ok_or_else(|| {
+                    GraphqlError::new(format!("{path}/$ref targets missing $defs key {key:?}"))
+                })?;
+                self.type_expression(target, &definition_path(endpoint), position)
+            }
+            Representation::String => Ok("String".to_owned()),
+            Representation::Boolean => Ok("Boolean".to_owned()),
+            Representation::Int => Ok("Int".to_owned()),
+            Representation::Fallback => Ok(self.config.fallback_scalar_name.clone()),
+        }
+    }
+
+    fn render_sdl(&self) -> Result<String, GraphqlError> {
+        let mut output = String::new();
+        write_comment(&mut output, &self.config.package_docstring);
+        write_comment(&mut output, &self.config.module_docstring);
+        writeln!(output, "# Package: {}", self.config.schema_name)
+            .expect("writing GraphQL SDL to a String cannot fail");
+        writeln!(output).expect("writing GraphQL SDL to a String cannot fail");
+        writeln!(output, "scalar {}", self.config.fallback_scalar_name)
+            .expect("writing GraphQL SDL to a String cannot fail");
+
+        let mut declarations = Vec::<(String, DeclarationKind, String)>::new();
+        for (path, name) in &self.enums {
+            declarations.push((name.clone(), DeclarationKind::Enum, path.clone()));
+        }
+        for (path, names) in &self.objects {
+            declarations.push((names.output.clone(), DeclarationKind::Output, path.clone()));
+            declarations.push((names.input.clone(), DeclarationKind::Input, path.clone()));
+        }
+        declarations.sort();
+        for (_, kind, path) in declarations {
+            output.push('\n');
+            match kind {
+                DeclarationKind::Enum => self.render_enum(&mut output, &path)?,
+                DeclarationKind::Output => {
+                    self.render_object_type(&mut output, &path, TypePosition::Output)?;
+                }
+                DeclarationKind::Input => {
+                    self.render_object_type(&mut output, &path, TypePosition::Input)?;
+                }
+            }
+        }
+        Ok(finish_text(output))
+    }
+
+    fn render_enum(&self, output: &mut String, path: &str) -> Result<(), GraphqlError> {
+        let name = self
+            .enums
+            .get(path)
+            .expect("rendered enum has a planned name");
+        if let Some(description) = schema_doc(
+            self.schemas
+                .get(path)
+                .expect("rendered enum has a retained schema"),
+        )? {
+            writeln!(output, "{}", graphql_string(description))
+                .expect("writing GraphQL SDL to a String cannot fail");
+        }
+        writeln!(output, "enum {name} {{").expect("writing GraphQL SDL to a String cannot fail");
+        for mapping in self
+            .enum_values
+            .get(path)
+            .expect("rendered enum has value mappings")
+        {
+            writeln!(output, "  {}", mapping.graphql_name)
+                .expect("writing GraphQL SDL to a String cannot fail");
+        }
+        writeln!(output, "}}").expect("writing GraphQL SDL to a String cannot fail");
+        Ok(())
+    }
+
+    fn render_object_type(
+        &self,
+        output: &mut String,
+        path: &str,
+        position: TypePosition,
+    ) -> Result<(), GraphqlError> {
+        let schema = self
+            .schemas
+            .get(path)
+            .expect("rendered object has a retained schema");
+        let object = schema
+            .as_object()
+            .expect("rendered object has an object schema");
+        if let Some(description) = schema_doc(schema)? {
+            writeln!(output, "{}", graphql_string(description))
+                .expect("writing GraphQL SDL to a String cannot fail");
+        }
+        let names = self
+            .objects
+            .get(path)
+            .expect("rendered object has planned names");
+        let (keyword, name) = match position {
+            TypePosition::Output => ("type", names.output.as_str()),
+            TypePosition::Input => ("input", names.input.as_str()),
+        };
+        writeln!(output, "{keyword} {name} {{")
+            .expect("writing GraphQL SDL to a String cannot fail");
+
+        let empty = Map::new();
+        let properties = object
+            .get("properties")
+            .and_then(Value::as_object)
+            .unwrap_or(&empty);
+        let required = required_names(object, path)?;
+        let field_map = self
+            .fields
+            .get(path)
+            .expect("rendered object has a field map");
+        let mut ordered_fields = field_map.iter().collect::<Vec<_>>();
+        ordered_fields.sort_by(|left, right| left.1.cmp(right.1));
+        for (source, graphql) in ordered_fields {
+            let child_path = format!("{path}/properties/{}", pointer_escape(source));
+            let child = properties.get(source);
+            if let Some(description) = child.map(schema_doc).transpose()?.flatten() {
+                writeln!(output, "  {}", graphql_string(description))
+                    .expect("writing GraphQL SDL to a String cannot fail");
+            }
+            let mut expression = if let Some(child) = child {
+                self.type_expression(child, &child_path, position)?
+            } else {
+                self.config.fallback_scalar_name.clone()
+            };
+            let source_non_null = required.contains(source)
+                && child.is_some_and(|schema| {
+                    !schema_allows_null(schema, self.definitions, &mut BTreeSet::new())
+                        .unwrap_or(true)
+                });
+            let relaxed =
+                position == TypePosition::Input && self.relaxed_fields.contains(&child_path);
+            if source_non_null && !relaxed {
+                expression.push('!');
+            }
+            writeln!(output, "  {graphql}: {expression}")
+                .expect("writing GraphQL SDL to a String cannot fail");
+        }
+        writeln!(output, "}}").expect("writing GraphQL SDL to a String cannot fail");
+        Ok(())
+    }
+
+    fn relax_invalid_input_cycles(&mut self) -> Result<(), GraphqlError> {
+        let edges = self.mandatory_input_edges()?;
+        while let Some(path) = find_cycle_edge(&self.objects, &edges, &self.relaxed_fields) {
+            self.relaxed_fields.insert(path.clone());
+            self.record(
+                "recursive-input-nullability-relaxed",
+                &path,
+                "this singular required non-null edge closes an invalid GraphQL input cycle",
+            );
+        }
+        Ok(())
+    }
+
+    fn mandatory_input_edges(&self) -> Result<Vec<InputEdge>, GraphqlError> {
+        let mut edges = Vec::new();
+        for (path, schema) in &self.schemas {
+            if self.representations.get(path) != Some(&Representation::Object) {
+                continue;
+            }
+            let object = schema
+                .as_object()
+                .expect("planned object representation has an object schema");
+            let empty = Map::new();
+            let properties = object
+                .get("properties")
+                .and_then(Value::as_object)
+                .unwrap_or(&empty);
+            let required = required_names(object, path)?;
+            for (source, child) in properties {
+                if !required.contains(source)
+                    || schema_allows_null(child, self.definitions, &mut BTreeSet::new())?
+                {
+                    continue;
+                }
+                let child_path = format!("{path}/properties/{}", pointer_escape(source));
+                if let Some(target) = self.resolve_object_path(&child_path)? {
+                    edges.push(InputEdge {
+                        source: path.clone(),
+                        target,
+                        field_path: child_path,
+                    });
+                }
+            }
+        }
+        edges.sort();
+        Ok(edges)
+    }
+
+    fn resolve_object_path(&self, path: &str) -> Result<Option<String>, GraphqlError> {
+        match self.representations.get(path) {
+            Some(Representation::Object) => Ok(Some(path.to_owned())),
+            Some(Representation::Reference(key)) => {
+                let endpoint = self.reference_targets.get(key).ok_or_else(|| {
+                    GraphqlError::new(format!("missing resolved GraphQL reference for {key:?}"))
+                })?;
+                let target_path = definition_path(endpoint);
+                Ok(
+                    (self.representations.get(&target_path) == Some(&Representation::Object))
+                        .then_some(target_path),
+                )
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum DeclarationKind {
+    Enum,
+    Output,
+    Input,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct InputEdge {
+    source: String,
+    target: String,
+    field_path: String,
+}
+
+impl GraphqlPackage {
+    fn translate_value(
+        &self,
+        schema: &Value,
+        path: &str,
+        value: &Value,
+        direction: CodecDirection,
+        depth: usize,
+    ) -> Result<Value, GraphqlError> {
+        ensure_depth(depth, path)?;
+        let representation = self
+            .representations
+            .get(path)
+            .cloned()
+            .unwrap_or(Representation::Fallback);
+        if representation != Representation::Enum && value.is_null() {
+            return Ok(Value::Null);
+        }
+        match representation {
+            Representation::Enum => self.translate_enum(path, value, direction),
+            Representation::Object => self.translate_object(schema, path, value, direction, depth),
+            Representation::Array => {
+                let values = value.as_array().ok_or_else(|| {
+                    GraphqlError::new(format!("GraphQL value at {path} must be a JSON array"))
+                })?;
+                let object = schema
+                    .as_object()
+                    .expect("array representation comes from an object schema");
+                let items = object.get("items");
+                let mut translated = Vec::with_capacity(values.len());
+                for (index, item) in values.iter().enumerate() {
+                    translated.push(if let Some(item_schema) = items {
+                        self.translate_value(
+                            item_schema,
+                            &format!("{path}/items"),
+                            item,
+                            direction,
+                            depth + 1,
+                        )?
+                    } else {
+                        item.clone()
+                    });
+                    ensure_depth(depth + 1, &format!("{path}/value/{index}"))?;
+                }
+                Ok(Value::Array(translated))
+            }
+            Representation::Reference(key) => {
+                let endpoint = self.reference_targets.get(&key).ok_or_else(|| {
+                    GraphqlError::new(format!("missing resolved GraphQL reference for {key:?}"))
+                })?;
+                let target = self.source_definitions.get(endpoint).ok_or_else(|| {
+                    GraphqlError::new(format!("{path}/$ref targets missing definition {key:?}"))
+                })?;
+                self.translate_value(
+                    target,
+                    &definition_path(endpoint),
+                    value,
+                    direction,
+                    depth + 1,
+                )
+            }
+            Representation::String => {
+                if value.is_string() {
+                    Ok(value.clone())
+                } else {
+                    Err(GraphqlError::new(format!(
+                        "GraphQL value at {path} must be a JSON string"
+                    )))
+                }
+            }
+            Representation::Boolean => {
+                if value.is_boolean() {
+                    Ok(value.clone())
+                } else {
+                    Err(GraphqlError::new(format!(
+                        "GraphQL value at {path} must be a JSON boolean"
+                    )))
+                }
+            }
+            Representation::Int => {
+                if value
+                    .as_i64()
+                    .is_some_and(|integer| i32::try_from(integer).is_ok())
+                    || value
+                        .as_u64()
+                        .is_some_and(|integer| i32::try_from(integer).is_ok())
+                {
+                    Ok(value.clone())
+                } else {
+                    Err(GraphqlError::new(format!(
+                        "GraphQL value at {path} must be a signed 32-bit integer"
+                    )))
+                }
+            }
+            Representation::Fallback => Ok(value.clone()),
+        }
+    }
+
+    fn translate_enum(
+        &self,
+        path: &str,
+        value: &Value,
+        direction: CodecDirection,
+    ) -> Result<Value, GraphqlError> {
+        let mappings =
+            self.names.enum_values.get(path).ok_or_else(|| {
+                GraphqlError::new(format!("GraphQL enum at {path} has no value map"))
+            })?;
+        match direction {
+            CodecDirection::EncodeInput => mappings
+                .iter()
+                .find(|mapping| mapping.source_value == *value)
+                .map(|mapping| Value::String(mapping.graphql_name.clone()))
+                .ok_or_else(|| {
+                    GraphqlError::new(format!(
+                        "source value at {path} is not present in the generated GraphQL enum map"
+                    ))
+                }),
+            CodecDirection::DecodeOutput => {
+                let symbol = value.as_str().ok_or_else(|| {
+                    GraphqlError::new(format!(
+                        "GraphQL enum output at {path} must be a string symbol"
+                    ))
+                })?;
+                mappings
+                    .iter()
+                    .find(|mapping| mapping.graphql_name == symbol)
+                    .map(|mapping| mapping.source_value.clone())
+                    .ok_or_else(|| {
+                        GraphqlError::new(format!(
+                            "GraphQL enum symbol {symbol:?} is not mapped at {path}"
+                        ))
+                    })
+            }
+        }
+    }
+
+    fn translate_object(
+        &self,
+        schema: &Value,
+        path: &str,
+        value: &Value,
+        direction: CodecDirection,
+        depth: usize,
+    ) -> Result<Value, GraphqlError> {
+        let value = value.as_object().ok_or_else(|| {
+            GraphqlError::new(format!("GraphQL value at {path} must be a JSON object"))
+        })?;
+        let schema = schema
+            .as_object()
+            .expect("object representation comes from an object schema");
+        let empty = Map::new();
+        let properties = schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .unwrap_or(&empty);
+        let field_map = self.names.fields.get(path).ok_or_else(|| {
+            GraphqlError::new(format!("GraphQL object at {path} has no field map"))
+        })?;
+        let reverse = field_map
+            .iter()
+            .map(|(source, graphql)| (graphql.as_str(), source.as_str()))
+            .collect::<BTreeMap<_, _>>();
+        let mut output = Map::new();
+        for (input_key, input_value) in value {
+            let (source_key, output_key) = match direction {
+                CodecDirection::EncodeInput => {
+                    let graphql = field_map.get(input_key).ok_or_else(|| {
+                        GraphqlError::new(format!(
+                            "source field {input_key:?} is not representable by GraphQL object \
+                             at {path}"
+                        ))
+                    })?;
+                    (input_key.as_str(), graphql.as_str())
+                }
+                CodecDirection::DecodeOutput => {
+                    let source = reverse.get(input_key.as_str()).ok_or_else(|| {
+                        GraphqlError::new(format!(
+                            "GraphQL field {input_key:?} is not mapped at {path}"
+                        ))
+                    })?;
+                    (*source, *source)
+                }
+            };
+            let child_path = format!("{path}/properties/{}", pointer_escape(source_key));
+            let translated = if let Some(child) = properties.get(source_key) {
+                self.translate_value(child, &child_path, input_value, direction, depth + 1)?
+            } else {
+                input_value.clone()
+            };
+            if output.insert(output_key.to_owned(), translated).is_some() {
+                return Err(GraphqlError::new(format!(
+                    "GraphQL value translation produced duplicate field {output_key:?} at {path}"
+                )));
+            }
+        }
+        Ok(Value::Object(output))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum JsonKind {
+    Null,
+    Boolean,
+    Integer,
+    Number,
+    String,
+    Array,
+    Object,
+}
+
+fn classify_schema(schema: &Value, path: &str) -> Result<Representation, GraphqlError> {
+    let Value::Object(object) = schema else {
+        return Ok(Representation::Fallback);
+    };
+    if finite_values(schema, path)?.is_some() {
+        return Ok(Representation::Enum);
+    }
+    if let Some(reference) = pure_reference(object) {
+        let key = reference_key(reference).ok_or_else(|| {
+            GraphqlError::new(format!("{path}/$ref is not a direct #/$defs reference"))
+        })?;
+        return Ok(Representation::Reference(key));
+    }
+    if has_unknown_assertion(object)
+        || object.contains_key("allOf")
+        || object.contains_key("anyOf")
+        || object.contains_key("oneOf")
+        || object.contains_key("not")
+    {
+        return Ok(Representation::Fallback);
+    }
+    let Some(kinds) = declared_types(object, path)? else {
+        return Ok(Representation::Fallback);
+    };
+    let non_null = kinds
+        .iter()
+        .copied()
+        .filter(|kind| *kind != JsonKind::Null)
+        .collect::<BTreeSet<_>>();
+    if non_null.len() != 1 {
+        return Ok(Representation::Fallback);
+    }
+    Ok(match *non_null.iter().next().expect("length checked") {
+        JsonKind::String => Representation::String,
+        JsonKind::Boolean => Representation::Boolean,
+        JsonKind::Integer if is_exact_graphql_int_domain(object) => Representation::Int,
+        JsonKind::Integer | JsonKind::Number => Representation::Fallback,
+        JsonKind::Array
+            if object
+                .get("prefixItems")
+                .and_then(Value::as_array)
+                .is_none_or(Vec::is_empty)
+                && object.get("items") != Some(&Value::Bool(false)) =>
+        {
+            Representation::Array
+        }
+        JsonKind::Object if object_field_count(object, path)? > 0 => Representation::Object,
+        JsonKind::Null | JsonKind::Array | JsonKind::Object => Representation::Fallback,
+    })
+}
+
+fn finite_values(schema: &Value, path: &str) -> Result<Option<Vec<Value>>, GraphqlError> {
+    let Value::Object(object) = schema else {
+        return Ok(None);
+    };
+    if object.keys().any(|key| {
+        !is_annotation_keyword(key)
+            && !matches!(key.as_str(), "type" | "enum" | "const" | "anyOf" | "oneOf")
+    }) {
+        return Ok(None);
+    }
+    let values = if let Some(value) = object.get("const") {
+        if object.contains_key("enum")
+            || object.contains_key("anyOf")
+            || object.contains_key("oneOf")
+        {
+            return Ok(None);
+        }
+        vec![value.clone()]
+    } else if let Some(values) = object.get("enum") {
+        if object.contains_key("anyOf") || object.contains_key("oneOf") {
+            return Ok(None);
+        }
+        values
+            .as_array()
+            .expect("enum shape is validated before classification")
+            .clone()
+    } else if let Some(branches) = object.get("anyOf").or_else(|| object.get("oneOf")) {
+        let mut values = Vec::new();
+        for (index, branch) in branches
+            .as_array()
+            .expect("applicator shape is validated before classification")
+            .iter()
+            .enumerate()
+        {
+            let Some(branch_values) = finite_values(branch, &format!("{path}/branch/{index}"))?
+            else {
+                return Ok(None);
+            };
+            values.extend(branch_values);
+        }
+        values
+    } else if object.get("type").is_some_and(|value| value == "null") {
+        vec![Value::Null]
+    } else {
+        return Ok(None);
+    };
+
+    if let Some(kinds) = declared_types(object, path)?
+        && values
+            .iter()
+            .any(|value| !value_matches_types(value, &kinds))
+    {
+        return Ok(None);
+    }
+    let mut canonical = BTreeMap::<String, Value>::new();
+    for value in values {
+        let key = serde_json::to_string(&value)
+            .map_err(|error| GraphqlError::new(format!("cannot inspect {path}: {error}")))?;
+        canonical.insert(key, value);
+    }
+    if canonical.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(canonical.into_values().collect()))
+}
+
+fn pure_reference(object: &Map<String, Value>) -> Option<&str> {
+    let reference = object.get("$ref")?.as_str()?;
+    object
+        .keys()
+        .all(|key| key == "$ref" || is_annotation_keyword(key))
+        .then_some(reference)
+}
+
+fn declared_types(
+    object: &Map<String, Value>,
+    path: &str,
+) -> Result<Option<BTreeSet<JsonKind>>, GraphqlError> {
+    let Some(value) = object.get("type") else {
+        return Ok(None);
+    };
+    let values = match value {
+        Value::String(value) => vec![(value.as_str(), format!("{path}/type"))],
+        Value::Array(values) if !values.is_empty() => values
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                value
+                    .as_str()
+                    .map(|value| (value, format!("{path}/type/{index}")))
+                    .ok_or_else(|| {
+                        GraphqlError::new(format!("{path}/type/{index} must be a string"))
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        Value::Array(_) => {
+            return Err(GraphqlError::new(format!(
+                "{path}/type array cannot be empty"
+            )));
+        }
+        _ => {
+            return Err(GraphqlError::new(format!(
+                "{path}/type must be a string or non-empty array of strings"
+            )));
+        }
+    };
+    let mut kinds = BTreeSet::new();
+    for (value, value_path) in values {
+        let kind = match value {
+            "null" => JsonKind::Null,
+            "boolean" => JsonKind::Boolean,
+            "integer" => JsonKind::Integer,
+            "number" => JsonKind::Number,
+            "string" => JsonKind::String,
+            "array" => JsonKind::Array,
+            "object" => JsonKind::Object,
+            _ => {
+                return Err(GraphqlError::new(format!(
+                    "{value_path} names unsupported JSON Schema type {value:?}"
+                )));
+            }
+        };
+        if !kinds.insert(kind) {
+            return Err(GraphqlError::new(format!(
+                "{path}/type repeats type {value:?}"
+            )));
+        }
+    }
+    Ok(Some(kinds))
+}
+
+fn value_matches_types(value: &Value, kinds: &BTreeSet<JsonKind>) -> bool {
+    let kind = match value {
+        Value::Null => JsonKind::Null,
+        Value::Bool(_) => JsonKind::Boolean,
+        Value::Number(number) if number.is_i64() || number.is_u64() => JsonKind::Integer,
+        Value::Number(_) => JsonKind::Number,
+        Value::String(_) => JsonKind::String,
+        Value::Array(_) => JsonKind::Array,
+        Value::Object(_) => JsonKind::Object,
+    };
+    kinds.contains(&kind) || (kind == JsonKind::Integer && kinds.contains(&JsonKind::Number))
+}
+
+fn is_exact_graphql_int_domain(object: &Map<String, Value>) -> bool {
+    object.get("minimum").and_then(Value::as_i64) == Some(i64::from(i32::MIN))
+        && object.get("maximum").and_then(Value::as_i64) == Some(i64::from(i32::MAX))
+        && !object.contains_key("exclusiveMinimum")
+        && !object.contains_key("exclusiveMaximum")
+}
+
+fn object_field_count(object: &Map<String, Value>, path: &str) -> Result<usize, GraphqlError> {
+    let properties = object
+        .get("properties")
+        .and_then(Value::as_object)
+        .map_or(0, Map::len);
+    let required = required_names(object, path)?;
+    let property_names = object
+        .get("properties")
+        .and_then(Value::as_object)
+        .map(|properties| properties.keys().cloned().collect::<BTreeSet<_>>())
+        .unwrap_or_default();
+    Ok(properties + required.difference(&property_names).count())
+}
+
+fn validate_schema_keywords(schema: &Value, path: &str, depth: usize) -> Result<(), GraphqlError> {
+    ensure_depth(depth, path)?;
+    let Value::Object(object) = schema else {
+        return if schema.is_boolean() {
+            Ok(())
+        } else {
+            Err(GraphqlError::new(format!(
+                "{path} must be an object or boolean JSON Schema"
+            )))
+        };
+    };
+    let _ = declared_types(object, path)?;
+    if let Some(value) = object.get("enum") {
+        let values = value
+            .as_array()
+            .ok_or_else(|| GraphqlError::new(format!("{path}/enum must be an array")))?;
+        if values.is_empty() {
+            return Err(GraphqlError::new(format!("{path}/enum cannot be empty")));
+        }
+        if values.len() > MAX_ENUM_VALUES {
+            return Err(GraphqlError::new(format!(
+                "{path}/enum exceeds the {MAX_ENUM_VALUES}-value limit"
+            )));
+        }
+        let mut seen = BTreeSet::new();
+        for (index, value) in values.iter().enumerate() {
+            let canonical = serde_json::to_string(value).map_err(|error| {
+                GraphqlError::new(format!("cannot inspect {path}/enum/{index}: {error}"))
+            })?;
+            if !seen.insert(canonical) {
+                return Err(GraphqlError::new(format!(
+                    "{path}/enum repeats value at index {index}"
+                )));
+            }
+        }
+    }
+    for keyword in ["allOf", "anyOf", "oneOf"] {
+        if object
+            .get(keyword)
+            .and_then(Value::as_array)
+            .is_some_and(Vec::is_empty)
+        {
+            return Err(GraphqlError::new(format!(
+                "{path}/{keyword} cannot be empty"
+            )));
+        }
+    }
+    for keyword in [
+        "title",
+        "description",
+        "pattern",
+        "format",
+        "contentEncoding",
+        "contentMediaType",
+    ] {
+        if object.get(keyword).is_some_and(|value| !value.is_string()) {
+            return Err(GraphqlError::new(format!(
+                "{path}/{keyword} must be a string"
+            )));
+        }
+    }
+    for keyword in [
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+    ] {
+        if object.get(keyword).is_some_and(|value| !value.is_number()) {
+            return Err(GraphqlError::new(format!(
+                "{path}/{keyword} must be a number"
+            )));
+        }
+    }
+    if object
+        .get("multipleOf")
+        .and_then(Value::as_f64)
+        .is_some_and(|value| value <= 0.0)
+    {
+        return Err(GraphqlError::new(format!(
+            "{path}/multipleOf must be greater than zero"
+        )));
+    }
+    for keyword in [
+        "minLength",
+        "maxLength",
+        "minItems",
+        "maxItems",
+        "minContains",
+        "maxContains",
+        "minProperties",
+        "maxProperties",
+    ] {
+        if object.contains_key(keyword) {
+            validate_nonnegative_integer(
+                object
+                    .get(keyword)
+                    .expect("present keyword was just checked"),
+                &format!("{path}/{keyword}"),
+            )?;
+        }
+    }
+    for keyword in ["uniqueItems", "deprecated", "readOnly", "writeOnly"] {
+        if object.get(keyword).is_some_and(|value| !value.is_boolean()) {
+            return Err(GraphqlError::new(format!(
+                "{path}/{keyword} must be a boolean"
+            )));
+        }
+    }
+    let _ = required_names(object, path)?;
+    if let Some(dependencies) = object.get("dependentRequired") {
+        let dependencies = dependencies.as_object().ok_or_else(|| {
+            GraphqlError::new(format!("{path}/dependentRequired must be an object"))
+        })?;
+        for (property, names) in dependencies {
+            let names = names.as_array().ok_or_else(|| {
+                GraphqlError::new(format!(
+                    "{path}/dependentRequired/{} must be an array",
+                    pointer_escape(property)
+                ))
+            })?;
+            let mut seen = BTreeSet::new();
+            for (index, name) in names.iter().enumerate() {
+                let name = name.as_str().ok_or_else(|| {
+                    GraphqlError::new(format!(
+                        "{path}/dependentRequired/{}/{index} must be a string",
+                        pointer_escape(property)
+                    ))
+                })?;
+                if !seen.insert(name) {
+                    return Err(GraphqlError::new(format!(
+                        "{path}/dependentRequired/{} repeats property {name:?}",
+                        pointer_escape(property)
+                    )));
+                }
+            }
+        }
+    }
+
+    for keyword in schema_map_keywords() {
+        if let Some(children) = object.get(*keyword).and_then(Value::as_object) {
+            for (key, child) in children {
+                validate_schema_keywords(
+                    child,
+                    &format!("{path}/{keyword}/{}", pointer_escape(key)),
+                    depth + 1,
+                )?;
+            }
+        }
+    }
+    for keyword in schema_array_keywords() {
+        if let Some(children) = object.get(*keyword).and_then(Value::as_array) {
+            for (index, child) in children.iter().enumerate() {
+                validate_schema_keywords(child, &format!("{path}/{keyword}/{index}"), depth + 1)?;
+            }
+        }
+    }
+    for keyword in schema_single_keywords() {
+        if let Some(child) = object.get(*keyword) {
+            validate_schema_keywords(child, &format!("{path}/{keyword}"), depth + 1)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_nonnegative_integer(value: &Value, path: &str) -> Result<(), GraphqlError> {
+    if value.as_u64().is_some()
+        || value
+            .as_f64()
+            .is_some_and(|number| number >= 0.0 && number.fract() == 0.0)
+    {
+        Ok(())
+    } else {
+        Err(GraphqlError::new(format!(
+            "{path} must be a non-negative integer"
+        )))
+    }
+}
+
+fn required_names(
+    object: &Map<String, Value>,
+    path: &str,
+) -> Result<BTreeSet<String>, GraphqlError> {
+    let Some(value) = object.get("required") else {
+        return Ok(BTreeSet::new());
+    };
+    let values = value
+        .as_array()
+        .ok_or_else(|| GraphqlError::new(format!("{path}/required must be an array")))?;
+    let mut required = BTreeSet::new();
+    for (index, value) in values.iter().enumerate() {
+        let name = value.as_str().ok_or_else(|| {
+            GraphqlError::new(format!("{path}/required/{index} must be a string"))
+        })?;
+        if !required.insert(name.to_owned()) {
+            return Err(GraphqlError::new(format!(
+                "{path}/required repeats property {name:?}"
+            )));
+        }
+    }
+    Ok(required)
+}
+
+fn schema_allows_null(
+    schema: &Value,
+    definitions: &Map<String, Value>,
+    active_references: &mut BTreeSet<String>,
+) -> Result<bool, GraphqlError> {
+    let mut current = schema;
+    loop {
+        match current {
+            Value::Bool(value) => return Ok(*value),
+            Value::Object(object) => {
+                if let Some(values) = finite_values(current, "nullable schema")? {
+                    return Ok(values.iter().any(Value::is_null));
+                }
+                if let Some(reference) = pure_reference(object) {
+                    let key = reference_key(reference).ok_or_else(|| {
+                        GraphqlError::new(
+                            "nullable schema reference is not a direct $defs reference",
+                        )
+                    })?;
+                    if !active_references.insert(key.clone()) {
+                        return Ok(true);
+                    }
+                    current = definitions.get(&key).ok_or_else(|| {
+                        GraphqlError::new(format!(
+                            "nullable schema targets missing definition {key:?}"
+                        ))
+                    })?;
+                    continue;
+                }
+                let Some(kinds) = declared_types(object, "nullable schema")? else {
+                    return Ok(true);
+                };
+                return Ok(kinds.contains(&JsonKind::Null));
+            }
+            _ => {
+                return Err(GraphqlError::new(
+                    "nullable schema must be an object or boolean JSON Schema",
+                ));
+            }
+        }
+    }
+}
+
+fn find_cycle_edge(
+    objects: &BTreeMap<String, ObjectNames>,
+    edges: &[InputEdge],
+    relaxed: &BTreeSet<String>,
+) -> Option<String> {
+    let mut adjacency = objects
+        .keys()
+        .map(|path| (path.clone(), Vec::<&InputEdge>::new()))
+        .collect::<BTreeMap<_, _>>();
+    for edge in edges {
+        if !relaxed.contains(&edge.field_path) {
+            adjacency.entry(edge.source.clone()).or_default().push(edge);
+        }
+    }
+    for outgoing in adjacency.values_mut() {
+        outgoing.sort_by(|left, right| {
+            left.target
+                .cmp(&right.target)
+                .then_with(|| left.field_path.cmp(&right.field_path))
+        });
+    }
+
+    let mut colors = BTreeMap::<String, u8>::new();
+    for start in objects.keys() {
+        if colors.get(start).copied().unwrap_or(0) != 0 {
+            continue;
+        }
+        colors.insert(start.clone(), 1);
+        let mut stack = vec![(start.clone(), 0_usize)];
+        while let Some((node, index)) = stack.last_mut() {
+            let outgoing = adjacency.get(node).map(Vec::as_slice).unwrap_or_default();
+            if *index >= outgoing.len() {
+                colors.insert(node.clone(), 2);
+                stack.pop();
+                continue;
+            }
+            let edge = outgoing[*index];
+            *index += 1;
+            match colors.get(&edge.target).copied().unwrap_or(0) {
+                0 => {
+                    colors.insert(edge.target.clone(), 1);
+                    stack.push((edge.target.clone(), 0));
+                }
+                1 => return Some(edge.field_path.clone()),
+                _ => {}
+            }
+        }
+    }
+    None
+}
+
+fn has_unknown_assertion(object: &Map<String, Value>) -> bool {
+    object
+        .keys()
+        .any(|key| !known_schema_keyword(key) && !is_annotation_keyword(key))
+        || object.contains_key("additionalItems")
+}
+
+fn known_schema_keyword(keyword: &str) -> bool {
+    matches!(
+        keyword,
+        "$ref"
+            | "$defs"
+            | "type"
+            | "enum"
+            | "const"
+            | "allOf"
+            | "anyOf"
+            | "oneOf"
+            | "not"
+            | "if"
+            | "then"
+            | "else"
+            | "properties"
+            | "required"
+            | "patternProperties"
+            | "additionalProperties"
+            | "dependentRequired"
+            | "dependentSchemas"
+            | "propertyNames"
+            | "minProperties"
+            | "maxProperties"
+            | "items"
+            | "prefixItems"
+            | "additionalItems"
+            | "contains"
+            | "minContains"
+            | "maxContains"
+            | "uniqueItems"
+            | "minItems"
+            | "maxItems"
+            | "unevaluatedItems"
+            | "unevaluatedProperties"
+            | "minimum"
+            | "maximum"
+            | "exclusiveMinimum"
+            | "exclusiveMaximum"
+            | "multipleOf"
+            | "minLength"
+            | "maxLength"
+            | "pattern"
+            | "format"
+            | "contentEncoding"
+            | "contentMediaType"
+            | "contentSchema"
+    )
+}
+
+fn is_annotation_keyword(keyword: &str) -> bool {
+    keyword.starts_with("x-")
+        || matches!(
+            keyword,
+            "$schema"
+                | "$id"
+                | "$anchor"
+                | "$dynamicAnchor"
+                | "$vocabulary"
+                | "$comment"
+                | "title"
+                | "description"
+                | "default"
+                | "examples"
+                | "deprecated"
+                | "readOnly"
+                | "writeOnly"
+        )
+}
+
+fn schema_doc(schema: &Value) -> Result<Option<&str>, GraphqlError> {
+    let Some(object) = schema.as_object() else {
+        return Ok(None);
+    };
+    if let Some(description) = object.get("description") {
+        return description
+            .as_str()
+            .map(Some)
+            .ok_or_else(|| GraphqlError::new("JSON Schema description must be a string"));
+    }
+    if let Some(title) = object.get("title") {
+        return title
+            .as_str()
+            .map(Some)
+            .ok_or_else(|| GraphqlError::new("JSON Schema title must be a string"));
+    }
+    Ok(None)
+}
+
+fn validate_graphql_name(label: &str, value: &str) -> Result<(), GraphqlError> {
+    if value.len() > MAX_GRAPHQL_NAME_BYTES || !is_graphql_name(value) || value.starts_with("__") {
+        return Err(GraphqlError::new(format!(
+            "GraphQL {label} {value:?} must be a non-introspection GraphQL Name no longer than \
+             {MAX_GRAPHQL_NAME_BYTES} bytes"
+        )));
+    }
+    Ok(())
+}
+
+fn checked_graphql_name(value: &str, label: &str) -> Result<String, GraphqlError> {
+    validate_graphql_name(label, value)?;
+    Ok(value.to_owned())
+}
+
+fn is_graphql_name(value: &str) -> bool {
+    let mut characters = value.chars();
+    characters
+        .next()
+        .is_some_and(|first| first == '_' || first.is_ascii_alphabetic())
+        && characters.all(|character| character == '_' || character.is_ascii_alphanumeric())
+}
+
+fn is_builtin_type(value: &str) -> bool {
+    matches!(value, "Boolean" | "Float" | "ID" | "Int" | "String")
+}
+
+fn graphql_type_name(raw: &str, fallback: &str) -> String {
+    let mut output = String::new();
+    let mut capitalize = true;
+    for character in raw.chars() {
+        if character.is_ascii_alphanumeric() {
+            if capitalize && character.is_ascii_alphabetic() {
+                output.push(character.to_ascii_uppercase());
+            } else {
+                output.push(character);
+            }
+            capitalize = false;
+        } else {
+            capitalize = true;
+        }
+    }
+    if output.is_empty() {
+        output.push_str(fallback);
+    }
+    if output
+        .chars()
+        .next()
+        .is_some_and(|first| first.is_ascii_digit())
+    {
+        output.insert(0, 'N');
+    }
+    if output.starts_with("__") {
+        output.insert(0, 'G');
+    }
+    output
+}
+
+fn graphql_field_name(raw: &str, fallback: &str) -> String {
+    if is_graphql_name(raw) && !raw.starts_with("__") {
+        return raw.to_owned();
+    }
+    let type_name = graphql_type_name(raw, fallback);
+    let mut characters = type_name.chars();
+    let Some(first) = characters.next() else {
+        return fallback.to_owned();
+    };
+    let mut output = first.to_ascii_lowercase().to_string();
+    output.extend(characters);
+    if output.starts_with("__") {
+        output.insert(0, 'g');
+    }
+    output
+}
+
+fn normalize_prose(label: &str, value: &str) -> Result<String, GraphqlError> {
+    let normalized = value.replace("\r\n", "\n").replace('\r', "\n");
+    if normalized.trim().is_empty() {
+        return Err(GraphqlError::new(format!(
+            "GraphQL {label} must be caller-supplied non-whitespace text"
+        )));
+    }
+    if normalized
+        .chars()
+        .any(|character| character.is_control() && character != '\n' && character != '\t')
+    {
+        return Err(GraphqlError::new(format!(
+            "GraphQL {label} contains an unsupported control character"
+        )));
+    }
+    Ok(normalized)
+}
+
+fn graphql_string(value: &str) -> String {
+    serde_json::to_string(value).expect("serializing a Rust string to JSON cannot fail")
+}
+
+fn write_comment(output: &mut String, value: &str) {
+    for line in value.lines() {
+        if line.is_empty() {
+            output.push_str("#\n");
+        } else {
+            writeln!(output, "# {line}").expect("writing GraphQL SDL to a String cannot fail");
+        }
+    }
+}
+
+fn ensure_depth(depth: usize, path: &str) -> Result<(), GraphqlError> {
+    if depth > MAX_SCHEMA_DEPTH {
+        Err(GraphqlError::new(format!(
+            "GraphQL schema expression at {path} exceeds depth {MAX_SCHEMA_DEPTH}"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn ensure_value_size(value: &Value) -> Result<(), GraphqlError> {
+    let mut stack = vec![(value, 0_usize)];
+    while let Some((current, depth)) = stack.pop() {
+        if depth > MAX_SCHEMA_DEPTH {
+            return Err(GraphqlError::new(format!(
+                "GraphQL JSON value exceeds depth {MAX_SCHEMA_DEPTH}"
+            )));
+        }
+        match current {
+            Value::Array(values) => {
+                stack.extend(values.iter().map(|value| (value, depth + 1)));
+            }
+            Value::Object(object) => {
+                stack.extend(object.values().map(|value| (value, depth + 1)));
+            }
+            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+        }
+    }
+    let bytes = serde_json::to_vec(value).map_err(|error| {
+        GraphqlError::new(format!("cannot inspect GraphQL JSON value: {error}"))
+    })?;
+    if bytes.len() > MAX_VALUE_JSON_BYTES {
+        Err(GraphqlError::new(format!(
+            "GraphQL JSON value exceeds the {MAX_VALUE_JSON_BYTES}-byte codec limit"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn finish_text(mut text: String) -> String {
+    while text.ends_with("\n\n") {
+        text.pop();
+    }
+    if !text.ends_with('\n') {
+        text.push('\n');
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::purrdf::loss::{check_ledger_complete, check_ledger_sound};
+    use proptest::prelude::*;
+    use serde_json::json;
+
+    fn compiled(schema: &Value) -> CompiledSchema {
+        CompiledSchema {
+            schema_json: format!(
+                "{}\n",
+                serde_json::to_string_pretty(schema).expect("fixture serializes")
+            ),
+            openapi_json: "{}\n".to_owned(),
+            losses: LossLedger::new(),
+        }
+    }
+
+    fn config() -> GraphqlConfig {
+        GraphqlConfig::new(
+            "ExampleSchema",
+            "Caller-owned package documentation.",
+            "Caller-owned GraphQL module documentation.",
+            "JsonCarrier",
+        )
+        .expect("valid config")
+    }
+
+    fn sdl(package: &GraphqlPackage) -> &str {
+        std::str::from_utf8(
+            package
+                .artifacts
+                .get(GRAPHQL_SCHEMA_PATH)
+                .expect("SDL artifact exists"),
+        )
+        .expect("SDL is UTF-8")
+    }
+
+    fn exact_schema() -> Value {
+        json!({
+            "$defs": {
+                "Alias": { "$ref": "#/$defs/Person" },
+                "Choice": { "enum": [true, { "state": "open" }] },
+                "Int32": {
+                    "type": "integer",
+                    "minimum": -2_147_483_648_i64,
+                    "maximum": 2_147_483_647_i64
+                },
+                "Person": {
+                    "type": "object",
+                    "title": "Person",
+                    "description": "A caller-described person.\nSecond line.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "@id": {
+                            "type": "string",
+                            "description": "Stable caller identifier."
+                        },
+                        "ex:choice": { "$ref": "#/$defs/Choice" },
+                        "ex:maybe": { "type": ["string", "null"] }
+                    },
+                    "required": ["@id", "ex:choice"]
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn exact_projection_is_deterministic_lossless_and_reversible() {
+        let schema = exact_schema();
+        let first = emit_graphql(&compiled(&schema), &config()).expect("exact schema emits");
+        let second = emit_graphql(&compiled(&schema), &config()).expect("exact schema emits");
+        assert_eq!(first, second);
+        assert!(first.losses.is_empty(), "{}", first.losses.render_json());
+        assert_eq!(first.schema_name, "ExampleSchema");
+        assert_eq!(first.artifacts.len(), 2);
+        assert_eq!(
+            first.names.definitions["Alias"],
+            GraphqlDefinitionMap {
+                output_type: "Person".to_owned(),
+                input_type: "PersonInput".to_owned(),
+            }
+        );
+        assert_eq!(first.names.definitions["Int32"].input_type, "Int");
+        assert_eq!(first.names.fields["#/$defs/Person"]["@id"], "id");
+        assert_eq!(
+            first.names.fields["#/$defs/Person"]["ex:choice"],
+            "exChoice"
+        );
+
+        let source = json!({
+            "@id": "ex:person",
+            "ex:choice": { "state": "open" },
+            "ex:maybe": null
+        });
+        let encoded = first
+            .encode_input("Person", &source)
+            .expect("source value encodes");
+        assert_eq!(
+            encoded,
+            json!({
+                "id": "ex:person",
+                "exChoice": "VALUE_1",
+                "exMaybe": null
+            })
+        );
+        assert_eq!(
+            first
+                .decode_output("Person", &encoded)
+                .expect("GraphQL value decodes"),
+            source
+        );
+
+        let schema_source = sdl(&first);
+        assert!(schema_source.ends_with('\n'));
+        assert!(schema_source.contains("scalar JsonCarrier"));
+        assert!(schema_source.contains("enum Choice"));
+        assert!(schema_source.contains("type Person {"));
+        assert!(schema_source.contains("input PersonInput {"));
+        assert!(schema_source.contains("id: String!"));
+        assert!(schema_source.contains("exChoice: Choice!"));
+        assert!(schema_source.contains("exMaybe: String"));
+        assert!(!schema_source.contains("type Query"));
+        assert!(!schema_source.contains("blackcatinformatics.ca"));
+        assert!(!schema_source.to_ascii_lowercase().contains("gmeow"));
+
+        let artifact: Value = serde_json::from_slice(
+            first
+                .artifacts
+                .get(GRAPHQL_NAME_MAP_PATH)
+                .expect("name map artifact exists"),
+        )
+        .expect("name map is JSON");
+        assert_eq!(artifact["dialect"], GRAPHQL_DIALECT);
+        assert_eq!(artifact["schema_name"], "ExampleSchema");
+    }
+
+    #[test]
+    fn lossy_projection_exercises_the_entire_closed_profile() {
+        let schema = json!({
+            "$defs": {
+                "ArrayLoss": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "minItems": 1,
+                    "maxItems": 4,
+                    "contains": { "const": "match" },
+                    "minContains": 1,
+                    "maxContains": 2,
+                    "uniqueItems": true,
+                    "unevaluatedItems": false
+                },
+                "ConditionalObject": {
+                    "type": "object",
+                    "properties": {
+                        "plain": { "type": "string", "pattern": "^[A-Z]" },
+                        "nullableRequired": { "type": ["string", "null"] }
+                    },
+                    "required": ["nullableRequired"],
+                    "patternProperties": { "^dynamic": { "type": "string" } },
+                    "propertyNames": { "pattern": "^[A-Za-z]" },
+                    "minProperties": 1,
+                    "maxProperties": 10,
+                    "dependentRequired": { "plain": ["nullableRequired"] },
+                    "dependentSchemas": { "plain": { "required": ["nullableRequired"] } },
+                    "if": { "properties": { "plain": { "const": "A" } } },
+                    "then": { "required": ["nullableRequired"] },
+                    "else": { "maxProperties": 2 },
+                    "unevaluatedProperties": false
+                },
+                "GenericInteger": { "type": "integer" },
+                "IntPredicate": {
+                    "type": "integer",
+                    "minimum": -2_147_483_648_i64,
+                    "maximum": 2_147_483_647_i64,
+                    "multipleOf": 2
+                },
+                "Intersection": {
+                    "allOf": [{ "type": "string" }, { "minLength": 1 }]
+                },
+                "Negated": { "type": "string", "not": { "const": "forbidden" } },
+                "OneOf": { "oneOf": [{ "type": "string" }, { "type": "boolean" }] },
+                "Tuple": {
+                    "type": "array",
+                    "prefixItems": [{ "type": "string" }, { "type": "boolean" }],
+                    "items": false
+                },
+                "Union": { "anyOf": [{ "type": "string" }, { "type": "boolean" }] },
+                "Unknown": { "type": "string", "unsupportedAssertion": true },
+                "A": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": { "b": { "$ref": "#/$defs/B" } },
+                    "required": ["b"]
+                },
+                "B": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": { "a": { "$ref": "#/$defs/A" } },
+                    "required": ["a"]
+                }
+            }
+        });
+        let package = emit_graphql(&compiled(&schema), &config()).expect("lossy schema emits");
+        let expected = [
+            "additional-properties-validation-narrowed",
+            "array-cardinality-validation-dropped",
+            "array-contains-validation-dropped",
+            "conditional-validation-dropped",
+            "custom-scalar-validation-delegated",
+            "dependency-validation-dropped",
+            "integer-domain-validation-delegated",
+            "intersection-validation-delegated",
+            "keyword-validation-delegated",
+            "negation-validation-delegated",
+            "nullable-presence-validation-widened",
+            "numeric-validation-dropped",
+            "one-of-validation-delegated",
+            "pattern-properties-validation-narrowed",
+            "property-count-validation-dropped",
+            "property-name-validation-narrowed",
+            "recursive-input-nullability-relaxed",
+            "singleton-list-coercion-widened",
+            "string-validation-dropped",
+            "tuple-array-validation-delegated",
+            "unevaluated-validation-dropped",
+            "union-validation-delegated",
+            "unique-items-validation-dropped",
+        ];
+        check_ledger_sound(&package.losses, LOSS_FROM, GRAPHQL_DIALECT)
+            .expect("all GraphQL losses are registered");
+        check_ledger_complete(&package.losses, &expected)
+            .expect("the complete closed GraphQL profile is exercised");
+        assert!(package.losses.entries().iter().all(|entry| {
+            entry
+                .location
+                .as_ref()
+                .and_then(|location| location.subject.as_deref())
+                .is_some_and(|subject| subject.starts_with("#/$defs/"))
+        }));
+        let source = sdl(&package);
+        let a_required = source.contains("a: AInput!");
+        let b_required = source.contains("b: BInput!");
+        assert_ne!(a_required, b_required, "exactly one cycle edge is relaxed");
+    }
+
+    #[test]
+    fn config_schema_and_codec_ambiguities_hard_fail() {
+        for config in [
+            GraphqlConfig::new("__Schema", "package", "module", "JsonCarrier"),
+            GraphqlConfig::new("Schema", " ", "module", "JsonCarrier"),
+            GraphqlConfig::new("Schema", "package", "module", "String"),
+        ] {
+            assert!(config.is_err());
+        }
+
+        let collision = json!({
+            "$defs": {
+                "a-b": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": { "value": { "type": "string" } }
+                },
+                "a_b": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": { "value": { "type": "string" } }
+                }
+            }
+        });
+        assert!(
+            emit_graphql(&compiled(&collision), &config())
+                .expect_err("type collision must fail")
+                .to_string()
+                .contains("collides")
+        );
+
+        let closed_required = json!({
+            "$defs": {
+                "Broken": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["missing"]
+                }
+            }
+        });
+        assert!(
+            emit_graphql(&compiled(&closed_required), &config())
+                .expect_err("unsatisfiable closed required field must fail")
+                .to_string()
+                .contains("no matching property schema")
+        );
+
+        let package = emit_graphql(&compiled(&exact_schema()), &config()).expect("exact emits");
+        assert!(
+            package
+                .encode_input("Person", &json!({ "unknown": true }))
+                .expect_err("unmapped source field must fail")
+                .to_string()
+                .contains("not representable")
+        );
+        assert!(
+            package
+                .decode_output("Choice", &json!("NOT_A_SYMBOL"))
+                .expect_err("unmapped enum symbol must fail")
+                .to_string()
+                .contains("not mapped")
+        );
+    }
+
+    #[test]
+    fn inline_objects_and_lists_share_the_public_value_map() {
+        let schema = json!({
+            "$defs": {
+                "Bag": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ex:entries": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "ex:value": { "type": "string" }
+                                },
+                                "required": ["ex:value"]
+                            }
+                        }
+                    },
+                    "required": ["ex:entries"]
+                }
+            }
+        });
+        let package = emit_graphql(&compiled(&schema), &config()).expect("inline schema emits");
+        check_ledger_complete(&package.losses, &["singleton-list-coercion-widened"])
+            .expect("only GraphQL singleton-list coercion differs");
+        let source = json!({
+            "ex:entries": [
+                { "ex:value": "first" },
+                { "ex:value": "second" }
+            ]
+        });
+        let encoded = package.encode_input("Bag", &source).expect("encodes");
+        assert_eq!(
+            encoded,
+            json!({
+                "exEntries": [
+                    { "exValue": "first" },
+                    { "exValue": "second" }
+                ]
+            })
+        );
+        assert_eq!(
+            package.decode_output("Bag", &encoded).expect("decodes"),
+            source
+        );
+        let source = sdl(&package);
+        assert!(source.contains("type BagExEntriesItem {"));
+        assert!(source.contains("input BagExEntriesItemInput {"));
+        assert!(source.contains("exEntries: [BagExEntriesItemInput!]!"));
+    }
+
+    #[test]
+    fn long_alias_catalog_is_iterative_and_alias_cycles_fail() {
+        const ALIASES: usize = 8_192;
+        let mut definitions = Map::new();
+        for index in 0..ALIASES {
+            let key = format!("Alias{index:04}");
+            let next = if index + 1 == ALIASES {
+                json!({ "type": "string" })
+            } else {
+                json!({ "$ref": format!("#/$defs/Alias{:04}", index + 1) })
+            };
+            definitions.insert(key, next);
+        }
+        let package = emit_graphql(&compiled(&json!({ "$defs": definitions })), &config())
+            .expect("long acyclic alias catalog emits iteratively");
+        assert!(package.losses.is_empty());
+        assert_eq!(package.names.definitions.len(), ALIASES);
+        assert_eq!(package.names.definitions["Alias0000"].input_type, "String");
+
+        let cycle = json!({
+            "$defs": {
+                "A": { "$ref": "#/$defs/B" },
+                "B": { "$ref": "#/$defs/A" }
+            }
+        });
+        assert!(
+            emit_graphql(&compiled(&cycle), &config())
+                .expect_err("alias cycle must fail")
+                .to_string()
+                .contains("alias cycle")
+        );
+    }
+
+    #[test]
+    fn malformed_schema_values_and_field_collisions_fail_at_source_locations() {
+        for (schema, expected) in [
+            (
+                json!({ "$defs": { "Broken": { "enum": [] } } }),
+                "enum cannot be empty",
+            ),
+            (
+                json!({ "$defs": { "Broken": { "$ref": "#/$defs/Missing" } } }),
+                "targets missing $defs key",
+            ),
+            (
+                json!({
+                    "$defs": {
+                        "Broken": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "a-b": { "type": "string" },
+                                "a:b": { "type": "string" }
+                            }
+                        }
+                    }
+                }),
+                "collide on GraphQL field name",
+            ),
+        ] {
+            let error = emit_graphql(&compiled(&schema), &config())
+                .expect_err("malformed schema must fail");
+            assert!(error.to_string().contains(expected), "{error}");
+        }
+    }
+
+    #[test]
+    fn schema_name_and_value_depth_limits_hard_fail() {
+        let fallback_collision = json!({
+            "$defs": {
+                "JsonCarrier": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": { "value": { "type": "string" } }
+                }
+            }
+        });
+        assert!(
+            emit_graphql(&compiled(&fallback_collision), &config())
+                .expect_err("fallback scalar collision must fail")
+                .to_string()
+                .contains("collides")
+        );
+
+        let long_field = "a".repeat(MAX_GRAPHQL_NAME_BYTES + 1);
+        let long_name_schema = json!({
+            "$defs": {
+                "Record": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": { (long_field): { "type": "string" } }
+                }
+            }
+        });
+        assert!(
+            emit_graphql(&compiled(&long_name_schema), &config())
+                .expect_err("overlong field name must fail")
+                .to_string()
+                .contains("no longer than")
+        );
+
+        let mut nested_schema = json!({ "type": "string" });
+        for _ in 0..=MAX_SCHEMA_DEPTH {
+            nested_schema = json!({ "type": "array", "items": nested_schema });
+        }
+        let error = emit_graphql(
+            &compiled(&json!({ "$defs": { "Deep": nested_schema } })),
+            &config(),
+        )
+        .expect_err("excessive schema depth must fail");
+        assert!(
+            error.to_string().contains("exceeds depth")
+                || error.to_string().contains("recursion limit exceeded"),
+            "{error}"
+        );
+
+        let package = emit_graphql(
+            &compiled(&json!({ "$defs": { "Anything": true } })),
+            &config(),
+        )
+        .expect("fallback package emits");
+        let mut nested_value = Value::Null;
+        for _ in 0..=MAX_SCHEMA_DEPTH {
+            nested_value = Value::Array(vec![nested_value]);
+        }
+        let error = package
+            .encode_input("Anything", &nested_value)
+            .expect_err("excessive value depth must fail");
+        assert!(error.to_string().contains("exceeds depth"), "{error}");
+    }
+
+    proptest! {
+        #[test]
+        fn arbitrary_source_field_names_round_trip(
+            source_field in "[A-Za-z0-9:@/_-]{1,24}",
+            source_value in "[A-Za-z0-9 ]{0,32}",
+        ) {
+            let schema = json!({
+                "$defs": {
+                    "Record": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": { (source_field.clone()): { "type": "string" } },
+                        "required": [source_field.as_str()]
+                    }
+                }
+            });
+            let package = emit_graphql(&compiled(&schema), &config()).expect("generated field emits");
+            prop_assert!(package.losses.is_empty(), "{}", package.losses.render_json());
+            let source = json!({ (source_field): source_value });
+            let encoded = package.encode_input("Record", &source).expect("encodes");
+            let decoded = package.decode_output("Record", &encoded).expect("decodes");
+            prop_assert_eq!(decoded, source);
+        }
+    }
+}

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -22,6 +22,7 @@ pub mod constraints;
 pub mod data;
 pub mod engine;
 pub mod expression;
+pub mod graphql;
 pub mod instance;
 pub mod json_schema;
 pub mod linkml;
@@ -39,6 +40,11 @@ pub mod term;
 pub mod text_ingest;
 pub mod typescript;
 
+pub use graphql::{
+    GRAPHQL_DIALECT, GRAPHQL_NAME_MAP_PATH, GRAPHQL_SCHEMA_PATH, GraphqlConfig,
+    GraphqlDefinitionMap, GraphqlEnumValueMap, GraphqlError, GraphqlNameMap, GraphqlPackage,
+    emit_graphql,
+};
 pub use json_schema::{Namespaces, ValueVocab, ValueVocabProjection, compile_with_value_vocab};
 pub use linkml::{
     LinkmlConfig, LinkmlDocument, LinkmlError, LinkmlPackage, emit_linkml, parse_linkml,

--- a/crates/shapes/tests/graphql_oracle.mjs
+++ b/crates/shapes/tests/graphql_oracle.mjs
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/**
+ * Validate generated SDL and execute real GraphQL variable coercion through
+ * the locked official GraphQL.js implementation, with boon as source truth.
+ */
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = fileURLToPath(new URL("../../..", import.meta.url));
+const TOOLCHAIN = path.join(REPO, "crates", "rdf-wasm", "js");
+const GRAPHQL_VERSION = "16.14.0";
+const requireFromToolchain = createRequire(path.join(TOOLCHAIN, "package.json"));
+const {
+  buildSchema,
+  graphql,
+  validateSchema,
+  valueFromASTUntyped,
+  version: graphqlVersion,
+} = requireFromToolchain("graphql");
+
+function fixtureManifest() {
+  const completed = spawnSync(
+    "cargo",
+    [
+      "run",
+      "-p",
+      "purrdf-shapes",
+      "--example",
+      "graphql_oracle_fixture",
+      "--locked",
+      "--quiet",
+    ],
+    {
+      cwd: REPO,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  );
+  if (completed.status !== 0) {
+    throw new Error(
+      `GraphQL oracle fixture failed (${completed.status}):\n${completed.stderr}`,
+    );
+  }
+  return JSON.parse(completed.stdout);
+}
+
+function lossSubject(entry) {
+  const marker = " subject=";
+  const start = entry.location?.indexOf(marker);
+  if (start === undefined || start < 0) {
+    throw new Error(`loss ${entry.code} has no logical subject: ${entry.location}`);
+  }
+  return entry.location.slice(start + marker.length);
+}
+
+function lossKey(loss) {
+  return `${loss.code}\u0000${loss.location}`;
+}
+
+function compareProbe(fixtureName, probe, actual, locatedLosses) {
+  if (probe.expectedLoss === undefined) {
+    if (actual !== probe.sourceValid) {
+      throw new Error(
+        `${fixtureName}/${probe.label} has an unlocated acceptance divergence: ` +
+          `boon=${probe.sourceValid}, GraphQL=${actual}`,
+      );
+    }
+    return;
+  }
+  if (!locatedLosses.has(lossKey(probe.expectedLoss))) {
+    throw new Error(
+      `${fixtureName}/${probe.label} names a missing ledger entry ` +
+        `${probe.expectedLoss.code} at ${probe.expectedLoss.location}`,
+    );
+  }
+  if (actual === probe.sourceValid) {
+    throw new Error(
+      `${fixtureName}/${probe.label} was expected to expose ` +
+        `${probe.expectedLoss.code}, but boon and GraphQL both classified it as ${actual}`,
+    );
+  }
+}
+
+function assertNameMap(fixture) {
+  const artifact = JSON.parse(fixture.nameMapArtifact);
+  assert.deepEqual(
+    artifact,
+    fixture.nameMap,
+    "typed GraphQL name map differs from name-map.json",
+  );
+}
+
+function assertSelfTest() {
+  assert.throws(
+    () =>
+      compareProbe(
+        "self-test",
+        { label: "flipped", sourceValid: true },
+        false,
+        new Set(),
+      ),
+    /unlocated acceptance divergence/,
+  );
+  assert.throws(
+    () =>
+      compareProbe(
+        "self-test",
+        {
+          label: "missing-location",
+          sourceValid: false,
+          expectedLoss: { code: "present", location: "#/missing" },
+        },
+        true,
+        new Set(["present\u0000#/present"]),
+      ),
+    /missing ledger entry/,
+  );
+  assert.throws(
+    () =>
+      compareProbe(
+        "self-test",
+        {
+          label: "hidden-divergence",
+          sourceValid: false,
+          expectedLoss: { code: "present", location: "#/present" },
+        },
+        false,
+        new Set(["present\u0000#/present"]),
+      ),
+    /expected to expose/,
+  );
+  assert.throws(
+    () =>
+      assertNameMap({
+        nameMapArtifact: '{"schema_name":"expected"}\n',
+        nameMap: { schema_name: "corrupted" },
+      }),
+    /typed GraphQL name map differs/,
+  );
+}
+
+function buildFixtureSchema(fixture) {
+  const queryFields = fixture.probes
+    .map((probe, index) => `  probe${index}(value: ${probe.graphqlType}): Boolean!`)
+    .join("\n");
+  const schema = buildSchema(`${fixture.sdl}\ntype Query {\n${queryFields}\n}\n`);
+  const scalar = schema.getType(fixture.fallbackScalar);
+  if (scalar === undefined || scalar.constructor.name !== "GraphQLScalarType") {
+    throw new Error(`fixture fallback scalar ${fixture.fallbackScalar} is absent`);
+  }
+  scalar.serialize = (value) => value;
+  scalar.parseValue = (value) => value;
+  scalar.parseLiteral = (node, variables) => valueFromASTUntyped(node, variables);
+  const errors = validateSchema(schema);
+  if (errors.length !== 0) {
+    throw new Error(
+      `generated GraphQL schema is invalid:\n${errors.map((error) => error.message).join("\n")}`,
+    );
+  }
+  return schema;
+}
+
+async function executeFixture(name, fixture) {
+  assertNameMap(fixture);
+  const losses = fixture.losses.losses;
+  if (!Array.isArray(losses) || !losses.every((entry) => entry.intentional === true)) {
+    throw new Error(`${name} fixture has a malformed or unregistered loss ledger`);
+  }
+  const locatedLosses = new Set(
+    losses.map((entry) => lossKey({ code: entry.code, location: lossSubject(entry) })),
+  );
+  const schema = buildFixtureSchema(fixture);
+  const results = [];
+  for (const [index, probe] of fixture.probes.entries()) {
+    const field = `probe${index}`;
+    const result = await graphql({
+      schema,
+      source: `query Probe($value: ${probe.graphqlType}) { ${field}(value: $value) }`,
+      rootValue: { [field]: () => true },
+      variableValues: { value: probe.graphqlValue },
+    });
+    const valid = result.errors === undefined;
+    try {
+      compareProbe(name, probe, valid, locatedLosses);
+    } catch (error) {
+      const diagnostics = result.errors?.map((entry) => entry.message).join("\n") ?? "";
+      error.message += diagnostics.length === 0 ? "" : `\n${diagnostics}`;
+      throw error;
+    }
+    results.push({ probe, valid });
+  }
+  return results;
+}
+
+if (graphqlVersion !== GRAPHQL_VERSION) {
+  throw new Error(
+    `GraphQL.js version drift: expected ${GRAPHQL_VERSION}, found ${graphqlVersion}`,
+  );
+}
+assertSelfTest();
+if (process.argv.includes("--self-test")) {
+  console.log(
+    "GraphQL oracle self-test: flipped, unlocated, hidden, and name-map corruptions were rejected",
+  );
+  process.exit(0);
+}
+
+const manifest = fixtureManifest();
+if (manifest.dialect !== "graphql-september-2025") {
+  throw new Error(`GraphQL dialect drift: ${manifest.dialect}`);
+}
+if (manifest.exact.losses.losses.length !== 0) {
+  throw new Error("exact GraphQL oracle fixture has a non-empty loss ledger");
+}
+const profile = new Set(manifest.closedProfile);
+const lossyCodes = new Set(manifest.lossy.losses.losses.map((entry) => entry.code));
+assert.deepEqual(lossyCodes, profile, "lossy fixture no longer covers the closed profile");
+
+const exactResults = await executeFixture("exact", manifest.exact);
+const lossyResults = await executeFixture("lossy", manifest.lossy);
+const divergenceCount = lossyResults.filter(
+  ({ probe, valid }) => valid !== probe.sourceValid,
+).length;
+if (divergenceCount !== manifest.lossy.probes.length) {
+  throw new Error(
+    `lossy fixture exposed ${divergenceCount}/${manifest.lossy.probes.length} divergences`,
+  );
+}
+const codecCount = [...manifest.exact.probes, ...manifest.lossy.probes].filter(
+  (probe) => probe.usedCodec,
+).length;
+console.log(
+  `GraphQL oracle: GraphQL.js ${graphqlVersion}; ` +
+    `${exactResults.length} exact boon/variable-coercion probes agree; ` +
+    `${divergenceCount} located divergences cover the complete ${profile.size}-code profile; ` +
+    `${codecCount} probes exercise the production value codec`,
+);

--- a/docs/book/src/validation/shacl.md
+++ b/docs/book/src/validation/shacl.md
@@ -123,6 +123,73 @@ projection is many-to-one. The retained `CompiledSchema` plus the reversible
 name map remains the authoritative reverse surface. TypeScript is only a
 dev-time oracle dependency; the Rust emitter is filesystem-free and wasm-clean.
 
+## GraphQL September 2025 projection
+
+`emit_graphql` projects `CompiledSchema` into deterministic GraphQL September
+2025 SDL. `GraphqlConfig` has no defaults: the caller supplies the schema name,
+package and module prose, and a non-built-in fallback-scalar name. The returned
+`GraphqlPackage` contains `schema.graphql`, canonical `name-map.json`, the same
+name map as typed Rust data, a located `json-schema` →
+`graphql-september-2025` loss ledger, and the production value codec.
+
+The SDL is deliberately a type-system fragment. PurRDF emits paired output
+`type` and input `input` objects, but no query, mutation, or subscription root,
+resolver, pagination rule, authorization policy, federation directive, or
+other application behavior. A caller composes the fragment with its own
+executable schema.
+
+The exact grammar includes GraphQL booleans, strings, numbers, the signed
+32-bit `Int` domain, explicit nullability, finite JSON `const`/`enum` sets,
+closed object fields, requiredness, homogeneous lists, direct local `$defs`
+references and aliases, descriptions, and inline object helpers. One global
+collision-checked namespace covers types, helpers, and the fallback scalar;
+fields and enum symbols are checked in their GraphQL-local namespaces. The
+typed/canonical name maps retain the source definition keys, property keys, and
+finite JSON values.
+
+`GraphqlPackage::encode_input` maps source JSON keys and finite values to input
+field names and enum symbols. `decode_output` performs the inverse for fields
+present in a GraphQL response, without inventing omitted selections. Unknown or
+incompatible values fail. This package codec is the precise reverse boundary;
+arbitrary GraphQL SDL has no unique JSON Schema acceptance relation and is not
+accepted as an inverse format.
+
+GraphQL variable coercion differs from JSON Schema validation at these closed
+boundaries:
+
+| Boundary | Located loss families |
+|---|---|
+| object fields and names | additional properties, pattern properties, property names/counts |
+| requiredness and recursion | nullable-presence widening, one deterministic recursive-input nullability relaxation |
+| lists | singleton coercion, cardinality, contains, uniqueness, tuples, unevaluated items |
+| scalar assertions | integer domain delegation, numeric predicates, string predicates |
+| applicators | conditionals, dependencies, intersections, unions, `oneOf`, negation |
+| runtime boundary | custom-scalar and unknown-keyword validation delegation |
+
+The caller-named fallback scalar is declared but PurRDF does not invent its
+`parseValue`, `parseLiteral`, or serialization semantics. Every delegated use
+is therefore ledgered. Loss entries carry stable codes and source JSON Pointer
+locations; an exact package has an empty ledger.
+
+Emission fails before returning bytes for invalid caller configuration,
+malformed schema keywords, `$id` rebasing, external/indirect/dangling `$ref`,
+`$dynamicRef`/`$recursiveRef`, alias cycles, unsatisfiable closed required
+fields, and generated-name collisions. The fixed limits are 16 MiB for the
+input schema, each artifact, and one codec value; 65,536 definitions, fields
+per object, or finite values; depth 128; and 255 bytes per GraphQL name.
+
+The independent dev oracle classifies source values with `boon`, builds the
+SDL with locked official GraphQL.js 16.14.0, and executes real variable
+coercion. It verifies exact agreement, every closed loss family and location,
+the name map and production codec, and deliberate corruption failures:
+
+```bash
+make graphql-oracle
+```
+
+GraphQL.js is dev-only. Emission and value translation remain filesystem-free,
+wasm-clean Rust.
+
 ## From Python
 
 ```python

--- a/generated/transcode-loss-matrix.json
+++ b/generated/transcode-loss-matrix.json
@@ -238,11 +238,11 @@
     "note": "JSON Schema oneOf requires exactly one branch to validate. GraphQL has no input union with exactly-one validation semantics, so a non-finite oneOf is carried through the caller-named fallback scalar and exclusivity is delegated."
   },
   {
-    "code": "pattern-properties-validation-narrowed",
+    "code": "pattern-properties-validation-changed",
     "from": "json-schema",
     "to": "graphql-september-2025",
     "intentional": true,
-    "note": "JSON Schema patternProperties can admit runtime keys selected by a regular expression. GraphQL input object fields are a fixed finite name set and reject those dynamic keys, so the accepted object key space is narrowed."
+    "note": "JSON Schema patternProperties can admit dynamic regex-selected keys and can add conjunctive validation to declared keys. GraphQL input objects instead expose a fixed field set with one type per field, so dynamic keys are narrowed while overlapping declared-field validation may be widened."
   },
   {
     "code": "property-count-validation-dropped",
@@ -252,11 +252,11 @@
     "note": "JSON Schema minProperties/maxProperties counts runtime object keys. GraphQL input object definitions express field requiredness but cannot bound the total supplied-field count."
   },
   {
-    "code": "property-name-validation-narrowed",
+    "code": "property-name-validation-changed",
     "from": "json-schema",
     "to": "graphql-september-2025",
     "intentional": true,
-    "note": "JSON Schema propertyNames can validate an open runtime key space. GraphQL input objects expose only their declared finite field set and reject all other names, narrowing any source key space that remains open after the property-name assertion."
+    "note": "JSON Schema propertyNames validates every runtime key, including declared properties. GraphQL input objects expose only a fixed declared field set: unknown names are narrowed, while a source property-name rule that rejects a generated declared field is not enforced and may widen acceptance."
   },
   {
     "code": "recursive-input-nullability-relaxed",

--- a/generated/transcode-loss-matrix.json
+++ b/generated/transcode-loss-matrix.json
@@ -147,6 +147,167 @@
     "note": "The target syntax has no named-graph construct; quads are folded into the default graph and graph names are dropped."
   },
   {
+    "code": "additional-properties-validation-narrowed",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "GraphQL input objects reject every field not declared by the input type before resolver execution. A JSON Schema object that permits additional properties therefore accepts source keys that the generated GraphQL input type rejects; named fields remain available and the narrowing is recorded on the object schema."
+  },
+  {
+    "code": "array-cardinality-validation-dropped",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "GraphQL list types have no minimum- or maximum-length expression. The generated list retains its item carrier while JSON Schema minItems/maxItems validation is omitted."
+  },
+  {
+    "code": "array-contains-validation-dropped",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "JSON Schema contains/minContains/maxContains quantifies matching array elements. GraphQL list input coercion has no corresponding predicate, so the item carrier remains while contains validation is omitted."
+  },
+  {
+    "code": "conditional-validation-dropped",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "JSON Schema if/then/else chooses validation constraints from runtime instance content. GraphQL input object definitions cannot express that conditional relationship; independently representable fields remain while the conditional is omitted."
+  },
+  {
+    "code": "custom-scalar-validation-delegated",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "GraphQL SDL declares a custom scalar name but does not define its parseValue, parseLiteral, or serialization behavior. Validation carried by the caller-named fallback scalar is therefore delegated to application code and is not an exact self-contained SDL projection."
+  },
+  {
+    "code": "dependency-validation-dropped",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "JSON Schema dependentRequired/dependentSchemas imposes cross-field validation. GraphQL input object definitions express each field independently and cannot enforce those dependencies, so the relationship is omitted."
+  },
+  {
+    "code": "integer-domain-validation-delegated",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "GraphQL Int accepts only signed 32-bit integers. A JSON Schema integer domain that is not exactly that domain is carried through the caller-named fallback scalar, whose integer acceptance behavior is application-defined."
+  },
+  {
+    "code": "intersection-validation-delegated",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "General JSON Schema allOf is an intersection of validation sets. GraphQL has no input intersection type, so a non-mergeable intersection is carried through the caller-named fallback scalar and its validation is delegated."
+  },
+  {
+    "code": "keyword-validation-delegated",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "A JSON Schema assertion outside the emitter's closed GraphQL capability table has no sound SDL expression. Its value is carried through the caller-named fallback scalar and the assertion is recorded rather than silently treated as enforced."
+  },
+  {
+    "code": "negation-validation-delegated",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "JSON Schema not is a complement of an instance-validation set. GraphQL input types have no complement operator, so the value is carried through the caller-named fallback scalar and negation validation is delegated."
+  },
+  {
+    "code": "nullable-presence-validation-widened",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "GraphQL uses one nullable field form for both omission and an explicit null. JSON Schema can distinguish required nullable properties from optional non-null properties; either source distinction must be widened when represented by a nullable GraphQL input field."
+  },
+  {
+    "code": "numeric-validation-dropped",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "GraphQL Int and Float types do not express JSON Schema bounds, exclusive bounds, or multipleOf. The built-in numeric carrier remains while those runtime predicates are omitted."
+  },
+  {
+    "code": "one-of-validation-delegated",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "JSON Schema oneOf requires exactly one branch to validate. GraphQL has no input union with exactly-one validation semantics, so a non-finite oneOf is carried through the caller-named fallback scalar and exclusivity is delegated."
+  },
+  {
+    "code": "pattern-properties-validation-narrowed",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "JSON Schema patternProperties can admit runtime keys selected by a regular expression. GraphQL input object fields are a fixed finite name set and reject those dynamic keys, so the accepted object key space is narrowed."
+  },
+  {
+    "code": "property-count-validation-dropped",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "JSON Schema minProperties/maxProperties counts runtime object keys. GraphQL input object definitions express field requiredness but cannot bound the total supplied-field count."
+  },
+  {
+    "code": "property-name-validation-narrowed",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "JSON Schema propertyNames can validate an open runtime key space. GraphQL input objects expose only their declared finite field set and reject all other names, narrowing any source key space that remains open after the property-name assertion."
+  },
+  {
+    "code": "recursive-input-nullability-relaxed",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "GraphQL forbids an unbroken cycle of singular non-null input-object fields because no finite value can satisfy it. The emitter makes one deterministic cycle edge nullable and records that required/non-null source constraint at the field location."
+  },
+  {
+    "code": "singleton-list-coercion-widened",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "GraphQL variable coercion accepts a non-list value for list input and wraps it as a single-element list. JSON Schema array validation rejects that same non-array value, so every generated list input has this explicit coercion widening."
+  },
+  {
+    "code": "string-validation-dropped",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "GraphQL String has no length, regular-expression, format, or content assertion. The string carrier remains while JSON Schema string predicates are omitted."
+  },
+  {
+    "code": "tuple-array-validation-delegated",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "JSON Schema prefixItems and closed tuple tails assign schemas by array position. GraphQL lists are homogeneous, so a non-homogeneous tuple is carried through the caller-named fallback scalar and position-specific validation is delegated."
+  },
+  {
+    "code": "unevaluated-validation-dropped",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "JSON Schema unevaluatedProperties/unevaluatedItems depends on applicator evaluation state that GraphQL input coercion does not expose. Representable local fields and items remain while the unevaluated assertion is omitted."
+  },
+  {
+    "code": "union-validation-delegated",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "General JSON Schema anyOf and type unions define input-value unions. GraphQL has no input union type, so a non-finite union is carried through the caller-named fallback scalar and branch validation is delegated."
+  },
+  {
+    "code": "unique-items-validation-dropped",
+    "from": "json-schema",
+    "to": "graphql-september-2025",
+    "intentional": true,
+    "note": "JSON Schema uniqueItems compares runtime array values for equality. GraphQL list input coercion cannot require pairwise-distinct elements, so item validation remains while uniqueness is omitted."
+  },
+  {
     "code": "additional-properties-validation-widened",
     "from": "json-schema",
     "to": "linkml-1.11",


### PR DESCRIPTION
## Summary

Add the production `CompiledSchema` → GraphQL September 2025 carrier projection as the fourth and final schema-emitter partition.

PurRDF now emits deterministic paired output/input SDL, canonical `name-map.json`, and a public Rust value codec that reversibly translates source JSON property names and finite values to GraphQL field names and enum symbols. The emitter requires caller-owned schema identity, prose, and fallback-scalar name. It creates no operation roots, resolver behavior, consumer vocabulary, or downstream brand.

The legacy gmeow GraphQL renderer was read only as migration evidence. Its private LinkML coupling, fabricated `id`/`iri` fields, irreversible normalized names, all-nullable object fields, scalar collapse, and fixed consumer identity are deliberately replaced rather than preserved. The gmeow cutover and legacy-model deletion remain tracked in `Blackcat-Informatics/gmeow-ontology#1571`; this PR does not claim that consumer cutover is complete.

## Stage 1 plan execution

| Task | Result | Signed commit |
|---|---|---|
| closed GraphQL loss contract | registered the closed 23-code `json-schema` → `graphql-september-2025` profile and regenerated its canonical matrix | `c74fe604fda19426b173c4c6571f746047b3732b` |
| production package and value codec | added caller configuration, paired SDL, typed/canonical name maps, encode/decode surface, deterministic limits, failure behavior, and focused/property tests | `ca6aa1bea789436eb38b3864182b3dc224e6110d` |
| adversarial loss correction | changed pattern/property-name descriptions from one-direction narrowing claims to their proven bidirectional acceptance changes | `c164bcb8751c9bcbebf808987b4de9240d704d7b` |
| independent coercion oracle | pinned GraphQL.js 16.14.0 dev-only, compared real variable coercion with `boon`, added corruption tests, and wired Make/CI | `b85a19d532e395015c058000399db3da57228f4e` |
| public integration and contract docs | added a runnable example, umbrella-facade proof, crate/Book documentation, and exact migration provenance | `9ba8945b34730b679bb3662a15113cc2a0d80b02` |

## Acceptance mapping

- Consumes `json_schema::CompiledSchema` directly through the shared validated `$defs` catalog; no copied LinkML or gmeow schema IR is introduced.
- Exposes `GraphqlConfig`, `GraphqlPackage`, typed definition/field/enum maps, `GraphqlError`, fixed dialect/path constants, and `emit_graphql` through both `purrdf-shapes` and `purrdf::shapes`.
- Requires caller-supplied GraphQL schema name, package/module prose, and non-built-in fallback-scalar name. There is no `Default`, fabricated IRI, or hard-coded Blackcat/GMEOW vocabulary.
- Emits byte-deterministic GraphQL September 2025 type-system SDL with paired output `type` and input `input` objects. Query/mutation/subscription roots and all application behavior remain caller-owned.
- Preserves the exact representable grammar: booleans, strings, numbers, signed 32-bit `Int`, nullability, finite JSON constants/enums, closed named objects, requiredness, homogeneous lists, direct local references/aliases, descriptions, and inline object helpers.
- Normalizes GraphQL names through collision-checked namespaces while retaining every source definition key, JSON property key, and finite JSON value in typed Rust data and canonical `name-map.json`.
- Provides `encode_input` and `decode_output` for the generated transport. The codec round-trips exact source values and rejects unknown definitions, keys, enum values/symbols, incompatible carriers, depth excess, and size excess.
- Records every non-exact coercion boundary on an always-computed, deterministic, source-located `LossLedger`. The profile covers object-key rules, nullable presence, recursive input relaxation, list coercion/cardinality/content/uniqueness/tuples, evaluation state, scalar predicates/domains, applicators, dependencies, and custom-scalar/unknown-keyword delegation.
- Relaxes exactly one deterministic edge in each otherwise-invalid singular non-null input cycle and records the affected source constraint.
- Hard-fails invalid caller configuration, malformed keyword values, `$id` rebasing, external/indirect/dangling references, `$dynamicRef`/`$recursiveRef`, pure-alias cycles, unsatisfiable closed required fields, generated-name collisions, and fixed resource-limit violations.
- Uses official GraphQL.js 16.14.0 only as an independent dev oracle. Production emission and translation remain filesystem-free Rust with no new release dependency, Cargo feature, or runtime JavaScript surface.
- Makes the reverse boundary explicit: the generated package's retained `CompiledSchema` plus name/value codec is bidirectional; arbitrary GraphQL SDL has no unique JSON Schema acceptance relation, so a general SDL reader would be semantically false.

## Oracle evidence

The final oracle run reports:

- Pydantic: 6 live model schemas agree; validation and alias probes pass.
- LinkML: exact `$defs` and 16 instance probes agree; 18 located losses and representable widening probes pass.
- TypeScript 7.0.2: 25 exact `boon` probes plus 3 optional/null/undefined probes agree; 20 divergences cover the closed 18-code profile.
- GraphQL.js 16.14.0: 8 exact source/coercion probes agree; 22 located acceptance divergences cover the complete 23-code profile; 24 probes exercise the production codec.
- GraphQL corruption self-test rejects flipped classifications, missing loss locations, hidden divergences, and altered name maps.

## Validation

- `UV_CACHE_DIR=/tmp/purrdf-109-graphql-uv make check` — formatting, warning-denied workspace Clippy, workspace checks/tests/doctests, no-feature/license/corpus/generated/version/issue-reference hygiene, kernel ring fences, and all 17 release-crate wasm32 builds passed.
- `make test` passed independently.
- `make metadata` plus check-only `scripts/check-generated.sh` passed with byte-identical generated artifacts.
- `make doc` passed with rustdoc warnings denied.
- The repository-pinned mdBook 0.5.3 built the PurRDF Book successfully.
- `make pydantic-oracle`, `make linkml-oracle`, `make typescript-oracle`, and `make graphql-oracle` passed on the final tree.
- `make wasm-pkg-test` passed TypeScript checking, 50/50 Node tests, packed-tarball smoke, and npm compressed/unpacked budgets: 1,459,469 bytes / 1,619,448 and 4,203,258 bytes / 4,586,013.
- `make wasm-pkg-size` verified 27,395 SIMD opcodes and an optimized wasm of 4,074,485 / 4,444,391 bytes (91%; gzip-9 1,434,916 bytes). The budget was not changed.
- `git -c core.whitespace=trailing-space,space-before-tab diff --check origin/main...HEAD` passed.
- Full branch-diff and commit-text scans contain no postponement markers.
- All five branch commits have good signatures. `origin/main` is the exact branch ancestor, local and remote heads agree, and the worktree is clean.

## Files

- `crates/shapes/src/graphql.rs`: complete emitter, name maps, codec, limits, errors, and tests.
- `crates/rdf-core/src/loss.rs` and `generated/transcode-loss-matrix.json`: closed loss profile and canonical projection.
- `crates/shapes/examples/graphql_oracle_fixture.rs` and `crates/shapes/tests/graphql_oracle.mjs`: differential source/coercion oracle.
- `crates/rdf-wasm/js/package{,-lock}.json`, `Makefile`, and CI: exact dev dependency and mandatory gate.
- `crates/shapes/examples/graphql_package.rs` and `crates/purrdf/src/lib.rs`: runnable production example and umbrella proof.
- `crates/shapes/README.md`, the PurRDF Book, and `PROVENANCE.md`: public contract and replacement boundary.

Closes #109
