### PR TITLE
feat(shapes): import schemas as SHACL

### DIFF
--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -77,9 +77,7 @@ Copied from `gmeow-ontology`:
 
 The five schema-language reverse paths are therefore PurRDF replacements, not
 compatibility layers around gmeow's private models. They share one deterministic
-schema-to-SHACL engine and caller-owned vocabulary boundary; gmeow's later
-deletion and rollover is tracked by
-[`gmeow-ontology#1571`](https://github.com/Blackcat-Informatics/gmeow-ontology/issues/1571).
+schema-to-SHACL engine and caller-owned vocabulary boundary.
 - The legacy graph/tabular writers in `crates/pipeline/src/stages/lpg.rs` and
   `crates/pipeline/src/stages/export.rs` at
   `d7745068f59b6dee187ab6b806bd2c04c9a1280a` were used solely as migration

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -28,7 +28,12 @@ Copied from `gmeow-ontology`:
   for `purrdf-shapes::pydantic`. PurRDF removes its repository, ontology,
   namespace, slice-routing, and fixed-package coupling; the carrier API consumes
   `CompiledSchema` in memory, takes package prose from the caller, and records
-  runtime projection gaps on the shared closed loss ledger.
+  runtime projection gaps on the shared closed loss ledger. The verified
+  `import_pydantic_package` reverse path retains the exact source schema and
+  rejects artifact/model-map drift. The legacy implementation is disposable
+  migration material, intended for deletion when gmeow integrates this
+  replacement; the consumer cutover is not yet complete and no downstream type
+  contract is preserved.
 - The legacy LinkML YAML model in
   `crates/pipeline/src/stages/schemas.rs` at
   `c91195e0c300cad9c9a32c8580c2910a6fd48fc1` was used solely as migration
@@ -37,9 +42,10 @@ Copied from `gmeow-ontology`:
   TypeScript/GraphQL model are not reused architecture. The replacement
   `purrdf-shapes::linkml` API consumes `CompiledSchema`, requires all identity
   and vocabulary from the caller, preserves a canonical LinkML 1.11 document,
-  and records projection gaps through the closed loss ledger. The legacy model
-  is intended for deletion once this replacement is integrated, not
-  preservation as a downstream contract.
+  reads native LinkML back into SHACL, verifies emitted packages, and records
+  projection/import gaps through direction-specific closed loss ledgers. The
+  legacy model is intended for deletion once this replacement is integrated,
+  not preservation as a downstream contract.
 - The legacy `render_typescript` path in
   `crates/pipeline/src/stages/schemas.rs` at
   `c91195e0c300cad9c9a32c8580c2910a6fd48fc1` was used only as evidence of the
@@ -49,10 +55,10 @@ Copied from `gmeow-ontology`:
   replacement `purrdf-shapes::typescript` projection consumes
   `CompiledSchema`, preserves exact JSON property names and requiredness,
   requires caller-owned package identity and prose, exposes a reversible type
-  map, and locates every non-projectable assertion on a closed loss ledger. The
-  old renderer and its shared private schema model are intended for deletion
-  once this replacement is integrated; no downstream type contract is being
-  preserved.
+  map, verifies intact packages before reverse SHACL import, and locates every
+  non-projectable assertion on a closed loss ledger. The old renderer and its
+  shared private schema model are intended for deletion once this replacement
+  is integrated; no downstream type contract is being preserved.
 - The legacy `render_graphql` path in
   `crates/pipeline/src/stages/schemas.rs` at
   `c91195e0c300cad9c9a32c8580c2910a6fd48fc1` was likewise used only as
@@ -63,11 +69,17 @@ Copied from `gmeow-ontology`:
   replacement `purrdf-shapes::graphql` projection consumes `CompiledSchema`,
   requires caller-owned identity, prose, and fallback-scalar name, emits paired
   output/input GraphQL September 2025 SDL, retains a canonical reversible name
-  map and value codec, and locates every coercion difference on a closed loss
-  ledger verified against GraphQL.js. The old renderer and shared legacy model
-  are intended for deletion when gmeow integrates this replacement; that
-  consumer cutover is not yet complete and no downstream type contract is being
-  preserved.
+  map and value codec, verifies intact packages before reverse SHACL import, and
+  locates every coercion difference on a closed loss ledger verified against
+  GraphQL.js. The old renderer and shared legacy model are intended for deletion
+  when gmeow integrates this replacement; that consumer cutover is not yet
+  complete and no downstream type contract is being preserved.
+
+The five schema-language reverse paths are therefore PurRDF replacements, not
+compatibility layers around gmeow's private models. They share one deterministic
+schema-to-SHACL engine and caller-owned vocabulary boundary; gmeow's later
+deletion and rollover is tracked by
+[`gmeow-ontology#1571`](https://github.com/Blackcat-Informatics/gmeow-ontology/issues/1571).
 - The legacy graph/tabular writers in `crates/pipeline/src/stages/lpg.rs` and
   `crates/pipeline/src/stages/export.rs` at
   `d7745068f59b6dee187ab6b806bd2c04c9a1280a` were used solely as migration

--- a/crates/cli/tests/projection_cli.rs
+++ b/crates/cli/tests/projection_cli.rs
@@ -24,12 +24,14 @@ fn run_with_stdin(args: &[&str], stdin: &[u8]) -> Output {
         .stderr(Stdio::piped())
         .spawn()
         .expect("spawn purrdf");
-    child
-        .stdin
-        .take()
-        .expect("stdin")
-        .write_all(stdin)
-        .expect("write stdin");
+    let write_result = child.stdin.take().expect("stdin").write_all(stdin);
+    if let Err(error) = write_result {
+        assert_eq!(
+            error.kind(),
+            std::io::ErrorKind::BrokenPipe,
+            "write stdin: {error}"
+        );
+    }
     child.wait_with_output().expect("wait")
 }
 

--- a/crates/purrdf/src/lib.rs
+++ b/crates/purrdf/src/lib.rs
@@ -204,6 +204,41 @@ mod tests {
     }
 
     #[test]
+    fn facade_exposes_all_schema_reverse_entry_points() {
+        let _: fn(
+            &str,
+            &shapes::SchemaImportConfig,
+        ) -> Result<shapes::ImportedShapes, shapes::SchemaImportError> = shapes::import_json_schema;
+        let _: fn(
+            &shapes::json_schema::CompiledSchema,
+            &shapes::SchemaImportConfig,
+        ) -> Result<shapes::ImportedShapes, shapes::SchemaImportError> =
+            shapes::import_compiled_schema;
+        let _: fn(
+            &shapes::LinkmlDocument,
+            &shapes::SchemaImportConfig,
+        ) -> Result<shapes::ImportedShapes, shapes::LinkmlError> = shapes::import_linkml;
+        let _: fn(
+            &shapes::LinkmlPackage,
+            &shapes::SchemaImportConfig,
+        ) -> Result<shapes::ImportedShapes, shapes::LinkmlError> = shapes::import_linkml_package;
+        let _: fn(
+            &shapes::PydanticPackage,
+            &shapes::SchemaImportConfig,
+        ) -> Result<shapes::ImportedShapes, shapes::PydanticError> =
+            shapes::import_pydantic_package;
+        let _: fn(
+            &shapes::TypeScriptPackage,
+            &shapes::SchemaImportConfig,
+        ) -> Result<shapes::ImportedShapes, shapes::TypeScriptError> =
+            shapes::import_typescript_package;
+        let _: fn(
+            &shapes::GraphqlPackage,
+            &shapes::SchemaImportConfig,
+        ) -> Result<shapes::ImportedShapes, shapes::GraphqlError> = shapes::import_graphql_package;
+    }
+
+    #[test]
     fn facade_exposes_the_completed_umbrella() {
         assert_eq!(columnar::Table::ALL.len(), 5);
 

--- a/crates/rdf-core/src/lib.rs
+++ b/crates/rdf-core/src/lib.rs
@@ -129,12 +129,13 @@ pub use lookaside::{
     RdfSuppressionRecord,
 };
 pub use loss::{
-    LossEntry, LossLedger, PROJECTION_CODECS, RESEARCH_OBJECT_CODECS, assert_ledger_complete,
-    assert_ledger_sound, check_ledger_complete, check_ledger_sound, gts_to_rdf_loss_ledger,
-    loss_matrix_json, lpg_to_rdf_loss_ledger, okf_to_rdf_loss_ledger, pair_loss_ledger,
-    profile_for, rdf_gts_loss_matrix_json, rdf_to_gts_loss_ledger, rdf_to_lpg_loss_ledger,
-    rdf_to_obo_graphs_loss_ledger, rdf_to_okf_loss_ledger, rdf_to_research_object_loss_ledger,
-    rdf_to_skos_loss_ledger, registered_pairs, research_object_to_rdf_loss_ledger,
+    LossEntry, LossLedger, PROJECTION_CODECS, RESEARCH_OBJECT_CODECS, SCHEMA_IMPORT_CODECS,
+    assert_ledger_complete, assert_ledger_sound, check_ledger_complete, check_ledger_sound,
+    gts_to_rdf_loss_ledger, loss_matrix_json, lpg_to_rdf_loss_ledger, okf_to_rdf_loss_ledger,
+    pair_loss_ledger, profile_for, rdf_gts_loss_matrix_json, rdf_to_gts_loss_ledger,
+    rdf_to_lpg_loss_ledger, rdf_to_obo_graphs_loss_ledger, rdf_to_okf_loss_ledger,
+    rdf_to_research_object_loss_ledger, rdf_to_skos_loss_ledger, registered_pairs,
+    research_object_to_rdf_loss_ledger, schema_to_shacl_loss_ledger,
 };
 pub use model::{
     RdfAnnotation, RdfLiteral, RdfQuad, RdfReifier, RdfTerm, RdfTermKind, RdfTextDirection,

--- a/crates/rdf-core/src/loss.rs
+++ b/crates/rdf-core/src/loss.rs
@@ -27,6 +27,7 @@
 //! the `json-schema`→`linkml-1.11` schema projection,
 //! the `json-schema`→`typescript-7.0` declaration projection,
 //! the `json-schema`→`graphql-september-2025` type-system projection,
+//! all five fixed schema-language→`shacl` interpretation profiles,
 //! the bidirectional RDF 1.2 dataset↔OKF profile, the bidirectional RDF↔LPG
 //! semantic lowering, and the OBO Graphs/SKOS views;
 //! [`loss_matrix_json`] renders that same enumerable registry.
@@ -53,6 +54,16 @@ pub const LOSS_ANNOTATION_LAYER_DROPPED: &str = "annotation-layer-dropped";
 /// predicates was the caller-configured standpoint `accordingTo` predicate — the
 /// standpoint scope is lost. Emitted in addition to the annotation-layer code, never alone.
 pub const LOSS_STANDPOINT_SCOPE_DROPPED: &str = "standpoint-scope-dropped";
+
+/// Fixed schema-language carriers that the shapes engine can interpret as
+/// SHACL. Order is canonical and used by the enumerable loss registry.
+pub const SCHEMA_IMPORT_CODECS: &[&str] = &[
+    "json-schema",
+    "linkml-1.11",
+    "pydantic-v2",
+    "typescript-7.0",
+    "graphql-september-2025",
+];
 
 /// One enumerated conversion loss between two representations.
 ///
@@ -638,12 +649,32 @@ pub fn research_object_to_rdf_loss_ledger(profile: &str) -> LossLedger {
     contract_profile(profile, "rdf-1.2-dataset", RESEARCH_OBJECT_RDF_PROFILE)
 }
 
+/// Closed schema-language→SHACL interpretation contract.
+///
+/// # Panics
+///
+/// Panics when `source` is not one of [`SCHEMA_IMPORT_CODECS`]. Public import
+/// APIs use fixed dialect identifiers, so an unknown value is a programming
+/// error rather than a runtime fallback.
+pub fn schema_to_shacl_loss_ledger(source: &str) -> LossLedger {
+    let source = canonical_schema_import_codec(source);
+    contract_profile(source, "shacl", SCHEMA_SHACL_PROFILE)
+}
+
 fn canonical_research_object_codec(profile: &str) -> &'static str {
     RESEARCH_OBJECT_CODECS
         .iter()
         .copied()
         .find(|candidate| *candidate == profile)
         .unwrap_or_else(|| panic!("unknown research-object codec `{profile}`"))
+}
+
+fn canonical_schema_import_codec(source: &str) -> &'static str {
+    SCHEMA_IMPORT_CODECS
+        .iter()
+        .copied()
+        .find(|candidate| *candidate == source)
+        .unwrap_or_else(|| panic!("unknown schema import codec `{source}`"))
 }
 
 /// The combined RDF↔GTS matrix as a single deterministic, sorted-by-code JSON
@@ -1376,6 +1407,137 @@ const JSON_SCHEMA_GRAPHQL_PROFILE: &[(&str, &str)] = &[
     ),
 ];
 
+/// Closed reverse profile shared by the five fixed schema-language carriers
+/// interpreted as SHACL. The adapters normalize their native document or
+/// verified generated-package contract into one ordered schema model before
+/// lowering, so the semantic loss families are deliberately identical across
+/// sources. Locations retain the native source path or JSON Pointer.
+const SCHEMA_SHACL_PROFILE: &[(&str, &str)] = &[
+    (
+        "additional-properties-schema-widened",
+        "A schema-valued additionalProperties assertion constrains arbitrary object members, \
+         while SHACL Core closure can only reject unlisted direct predicates. Named properties \
+         remain constrained and the arbitrary-value schema is widened.",
+    ),
+    (
+        "annotation-dropped",
+        "A schema title, description, comment, example, default, deprecation marker, or native \
+         documentation annotation has no exact validation meaning in the imported SHACL shape \
+         and is omitted.",
+    ),
+    (
+        "array-contains-validation-dropped",
+        "Schema contains/minContains/maxContains assertions quantify matching array members; \
+         the imported SHACL property retains item and total-cardinality constraints but cannot \
+         express that independent match count exactly.",
+    ),
+    (
+        "boolean-schema-dropped",
+        "A standalone true or false schema has no class-targeted SHACL shape identity. The \
+         definition is omitted rather than inventing a caller vocabulary term.",
+    ),
+    (
+        "conditional-validation-dropped",
+        "Schema if/then/else validation chooses constraints from runtime object content. SHACL \
+         Core has no equivalent conditional constraint, so independently representable \
+         constraints remain and the conditional relationship is omitted.",
+    ),
+    (
+        "content-validation-dropped",
+        "String contentEncoding/contentMediaType/contentSchema assertions describe or validate \
+         an embedded representation. SHACL Core constrains the RDF literal itself and cannot \
+         reproduce that nested content contract.",
+    ),
+    (
+        "dependency-validation-dropped",
+        "dependentRequired/dependentSchemas or an equivalent native cross-field dependency has \
+         no exact SHACL Core property-shape expression. Individual properties remain while the \
+         dependency is omitted.",
+    ),
+    (
+        "enum-metadata-dropped",
+        "A schema enum member's generated symbol, title, description, or other parallel metadata \
+         is not part of SHACL membership semantics and is omitted while the finite values remain.",
+    ),
+    (
+        "format-validation-widened",
+        "A string format without one exact caller-identifiable RDF datatype is imported as its \
+         scalar carrier. PurRDF does not mint or guess a datatype IRI, so format validation is \
+         widened and recorded.",
+    ),
+    (
+        "multiple-of-validation-dropped",
+        "A numeric multipleOf assertion has no SHACL Core numeric facet. Datatype and range \
+         bounds remain while divisibility validation is omitted.",
+    ),
+    (
+        "non-object-definition-dropped",
+        "A top-level schema definition describes a scalar, array, finite value set, or alias \
+         rather than a class-shaped object. Without a caller-supplied class/property use site it \
+         cannot become a top-level SHACL node shape and is omitted.",
+    ),
+    (
+        "numeric-lexical-form-normalized",
+        "A JSON/native numeric value carries numeric value but not the original RDF literal \
+         lexical form or derived XSD datatype. The importer uses the canonical configured \
+         numeric carrier, so that lexical distinction is normalized.",
+    ),
+    (
+        "object-key-validation-dropped",
+        "patternProperties/propertyNames or an equivalent native dynamic-key rule constrains \
+         JSON member names. Direct SHACL predicate paths retain named properties, but the \
+         dynamic key-space rule is omitted.",
+    ),
+    (
+        "property-count-validation-dropped",
+        "minProperties/maxProperties counts JSON object members independently of named \
+         predicates. SHACL property shapes retain named requiredness but cannot bound the total \
+         predicate count with a Core constraint.",
+    ),
+    (
+        "schema-applicator-dropped",
+        "A schema logical applicator cannot be lowered to an equivalent finite SHACL \
+         and/or/xone/not shape at its position. Independently representable constraints remain \
+         and the applicator is omitted.",
+    ),
+    (
+        "schema-identity-dropped",
+        "A schema document identifier, anchor, dialect declaration, generated package identity, \
+         or native module identity is not a SHACL vocabulary term. Caller-owned class and \
+         property IRIs remain; the carrier identity is omitted.",
+    ),
+    (
+        "tuple-validation-widened",
+        "Position-specific prefixItems/additionalItems or an equivalent tuple type has no direct \
+         RDF multi-value ordering contract on one predicate. Common item/cardinality constraints \
+         remain and positional validation is widened.",
+    ),
+    (
+        "unevaluated-validation-dropped",
+        "unevaluatedProperties/unevaluatedItems depends on schema-applicator evaluation state \
+         that SHACL Core does not expose. Local closure, named properties, and item constraints \
+         remain while the evaluation-state assertion is omitted.",
+    ),
+    (
+        "unique-items-validation-dropped",
+        "uniqueItems constrains duplicate JSON array members. RDF predicate values are a set in \
+         the data model, so the serialized-array assertion has no distinct imported SHACL \
+         constraint and is omitted.",
+    ),
+    (
+        "unknown-keyword-dropped",
+        "A valid extension or assertion outside the fixed importer capability table has no \
+         reviewed SHACL interpretation. It is omitted with a located entry rather than silently \
+         ignored or guessed.",
+    ),
+    (
+        "value-term-kind-widened",
+        "The schema carrier admits values whose RDF term kind or exact datatype cannot be \
+         recovered uniquely. The importer retains the representable scalar/node carrier and \
+         records the unresolved term-kind distinction.",
+    ),
+];
+
 /// Build the runtime-shaped [`LossEntry`] rows for the
 /// `("shacl", "json-schema")` shapes profile from [`SHACL_JSON_SCHEMA_PROFILE`]
 /// — one contract entry per declared `(code, note)` pair, `location: None`
@@ -1454,6 +1616,20 @@ fn json_schema_graphql_entries() -> Vec<LossEntry> {
         .collect()
 }
 
+/// Build static contract rows for one fixed schema-language→SHACL importer.
+fn schema_shacl_entries(source: &'static str) -> Vec<LossEntry> {
+    SCHEMA_SHACL_PROFILE
+        .iter()
+        .map(|&(code, note)| LossEntry {
+            code: Cow::Borrowed(code),
+            from: Cow::Borrowed(source),
+            to: Cow::Borrowed("shacl"),
+            note: Cow::Borrowed(note),
+            location: None,
+        })
+        .collect()
+}
+
 /// Extract the `&'static str` payload of a **contract**-discipline
 /// [`LossEntry`] field (one built via [`Cow::Borrowed`]).
 ///
@@ -1510,6 +1686,9 @@ fn registry_entries() -> Vec<LossEntry> {
     entries.extend(json_schema_linkml_entries());
     entries.extend(json_schema_typescript_entries());
     entries.extend(json_schema_graphql_entries());
+    for source in SCHEMA_IMPORT_CODECS {
+        entries.extend(schema_shacl_entries(source));
+    }
     entries
 }
 
@@ -2072,6 +2251,24 @@ mod tests {
     }
 
     #[test]
+    fn transcode_matrix_includes_every_schema_shacl_pair() {
+        let json = loss_matrix_json();
+        for source in SCHEMA_IMPORT_CODECS {
+            assert!(
+                json.contains(&format!("\"from\": \"{source}\"")),
+                "transcode-loss-matrix.json missing {source}->shacl source"
+            );
+        }
+        assert!(json.contains("\"to\": \"shacl\""));
+        for (code, _) in SCHEMA_SHACL_PROFILE {
+            assert!(
+                json.contains(&format!("\"code\": \"{code}\"")),
+                "transcode-loss-matrix.json missing schema-import code `{code}`"
+            );
+        }
+    }
+
+    #[test]
     fn graph_and_tabular_projection_contracts_are_closed_and_registered() {
         let contracts = [
             (
@@ -2405,6 +2602,31 @@ mod tests {
             .map(|(code, _)| *code)
             .collect();
         assert_eq!(profile, expected);
+    }
+
+    #[test]
+    fn schema_shacl_profiles_are_closed_and_registered() {
+        let expected: BTreeSet<&str> = SCHEMA_SHACL_PROFILE.iter().map(|(code, _)| *code).collect();
+        for source in SCHEMA_IMPORT_CODECS {
+            let contract = schema_to_shacl_loss_ledger(source);
+            let contract_codes = contract
+                .entries()
+                .iter()
+                .map(|entry| entry.code.as_ref())
+                .collect::<BTreeSet<_>>();
+            assert_eq!(contract_codes, expected, "contract drift for {source}");
+            assert_eq!(
+                profile_for(source, "shacl"),
+                expected,
+                "registry drift for {source}"
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown schema import codec")]
+    fn schema_shacl_contract_rejects_unknown_source() {
+        let _ = schema_to_shacl_loss_ledger("python-source");
     }
 
     #[test]

--- a/crates/shapes/README.md
+++ b/crates/shapes/README.md
@@ -58,6 +58,44 @@ cargo build -p purrdf-shapes
 cargo test -p purrdf-shapes
 ```
 
+## Schema → SHACL imports
+
+The schema-projection family is bidirectional. `SchemaImportConfig` requires a
+caller-owned `Namespaces` table and a complete scalar-to-RDF-datatype map; it
+has no default and PurRDF never fabricates a vocabulary IRI. Every reader
+returns `ImportedShapes`, containing deterministically ordered SHACL shapes and
+an always-computed reverse `LossLedger`:
+
+| Source | Production reverse boundary |
+|---|---|
+| JSON Schema draft 2020-12 | `import_json_schema` or `import_compiled_schema` |
+| LinkML 1.11 | `parse_linkml` + `import_linkml` for native documents; `import_linkml_package` for a verified emitted package |
+| Pydantic v2 | `import_pydantic_package` over an intact PurRDF-emitted package |
+| TypeScript 7.0 | `import_typescript_package` over an intact PurRDF-emitted package |
+| GraphQL September 2025 | `import_graphql_package` over an intact PurRDF-emitted package |
+
+JSON Schema is the shared semantic pivot, so CURIE expansion, datatype
+selection, constraint lowering, fixed resource limits, and located losses have
+one implementation. Malformed structures, open/dangling references, ambiguous
+identities, and generated-package drift fail closed. Valid source semantics
+without an exact SHACL representation remain visible as closed-profile loss
+entries at native JSON Pointer paths.
+
+Arbitrary Python, TypeScript, and GraphQL SDL are not accepted as inverse
+formats: those languages do not determine one unique JSON validation relation.
+The three verified generated-package readers retain the exact source schema and
+re-emit the complete artifacts, maps, identity, dialect, and forward ledger
+before importing. LinkML is different: it has a native document reader, and
+carrier identity/documentation fields can be ledgered even when the
+validation-bearing SHACL recompiles byte-exactly.
+
+The runnable example exercises all five public reverse directions with only an
+`example.org` caller vocabulary (plus the standard XSD and LinkML namespaces):
+
+```bash
+cargo run -p purrdf-shapes --example schema_reverse --locked
+```
+
 ## Pydantic v2 packages
 
 The Rust emitter consumes the same in-memory `CompiledSchema` produced by the
@@ -97,6 +135,11 @@ and alias round trips:
 ```bash
 make pydantic-oracle
 ```
+
+`import_pydantic_package` is the schema reverse API. It verifies the fixed
+`pydantic-v2` dialect, every generated file, the model-path map, and the forward
+loss ledger against deterministic re-emission before the retained source schema
+can enter the shared SHACL importer. Mutated or stale packages fail closed.
 
 ## LinkML 1.11 schemas
 
@@ -140,6 +183,12 @@ author, while rejecting duplicate keys, YAML tags, non-string mapping keys,
 non-finite numbers, and resource-limit violations. Thus read → write and write
 → read → write are stable without pretending YAML-only semantics can cross a
 language-neutral boundary.
+
+`import_linkml` interprets any validated native `LinkmlDocument` through the
+shared SHACL import model. `import_linkml_package` additionally verifies that an
+emitted package's canonical YAML and reversible element map still match its
+typed document. Native metamodel annotations and schema identity are ledgered
+instead of being mistaken for SHACL validation terms.
 
 The projection grammar is:
 
@@ -231,10 +280,12 @@ make typescript-oracle
 
 There is deliberately no general TypeScript → JSON Schema reader. Arbitrary
 TypeScript declarations have no unique runtime acceptance relation, and many
-different schemas project to the same declaration. The retained
-`CompiledSchema`, paired with `type_names`, is the authoritative reverse
-surface. The production emitter has no JavaScript dependency, performs no
-filesystem I/O, and remains wasm-clean; TypeScript is dev-only oracle tooling.
+different schemas project to the same declaration. `import_typescript_package`
+is the authoritative reverse surface: it verifies the fixed dialect, retained
+source schema, declaration bytes, reversible `type_names`, and forward ledger
+before importing SHACL. The production path has no JavaScript dependency,
+performs no filesystem I/O, and remains wasm-clean; TypeScript is dev-only
+oracle tooling.
 
 ## GraphQL September 2025 SDL
 
@@ -284,7 +335,10 @@ finite values into GraphQL input names and enum symbols.
 `GraphqlPackage::decode_output` reverses present response fields and symbols;
 it permits GraphQL's normal partial field selection and does not invent omitted
 fields. Unknown definitions, keys, values, symbols, or incompatible carriers
-fail. This generated codec is the bidirectional boundary. Arbitrary GraphQL SDL
+fail. This generated codec is the value boundary;
+`import_graphql_package` is the schema reverse boundary. The importer verifies
+the SDL, canonical and typed name/value maps, package identity, retained source
+schema, and forward ledger by deterministic re-emission. Arbitrary GraphQL SDL
 does not define one unique JSON Schema acceptance relation, so PurRDF does not
 claim or provide a general SDL-to-JSON-Schema reader.
 

--- a/crates/shapes/benches/validate.rs
+++ b/crates/shapes/benches/validate.rs
@@ -12,11 +12,49 @@
 //! nodes, run every constraint. This is the end-to-end number Phase 2 (regex /
 //! subclass-closure / SPARQL caching) and Phase 4 (focus-node `rayon`) move.
 
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
 use std::fs;
 use std::path::PathBuf;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use purrdf_shapes::engine::validate_graphs;
+use purrdf_shapes::{Namespaces, SchemaDatatypeMap, SchemaImportConfig, import_json_schema};
+use serde_json::{Map, Value, json};
+
+thread_local! {
+    static ALLOCATIONS: Cell<u64> = const { Cell::new(0) };
+    static ALLOCATED_BYTES: Cell<u64> = const { Cell::new(0) };
+}
+
+struct CountingAllocator;
+
+// SAFETY: every operation forwards the original pointer/layout to the system
+// allocator; thread-local counters are observational only.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.with(|count| count.set(count.get() + 1));
+        ALLOCATED_BYTES.with(|bytes| bytes.set(bytes.get() + layout.size() as u64));
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCATIONS.with(|count| count.set(count.get() + 1));
+        ALLOCATED_BYTES.with(|bytes| bytes.set(bytes.get() + new_size as u64));
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+const IMPORT_CLASSES: usize = 128;
+const IMPORT_PROPERTIES_PER_CLASS: usize = 8;
+const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
 
 /// Read every `corpus/<case>/{data.nt, shapes.ttl}` pair, sorted by case name.
 fn corpus_cases() -> Vec<(String, String, String)> {
@@ -129,5 +167,121 @@ fn bench_validate_large(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_validate, bench_validate_large);
+fn schema_import_config() -> SchemaImportConfig {
+    let namespaces = Namespaces::new(
+        "ex",
+        &[("ex".to_owned(), "https://example.org/bench/".to_owned())],
+    )
+    .expect("benchmark namespace configuration");
+    let datatypes = SchemaDatatypeMap::new(
+        format!("{XSD}string"),
+        format!("{XSD}boolean"),
+        format!("{XSD}integer"),
+        format!("{XSD}decimal"),
+        format!("{XSD}dateTime"),
+        format!("{XSD}date"),
+        format!("{XSD}time"),
+        format!("{XSD}anyURI"),
+    )
+    .expect("benchmark datatype configuration");
+    SchemaImportConfig::new(namespaces, datatypes)
+}
+
+fn schema_import_fixture() -> String {
+    let mut definitions = Map::new();
+    for class_idx in 0..IMPORT_CLASSES {
+        let mut properties = Map::new();
+        let mut required = Vec::new();
+        for property_idx in 0..IMPORT_PROPERTIES_PER_CLASS {
+            let key = format!("ex:field{property_idx}");
+            let schema = match property_idx {
+                0 => json!({ "type": "string", "minLength": 1, "maxLength": 96 }),
+                1 => json!({ "type": "integer", "minimum": 0, "maximum": 1_000_000 }),
+                2 => json!({ "type": "number", "minimum": 0, "maximum": 1_000_000 }),
+                3 => json!({ "type": "boolean" }),
+                4 => json!({ "type": "string", "pattern": "^[A-Za-z0-9_-]+$" }),
+                5 => json!({ "enum": ["open", "closed", "pending"] }),
+                6 => json!({
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "minItems": 1,
+                    "maxItems": 8,
+                    "uniqueItems": true
+                }),
+                7 => json!({
+                    "$ref": format!(
+                        "#/$defs/Class{:03}",
+                        (class_idx + IMPORT_CLASSES - 1) % IMPORT_CLASSES
+                    )
+                }),
+                _ => unreachable!("fixed eight-property fixture"),
+            };
+            properties.insert(key.clone(), schema);
+            if property_idx < IMPORT_PROPERTIES_PER_CLASS / 2 {
+                required.push(Value::String(key));
+            }
+        }
+        definitions.insert(
+            format!("Class{class_idx:03}"),
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": properties,
+                "required": required
+            }),
+        );
+    }
+    serde_json::to_string(&json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": definitions
+    }))
+    .expect("benchmark schema serializes")
+}
+
+fn allocation_snapshot() -> (u64, u64) {
+    (ALLOCATIONS.with(Cell::get), ALLOCATED_BYTES.with(Cell::get))
+}
+
+fn bench_schema_import(c: &mut Criterion) {
+    let schema = schema_import_fixture();
+    let config = schema_import_config();
+
+    let warm = import_json_schema(&schema, &config).expect("benchmark schema imports");
+    assert_eq!(warm.shapes.node_shapes.len(), IMPORT_CLASSES);
+    drop(warm);
+
+    let before = allocation_snapshot();
+    let observed = import_json_schema(&schema, &config).expect("allocation probe imports");
+    let after = allocation_snapshot();
+    assert_eq!(observed.shapes.node_shapes.len(), IMPORT_CLASSES);
+    println!(
+        "[shacl_schema_import] classes={IMPORT_CLASSES} properties={} allocations={} allocated_bytes={}",
+        IMPORT_CLASSES * IMPORT_PROPERTIES_PER_CLASS,
+        after.0 - before.0,
+        after.1 - before.1
+    );
+    black_box(observed);
+
+    let mut group = c.benchmark_group("shacl_schema_import");
+    group.sample_size(20);
+    group.throughput(Throughput::Elements(
+        u64::try_from(IMPORT_CLASSES * IMPORT_PROPERTIES_PER_CLASS).expect("fixture size fits u64"),
+    ));
+    group.bench_function("json_schema_128_classes_1024_properties", |bencher| {
+        bencher.iter(|| {
+            let imported = import_json_schema(black_box(&schema), black_box(&config))
+                .expect("benchmark schema imports");
+            assert_eq!(imported.shapes.node_shapes.len(), IMPORT_CLASSES);
+            black_box(imported);
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_validate,
+    bench_validate_large,
+    bench_schema_import
+);
 criterion_main!(benches);

--- a/crates/shapes/benches/validate.rs
+++ b/crates/shapes/benches/validate.rs
@@ -14,12 +14,16 @@
 
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::Cell;
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use purrdf_shapes::engine::validate_graphs;
-use purrdf_shapes::{Namespaces, SchemaDatatypeMap, SchemaImportConfig, import_json_schema};
+use purrdf_shapes::{
+    LinkmlConfig, LinkmlDocument, Namespaces, SchemaDatatypeMap, SchemaImportConfig, emit_linkml,
+    import_json_schema, import_linkml,
+};
 use serde_json::{Map, Value, json};
 
 thread_local! {
@@ -54,6 +58,7 @@ static GLOBAL: CountingAllocator = CountingAllocator;
 
 const IMPORT_CLASSES: usize = 128;
 const IMPORT_PROPERTIES_PER_CLASS: usize = 8;
+const LINKML: &str = "https://w3id.org/linkml/";
 const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
 
 /// Read every `corpus/<case>/{data.nt, shapes.ttl}` pair, sorted by case name.
@@ -242,6 +247,26 @@ fn allocation_snapshot() -> (u64, u64) {
     (ALLOCATIONS.with(Cell::get), ALLOCATED_BYTES.with(Cell::get))
 }
 
+fn linkml_import_fixture(config: &SchemaImportConfig) -> LinkmlDocument {
+    let imported = import_json_schema(&schema_import_fixture(), config)
+        .expect("benchmark source schema imports");
+    let compiled = purrdf_shapes::json_schema::compile(&imported.shapes, config.namespaces());
+    let linkml_config = LinkmlConfig::new(
+        "https://example.org/bench/schema",
+        "BenchSchema",
+        "Representative LinkML import benchmark fixture.",
+        "ex",
+        BTreeMap::from([
+            ("ex".to_owned(), "https://example.org/bench/".to_owned()),
+            ("linkml".to_owned(), LINKML.to_owned()),
+        ]),
+    )
+    .expect("benchmark LinkML configuration");
+    emit_linkml(&compiled, &linkml_config)
+        .expect("benchmark LinkML fixture emits")
+        .document
+}
+
 fn bench_schema_import(c: &mut Criterion) {
     let schema = schema_import_fixture();
     let config = schema_import_config();
@@ -278,10 +303,53 @@ fn bench_schema_import(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_linkml_import(c: &mut Criterion) {
+    let config = schema_import_config();
+    let document = linkml_import_fixture(&config);
+    let expected_shapes = document
+        .as_value()
+        .get("classes")
+        .and_then(Value::as_object)
+        .map(Map::len)
+        .expect("benchmark LinkML fixture has classes");
+
+    let warm = import_linkml(&document, &config).expect("benchmark LinkML imports");
+    assert_eq!(warm.shapes.node_shapes.len(), expected_shapes);
+    drop(warm);
+
+    let before = allocation_snapshot();
+    let observed = import_linkml(&document, &config).expect("allocation probe imports");
+    let after = allocation_snapshot();
+    assert_eq!(observed.shapes.node_shapes.len(), expected_shapes);
+    println!(
+        "[shacl_linkml_import] source_classes={IMPORT_CLASSES} source_properties={} imported_shapes={expected_shapes} allocations={} allocated_bytes={}",
+        IMPORT_CLASSES * IMPORT_PROPERTIES_PER_CLASS,
+        after.0 - before.0,
+        after.1 - before.1
+    );
+    black_box(observed);
+
+    let mut group = c.benchmark_group("shacl_linkml_import");
+    group.sample_size(20);
+    group.throughput(Throughput::Elements(
+        u64::try_from(IMPORT_CLASSES * IMPORT_PROPERTIES_PER_CLASS).expect("fixture size fits u64"),
+    ));
+    group.bench_function("from_128_class_1024_property_schema", |bencher| {
+        bencher.iter(|| {
+            let imported = import_linkml(black_box(&document), black_box(&config))
+                .expect("benchmark LinkML imports");
+            assert_eq!(imported.shapes.node_shapes.len(), expected_shapes);
+            black_box(imported);
+        });
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_validate,
     bench_validate_large,
-    bench_schema_import
+    bench_schema_import,
+    bench_linkml_import
 );
 criterion_main!(benches);

--- a/crates/shapes/examples/graphql_oracle_fixture.rs
+++ b/crates/shapes/examples/graphql_oracle_fixture.rs
@@ -9,10 +9,10 @@ use std::error::Error;
 
 use boon::{Compiler, Schemas};
 use purrdf::loss::{LossLedger, check_ledger_complete, check_ledger_sound};
-use purrdf_shapes::json_schema::CompiledSchema;
+use purrdf_shapes::json_schema::{CompiledSchema, Namespaces};
 use purrdf_shapes::{
     GRAPHQL_DIALECT, GRAPHQL_NAME_MAP_PATH, GRAPHQL_SCHEMA_PATH, GraphqlConfig, GraphqlPackage,
-    emit_graphql,
+    SchemaDatatypeMap, SchemaImportConfig, emit_graphql, import_graphql_package,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -42,6 +42,7 @@ const CLOSED_PROFILE: [&str; 23] = [
     "union-validation-delegated",
     "unique-items-validation-dropped",
 ];
+const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -90,6 +91,50 @@ fn config() -> Result<GraphqlConfig, Box<dyn Error>> {
         "Type-system definitions checked against source JSON Schema acceptance.",
         "JsonCarrier",
     )?)
+}
+
+fn import_config() -> Result<SchemaImportConfig, Box<dyn Error>> {
+    let namespaces = Namespaces::new(
+        "ex",
+        &[("ex".to_owned(), "https://example.org/".to_owned())],
+    )?;
+    let datatypes = SchemaDatatypeMap::new(
+        format!("{XSD}string"),
+        format!("{XSD}boolean"),
+        format!("{XSD}integer"),
+        format!("{XSD}decimal"),
+        format!("{XSD}dateTime"),
+        format!("{XSD}date"),
+        format!("{XSD}time"),
+        format!("{XSD}anyURI"),
+    )?;
+    Ok(SchemaImportConfig::new(namespaces, datatypes))
+}
+
+fn reverse_evidence(
+    package: &GraphqlPackage,
+    config: &SchemaImportConfig,
+) -> Result<Value, Box<dyn Error>> {
+    let imported = import_graphql_package(package, config)?;
+    check_ledger_sound(&imported.losses, GRAPHQL_DIALECT, "shacl")?;
+    let repeated = import_graphql_package(package, config)?;
+    if imported.losses.render_json() != repeated.losses.render_json() {
+        return Err("GraphQL reverse ledger is not deterministic".into());
+    }
+    let first = purrdf_shapes::json_schema::compile(&imported.shapes, config.namespaces());
+    let second = purrdf_shapes::json_schema::compile(&repeated.shapes, config.namespaces());
+    if first.schema_json != second.schema_json {
+        return Err("GraphQL reverse shapes are not byte-deterministic".into());
+    }
+    Ok(json!({
+        "losses": serde_json::from_str::<Value>(&imported.losses.render_json())?,
+        "shapeIds": imported
+            .shapes
+            .node_shapes
+            .iter()
+            .map(|shape| shape.id.to_string())
+            .collect::<Vec<_>>(),
+    }))
 }
 
 fn exact_schema() -> Value {
@@ -737,6 +782,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         "closedProfile": CLOSED_PROFILE,
         "exact": exact_fixture(&exact_schema, &exact_package)?,
         "lossy": lossy_fixture(&lossy_schema, &lossy_package)?,
+        "reverse": reverse_evidence(&exact_package, &import_config()?)?,
     });
     println!("{}", serde_json::to_string(&output)?);
     Ok(())

--- a/crates/shapes/examples/linkml_oracle_fixture.rs
+++ b/crates/shapes/examples/linkml_oracle_fixture.rs
@@ -8,7 +8,10 @@ use std::error::Error;
 
 use purrdf::loss::{LossLedger, check_ledger_sound};
 use purrdf_shapes::json_schema::CompiledSchema;
-use purrdf_shapes::{LinkmlConfig, emit_linkml, parse_linkml, write_linkml};
+use purrdf_shapes::{
+    ImportedShapes, LinkmlConfig, LinkmlPackage, Namespaces, SchemaDatatypeMap, SchemaImportConfig,
+    emit_linkml, import_linkml_package, parse_linkml, write_linkml,
+};
 use serde_json::{Value, json};
 
 fn compiled(schema: &Value) -> Result<CompiledSchema, serde_json::Error> {
@@ -30,6 +33,58 @@ fn config() -> Result<LinkmlConfig, Box<dyn Error>> {
             ("linkml".to_owned(), "https://w3id.org/linkml/".to_owned()),
         ]),
     )?)
+}
+
+fn import_config() -> Result<SchemaImportConfig, Box<dyn Error>> {
+    let namespaces = Namespaces::new(
+        "ex",
+        &[("ex".to_owned(), "https://example.org/".to_owned())],
+    )?;
+    let xsd = "http://www.w3.org/2001/XMLSchema#";
+    let datatypes = SchemaDatatypeMap::new(
+        format!("{xsd}string"),
+        format!("{xsd}boolean"),
+        format!("{xsd}integer"),
+        format!("{xsd}decimal"),
+        format!("{xsd}dateTime"),
+        format!("{xsd}date"),
+        format!("{xsd}time"),
+        format!("{xsd}anyURI"),
+    )?;
+    Ok(SchemaImportConfig::new(namespaces, datatypes))
+}
+
+fn reverse_payload(
+    package: &LinkmlPackage,
+    config: &SchemaImportConfig,
+) -> Result<Value, Box<dyn Error>> {
+    let imported = import_linkml_package(package, config)?;
+    check_ledger_sound(&imported.losses, "linkml-1.11", "shacl")?;
+    let repeated = import_linkml_package(package, config)?;
+    if imported.losses.render_json() != repeated.losses.render_json() {
+        return Err("LinkML reverse ledger is not deterministic".into());
+    }
+
+    let compile_imported = |value: &ImportedShapes| {
+        purrdf_shapes::json_schema::compile(&value.shapes, config.namespaces())
+    };
+    let compiled = compile_imported(&imported);
+    let repeated_compiled = compile_imported(&repeated);
+    if compiled.schema_json != repeated_compiled.schema_json {
+        return Err("LinkML reverse shapes are not byte-deterministic".into());
+    }
+
+    let shape_ids = imported
+        .shapes
+        .node_shapes
+        .iter()
+        .map(|shape| shape.id.to_string())
+        .collect::<Vec<_>>();
+    Ok(json!({
+        "losses": serde_json::from_str::<Value>(&imported.losses.render_json())?,
+        "schema": serde_json::from_str::<Value>(&compiled.schema_json)?,
+        "shape_ids": shape_ids,
+    }))
 }
 
 fn exact_schema() -> Value {
@@ -139,6 +194,7 @@ fn lossy_schema() -> Value {
 
 fn main() -> Result<(), Box<dyn Error>> {
     let config = config()?;
+    let import_config = import_config()?;
     let exact_schema = exact_schema();
     let lossy_schema = lossy_schema();
     let exact = emit_linkml(&compiled(&exact_schema)?, &config)?;
@@ -253,12 +309,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     let output = json!({
         "exact": {
             "element_names": exact.element_names,
+            "reverse": reverse_payload(&exact, &import_config)?,
             "schema": exact_schema,
             "yaml": exact.yaml,
         },
         "lossy": {
             "element_names": lossy.element_names,
             "losses": serde_json::from_str::<Value>(&lossy.losses.render_json())?,
+            "reverse": reverse_payload(&lossy, &import_config)?,
             "schema": lossy_schema,
             "yaml": lossy.yaml,
         }

--- a/crates/shapes/examples/pydantic_oracle_fixture.rs
+++ b/crates/shapes/examples/pydantic_oracle_fixture.rs
@@ -6,10 +6,59 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 
-use purrdf::loss::LossLedger;
-use purrdf_shapes::json_schema::CompiledSchema;
-use purrdf_shapes::{PydanticConfig, emit_pydantic};
-use serde_json::json;
+use purrdf::loss::{LossLedger, check_ledger_sound};
+use purrdf_shapes::json_schema::{CompiledSchema, Namespaces};
+use purrdf_shapes::{
+    PYDANTIC_DIALECT, PydanticConfig, PydanticPackage, SchemaDatatypeMap, SchemaImportConfig,
+    emit_pydantic, import_pydantic_package,
+};
+use serde_json::{Value, json};
+
+const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+
+fn import_config() -> Result<SchemaImportConfig, Box<dyn Error>> {
+    let namespaces = Namespaces::new(
+        "ex",
+        &[("ex".to_owned(), "https://example.org/".to_owned())],
+    )?;
+    let datatypes = SchemaDatatypeMap::new(
+        format!("{XSD}string"),
+        format!("{XSD}boolean"),
+        format!("{XSD}integer"),
+        format!("{XSD}decimal"),
+        format!("{XSD}dateTime"),
+        format!("{XSD}date"),
+        format!("{XSD}time"),
+        format!("{XSD}anyURI"),
+    )?;
+    Ok(SchemaImportConfig::new(namespaces, datatypes))
+}
+
+fn reverse_evidence(
+    package: &PydanticPackage,
+    config: &SchemaImportConfig,
+) -> Result<Value, Box<dyn Error>> {
+    let imported = import_pydantic_package(package, config)?;
+    check_ledger_sound(&imported.losses, PYDANTIC_DIALECT, "shacl")?;
+    let repeated = import_pydantic_package(package, config)?;
+    if imported.losses.render_json() != repeated.losses.render_json() {
+        return Err("Pydantic reverse ledger is not deterministic".into());
+    }
+    let first = purrdf_shapes::json_schema::compile(&imported.shapes, config.namespaces());
+    let second = purrdf_shapes::json_schema::compile(&repeated.shapes, config.namespaces());
+    if first.schema_json != second.schema_json {
+        return Err("Pydantic reverse shapes are not byte-deterministic".into());
+    }
+    Ok(json!({
+        "losses": serde_json::from_str::<Value>(&imported.losses.render_json())?,
+        "shape_ids": imported
+            .shapes
+            .node_shapes
+            .iter()
+            .map(|shape| shape.id.to_string())
+            .collect::<Vec<_>>(),
+    }))
+}
 
 fn main() -> Result<(), Box<dyn Error>> {
     let schema = json!({
@@ -116,6 +165,20 @@ fn main() -> Result<(), Box<dyn Error>> {
         "Caller-owned oracle model documentation.",
     )?;
     let package = emit_pydantic(&compiled, &config)?;
+    let mut reverse_schema = schema.clone();
+    reverse_schema["$defs"]
+        .as_object_mut()
+        .ok_or("oracle schema has no $defs")?
+        .remove("Empty");
+    let reverse_package = emit_pydantic(
+        &CompiledSchema {
+            schema_json: format!("{}\n", serde_json::to_string_pretty(&reverse_schema)?),
+            openapi_json: "{}\n".to_owned(),
+            losses: LossLedger::new(),
+        },
+        &config,
+    )?;
+    let reverse = reverse_evidence(&reverse_package, &import_config()?)?;
     let observed_losses: BTreeSet<(&str, &str)> = package
         .losses
         .entries()
@@ -157,6 +220,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let output = json!({
         "artifacts": artifacts,
         "model_paths": package.model_paths,
+        "reverse": reverse,
         "schema": schema,
     });
     println!("{}", serde_json::to_string(&output)?);

--- a/crates/shapes/examples/schema_reverse.rs
+++ b/crates/shapes/examples/schema_reverse.rs
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Exercise every schema-language → SHACL production entry point.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+
+use purrdf_shapes::{
+    GraphqlConfig, LinkmlConfig, Namespaces, PydanticConfig, SchemaDatatypeMap, SchemaImportConfig,
+    TypeScriptConfig, emit_graphql, emit_linkml, emit_pydantic, emit_typescript,
+    import_graphql_package, import_json_schema, import_linkml, import_linkml_package,
+    import_pydantic_package, import_typescript_package, parse_linkml, write_linkml,
+};
+
+const EX: &str = "https://example.org/";
+const LINKML: &str = "https://w3id.org/linkml/";
+const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+const SOURCE_SHAPES: &str = r#"
+@prefix ex:  <https://example.org/> .
+@prefix sh:  <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:PersonShape a sh:NodeShape ;
+    sh:targetClass ex:Person ;
+    sh:closed true ;
+    sh:property [
+        sh:path ex:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1
+    ] ;
+    sh:property [
+        sh:path ex:status ;
+        sh:maxCount 1 ;
+        sh:in ( "active" "paused" )
+    ] .
+"#;
+
+fn import_config() -> Result<SchemaImportConfig, Box<dyn Error>> {
+    let namespaces = Namespaces::new("ex", &[("ex".to_owned(), EX.to_owned())])?;
+    let datatypes = SchemaDatatypeMap::new(
+        format!("{XSD}string"),
+        format!("{XSD}boolean"),
+        format!("{XSD}integer"),
+        format!("{XSD}decimal"),
+        format!("{XSD}dateTime"),
+        format!("{XSD}date"),
+        format!("{XSD}time"),
+        format!("{XSD}anyURI"),
+    )?;
+    Ok(SchemaImportConfig::new(namespaces, datatypes))
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let config = import_config()?;
+    let dataset = purrdf_shapes::text_ingest::parse_turtle_to_dataset(SOURCE_SHAPES)
+        .map_err(|errors| std::io::Error::other(errors.join("\n")))?;
+    let source_shapes = purrdf_shapes::shapes::from_dataset(&dataset)?;
+    let compiled = purrdf_shapes::json_schema::compile(&source_shapes, config.namespaces());
+    if !compiled.losses.is_empty() {
+        return Err("example SHACL source must compile without forward losses".into());
+    }
+
+    let json_schema = import_json_schema(&compiled.schema_json, &config)?;
+
+    let linkml_config = LinkmlConfig::new(
+        "https://example.org/schema/linkml",
+        "ExampleSchema",
+        "Schema package owned by the example.org caller.",
+        "ex",
+        BTreeMap::from([
+            ("ex".to_owned(), EX.to_owned()),
+            ("linkml".to_owned(), LINKML.to_owned()),
+        ]),
+    )?;
+    let linkml_package = emit_linkml(&compiled, &linkml_config)?;
+    let linkml_document = parse_linkml(&linkml_package.yaml)?;
+    if write_linkml(&linkml_document)? != linkml_package.yaml {
+        return Err("native LinkML read/write path drifted".into());
+    }
+    let native_linkml = import_linkml(&linkml_document, &config)?;
+    purrdf::loss::check_ledger_sound(&native_linkml.losses, "linkml-1.11", "shacl")?;
+    println!(
+        "linkml-1.11/native: canonical read/write; {} located reverse loss(es)",
+        native_linkml.losses.entries().len()
+    );
+    let verified_linkml = import_linkml_package(&linkml_package, &config)?;
+
+    let pydantic_package = emit_pydantic(
+        &compiled,
+        &PydanticConfig::new(
+            "example_models",
+            "Models owned by the example.org caller.",
+            "Validation models generated from the caller's shapes.",
+        )?,
+    )?;
+    let pydantic = import_pydantic_package(&pydantic_package, &config)?;
+
+    let typescript_package = emit_typescript(
+        &compiled,
+        &TypeScriptConfig::new(
+            "@example/schema-types",
+            "Types owned by the example.org caller.",
+            "Declarations generated from the caller's shapes.",
+        )?,
+    )?;
+    let typescript = import_typescript_package(&typescript_package, &config)?;
+
+    let graphql_package = emit_graphql(
+        &compiled,
+        &GraphqlConfig::new(
+            "ExampleSchema",
+            "GraphQL package owned by the example.org caller.",
+            "Types generated from the caller's shapes.",
+            "JsonCarrier",
+        )?,
+    )?;
+    let graphql = import_graphql_package(&graphql_package, &config)?;
+
+    for (label, profile, imported) in [
+        ("json-schema", "json-schema", json_schema),
+        ("linkml-1.11/package", "linkml-1.11", verified_linkml),
+        ("pydantic-v2", "pydantic-v2", pydantic),
+        ("typescript-7.0", "typescript-7.0", typescript),
+        ("graphql-september-2025", "graphql-september-2025", graphql),
+    ] {
+        purrdf::loss::check_ledger_sound(&imported.losses, profile, "shacl")?;
+        let round_trip = purrdf_shapes::json_schema::compile(&imported.shapes, config.namespaces());
+        if round_trip.schema_json != compiled.schema_json {
+            return Err(format!("{label} reverse path did not round-trip byte-exactly").into());
+        }
+        println!(
+            "{label}: {} SHACL node shape(s), byte-exact; {} located reverse loss(es)",
+            imported.shapes.node_shapes.len(),
+            imported.losses.entries().len()
+        );
+    }
+    Ok(())
+}

--- a/crates/shapes/examples/typescript_oracle_fixture.rs
+++ b/crates/shapes/examples/typescript_oracle_fixture.rs
@@ -8,9 +8,10 @@ use std::error::Error;
 
 use boon::{Compiler, Schemas};
 use purrdf::loss::{LossLedger, check_ledger_complete, check_ledger_sound};
-use purrdf_shapes::json_schema::CompiledSchema;
+use purrdf_shapes::json_schema::{CompiledSchema, Namespaces};
 use purrdf_shapes::{
-    TYPESCRIPT_DECLARATION_PATH, TypeScriptConfig, TypeScriptPackage, emit_typescript,
+    SchemaDatatypeMap, SchemaImportConfig, TYPESCRIPT_DECLARATION_PATH, TYPESCRIPT_DIALECT,
+    TypeScriptConfig, TypeScriptPackage, emit_typescript, import_typescript_package,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -35,6 +36,7 @@ const CLOSED_PROFILE: [&str; 18] = [
     "unevaluated-validation-dropped",
     "unique-items-validation-dropped",
 ];
+const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -88,6 +90,50 @@ fn config() -> Result<TypeScriptConfig, Box<dyn Error>> {
         "Caller-owned TypeScript differential-oracle fixture.",
         "Declarations checked against the source JSON Schema acceptance relation.",
     )?)
+}
+
+fn import_config() -> Result<SchemaImportConfig, Box<dyn Error>> {
+    let namespaces = Namespaces::new(
+        "ex",
+        &[("ex".to_owned(), "https://example.org/".to_owned())],
+    )?;
+    let datatypes = SchemaDatatypeMap::new(
+        format!("{XSD}string"),
+        format!("{XSD}boolean"),
+        format!("{XSD}integer"),
+        format!("{XSD}decimal"),
+        format!("{XSD}dateTime"),
+        format!("{XSD}date"),
+        format!("{XSD}time"),
+        format!("{XSD}anyURI"),
+    )?;
+    Ok(SchemaImportConfig::new(namespaces, datatypes))
+}
+
+fn reverse_evidence(
+    package: &TypeScriptPackage,
+    config: &SchemaImportConfig,
+) -> Result<Value, Box<dyn Error>> {
+    let imported = import_typescript_package(package, config)?;
+    check_ledger_sound(&imported.losses, TYPESCRIPT_DIALECT, "shacl")?;
+    let repeated = import_typescript_package(package, config)?;
+    if imported.losses.render_json() != repeated.losses.render_json() {
+        return Err("TypeScript reverse ledger is not deterministic".into());
+    }
+    let first = purrdf_shapes::json_schema::compile(&imported.shapes, config.namespaces());
+    let second = purrdf_shapes::json_schema::compile(&repeated.shapes, config.namespaces());
+    if first.schema_json != second.schema_json {
+        return Err("TypeScript reverse shapes are not byte-deterministic".into());
+    }
+    Ok(json!({
+        "losses": serde_json::from_str::<Value>(&imported.losses.render_json())?,
+        "shapeIds": imported
+            .shapes
+            .node_shapes
+            .iter()
+            .map(|shape| shape.id.to_string())
+            .collect::<Vec<_>>(),
+    }))
 }
 
 fn exact_schema() -> Value {
@@ -963,9 +1009,21 @@ fn main() -> Result<(), Box<dyn Error>> {
     let lossy_schema = lossy_schema();
     let exact_package = emit_typescript(&compiled(&exact_schema)?, &config)?;
     let lossy_package = emit_typescript(&compiled(&lossy_schema)?, &config)?;
+    let mut reverse_schema = exact_schema.clone();
+    let reverse_definitions = reverse_schema["$defs"]
+        .as_object_mut()
+        .ok_or("oracle schema has no $defs")?;
+    reverse_definitions.remove("Empty");
+    // The differential fixture's Tree deliberately uses bare JSON field names.
+    // They have no caller-supplied RDF property identity, so the verified
+    // reverse fixture excludes that definition instead of inventing one.
+    reverse_definitions.remove("Tree");
+    let reverse_package = emit_typescript(&compiled(&reverse_schema)?, &config)?;
+    let reverse = reverse_evidence(&reverse_package, &import_config()?)?;
     let output = json!({
         "exact": exact_fixture(&exact_schema, exact_package)?,
         "lossy": lossy_fixture(&lossy_schema, lossy_package)?,
+        "reverse": reverse,
     });
     println!("{}", serde_json::to_string(&output)?);
     Ok(())

--- a/crates/shapes/src/graphql.rs
+++ b/crates/shapes/src/graphql.rs
@@ -13,6 +13,12 @@
 //! as singleton-list coercion, fixed input-field sets, custom-scalar behavior,
 //! and required/null presence are recorded on [`GraphqlPackage::losses`] at
 //! their source JSON Pointer locations.
+//!
+//! Arbitrary SDL is not an inverse format: resolver behavior, custom scalars,
+//! and output selection do not define one JSON acceptance relation. Emitted
+//! packages retain their exact source schema and verify it against the SDL and
+//! canonical name/value map before [`import_graphql_package`] lowers it to
+//! SHACL.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
@@ -28,6 +34,7 @@ use crate::schema_catalog::{
     CompiledSchemaCatalog, definition_path, pointer_escape, reference_key, schema_array_keywords,
     schema_map_keywords, schema_single_keywords,
 };
+use crate::schema_import::{ImportedShapes, SchemaImportConfig, import_json_schema_from};
 
 /// Fixed GraphQL language revision used by the emitter and loss registry.
 pub const GRAPHQL_DIALECT: &str = "graphql-september-2025";
@@ -167,12 +174,21 @@ pub struct GraphqlPackage {
     pub names: GraphqlNameMap,
     /// JSON Schema assertions not represented exactly by GraphQL coercion.
     pub losses: LossLedger,
+    source_schema_json: String,
+    config: GraphqlConfig,
     source_definitions: BTreeMap<String, Value>,
     representations: BTreeMap<String, Representation>,
     reference_targets: BTreeMap<String, String>,
 }
 
 impl GraphqlPackage {
+    /// Exact immutable source JSON Schema bytes retained for verified reverse
+    /// import.
+    #[must_use]
+    pub fn source_schema_json(&self) -> &str {
+        &self.source_schema_json
+    }
+
     /// Translate one source JSON value into the generated GraphQL input naming
     /// and finite-enum transport representation.
     ///
@@ -313,6 +329,8 @@ pub fn emit_graphql(
         artifacts,
         names,
         losses: planner.ledger,
+        source_schema_json: compiled.schema_json.clone(),
+        config: config.clone(),
         source_definitions: definitions
             .iter()
             .map(|(key, value)| (key.clone(), value.clone()))
@@ -320,6 +338,60 @@ pub fn emit_graphql(
         representations: planner.representations,
         reference_targets: planner.reference_targets,
     })
+}
+
+/// Import a deterministic PurRDF-emitted GraphQL September 2025 package as
+/// SHACL shapes.
+///
+/// This verified inverse uses the exact retained JSON Schema. Arbitrary SDL is
+/// intentionally outside the API because GraphQL custom scalars, resolvers,
+/// and output selection do not define a unique runtime JSON validation model.
+///
+/// # Errors
+///
+/// Returns [`GraphqlError`] when the dialect, package identity, retained source
+/// schema, SDL/name-map artifacts, typed name/value map, or forward ledger
+/// differs from deterministic re-emission, or when shared schema import fails.
+pub fn import_graphql_package(
+    package: &GraphqlPackage,
+    config: &SchemaImportConfig,
+) -> Result<ImportedShapes, GraphqlError> {
+    if package.names.dialect != GRAPHQL_DIALECT {
+        return Err(GraphqlError::new(format!(
+            "GraphQL package dialect must be {GRAPHQL_DIALECT:?}, got {:?}",
+            package.names.dialect
+        )));
+    }
+    {
+        let retained = CompiledSchema {
+            schema_json: package.source_schema_json.clone(),
+            openapi_json: "{}\n".to_owned(),
+            losses: LossLedger::new(),
+        };
+        let expected = emit_graphql(&retained, &package.config)?;
+        if package.schema_name != expected.schema_name {
+            return Err(GraphqlError::new(
+                "GraphQL package identity differs from deterministic re-emission",
+            ));
+        }
+        if package.artifacts != expected.artifacts {
+            return Err(GraphqlError::new(
+                "GraphQL package artifacts differ from deterministic re-emission",
+            ));
+        }
+        if package.names != expected.names {
+            return Err(GraphqlError::new(
+                "GraphQL package typed name map differs from deterministic re-emission",
+            ));
+        }
+        if package.losses.render_json() != expected.losses.render_json() {
+            return Err(GraphqlError::new(
+                "GraphQL package forward loss ledger differs from deterministic re-emission",
+            ));
+        }
+    }
+    import_json_schema_from(GRAPHQL_DIALECT, &package.source_schema_json, config)
+        .map_err(|error| GraphqlError::new(format!("GraphQL package import: {error}")))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2188,9 +2260,13 @@ fn finish_text(mut text: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::json_schema::Namespaces;
+    use crate::schema_import::SchemaDatatypeMap;
     use ::purrdf::loss::{check_ledger_complete, check_ledger_sound};
     use proptest::prelude::*;
     use serde_json::json;
+
+    const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
 
     fn compiled(schema: &Value) -> CompiledSchema {
         CompiledSchema {
@@ -2211,6 +2287,40 @@ mod tests {
             "JsonCarrier",
         )
         .expect("valid config")
+    }
+
+    fn import_config() -> SchemaImportConfig {
+        let namespaces = Namespaces::new(
+            "ex",
+            &[("ex".to_owned(), "https://example.org/".to_owned())],
+        )
+        .expect("namespaces");
+        let datatypes = SchemaDatatypeMap::new(
+            format!("{XSD}string"),
+            format!("{XSD}boolean"),
+            format!("{XSD}integer"),
+            format!("{XSD}decimal"),
+            format!("{XSD}dateTime"),
+            format!("{XSD}date"),
+            format!("{XSD}time"),
+            format!("{XSD}anyURI"),
+        )
+        .expect("datatypes");
+        SchemaImportConfig::new(namespaces, datatypes)
+    }
+
+    fn compile_turtle(body: &str) -> CompiledSchema {
+        let source = format!(
+            r"
+            @prefix ex:  <https://example.org/> .
+            @prefix sh:  <http://www.w3.org/ns/shacl#> .
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            {body}
+            "
+        );
+        let dataset = crate::text_ingest::parse_turtle_to_dataset(&source).expect("parse");
+        let shapes = crate::shapes::from_dataset(&dataset).expect("shapes");
+        crate::json_schema::compile(&shapes, import_config().namespaces())
     }
 
     fn sdl(package: &GraphqlPackage) -> &str {
@@ -2320,6 +2430,105 @@ mod tests {
         .expect("name map is JSON");
         assert_eq!(artifact["dialect"], GRAPHQL_DIALECT);
         assert_eq!(artifact["schema_name"], "ExampleSchema");
+    }
+
+    #[test]
+    fn emitted_package_imports_byte_exactly_and_corruption_fails_closed() {
+        let compiled = compile_turtle(
+            r#"
+            ex:PersonShape a sh:NodeShape ;
+                sh:targetClass ex:Person ;
+                sh:closed true ;
+                sh:property [
+                    sh:path ex:name ;
+                    sh:datatype xsd:string ;
+                    sh:minCount 1 ;
+                    sh:maxCount 1 ;
+                    sh:pattern "^[A-Z]"
+                ] ;
+                sh:property [
+                    sh:path ex:friend ;
+                    sh:class ex:Person ;
+                    sh:maxCount 1
+                ] ;
+                sh:property [
+                    sh:path ex:state ;
+                    sh:maxCount 1 ;
+                    sh:in ( ex:active "inactive" )
+                ] .
+            "#,
+        );
+        let package = emit_graphql(&compiled, &config()).expect("emit");
+        assert_eq!(package.source_schema_json(), compiled.schema_json);
+        let imported = import_graphql_package(&package, &import_config()).expect("import");
+        assert!(
+            imported.losses.is_empty(),
+            "{}",
+            imported.losses.render_json()
+        );
+        let recompiled =
+            crate::json_schema::compile(&imported.shapes, import_config().namespaces());
+        assert_eq!(recompiled.schema_json, compiled.schema_json);
+
+        let repeated = import_graphql_package(&package, &import_config()).expect("repeat");
+        let repeated = crate::json_schema::compile(&repeated.shapes, import_config().namespaces());
+        assert_eq!(repeated.schema_json, recompiled.schema_json);
+
+        let mut bad = package.clone();
+        bad.names.dialect = "graphql-future".to_owned();
+        assert!(import_graphql_package(&bad, &import_config()).is_err());
+
+        let mut bad = package.clone();
+        bad.schema_name = "Drift".to_owned();
+        assert!(import_graphql_package(&bad, &import_config()).is_err());
+
+        let mut bad = package.clone();
+        bad.artifacts
+            .get_mut(GRAPHQL_SCHEMA_PATH)
+            .expect("SDL")
+            .extend_from_slice(b"# drift\n");
+        assert!(import_graphql_package(&bad, &import_config()).is_err());
+
+        let mut bad = package;
+        bad.names
+            .fields
+            .values_mut()
+            .next()
+            .expect("field map")
+            .insert("ex:drift".to_owned(), "drift".to_owned());
+        assert!(import_graphql_package(&bad, &import_config()).is_err());
+    }
+
+    #[test]
+    fn verified_package_imports_alias_recursive_nullable_and_finite_schema() {
+        let schema = json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "Alias": { "$ref": "#/$defs/Person" },
+                "Choice": { "enum": [true, { "state": "open" }] },
+                "Person": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ex:choice": { "$ref": "#/$defs/Choice" },
+                        "ex:friend": { "$ref": "#/$defs/Person" },
+                        "ex:maybe": { "type": ["string", "null"] }
+                    }
+                }
+            }
+        });
+        let package = emit_graphql(&compiled(&schema), &config()).expect("emit");
+        let imported = import_graphql_package(&package, &import_config()).expect("import");
+        check_ledger_sound(&imported.losses, GRAPHQL_DIALECT, "shacl")
+            .expect("sound reverse ledger");
+        assert_eq!(imported.shapes.node_shapes.len(), 1);
+        assert!(imported.losses.entries().iter().all(|entry| {
+            entry
+                .location
+                .as_ref()
+                .and_then(|location| location.subject.as_deref())
+                .is_some_and(|subject| subject.starts_with("#/"))
+        }));
     }
 
     #[test]

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -221,6 +221,69 @@ impl Namespaces {
         &self.primary_ns
     }
 
+    /// Expand one caller-declared CURIE, or validate and retain an absolute
+    /// IRI. A caller-declared prefix wins over the RFC scheme interpretation,
+    /// so `ex:Term` expands through `ex` while an undeclared `urn:...` remains
+    /// an absolute IRI.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the value is neither an absolute IRI nor a valid
+    /// CURIE using the caller's prefix table.
+    pub fn expand_iri(&self, value: &str) -> Result<String, String> {
+        if let Some((prefix, local)) = value.split_once(':')
+            && let Some(namespace) = self
+                .prefixes
+                .iter()
+                .find_map(|(candidate, namespace)| (candidate == prefix).then_some(namespace))
+        {
+            if local.is_empty() {
+                return Err(format!("CURIE {value:?} must have a non-empty local part"));
+            }
+            let expanded = format!("{namespace}{local}");
+            let parsed = purrdf_iri::parse(&expanded).map_err(|error| {
+                format!("expanded CURIE {value:?} is not an absolute IRI: {error}")
+            })?;
+            if !parsed.has_scheme() {
+                return Err(format!("expanded CURIE {value:?} is not an absolute IRI"));
+            }
+            return Ok(expanded);
+        }
+        let parsed = purrdf_iri::parse(value).map_err(|error| {
+            format!("IRI value {value:?} is neither absolute nor a caller-declared CURIE: {error}")
+        })?;
+        if !parsed.has_scheme() {
+            return Err(format!(
+                "IRI value {value:?} is neither absolute nor a caller-declared CURIE"
+            ));
+        }
+        Ok(value.to_owned())
+    }
+
+    /// Recover the caller-owned class IRI represented by one compiled `$defs`
+    /// key: colon-free keys belong to the primary namespace, while CURIE or
+    /// absolute-IRI keys use [`Self::expand_iri`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an empty key or an invalid/unknown qualified key.
+    pub fn class_iri_for_def_key(&self, key: &str) -> Result<String, String> {
+        if key.is_empty() {
+            return Err("JSON Schema $defs key cannot be empty when used as a class".to_owned());
+        }
+        if key.contains(':') {
+            self.expand_iri(key)
+        } else {
+            let iri = format!("{}{key}", self.primary_ns);
+            let parsed = purrdf_iri::parse(&iri)
+                .map_err(|error| format!("class key {key:?} does not form a valid IRI: {error}"))?;
+            if !parsed.has_scheme() {
+                return Err(format!("class key {key:?} does not form an absolute IRI"));
+            }
+            Ok(iri)
+        }
+    }
+
     /// Whether an IRI is in a declared namespace (i.e. [`Self::compact_iri`]
     /// would compact it to a `prefix:Local` CURIE rather than returning it
     /// verbatim).

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -44,14 +44,17 @@ pub mod typescript;
 pub use graphql::{
     GRAPHQL_DIALECT, GRAPHQL_NAME_MAP_PATH, GRAPHQL_SCHEMA_PATH, GraphqlConfig,
     GraphqlDefinitionMap, GraphqlEnumValueMap, GraphqlError, GraphqlNameMap, GraphqlPackage,
-    emit_graphql,
+    emit_graphql, import_graphql_package,
 };
 pub use json_schema::{Namespaces, ValueVocab, ValueVocabProjection, compile_with_value_vocab};
 pub use linkml::{
     LinkmlConfig, LinkmlDocument, LinkmlError, LinkmlPackage, emit_linkml, import_linkml,
     import_linkml_package, parse_linkml, write_linkml,
 };
-pub use pydantic::{PydanticConfig, PydanticError, PydanticPackage, emit_pydantic};
+pub use pydantic::{
+    PYDANTIC_DIALECT, PydanticConfig, PydanticError, PydanticPackage, emit_pydantic,
+    import_pydantic_package,
+};
 pub use rules::{apply_rules, entail_dataset};
 pub use schema_import::{
     ImportedShapes, SchemaDatatypeMap, SchemaImportConfig, SchemaImportError,
@@ -59,7 +62,7 @@ pub use schema_import::{
 };
 pub use typescript::{
     TYPESCRIPT_DECLARATION_PATH, TYPESCRIPT_DIALECT, TypeScriptConfig, TypeScriptError,
-    TypeScriptPackage, emit_typescript,
+    TypeScriptPackage, emit_typescript, import_typescript_package,
 };
 
 /// Crate version string for cache/toolchain salt parity with Python package

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -33,6 +33,7 @@ pub mod pydantic;
 pub mod report;
 pub mod rules;
 mod schema_catalog;
+pub mod schema_import;
 pub mod shape_union;
 pub mod shapes;
 pub mod sparql;
@@ -52,6 +53,10 @@ pub use linkml::{
 };
 pub use pydantic::{PydanticConfig, PydanticError, PydanticPackage, emit_pydantic};
 pub use rules::{apply_rules, entail_dataset};
+pub use schema_import::{
+    ImportedShapes, SchemaDatatypeMap, SchemaImportConfig, SchemaImportError,
+    import_compiled_schema, import_json_schema,
+};
 pub use typescript::{
     TYPESCRIPT_DECLARATION_PATH, TYPESCRIPT_DIALECT, TypeScriptConfig, TypeScriptError,
     TypeScriptPackage, emit_typescript,

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -48,8 +48,8 @@ pub use graphql::{
 };
 pub use json_schema::{Namespaces, ValueVocab, ValueVocabProjection, compile_with_value_vocab};
 pub use linkml::{
-    LinkmlConfig, LinkmlDocument, LinkmlError, LinkmlPackage, emit_linkml, parse_linkml,
-    write_linkml,
+    LinkmlConfig, LinkmlDocument, LinkmlError, LinkmlPackage, emit_linkml, import_linkml,
+    import_linkml_package, parse_linkml, write_linkml,
 };
 pub use pydantic::{PydanticConfig, PydanticError, PydanticPackage, emit_pydantic};
 pub use rules::{apply_rules, entail_dataset};

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -10,6 +10,13 @@
 //! (`sh:sparql`/`sh:SPARQLConstraint`) and targets (`sh:SPARQLTarget`) are
 //! implemented in the [`sparql`] module on the native `purrdf-sparql-eval`
 //! engine.
+//!
+//! The crate also owns the bidirectional schema boundary. [`import_json_schema`]
+//! and [`import_linkml`] read native documents; [`import_pydantic_package`],
+//! [`import_typescript_package`], and [`import_graphql_package`] verify intact
+//! PurRDF-generated packages before lowering through the same deterministic
+//! schema-import engine. Every reader requires caller-owned namespace and
+//! datatype configuration and returns an always-computed reverse loss ledger.
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/Blackcat-Informatics/purrdf/main/docs/purrdf-logo.svg"
 )]

--- a/crates/shapes/src/linkml.rs
+++ b/crates/shapes/src/linkml.rs
@@ -20,7 +20,9 @@ use serde_json::{Map, Number, Value};
 use serde_yaml::Value as YamlValue;
 
 use crate::json_schema::CompiledSchema;
+use crate::schema_import::{ImportedShapes, SchemaImportConfig};
 
+mod importer;
 mod projection;
 
 /// The exact LinkML metamodel version carried by this codec.
@@ -30,6 +32,7 @@ const LINKML_PREFIX: &str = "linkml";
 const MAX_LINKML_YAML_BYTES: usize = 16 * 1024 * 1024;
 const MAX_LINKML_YAML_DEPTH: usize = 256;
 const MAX_LINKML_YAML_NODES: usize = 1_000_000;
+const MAX_LINKML_STRING_BYTES: usize = 16 * 1024 * 1024;
 
 /// Caller-owned identity and vocabulary configuration for LinkML emission.
 ///
@@ -179,6 +182,8 @@ pub struct LinkmlPackage {
     pub element_names: BTreeMap<String, String>,
     /// JSON Schema assertions not represented exactly in LinkML 1.11.
     pub losses: LossLedger,
+    canonical_yaml: String,
+    canonical_element_names: BTreeMap<String, String>,
 }
 
 /// A malformed LinkML configuration, document, or projection input.
@@ -266,7 +271,42 @@ pub fn emit_linkml(
     projection::emit(compiled, config)
 }
 
+/// Import one validated native LinkML 1.11 document as SHACL shapes.
+///
+/// Every accepted native construct without an exact SHACL interpretation is
+/// returned in the always-computed `linkml-1.11` → `shacl` loss ledger. Element
+/// and slot identities come only from the document's caller-supplied prefix
+/// map; scalar RDF datatypes come only from [`SchemaImportConfig`].
+///
+/// # Errors
+///
+/// Returns [`LinkmlError`] for malformed native class/slot/type/enum
+/// structures, unknown or cyclic references, identity collisions, or a shared
+/// schema-import failure.
+pub fn import_linkml(
+    document: &LinkmlDocument,
+    config: &SchemaImportConfig,
+) -> Result<ImportedShapes, LinkmlError> {
+    importer::import_document(document, config, None)
+}
+
+/// Import a deterministic PurRDF-emitted LinkML package as SHACL shapes after
+/// verifying its YAML bytes and source-definition → element-name map.
+///
+/// # Errors
+///
+/// Returns [`LinkmlError`] when the package artifacts or reversible element
+/// map drift from the validated document, or when [`import_linkml`] fails.
+pub fn import_linkml_package(
+    package: &LinkmlPackage,
+    config: &SchemaImportConfig,
+) -> Result<ImportedShapes, LinkmlError> {
+    importer::import_package(package, config)
+}
+
 fn validate_document(value: &Value) -> Result<(), LinkmlError> {
+    let mut nodes = 0;
+    validate_json_value(value, 0, &mut nodes, "#")?;
     let root = value
         .as_object()
         .ok_or_else(|| LinkmlError::new("LinkML document root must be a mapping"))?;
@@ -337,6 +377,55 @@ fn validate_document(value: &Value) -> Result<(), LinkmlError> {
     }
 
     Ok(())
+}
+
+fn validate_json_value(
+    value: &Value,
+    depth: usize,
+    nodes: &mut usize,
+    path: &str,
+) -> Result<(), LinkmlError> {
+    if depth > MAX_LINKML_YAML_DEPTH {
+        return Err(LinkmlError::new(format!(
+            "LinkML document at {path} exceeds depth {MAX_LINKML_YAML_DEPTH}"
+        )));
+    }
+    *nodes = nodes
+        .checked_add(1)
+        .ok_or_else(|| LinkmlError::new("LinkML document node count overflow"))?;
+    if *nodes > MAX_LINKML_YAML_NODES {
+        return Err(LinkmlError::new(format!(
+            "LinkML document exceeds {MAX_LINKML_YAML_NODES} nodes"
+        )));
+    }
+    match value {
+        Value::String(value) if value.len() > MAX_LINKML_STRING_BYTES => Err(LinkmlError::new(
+            format!("LinkML string at {path} exceeds {MAX_LINKML_STRING_BYTES} bytes"),
+        )),
+        Value::Array(values) => {
+            for (index, child) in values.iter().enumerate() {
+                validate_json_value(child, depth + 1, nodes, &format!("{path}/{index}"))?;
+            }
+            Ok(())
+        }
+        Value::Object(values) => {
+            for (key, child) in values {
+                if key.len() > MAX_LINKML_STRING_BYTES {
+                    return Err(LinkmlError::new(format!(
+                        "LinkML key at {path} exceeds {MAX_LINKML_STRING_BYTES} bytes"
+                    )));
+                }
+                validate_json_value(
+                    child,
+                    depth + 1,
+                    nodes,
+                    &format!("{path}/{}", key.replace('~', "~0").replace('/', "~1")),
+                )?;
+            }
+            Ok(())
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => Ok(()),
+    }
 }
 
 fn validate_prefixes(prefixes: &BTreeMap<String, String>) -> Result<(), LinkmlError> {
@@ -875,6 +964,22 @@ x-value: .nan
         let mut value = valid_value();
         value["imports"] = json!([7]);
         assert!(LinkmlDocument::from_value(value).is_err());
+    }
+
+    #[test]
+    fn programmatic_documents_enforce_the_same_depth_limit_as_yaml() {
+        let mut nested = Value::Null;
+        for _ in 0..=MAX_LINKML_YAML_DEPTH {
+            nested = Value::Array(vec![nested]);
+        }
+        let mut value = valid_value();
+        value["x-too-deep"] = nested;
+        assert!(
+            LinkmlDocument::from_value(value)
+                .expect_err("over-depth document")
+                .to_string()
+                .contains("exceeds depth")
+        );
     }
 
     #[test]

--- a/crates/shapes/src/linkml.rs
+++ b/crates/shapes/src/linkml.rs
@@ -10,6 +10,7 @@
 //! byte-stable YAML representation while preserving fields the emitter does
 //! not author.
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt;
@@ -419,12 +420,20 @@ fn validate_json_value(
                     child,
                     depth + 1,
                     nodes,
-                    &format!("{path}/{}", key.replace('~', "~0").replace('/', "~1")),
+                    &format!("{path}/{}", pointer_escape(key)),
                 )?;
             }
             Ok(())
         }
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => Ok(()),
+    }
+}
+
+fn pointer_escape(value: &str) -> Cow<'_, str> {
+    if value.contains('~') || value.contains('/') {
+        Cow::Owned(value.replace('~', "~0").replace('/', "~1"))
+    } else {
+        Cow::Borrowed(value)
     }
 }
 

--- a/crates/shapes/src/linkml/importer.rs
+++ b/crates/shapes/src/linkml/importer.rs
@@ -1,0 +1,2031 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Native LinkML 1.11 to the shared deterministic schema-import model.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use ::purrdf::RdfLocation;
+use ::purrdf::loss::{LossEntry, LossLedger, check_ledger_sound, schema_to_shacl_loss_ledger};
+use serde_json::{Map, Value};
+
+use super::{LinkmlDocument, LinkmlError, LinkmlPackage, parse_linkml, projection, write_linkml};
+use crate::schema_import::{ImportedShapes, SchemaImportConfig, import_schema_value_from};
+use crate::term::Term;
+
+const SOURCE: &str = "linkml-1.11";
+const TARGET: &str = "shacl";
+const LOSS_CONTEXT: &str = "shapes:linkml-import";
+const MAX_ELEMENTS: usize = 65_536;
+const MAX_ELEMENT_DEPTH: usize = 128;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ElementKind {
+    Class,
+    Enum,
+    Type,
+}
+
+pub(super) fn import_package(
+    package: &LinkmlPackage,
+    config: &SchemaImportConfig,
+) -> Result<ImportedShapes, LinkmlError> {
+    let canonical = write_linkml(&package.document)?;
+    if canonical != package.yaml {
+        return Err(LinkmlError::new(
+            "LinkML package YAML differs from its canonical validated document",
+        ));
+    }
+    if parse_linkml(&package.yaml)? != package.document {
+        return Err(LinkmlError::new(
+            "LinkML package YAML does not parse back to its validated document",
+        ));
+    }
+    let visible = verify_element_names(package)?;
+    import_document(&package.document, config, Some(&visible))
+}
+
+pub(super) fn import_document(
+    document: &LinkmlDocument,
+    config: &SchemaImportConfig,
+    visible_classes: Option<&BTreeSet<String>>,
+) -> Result<ImportedShapes, LinkmlError> {
+    let mut importer = NativeImporter::new(document)?;
+    let (pivot, ignored_class_iris) = importer.build_pivot(visible_classes)?;
+    let mut imported = import_schema_value_from(SOURCE, &pivot, config)
+        .map_err(|error| LinkmlError::new(format!("LinkML import model: {error}")))?;
+
+    if !ignored_class_iris.is_empty() {
+        imported.shapes.node_shapes.retain(|shape| {
+            let Term::NamedNode(identity) = &shape.id else {
+                return true;
+            };
+            !ignored_class_iris.contains(identity.as_str())
+        });
+    }
+
+    let mut losses = importer.losses;
+    for entry in imported.losses.entries() {
+        let mut remapped = entry.clone();
+        if let Some(location) = remapped.location.as_mut() {
+            if let Some(subject) = location.subject.as_deref() {
+                location.subject = Some(remap_location(subject, &importer.locations));
+            }
+            location.logical = Some(LOSS_CONTEXT.to_owned());
+        }
+        losses.record(remapped);
+    }
+    check_ledger_sound(&losses, SOURCE, TARGET).map_err(LinkmlError::new)?;
+    imported.losses = losses;
+    Ok(imported)
+}
+
+fn verify_element_names(package: &LinkmlPackage) -> Result<BTreeSet<String>, LinkmlError> {
+    if package.yaml != package.canonical_yaml {
+        return Err(LinkmlError::new(
+            "LinkML package YAML differs from its retained emitted artifact",
+        ));
+    }
+    if package.element_names != package.canonical_element_names {
+        return Err(LinkmlError::new(
+            "LinkML package element map differs from its retained emitted map",
+        ));
+    }
+    let root = package
+        .document
+        .as_value()
+        .as_object()
+        .expect("LinkmlDocument validates an object root");
+    let mut available = BTreeSet::new();
+    for section in ["classes", "enums", "types"] {
+        if let Some(elements) = root.get(section).and_then(Value::as_object) {
+            available.extend(elements.keys().cloned());
+        }
+    }
+    let mut reverse = BTreeMap::new();
+    for (source_key, element_name) in &package.element_names {
+        if projection::element_name(source_key) != *element_name {
+            return Err(LinkmlError::new(format!(
+                "LinkML package source key {source_key:?} does not normalize to element {element_name:?}"
+            )));
+        }
+        if !available.contains(element_name) {
+            return Err(LinkmlError::new(format!(
+                "LinkML package element map targets missing element {element_name:?}"
+            )));
+        }
+        if let Some(previous) = reverse.insert(element_name.clone(), source_key.clone()) {
+            return Err(LinkmlError::new(format!(
+                "LinkML package source keys {previous:?} and {source_key:?} target the same element {element_name:?}"
+            )));
+        }
+        if let Some(class) = root
+            .get("classes")
+            .and_then(Value::as_object)
+            .and_then(|classes| classes.get(element_name))
+            .and_then(Value::as_object)
+        {
+            let alias = class.get("alias").and_then(Value::as_str);
+            if source_key != element_name && alias != Some(source_key.as_str()) {
+                return Err(LinkmlError::new(format!(
+                    "LinkML package class {element_name:?} does not retain source alias {source_key:?}"
+                )));
+            }
+            if alias.is_some_and(|alias| alias != source_key) {
+                return Err(LinkmlError::new(format!(
+                    "LinkML package class {element_name:?} alias disagrees with its source map"
+                )));
+            }
+        }
+    }
+    Ok(reverse.into_keys().collect())
+}
+
+struct NativeImporter {
+    root: Map<String, Value>,
+    prefixes: BTreeMap<String, String>,
+    default_prefix: String,
+    classes: Map<String, Value>,
+    enums: Map<String, Value>,
+    types: Map<String, Value>,
+    slots: Map<String, Value>,
+    kinds: BTreeMap<String, ElementKind>,
+    identities: BTreeMap<String, String>,
+    reverse_identities: BTreeMap<String, String>,
+    class_cache: BTreeMap<String, Value>,
+    type_cache: BTreeMap<String, Value>,
+    ignored_class_names: BTreeSet<String>,
+    used_slots: BTreeSet<String>,
+    locations: BTreeMap<String, String>,
+    contract: LossLedger,
+    losses: LossLedger,
+    recorded_losses: BTreeSet<(String, String)>,
+}
+
+impl NativeImporter {
+    fn new(document: &LinkmlDocument) -> Result<Self, LinkmlError> {
+        let root = document
+            .as_value()
+            .as_object()
+            .expect("LinkmlDocument validates an object root")
+            .clone();
+        let prefixes = document_prefixes(&root)?;
+        let default_prefix =
+            required_string(&root, "default_prefix", "#/default_prefix")?.to_owned();
+        let classes = section(&root, "classes")?.clone();
+        let enums = section(&root, "enums")?.clone();
+        let types = section(&root, "types")?.clone();
+        let slots = section(&root, "slots")?.clone();
+        let count = classes.len() + enums.len() + types.len() + slots.len();
+        if count > MAX_ELEMENTS {
+            return Err(LinkmlError::new(format!(
+                "LinkML document contains {count} elements; limit is {MAX_ELEMENTS}"
+            )));
+        }
+        let mut importer = Self {
+            root,
+            prefixes,
+            default_prefix,
+            classes,
+            enums,
+            types,
+            slots,
+            kinds: BTreeMap::new(),
+            identities: BTreeMap::new(),
+            reverse_identities: BTreeMap::new(),
+            class_cache: BTreeMap::new(),
+            type_cache: BTreeMap::new(),
+            ignored_class_names: BTreeSet::new(),
+            used_slots: BTreeSet::new(),
+            locations: BTreeMap::new(),
+            contract: schema_to_shacl_loss_ledger(SOURCE),
+            losses: LossLedger::new(),
+            recorded_losses: BTreeSet::new(),
+        };
+        importer.prepare_elements()?;
+        Ok(importer)
+    }
+
+    fn prepare_elements(&mut self) -> Result<(), LinkmlError> {
+        for (kind, section_name, elements, identity_field) in [
+            (
+                ElementKind::Class,
+                "classes",
+                self.classes.clone(),
+                "class_uri",
+            ),
+            (ElementKind::Enum, "enums", self.enums.clone(), "enum_uri"),
+            (ElementKind::Type, "types", self.types.clone(), "uri"),
+        ] {
+            for (name, value) in elements {
+                let path = element_path(section_name, &name);
+                let object = value
+                    .as_object()
+                    .ok_or_else(|| LinkmlError::new(format!("{path} must be a mapping")))?;
+                if self.kinds.insert(name.clone(), kind).is_some() {
+                    return Err(LinkmlError::new(format!(
+                        "LinkML element name {name:?} occurs in more than one section"
+                    )));
+                }
+                let identity = object
+                    .get(identity_field)
+                    .map(|value| {
+                        value.as_str().ok_or_else(|| {
+                            LinkmlError::new(format!("{path}/{identity_field} must be a string"))
+                        })
+                    })
+                    .transpose()?
+                    .unwrap_or(&name);
+                let identity = self.expand_iri(identity, &path)?;
+                if let Some(previous) = self
+                    .reverse_identities
+                    .insert(identity.clone(), format!("{section_name}/{name}"))
+                {
+                    return Err(LinkmlError::new(format!(
+                        "LinkML elements {previous:?} and {section_name}/{name} resolve to the same IRI {identity:?}"
+                    )));
+                }
+                self.identities.insert(name, identity);
+            }
+        }
+        Ok(())
+    }
+
+    fn build_pivot(
+        &mut self,
+        visible_classes: Option<&BTreeSet<String>>,
+    ) -> Result<(Value, BTreeSet<String>), LinkmlError> {
+        self.audit_root()?;
+        let mut definitions = Map::new();
+        let ignored_class_names = visible_classes.map_or_else(BTreeSet::new, |visible| {
+            self.classes
+                .keys()
+                .filter(|name| !visible.contains(*name) || self.is_package_infrastructure(name))
+                .cloned()
+                .collect()
+        });
+        self.ignored_class_names.clone_from(&ignored_class_names);
+
+        for (name, _) in self.enums.clone() {
+            let identity = self.identity(&name)?.to_owned();
+            let schema = self.enum_schema(&name)?;
+            self.map_location(&definition_path(&identity), &element_path("enums", &name));
+            definitions.insert(identity, schema);
+        }
+        for (name, _) in self.types.clone() {
+            let identity = self.identity(&name)?.to_owned();
+            let schema = self.type_schema(&name, &mut BTreeSet::new(), 0)?;
+            self.map_location(&definition_path(&identity), &element_path("types", &name));
+            definitions.insert(identity, schema);
+        }
+        for (name, _) in self.classes.clone() {
+            let identity = self.identity(&name)?.to_owned();
+            let schema = self.class_schema(&name, &mut BTreeSet::new(), 0)?;
+            if ignored_class_names.contains(&name) {
+                continue;
+            }
+            self.map_location(&definition_path(&identity), &element_path("classes", &name));
+            definitions.insert(identity, schema);
+        }
+
+        for (name, _) in self.slots.clone() {
+            if !self.used_slots.contains(&name) {
+                self.record(
+                    "non-object-definition-dropped",
+                    &element_path("slots", &name),
+                );
+            }
+        }
+
+        let ignored_class_iris = ignored_class_names
+            .iter()
+            .filter_map(|name| self.identities.get(name).cloned())
+            .collect();
+        Ok((
+            Value::Object(Map::from_iter([(
+                "$defs".to_owned(),
+                Value::Object(definitions),
+            )])),
+            ignored_class_iris,
+        ))
+    }
+
+    fn audit_root(&mut self) -> Result<(), LinkmlError> {
+        for key in ["id", "name"] {
+            if self.root.contains_key(key) {
+                self.record(
+                    "schema-identity-dropped",
+                    &format!("#/{}", pointer_escape(key)),
+                );
+            }
+        }
+        if self.root.contains_key("description") {
+            self.record("annotation-dropped", "#/description");
+        }
+        if let Some(imports) = self.root.get("imports") {
+            let values: Vec<String> = match imports {
+                Value::String(value) => vec![value.clone()],
+                Value::Array(values) => values
+                    .iter()
+                    .map(|value| {
+                        value
+                            .as_str()
+                            .map(str::to_owned)
+                            .ok_or_else(|| LinkmlError::new("#/imports must contain only strings"))
+                    })
+                    .collect::<Result<_, _>>()?,
+                _ => {
+                    return Err(LinkmlError::new(
+                        "#/imports must be a string or string array",
+                    ));
+                }
+            };
+            for (index, import) in values.into_iter().enumerate() {
+                if import != "linkml:types" {
+                    self.record("schema-identity-dropped", &format!("#/imports/{index}"));
+                }
+            }
+        }
+        if let Some(prefixes) = self
+            .root
+            .get("prefixes")
+            .and_then(Value::as_object)
+            .cloned()
+        {
+            for (prefix, definition) in prefixes {
+                let Some(definition) = definition.as_object() else {
+                    continue;
+                };
+                for key in definition.keys() {
+                    if !matches!(key.as_str(), "prefix_prefix" | "prefix_reference") {
+                        self.record(
+                            "unknown-keyword-dropped",
+                            &format!(
+                                "#/prefixes/{}/{}",
+                                pointer_escape(&prefix),
+                                pointer_escape(key)
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+        for (key, _) in self.root.clone() {
+            if !matches!(
+                key.as_str(),
+                "id" | "name"
+                    | "description"
+                    | "metamodel_version"
+                    | "prefixes"
+                    | "default_prefix"
+                    | "imports"
+                    | "classes"
+                    | "enums"
+                    | "types"
+                    | "slots"
+            ) {
+                self.record(
+                    "unknown-keyword-dropped",
+                    &format!("#/{}", pointer_escape(&key)),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn class_schema(
+        &mut self,
+        name: &str,
+        visiting: &mut BTreeSet<String>,
+        depth: usize,
+    ) -> Result<Value, LinkmlError> {
+        if let Some(schema) = self.class_cache.get(name) {
+            return Ok(schema.clone());
+        }
+        self.enter_element("class", name, visiting, depth)?;
+        let path = element_path("classes", name);
+        let object = self
+            .classes
+            .get(name)
+            .and_then(Value::as_object)
+            .ok_or_else(|| LinkmlError::new(format!("{path} must be a mapping")))?
+            .clone();
+
+        let mut schema = Map::from_iter([("type".to_owned(), Value::String("object".to_owned()))]);
+        let mut properties = Map::new();
+        let mut required = BTreeSet::new();
+
+        let mut local_slots = BTreeMap::<String, (Map<String, Value>, String)>::new();
+        if let Some(names) = object.get("slots") {
+            let names = names
+                .as_array()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/slots must be an array")))?;
+            for (index, slot_name) in names.iter().enumerate() {
+                let slot_name = slot_name.as_str().ok_or_else(|| {
+                    LinkmlError::new(format!("{path}/slots/{index} must be a string"))
+                })?;
+                let slot = self
+                    .slots
+                    .get(slot_name)
+                    .and_then(Value::as_object)
+                    .ok_or_else(|| {
+                        LinkmlError::new(format!(
+                            "{path}/slots/{index} targets missing global slot {slot_name:?}"
+                        ))
+                    })?
+                    .clone();
+                self.used_slots.insert(slot_name.to_owned());
+                if local_slots
+                    .insert(
+                        slot_name.to_owned(),
+                        (slot, element_path("slots", slot_name)),
+                    )
+                    .is_some()
+                {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/slots contains duplicate slot {slot_name:?}"
+                    )));
+                }
+            }
+        }
+        if let Some(usages) = object.get("slot_usage") {
+            let usages = usages
+                .as_object()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/slot_usage must be a mapping")))?;
+            for (slot_name, usage) in usages {
+                let usage = usage.as_object().ok_or_else(|| {
+                    LinkmlError::new(format!(
+                        "{path}/slot_usage/{} must be a mapping",
+                        pointer_escape(slot_name)
+                    ))
+                })?;
+                let usage_path = format!("{path}/slot_usage/{}", pointer_escape(slot_name));
+                if let Some((slot, slot_path)) = local_slots.get_mut(slot_name) {
+                    slot.extend(usage.clone());
+                    *slot_path = usage_path;
+                } else if object.contains_key("is_a") || object.contains_key("mixins") {
+                    // LinkML permits slot_usage to override an inherited slot,
+                    // but its inherited slot_uri is not necessarily derivable
+                    // from this local name. Validate the complete expression,
+                    // retain the ancestor contract, and ledger the override
+                    // rather than inventing a predicate identity.
+                    let _ = self.slot_schema(usage, &usage_path, visiting, depth + 1)?;
+                    self.record("schema-applicator-dropped", &usage_path);
+                } else {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/slot_usage names {slot_name:?}, absent from this class's slots or ancestors"
+                    )));
+                }
+            }
+        }
+        if let Some(attributes) = object.get("attributes") {
+            let attributes = attributes
+                .as_object()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/attributes must be a mapping")))?;
+            for (slot_name, slot) in attributes {
+                let slot = slot.as_object().ok_or_else(|| {
+                    LinkmlError::new(format!(
+                        "{path}/attributes/{} must be a mapping",
+                        pointer_escape(slot_name)
+                    ))
+                })?;
+                if local_slots
+                    .insert(
+                        slot_name.clone(),
+                        (
+                            slot.clone(),
+                            format!("{path}/attributes/{}", pointer_escape(slot_name)),
+                        ),
+                    )
+                    .is_some()
+                {
+                    return Err(LinkmlError::new(format!(
+                        "{path} defines slot {slot_name:?} in both slots and attributes"
+                    )));
+                }
+            }
+        }
+
+        let mut property_identities = BTreeMap::new();
+        for (slot_name, (slot, slot_path)) in local_slots {
+            if matches!(
+                slot_name.as_str(),
+                "@id" | "@type" | "@annotation" | "@value" | "@language"
+            ) {
+                self.record("value-term-kind-widened", &slot_path);
+                continue;
+            }
+            let (property_schema, is_required) =
+                self.slot_schema(&slot, &slot_path, visiting, depth + 1)?;
+            let property_identity = self.slot_identity(&slot_name, &slot, &slot_path)?;
+            if let Some(previous) =
+                property_identities.insert(property_identity.clone(), slot_path.clone())
+            {
+                return Err(LinkmlError::new(format!(
+                    "{slot_path} and {previous} resolve to the same slot IRI {property_identity:?}"
+                )));
+            }
+            let pivot_path = format!(
+                "{}/properties/{}",
+                definition_path(self.identity(name)?),
+                pointer_escape(&property_identity)
+            );
+            self.map_location(&pivot_path, &slot_path);
+            self.map_expression_locations(&pivot_path, &slot_path, &slot, &property_schema);
+            for (native, schema_keyword) in [
+                ("minimum_cardinality", "minItems"),
+                ("maximum_cardinality", "maxItems"),
+                ("list_elements_unique", "uniqueItems"),
+            ] {
+                if slot.contains_key(native) {
+                    self.map_location(
+                        &format!("{pivot_path}/{schema_keyword}"),
+                        &format!("{slot_path}/{native}"),
+                    );
+                }
+            }
+            properties.insert(property_identity.clone(), property_schema);
+            if is_required {
+                required.insert(property_identity);
+            }
+        }
+        schema.insert("properties".to_owned(), Value::Object(properties));
+        if !required.is_empty() {
+            schema.insert(
+                "required".to_owned(),
+                Value::Array(required.into_iter().map(Value::String).collect()),
+            );
+            self.map_location(
+                &format!("{}/required", definition_path(self.identity(name)?)),
+                &format!("{path}/attributes"),
+            );
+        }
+
+        if let Some(extra) = object.get("extra_slots") {
+            let extra = extra
+                .as_object()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/extra_slots must be a mapping")))?;
+            let allowed = required_bool(extra, "allowed", &format!("{path}/extra_slots/allowed"))?;
+            if let Some(expression) = extra.get("range_expression") {
+                if !allowed {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/extra_slots cannot carry range_expression when allowed is false"
+                    )));
+                }
+                let expression = expression.as_object().ok_or_else(|| {
+                    LinkmlError::new(format!(
+                        "{path}/extra_slots/range_expression must be a mapping"
+                    ))
+                })?;
+                let expression_path = format!("{path}/extra_slots/range_expression");
+                schema.insert(
+                    "additionalProperties".to_owned(),
+                    self.expression_schema(expression, &expression_path, visiting, depth + 1)?,
+                );
+                self.audit_expression_fields(expression, &expression_path)?;
+            } else {
+                schema.insert("additionalProperties".to_owned(), Value::Bool(allowed));
+            }
+            for key in extra.keys() {
+                if !matches!(key.as_str(), "allowed" | "range_expression") {
+                    self.record(
+                        "unknown-keyword-dropped",
+                        &format!("{path}/extra_slots/{}", pointer_escape(key)),
+                    );
+                }
+            }
+            self.map_location(
+                &format!(
+                    "{}/additionalProperties",
+                    definition_path(self.identity(name)?)
+                ),
+                &format!("{path}/extra_slots"),
+            );
+        }
+
+        let mut inherited = Vec::new();
+        if let Some(parent) = object.get("is_a") {
+            let parent = parent
+                .as_str()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/is_a must be a string")))?;
+            inherited.push(self.class_schema(parent, visiting, depth + 1)?);
+            self.record("schema-identity-dropped", &format!("{path}/is_a"));
+        }
+        if let Some(mixins) = object.get("mixins") {
+            let mixins = mixins
+                .as_array()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/mixins must be an array")))?;
+            for (index, mixin) in mixins.iter().enumerate() {
+                let mixin = mixin.as_str().ok_or_else(|| {
+                    LinkmlError::new(format!("{path}/mixins/{index} must be a string"))
+                })?;
+                inherited.push(self.class_schema(mixin, visiting, depth + 1)?);
+                self.record("schema-identity-dropped", &format!("{path}/mixins/{index}"));
+            }
+        }
+        self.apply_compositions(&object, &path, visiting, depth, &mut schema, true)?;
+        if !inherited.is_empty() {
+            let existing = schema
+                .remove("allOf")
+                .and_then(|value| value.as_array().cloned())
+                .unwrap_or_default();
+            inherited.extend(existing);
+            schema.insert("allOf".to_owned(), Value::Array(inherited));
+        }
+
+        self.audit_element_fields(
+            &object,
+            &path,
+            &[
+                "class_uri",
+                "alias",
+                "title",
+                "description",
+                "slots",
+                "slot_usage",
+                "attributes",
+                "extra_slots",
+                "is_a",
+                "mixins",
+                "any_of",
+                "all_of",
+                "exactly_one_of",
+                "none_of",
+            ],
+        )?;
+        self.map_expression_locations(
+            &definition_path(self.identity(name)?),
+            &path,
+            &object,
+            &Value::Object(schema.clone()),
+        );
+        visiting.remove(&format!("class:{name}"));
+        let value = Value::Object(schema);
+        self.class_cache.insert(name.to_owned(), value.clone());
+        Ok(value)
+    }
+
+    fn slot_schema(
+        &mut self,
+        slot: &Map<String, Value>,
+        path: &str,
+        visiting: &mut BTreeSet<String>,
+        depth: usize,
+    ) -> Result<(Value, bool), LinkmlError> {
+        let required = optional_bool(slot, "required", path)?.unwrap_or(false);
+        let minimum = optional_u64(slot, "minimum_cardinality", path)?;
+        let maximum = optional_u64(slot, "maximum_cardinality", path)?;
+        let multivalued = optional_bool(slot, "multivalued", path)?.unwrap_or(false);
+        let scalar = self.expression_schema(slot, path, visiting, depth)?;
+        let wrap = multivalued || minimum.is_some() || maximum.is_some();
+        let schema = if wrap {
+            let mut array = Map::from_iter([
+                ("type".to_owned(), Value::String("array".to_owned())),
+                ("items".to_owned(), scalar),
+            ]);
+            if let Some(value) = minimum {
+                array.insert("minItems".to_owned(), Value::from(value));
+            }
+            if let Some(value) = maximum {
+                array.insert("maxItems".to_owned(), Value::from(value));
+            }
+            if let Some(unique) = optional_bool(slot, "list_elements_unique", path)? {
+                array.insert("uniqueItems".to_owned(), Value::Bool(unique));
+            }
+            if optional_bool(slot, "list_elements_ordered", path)?.unwrap_or(false) {
+                self.record(
+                    "value-term-kind-widened",
+                    &format!("{path}/list_elements_ordered"),
+                );
+            }
+            Value::Object(array)
+        } else {
+            if slot.contains_key("list_elements_unique")
+                || slot.contains_key("list_elements_ordered")
+            {
+                return Err(LinkmlError::new(format!(
+                    "{path} applies list semantics to a non-multivalued slot"
+                )));
+            }
+            scalar
+        };
+        for field in ["inlined", "inlined_as_list"] {
+            if optional_bool(slot, field, path)?.is_some() {
+                self.record("value-term-kind-widened", &format!("{path}/{field}"));
+            }
+        }
+        self.audit_slot_fields(slot, path)?;
+        Ok((schema, required || minimum.is_some_and(|value| value > 0)))
+    }
+
+    fn expression_schema(
+        &mut self,
+        expression: &Map<String, Value>,
+        path: &str,
+        visiting: &mut BTreeSet<String>,
+        depth: usize,
+    ) -> Result<Value, LinkmlError> {
+        if depth > MAX_ELEMENT_DEPTH {
+            return Err(LinkmlError::new(format!(
+                "{path} exceeds LinkML expression depth {MAX_ELEMENT_DEPTH}"
+            )));
+        }
+        let mut schema = match expression.get("range") {
+            Some(range) => {
+                let range = range
+                    .as_str()
+                    .ok_or_else(|| LinkmlError::new(format!("{path}/range must be a string")))?;
+                self.range_schema(range, visiting, depth + 1, &format!("{path}/range"))?
+            }
+            None => Value::Object(Map::new()),
+        };
+        let object = schema.as_object_mut().ok_or_else(|| {
+            LinkmlError::new(format!(
+                "{path} range cannot be combined with this expression"
+            ))
+        })?;
+        self.apply_scalar_fields(expression, object, path)?;
+        self.apply_compositions(expression, path, visiting, depth, object, false)?;
+        Ok(schema)
+    }
+
+    fn range_schema(
+        &mut self,
+        range: &str,
+        visiting: &mut BTreeSet<String>,
+        depth: usize,
+        path: &str,
+    ) -> Result<Value, LinkmlError> {
+        let scalar = match range {
+            "string" | "ncname" | "nodeidentifier" | "objectidentifier" | "jsonpath"
+            | "jsonpointer" | "sparqlpath" => Some(("string", None)),
+            "boolean" => Some(("boolean", None)),
+            "integer" => Some(("integer", None)),
+            "float" | "double" | "decimal" => Some(("number", None)),
+            "datetime" => Some(("string", Some("date-time"))),
+            "date" => Some(("string", Some("date"))),
+            "time" => Some(("string", Some("time"))),
+            "uri" => Some(("string", Some("uri"))),
+            "uriorcurie" => {
+                self.record("format-validation-widened", path);
+                Some(("string", None))
+            }
+            "Any" | "any" => {
+                self.record("value-term-kind-widened", path);
+                return Ok(Value::Object(Map::new()));
+            }
+            _ => None,
+        };
+        if let Some((kind, format)) = scalar {
+            let mut schema = Map::from_iter([("type".to_owned(), Value::String(kind.to_owned()))]);
+            if let Some(format) = format {
+                schema.insert("format".to_owned(), Value::String(format.to_owned()));
+            }
+            return Ok(Value::Object(schema));
+        }
+        match self.kinds.get(range).copied() {
+            Some(ElementKind::Class) if self.ignored_class_names.contains(range) => {
+                if let Some(carrier) = self.package_carrier_schema(range)? {
+                    Ok(carrier)
+                } else {
+                    self.class_schema(range, visiting, depth)
+                }
+            }
+            Some(ElementKind::Class | ElementKind::Enum) => Ok(Value::Object(Map::from_iter([(
+                "$ref".to_owned(),
+                Value::String(format!("#/$defs/{}", pointer_escape(self.identity(range)?))),
+            )]))),
+            Some(ElementKind::Type) => self.type_schema(range, visiting, depth),
+            None => Err(LinkmlError::new(format!(
+                "{path} names unknown LinkML range {range:?}"
+            ))),
+        }
+    }
+
+    fn type_schema(
+        &mut self,
+        name: &str,
+        visiting: &mut BTreeSet<String>,
+        depth: usize,
+    ) -> Result<Value, LinkmlError> {
+        if let Some(schema) = self.type_cache.get(name) {
+            return Ok(schema.clone());
+        }
+        self.enter_element("type", name, visiting, depth)?;
+        let path = element_path("types", name);
+        let object = self
+            .types
+            .get(name)
+            .and_then(Value::as_object)
+            .ok_or_else(|| LinkmlError::new(format!("{path} must be a mapping")))?
+            .clone();
+        let base = required_string(&object, "typeof", &format!("{path}/typeof"))?;
+        let mut schema = self.range_schema(base, visiting, depth + 1, &format!("{path}/typeof"))?;
+        let schema_object = schema.as_object_mut().ok_or_else(|| {
+            LinkmlError::new(format!("{path}/typeof does not form a scalar schema"))
+        })?;
+        self.apply_scalar_fields(&object, schema_object, &path)?;
+        self.apply_compositions(&object, &path, visiting, depth, schema_object, false)?;
+        self.audit_element_fields(
+            &object,
+            &path,
+            &[
+                "uri",
+                "typeof",
+                "title",
+                "description",
+                "pattern",
+                "minimum_value",
+                "maximum_value",
+                "equals_string",
+                "equals_number",
+                "any_of",
+                "all_of",
+                "exactly_one_of",
+                "none_of",
+            ],
+        )?;
+        self.map_expression_locations(
+            &definition_path(self.identity(name)?),
+            &path,
+            &object,
+            &schema,
+        );
+        visiting.remove(&format!("type:{name}"));
+        self.type_cache.insert(name.to_owned(), schema.clone());
+        Ok(schema)
+    }
+
+    fn enum_schema(&mut self, name: &str) -> Result<Value, LinkmlError> {
+        let path = element_path("enums", name);
+        let object = self
+            .enums
+            .get(name)
+            .and_then(Value::as_object)
+            .ok_or_else(|| LinkmlError::new(format!("{path} must be a mapping")))?
+            .clone();
+        let values = object
+            .get("permissible_values")
+            .and_then(Value::as_object)
+            .ok_or_else(|| {
+                LinkmlError::new(format!("{path}/permissible_values must be a mapping"))
+            })?;
+        if values.is_empty() {
+            return Err(LinkmlError::new(format!(
+                "{path}/permissible_values cannot be empty"
+            )));
+        }
+        let mut members = Vec::new();
+        for (text, definition) in values {
+            let member_path = format!("{path}/permissible_values/{}", pointer_escape(text));
+            let member = match definition {
+                Value::Null => Value::String(text.clone()),
+                Value::String(description) => {
+                    if !description.trim().is_empty() {
+                        self.record("enum-metadata-dropped", &member_path);
+                    }
+                    Value::String(text.clone())
+                }
+                Value::Object(definition) => {
+                    let value = if let Some(meaning) = definition.get("meaning") {
+                        let meaning = meaning.as_str().ok_or_else(|| {
+                            LinkmlError::new(format!("{member_path}/meaning must be a string"))
+                        })?;
+                        Value::Object(Map::from_iter([(
+                            "@id".to_owned(),
+                            Value::String(self.expand_iri(meaning, &member_path)?),
+                        )]))
+                    } else {
+                        Value::String(text.clone())
+                    };
+                    for (key, value) in definition {
+                        if matches!(key.as_str(), "title" | "description") {
+                            if !value.is_string() {
+                                return Err(LinkmlError::new(format!(
+                                    "{member_path}/{} must be a string",
+                                    pointer_escape(key)
+                                )));
+                            }
+                            self.record(
+                                "enum-metadata-dropped",
+                                &format!("{member_path}/{}", pointer_escape(key)),
+                            );
+                        } else if key != "meaning" {
+                            self.record(
+                                "unknown-keyword-dropped",
+                                &format!("{member_path}/{}", pointer_escape(key)),
+                            );
+                        }
+                    }
+                    value
+                }
+                _ => {
+                    return Err(LinkmlError::new(format!(
+                        "{member_path} must be null, a string, or a mapping"
+                    )));
+                }
+            };
+            members.push(member);
+        }
+        for (key, value) in &object {
+            if matches!(key.as_str(), "title" | "description") {
+                if !value.is_string() {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/{} must be a string",
+                        pointer_escape(key)
+                    )));
+                }
+                self.record(
+                    "annotation-dropped",
+                    &format!("{path}/{}", pointer_escape(key)),
+                );
+            } else if !matches!(key.as_str(), "enum_uri" | "permissible_values") {
+                self.record(
+                    "unknown-keyword-dropped",
+                    &format!("{path}/{}", pointer_escape(key)),
+                );
+            }
+        }
+        Ok(Value::Object(Map::from_iter([(
+            "enum".to_owned(),
+            Value::Array(members),
+        )])))
+    }
+
+    fn apply_scalar_fields(
+        &self,
+        source: &Map<String, Value>,
+        target: &mut Map<String, Value>,
+        path: &str,
+    ) -> Result<(), LinkmlError> {
+        if let Some(pattern) = source.get("pattern") {
+            let pattern = pattern
+                .as_str()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/pattern must be a string")))?;
+            target.insert("pattern".to_owned(), Value::String(pattern.to_owned()));
+        }
+        for (native, schema) in [("minimum_value", "minimum"), ("maximum_value", "maximum")] {
+            if let Some(value) = source.get(native) {
+                if !value.is_number() {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/{native} must be a number"
+                    )));
+                }
+                target.insert(schema.to_owned(), value.clone());
+            }
+        }
+        let equality = match (source.get("equals_string"), source.get("equals_number")) {
+            (Some(_), Some(_)) => {
+                return Err(LinkmlError::new(format!(
+                    "{path} cannot declare both equals_string and equals_number"
+                )));
+            }
+            (Some(value), None) => {
+                if !value.is_string() {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/equals_string must be a string"
+                    )));
+                }
+                Some(value.clone())
+            }
+            (None, Some(value)) => {
+                if !value.is_number() {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/equals_number must be a number"
+                    )));
+                }
+                Some(value.clone())
+            }
+            (None, None) => None,
+        };
+        if let Some(equality) = equality {
+            target.insert("const".to_owned(), equality);
+        }
+        Ok(())
+    }
+
+    fn apply_compositions(
+        &mut self,
+        source: &Map<String, Value>,
+        path: &str,
+        visiting: &mut BTreeSet<String>,
+        depth: usize,
+        target: &mut Map<String, Value>,
+        class_expression: bool,
+    ) -> Result<(), LinkmlError> {
+        for (native, schema) in [
+            ("any_of", "anyOf"),
+            ("all_of", "allOf"),
+            ("exactly_one_of", "oneOf"),
+        ] {
+            let Some(branches) = source.get(native) else {
+                continue;
+            };
+            let branches = branches
+                .as_array()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/{native} must be an array")))?;
+            if branches.is_empty() {
+                return Err(LinkmlError::new(format!("{path}/{native} cannot be empty")));
+            }
+            let mut translated = Vec::new();
+            for (index, branch) in branches.iter().enumerate() {
+                let branch_path = format!("{path}/{native}/{index}");
+                let branch = branch
+                    .as_object()
+                    .ok_or_else(|| LinkmlError::new(format!("{branch_path} must be a mapping")))?;
+                translated.push(if class_expression {
+                    self.class_expression_schema(branch, &branch_path, visiting, depth + 1)?
+                } else {
+                    let translated =
+                        self.expression_schema(branch, &branch_path, visiting, depth + 1)?;
+                    self.audit_expression_fields(branch, &branch_path)?;
+                    translated
+                });
+            }
+            target.insert(schema.to_owned(), Value::Array(translated));
+        }
+        if let Some(branches) = source.get("none_of") {
+            let branches = branches
+                .as_array()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/none_of must be an array")))?;
+            if branches.is_empty() {
+                return Err(LinkmlError::new(format!("{path}/none_of cannot be empty")));
+            }
+            let mut translated = Vec::new();
+            for (index, branch) in branches.iter().enumerate() {
+                let branch_path = format!("{path}/none_of/{index}");
+                let branch = branch
+                    .as_object()
+                    .ok_or_else(|| LinkmlError::new(format!("{branch_path} must be a mapping")))?;
+                translated.push(if class_expression {
+                    self.class_expression_schema(branch, &branch_path, visiting, depth + 1)?
+                } else {
+                    let translated =
+                        self.expression_schema(branch, &branch_path, visiting, depth + 1)?;
+                    self.audit_expression_fields(branch, &branch_path)?;
+                    translated
+                });
+            }
+            let negated = if translated.len() == 1 {
+                translated.pop().expect("length checked")
+            } else {
+                Value::Object(Map::from_iter([(
+                    "anyOf".to_owned(),
+                    Value::Array(translated),
+                )]))
+            };
+            target.insert("not".to_owned(), negated);
+        }
+        Ok(())
+    }
+
+    fn class_expression_schema(
+        &mut self,
+        expression: &Map<String, Value>,
+        path: &str,
+        visiting: &mut BTreeSet<String>,
+        depth: usize,
+    ) -> Result<Value, LinkmlError> {
+        let parent = if let Some(parent) = expression.get("is_a") {
+            let parent = parent
+                .as_str()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/is_a must be a string")))?;
+            self.record("schema-identity-dropped", &format!("{path}/is_a"));
+            Some(self.class_schema(parent, visiting, depth + 1)?)
+        } else {
+            None
+        };
+        let mut own = Map::from_iter([("type".to_owned(), Value::String("object".to_owned()))]);
+        self.apply_compositions(expression, path, visiting, depth, &mut own, true)?;
+        if let Some(slot_conditions) = expression.get("slot_conditions") {
+            let slot_conditions = slot_conditions.as_object().ok_or_else(|| {
+                LinkmlError::new(format!("{path}/slot_conditions must be a mapping"))
+            })?;
+            for (slot, condition) in slot_conditions {
+                if !condition.is_object() {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/slot_conditions/{} must be a mapping",
+                        pointer_escape(slot)
+                    )));
+                }
+            }
+            self.record(
+                "schema-applicator-dropped",
+                &format!("{path}/slot_conditions"),
+            );
+        }
+        self.audit_element_fields(
+            expression,
+            path,
+            &[
+                "is_a",
+                "slot_conditions",
+                "any_of",
+                "all_of",
+                "exactly_one_of",
+                "none_of",
+            ],
+        )?;
+        let has_own_semantics = own.len() > 1;
+        if parent.is_none() && !has_own_semantics && !expression.contains_key("slot_conditions") {
+            self.record("schema-applicator-dropped", path);
+        }
+        if let Some(parent) = parent {
+            if has_own_semantics {
+                Ok(Value::Object(Map::from_iter([
+                    (
+                        "allOf".to_owned(),
+                        Value::Array(vec![parent, Value::Object(own)]),
+                    ),
+                    ("type".to_owned(), Value::String("object".to_owned())),
+                ])))
+            } else {
+                Ok(parent)
+            }
+        } else {
+            Ok(Value::Object(own))
+        }
+    }
+
+    fn slot_identity(
+        &self,
+        name: &str,
+        slot: &Map<String, Value>,
+        path: &str,
+    ) -> Result<String, LinkmlError> {
+        if name.starts_with('@') {
+            if slot.contains_key("slot_uri") {
+                return Err(LinkmlError::new(format!(
+                    "{path} reserved JSON-LD slot {name:?} cannot declare slot_uri"
+                )));
+            }
+            return Ok(name.to_owned());
+        }
+        let identity = slot
+            .get("slot_uri")
+            .map(|value| {
+                value
+                    .as_str()
+                    .ok_or_else(|| LinkmlError::new(format!("{path}/slot_uri must be a string")))
+            })
+            .transpose()?
+            .unwrap_or(name);
+        self.expand_iri(identity, path)
+    }
+
+    fn expand_iri(&self, value: &str, path: &str) -> Result<String, LinkmlError> {
+        if let Some((prefix, local)) = value.split_once(':')
+            && let Some(namespace) = self.prefixes.get(prefix)
+        {
+            if local.is_empty() {
+                return Err(LinkmlError::new(format!(
+                    "{path} CURIE {value:?} has an empty local part"
+                )));
+            }
+            return validate_absolute(&format!("{namespace}{local}"), path);
+        }
+        if purrdf_iri::parse(value).is_ok_and(|iri| iri.has_scheme()) {
+            return Ok(value.to_owned());
+        }
+        if value.is_empty() || value.contains(':') {
+            return Err(LinkmlError::new(format!(
+                "{path} identity {value:?} is neither an absolute IRI nor a declared CURIE"
+            )));
+        }
+        let namespace = self.prefixes.get(&self.default_prefix).ok_or_else(|| {
+            LinkmlError::new("LinkML default prefix is missing from the validated prefix map")
+        })?;
+        validate_absolute(&format!("{namespace}{value}"), path)
+    }
+
+    fn identity(&self, name: &str) -> Result<&str, LinkmlError> {
+        self.identities
+            .get(name)
+            .map(String::as_str)
+            .ok_or_else(|| LinkmlError::new(format!("unknown LinkML element reference {name:?}")))
+    }
+
+    fn enter_element(
+        &self,
+        kind: &str,
+        name: &str,
+        visiting: &mut BTreeSet<String>,
+        depth: usize,
+    ) -> Result<(), LinkmlError> {
+        if depth > MAX_ELEMENT_DEPTH {
+            return Err(LinkmlError::new(format!(
+                "LinkML {kind} {name:?} exceeds reference depth {MAX_ELEMENT_DEPTH}"
+            )));
+        }
+        if !visiting.insert(format!("{kind}:{name}")) {
+            return Err(LinkmlError::new(format!(
+                "cyclic LinkML {kind} reference includes {name:?}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn is_package_infrastructure(&self, name: &str) -> bool {
+        let Some(class) = self.classes.get(name).and_then(Value::as_object) else {
+            return false;
+        };
+        if name == "Node" {
+            return class
+                .get("attributes")
+                .and_then(Value::as_object)
+                .is_some_and(|attributes| {
+                    ["@id", "@type", "@annotation"]
+                        .iter()
+                        .all(|key| attributes.contains_key(*key))
+                });
+        }
+        name == "Annotation"
+            && class.get("title").and_then(Value::as_str)
+                == Some("RDF-1.2 statement metadata (reifier annotation)")
+    }
+
+    fn package_carrier_schema(&self, name: &str) -> Result<Option<Value>, LinkmlError> {
+        let Some(class) = self.classes.get(name).and_then(Value::as_object) else {
+            return Ok(None);
+        };
+        let Some(attributes) = class.get("attributes").and_then(Value::as_object) else {
+            return Ok(None);
+        };
+        if attributes.len() == 1 && attributes.contains_key("@id") {
+            let id = attributes["@id"].as_object().ok_or_else(|| {
+                LinkmlError::new(format!("#/classes/{name}/attributes/@id must be a mapping"))
+            })?;
+            if optional_bool(id, "required", "#/classes/helper/attributes/@id")? == Some(true) {
+                return Ok(Some(serde_json::json!({
+                    "type": "object",
+                    "properties": { "@id": { "type": "string" } },
+                    "required": ["@id"]
+                })));
+            }
+        }
+        if attributes.len() == 2
+            && attributes.contains_key("@value")
+            && attributes.contains_key("@type")
+        {
+            let value = attributes["@value"].as_object().ok_or_else(|| {
+                LinkmlError::new(format!(
+                    "#/classes/{name}/attributes/@value must be a mapping"
+                ))
+            })?;
+            let datatype = attributes["@type"].as_object().ok_or_else(|| {
+                LinkmlError::new(format!(
+                    "#/classes/{name}/attributes/@type must be a mapping"
+                ))
+            })?;
+            if optional_bool(value, "required", "#/classes/helper/attributes/@value")? == Some(true)
+                && datatype.get("range").and_then(Value::as_str) == Some("string")
+            {
+                return Ok(Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "@value": {},
+                        "@type": { "type": "string" }
+                    },
+                    "required": ["@value"]
+                })));
+            }
+        }
+        if attributes.len() == 2
+            && attributes.contains_key("@value")
+            && attributes.contains_key("@language")
+        {
+            let value = attributes["@value"].as_object().ok_or_else(|| {
+                LinkmlError::new(format!(
+                    "#/classes/{name}/attributes/@value must be a mapping"
+                ))
+            })?;
+            let language = attributes["@language"].as_object().ok_or_else(|| {
+                LinkmlError::new(format!(
+                    "#/classes/{name}/attributes/@language must be a mapping"
+                ))
+            })?;
+            if optional_bool(value, "required", "#/classes/helper/attributes/@value")? == Some(true)
+                && optional_bool(
+                    language,
+                    "required",
+                    "#/classes/helper/attributes/@language",
+                )? == Some(true)
+            {
+                let pattern = language
+                    .get("pattern")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        LinkmlError::new(format!(
+                            "#/classes/{name}/attributes/@language/pattern must be a string"
+                        ))
+                    })?;
+                return Ok(Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "@value": { "type": "string" },
+                        "@language": { "type": "string", "pattern": pattern }
+                    },
+                    "required": ["@value", "@language"]
+                })));
+            }
+        }
+        Ok(None)
+    }
+
+    fn audit_element_fields(
+        &mut self,
+        object: &Map<String, Value>,
+        path: &str,
+        known: &[&str],
+    ) -> Result<(), LinkmlError> {
+        for (key, value) in object {
+            if matches!(key.as_str(), "title" | "description") {
+                if !value.is_string() {
+                    return Err(LinkmlError::new(format!(
+                        "{path}/{} must be a string",
+                        pointer_escape(key)
+                    )));
+                }
+                self.record(
+                    "annotation-dropped",
+                    &format!("{path}/{}", pointer_escape(key)),
+                );
+            } else if key == "alias" {
+                if !value.is_string() {
+                    return Err(LinkmlError::new(format!("{path}/alias must be a string")));
+                }
+                self.record("schema-identity-dropped", &format!("{path}/alias"));
+            } else if !known.contains(&key.as_str()) {
+                self.record(
+                    "unknown-keyword-dropped",
+                    &format!("{path}/{}", pointer_escape(key)),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn audit_slot_fields(
+        &mut self,
+        object: &Map<String, Value>,
+        path: &str,
+    ) -> Result<(), LinkmlError> {
+        let known = [
+            "slot_uri",
+            "alias",
+            "title",
+            "description",
+            "range",
+            "required",
+            "multivalued",
+            "minimum_cardinality",
+            "maximum_cardinality",
+            "list_elements_ordered",
+            "list_elements_unique",
+            "inlined",
+            "inlined_as_list",
+            "pattern",
+            "minimum_value",
+            "maximum_value",
+            "equals_string",
+            "equals_number",
+            "any_of",
+            "all_of",
+            "exactly_one_of",
+            "none_of",
+        ];
+        self.audit_element_fields(object, path, &known)
+    }
+
+    fn audit_expression_fields(
+        &mut self,
+        object: &Map<String, Value>,
+        path: &str,
+    ) -> Result<(), LinkmlError> {
+        self.audit_element_fields(
+            object,
+            path,
+            &[
+                "range",
+                "pattern",
+                "minimum_value",
+                "maximum_value",
+                "equals_string",
+                "equals_number",
+                "any_of",
+                "all_of",
+                "exactly_one_of",
+                "none_of",
+            ],
+        )
+    }
+
+    fn map_expression_locations(
+        &mut self,
+        pivot_path: &str,
+        native_path: &str,
+        source: &Map<String, Value>,
+        translated: &Value,
+    ) {
+        let scalar_path = if translated
+            .as_object()
+            .and_then(|object| object.get("type"))
+            .and_then(Value::as_str)
+            == Some("array")
+        {
+            format!("{pivot_path}/items")
+        } else {
+            pivot_path.to_owned()
+        };
+        if source.contains_key("range") {
+            for keyword in ["type", "format", "$ref"] {
+                self.map_location(
+                    &format!("{scalar_path}/{keyword}"),
+                    &format!("{native_path}/range"),
+                );
+            }
+        }
+        for (native, schema) in [
+            ("pattern", "pattern"),
+            ("minimum_value", "minimum"),
+            ("maximum_value", "maximum"),
+            ("equals_string", "const"),
+            ("equals_number", "const"),
+            ("any_of", "anyOf"),
+            ("all_of", "allOf"),
+            ("exactly_one_of", "oneOf"),
+            ("none_of", "not"),
+        ] {
+            if source.contains_key(native) {
+                self.map_location(
+                    &format!("{scalar_path}/{schema}"),
+                    &format!("{native_path}/{native}"),
+                );
+            }
+        }
+    }
+
+    fn record(&mut self, code: &str, path: &str) {
+        if !self
+            .recorded_losses
+            .insert((code.to_owned(), path.to_owned()))
+        {
+            return;
+        }
+        let contract = self
+            .contract
+            .entries()
+            .iter()
+            .find(|entry| entry.code == code)
+            .unwrap_or_else(|| panic!("unregistered LinkML import loss code `{code}`"));
+        self.losses.record(LossEntry {
+            code: code.to_owned().into(),
+            from: SOURCE.to_owned().into(),
+            to: TARGET.to_owned().into(),
+            note: contract.note.to_string().into(),
+            location: Some(Box::new(
+                RdfLocation::logical(LOSS_CONTEXT).with_subject(path),
+            )),
+        });
+    }
+
+    fn map_location(&mut self, pivot: &str, native: &str) {
+        self.locations.insert(pivot.to_owned(), native.to_owned());
+    }
+}
+
+fn section<'a>(
+    root: &'a Map<String, Value>,
+    name: &str,
+) -> Result<&'a Map<String, Value>, LinkmlError> {
+    static EMPTY: std::sync::OnceLock<Map<String, Value>> = std::sync::OnceLock::new();
+    root.get(name)
+        .map(|value| {
+            value
+                .as_object()
+                .ok_or_else(|| LinkmlError::new(format!("#/{name} must be a mapping")))
+        })
+        .transpose()
+        .map(|value| value.unwrap_or_else(|| EMPTY.get_or_init(Map::new)))
+}
+
+fn document_prefixes(root: &Map<String, Value>) -> Result<BTreeMap<String, String>, LinkmlError> {
+    let prefixes = root
+        .get("prefixes")
+        .and_then(Value::as_object)
+        .ok_or_else(|| LinkmlError::new("#/prefixes must be a mapping"))?;
+    prefixes
+        .iter()
+        .map(|(prefix, value)| {
+            let namespace = match value {
+                Value::String(namespace) => namespace,
+                Value::Object(object) => object
+                    .get("prefix_reference")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        LinkmlError::new(format!(
+                            "#/prefixes/{} requires string prefix_reference",
+                            pointer_escape(prefix)
+                        ))
+                    })?,
+                _ => {
+                    return Err(LinkmlError::new(format!(
+                        "#/prefixes/{} must be a string or mapping",
+                        pointer_escape(prefix)
+                    )));
+                }
+            };
+            Ok((prefix.clone(), namespace.to_owned()))
+        })
+        .collect()
+}
+
+fn validate_absolute(value: &str, path: &str) -> Result<String, LinkmlError> {
+    let iri = purrdf_iri::parse(value).map_err(|error| {
+        LinkmlError::new(format!("{path} forms invalid IRI {value:?}: {error}"))
+    })?;
+    if !iri.has_scheme() {
+        return Err(LinkmlError::new(format!(
+            "{path} forms relative IRI {value:?}"
+        )));
+    }
+    Ok(value.to_owned())
+}
+
+fn required_string<'a>(
+    object: &'a Map<String, Value>,
+    key: &str,
+    path: &str,
+) -> Result<&'a str, LinkmlError> {
+    object
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| LinkmlError::new(format!("{path} must be a string")))
+}
+
+fn required_bool(object: &Map<String, Value>, key: &str, path: &str) -> Result<bool, LinkmlError> {
+    object
+        .get(key)
+        .and_then(Value::as_bool)
+        .ok_or_else(|| LinkmlError::new(format!("{path} must be a boolean")))
+}
+
+fn optional_bool(
+    object: &Map<String, Value>,
+    key: &str,
+    path: &str,
+) -> Result<Option<bool>, LinkmlError> {
+    object
+        .get(key)
+        .map(|value| {
+            value
+                .as_bool()
+                .ok_or_else(|| LinkmlError::new(format!("{path}/{key} must be a boolean")))
+        })
+        .transpose()
+}
+
+fn optional_u64(
+    object: &Map<String, Value>,
+    key: &str,
+    path: &str,
+) -> Result<Option<u64>, LinkmlError> {
+    object
+        .get(key)
+        .map(|value| {
+            value.as_u64().ok_or_else(|| {
+                LinkmlError::new(format!("{path}/{key} must be a non-negative integer"))
+            })
+        })
+        .transpose()
+}
+
+fn element_path(section: &str, name: &str) -> String {
+    format!("#/{section}/{}", pointer_escape(name))
+}
+
+fn definition_path(key: &str) -> String {
+    format!("#/$defs/{}", pointer_escape(key))
+}
+
+fn pointer_escape(value: &str) -> String {
+    value.replace('~', "~0").replace('/', "~1")
+}
+
+fn remap_location(subject: &str, mappings: &BTreeMap<String, String>) -> String {
+    mappings
+        .iter()
+        .filter(|(pivot, _)| {
+            subject == pivot.as_str()
+                || subject
+                    .strip_prefix(pivot.as_str())
+                    .is_some_and(|suffix| suffix.starts_with('/'))
+        })
+        .max_by_key(|(pivot, _)| pivot.len())
+        .map_or_else(
+            || subject.to_owned(),
+            |(pivot, native)| format!("{native}{}", &subject[pivot.len()..]),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::json_schema::{CompiledSchema, Namespaces};
+    use crate::linkml::{LinkmlConfig, emit_linkml};
+    use crate::schema_import::SchemaDatatypeMap;
+    use crate::shapes::{Constraint, Path};
+    use serde_json::json;
+
+    const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+
+    fn config() -> SchemaImportConfig {
+        let namespaces = Namespaces::new(
+            "ex",
+            &[("ex".to_owned(), "https://example.org/".to_owned())],
+        )
+        .expect("namespaces");
+        let datatypes = SchemaDatatypeMap::new(
+            format!("{XSD}string"),
+            format!("{XSD}boolean"),
+            format!("{XSD}integer"),
+            format!("{XSD}decimal"),
+            format!("{XSD}dateTime"),
+            format!("{XSD}date"),
+            format!("{XSD}time"),
+            format!("{XSD}anyURI"),
+        )
+        .expect("datatypes");
+        SchemaImportConfig::new(namespaces, datatypes)
+    }
+
+    fn linkml_config() -> LinkmlConfig {
+        LinkmlConfig::new(
+            "https://example.org/schema/linkml",
+            "Example-Schema",
+            "Caller document.",
+            "ex",
+            BTreeMap::from([
+                ("ex".to_owned(), "https://example.org/".to_owned()),
+                ("linkml".to_owned(), "https://w3id.org/linkml/".to_owned()),
+            ]),
+        )
+        .expect("LinkML config")
+    }
+
+    fn native_document() -> LinkmlDocument {
+        LinkmlDocument::from_value(json!({
+            "id": "https://example.org/schema/linkml",
+            "name": "Example-Schema",
+            "description": "Native source.",
+            "metamodel_version": "1.11.0",
+            "prefixes": {
+                "ex": "https://example.org/",
+                "linkml": "https://w3id.org/linkml/"
+            },
+            "default_prefix": "ex",
+            "imports": ["linkml:types"],
+            "types": {
+                "PositiveInteger": {
+                    "uri": "ex:PositiveInteger",
+                    "typeof": "integer",
+                    "minimum_value": 0
+                }
+            },
+            "enums": {
+                "Color": {
+                    "enum_uri": "ex:Color",
+                    "permissible_values": {
+                        "red": { "meaning": "ex:red", "title": "Red" },
+                        "plain": {}
+                    }
+                }
+            },
+            "slots": {
+                "name": {
+                    "slot_uri": "ex:name",
+                    "range": "string",
+                    "required": true,
+                    "pattern": "^[A-Z]"
+                }
+            },
+            "classes": {
+                "Address": {
+                    "class_uri": "ex:Address",
+                    "attributes": {
+                        "city": {
+                            "slot_uri": "ex:city",
+                            "range": "string",
+                            "required": true
+                        }
+                    },
+                    "extra_slots": { "allowed": false }
+                },
+                "Person": {
+                    "class_uri": "ex:Person",
+                    "slots": ["name"],
+                    "attributes": {
+                        "age": {
+                            "slot_uri": "ex:age",
+                            "range": "PositiveInteger",
+                            "required": true
+                        },
+                        "color": {
+                            "slot_uri": "ex:color",
+                            "range": "Color"
+                        },
+                        "friend": {
+                            "slot_uri": "ex:friend",
+                            "range": "Person",
+                            "inlined": true
+                        },
+                        "tags": {
+                            "slot_uri": "ex:tags",
+                            "range": "string",
+                            "multivalued": true,
+                            "minimum_cardinality": 2,
+                            "maximum_cardinality": 4,
+                            "list_elements_unique": true
+                        }
+                    },
+                    "extra_slots": { "allowed": false }
+                }
+            }
+        }))
+        .expect("native LinkML")
+    }
+
+    fn compile_turtle(body: &str) -> CompiledSchema {
+        let source = format!(
+            r"
+            @prefix ex:  <https://example.org/> .
+            @prefix sh:  <http://www.w3.org/ns/shacl#> .
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            {body}
+            "
+        );
+        let dataset = crate::text_ingest::parse_turtle_to_dataset(&source).expect("parse");
+        let shapes = crate::shapes::from_dataset(&dataset).expect("shapes");
+        crate::json_schema::compile(&shapes, config().namespaces())
+    }
+
+    #[test]
+    fn native_classes_slots_types_and_enums_import_deterministically() {
+        let document = native_document();
+        let imported = import_document(&document, &config(), None).expect("import");
+        assert_eq!(imported.shapes.node_shapes.len(), 2);
+        let person = imported
+            .shapes
+            .node_shapes
+            .iter()
+            .find(|shape| shape.id.to_string().contains("Person"))
+            .expect("Person shape");
+        let tags = person
+            .property_shapes
+            .iter()
+            .find(|property| {
+                matches!(&property.path, Path::Predicate(predicate) if predicate.as_str() == "https://example.org/tags")
+            })
+            .expect("tags");
+        assert!(
+            tags.constraints
+                .iter()
+                .any(|constraint| matches!(constraint, Constraint::MinCount(2)))
+        );
+        assert!(
+            tags.constraints
+                .iter()
+                .any(|constraint| matches!(constraint, Constraint::MaxCount(4)))
+        );
+        let observed = imported
+            .losses
+            .entries()
+            .iter()
+            .filter_map(|entry| {
+                Some((
+                    entry.code.as_ref(),
+                    entry.location.as_ref()?.subject.as_deref()?,
+                ))
+            })
+            .collect::<BTreeSet<_>>();
+        assert!(observed.contains(&(
+            "unique-items-validation-dropped",
+            "#/classes/Person/attributes/tags/list_elements_unique"
+        )));
+        assert!(observed.contains(&(
+            "enum-metadata-dropped",
+            "#/enums/Color/permissible_values/red/title"
+        )));
+        check_ledger_sound(&imported.losses, SOURCE, TARGET).expect("sound ledger");
+
+        let repeated = import_document(&document, &config(), None).expect("repeat import");
+        assert_eq!(imported.losses.render_json(), repeated.losses.render_json());
+        let first = crate::json_schema::compile(&imported.shapes, config().namespaces());
+        let second = crate::json_schema::compile(&repeated.shapes, config().namespaces());
+        assert_eq!(first.schema_json, second.schema_json);
+
+        let yaml = write_linkml(&document).expect("canonical YAML");
+        let reparsed = parse_linkml(&yaml).expect("parse canonical YAML");
+        let from_yaml = import_document(&reparsed, &config(), None).expect("import YAML");
+        assert_eq!(
+            imported.losses.render_json(),
+            from_yaml.losses.render_json()
+        );
+        let yaml_compiled = crate::json_schema::compile(&from_yaml.shapes, config().namespaces());
+        assert_eq!(first.schema_json, yaml_compiled.schema_json);
+    }
+
+    #[test]
+    fn emitted_package_verifies_artifacts_and_imports_without_helpers() {
+        let compiled = compile_turtle(
+            r#"
+            ex:AddressShape a sh:NodeShape ;
+                sh:targetClass ex:Address ;
+                sh:closed true ;
+                sh:property [
+                    sh:path ex:city ;
+                    sh:datatype xsd:string ;
+                    sh:minCount 1 ;
+                    sh:maxCount 1 ;
+                    sh:pattern "^[A-Z]"
+                ] .
+
+            ex:PersonShape a sh:NodeShape ;
+                sh:targetClass ex:Person ;
+                sh:closed true ;
+                sh:property [
+                    sh:path ex:name ;
+                    sh:datatype xsd:string ;
+                    sh:minCount 1 ;
+                    sh:maxCount 1 ;
+                    sh:pattern "^[A-Z]"
+                ] ;
+                sh:property [
+                    sh:path ex:address ;
+                    sh:class ex:Address ;
+                    sh:maxCount 1
+                ] ;
+                sh:property [
+                    sh:path ex:age ;
+                    sh:datatype xsd:integer ;
+                    sh:maxCount 1 ;
+                    sh:minInclusive 0 ;
+                    sh:maxInclusive 130
+                ] ;
+                sh:property [
+                    sh:path ex:tags ;
+                    sh:datatype xsd:string ;
+                    sh:minCount 2 ;
+                    sh:maxCount 4
+                ] ;
+                sh:property [
+                    sh:path ex:state ;
+                    sh:maxCount 1 ;
+                    sh:in ( ex:active "inactive" )
+                ] .
+            "#,
+        );
+        let package = emit_linkml(&compiled, &linkml_config()).expect("emit LinkML");
+        let imported = import_package(&package, &config()).expect("import package");
+        assert_eq!(imported.shapes.node_shapes.len(), 2);
+        assert!(
+            imported
+                .shapes
+                .node_shapes
+                .iter()
+                .any(|shape| shape.id.to_string().contains("Person"))
+        );
+        let recompiled = crate::json_schema::compile(&imported.shapes, config().namespaces());
+        assert_eq!(recompiled.schema_json, compiled.schema_json);
+
+        let mut bad_yaml = package.clone();
+        bad_yaml.yaml.push_str("# drift\n");
+        assert!(import_package(&bad_yaml, &config()).is_err());
+
+        let mut bad_map = package;
+        *bad_map
+            .element_names
+            .values_mut()
+            .next()
+            .expect("element map") = "MissingElement".to_owned();
+        assert!(import_package(&bad_map, &config()).is_err());
+    }
+
+    #[test]
+    fn accepted_native_omissions_are_located_and_malformed_fields_fail_closed() {
+        let mut value = native_document().into_value();
+        value["prefixes"]["ex"] = json!({
+            "prefix_prefix": "ex",
+            "prefix_reference": "https://example.org/",
+            "x-prefix-extension": true
+        });
+        value["classes"]["Child"] = json!({
+            "class_uri": "ex:Child",
+            "is_a": "Person",
+            "slot_usage": {
+                "name": { "required": false }
+            },
+            "extra_slots": {
+                "allowed": true,
+                "range_expression": {
+                    "range": "string",
+                    "x-range-extension": true
+                },
+                "x-extra-extension": true
+            },
+            "any_of": [{
+                "slot_conditions": {
+                    "name": { "required": true }
+                },
+                "x-branch-extension": true
+            }]
+        });
+        let document = LinkmlDocument::from_value(value).expect("extended native document");
+        let imported = import_document(&document, &config(), None).expect("ledgered import");
+        assert_eq!(imported.shapes.node_shapes.len(), 3);
+        let observed = imported
+            .losses
+            .entries()
+            .iter()
+            .filter_map(|entry| {
+                Some((
+                    entry.code.as_ref(),
+                    entry.location.as_ref()?.subject.as_deref()?,
+                ))
+            })
+            .collect::<BTreeSet<_>>();
+        for expected in [
+            (
+                "unknown-keyword-dropped",
+                "#/prefixes/ex/x-prefix-extension",
+            ),
+            (
+                "schema-applicator-dropped",
+                "#/classes/Child/slot_usage/name",
+            ),
+            (
+                "schema-applicator-dropped",
+                "#/classes/Child/any_of/0/slot_conditions",
+            ),
+            (
+                "unknown-keyword-dropped",
+                "#/classes/Child/any_of/0/x-branch-extension",
+            ),
+            (
+                "unknown-keyword-dropped",
+                "#/classes/Child/extra_slots/range_expression/x-range-extension",
+            ),
+            (
+                "unknown-keyword-dropped",
+                "#/classes/Child/extra_slots/x-extra-extension",
+            ),
+        ] {
+            assert!(observed.contains(&expected), "missing {expected:?}");
+        }
+        check_ledger_sound(&imported.losses, SOURCE, TARGET).expect("sound ledger");
+
+        let mut value = native_document().into_value();
+        value["classes"]["Person"]["attributes"]["tags"]["inlined"] = json!("yes");
+        let document = LinkmlDocument::from_value(value).expect("valid envelope");
+        assert!(
+            import_document(&document, &config(), None)
+                .expect_err("malformed inlined flag")
+                .to_string()
+                .contains("must be a boolean")
+        );
+
+        let mut value = native_document().into_value();
+        value["enums"]["Color"]["permissible_values"]["red"]["title"] = json!(7);
+        let document = LinkmlDocument::from_value(value).expect("valid envelope");
+        assert!(
+            import_document(&document, &config(), None)
+                .expect_err("malformed enum title")
+                .to_string()
+                .contains("must be a string")
+        );
+    }
+
+    #[test]
+    fn malformed_native_references_and_identity_collisions_fail_closed() {
+        let mut value = native_document().into_value();
+        value["classes"]["Person"]["attributes"]["friend"]["range"] =
+            Value::String("Missing".to_owned());
+        let document = LinkmlDocument::from_value(value).expect("envelope remains valid");
+        assert!(
+            import_document(&document, &config(), None)
+                .expect_err("missing range")
+                .to_string()
+                .contains("unknown LinkML range")
+        );
+
+        let mut value = native_document().into_value();
+        value["classes"]["Address"]["class_uri"] = Value::String("ex:Person".to_owned());
+        let document = LinkmlDocument::from_value(value).expect("envelope remains valid");
+        assert!(
+            import_document(&document, &config(), None)
+                .expect_err("identity collision")
+                .to_string()
+                .contains("same IRI")
+        );
+    }
+}

--- a/crates/shapes/src/linkml/importer.rs
+++ b/crates/shapes/src/linkml/importer.rs
@@ -9,7 +9,10 @@ use ::purrdf::RdfLocation;
 use ::purrdf::loss::{LossEntry, LossLedger, check_ledger_sound, schema_to_shacl_loss_ledger};
 use serde_json::{Map, Value};
 
-use super::{LinkmlDocument, LinkmlError, LinkmlPackage, parse_linkml, projection, write_linkml};
+use super::{
+    LinkmlDocument, LinkmlError, LinkmlPackage, parse_linkml, pointer_escape, projection,
+    write_linkml,
+};
 use crate::schema_import::{ImportedShapes, SchemaImportConfig, import_schema_value_from};
 use crate::term::Term;
 
@@ -266,21 +269,27 @@ impl NativeImporter {
         });
         self.ignored_class_names.clone_from(&ignored_class_names);
 
-        for (name, _) in self.enums.clone() {
+        let enum_names = self.enums.keys().cloned().collect::<Vec<_>>();
+        for name in enum_names {
             let identity = self.identity(&name)?.to_owned();
             let schema = self.enum_schema(&name)?;
             self.map_location(&definition_path(&identity), &element_path("enums", &name));
             definitions.insert(identity, schema);
         }
-        for (name, _) in self.types.clone() {
+        let mut visiting = BTreeSet::new();
+        let type_names = self.types.keys().cloned().collect::<Vec<_>>();
+        for name in type_names {
+            visiting.clear();
             let identity = self.identity(&name)?.to_owned();
-            let schema = self.type_schema(&name, &mut BTreeSet::new(), 0)?;
+            let schema = self.type_schema(&name, &mut visiting, 0)?;
             self.map_location(&definition_path(&identity), &element_path("types", &name));
             definitions.insert(identity, schema);
         }
-        for (name, _) in self.classes.clone() {
+        let class_names = self.classes.keys().cloned().collect::<Vec<_>>();
+        for name in class_names {
+            visiting.clear();
             let identity = self.identity(&name)?.to_owned();
-            let schema = self.class_schema(&name, &mut BTreeSet::new(), 0)?;
+            let schema = self.class_schema(&name, &mut visiting, 0)?;
             if ignored_class_names.contains(&name) {
                 continue;
             }
@@ -288,7 +297,8 @@ impl NativeImporter {
             definitions.insert(identity, schema);
         }
 
-        for (name, _) in self.slots.clone() {
+        let slot_names = self.slots.keys().cloned().collect::<Vec<_>>();
+        for name in slot_names {
             if !self.used_slots.contains(&name) {
                 self.record(
                     "non-object-definition-dropped",
@@ -1606,10 +1616,6 @@ fn element_path(section: &str, name: &str) -> String {
 
 fn definition_path(key: &str) -> String {
     format!("#/$defs/{}", pointer_escape(key))
-}
-
-fn pointer_escape(value: &str) -> String {
-    value.replace('~', "~0").replace('/', "~1")
 }
 
 fn remap_location(subject: &str, mappings: &BTreeMap<String, String>) -> String {

--- a/crates/shapes/src/linkml/projection.rs
+++ b/crates/shapes/src/linkml/projection.rs
@@ -44,7 +44,7 @@ pub(super) fn emit(
         .map_err(|error| LinkmlError::new(error.to_string()))?;
     let definitions = catalog.definitions();
     let elements = element_infos(definitions)?;
-    let element_names = elements
+    let element_names: BTreeMap<String, String> = elements
         .iter()
         .map(|(key, info)| (key.clone(), info.name.clone()))
         .collect();
@@ -110,7 +110,9 @@ pub(super) fn emit(
     let yaml = write_linkml(&document)?;
     Ok(LinkmlPackage {
         document,
+        canonical_yaml: yaml.clone(),
         yaml,
+        canonical_element_names: element_names.clone(),
         element_names,
         losses: renderer.ledger,
     })
@@ -235,7 +237,7 @@ fn is_alias_only(object: &Map<String, Value>) -> bool {
             .all(|key| key == "$ref" || is_annotation_keyword(key))
 }
 
-fn element_name(raw: &str) -> String {
+pub(super) fn element_name(raw: &str) -> String {
     let mut output = String::new();
     let mut capitalize = true;
     for character in raw.chars() {

--- a/crates/shapes/src/pydantic.rs
+++ b/crates/shapes/src/pydantic.rs
@@ -17,10 +17,12 @@
 //! Pydantic runtime-annotation equivalent remain on that schema surface and are
 //! also recorded, at their JSON-pointer location, on [`PydanticPackage::losses`].
 //!
-//! This is a code generator, so a source-language reader is not meaningful.
-//! Pydantic itself supplies the executable reverse surface through
-//! `model_json_schema()`; the dev-only oracle exercises that surface against the
-//! source [`CompiledSchema`].
+//! Arbitrary Python source has no unique JSON Schema acceptance relation, so it
+//! is not treated as an inverse format. A [`PydanticPackage`] emitted by PurRDF
+//! retains and verifies its exact source schema, artifact set, and reversible
+//! model map; [`import_pydantic_package`] is the deterministic reverse surface.
+//! Pydantic's live `model_json_schema()` remains an independent oracle for the
+//! generated runtime models.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
@@ -35,10 +37,14 @@ use crate::schema_catalog::{
     CompiledSchemaCatalog, definition_path, pointer_escape, reference_key, schema_array_keywords,
     schema_map_keywords, schema_single_keywords,
 };
+use crate::schema_import::{ImportedShapes, SchemaImportConfig, import_json_schema_from};
 
 const MODELS_MODULE: &str = "models";
 const BASE_MODULE: &str = "_base";
 const BASE_CLASS: &str = "PurrdfBaseModel";
+
+/// Fixed generated-package dialect and reverse-loss source identifier.
+pub const PYDANTIC_DIALECT: &str = "pydantic-v2";
 
 /// Caller-owned configuration for a generated Pydantic package.
 ///
@@ -120,6 +126,8 @@ impl PydanticConfig {
 /// Deterministic generated Pydantic package and its runtime-projection losses.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PydanticPackage {
+    /// Fixed generated-package dialect.
+    pub dialect: String,
     /// Relative package paths → exact file bytes, sorted by path.
     pub artifacts: BTreeMap<String, Vec<u8>>,
     /// Source `$defs` key → importable generated model path, sorted by key.
@@ -127,6 +135,17 @@ pub struct PydanticPackage {
     /// JSON Schema assertions preserved on `model_json_schema()` but not exactly
     /// enforced by Pydantic runtime annotations.
     pub losses: LossLedger,
+    source_schema_json: String,
+    config: PydanticConfig,
+}
+
+impl PydanticPackage {
+    /// Exact immutable source JSON Schema bytes retained for verified reverse
+    /// import.
+    #[must_use]
+    pub fn source_schema_json(&self) -> &str {
+        &self.source_schema_json
+    }
 }
 
 /// A malformed emitter configuration or input schema.
@@ -227,10 +246,63 @@ pub fn emit_pydantic(
     artifacts.insert(format!("{package_path}/py.typed"), Vec::new());
 
     Ok(PydanticPackage {
+        dialect: PYDANTIC_DIALECT.to_owned(),
         artifacts,
         model_paths,
         losses: renderer.ledger,
+        source_schema_json: compiled.schema_json.clone(),
+        config: config.clone(),
     })
+}
+
+/// Import a deterministic PurRDF-emitted Pydantic v2 package as SHACL shapes.
+///
+/// Arbitrary Python source is intentionally outside this API: Python classes
+/// and validators do not define one reversible JSON Schema acceptance
+/// relation. This function verifies the fixed package dialect, exact retained
+/// source schema, complete artifact bytes, model map, and forward loss ledger
+/// before using the shared schema importer.
+///
+/// # Errors
+///
+/// Returns [`PydanticError`] when any package field has drifted from a fresh
+/// deterministic emission or when the retained source schema cannot be
+/// imported with the caller's [`SchemaImportConfig`].
+pub fn import_pydantic_package(
+    package: &PydanticPackage,
+    config: &SchemaImportConfig,
+) -> Result<ImportedShapes, PydanticError> {
+    if package.dialect != PYDANTIC_DIALECT {
+        return Err(PydanticError::new(format!(
+            "Pydantic package dialect must be {PYDANTIC_DIALECT:?}, got {:?}",
+            package.dialect
+        )));
+    }
+    {
+        let retained = CompiledSchema {
+            schema_json: package.source_schema_json.clone(),
+            openapi_json: "{}\n".to_owned(),
+            losses: LossLedger::new(),
+        };
+        let expected = emit_pydantic(&retained, &package.config)?;
+        if package.artifacts != expected.artifacts {
+            return Err(PydanticError::new(
+                "Pydantic package artifacts differ from deterministic re-emission",
+            ));
+        }
+        if package.model_paths != expected.model_paths {
+            return Err(PydanticError::new(
+                "Pydantic package model map differs from deterministic re-emission",
+            ));
+        }
+        if package.losses.render_json() != expected.losses.render_json() {
+            return Err(PydanticError::new(
+                "Pydantic package forward loss ledger differs from deterministic re-emission",
+            ));
+        }
+    }
+    import_json_schema_from(PYDANTIC_DIALECT, &package.source_schema_json, config)
+        .map_err(|error| PydanticError::new(format!("Pydantic package import: {error}")))
 }
 
 fn definition_names(defs: &Map<String, Value>) -> Result<BTreeMap<String, String>, PydanticError> {
@@ -895,7 +967,7 @@ impl<'a> Renderer<'a> {
         self.ledger.record(LossEntry {
             code: code.to_owned().into(),
             from: "json-schema".into(),
-            to: "pydantic-v2".into(),
+            to: PYDANTIC_DIALECT.into(),
             note: note.to_owned().into(),
             location: Some(Box::new(
                 RdfLocation::logical("pydantic-emitter").with_subject(path),
@@ -1557,8 +1629,12 @@ fn reserved_type_names() -> BTreeSet<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::json_schema::Namespaces;
+    use crate::schema_import::SchemaDatatypeMap;
     use ::purrdf::loss::check_ledger_sound;
     use serde_json::json;
+
+    const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
 
     fn compiled(schema: &Value) -> CompiledSchema {
         CompiledSchema {
@@ -1578,6 +1654,40 @@ mod tests {
             "Caller model documentation.",
         )
         .expect("valid config")
+    }
+
+    fn import_config() -> SchemaImportConfig {
+        let namespaces = Namespaces::new(
+            "ex",
+            &[("ex".to_owned(), "https://example.org/".to_owned())],
+        )
+        .expect("namespaces");
+        let datatypes = SchemaDatatypeMap::new(
+            format!("{XSD}string"),
+            format!("{XSD}boolean"),
+            format!("{XSD}integer"),
+            format!("{XSD}decimal"),
+            format!("{XSD}dateTime"),
+            format!("{XSD}date"),
+            format!("{XSD}time"),
+            format!("{XSD}anyURI"),
+        )
+        .expect("datatypes");
+        SchemaImportConfig::new(namespaces, datatypes)
+    }
+
+    fn compile_turtle(body: &str) -> CompiledSchema {
+        let source = format!(
+            r"
+            @prefix ex:  <https://example.org/> .
+            @prefix sh:  <http://www.w3.org/ns/shacl#> .
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            {body}
+            "
+        );
+        let dataset = crate::text_ingest::parse_turtle_to_dataset(&source).expect("parse");
+        let shapes = crate::shapes::from_dataset(&dataset).expect("shapes");
+        crate::json_schema::compile(&shapes, import_config().namespaces())
     }
 
     fn lossless_schema() -> Value {
@@ -1668,6 +1778,155 @@ mod tests {
     }
 
     #[test]
+    fn emitted_package_imports_byte_exactly_and_corruption_fails_closed() {
+        let compiled = compile_turtle(
+            r#"
+            ex:PersonShape a sh:NodeShape ;
+                sh:targetClass ex:Person ;
+                sh:closed true ;
+                sh:property [
+                    sh:path ex:name ;
+                    sh:datatype xsd:string ;
+                    sh:minCount 1 ;
+                    sh:maxCount 1 ;
+                    sh:pattern "^[A-Z]"
+                ] ;
+                sh:property [
+                    sh:path ex:friend ;
+                    sh:class ex:Person ;
+                    sh:maxCount 1
+                ] ;
+                sh:property [
+                    sh:path ex:state ;
+                    sh:maxCount 1 ;
+                    sh:in ( ex:active "inactive" )
+                ] .
+            "#,
+        );
+        let package = emit_pydantic(&compiled, &config()).expect("emit");
+        assert_eq!(package.source_schema_json(), compiled.schema_json);
+        let imported = import_pydantic_package(&package, &import_config()).expect("import");
+        assert!(
+            imported.losses.is_empty(),
+            "{}",
+            imported.losses.render_json()
+        );
+        let recompiled =
+            crate::json_schema::compile(&imported.shapes, import_config().namespaces());
+        assert_eq!(recompiled.schema_json, compiled.schema_json);
+
+        let repeated = import_pydantic_package(&package, &import_config()).expect("repeat");
+        let repeated = crate::json_schema::compile(&repeated.shapes, import_config().namespaces());
+        assert_eq!(repeated.schema_json, recompiled.schema_json);
+
+        let mut bad = package.clone();
+        bad.dialect = "pydantic-v3".to_owned();
+        assert!(import_pydantic_package(&bad, &import_config()).is_err());
+
+        let mut bad = package.clone();
+        bad.artifacts
+            .values_mut()
+            .next()
+            .expect("artifact")
+            .extend_from_slice(b"# drift\n");
+        assert!(import_pydantic_package(&bad, &import_config()).is_err());
+
+        let mut bad = package;
+        *bad.model_paths.values_mut().next().expect("model path") =
+            "oracle_models.models.Missing".to_owned();
+        assert!(import_pydantic_package(&bad, &import_config()).is_err());
+    }
+
+    #[test]
+    fn verified_package_imports_recursive_nullable_and_finite_schema() {
+        let schema = json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "Choice": { "enum": ["ex:open", "ex:closed"] },
+                "Person": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ex:choice": { "$ref": "#/$defs/Choice" },
+                        "ex:friend": { "$ref": "#/$defs/Person" },
+                        "ex:maybe": { "type": ["string", "null"] }
+                    }
+                }
+            }
+        });
+        let package = emit_pydantic(&compiled(&schema), &config()).expect("emit");
+        let imported = import_pydantic_package(&package, &import_config()).expect("import");
+        check_ledger_sound(&imported.losses, PYDANTIC_DIALECT, "shacl")
+            .expect("sound reverse ledger");
+        assert_eq!(imported.shapes.node_shapes.len(), 1);
+        assert!(imported.losses.entries().iter().all(|entry| {
+            entry
+                .location
+                .as_ref()
+                .and_then(|location| location.subject.as_deref())
+                .is_some_and(|subject| subject.starts_with("#/"))
+        }));
+    }
+
+    #[test]
+    fn generated_packages_propagate_shared_import_resource_limits() {
+        let schema = json!({
+            "$defs": {
+                "ResourceHolder": {
+                    "type": "object",
+                    "x-resource-probe": vec![Value::Null; 1_000_000]
+                }
+            }
+        });
+        let compiled = CompiledSchema {
+            schema_json: serde_json::to_string(&schema).expect("compact resource fixture"),
+            openapi_json: "{}\n".to_owned(),
+            losses: LossLedger::new(),
+        };
+
+        let package = emit_pydantic(&compiled, &config()).expect("Pydantic emits annotation");
+        assert!(
+            import_pydantic_package(&package, &import_config())
+                .expect_err("Pydantic shared node limit")
+                .to_string()
+                .contains("node limit")
+        );
+        drop(package);
+
+        let typescript_config = crate::typescript::TypeScriptConfig::new(
+            "@example/resource-probe",
+            "Caller package.",
+            "Caller module.",
+        )
+        .expect("TypeScript config");
+        let package = crate::typescript::emit_typescript(&compiled, &typescript_config)
+            .expect("TypeScript emits annotation");
+        assert!(
+            crate::typescript::import_typescript_package(&package, &import_config())
+                .expect_err("TypeScript shared node limit")
+                .to_string()
+                .contains("node limit")
+        );
+        drop(package);
+
+        let graphql_config = crate::graphql::GraphqlConfig::new(
+            "ResourceProbe",
+            "Caller package.",
+            "Caller module.",
+            "JsonCarrier",
+        )
+        .expect("GraphQL config");
+        let package = crate::graphql::emit_graphql(&compiled, &graphql_config)
+            .expect("GraphQL emits annotation");
+        assert!(
+            crate::graphql::import_graphql_package(&package, &import_config())
+                .expect_err("GraphQL shared node limit")
+                .to_string()
+                .contains("node limit")
+        );
+    }
+
+    #[test]
     fn caller_docstrings_are_the_only_module_prose() {
         let out = emit_pydantic(&compiled(&lossless_schema()), &config()).expect("emit");
         let init = std::str::from_utf8(&out.artifacts["example_models/__init__.py"]).unwrap();
@@ -1749,7 +2008,7 @@ mod tests {
         ";
         let dataset = crate::text_ingest::parse_turtle_to_dataset(turtle).expect("parse SHACL");
         let shapes = crate::shapes::from_dataset(&dataset).expect("type SHACL");
-        let namespaces = crate::json_schema::Namespaces::new(
+        let namespaces = Namespaces::new(
             "ex",
             &[("ex".to_owned(), "https://example.org/".to_owned())],
         )

--- a/crates/shapes/src/schema_import.rs
+++ b/crates/shapes/src/schema_import.rs
@@ -1,0 +1,2678 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Deterministic schema-language → SHACL interpretation.
+//!
+//! JSON Schema draft 2020-12 is the shared semantic pivot. Native LinkML and
+//! the fixed generated-package adapters normalize into this boundary, so CURIE
+//! expansion, constraint lowering, loss accounting, and resource limits cannot
+//! drift between five readers. Accepted omissions are always recorded on a
+//! closed source-language → `shacl` loss profile.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
+use std::sync::{Arc, OnceLock};
+
+use ::purrdf::RdfLocation;
+use ::purrdf::loss::{LossEntry, LossLedger, check_ledger_sound, schema_to_shacl_loss_ledger};
+use serde_json::{Map, Number, Value};
+
+use crate::json_schema::{CompiledSchema, Namespaces};
+use crate::report::Severity;
+use crate::shapes::{Constraint, NodeKindValue, Path, PropertyShape, Shape, Shapes, Target};
+use crate::term::{Literal, NamedNode, Term};
+
+const JSON_SCHEMA_DIALECT: &str = "https://json-schema.org/draft/2020-12/schema";
+const JSON_SCHEMA_SOURCE: &str = "json-schema";
+const MAX_SCHEMA_BYTES: usize = 16 * 1024 * 1024;
+const MAX_DEFINITIONS: usize = 65_536;
+const MAX_PROPERTIES: usize = 65_536;
+const MAX_SCHEMA_DEPTH: usize = 128;
+const MAX_SCHEMA_NODES: usize = 1_000_000;
+const MAX_STRING_BYTES: usize = 16 * 1024 * 1024;
+
+/// Caller-owned RDF datatypes used when a scalar schema has no original RDF
+/// literal attached to it.
+///
+/// There is intentionally no [`Default`] implementation. PurRDF does not guess
+/// which RDF datatype vocabulary a caller wants for JSON strings, numbers, or
+/// temporal formats.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaDatatypeMap {
+    string: String,
+    boolean: String,
+    integer: String,
+    number: String,
+    date_time: String,
+    date: String,
+    time: String,
+    uri: String,
+}
+
+impl SchemaDatatypeMap {
+    /// Validate and construct the complete scalar → RDF datatype mapping.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchemaImportError`] when any supplied value is not an absolute
+    /// IRI. Empty or relative datatype names never receive a built-in fallback.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "the eight mandatory scalar roles make missing vocabulary configuration unrepresentable"
+    )]
+    pub fn new(
+        string: impl Into<String>,
+        boolean: impl Into<String>,
+        integer: impl Into<String>,
+        number: impl Into<String>,
+        date_time: impl Into<String>,
+        date: impl Into<String>,
+        time: impl Into<String>,
+        uri: impl Into<String>,
+    ) -> Result<Self, SchemaImportError> {
+        let values = [
+            ("string", string.into()),
+            ("boolean", boolean.into()),
+            ("integer", integer.into()),
+            ("number", number.into()),
+            ("date-time", date_time.into()),
+            ("date", date.into()),
+            ("time", time.into()),
+            ("uri", uri.into()),
+        ];
+        for (label, value) in &values {
+            validate_absolute_iri(&format!("{label} datatype"), value)?;
+        }
+        let [
+            (_, string),
+            (_, boolean),
+            (_, integer),
+            (_, number),
+            (_, date_time),
+            (_, date),
+            (_, time),
+            (_, uri),
+        ] = values;
+        Ok(Self {
+            string,
+            boolean,
+            integer,
+            number,
+            date_time,
+            date,
+            time,
+            uri,
+        })
+    }
+
+    fn for_scalar(&self, kind: &str, format: Option<&str>) -> Option<&str> {
+        match (kind, format) {
+            ("string", Some("date-time")) => Some(&self.date_time),
+            ("string", Some("date")) => Some(&self.date),
+            ("string", Some("time")) => Some(&self.time),
+            ("string", Some("uri")) => Some(&self.uri),
+            ("string", _) => Some(&self.string),
+            ("boolean", _) => Some(&self.boolean),
+            ("integer", _) => Some(&self.integer),
+            ("number", _) => Some(&self.number),
+            _ => None,
+        }
+    }
+
+    fn for_number(&self, integer: bool) -> &str {
+        if integer { &self.integer } else { &self.number }
+    }
+}
+
+/// Mandatory caller configuration for every schema importer.
+#[derive(Debug, Clone)]
+pub struct SchemaImportConfig {
+    namespaces: Namespaces,
+    datatypes: SchemaDatatypeMap,
+}
+
+impl SchemaImportConfig {
+    /// Construct a schema importer configuration from caller-owned namespaces
+    /// and scalar datatype identities.
+    #[must_use]
+    pub fn new(namespaces: Namespaces, datatypes: SchemaDatatypeMap) -> Self {
+        Self {
+            namespaces,
+            datatypes,
+        }
+    }
+
+    /// Namespace table used for every class, property, datatype, and value IRI.
+    #[must_use]
+    pub fn namespaces(&self) -> &Namespaces {
+        &self.namespaces
+    }
+
+    /// Scalar datatype mapping used by the importer.
+    #[must_use]
+    pub fn datatypes(&self) -> &SchemaDatatypeMap {
+        &self.datatypes
+    }
+}
+
+/// Typed SHACL import result and its always-computed reverse loss ledger.
+#[derive(Debug, Clone)]
+pub struct ImportedShapes {
+    /// Deterministically ordered SHACL node shapes.
+    pub shapes: Shapes,
+    /// Every accepted source construct without an exact SHACL representation.
+    pub losses: LossLedger,
+}
+
+/// A malformed, ambiguous, unsupported-resource, or internally inconsistent
+/// schema import request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaImportError {
+    detail: String,
+}
+
+impl SchemaImportError {
+    fn new(detail: impl Into<String>) -> Self {
+        Self {
+            detail: detail.into(),
+        }
+    }
+
+    /// Stable human-readable error detail.
+    #[must_use]
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+}
+
+impl fmt::Display for SchemaImportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.detail)
+    }
+}
+
+impl Error for SchemaImportError {}
+
+/// Import one JSON Schema draft 2020-12 document as SHACL shapes.
+///
+/// The accepted identity convention is the same one [`crate::json_schema`]
+/// emits: colon-free `$defs` keys belong to the caller's primary namespace;
+/// qualified keys must be absolute IRIs or use a caller-declared prefix.
+///
+/// # Errors
+///
+/// Returns [`SchemaImportError`] for malformed JSON/schema structures, a wrong
+/// dialect, open or dangling references, invalid/ambiguous identities,
+/// inconsistent cardinality wrappers, or fixed resource-limit exhaustion.
+pub fn import_json_schema(
+    input: &str,
+    config: &SchemaImportConfig,
+) -> Result<ImportedShapes, SchemaImportError> {
+    import_json_schema_from(JSON_SCHEMA_SOURCE, input, config)
+}
+
+/// Import the JSON Schema artifact held by one [`CompiledSchema`]. Existing
+/// forward losses remain on the caller's compiled value; the returned ledger
+/// describes only this reverse transformation.
+///
+/// # Errors
+///
+/// Returns the same errors as [`import_json_schema`].
+pub fn import_compiled_schema(
+    compiled: &CompiledSchema,
+    config: &SchemaImportConfig,
+) -> Result<ImportedShapes, SchemaImportError> {
+    import_json_schema(&compiled.schema_json, config)
+}
+
+pub(crate) fn import_json_schema_from(
+    source: &'static str,
+    input: &str,
+    config: &SchemaImportConfig,
+) -> Result<ImportedShapes, SchemaImportError> {
+    if input.len() > MAX_SCHEMA_BYTES {
+        return Err(SchemaImportError::new(format!(
+            "schema input exceeds the {MAX_SCHEMA_BYTES}-byte limit"
+        )));
+    }
+    let document: Value = serde_json::from_str(input)
+        .map_err(|error| SchemaImportError::new(format!("invalid JSON Schema JSON: {error}")))?;
+    import_schema_value_from(source, &document, config)
+}
+
+pub(crate) fn import_schema_value_from(
+    source: &'static str,
+    document: &Value,
+    config: &SchemaImportConfig,
+) -> Result<ImportedShapes, SchemaImportError> {
+    let mut nodes = 0;
+    validate_value_limits(document, 0, &mut nodes, "#")?;
+    let root = document
+        .as_object()
+        .ok_or_else(|| SchemaImportError::new("JSON Schema document root must be an object"))?;
+    if let Some(dialect) = root.get("$schema") {
+        let dialect = dialect
+            .as_str()
+            .ok_or_else(|| SchemaImportError::new("#/$schema must be a string"))?;
+        if dialect != JSON_SCHEMA_DIALECT {
+            return Err(SchemaImportError::new(format!(
+                "#/$schema must be {JSON_SCHEMA_DIALECT:?}, got {dialect:?}"
+            )));
+        }
+    }
+    let definitions = root
+        .get("$defs")
+        .and_then(Value::as_object)
+        .ok_or_else(|| SchemaImportError::new("JSON Schema must contain object-valued #/$defs"))?;
+    if definitions.len() > MAX_DEFINITIONS {
+        return Err(SchemaImportError::new(format!(
+            "JSON Schema contains {} definitions; limit is {MAX_DEFINITIONS}",
+            definitions.len()
+        )));
+    }
+
+    validate_references(document, definitions, "#", 0)?;
+    let generated_envelope = is_generated_envelope(root, definitions, &config.namespaces);
+    let mut context = ImportContext::new(source, config, definitions, generated_envelope);
+    context.audit_root(root, generated_envelope)?;
+    let mut model = SchemaImportModel::default();
+    let mut shape_identities = BTreeMap::new();
+    for (key, schema) in definitions {
+        if generated_envelope && matches!(key.as_str(), "Annotation" | "Node") {
+            continue;
+        }
+        let path = definition_path(key);
+        let Some(shape) = context.import_definition(key, schema, &path)? else {
+            continue;
+        };
+        let Term::NamedNode(identity) = &shape.id else {
+            unreachable!("top-level schema definitions always use caller-owned class IRIs");
+        };
+        if let Some(previous) = shape_identities.insert(identity.as_str().to_owned(), path.clone())
+        {
+            return Err(SchemaImportError::new(format!(
+                "{path} and {previous} resolve to the same class IRI {:?}",
+                identity.as_str()
+            )));
+        }
+        model.node_shapes.push(shape);
+    }
+    model
+        .node_shapes
+        .sort_by_cached_key(|shape| shape.id.to_string());
+    context.finish(model)
+}
+
+#[derive(Default)]
+struct SchemaImportModel {
+    node_shapes: Vec<Shape>,
+}
+
+struct ImportContext<'a> {
+    source: &'static str,
+    config: &'a SchemaImportConfig,
+    definitions: &'a Map<String, Value>,
+    contract: LossLedger,
+    losses: LossLedger,
+    nested_shape_counter: usize,
+    generated_envelope: bool,
+}
+
+impl<'a> ImportContext<'a> {
+    fn new(
+        source: &'static str,
+        config: &'a SchemaImportConfig,
+        definitions: &'a Map<String, Value>,
+        generated_envelope: bool,
+    ) -> Self {
+        Self {
+            source,
+            config,
+            definitions,
+            contract: schema_to_shacl_loss_ledger(source),
+            losses: LossLedger::new(),
+            nested_shape_counter: 0,
+            generated_envelope,
+        }
+    }
+
+    fn finish(self, model: SchemaImportModel) -> Result<ImportedShapes, SchemaImportError> {
+        check_ledger_sound(&self.losses, self.source, "shacl").map_err(SchemaImportError::new)?;
+        let shapes = Shapes {
+            node_shapes: model.node_shapes,
+            ..Shapes::default()
+        };
+        Ok(ImportedShapes {
+            shapes,
+            losses: self.losses,
+        })
+    }
+
+    fn record(&mut self, code: &str, path: &str) {
+        let contract = self
+            .contract
+            .entries()
+            .iter()
+            .find(|entry| entry.code == code)
+            .unwrap_or_else(|| panic!("unregistered schema import loss code `{code}`"));
+        self.losses.record(LossEntry {
+            code: code.to_owned().into(),
+            from: self.source.to_owned().into(),
+            to: "shacl".to_owned().into(),
+            note: contract.note.to_string().into(),
+            location: Some(Box::new(
+                RdfLocation::logical("schema-importer").with_subject(path),
+            )),
+        });
+    }
+
+    fn nested_shape_id(&mut self, path: &str) -> Term {
+        let id = self.nested_shape_counter;
+        self.nested_shape_counter += 1;
+        Term::blank(format!("schema-import-{id:08x}-{}", fnv1a(path.as_bytes())))
+    }
+}
+
+fn validate_absolute_iri(label: &str, value: &str) -> Result<(), SchemaImportError> {
+    let iri = purrdf_iri::parse(value)
+        .map_err(|error| SchemaImportError::new(format!("{label} is not a valid IRI: {error}")))?;
+    if !iri.has_scheme() {
+        return Err(SchemaImportError::new(format!(
+            "{label} must be an absolute IRI"
+        )));
+    }
+    Ok(())
+}
+
+fn definition_path(key: &str) -> String {
+    format!("#/$defs/{}", pointer_escape(key))
+}
+
+fn pointer_escape(value: &str) -> String {
+    value.replace('~', "~0").replace('/', "~1")
+}
+
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+impl ImportContext<'_> {
+    fn audit_root(
+        &mut self,
+        root: &Map<String, Value>,
+        generated_envelope: bool,
+    ) -> Result<(), SchemaImportError> {
+        for (keyword, value) in root {
+            let path = format!("#/{}", pointer_escape(keyword));
+            match keyword.as_str() {
+                "$schema" | "$id" if generated_envelope => {}
+                "$schema" | "$id" | "$anchor" | "$dynamicAnchor" => {
+                    self.record("schema-identity-dropped", &path);
+                }
+                "title" if generated_envelope => {}
+                "title" | "description" | "$comment" | "default" | "examples" | "deprecated"
+                | "readOnly" | "writeOnly" => {
+                    self.record("annotation-dropped", &path);
+                }
+                "$defs" => {}
+                "type" | "anyOf" | "properties" if generated_envelope => {}
+                keyword if is_known_assertion_keyword(keyword) => {
+                    self.record(root_loss_code(keyword), &path);
+                }
+                keyword if is_annotation_keyword(keyword) => {
+                    self.record("annotation-dropped", &path);
+                }
+                _ => {
+                    validate_json_keyword_value(keyword, value, &path)?;
+                    self.record("unknown-keyword-dropped", &path);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn import_definition(
+        &mut self,
+        key: &str,
+        schema: &Value,
+        path: &str,
+    ) -> Result<Option<Shape>, SchemaImportError> {
+        if schema.is_boolean() {
+            self.record("boolean-schema-dropped", path);
+            return Ok(None);
+        }
+        let object = schema.as_object().ok_or_else(|| {
+            SchemaImportError::new(format!("{path} must be an object or boolean schema"))
+        })?;
+        if !is_object_schema(object) {
+            self.audit_non_object_definition(object, path)?;
+            self.record("non-object-definition-dropped", path);
+            return Ok(None);
+        }
+        let class_iri = self
+            .config
+            .namespaces
+            .class_iri_for_def_key(key)
+            .map_err(|error| SchemaImportError::new(format!("{path}: {error}")))?;
+        let id = Term::NamedNode(NamedNode::new_unchecked(class_iri));
+        let target = Target::ImplicitClass(id.clone());
+        self.import_object_shape(object, path, id, vec![target])
+            .map(Some)
+    }
+
+    fn audit_non_object_definition(
+        &mut self,
+        object: &Map<String, Value>,
+        path: &str,
+    ) -> Result<(), SchemaImportError> {
+        for (keyword, value) in object {
+            let location = format!("{path}/{}", pointer_escape(keyword));
+            match keyword.as_str() {
+                "$ref" => {}
+                "title" | "description" | "$comment" | "default" | "examples" | "deprecated"
+                | "readOnly" | "writeOnly" => {
+                    self.record("annotation-dropped", &location);
+                }
+                "x-enum-varnames" | "x-enum-descriptions" => {
+                    self.record("enum-metadata-dropped", &location);
+                }
+                keyword if is_known_assertion_keyword(keyword) => {
+                    self.record(root_loss_code(keyword), &location);
+                }
+                keyword if is_annotation_keyword(keyword) => {
+                    self.record("annotation-dropped", &location);
+                }
+                _ => {
+                    validate_json_keyword_value(keyword, value, &location)?;
+                    self.record("unknown-keyword-dropped", &location);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn import_object_shape(
+        &mut self,
+        object: &Map<String, Value>,
+        path: &str,
+        id: Term,
+        targets: Vec<Target>,
+    ) -> Result<Shape, SchemaImportError> {
+        validate_object_type(object.get("type"), path)?;
+        if let Some(kind) = object.get("type")
+            && schema_types(kind, &format!("{path}/type"))?.len() != 1
+        {
+            self.record("value-term-kind-widened", &format!("{path}/type"));
+        }
+        let properties = optional_object(object, "properties", path)?;
+        if properties.len() > MAX_PROPERTIES {
+            return Err(SchemaImportError::new(format!(
+                "{path}/properties contains {} members; limit is {MAX_PROPERTIES}",
+                properties.len()
+            )));
+        }
+        let required = required_names(object, properties, path)?;
+        let mut property_shapes = Vec::new();
+        let mut closed_ignored = Vec::new();
+        let mut imported_property_names = BTreeSet::new();
+        let mut property_identities = BTreeMap::new();
+        for (key, schema) in properties {
+            if matches!(key.as_str(), "@id" | "@type" | "@annotation") {
+                if !self.generated_envelope {
+                    self.record(
+                        "value-term-kind-widened",
+                        &format!("{path}/properties/{}", pointer_escape(key)),
+                    );
+                }
+                continue;
+            }
+            imported_property_names.insert(key.clone());
+            let property_path = format!("{path}/properties/{}", pointer_escape(key));
+            let predicate_iri = self
+                .config
+                .namespaces
+                .expand_iri(key)
+                .map_err(|error| SchemaImportError::new(format!("{property_path}: {error}")))?;
+            if let Some(previous) =
+                property_identities.insert(predicate_iri.clone(), property_path.clone())
+            {
+                return Err(SchemaImportError::new(format!(
+                    "{property_path} and {previous} resolve to the same property IRI {predicate_iri:?}"
+                )));
+            }
+            let predicate = NamedNode::new_unchecked(predicate_iri);
+            if schema == &Value::Bool(true) && !required.contains(key) {
+                closed_ignored.push(predicate);
+                continue;
+            }
+            let mut constraints = self.import_property_schema(schema, &property_path)?;
+            if required.contains(key)
+                && !constraints.iter().any(
+                    |constraint| matches!(constraint, Constraint::MinCount(value) if *value >= 1),
+                )
+            {
+                constraints.push(Constraint::MinCount(1));
+            }
+            property_shapes.push(PropertyShape {
+                path: Path::Predicate(predicate),
+                constraints,
+                property_shapes: Vec::new(),
+                reifier_shapes: Vec::new(),
+                reification_required: false,
+                severity: Severity::Violation,
+                message: None,
+                deactivated: false,
+                box_roles: Vec::new(),
+            });
+        }
+        for key in required.difference(&imported_property_names) {
+            if matches!(key.as_str(), "@id" | "@type" | "@annotation") {
+                if !self.generated_envelope && !properties.contains_key(key) {
+                    self.record("value-term-kind-widened", &format!("{path}/required"));
+                }
+                continue;
+            }
+            let predicate_iri = self
+                .config
+                .namespaces
+                .expand_iri(key)
+                .map_err(|error| SchemaImportError::new(format!("{path}/required: {error}")))?;
+            let required_path = format!("{path}/required");
+            if let Some(previous) =
+                property_identities.insert(predicate_iri.clone(), required_path.clone())
+            {
+                return Err(SchemaImportError::new(format!(
+                    "{required_path} property {key:?} and {previous} resolve to the same property IRI {predicate_iri:?}"
+                )));
+            }
+            property_shapes.push(PropertyShape {
+                path: Path::Predicate(NamedNode::new_unchecked(predicate_iri)),
+                constraints: vec![Constraint::MinCount(1)],
+                property_shapes: Vec::new(),
+                reifier_shapes: Vec::new(),
+                reification_required: false,
+                severity: Severity::Violation,
+                message: None,
+                deactivated: false,
+                box_roles: Vec::new(),
+            });
+        }
+        property_shapes.sort_by_cached_key(|property| match &property.path {
+            Path::Predicate(predicate) => predicate.as_str().to_owned(),
+            _ => unreachable!("schema imports create direct predicate paths only"),
+        });
+
+        let mut constraints = Vec::new();
+        if let Some(class) = type_discriminator_class(object, &self.config.namespaces)? {
+            constraints.push(Constraint::Class(class));
+        }
+        if let Some(additional) = object.get("additionalProperties") {
+            match additional {
+                Value::Bool(false) => constraints.push(Constraint::Closed {
+                    ignored: closed_ignored,
+                }),
+                Value::Bool(true) => {}
+                Value::Object(_) => self.record(
+                    "additional-properties-schema-widened",
+                    &format!("{path}/additionalProperties"),
+                ),
+                _ => {
+                    return Err(SchemaImportError::new(format!(
+                        "{path}/additionalProperties must be a boolean or schema"
+                    )));
+                }
+            }
+        }
+        self.import_object_logic(object, path, &mut constraints)?;
+        self.audit_object_keywords(object, path)?;
+        Ok(Shape {
+            id,
+            targets,
+            constraints,
+            property_shapes,
+            severity: Severity::Violation,
+            message: None,
+            deactivated: false,
+            box_roles: Vec::new(),
+            rules: Vec::new(),
+        })
+    }
+
+    fn import_object_logic(
+        &mut self,
+        object: &Map<String, Value>,
+        path: &str,
+        constraints: &mut Vec<Constraint>,
+    ) -> Result<(), SchemaImportError> {
+        if let Some(branches) = object.get("allOf") {
+            let branches = branches
+                .as_array()
+                .ok_or_else(|| SchemaImportError::new(format!("{path}/allOf must be an array")))?;
+            let mut members = Vec::new();
+            for (index, branch) in branches.iter().enumerate() {
+                let branch_path = format!("{path}/allOf/{index}");
+                if let Some(negand) = branch
+                    .as_object()
+                    .and_then(|map| (map.len() == 1).then(|| map.get("not")).flatten())
+                {
+                    if let Some(inner) =
+                        self.import_nested_shape(negand, &format!("{branch_path}/not"))?
+                    {
+                        constraints.push(Constraint::Not(Box::new(inner)));
+                    }
+                } else if let Some(member) = self.import_nested_shape(branch, &branch_path)? {
+                    members.push(member);
+                }
+            }
+            if !members.is_empty() {
+                constraints.push(Constraint::And(members));
+            }
+        }
+        for (keyword, xone) in [("anyOf", false), ("oneOf", true)] {
+            let Some(branches) = object.get(keyword) else {
+                continue;
+            };
+            let branches = branches.as_array().ok_or_else(|| {
+                SchemaImportError::new(format!("{path}/{keyword} must be an array"))
+            })?;
+            let mut members = Vec::new();
+            for (index, branch) in branches.iter().enumerate() {
+                if let Some(member) =
+                    self.import_nested_shape(branch, &format!("{path}/{keyword}/{index}"))?
+                {
+                    members.push(member);
+                }
+            }
+            if !members.is_empty() {
+                constraints.push(if xone {
+                    Constraint::Xone(members)
+                } else {
+                    Constraint::Or(members)
+                });
+            }
+        }
+        if let Some(negand) = object.get("not")
+            && let Some(inner) = self.import_nested_shape(negand, &format!("{path}/not"))?
+        {
+            constraints.push(Constraint::Not(Box::new(inner)));
+        }
+        Ok(())
+    }
+
+    fn import_nested_shape(
+        &mut self,
+        schema: &Value,
+        path: &str,
+    ) -> Result<Option<Shape>, SchemaImportError> {
+        let Some(object) = schema.as_object() else {
+            self.record("schema-applicator-dropped", path);
+            return Ok(None);
+        };
+        if !is_object_schema(object) {
+            self.record("schema-applicator-dropped", path);
+            return Ok(None);
+        }
+        let id = self.nested_shape_id(path);
+        self.import_object_shape(object, path, id, Vec::new())
+            .map(Some)
+    }
+
+    fn audit_object_keywords(
+        &mut self,
+        object: &Map<String, Value>,
+        path: &str,
+    ) -> Result<(), SchemaImportError> {
+        for (keyword, value) in object {
+            let location = format!("{path}/{}", pointer_escape(keyword));
+            match keyword.as_str() {
+                "type"
+                | "properties"
+                | "required"
+                | "additionalProperties"
+                | "allOf"
+                | "anyOf"
+                | "oneOf"
+                | "not" => {}
+                "title" | "description" | "$comment" | "default" | "examples" | "deprecated"
+                | "readOnly" | "writeOnly" => {
+                    self.record("annotation-dropped", &location);
+                }
+                "$id" | "$anchor" | "$dynamicAnchor" => {
+                    self.record("schema-identity-dropped", &location);
+                }
+                "patternProperties" | "propertyNames" => {
+                    self.record("object-key-validation-dropped", &location);
+                }
+                "minProperties" | "maxProperties" => {
+                    validate_nonnegative_integer(value, &location)?;
+                    self.record("property-count-validation-dropped", &location);
+                }
+                "dependentRequired" | "dependentSchemas" => {
+                    self.record("dependency-validation-dropped", &location);
+                }
+                "if" | "then" | "else" => {
+                    self.record("conditional-validation-dropped", &location);
+                }
+                "unevaluatedProperties" => {
+                    self.record("unevaluated-validation-dropped", &location);
+                }
+                keyword if is_annotation_keyword(keyword) => {
+                    self.record("annotation-dropped", &location);
+                }
+                _ => {
+                    validate_json_keyword_value(keyword, value, &location)?;
+                    self.record("unknown-keyword-dropped", &location);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn import_property_schema(
+        &mut self,
+        schema: &Value,
+        path: &str,
+    ) -> Result<Vec<Constraint>, SchemaImportError> {
+        if schema == &Value::Bool(false) {
+            return Ok(vec![Constraint::MaxCount(0)]);
+        }
+        if schema == &Value::Bool(true) {
+            return Ok(Vec::new());
+        }
+        let (scalar, min_count, max_count) = self.split_cardinality(schema, path)?;
+        let mut constraints = Vec::new();
+        if let Some(minimum) = min_count {
+            constraints.push(Constraint::MinCount(minimum));
+        }
+        if let Some(maximum) = max_count {
+            constraints.push(Constraint::MaxCount(maximum));
+        }
+        self.import_scalar_schema(&scalar, path, &mut constraints)?;
+        Ok(constraints)
+    }
+
+    fn split_cardinality(
+        &mut self,
+        schema: &Value,
+        path: &str,
+    ) -> Result<(Value, Option<u64>, Option<u64>), SchemaImportError> {
+        let object = schema.as_object().ok_or_else(|| {
+            SchemaImportError::new(format!("{path} must be a boolean or object schema"))
+        })?;
+        if is_array_schema(object) {
+            return self.array_cardinality(object, path);
+        }
+        if let Some(branches) = object.get("anyOf").and_then(Value::as_array)
+            && branches.len() == 2
+        {
+            let left_array = branches[0]
+                .as_object()
+                .filter(|branch| is_array_schema(branch));
+            let right_array = branches[1]
+                .as_object()
+                .filter(|branch| is_array_schema(branch));
+            let (single, array, array_path) = match (left_array, right_array) {
+                (Some(array), None) => (&branches[1], array, format!("{path}/anyOf/0")),
+                (None, Some(array)) => (&branches[0], array, format!("{path}/anyOf/1")),
+                _ => return Ok((schema.clone(), None, Some(1))),
+            };
+            let (items, min_count, max_count) = self.array_cardinality(array, &array_path)?;
+            if &items != single {
+                return Err(SchemaImportError::new(format!(
+                    "{path}/anyOf single-value branch must equal the array items schema"
+                )));
+            }
+            return Ok((items, min_count, max_count));
+        }
+        Ok((schema.clone(), None, Some(1)))
+    }
+
+    fn array_cardinality(
+        &mut self,
+        object: &Map<String, Value>,
+        path: &str,
+    ) -> Result<(Value, Option<u64>, Option<u64>), SchemaImportError> {
+        // Omitting `items` is the draft-2020-12 identity schema. Keep the
+        // cardinality carrier without inventing an item constraint.
+        let items = object.get("items").cloned().unwrap_or(Value::Bool(true));
+        let min_count = object
+            .get("minItems")
+            .map(|value| nonnegative_integer(value, &format!("{path}/minItems")))
+            .transpose()?;
+        let max_count = object
+            .get("maxItems")
+            .map(|value| nonnegative_integer(value, &format!("{path}/maxItems")))
+            .transpose()?;
+        for (keyword, code) in [
+            ("contains", "array-contains-validation-dropped"),
+            ("minContains", "array-contains-validation-dropped"),
+            ("maxContains", "array-contains-validation-dropped"),
+            ("prefixItems", "tuple-validation-widened"),
+            ("additionalItems", "tuple-validation-widened"),
+            ("unevaluatedItems", "unevaluated-validation-dropped"),
+            ("uniqueItems", "unique-items-validation-dropped"),
+        ] {
+            if object.contains_key(keyword) {
+                self.record(code, &format!("{path}/{keyword}"));
+            }
+        }
+        for (keyword, value) in object {
+            let location = format!("{path}/{}", pointer_escape(keyword));
+            match keyword.as_str() {
+                "type" | "items" | "minItems" | "maxItems" | "contains" | "minContains"
+                | "maxContains" | "prefixItems" | "additionalItems" | "unevaluatedItems"
+                | "uniqueItems" => {}
+                "title" | "description" | "$comment" | "default" | "examples" | "deprecated"
+                | "readOnly" | "writeOnly" => {
+                    self.record("annotation-dropped", &location);
+                }
+                _ => {
+                    validate_json_keyword_value(keyword, value, &location)?;
+                    self.record("unknown-keyword-dropped", &location);
+                }
+            }
+        }
+        Ok((items, min_count, max_count))
+    }
+
+    fn import_scalar_schema(
+        &mut self,
+        schema: &Value,
+        path: &str,
+        constraints: &mut Vec<Constraint>,
+    ) -> Result<(), SchemaImportError> {
+        match schema {
+            Value::Bool(true) => return Ok(()),
+            Value::Bool(false) => {
+                self.record("boolean-schema-dropped", path);
+                return Ok(());
+            }
+            Value::Object(_) => {}
+            _ => {
+                return Err(SchemaImportError::new(format!(
+                    "{path} must be an object or boolean schema"
+                )));
+            }
+        }
+        let object = schema.as_object().expect("matched object");
+        let mut handled = BTreeSet::new();
+
+        if is_language_literal_schema(object) {
+            if let Some(tags) = language_tags(object) {
+                constraints.push(Constraint::LanguageIn(tags));
+            } else {
+                self.record("value-term-kind-widened", path);
+            }
+            return Ok(());
+        }
+        if is_node_ref_schema(schema) {
+            if let Some(class) = node_ref_class(object, &self.config.namespaces)? {
+                constraints.push(Constraint::Class(class));
+            } else {
+                if object.contains_key("$comment") {
+                    self.record("annotation-dropped", &format!("{path}/$comment"));
+                }
+                constraints.push(Constraint::NodeKind(NodeKindValue::BlankNodeOrIri));
+            }
+            return Ok(());
+        }
+
+        if let Some(reference) = object.get("$ref") {
+            let reference = reference
+                .as_str()
+                .ok_or_else(|| SchemaImportError::new(format!("{path}/$ref must be a string")))?;
+            self.import_reference(reference, &format!("{path}/$ref"), constraints)?;
+            handled.insert("$ref");
+        }
+
+        if let Some(branches) = object.get("allOf") {
+            let branches = branches
+                .as_array()
+                .ok_or_else(|| SchemaImportError::new(format!("{path}/allOf must be an array")))?;
+            for (index, branch) in branches.iter().enumerate() {
+                self.import_scalar_schema(branch, &format!("{path}/allOf/{index}"), constraints)?;
+            }
+            handled.insert("allOf");
+        }
+
+        if let Some(branches) = object.get("anyOf") {
+            let branches = branches
+                .as_array()
+                .ok_or_else(|| SchemaImportError::new(format!("{path}/anyOf must be an array")))?;
+            self.import_scalar_alternatives(branches, &format!("{path}/anyOf"), constraints)?;
+            handled.insert("anyOf");
+        }
+
+        if let Some(enum_values) = object.get("enum") {
+            let enum_values = enum_values
+                .as_array()
+                .ok_or_else(|| SchemaImportError::new(format!("{path}/enum must be an array")))?;
+            let mut terms = Vec::new();
+            for (index, value) in enum_values.iter().enumerate() {
+                if let Some(term) = self.import_term(value, &format!("{path}/enum/{index}"))? {
+                    terms.push(term);
+                }
+            }
+            crate::term::sort_canonical(&mut terms);
+            terms.dedup();
+            constraints.push(Constraint::In(terms));
+            handled.insert("enum");
+        }
+        if let Some(value) = object.get("const") {
+            if let Some(term) = self.import_term(value, &format!("{path}/const"))? {
+                constraints.push(Constraint::HasValue(term));
+            }
+            handled.insert("const");
+        }
+
+        if let Some(kind) = object.get("type") {
+            self.import_scalar_type(kind, object.get("format"), path, constraints)?;
+            handled.insert("type");
+            if object.contains_key("format") {
+                handled.insert("format");
+            }
+        } else if object.contains_key("format") {
+            self.record("format-validation-widened", &format!("{path}/format"));
+            handled.insert("format");
+        }
+
+        if let Some(pattern) = object.get("pattern") {
+            let regex = pattern.as_str().ok_or_else(|| {
+                SchemaImportError::new(format!("{path}/pattern must be a string"))
+            })?;
+            constraints.push(Constraint::Pattern {
+                regex: regex.to_owned(),
+                flags: None,
+                compiled: Arc::new(OnceLock::new()),
+            });
+            handled.insert("pattern");
+        }
+        for (keyword, constructor) in [
+            ("minLength", Constraint::MinLength as fn(u64) -> Constraint),
+            ("maxLength", Constraint::MaxLength as fn(u64) -> Constraint),
+        ] {
+            if let Some(value) = object.get(keyword) {
+                constraints.push(constructor(nonnegative_integer(
+                    value,
+                    &format!("{path}/{keyword}"),
+                )?));
+                handled.insert(keyword);
+            }
+        }
+        for (keyword, bound_kind) in [
+            ("minimum", BoundKind::Minimum),
+            ("maximum", BoundKind::Maximum),
+            ("exclusiveMinimum", BoundKind::ExclusiveMinimum),
+            ("exclusiveMaximum", BoundKind::ExclusiveMaximum),
+        ] {
+            if let Some(value) = object.get(keyword) {
+                let term = self.numeric_term(value, &format!("{path}/{keyword}"))?;
+                constraints.push(bound_kind.constraint(term));
+                handled.insert(keyword);
+            }
+        }
+        if object.contains_key("multipleOf") {
+            self.record(
+                "multiple-of-validation-dropped",
+                &format!("{path}/multipleOf"),
+            );
+            handled.insert("multipleOf");
+        }
+
+        for (keyword, value) in object {
+            if handled.contains(keyword.as_str()) {
+                continue;
+            }
+            let location = format!("{path}/{}", pointer_escape(keyword));
+            match keyword.as_str() {
+                "title" | "description" | "$comment" | "default" | "examples" | "deprecated"
+                | "readOnly" | "writeOnly" => {
+                    self.record("annotation-dropped", &location);
+                }
+                "x-enum-varnames" | "x-enum-descriptions" => {
+                    self.record("enum-metadata-dropped", &location);
+                }
+                "oneOf" | "not" => self.record("schema-applicator-dropped", &location),
+                "if" | "then" | "else" => {
+                    self.record("conditional-validation-dropped", &location);
+                }
+                "contentEncoding" | "contentMediaType" | "contentSchema" => {
+                    self.record("content-validation-dropped", &location);
+                }
+                keyword if is_annotation_keyword(keyword) => {
+                    self.record("annotation-dropped", &location);
+                }
+                _ => {
+                    validate_json_keyword_value(keyword, value, &location)?;
+                    self.record("unknown-keyword-dropped", &location);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn import_reference(
+        &mut self,
+        reference: &str,
+        path: &str,
+        constraints: &mut Vec<Constraint>,
+    ) -> Result<(), SchemaImportError> {
+        let key = reference_key(reference).ok_or_else(|| {
+            SchemaImportError::new(format!(
+                "{path} must be a direct local #/$defs reference, got {reference:?}"
+            ))
+        })?;
+        let target = self.definitions.get(&key).ok_or_else(|| {
+            SchemaImportError::new(format!("{path} targets missing definition {key:?}"))
+        })?;
+        if target.as_object().is_some_and(is_object_schema) {
+            let iri = self
+                .config
+                .namespaces
+                .class_iri_for_def_key(&key)
+                .map_err(|error| SchemaImportError::new(format!("{path}: {error}")))?;
+            constraints.push(Constraint::Class(NamedNode::new_unchecked(iri)));
+            return Ok(());
+        }
+        if let Some(values) = target
+            .as_object()
+            .and_then(|object| object.get("enum"))
+            .and_then(Value::as_array)
+        {
+            let mut terms = Vec::new();
+            for (index, value) in values.iter().enumerate() {
+                if let Some(term) =
+                    self.import_term(value, &format!("{}/enum/{index}", definition_path(&key)))?
+                {
+                    terms.push(term);
+                }
+            }
+            crate::term::sort_canonical(&mut terms);
+            terms.dedup();
+            constraints.push(Constraint::In(terms));
+            self.record("non-object-definition-dropped", &definition_path(&key));
+            return Ok(());
+        }
+        self.record("non-object-definition-dropped", &definition_path(&key));
+        Ok(())
+    }
+
+    fn import_scalar_alternatives(
+        &mut self,
+        branches: &[Value],
+        path: &str,
+        constraints: &mut Vec<Constraint>,
+    ) -> Result<(), SchemaImportError> {
+        if branches.len() == 2 {
+            let typed = branches.iter().position(is_typed_literal_schema);
+            if let Some(typed_index) = typed {
+                let scalar_index = usize::from(typed_index == 0);
+                if let Some(scalar) = branches[scalar_index].as_object()
+                    && is_simple_scalar_carrier(scalar)
+                    && let Some(kind) = scalar.get("type")
+                {
+                    self.import_scalar_type(
+                        kind,
+                        scalar.get("format"),
+                        &format!("{path}/{scalar_index}"),
+                        constraints,
+                    )?;
+                    return Ok(());
+                }
+            }
+        }
+
+        let mut node_branches = 0_usize;
+        let mut typed_branches = 0_usize;
+        let mut language_branches = 0_usize;
+        let mut reference_branches = 0_usize;
+        let mut scalar_branches = 0_usize;
+        let mut saw_true = false;
+        let mut unsupported = false;
+        let mut node_constraints = Vec::new();
+        let mut reference_constraints = Vec::new();
+        let mut scalar_constraints = Vec::new();
+        for (index, branch) in branches.iter().enumerate() {
+            let branch_path = format!("{path}/{index}");
+            if branch == &Value::Bool(true) {
+                saw_true = true;
+                continue;
+            }
+            if branch == &Value::Bool(false) {
+                continue;
+            }
+            if is_node_ref_schema(branch) {
+                node_branches += 1;
+                let object = branch.as_object().expect("node carrier is an object");
+                if let Some(class) = node_ref_class(object, &self.config.namespaces)? {
+                    node_constraints.push(Constraint::Class(class));
+                } else {
+                    if object.contains_key("$comment") {
+                        self.record("annotation-dropped", &format!("{branch_path}/$comment"));
+                    }
+                    node_constraints.push(Constraint::NodeKind(NodeKindValue::BlankNodeOrIri));
+                }
+                continue;
+            }
+            if is_typed_literal_schema(branch) {
+                typed_branches += 1;
+                continue;
+            }
+            let Some(object) = branch.as_object() else {
+                unreachable!("reference validation accepts only object or boolean schemas");
+            };
+            if is_language_literal_schema(object) {
+                language_branches += 1;
+                if let Some(tags) = language_tags(object) {
+                    scalar_constraints.push(Constraint::LanguageIn(tags));
+                } else {
+                    self.record("value-term-kind-widened", &branch_path);
+                }
+                continue;
+            }
+            if let Some(reference) = object.get("$ref").and_then(Value::as_str) {
+                reference_branches += 1;
+                self.import_reference(
+                    reference,
+                    &format!("{branch_path}/$ref"),
+                    &mut reference_constraints,
+                )?;
+                continue;
+            }
+            if object.get("type").is_some() {
+                scalar_branches += 1;
+                if !is_simple_scalar_carrier(object) {
+                    unsupported = true;
+                }
+                self.import_scalar_schema(branch, &branch_path, &mut scalar_constraints)?;
+                continue;
+            }
+            let mut discarded = Vec::new();
+            self.import_scalar_schema(branch, &branch_path, &mut discarded)?;
+            unsupported = true;
+        }
+
+        if saw_true {
+            return Ok(());
+        }
+        let effective_branches = node_branches
+            + typed_branches
+            + language_branches
+            + reference_branches
+            + scalar_branches
+            + usize::from(unsupported);
+        if effective_branches == 0 {
+            self.record("boolean-schema-dropped", path);
+            return Ok(());
+        }
+        if !unsupported && effective_branches == 1 {
+            if node_branches == 1 {
+                constraints.extend(node_constraints);
+            } else if typed_branches == 1 {
+                constraints.push(Constraint::NodeKind(NodeKindValue::Literal));
+            } else if reference_branches == 1 {
+                constraints.extend(reference_constraints);
+            } else {
+                constraints.extend(scalar_constraints);
+            }
+            return Ok(());
+        }
+        if !unsupported
+            && reference_branches == 1
+            && node_branches > 0
+            && effective_branches == reference_branches + node_branches
+        {
+            constraints.extend(reference_constraints);
+            return Ok(());
+        }
+        if !unsupported
+            && reference_branches == 0
+            && node_branches > 0
+            && typed_branches > 0
+            && scalar_branches > 0
+            && language_branches == 0
+            && effective_branches
+                == node_branches + typed_branches + language_branches + scalar_branches
+        {
+            constraints.push(Constraint::NodeKind(NodeKindValue::IriOrLiteral));
+            return Ok(());
+        }
+        self.record("schema-applicator-dropped", path);
+        Ok(())
+    }
+
+    fn import_scalar_type(
+        &mut self,
+        value: &Value,
+        format: Option<&Value>,
+        path: &str,
+        constraints: &mut Vec<Constraint>,
+    ) -> Result<(), SchemaImportError> {
+        let kinds = schema_types(value, &format!("{path}/type"))?;
+        let format = format
+            .map(|value| {
+                value.as_str().ok_or_else(|| {
+                    SchemaImportError::new(format!("{path}/format must be a string"))
+                })
+            })
+            .transpose()?;
+        let mut datatypes = BTreeSet::new();
+        let mut has_unmapped_kind = false;
+        for kind in kinds {
+            let Some(datatype) = self.config.datatypes.for_scalar(&kind, format) else {
+                has_unmapped_kind = true;
+                continue;
+            };
+            if kind == "string"
+                && format.is_some()
+                && !matches!(format, Some("date-time" | "date" | "time" | "uri"))
+            {
+                self.record("format-validation-widened", &format!("{path}/format"));
+            }
+            datatypes.insert(datatype);
+        }
+        if has_unmapped_kind || datatypes.len() > 1 {
+            self.record("value-term-kind-widened", &format!("{path}/type"));
+        } else if let Some(datatype) = datatypes.into_iter().next() {
+            constraints.push(Constraint::Datatype(NamedNode::new_unchecked(datatype)));
+        }
+        Ok(())
+    }
+
+    fn import_term(
+        &mut self,
+        value: &Value,
+        path: &str,
+    ) -> Result<Option<Term>, SchemaImportError> {
+        match value {
+            Value::String(value) => Ok(Some(Term::Literal(Literal::new_typed_literal(
+                value,
+                NamedNode::new_unchecked(&self.config.datatypes.string),
+            )))),
+            Value::Bool(value) => Ok(Some(Term::Literal(Literal::new_typed_literal(
+                value.to_string(),
+                NamedNode::new_unchecked(&self.config.datatypes.boolean),
+            )))),
+            Value::Number(number) => {
+                self.record("numeric-lexical-form-normalized", path);
+                Ok(Some(self.number_term(number)))
+            }
+            Value::Object(object) => self.import_term_object(object, path),
+            Value::Null | Value::Array(_) => {
+                self.record("value-term-kind-widened", path);
+                Ok(None)
+            }
+        }
+    }
+
+    fn import_term_object(
+        &mut self,
+        object: &Map<String, Value>,
+        path: &str,
+    ) -> Result<Option<Term>, SchemaImportError> {
+        if let Some(id) = object.get("@id") {
+            if object.len() != 1 {
+                return Err(SchemaImportError::new(format!(
+                    "{path} @id value object cannot contain additional members"
+                )));
+            }
+            let id = id
+                .as_str()
+                .ok_or_else(|| SchemaImportError::new(format!("{path}/@id must be a string")))?;
+            if let Some(label) = id.strip_prefix("_:") {
+                if label.is_empty() {
+                    return Err(SchemaImportError::new(format!(
+                        "{path}/@id blank-node label cannot be empty"
+                    )));
+                }
+                return Ok(Some(Term::blank(label)));
+            }
+            let iri = self
+                .config
+                .namespaces
+                .expand_iri(id)
+                .map_err(|error| SchemaImportError::new(format!("{path}/@id: {error}")))?;
+            return Ok(Some(Term::NamedNode(NamedNode::new_unchecked(iri))));
+        }
+        let Some(raw) = object.get("@value") else {
+            self.record("value-term-kind-widened", path);
+            return Ok(None);
+        };
+        if let Some(language) = object.get("@language") {
+            if object.len() != 2 {
+                return Err(SchemaImportError::new(format!(
+                    "{path} language value object has unexpected members"
+                )));
+            }
+            let lexical = raw.as_str().ok_or_else(|| {
+                SchemaImportError::new(format!("{path}/@value must be a string with @language"))
+            })?;
+            let language = language.as_str().ok_or_else(|| {
+                SchemaImportError::new(format!("{path}/@language must be a string"))
+            })?;
+            return Ok(Some(Term::Literal(
+                Literal::new_language_tagged_literal_unchecked(lexical, language),
+            )));
+        }
+        let datatype = object.get("@type").ok_or_else(|| {
+            SchemaImportError::new(format!(
+                "{path} typed value object must contain @type or @language"
+            ))
+        })?;
+        if object.len() != 2 {
+            return Err(SchemaImportError::new(format!(
+                "{path} typed value object has unexpected members"
+            )));
+        }
+        let datatype = datatype
+            .as_str()
+            .ok_or_else(|| SchemaImportError::new(format!("{path}/@type must be a string")))?;
+        let datatype = self
+            .config
+            .namespaces
+            .expand_iri(datatype)
+            .map_err(|error| SchemaImportError::new(format!("{path}/@type: {error}")))?;
+        let lexical = json_scalar_lexical(raw).ok_or_else(|| {
+            SchemaImportError::new(format!("{path}/@value must be a JSON scalar"))
+        })?;
+        Ok(Some(Term::Literal(Literal::new_typed_literal(
+            lexical,
+            NamedNode::new_unchecked(datatype),
+        ))))
+    }
+
+    fn numeric_term(&self, value: &Value, path: &str) -> Result<Term, SchemaImportError> {
+        let number = value.as_number().ok_or_else(|| {
+            SchemaImportError::new(format!("{path} must be a finite JSON number"))
+        })?;
+        Ok(self.number_term(number))
+    }
+
+    fn number_term(&self, number: &Number) -> Term {
+        let datatype = self
+            .config
+            .datatypes
+            .for_number(number.is_i64() || number.is_u64());
+        Term::Literal(Literal::new_typed_literal(
+            number.to_string(),
+            NamedNode::new_unchecked(datatype),
+        ))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum BoundKind {
+    Minimum,
+    Maximum,
+    ExclusiveMinimum,
+    ExclusiveMaximum,
+}
+
+impl BoundKind {
+    fn constraint(self, term: Term) -> Constraint {
+        match self {
+            Self::Minimum => Constraint::MinInclusive(term),
+            Self::Maximum => Constraint::MaxInclusive(term),
+            Self::ExclusiveMinimum => Constraint::MinExclusive(term),
+            Self::ExclusiveMaximum => Constraint::MaxExclusive(term),
+        }
+    }
+}
+
+fn validate_value_limits(
+    value: &Value,
+    depth: usize,
+    nodes: &mut usize,
+    path: &str,
+) -> Result<(), SchemaImportError> {
+    if depth > MAX_SCHEMA_DEPTH {
+        return Err(SchemaImportError::new(format!(
+            "{path} exceeds the schema nesting limit of {MAX_SCHEMA_DEPTH}"
+        )));
+    }
+    *nodes = nodes
+        .checked_add(1)
+        .ok_or_else(|| SchemaImportError::new("schema node count overflow"))?;
+    if *nodes > MAX_SCHEMA_NODES {
+        return Err(SchemaImportError::new(format!(
+            "schema exceeds the {MAX_SCHEMA_NODES}-node limit"
+        )));
+    }
+    match value {
+        Value::String(value) if value.len() > MAX_STRING_BYTES => Err(SchemaImportError::new(
+            format!("{path} string exceeds the {MAX_STRING_BYTES}-byte limit"),
+        )),
+        Value::Array(values) => {
+            for (index, value) in values.iter().enumerate() {
+                validate_value_limits(value, depth + 1, nodes, &format!("{path}/{index}"))?;
+            }
+            Ok(())
+        }
+        Value::Object(values) => {
+            for (key, value) in values {
+                if key.len() > MAX_STRING_BYTES {
+                    return Err(SchemaImportError::new(format!(
+                        "{path} member name exceeds the {MAX_STRING_BYTES}-byte limit"
+                    )));
+                }
+                validate_value_limits(
+                    value,
+                    depth + 1,
+                    nodes,
+                    &format!("{path}/{}", pointer_escape(key)),
+                )?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+fn validate_references(
+    value: &Value,
+    definitions: &Map<String, Value>,
+    path: &str,
+    depth: usize,
+) -> Result<(), SchemaImportError> {
+    if depth > MAX_SCHEMA_DEPTH {
+        return Err(SchemaImportError::new(format!(
+            "{path} exceeds the reference scan depth limit"
+        )));
+    }
+    let Value::Object(object) = value else {
+        return if value.is_boolean() {
+            Ok(())
+        } else {
+            Err(SchemaImportError::new(format!(
+                "{path} must be an object or boolean schema"
+            )))
+        };
+    };
+    for (keyword, value) in object {
+        validate_json_keyword_value(
+            keyword,
+            value,
+            &format!("{path}/{}", pointer_escape(keyword)),
+        )?;
+    }
+    for keyword in ["$dynamicRef", "$recursiveRef"] {
+        if object.contains_key(keyword) {
+            return Err(SchemaImportError::new(format!(
+                "{path}/{keyword} is not a closed direct reference"
+            )));
+        }
+    }
+    if path != "#" && object.contains_key("$id") {
+        return Err(SchemaImportError::new(format!(
+            "{path}/$id cannot rebase a closed schema import"
+        )));
+    }
+    if path != "#" && object.contains_key("$schema") {
+        return Err(SchemaImportError::new(format!(
+            "{path}/$schema cannot change the fixed draft-2020-12 dialect"
+        )));
+    }
+    if let Some(reference) = object.get("$ref") {
+        let reference = reference
+            .as_str()
+            .ok_or_else(|| SchemaImportError::new(format!("{path}/$ref must be a string")))?;
+        let key = reference_key(reference).ok_or_else(|| {
+            SchemaImportError::new(format!(
+                "{path}/$ref is external or not a direct #/$defs reference: {reference:?}"
+            ))
+        })?;
+        if !definitions.contains_key(&key) {
+            return Err(SchemaImportError::new(format!(
+                "{path}/$ref targets missing definition {key:?}"
+            )));
+        }
+    }
+    for keyword in [
+        "$defs",
+        "properties",
+        "patternProperties",
+        "dependentSchemas",
+    ] {
+        if let Some(children) = object.get(keyword) {
+            let children = children.as_object().ok_or_else(|| {
+                SchemaImportError::new(format!("{path}/{keyword} must be an object"))
+            })?;
+            for (key, child) in children {
+                validate_references(
+                    child,
+                    definitions,
+                    &format!("{path}/{keyword}/{}", pointer_escape(key)),
+                    depth + 1,
+                )?;
+            }
+        }
+    }
+    for keyword in ["allOf", "anyOf", "oneOf", "prefixItems"] {
+        if let Some(children) = object.get(keyword) {
+            let children = children.as_array().ok_or_else(|| {
+                SchemaImportError::new(format!("{path}/{keyword} must be an array"))
+            })?;
+            for (index, child) in children.iter().enumerate() {
+                validate_references(
+                    child,
+                    definitions,
+                    &format!("{path}/{keyword}/{index}"),
+                    depth + 1,
+                )?;
+            }
+        }
+    }
+    for keyword in [
+        "items",
+        "additionalItems",
+        "unevaluatedItems",
+        "additionalProperties",
+        "unevaluatedProperties",
+        "propertyNames",
+        "contains",
+        "not",
+        "if",
+        "then",
+        "else",
+        "contentSchema",
+    ] {
+        if let Some(child) = object.get(keyword) {
+            validate_references(child, definitions, &format!("{path}/{keyword}"), depth + 1)?;
+        }
+    }
+    Ok(())
+}
+
+fn is_generated_envelope(
+    root: &Map<String, Value>,
+    definitions: &Map<String, Value>,
+    namespaces: &Namespaces,
+) -> bool {
+    let Some(node) = definitions.get("Node").and_then(Value::as_object) else {
+        return false;
+    };
+    let Some(annotation) = definitions.get("Annotation") else {
+        return false;
+    };
+    let node_ref = serde_json::json!({ "$ref": "#/$defs/Node" });
+    let graph_envelope = serde_json::json!({
+        "type": "object",
+        "required": ["@graph"],
+        "properties": {
+            "@context": true,
+            "@graph": { "type": "array", "items": node_ref }
+        }
+    });
+    let expected_properties = serde_json::json!({
+        "@context": true,
+        "@graph": { "type": "array", "items": node_ref }
+    });
+    let expected_annotation = serde_json::json!({
+        "type": "object",
+        "title": "RDF-1.2 statement metadata (reifier annotation)",
+        "description": "Free-form metadata about an asserted triple (e.g. meta:accordingTo, meta:confidence, meta:assertedAt). Permissive.",
+        "additionalProperties": {
+            "anyOf": [
+                { "type": "string" },
+                { "type": "number" },
+                { "type": "boolean" },
+                {
+                    "type": "object",
+                    "properties": { "@id": { "type": "string" } },
+                    "required": ["@id"]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "@value": {},
+                        "@type": { "type": "string" }
+                    },
+                    "required": ["@value"]
+                }
+            ]
+        }
+    });
+    let node_properties = node.get("properties").and_then(Value::as_object);
+    let has_node_contract = node.get("type").and_then(Value::as_str) == Some("object")
+        && node.get("title").and_then(Value::as_str)
+            == Some("A single discriminated PURRDF instance node")
+        && node.get("allOf").is_some_and(Value::is_array)
+        && node_properties.is_some_and(|properties| {
+            properties.len() == 3
+                && ["@id", "@type", "@annotation"]
+                    .iter()
+                    .all(|key| properties.contains_key(*key))
+        });
+    root.get("$schema").and_then(Value::as_str) == Some(JSON_SCHEMA_DIALECT)
+        && root.get("$id").and_then(Value::as_str)
+            == Some(format!("{}schema/instance.schema.json", namespaces.primary_ns()).as_str())
+        && root.get("title").and_then(Value::as_str)
+            == Some("PURRDF instance schema (SHACL-derived, closed-world)")
+        && root.get("type").and_then(Value::as_str) == Some("object")
+        && root.get("anyOf") == Some(&serde_json::json!([graph_envelope, node_ref]))
+        && root.get("properties") == Some(&expected_properties)
+        && annotation == &expected_annotation
+        && has_node_contract
+}
+
+fn is_object_schema(object: &Map<String, Value>) -> bool {
+    schema_type_contains(object.get("type"), "object")
+        || object.contains_key("properties")
+        || object.contains_key("required")
+        || object.contains_key("additionalProperties")
+        || ["allOf", "anyOf", "oneOf"].iter().any(|keyword| {
+            object
+                .get(*keyword)
+                .and_then(Value::as_array)
+                .is_some_and(|branches| {
+                    branches
+                        .iter()
+                        .any(|branch| branch.as_object().is_some_and(is_object_schema))
+                })
+        })
+}
+
+fn is_array_schema(object: &Map<String, Value>) -> bool {
+    schema_type_contains(object.get("type"), "array") || object.contains_key("items")
+}
+
+fn is_simple_scalar_carrier(object: &Map<String, Value>) -> bool {
+    object.contains_key("type")
+        && object
+            .keys()
+            .all(|keyword| matches!(keyword.as_str(), "type" | "format"))
+}
+
+fn schema_type_contains(value: Option<&Value>, expected: &str) -> bool {
+    match value {
+        Some(Value::String(value)) => value == expected,
+        Some(Value::Array(values)) => values.iter().any(|value| value.as_str() == Some(expected)),
+        _ => false,
+    }
+}
+
+fn optional_object<'a>(
+    object: &'a Map<String, Value>,
+    keyword: &str,
+    path: &str,
+) -> Result<&'a Map<String, Value>, SchemaImportError> {
+    static EMPTY: OnceLock<Map<String, Value>> = OnceLock::new();
+    object
+        .get(keyword)
+        .map(|value| {
+            value.as_object().ok_or_else(|| {
+                SchemaImportError::new(format!("{path}/{keyword} must be an object"))
+            })
+        })
+        .transpose()
+        .map(|value| value.unwrap_or_else(|| EMPTY.get_or_init(Map::new)))
+}
+
+fn required_names(
+    object: &Map<String, Value>,
+    _properties: &Map<String, Value>,
+    path: &str,
+) -> Result<BTreeSet<String>, SchemaImportError> {
+    let Some(required) = object.get("required") else {
+        return Ok(BTreeSet::new());
+    };
+    let required = required
+        .as_array()
+        .ok_or_else(|| SchemaImportError::new(format!("{path}/required must be an array")))?;
+    let mut names = BTreeSet::new();
+    for (index, name) in required.iter().enumerate() {
+        let name = name.as_str().ok_or_else(|| {
+            SchemaImportError::new(format!("{path}/required/{index} must be a string"))
+        })?;
+        if !names.insert(name.to_owned()) {
+            return Err(SchemaImportError::new(format!(
+                "{path}/required contains duplicate property {name:?}"
+            )));
+        }
+    }
+    Ok(names)
+}
+
+fn validate_object_type(value: Option<&Value>, path: &str) -> Result<(), SchemaImportError> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let kinds = schema_types(value, &format!("{path}/type"))?;
+    if !kinds.iter().any(|kind| kind == "object") {
+        return Err(SchemaImportError::new(format!(
+            "{path}/type must include object for an object definition"
+        )));
+    }
+    Ok(())
+}
+
+fn schema_types(value: &Value, path: &str) -> Result<Vec<String>, SchemaImportError> {
+    let mut kinds = match value {
+        Value::String(kind) => vec![kind.clone()],
+        Value::Array(values) => values
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                value.as_str().map(str::to_owned).ok_or_else(|| {
+                    SchemaImportError::new(format!("{path}/{index} must be a string"))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        _ => {
+            return Err(SchemaImportError::new(format!(
+                "{path} must be a string or array of strings"
+            )));
+        }
+    };
+    kinds.sort();
+    if kinds.is_empty() || kinds.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(SchemaImportError::new(format!(
+            "{path} must contain unique schema primitive names"
+        )));
+    }
+    for kind in &kinds {
+        if !matches!(
+            kind.as_str(),
+            "null" | "boolean" | "object" | "array" | "number" | "string" | "integer"
+        ) {
+            return Err(SchemaImportError::new(format!(
+                "{path} contains unknown JSON Schema type {kind:?}"
+            )));
+        }
+    }
+    Ok(kinds)
+}
+
+fn nonnegative_integer(value: &Value, path: &str) -> Result<u64, SchemaImportError> {
+    value
+        .as_u64()
+        .ok_or_else(|| SchemaImportError::new(format!("{path} must be a non-negative integer")))
+}
+
+fn validate_nonnegative_integer(value: &Value, path: &str) -> Result<(), SchemaImportError> {
+    nonnegative_integer(value, path).map(|_| ())
+}
+
+fn reference_key(reference: &str) -> Option<String> {
+    let encoded = reference.strip_prefix("#/$defs/")?;
+    if encoded.contains('/') {
+        return None;
+    }
+    pointer_unescape(encoded)
+}
+
+fn pointer_unescape(value: &str) -> Option<String> {
+    let mut output = String::with_capacity(value.len());
+    let mut characters = value.chars();
+    while let Some(character) = characters.next() {
+        if character != '~' {
+            output.push(character);
+            continue;
+        }
+        match characters.next()? {
+            '0' => output.push('~'),
+            '1' => output.push('/'),
+            _ => return None,
+        }
+    }
+    Some(output)
+}
+
+fn is_typed_literal_schema(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    let Some(properties) = object.get("properties").and_then(Value::as_object) else {
+        return false;
+    };
+    object.len() == 3
+        && object.get("type").and_then(Value::as_str) == Some("object")
+        && properties.len() == 2
+        && properties
+            .get("@value")
+            .and_then(Value::as_object)
+            .is_some_and(Map::is_empty)
+        && properties
+            .get("@type")
+            .is_some_and(|schema| is_exact_type_schema(schema, "string"))
+        && is_exact_required(object.get("required"), &["@value"])
+}
+
+fn is_node_ref_schema(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    let Some(properties) = object.get("properties").and_then(Value::as_object) else {
+        return false;
+    };
+    (object.len() == 3 || (object.len() == 4 && object.contains_key("$comment")))
+        && object.keys().all(|key| {
+            matches!(
+                key.as_str(),
+                "type" | "properties" | "required" | "$comment"
+            )
+        })
+        && object.get("type").and_then(Value::as_str) == Some("object")
+        && properties.len() == 1
+        && properties
+            .get("@id")
+            .is_some_and(|schema| is_exact_type_schema(schema, "string"))
+        && is_exact_required(object.get("required"), &["@id"])
+        && object.get("$comment").is_none_or(Value::is_string)
+}
+
+fn is_exact_type_schema(value: &Value, expected: &str) -> bool {
+    value.as_object().is_some_and(|object| {
+        object.len() == 1 && object.get("type").and_then(Value::as_str) == Some(expected)
+    })
+}
+
+fn is_exact_required(value: Option<&Value>, expected: &[&str]) -> bool {
+    value.and_then(Value::as_array).is_some_and(|values| {
+        values.len() == expected.len()
+            && values
+                .iter()
+                .zip(expected)
+                .all(|(value, expected)| value.as_str() == Some(*expected))
+    })
+}
+
+fn node_ref_class(
+    object: &Map<String, Value>,
+    namespaces: &Namespaces,
+) -> Result<Option<NamedNode>, SchemaImportError> {
+    let Some(comment) = object.get("$comment").and_then(Value::as_str) else {
+        return Ok(None);
+    };
+    let identity = comment
+        .strip_prefix("external class ")
+        .or_else(|| comment.strip_suffix(" has no NodeShape; node reference only"));
+    let Some(identity) = identity else {
+        return Ok(None);
+    };
+    let iri = namespaces.expand_iri(identity).map_err(|error| {
+        SchemaImportError::new(format!("node-reference class {identity:?}: {error}"))
+    })?;
+    Ok(Some(NamedNode::new_unchecked(iri)))
+}
+
+fn type_discriminator_class(
+    object: &Map<String, Value>,
+    namespaces: &Namespaces,
+) -> Result<Option<NamedNode>, SchemaImportError> {
+    let required = object.get("required").and_then(Value::as_array);
+    if !required.is_some_and(|required| required.iter().any(|value| value == "@type")) {
+        return Ok(None);
+    }
+    let Some(branches) = object
+        .get("properties")
+        .and_then(Value::as_object)
+        .and_then(|properties| properties.get("@type"))
+        .and_then(|schema| schema.get("anyOf"))
+        .and_then(Value::as_array)
+    else {
+        return Ok(None);
+    };
+    let direct = branches.iter().find_map(|branch| branch.get("const"));
+    let contained = branches
+        .iter()
+        .find_map(|branch| branch.get("contains"))
+        .and_then(|contains| contains.get("const"));
+    let (Some(direct), Some(contained)) = (direct, contained) else {
+        return Ok(None);
+    };
+    if direct != contained {
+        return Err(SchemaImportError::new(
+            "@type discriminator direct and array-member constants disagree",
+        ));
+    }
+    let identity = direct
+        .as_str()
+        .ok_or_else(|| SchemaImportError::new("@type discriminator constant must be a string"))?;
+    let iri = namespaces.expand_iri(identity).map_err(|error| {
+        SchemaImportError::new(format!("@type discriminator {identity:?}: {error}"))
+    })?;
+    Ok(Some(NamedNode::new_unchecked(iri)))
+}
+
+fn is_language_literal_schema(object: &Map<String, Value>) -> bool {
+    let Some(properties) = object.get("properties").and_then(Value::as_object) else {
+        return false;
+    };
+    object.len() == 3
+        && object.get("type").and_then(Value::as_str) == Some("object")
+        && properties.len() == 2
+        && properties
+            .get("@value")
+            .is_some_and(|schema| is_exact_type_schema(schema, "string"))
+        && properties
+            .get("@language")
+            .and_then(Value::as_object)
+            .is_some_and(|schema| {
+                schema.len() == 2
+                    && schema.get("type").and_then(Value::as_str) == Some("string")
+                    && schema.get("pattern").is_some_and(Value::is_string)
+            })
+        && is_exact_required(object.get("required"), &["@value", "@language"])
+}
+
+fn language_tags(object: &Map<String, Value>) -> Option<Vec<String>> {
+    let pattern = object
+        .get("properties")?
+        .get("@language")?
+        .get("pattern")?
+        .as_str()?;
+    let inner = pattern.strip_prefix("^(")?.strip_suffix(")(-.*)?$")?;
+    let mut tags = inner
+        .split('|')
+        .map(unescape_regex_literal)
+        .collect::<Option<Vec<_>>>()?;
+    tags.sort();
+    tags.dedup();
+    (!tags.is_empty()).then_some(tags)
+}
+
+fn unescape_regex_literal(value: &str) -> Option<String> {
+    let mut output = String::with_capacity(value.len());
+    let mut chars = value.chars();
+    while let Some(character) = chars.next() {
+        if character == '\\' {
+            output.push(chars.next()?);
+        } else {
+            output.push(character);
+        }
+    }
+    Some(output)
+}
+
+fn json_scalar_lexical(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) => Some(value.clone()),
+        Value::Bool(value) => Some(value.to_string()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Null | Value::Array(_) | Value::Object(_) => None,
+    }
+}
+
+fn is_annotation_keyword(keyword: &str) -> bool {
+    matches!(
+        keyword,
+        "title"
+            | "description"
+            | "$comment"
+            | "default"
+            | "examples"
+            | "deprecated"
+            | "readOnly"
+            | "writeOnly"
+    )
+}
+
+fn is_known_assertion_keyword(keyword: &str) -> bool {
+    matches!(
+        keyword,
+        "type"
+            | "enum"
+            | "const"
+            | "multipleOf"
+            | "maximum"
+            | "exclusiveMaximum"
+            | "minimum"
+            | "exclusiveMinimum"
+            | "maxLength"
+            | "minLength"
+            | "pattern"
+            | "maxItems"
+            | "minItems"
+            | "uniqueItems"
+            | "maxContains"
+            | "minContains"
+            | "contains"
+            | "prefixItems"
+            | "items"
+            | "additionalItems"
+            | "unevaluatedItems"
+            | "maxProperties"
+            | "minProperties"
+            | "properties"
+            | "patternProperties"
+            | "additionalProperties"
+            | "propertyNames"
+            | "required"
+            | "dependentRequired"
+            | "dependentSchemas"
+            | "allOf"
+            | "anyOf"
+            | "oneOf"
+            | "not"
+            | "if"
+            | "then"
+            | "else"
+            | "format"
+            | "contentEncoding"
+            | "contentMediaType"
+            | "contentSchema"
+            | "unevaluatedProperties"
+    )
+}
+
+fn root_loss_code(keyword: &str) -> &'static str {
+    match keyword {
+        "contains" | "minContains" | "maxContains" => "array-contains-validation-dropped",
+        "prefixItems" | "additionalItems" => "tuple-validation-widened",
+        "uniqueItems" => "unique-items-validation-dropped",
+        "dependentRequired" | "dependentSchemas" => "dependency-validation-dropped",
+        "if" | "then" | "else" => "conditional-validation-dropped",
+        "unevaluatedProperties" | "unevaluatedItems" => "unevaluated-validation-dropped",
+        "patternProperties" | "propertyNames" => "object-key-validation-dropped",
+        "minProperties" | "maxProperties" => "property-count-validation-dropped",
+        "contentEncoding" | "contentMediaType" | "contentSchema" => "content-validation-dropped",
+        "format" => "format-validation-widened",
+        "multipleOf" => "multiple-of-validation-dropped",
+        "allOf" | "anyOf" | "oneOf" | "not" => "schema-applicator-dropped",
+        _ => "unknown-keyword-dropped",
+    }
+}
+
+fn validate_json_keyword_value(
+    keyword: &str,
+    value: &Value,
+    path: &str,
+) -> Result<(), SchemaImportError> {
+    let invalid =
+        |expected: &str| Err(SchemaImportError::new(format!("{path} must be {expected}")));
+    match keyword {
+        "$schema" | "$id" | "$anchor" | "$dynamicAnchor" | "$ref" | "$dynamicRef"
+        | "$recursiveRef" | "title" | "description" | "$comment" | "pattern" | "format"
+        | "contentEncoding" | "contentMediaType" => {
+            if value.is_string() {
+                Ok(())
+            } else {
+                invalid("a string")
+            }
+        }
+        "$recursiveAnchor" | "deprecated" | "readOnly" | "writeOnly" | "uniqueItems" => {
+            if value.is_boolean() {
+                Ok(())
+            } else {
+                invalid("a boolean")
+            }
+        }
+        "$vocabulary" => {
+            let Some(entries) = value.as_object() else {
+                return invalid("an object of IRI-to-boolean entries");
+            };
+            if entries.values().all(Value::is_boolean) {
+                Ok(())
+            } else {
+                invalid("an object of IRI-to-boolean entries")
+            }
+        }
+        "$defs" | "properties" | "patternProperties" | "dependentSchemas" => {
+            if value.is_object() {
+                Ok(())
+            } else {
+                invalid("an object of schemas")
+            }
+        }
+        "type" => schema_types(value, path).map(|_| ()),
+        "enum" => validate_array(value, path, true, true),
+        "examples" => {
+            if value.is_array() {
+                Ok(())
+            } else {
+                invalid("an array")
+            }
+        }
+        "required" => validate_unique_string_array(value, path),
+        "dependentRequired" => {
+            let Some(entries) = value.as_object() else {
+                return invalid("an object of unique string arrays");
+            };
+            for (name, names) in entries {
+                validate_unique_string_array(names, &format!("{path}/{}", pointer_escape(name)))?;
+            }
+            Ok(())
+        }
+        "allOf" | "anyOf" | "oneOf" | "prefixItems" => validate_array(value, path, true, false),
+        "multipleOf" => {
+            if value.as_f64().is_some_and(|number| number > 0.0) {
+                Ok(())
+            } else {
+                invalid("a positive JSON number")
+            }
+        }
+        "maximum" | "exclusiveMaximum" | "minimum" | "exclusiveMinimum" => {
+            if value.is_number() {
+                Ok(())
+            } else {
+                invalid("a JSON number")
+            }
+        }
+        "maxLength" | "minLength" | "maxItems" | "minItems" | "maxContains" | "minContains"
+        | "maxProperties" | "minProperties" => validate_nonnegative_integer(value, path),
+        "additionalProperties"
+        | "propertyNames"
+        | "items"
+        | "additionalItems"
+        | "contains"
+        | "not"
+        | "if"
+        | "then"
+        | "else"
+        | "unevaluatedProperties"
+        | "unevaluatedItems"
+        | "contentSchema" => {
+            if value.is_object() || value.is_boolean() {
+                Ok(())
+            } else {
+                invalid("an object or boolean schema")
+            }
+        }
+        // `const`, `default`, and unknown extension keywords accept any JSON
+        // value. Unknown keywords remain valid annotations under 2020-12 and
+        // are ledgered by the importer rather than rejected.
+        _ => Ok(()),
+    }
+}
+
+fn validate_array(
+    value: &Value,
+    path: &str,
+    require_nonempty: bool,
+    require_unique: bool,
+) -> Result<(), SchemaImportError> {
+    let values = value
+        .as_array()
+        .ok_or_else(|| SchemaImportError::new(format!("{path} must be an array")))?;
+    if require_nonempty && values.is_empty() {
+        return Err(SchemaImportError::new(format!(
+            "{path} must contain at least one schema"
+        )));
+    }
+    if require_unique {
+        let mut seen = BTreeSet::new();
+        for item in values {
+            let canonical = serde_json::to_string(item).map_err(|error| {
+                SchemaImportError::new(format!("{path} cannot be canonicalized: {error}"))
+            })?;
+            if !seen.insert(canonical) {
+                return Err(SchemaImportError::new(format!(
+                    "{path} must not contain duplicate values"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_unique_string_array(value: &Value, path: &str) -> Result<(), SchemaImportError> {
+    let values = value
+        .as_array()
+        .ok_or_else(|| SchemaImportError::new(format!("{path} must be an array of strings")))?;
+    let mut seen = BTreeSet::new();
+    for (index, value) in values.iter().enumerate() {
+        let value = value
+            .as_str()
+            .ok_or_else(|| SchemaImportError::new(format!("{path}/{index} must be a string")))?;
+        if !seen.insert(value) {
+            return Err(SchemaImportError::new(format!(
+                "{path} must not contain duplicate strings"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+
+    fn config() -> SchemaImportConfig {
+        let namespaces = Namespaces::new(
+            "ex",
+            &[("ex".to_owned(), "https://example.org/".to_owned())],
+        )
+        .expect("namespace config");
+        let datatypes = SchemaDatatypeMap::new(
+            format!("{XSD}string"),
+            format!("{XSD}boolean"),
+            format!("{XSD}integer"),
+            format!("{XSD}decimal"),
+            format!("{XSD}dateTime"),
+            format!("{XSD}date"),
+            format!("{XSD}time"),
+            format!("{XSD}anyURI"),
+        )
+        .expect("datatype config");
+        SchemaImportConfig::new(namespaces, datatypes)
+    }
+
+    fn compile_turtle(body: &str) -> CompiledSchema {
+        let source = format!(
+            r"
+            @prefix ex:  <https://example.org/> .
+            @prefix sh:  <http://www.w3.org/ns/shacl#> .
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            {body}
+            "
+        );
+        let dataset = crate::text_ingest::parse_turtle_to_dataset(&source).expect("parse shape");
+        let shapes = crate::shapes::from_dataset(&dataset).expect("type shape");
+        crate::json_schema::compile(&shapes, config().namespaces())
+    }
+
+    #[test]
+    fn emitted_json_schema_round_trips_byte_exactly() {
+        let compiled = compile_turtle(
+            r#"
+            ex:PersonShape a sh:NodeShape ;
+                sh:targetClass ex:Person ;
+                sh:closed true ;
+                sh:ignoredProperties ( ex:legacy ) ;
+                sh:property [
+                    sh:path ex:name ;
+                    sh:datatype xsd:string ;
+                    sh:minCount 1 ;
+                    sh:maxCount 1 ;
+                    sh:minLength 2 ;
+                    sh:maxLength 80 ;
+                    sh:pattern "^[A-Z]"
+                ] ;
+                sh:property [
+                    sh:path ex:age ;
+                    sh:datatype xsd:integer ;
+                    sh:maxCount 1 ;
+                    sh:minInclusive 0 ;
+                    sh:maxExclusive 150
+                ] ;
+                sh:property [
+                    sh:path ex:tag ;
+                    sh:datatype xsd:string ;
+                    sh:minCount 2 ;
+                    sh:maxCount 4
+                ] ;
+                sh:property [
+                    sh:path ex:friend ;
+                    sh:class ex:Person ;
+                    sh:maxCount 1
+                ] ;
+                sh:property [
+                    sh:path ex:state ;
+                    sh:maxCount 1 ;
+                    sh:in ( ex:active "inactive" )
+                ] ;
+                sh:property [
+                    sh:path ex:label ;
+                    sh:maxCount 1 ;
+                    sh:languageIn ( "en" "fr" )
+                ] ;
+                sh:property [
+                    sh:path ex:resource ;
+                    sh:maxCount 1 ;
+                    sh:nodeKind sh:IRI
+                ] ;
+                sh:property [
+                    sh:path ex:unshaped ;
+                    sh:maxCount 1 ;
+                    sh:class ex:Unshaped
+                ] .
+            "#,
+        );
+        assert!(compiled.losses.is_empty());
+        let imported = import_compiled_schema(&compiled, &config()).expect("import schema");
+        assert!(
+            imported.losses.is_empty(),
+            "unexpected reverse losses: {}",
+            imported.losses.render_json()
+        );
+        let recompiled = crate::json_schema::compile(&imported.shapes, config().namespaces());
+        assert_eq!(recompiled.schema_json, compiled.schema_json);
+        assert_eq!(recompiled.openapi_json, compiled.openapi_json);
+        assert!(recompiled.losses.is_empty());
+    }
+
+    #[test]
+    fn emitted_logical_shapes_round_trip_byte_exactly() {
+        let compiled = compile_turtle(
+            r"
+            ex:ChoiceShape a sh:NodeShape ;
+                sh:targetClass ex:Choice ;
+                sh:and (
+                    [ sh:property [ sh:path ex:base ; sh:minCount 1 ] ]
+                    [ sh:property [ sh:path ex:enabled ; sh:hasValue true ] ]
+                ) ;
+                sh:or (
+                    [ sh:property [ sh:path ex:left ; sh:minCount 1 ] ]
+                    [ sh:property [ sh:path ex:right ; sh:minCount 1 ] ]
+                ) ;
+                sh:xone (
+                    [ sh:property [ sh:path ex:alpha ; sh:minCount 1 ] ]
+                    [ sh:property [ sh:path ex:beta ; sh:minCount 1 ] ]
+                ) ;
+                sh:not [ sh:property [ sh:path ex:blocked ; sh:minCount 1 ] ] ;
+                sh:not [ sh:class ex:Other ] .
+
+            ex:OtherShape a sh:NodeShape ;
+                sh:targetClass ex:Other .
+            ",
+        );
+        assert!(compiled.losses.is_empty());
+        let imported = import_compiled_schema(&compiled, &config()).expect("import schema");
+        assert!(
+            imported.losses.is_empty(),
+            "unexpected reverse losses: {}",
+            imported.losses.render_json()
+        );
+        let recompiled = crate::json_schema::compile(&imported.shapes, config().namespaces());
+        assert_eq!(recompiled.schema_json, compiled.schema_json);
+        assert!(recompiled.losses.is_empty());
+    }
+
+    #[test]
+    fn valid_unrepresentable_keywords_are_all_located_and_sound() {
+        let schema = json!({
+            "$schema": JSON_SCHEMA_DIALECT,
+            "$id": "https://example.org/schema.json",
+            "$defs": {
+                "Record": {
+                    "type": "object",
+                    "description": "Source documentation.",
+                    "properties": {
+                        "ex:value": {
+                            "type": "number",
+                            "multipleOf": 2,
+                            "x-example-rule": true
+                        }
+                    },
+                    "patternProperties": { "^x-": { "type": "string" } },
+                    "minProperties": 1,
+                    "dependentRequired": { "ex:value": ["ex:other"] },
+                    "if": { "required": ["ex:value"] },
+                    "then": { "required": ["ex:other"] },
+                    "unevaluatedProperties": false
+                },
+                "Scalar": { "type": "string" },
+                "Impossible": false
+            }
+        });
+        let imported = import_json_schema(&schema.to_string(), &config()).expect("import schema");
+        let observed = imported
+            .losses
+            .entries()
+            .iter()
+            .map(|entry| {
+                (
+                    entry.code.as_ref(),
+                    entry
+                        .location
+                        .as_ref()
+                        .and_then(|location| location.subject.as_deref())
+                        .expect("located loss"),
+                )
+            })
+            .collect::<BTreeSet<_>>();
+        for expected in [
+            ("schema-identity-dropped", "#/$schema"),
+            ("schema-identity-dropped", "#/$id"),
+            ("annotation-dropped", "#/$defs/Record/description"),
+            (
+                "multiple-of-validation-dropped",
+                "#/$defs/Record/properties/ex:value/multipleOf",
+            ),
+            (
+                "unknown-keyword-dropped",
+                "#/$defs/Record/properties/ex:value/x-example-rule",
+            ),
+            (
+                "object-key-validation-dropped",
+                "#/$defs/Record/patternProperties",
+            ),
+            (
+                "property-count-validation-dropped",
+                "#/$defs/Record/minProperties",
+            ),
+            (
+                "dependency-validation-dropped",
+                "#/$defs/Record/dependentRequired",
+            ),
+            ("conditional-validation-dropped", "#/$defs/Record/if"),
+            ("conditional-validation-dropped", "#/$defs/Record/then"),
+            (
+                "unevaluated-validation-dropped",
+                "#/$defs/Record/unevaluatedProperties",
+            ),
+            ("non-object-definition-dropped", "#/$defs/Scalar"),
+            ("boolean-schema-dropped", "#/$defs/Impossible"),
+        ] {
+            assert!(
+                observed.contains(&expected),
+                "missing {expected:?}: {observed:?}"
+            );
+        }
+        check_ledger_sound(&imported.losses, JSON_SCHEMA_SOURCE, "shacl")
+            .expect("runtime ledger stays in the closed profile");
+    }
+
+    #[test]
+    fn malformed_dialect_references_and_identities_fail_closed() {
+        for (schema, expected) in [
+            (
+                json!({ "$schema": "https://example.org/other", "$defs": {} }),
+                "#/$schema must be",
+            ),
+            (
+                json!({ "$defs": { "Record": { "$ref": "https://example.org/open" } } }),
+                "external or not a direct",
+            ),
+            (
+                json!({ "$defs": { "Record": { "$ref": "#/$defs/Missing" } } }),
+                "targets missing definition",
+            ),
+            (
+                json!({ "$defs": { "Record": {
+                    "type": "object",
+                    "properties": { "ex:": { "type": "string" } }
+                } } }),
+                "non-empty local part",
+            ),
+        ] {
+            let error = import_json_schema(&schema.to_string(), &config())
+                .expect_err("malformed schema must fail");
+            assert!(error.to_string().contains(expected), "{error}");
+        }
+    }
+
+    #[test]
+    fn malformed_keyword_values_and_identity_collisions_fail_closed() {
+        for (schema, expected) in [
+            (
+                json!({ "$defs": { "Record": {
+                    "type": "object",
+                    "properties": { "ex:value": { "multipleOf": 0 } }
+                } } }),
+                "positive JSON number",
+            ),
+            (
+                json!({ "$defs": { "Record": {
+                    "type": "object",
+                    "required": ["ex:value", "ex:value"]
+                } } }),
+                "duplicate strings",
+            ),
+            (
+                json!({ "$defs": { "Record": {
+                    "type": "object",
+                    "anyOf": []
+                } } }),
+                "at least one schema",
+            ),
+            (
+                json!({ "$defs": { "Record": {
+                    "type": "object",
+                    "properties": {
+                        "ex:value": {
+                            "$schema": "https://json-schema.org/draft/2019-09/schema"
+                        }
+                    }
+                } } }),
+                "cannot change the fixed",
+            ),
+            (
+                json!({ "$defs": {
+                    "Record": { "type": "object" },
+                    "ex:Record": { "type": "object" }
+                } }),
+                "same class IRI",
+            ),
+            (
+                json!({ "$defs": { "Record": {
+                    "type": "object",
+                    "properties": {
+                        "ex:value": true,
+                        "https://example.org/value": true
+                    }
+                } } }),
+                "same property IRI",
+            ),
+        ] {
+            let error = import_json_schema(&schema.to_string(), &config())
+                .expect_err("invalid or ambiguous schema must fail");
+            assert!(error.to_string().contains(expected), "{error}");
+        }
+    }
+
+    #[test]
+    fn valid_native_widenings_are_explicit_and_cardinality_stays_representable() {
+        let schema = json!({
+            "$defs": {
+                "Record": {
+                    "type": "object",
+                    "required": ["@id"],
+                    "properties": {
+                        "@id": { "type": "string" },
+                        "ex:values": {
+                            "type": "array",
+                            "minItems": 2
+                        },
+                        "ex:choice": {
+                            "type": ["number", "string"]
+                        },
+                        "ex:alternative": {
+                            "anyOf": [
+                                { "type": "number" },
+                                { "type": "string" }
+                            ]
+                        }
+                    }
+                }
+            }
+        });
+        let imported = import_json_schema(&schema.to_string(), &config()).expect("valid schema");
+        let shape = &imported.shapes.node_shapes[0];
+        let values = shape
+            .property_shapes
+            .iter()
+            .find(|property| {
+                matches!(&property.path, Path::Predicate(predicate) if predicate.as_str() == "https://example.org/values")
+            })
+            .expect("values property");
+        assert!(
+            values
+                .constraints
+                .iter()
+                .any(|constraint| matches!(constraint, Constraint::MinCount(2)))
+        );
+        let choice = shape
+            .property_shapes
+            .iter()
+            .find(|property| {
+                matches!(&property.path, Path::Predicate(predicate) if predicate.as_str() == "https://example.org/choice")
+            })
+            .expect("choice property");
+        assert!(
+            choice
+                .constraints
+                .iter()
+                .all(|constraint| !matches!(constraint, Constraint::Datatype(_))),
+            "a JSON union must not become an impossible SHACL datatype conjunction"
+        );
+        let alternative = shape
+            .property_shapes
+            .iter()
+            .find(|property| {
+                matches!(&property.path, Path::Predicate(predicate) if predicate.as_str() == "https://example.org/alternative")
+            })
+            .expect("alternative property");
+        assert!(
+            alternative
+                .constraints
+                .iter()
+                .all(|constraint| !matches!(constraint, Constraint::Datatype(_))),
+            "anyOf alternatives must not be imported as a conjunction"
+        );
+        let observed = imported
+            .losses
+            .entries()
+            .iter()
+            .map(|entry| {
+                (
+                    entry.code.as_ref(),
+                    entry
+                        .location
+                        .as_ref()
+                        .and_then(|location| location.subject.as_deref()),
+                )
+            })
+            .collect::<BTreeSet<_>>();
+        assert!(observed.contains(&(
+            "value-term-kind-widened",
+            Some("#/$defs/Record/properties/@id")
+        )));
+        assert!(observed.contains(&(
+            "value-term-kind-widened",
+            Some("#/$defs/Record/properties/ex:choice/type")
+        )));
+        assert!(observed.contains(&(
+            "schema-applicator-dropped",
+            Some("#/$defs/Record/properties/ex:alternative/anyOf")
+        )));
+    }
+
+    #[test]
+    fn datatype_and_namespace_configuration_has_no_defaults() {
+        assert!(
+            SchemaDatatypeMap::new(
+                "relative",
+                format!("{XSD}boolean"),
+                format!("{XSD}integer"),
+                format!("{XSD}decimal"),
+                format!("{XSD}dateTime"),
+                format!("{XSD}date"),
+                format!("{XSD}time"),
+                format!("{XSD}anyURI"),
+            )
+            .is_err()
+        );
+        let namespaces = config().namespaces;
+        assert_eq!(
+            namespaces.expand_iri("ex:Record").as_deref(),
+            Ok("https://example.org/Record")
+        );
+        assert_eq!(
+            namespaces.class_iri_for_def_key("Record").as_deref(),
+            Ok("https://example.org/Record")
+        );
+        assert!(namespaces.expand_iri("unqualified").is_err());
+    }
+}

--- a/crates/shapes/src/schema_import.rs
+++ b/crates/shapes/src/schema_import.rs
@@ -9,6 +9,7 @@
 //! drift between five readers. Accepted omissions are always recorded on a
 //! closed source-language → `shacl` loss profile.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
@@ -389,8 +390,12 @@ fn definition_path(key: &str) -> String {
     format!("#/$defs/{}", pointer_escape(key))
 }
 
-fn pointer_escape(value: &str) -> String {
-    value.replace('~', "~0").replace('/', "~1")
+fn pointer_escape(value: &str) -> Cow<'_, str> {
+    if value.contains('~') || value.contains('/') {
+        Cow::Owned(value.replace('~', "~0").replace('/', "~1"))
+    } else {
+        Cow::Borrowed(value)
+    }
 }
 
 fn fnv1a(bytes: &[u8]) -> u64 {

--- a/crates/shapes/src/typescript.rs
+++ b/crates/shapes/src/typescript.rs
@@ -19,9 +19,10 @@
 //! An arbitrary TypeScript → JSON Schema reader is semantically undefined:
 //! conditional/generic/ambient TypeScript declarations have no unique runtime
 //! acceptance relation, and many distinct JSON Schemas intentionally project to
-//! the same declaration. The authoritative reverse surface is therefore the
-//! source [`CompiledSchema`], retained by the caller alongside the reversible
-//! `$defs` key → exported type-name map.
+//! the same declaration. A [`TypeScriptPackage`] emitted by PurRDF therefore
+//! retains its exact source schema and verifies it against the declaration and
+//! reversible type-name map; [`import_typescript_package`] is the authoritative
+//! reverse surface.
 
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
@@ -37,6 +38,7 @@ use crate::schema_catalog::{
     CompiledSchemaCatalog, definition_path, pointer_escape, reference_key, schema_array_keywords,
     schema_map_keywords, schema_single_keywords,
 };
+use crate::schema_import::{ImportedShapes, SchemaImportConfig, import_json_schema_from};
 
 /// Fixed loss-registry target and compiler-dialect identifier.
 pub const TYPESCRIPT_DIALECT: &str = "typescript-7.0";
@@ -145,6 +147,8 @@ impl TypeScriptConfig {
 /// Deterministic generated declaration package and its projection losses.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeScriptPackage {
+    /// Fixed generated-package dialect.
+    pub dialect: String,
     /// Caller-owned package identifier copied from [`TypeScriptConfig`].
     pub package_name: String,
     /// Relative package paths → exact file bytes, sorted by path.
@@ -154,6 +158,17 @@ pub struct TypeScriptPackage {
     /// JSON Schema assertions not represented exactly by TypeScript 7.0
     /// assignability.
     pub losses: LossLedger,
+    source_schema_json: String,
+    config: TypeScriptConfig,
+}
+
+impl TypeScriptPackage {
+    /// Exact immutable source JSON Schema bytes retained for verified reverse
+    /// import.
+    #[must_use]
+    pub fn source_schema_json(&self) -> &str {
+        &self.source_schema_json
+    }
 }
 
 /// A malformed TypeScript configuration, input schema, or declaration graph.
@@ -274,11 +289,68 @@ pub fn emit_typescript(
         declaration.into_bytes(),
     );
     Ok(TypeScriptPackage {
+        dialect: TYPESCRIPT_DIALECT.to_owned(),
         package_name: config.package_name.clone(),
         artifacts,
         type_names,
         losses,
+        source_schema_json: compiled.schema_json.clone(),
+        config: config.clone(),
     })
+}
+
+/// Import a deterministic PurRDF-emitted TypeScript 7.0 package as SHACL.
+///
+/// Arbitrary TypeScript declarations are intentionally not parsed because
+/// structural/generic/conditional types do not define a unique runtime JSON
+/// acceptance relation. The emitted package instead carries the exact source
+/// schema used for this verified inverse.
+///
+/// # Errors
+///
+/// Returns [`TypeScriptError`] when the dialect, package identity, source
+/// schema, declaration artifact, type-name map, or forward loss ledger differs
+/// from deterministic re-emission, or when shared schema import fails.
+pub fn import_typescript_package(
+    package: &TypeScriptPackage,
+    config: &SchemaImportConfig,
+) -> Result<ImportedShapes, TypeScriptError> {
+    if package.dialect != TYPESCRIPT_DIALECT {
+        return Err(TypeScriptError::new(format!(
+            "TypeScript package dialect must be {TYPESCRIPT_DIALECT:?}, got {:?}",
+            package.dialect
+        )));
+    }
+    {
+        let retained = CompiledSchema {
+            schema_json: package.source_schema_json.clone(),
+            openapi_json: "{}\n".to_owned(),
+            losses: LossLedger::new(),
+        };
+        let expected = emit_typescript(&retained, &package.config)?;
+        if package.package_name != expected.package_name {
+            return Err(TypeScriptError::new(
+                "TypeScript package identity differs from deterministic re-emission",
+            ));
+        }
+        if package.artifacts != expected.artifacts {
+            return Err(TypeScriptError::new(
+                "TypeScript package artifacts differ from deterministic re-emission",
+            ));
+        }
+        if package.type_names != expected.type_names {
+            return Err(TypeScriptError::new(
+                "TypeScript package type map differs from deterministic re-emission",
+            ));
+        }
+        if package.losses.render_json() != expected.losses.render_json() {
+            return Err(TypeScriptError::new(
+                "TypeScript package forward loss ledger differs from deterministic re-emission",
+            ));
+        }
+    }
+    import_json_schema_from(TYPESCRIPT_DIALECT, &package.source_schema_json, config)
+        .map_err(|error| TypeScriptError::new(format!("TypeScript package import: {error}")))
 }
 
 fn validate_unguarded_reference_cycles(
@@ -1868,8 +1940,12 @@ fn finish_text(mut text: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::json_schema::Namespaces;
+    use crate::schema_import::SchemaDatatypeMap;
     use ::purrdf::loss::{check_ledger_complete, check_ledger_sound};
     use serde_json::json;
+
+    const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
 
     fn compiled(schema: &Value) -> CompiledSchema {
         CompiledSchema {
@@ -1889,6 +1965,40 @@ mod tests {
             "Caller-owned module documentation.",
         )
         .expect("valid config")
+    }
+
+    fn import_config() -> SchemaImportConfig {
+        let namespaces = Namespaces::new(
+            "ex",
+            &[("ex".to_owned(), "https://example.org/".to_owned())],
+        )
+        .expect("namespaces");
+        let datatypes = SchemaDatatypeMap::new(
+            format!("{XSD}string"),
+            format!("{XSD}boolean"),
+            format!("{XSD}integer"),
+            format!("{XSD}decimal"),
+            format!("{XSD}dateTime"),
+            format!("{XSD}date"),
+            format!("{XSD}time"),
+            format!("{XSD}anyURI"),
+        )
+        .expect("datatypes");
+        SchemaImportConfig::new(namespaces, datatypes)
+    }
+
+    fn compile_turtle(body: &str) -> CompiledSchema {
+        let source = format!(
+            r"
+            @prefix ex:  <https://example.org/> .
+            @prefix sh:  <http://www.w3.org/ns/shacl#> .
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            {body}
+            "
+        );
+        let dataset = crate::text_ingest::parse_turtle_to_dataset(&source).expect("parse");
+        let shapes = crate::shapes::from_dataset(&dataset).expect("shapes");
+        crate::json_schema::compile(&shapes, import_config().namespaces())
     }
 
     fn declaration(package: &TypeScriptPackage) -> &str {
@@ -1991,6 +2101,100 @@ mod tests {
                 .split(|character: char| !character.is_ascii_alphanumeric())
                 .any(|token| token == "any")
         );
+    }
+
+    #[test]
+    fn emitted_package_imports_byte_exactly_and_corruption_fails_closed() {
+        let compiled = compile_turtle(
+            r#"
+            ex:PersonShape a sh:NodeShape ;
+                sh:targetClass ex:Person ;
+                sh:closed true ;
+                sh:property [
+                    sh:path ex:name ;
+                    sh:datatype xsd:string ;
+                    sh:minCount 1 ;
+                    sh:maxCount 1 ;
+                    sh:pattern "^[A-Z]"
+                ] ;
+                sh:property [
+                    sh:path ex:friend ;
+                    sh:class ex:Person ;
+                    sh:maxCount 1
+                ] ;
+                sh:property [
+                    sh:path ex:state ;
+                    sh:maxCount 1 ;
+                    sh:in ( ex:active "inactive" )
+                ] .
+            "#,
+        );
+        let package = emit_typescript(&compiled, &config()).expect("emit");
+        assert_eq!(package.source_schema_json(), compiled.schema_json);
+        let imported = import_typescript_package(&package, &import_config()).expect("import");
+        assert!(
+            imported.losses.is_empty(),
+            "{}",
+            imported.losses.render_json()
+        );
+        let recompiled =
+            crate::json_schema::compile(&imported.shapes, import_config().namespaces());
+        assert_eq!(recompiled.schema_json, compiled.schema_json);
+
+        let repeated = import_typescript_package(&package, &import_config()).expect("repeat");
+        let repeated = crate::json_schema::compile(&repeated.shapes, import_config().namespaces());
+        assert_eq!(repeated.schema_json, recompiled.schema_json);
+
+        let mut bad = package.clone();
+        bad.dialect = "typescript-8.0".to_owned();
+        assert!(import_typescript_package(&bad, &import_config()).is_err());
+
+        let mut bad = package.clone();
+        bad.package_name = "@example/drift".to_owned();
+        assert!(import_typescript_package(&bad, &import_config()).is_err());
+
+        let mut bad = package.clone();
+        bad.artifacts
+            .get_mut(TYPESCRIPT_DECLARATION_PATH)
+            .expect("declaration")
+            .extend_from_slice(b"// drift\n");
+        assert!(import_typescript_package(&bad, &import_config()).is_err());
+
+        let mut bad = package;
+        *bad.type_names.values_mut().next().expect("type name") = "Missing".to_owned();
+        assert!(import_typescript_package(&bad, &import_config()).is_err());
+    }
+
+    #[test]
+    fn verified_package_imports_alias_recursive_nullable_and_finite_schema() {
+        let schema = json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "Alias": { "$ref": "#/$defs/Person" },
+                "Choice": { "enum": ["ex:open", "ex:closed"] },
+                "Person": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ex:choice": { "$ref": "#/$defs/Choice" },
+                        "ex:friend": { "$ref": "#/$defs/Person" },
+                        "ex:maybe": { "type": ["string", "null"] }
+                    }
+                }
+            }
+        });
+        let package = emit_typescript(&compiled(&schema), &config()).expect("emit");
+        let imported = import_typescript_package(&package, &import_config()).expect("import");
+        check_ledger_sound(&imported.losses, TYPESCRIPT_DIALECT, "shacl")
+            .expect("sound reverse ledger");
+        assert_eq!(imported.shapes.node_shapes.len(), 1);
+        assert!(imported.losses.entries().iter().all(|entry| {
+            entry
+                .location
+                .as_ref()
+                .and_then(|location| location.subject.as_deref())
+                .is_some_and(|subject| subject.starts_with("#/"))
+        }));
     }
 
     #[test]

--- a/crates/shapes/tests/graphql_oracle.mjs
+++ b/crates/shapes/tests/graphql_oracle.mjs
@@ -215,6 +215,20 @@ const manifest = fixtureManifest();
 if (manifest.dialect !== "graphql-september-2025") {
   throw new Error(`GraphQL dialect drift: ${manifest.dialect}`);
 }
+if (!manifest.reverse.shapeIds.includes("<https://example.org/Person>")) {
+  throw new Error(`GraphQL reverse import lost Person: ${manifest.reverse.shapeIds}`);
+}
+if (
+  !manifest.reverse.losses.losses.every(
+    (entry) =>
+      entry.from === "graphql-september-2025" &&
+      entry.to === "shacl" &&
+      entry.intentional === true &&
+      lossSubject(entry).startsWith("#/"),
+  )
+) {
+  throw new Error("GraphQL reverse package has an unsound or unlocated loss");
+}
 if (manifest.exact.losses.losses.length !== 0) {
   throw new Error("exact GraphQL oracle fixture has a non-empty loss ledger");
 }
@@ -239,5 +253,6 @@ console.log(
   `GraphQL oracle: GraphQL.js ${graphqlVersion}; ` +
     `${exactResults.length} exact boon/variable-coercion probes agree; ` +
     `${divergenceCount} located divergences cover the complete ${profile.size}-code profile; ` +
-    `${codecCount} probes exercise the production value codec`,
+    `${codecCount} probes exercise the production value codec; ` +
+    "verified reverse SHACL import passes",
 );

--- a/crates/shapes/tests/linkml_oracle.py
+++ b/crates/shapes/tests/linkml_oracle.py
@@ -138,6 +138,24 @@ def _assert_reference_closure(document: dict[str, Any]) -> None:
     walk(definitions)
 
 
+def _assert_reverse(payload: dict[str, Any], expected_shape_ids: list[str]) -> None:
+    reverse = payload["reverse"]
+    if reverse["shape_ids"] != expected_shape_ids:
+        raise AssertionError(
+            f"unexpected reverse SHACL shapes: {reverse['shape_ids']!r}"
+        )
+    _assert_reference_closure(reverse["schema"])
+    losses = reverse["losses"]["losses"]
+    if not all(entry["from"] == "linkml-1.11" for entry in losses):
+        raise AssertionError("reverse ledger contains a foreign source format")
+    if not all(entry["to"] == "shacl" for entry in losses):
+        raise AssertionError("reverse ledger contains a foreign target format")
+    if not all(entry["intentional"] for entry in losses):
+        raise AssertionError("reverse fixture contains an unregistered loss")
+    if not all(" subject=#/" in entry["location"] for entry in losses):
+        raise AssertionError("reverse loss was not remapped to a native LinkML path")
+
+
 def _assert_exact(payload: dict[str, Any]) -> None:
     source = payload["schema"]
     element_names = payload["element_names"]
@@ -213,6 +231,10 @@ def _assert_exact(payload: dict[str, Any]) -> None:
         generated,
         probes,
     )
+    _assert_reverse(
+        payload,
+        ["<https://example.org/Address>", "<https://example.org/Person>"],
+    )
 
 
 def _assert_lossy(payload: dict[str, Any]) -> None:
@@ -283,6 +305,7 @@ def _assert_lossy(payload: dict[str, Any]) -> None:
         raise AssertionError("source string length unexpectedly accepted a short label")
     if not _is_valid(generated, "Lossy", {"ex:label": "x"}):
         raise AssertionError("recorded string-length drop is not observable")
+    _assert_reverse(payload, ["<https://example.org/Lossy>"])
 
 
 def main() -> None:
@@ -296,7 +319,7 @@ def main() -> None:
     _assert_lossy(payload["lossy"])
     print(
         "LinkML oracle: exact $defs and 16 instance probes agree; "
-        "18 located losses and representable widening probes pass"
+        "18 located losses, reverse SHACL imports, and representable widening probes pass"
     )
 
 

--- a/crates/shapes/tests/never_panic.rs
+++ b/crates/shapes/tests/never_panic.rs
@@ -11,6 +11,9 @@
 
 use proptest::prelude::*;
 use purrdf_shapes::engine::parse_shapes;
+use purrdf_shapes::json_schema::Namespaces;
+use purrdf_shapes::{SchemaDatatypeMap, SchemaImportConfig, import_json_schema};
+use serde_json::{Map, Number, Value};
 
 fn arbitrary_bytes() -> impl Strategy<Value = Vec<u8>> {
     prop::collection::vec(any::<u8>(), 0..4096)
@@ -37,6 +40,44 @@ fn structured_shapes() -> impl Strategy<Value = String> {
     prop::collection::vec(prop::sample::select(fragments), 0..24).prop_map(|parts| parts.concat())
 }
 
+fn arbitrary_json() -> impl Strategy<Value = Value> {
+    let leaf = prop_oneof![
+        Just(Value::Null),
+        any::<bool>().prop_map(Value::Bool),
+        any::<i64>().prop_map(|value| Value::Number(Number::from(value))),
+        ".{0,64}".prop_map(Value::String),
+    ];
+    leaf.prop_recursive(5, 128, 8, |inner| {
+        prop_oneof![
+            prop::collection::vec(inner.clone(), 0..8).prop_map(Value::Array),
+            prop::collection::btree_map(".{0,24}", inner, 0..8).prop_map(|entries| {
+                Value::Object(entries.into_iter().collect::<Map<String, Value>>())
+            }),
+        ]
+    })
+}
+
+fn schema_import_config() -> SchemaImportConfig {
+    const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+    let namespaces = Namespaces::new(
+        "ex",
+        &[("ex".to_owned(), "https://example.org/".to_owned())],
+    )
+    .expect("valid test namespace");
+    let datatypes = SchemaDatatypeMap::new(
+        format!("{XSD}string"),
+        format!("{XSD}boolean"),
+        format!("{XSD}integer"),
+        format!("{XSD}decimal"),
+        format!("{XSD}dateTime"),
+        format!("{XSD}date"),
+        format!("{XSD}time"),
+        format!("{XSD}anyURI"),
+    )
+    .expect("valid test datatypes");
+    SchemaImportConfig::new(namespaces, datatypes)
+}
+
 proptest! {
     #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
 
@@ -50,5 +91,11 @@ proptest! {
     #[test]
     fn parse_shapes_never_panics_structured(text in structured_shapes()) {
         let _ = parse_shapes(&text);
+    }
+
+    #[test]
+    fn import_json_schema_never_panics(value in arbitrary_json()) {
+        let input = serde_json::to_string(&value).expect("JSON value serializes");
+        let _ = import_json_schema(&input, &schema_import_config());
     }
 }

--- a/crates/shapes/tests/never_panic.rs
+++ b/crates/shapes/tests/never_panic.rs
@@ -12,7 +12,10 @@
 use proptest::prelude::*;
 use purrdf_shapes::engine::parse_shapes;
 use purrdf_shapes::json_schema::Namespaces;
-use purrdf_shapes::{SchemaDatatypeMap, SchemaImportConfig, import_json_schema};
+use purrdf_shapes::{
+    LinkmlDocument, SchemaDatatypeMap, SchemaImportConfig, import_json_schema, import_linkml,
+    parse_linkml,
+};
 use serde_json::{Map, Number, Value};
 
 fn arbitrary_bytes() -> impl Strategy<Value = Vec<u8>> {
@@ -97,5 +100,35 @@ proptest! {
     fn import_json_schema_never_panics(value in arbitrary_json()) {
         let input = serde_json::to_string(&value).expect("JSON value serializes");
         let _ = import_json_schema(&input, &schema_import_config());
+    }
+
+    #[test]
+    fn parse_linkml_never_panics(data in arbitrary_bytes()) {
+        if let Ok(text) = std::str::from_utf8(&data) {
+            let _ = parse_linkml(text);
+        }
+    }
+
+    #[test]
+    fn import_linkml_never_panics(section in 0_usize..4, value in arbitrary_json()) {
+        let mut document = serde_json::json!({
+            "id": "https://example.org/schema/linkml",
+            "name": "Generated-Schema",
+            "metamodel_version": "1.11.0",
+            "prefixes": {
+                "ex": "https://example.org/",
+                "linkml": "https://w3id.org/linkml/"
+            },
+            "default_prefix": "ex",
+            "classes": {},
+            "enums": {},
+            "slots": {},
+            "types": {}
+        });
+        let section_name = ["classes", "enums", "slots", "types"][section];
+        document[section_name]["Generated"] = value;
+        if let Ok(document) = LinkmlDocument::from_value(document) {
+            let _ = import_linkml(&document, &schema_import_config());
+        }
     }
 }

--- a/crates/shapes/tests/pydantic_oracle.py
+++ b/crates/shapes/tests/pydantic_oracle.py
@@ -125,6 +125,18 @@ def _normalize_inferred_types(actual: Any, expected: Any) -> Any:
 
 def main() -> None:
     payload = _fixture()
+    reverse = payload["reverse"]
+    if reverse["shape_ids"] != ["<https://example.org/Person>"]:
+        raise AssertionError(f"unexpected reverse SHACL shapes: {reverse['shape_ids']!r}")
+    reverse_losses = reverse["losses"]["losses"]
+    if not all(
+        entry["from"] == "pydantic-v2"
+        and entry["to"] == "shacl"
+        and entry["intentional"]
+        and " subject=#/" in entry["location"]
+        for entry in reverse_losses
+    ):
+        raise AssertionError("Pydantic reverse package has an unsound or unlocated loss")
     with tempfile.TemporaryDirectory(prefix="purrdf-pydantic-oracle-") as directory:
         root = Path(directory)
         for relative, text in payload["artifacts"].items():
@@ -284,7 +296,10 @@ def main() -> None:
         finally:
             sys.path.remove(str(root))
 
-    print("Pydantic oracle: 6 live model schemas agree; validation/alias probes pass")
+    print(
+        "Pydantic oracle: 6 live model schemas agree; validation/alias probes and "
+        "verified reverse SHACL import pass"
+    )
 
 
 if __name__ == "__main__":

--- a/crates/shapes/tests/typescript_oracle.mjs
+++ b/crates/shapes/tests/typescript_oracle.mjs
@@ -338,6 +338,20 @@ if (process.argv.includes("--self-test")) {
   process.exit(0);
 }
 const manifest = fixtureManifest();
+if (!manifest.reverse.shapeIds.includes("<https://example.org/Person>")) {
+  throw new Error(`TypeScript reverse import lost Person: ${manifest.reverse.shapeIds}`);
+}
+if (
+  !manifest.reverse.losses.losses.every(
+    (entry) =>
+      entry.from === "typescript-7.0" &&
+      entry.to === "shacl" &&
+      entry.intentional === true &&
+      lossSubject(entry).startsWith("#/"),
+  )
+) {
+  throw new Error("TypeScript reverse package has an unsound or unlocated loss");
+}
 if (manifest.exact.losses.losses.length !== 0) {
   throw new Error("exact TypeScript oracle fixture has a non-empty loss ledger");
 }
@@ -360,7 +374,8 @@ try {
     `TypeScript oracle: compiler ${compilerVersion}; ` +
       `${manifest.exact.probes.length} exact boon probes and ` +
       `${manifest.exact.compilerProbes.length} optional/null/undefined probes agree; ` +
-      `${divergenceCount} divergences map to the complete 18-code loss profile`,
+      `${divergenceCount} divergences map to the complete 18-code loss profile; ` +
+      "verified reverse SHACL import passes",
   );
 } finally {
   rmSync(directory, { recursive: true, force: true });

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -50,8 +50,8 @@ They live under `crates/*/benches/`:
   anti-join cost with and without the `exists_memo` decorrelation path.
 - `crates/sparql-eval/benches/lateral_service.rs` — variable-endpoint
   `SERVICE ?g` evaluated as a LATERAL join vs. a fixed-IRI `SERVICE <ep>`.
-- `crates/shapes/benches/validate.rs` — SHACL validation plus shared JSON Schema
-  import/lowering throughput and one-operation allocation traffic.
+- `crates/shapes/benches/validate.rs` — SHACL validation plus JSON Schema and
+  LinkML import/lowering throughput and one-operation allocation traffic.
 - `crates/entail/benches/chase.rs` — RDFS forward-materialization chase scaling.
 - `crates/gts/benches/authoring.rs` — GTS container authoring.
 - `crates/rdf-wasm/benches/query_engine_reuse.rs` — package-root
@@ -82,7 +82,7 @@ Additional benches are run package-by-package, e.g.
 | `crates/sparql-eval/benches/cost_based_bgp_planner.rs` | Planner regression watch: cost-based BGP ordering vs. the retired structural heuristic. |
 | `crates/sparql-eval/benches/exists_decorrelation.rs` | `FILTER NOT EXISTS` inner-pattern re-evaluation and index-rebuild cost with/without memoization. |
 | `crates/sparql-eval/benches/lateral_service.rs` | `SERVICE ?g` LATERAL substitute-and-forward cost as the number of distinct endpoint bindings grows. |
-| `crates/shapes/benches/validate.rs` | SHACL Core validation latency plus JSON Schema → SHACL import/lowering throughput and allocation traffic on deterministic fixtures. |
+| `crates/shapes/benches/validate.rs` | SHACL Core validation latency plus JSON Schema/LinkML → SHACL import/lowering throughput and allocation traffic on deterministic fixtures. |
 | `crates/entail/benches/chase.rs` | RDFS semi-naive materialization scaling on subclass chains. |
 | `crates/gts/benches/authoring.rs` | GTS container authoring: append, hash, and CBOR-log construction throughput. |
 | `crates/rdf-wasm/benches/query_engine_reuse.rs` | Binding-level SELECT overhead for reused package-root `QueryEngine` instances vs. fresh construction. |
@@ -97,6 +97,13 @@ local references. Fixture construction and caller-owned namespace/datatype
 configuration remain outside the timed loop; Criterion measures the complete
 JSON parse, validation, ordered lowering, and loss-ledger path.
 
+The `shacl_linkml_import` group derives one canonical LinkML 1.11 document from
+the same source fixture before timing begins. It measures native document
+validation, class/slot/type traversal, shared schema lowering, and reverse-loss
+construction. Both groups assert the imported shape count in their warmup,
+allocation probe, and measured loop so a failed or vacuous import cannot appear
+as a speedup.
+
 A counting global allocator also prints calls and requested bytes for one
 warmed import. Those counters represent cumulative allocation traffic, not
 retained or peak memory, and the benchmark is report-only: neither timing nor
@@ -105,6 +112,8 @@ allocation output is a CI threshold or performance promise.
 ```sh
 cargo bench -p purrdf-shapes --bench validate --locked -- shacl_schema_import
 cargo bench -p purrdf-shapes --bench validate --locked -- shacl_schema_import --quick
+cargo bench -p purrdf-shapes --bench validate --locked -- shacl_linkml_import
+cargo bench -p purrdf-shapes --bench validate --locked -- shacl_linkml_import --quick
 ```
 
 ### Graph, tabular, and research-object projections

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -50,7 +50,8 @@ They live under `crates/*/benches/`:
   anti-join cost with and without the `exists_memo` decorrelation path.
 - `crates/sparql-eval/benches/lateral_service.rs` — variable-endpoint
   `SERVICE ?g` evaluated as a LATERAL join vs. a fixed-IRI `SERVICE <ep>`.
-- `crates/shapes/benches/validate.rs` — SHACL validation.
+- `crates/shapes/benches/validate.rs` — SHACL validation plus shared JSON Schema
+  import/lowering throughput and one-operation allocation traffic.
 - `crates/entail/benches/chase.rs` — RDFS forward-materialization chase scaling.
 - `crates/gts/benches/authoring.rs` — GTS container authoring.
 - `crates/rdf-wasm/benches/query_engine_reuse.rs` — package-root
@@ -81,11 +82,30 @@ Additional benches are run package-by-package, e.g.
 | `crates/sparql-eval/benches/cost_based_bgp_planner.rs` | Planner regression watch: cost-based BGP ordering vs. the retired structural heuristic. |
 | `crates/sparql-eval/benches/exists_decorrelation.rs` | `FILTER NOT EXISTS` inner-pattern re-evaluation and index-rebuild cost with/without memoization. |
 | `crates/sparql-eval/benches/lateral_service.rs` | `SERVICE ?g` LATERAL substitute-and-forward cost as the number of distinct endpoint bindings grows. |
-| `crates/shapes/benches/validate.rs` | SHACL Core validation latency on synthetic shapes/graphs. |
+| `crates/shapes/benches/validate.rs` | SHACL Core validation latency plus JSON Schema → SHACL import/lowering throughput and allocation traffic on deterministic fixtures. |
 | `crates/entail/benches/chase.rs` | RDFS semi-naive materialization scaling on subclass chains. |
 | `crates/gts/benches/authoring.rs` | GTS container authoring: append, hash, and CBOR-log construction throughput. |
 | `crates/rdf-wasm/benches/query_engine_reuse.rs` | Binding-level SELECT overhead for reused package-root `QueryEngine` instances vs. fresh construction. |
 | `crates/iri/benches/parse.rs` | `purrdf_iri::parse` component validation across scheme, authority, path, query, and fragment classes. |
+
+### SHACL schema import
+
+The `shacl_schema_import` group constructs a compact, deterministic draft
+2020-12 document with 128 classes and 1,024 properties. Its mix covers scalar
+facets, finite values, homogeneous arrays, requiredness, closure, and cyclic
+local references. Fixture construction and caller-owned namespace/datatype
+configuration remain outside the timed loop; Criterion measures the complete
+JSON parse, validation, ordered lowering, and loss-ledger path.
+
+A counting global allocator also prints calls and requested bytes for one
+warmed import. Those counters represent cumulative allocation traffic, not
+retained or peak memory, and the benchmark is report-only: neither timing nor
+allocation output is a CI threshold or performance promise.
+
+```sh
+cargo bench -p purrdf-shapes --bench validate --locked -- shacl_schema_import
+cargo bench -p purrdf-shapes --bench validate --locked -- shacl_schema_import --quick
+```
 
 ### Graph, tabular, and research-object projections
 

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -71,6 +71,7 @@ number, never a silent skip (see [Ledger discipline](#ledger-discipline) and
 | ShEx negative structure | shexTest v2.1.0, `negativeStructure/` | **14 / 14** rejected |
 | SHACL | W3C data-shapes, `core/` + `sparql/` + `af/` | **126 / 126** · 0 ledgered |
 | SHACL (first-party corpus) | `crates/shapes/corpus/` | **69 / 69** frozen expected reports |
+| Schema → SHACL | first-party exact/lossy/corruption/resource suites + locked language oracles | **5 / 5** production directions; exact emitted-schema recompilation or located closed-profile losses; no deferred reader |
 | Syntax codecs | W3C rdf-tests `crates/rdf/tests/corpus/w3c/` | **250 / 250** round-trip (nquads 27, ntriples 29, rdfxml 31, trig 60, turtle 103) · 0 gaps |
 | CSVW | W3C CSVW manifests, `crates/rdf/tests/fixtures/csvw-w3c/` | **270 / 270** RDF cases · **282 / 282** validation cases · 0 xfail; production output also accepted by locked `csvw==4.1.0` |
 | OBO Graphs view | official OBO Graphs 0.3.2 JSON Schema | production advanced-object fixture accepted; deliberate node/chain corruptions rejected |
@@ -97,6 +98,12 @@ number, never a silent skip (see [Ledger discipline](#ledger-discipline) and
   byte-frozen expected reports, covering purrdf-specific behavior (reifier
   shapes, path forms, property pairs, qualified shapes, SHACL-AF
   `sh:expression`).
+- `crates/shapes/src/schema_import.rs`, `crates/shapes/src/linkml/importer.rs`,
+  and the Pydantic/TypeScript/GraphQL module tests — the five schema → SHACL
+  reverse contracts, including deterministic exact recompilation, complete
+  located loss profiles, corruption failures, fixed resource limits, and
+  arbitrary-input panic guards. `crates/shapes/examples/schema_reverse.rs`
+  exercises the public facade end to end.
 - `crates/sparql-conformance/` — the W3C SPARQL 1.1 harness plus first-party
   extension-function and standpoint suites.
 - `crates/rdf/tests/corpus/w3c/` — the W3C rdf-tests syntax corpus (Turtle,
@@ -129,6 +136,8 @@ cargo test -p purrdf-iri                               # IRI + RFC 3986 resoluti
 cargo test -p purrdf-shex                              # all four ShEx suites
 cargo test -p purrdf-shapes --test w3c_conformance -- --nocapture   # W3C SHACL scoreboard
 cargo test -p purrdf-shapes --test conformance         # the 69-case frozen corpus
+cargo run -p purrdf-shapes --example schema_reverse --locked        # all five schema readers
+make pydantic-oracle linkml-oracle typescript-oracle graphql-oracle # independent schema runtimes
 cargo test -p purrdf-sparql-conformance                # W3C SPARQL
 cargo test -p purrdf-rdf                               # RDFC-1.0 + codec goldens
 make projection-oracles                               # W3C CSVW + independent CSVW/OBO checks
@@ -222,6 +231,15 @@ issue, so the matrix stays honest:
   first-party fixtures under `vectors/shacl/af/rules/`, discovered by
   `crates/shapes/tests/rules_conformance.rs`, with the derived graph compared to
   the expected inferred graph by RDFC-1.0 isomorphism.
+
+  **Schema-import bidirectionality sign-off.** JSON Schema draft 2020-12 and
+  LinkML 1.11 have native readers. Pydantic v2, TypeScript 7.0, and GraphQL
+  September 2025 reverse only intact PurRDF-emitted packages because arbitrary
+  source in those languages has no unique JSON acceptance relation. All five
+  share caller-owned namespace/datatype configuration, deterministic lowering,
+  fixed resource limits, and closed reverse-loss profiles. Supported emitted
+  SHACL schemas recompile byte-exactly; accepted carrier-only or
+  non-representable semantics are located and ledgered, never silently skipped.
 
   **SHACL-AF completeness sign-off.** Every SHACL-AF component is now
   implemented, with nothing remaining out of scope: SPARQL-based constraints and

--- a/docs/book/src/validation/shacl.md
+++ b/docs/book/src/validation/shacl.md
@@ -44,6 +44,33 @@ so shapes can constrain the RDF 1.2 reifier metadata attached to statements
 draft is dated 2026-06-02. **This is not a claim of full SHACL 1.2
 conformance** — it is one draft feature, explicitly scoped and tested.
 
+## Schema → SHACL imports
+
+The schema-projection surface is bidirectional. `SchemaImportConfig` requires
+the caller's namespace table and the complete RDF datatype mapping for JSON
+scalars; there is no default vocabulary. The five production reverse directions
+are JSON Schema draft 2020-12 (`import_json_schema`), native LinkML 1.11
+(`import_linkml`), and verified PurRDF-emitted Pydantic v2, TypeScript 7.0, and
+GraphQL September 2025 packages (`import_*_package`). All five lower through one
+ordered JSON-Schema semantic model and return typed shapes plus an
+always-computed, located reverse `LossLedger`.
+
+Malformed values, open or dangling references, identity collisions, generated
+artifact/map drift, and resource-limit exhaustion fail closed. Valid source
+constructs without an exact SHACL interpretation are ledgered at their native
+JSON Pointer. Arbitrary Python, TypeScript, and GraphQL SDL are intentionally
+outside the inverse boundary because none defines one unique runtime JSON
+acceptance relation. LinkML does have a native reader; its schema identity and
+documentation can therefore appear as losses even when the validation-bearing
+SHACL recompiles byte-exactly.
+
+The executable example constructs caller-owned `example.org` configuration and
+exercises all five paths:
+
+```bash
+cargo run -p purrdf-shapes --example schema_reverse --locked
+```
+
 ## Pydantic v2 projection
 
 `purrdf-shapes` can transliterate a compiled SHACL-derived JSON Schema into a
@@ -61,6 +88,8 @@ located entry in the always-computed `json-schema` → `pydantic-v2`
 `LossLedger`; a lossless input yields an empty ledger. The renderer itself has no
 Python dependency and stays wasm-clean. A dev-only Python oracle executes the
 generated code and checks the live reverse/schema surface.
+`import_pydantic_package` separately verifies the retained source schema,
+generated files, model map, dialect, and forward ledger before importing SHACL.
 
 ## LinkML 1.11 projection
 
@@ -80,6 +109,10 @@ collisions fail closed. `parse_linkml` and `write_linkml` preserve all
 JSON-compatible metamodel fields and provide byte-stable read/write round trips
 while rejecting YAML-only tags, duplicate keys, non-string keys, and non-finite
 numbers.
+
+`import_linkml` consumes that validated native document; the emitted-package
+variant `import_linkml_package` first verifies canonical YAML and the reversible
+element map. Both use the same caller-owned SHACL import configuration.
 
 The Rust production path has no LinkML-toolkit dependency. CI uses the locked
 official LinkML 1.11.1 Python packages only as a differential oracle:
@@ -119,9 +152,11 @@ make typescript-oracle
 
 The projection intentionally has no arbitrary TypeScript reader. TypeScript
 declarations do not define a unique runtime JSON acceptance relation, and the
-projection is many-to-one. The retained `CompiledSchema` plus the reversible
-name map remains the authoritative reverse surface. TypeScript is only a
-dev-time oracle dependency; the Rust emitter is filesystem-free and wasm-clean.
+projection is many-to-one. `import_typescript_package` is the authoritative
+reverse surface: it deterministically verifies the retained source schema,
+declaration, reversible name map, dialect, and forward ledger. TypeScript is
+only a dev-time oracle dependency; the Rust emitter/importer is filesystem-free
+and wasm-clean.
 
 ## GraphQL September 2025 projection
 
@@ -150,8 +185,10 @@ finite JSON values.
 `GraphqlPackage::encode_input` maps source JSON keys and finite values to input
 field names and enum symbols. `decode_output` performs the inverse for fields
 present in a GraphQL response, without inventing omitted selections. Unknown or
-incompatible values fail. This package codec is the precise reverse boundary;
-arbitrary GraphQL SDL has no unique JSON Schema acceptance relation and is not
+incompatible values fail. This package codec is the precise value boundary;
+`import_graphql_package` is the schema reverse boundary and verifies the SDL,
+typed/canonical maps, identity, retained source schema, and forward ledger.
+Arbitrary GraphQL SDL has no unique JSON Schema acceptance relation and is not
 accepted as an inverse format.
 
 GraphQL variable coercion differs from JSON Schema validation at these closed

--- a/generated/transcode-loss-matrix.json
+++ b/generated/transcode-loss-matrix.json
@@ -140,6 +140,153 @@
     "note": "A recognized native member used a value shape outside the supported semantic mapping and is omitted with its source location recorded."
   },
   {
+    "code": "additional-properties-schema-widened",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema-valued additionalProperties assertion constrains arbitrary object members, while SHACL Core closure can only reject unlisted direct predicates. Named properties remain constrained and the arbitrary-value schema is widened."
+  },
+  {
+    "code": "annotation-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema title, description, comment, example, default, deprecation marker, or native documentation annotation has no exact validation meaning in the imported SHACL shape and is omitted."
+  },
+  {
+    "code": "array-contains-validation-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "Schema contains/minContains/maxContains assertions quantify matching array members; the imported SHACL property retains item and total-cardinality constraints but cannot express that independent match count exactly."
+  },
+  {
+    "code": "boolean-schema-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A standalone true or false schema has no class-targeted SHACL shape identity. The definition is omitted rather than inventing a caller vocabulary term."
+  },
+  {
+    "code": "conditional-validation-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "Schema if/then/else validation chooses constraints from runtime object content. SHACL Core has no equivalent conditional constraint, so independently representable constraints remain and the conditional relationship is omitted."
+  },
+  {
+    "code": "content-validation-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "String contentEncoding/contentMediaType/contentSchema assertions describe or validate an embedded representation. SHACL Core constrains the RDF literal itself and cannot reproduce that nested content contract."
+  },
+  {
+    "code": "dependency-validation-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "dependentRequired/dependentSchemas or an equivalent native cross-field dependency has no exact SHACL Core property-shape expression. Individual properties remain while the dependency is omitted."
+  },
+  {
+    "code": "enum-metadata-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema enum member's generated symbol, title, description, or other parallel metadata is not part of SHACL membership semantics and is omitted while the finite values remain."
+  },
+  {
+    "code": "format-validation-widened",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A string format without one exact caller-identifiable RDF datatype is imported as its scalar carrier. PurRDF does not mint or guess a datatype IRI, so format validation is widened and recorded."
+  },
+  {
+    "code": "multiple-of-validation-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A numeric multipleOf assertion has no SHACL Core numeric facet. Datatype and range bounds remain while divisibility validation is omitted."
+  },
+  {
+    "code": "non-object-definition-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A top-level schema definition describes a scalar, array, finite value set, or alias rather than a class-shaped object. Without a caller-supplied class/property use site it cannot become a top-level SHACL node shape and is omitted."
+  },
+  {
+    "code": "numeric-lexical-form-normalized",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A JSON/native numeric value carries numeric value but not the original RDF literal lexical form or derived XSD datatype. The importer uses the canonical configured numeric carrier, so that lexical distinction is normalized."
+  },
+  {
+    "code": "object-key-validation-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "patternProperties/propertyNames or an equivalent native dynamic-key rule constrains JSON member names. Direct SHACL predicate paths retain named properties, but the dynamic key-space rule is omitted."
+  },
+  {
+    "code": "property-count-validation-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "minProperties/maxProperties counts JSON object members independently of named predicates. SHACL property shapes retain named requiredness but cannot bound the total predicate count with a Core constraint."
+  },
+  {
+    "code": "schema-applicator-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema logical applicator cannot be lowered to an equivalent finite SHACL and/or/xone/not shape at its position. Independently representable constraints remain and the applicator is omitted."
+  },
+  {
+    "code": "schema-identity-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema document identifier, anchor, dialect declaration, generated package identity, or native module identity is not a SHACL vocabulary term. Caller-owned class and property IRIs remain; the carrier identity is omitted."
+  },
+  {
+    "code": "tuple-validation-widened",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "Position-specific prefixItems/additionalItems or an equivalent tuple type has no direct RDF multi-value ordering contract on one predicate. Common item/cardinality constraints remain and positional validation is widened."
+  },
+  {
+    "code": "unevaluated-validation-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "unevaluatedProperties/unevaluatedItems depends on schema-applicator evaluation state that SHACL Core does not expose. Local closure, named properties, and item constraints remain while the evaluation-state assertion is omitted."
+  },
+  {
+    "code": "unique-items-validation-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "uniqueItems constrains duplicate JSON array members. RDF predicate values are a set in the data model, so the serialized-array assertion has no distinct imported SHACL constraint and is omitted."
+  },
+  {
+    "code": "unknown-keyword-dropped",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A valid extension or assertion outside the fixed importer capability table has no reviewed SHACL interpretation. It is omitted with a located entry rather than silently ignored or guessed."
+  },
+  {
+    "code": "value-term-kind-widened",
+    "from": "graphql-september-2025",
+    "to": "shacl",
+    "intentional": true,
+    "note": "The schema carrier admits values whose RDF term kind or exact datatype cannot be recovered uniquely. The importer retains the representable scalar/node carrier and records the unresolved term-kind distinction."
+  },
+  {
     "code": "canonical-rdf12-projection",
     "from": "gts",
     "to": "canonical-rdf12",
@@ -595,6 +742,153 @@
     "note": "Pydantic v2 unions implement any-branch semantics and cannot enforce JSON Schema oneOf's exactly-one matching rule; runtime validation uses a union while model_json_schema() retains oneOf."
   },
   {
+    "code": "additional-properties-schema-widened",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema-valued additionalProperties assertion constrains arbitrary object members, while SHACL Core closure can only reject unlisted direct predicates. Named properties remain constrained and the arbitrary-value schema is widened."
+  },
+  {
+    "code": "annotation-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema title, description, comment, example, default, deprecation marker, or native documentation annotation has no exact validation meaning in the imported SHACL shape and is omitted."
+  },
+  {
+    "code": "array-contains-validation-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "Schema contains/minContains/maxContains assertions quantify matching array members; the imported SHACL property retains item and total-cardinality constraints but cannot express that independent match count exactly."
+  },
+  {
+    "code": "boolean-schema-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A standalone true or false schema has no class-targeted SHACL shape identity. The definition is omitted rather than inventing a caller vocabulary term."
+  },
+  {
+    "code": "conditional-validation-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "Schema if/then/else validation chooses constraints from runtime object content. SHACL Core has no equivalent conditional constraint, so independently representable constraints remain and the conditional relationship is omitted."
+  },
+  {
+    "code": "content-validation-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "String contentEncoding/contentMediaType/contentSchema assertions describe or validate an embedded representation. SHACL Core constrains the RDF literal itself and cannot reproduce that nested content contract."
+  },
+  {
+    "code": "dependency-validation-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "dependentRequired/dependentSchemas or an equivalent native cross-field dependency has no exact SHACL Core property-shape expression. Individual properties remain while the dependency is omitted."
+  },
+  {
+    "code": "enum-metadata-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema enum member's generated symbol, title, description, or other parallel metadata is not part of SHACL membership semantics and is omitted while the finite values remain."
+  },
+  {
+    "code": "format-validation-widened",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A string format without one exact caller-identifiable RDF datatype is imported as its scalar carrier. PurRDF does not mint or guess a datatype IRI, so format validation is widened and recorded."
+  },
+  {
+    "code": "multiple-of-validation-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A numeric multipleOf assertion has no SHACL Core numeric facet. Datatype and range bounds remain while divisibility validation is omitted."
+  },
+  {
+    "code": "non-object-definition-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A top-level schema definition describes a scalar, array, finite value set, or alias rather than a class-shaped object. Without a caller-supplied class/property use site it cannot become a top-level SHACL node shape and is omitted."
+  },
+  {
+    "code": "numeric-lexical-form-normalized",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A JSON/native numeric value carries numeric value but not the original RDF literal lexical form or derived XSD datatype. The importer uses the canonical configured numeric carrier, so that lexical distinction is normalized."
+  },
+  {
+    "code": "object-key-validation-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "patternProperties/propertyNames or an equivalent native dynamic-key rule constrains JSON member names. Direct SHACL predicate paths retain named properties, but the dynamic key-space rule is omitted."
+  },
+  {
+    "code": "property-count-validation-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "minProperties/maxProperties counts JSON object members independently of named predicates. SHACL property shapes retain named requiredness but cannot bound the total predicate count with a Core constraint."
+  },
+  {
+    "code": "schema-applicator-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema logical applicator cannot be lowered to an equivalent finite SHACL and/or/xone/not shape at its position. Independently representable constraints remain and the applicator is omitted."
+  },
+  {
+    "code": "schema-identity-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema document identifier, anchor, dialect declaration, generated package identity, or native module identity is not a SHACL vocabulary term. Caller-owned class and property IRIs remain; the carrier identity is omitted."
+  },
+  {
+    "code": "tuple-validation-widened",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "Position-specific prefixItems/additionalItems or an equivalent tuple type has no direct RDF multi-value ordering contract on one predicate. Common item/cardinality constraints remain and positional validation is widened."
+  },
+  {
+    "code": "unevaluated-validation-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "unevaluatedProperties/unevaluatedItems depends on schema-applicator evaluation state that SHACL Core does not expose. Local closure, named properties, and item constraints remain while the evaluation-state assertion is omitted."
+  },
+  {
+    "code": "unique-items-validation-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "uniqueItems constrains duplicate JSON array members. RDF predicate values are a set in the data model, so the serialized-array assertion has no distinct imported SHACL constraint and is omitted."
+  },
+  {
+    "code": "unknown-keyword-dropped",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A valid extension or assertion outside the fixed importer capability table has no reviewed SHACL interpretation. It is omitted with a located entry rather than silently ignored or guessed."
+  },
+  {
+    "code": "value-term-kind-widened",
+    "from": "json-schema",
+    "to": "shacl",
+    "intentional": true,
+    "note": "The schema carrier admits values whose RDF term kind or exact datatype cannot be recovered uniquely. The importer retains the representable scalar/node carrier and records the unresolved term-kind distinction."
+  },
+  {
     "code": "additional-properties-validation-widened",
     "from": "json-schema",
     "to": "typescript-7.0",
@@ -987,6 +1281,153 @@
     "note": "The target syntax has no named-graph construct; quads are folded into the default graph and graph names are dropped."
   },
   {
+    "code": "additional-properties-schema-widened",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema-valued additionalProperties assertion constrains arbitrary object members, while SHACL Core closure can only reject unlisted direct predicates. Named properties remain constrained and the arbitrary-value schema is widened."
+  },
+  {
+    "code": "annotation-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema title, description, comment, example, default, deprecation marker, or native documentation annotation has no exact validation meaning in the imported SHACL shape and is omitted."
+  },
+  {
+    "code": "array-contains-validation-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "Schema contains/minContains/maxContains assertions quantify matching array members; the imported SHACL property retains item and total-cardinality constraints but cannot express that independent match count exactly."
+  },
+  {
+    "code": "boolean-schema-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A standalone true or false schema has no class-targeted SHACL shape identity. The definition is omitted rather than inventing a caller vocabulary term."
+  },
+  {
+    "code": "conditional-validation-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "Schema if/then/else validation chooses constraints from runtime object content. SHACL Core has no equivalent conditional constraint, so independently representable constraints remain and the conditional relationship is omitted."
+  },
+  {
+    "code": "content-validation-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "String contentEncoding/contentMediaType/contentSchema assertions describe or validate an embedded representation. SHACL Core constrains the RDF literal itself and cannot reproduce that nested content contract."
+  },
+  {
+    "code": "dependency-validation-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "dependentRequired/dependentSchemas or an equivalent native cross-field dependency has no exact SHACL Core property-shape expression. Individual properties remain while the dependency is omitted."
+  },
+  {
+    "code": "enum-metadata-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema enum member's generated symbol, title, description, or other parallel metadata is not part of SHACL membership semantics and is omitted while the finite values remain."
+  },
+  {
+    "code": "format-validation-widened",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A string format without one exact caller-identifiable RDF datatype is imported as its scalar carrier. PurRDF does not mint or guess a datatype IRI, so format validation is widened and recorded."
+  },
+  {
+    "code": "multiple-of-validation-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A numeric multipleOf assertion has no SHACL Core numeric facet. Datatype and range bounds remain while divisibility validation is omitted."
+  },
+  {
+    "code": "non-object-definition-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A top-level schema definition describes a scalar, array, finite value set, or alias rather than a class-shaped object. Without a caller-supplied class/property use site it cannot become a top-level SHACL node shape and is omitted."
+  },
+  {
+    "code": "numeric-lexical-form-normalized",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A JSON/native numeric value carries numeric value but not the original RDF literal lexical form or derived XSD datatype. The importer uses the canonical configured numeric carrier, so that lexical distinction is normalized."
+  },
+  {
+    "code": "object-key-validation-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "patternProperties/propertyNames or an equivalent native dynamic-key rule constrains JSON member names. Direct SHACL predicate paths retain named properties, but the dynamic key-space rule is omitted."
+  },
+  {
+    "code": "property-count-validation-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "minProperties/maxProperties counts JSON object members independently of named predicates. SHACL property shapes retain named requiredness but cannot bound the total predicate count with a Core constraint."
+  },
+  {
+    "code": "schema-applicator-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema logical applicator cannot be lowered to an equivalent finite SHACL and/or/xone/not shape at its position. Independently representable constraints remain and the applicator is omitted."
+  },
+  {
+    "code": "schema-identity-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema document identifier, anchor, dialect declaration, generated package identity, or native module identity is not a SHACL vocabulary term. Caller-owned class and property IRIs remain; the carrier identity is omitted."
+  },
+  {
+    "code": "tuple-validation-widened",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "Position-specific prefixItems/additionalItems or an equivalent tuple type has no direct RDF multi-value ordering contract on one predicate. Common item/cardinality constraints remain and positional validation is widened."
+  },
+  {
+    "code": "unevaluated-validation-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "unevaluatedProperties/unevaluatedItems depends on schema-applicator evaluation state that SHACL Core does not expose. Local closure, named properties, and item constraints remain while the evaluation-state assertion is omitted."
+  },
+  {
+    "code": "unique-items-validation-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "uniqueItems constrains duplicate JSON array members. RDF predicate values are a set in the data model, so the serialized-array assertion has no distinct imported SHACL constraint and is omitted."
+  },
+  {
+    "code": "unknown-keyword-dropped",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A valid extension or assertion outside the fixed importer capability table has no reviewed SHACL interpretation. It is omitted with a located entry rather than silently ignored or guessed."
+  },
+  {
+    "code": "value-term-kind-widened",
+    "from": "linkml-1.11",
+    "to": "shacl",
+    "intentional": true,
+    "note": "The schema carrier admits values whose RDF term kind or exact datatype cannot be recovered uniquely. The importer retains the representable scalar/node carrier and records the unresolved term-kind distinction."
+  },
+  {
     "code": "lpg-edge-id-dropped",
     "from": "lpg",
     "to": "rdf-1.2-dataset",
@@ -1300,6 +1741,153 @@
     "to": "rdfxml",
     "intentional": true,
     "note": "RDF/XML has no triple-term (RDF-1.2 quoted triple) syntax; reifying triples and their annotations are dropped."
+  },
+  {
+    "code": "additional-properties-schema-widened",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema-valued additionalProperties assertion constrains arbitrary object members, while SHACL Core closure can only reject unlisted direct predicates. Named properties remain constrained and the arbitrary-value schema is widened."
+  },
+  {
+    "code": "annotation-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema title, description, comment, example, default, deprecation marker, or native documentation annotation has no exact validation meaning in the imported SHACL shape and is omitted."
+  },
+  {
+    "code": "array-contains-validation-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "Schema contains/minContains/maxContains assertions quantify matching array members; the imported SHACL property retains item and total-cardinality constraints but cannot express that independent match count exactly."
+  },
+  {
+    "code": "boolean-schema-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A standalone true or false schema has no class-targeted SHACL shape identity. The definition is omitted rather than inventing a caller vocabulary term."
+  },
+  {
+    "code": "conditional-validation-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "Schema if/then/else validation chooses constraints from runtime object content. SHACL Core has no equivalent conditional constraint, so independently representable constraints remain and the conditional relationship is omitted."
+  },
+  {
+    "code": "content-validation-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "String contentEncoding/contentMediaType/contentSchema assertions describe or validate an embedded representation. SHACL Core constrains the RDF literal itself and cannot reproduce that nested content contract."
+  },
+  {
+    "code": "dependency-validation-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "dependentRequired/dependentSchemas or an equivalent native cross-field dependency has no exact SHACL Core property-shape expression. Individual properties remain while the dependency is omitted."
+  },
+  {
+    "code": "enum-metadata-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema enum member's generated symbol, title, description, or other parallel metadata is not part of SHACL membership semantics and is omitted while the finite values remain."
+  },
+  {
+    "code": "format-validation-widened",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A string format without one exact caller-identifiable RDF datatype is imported as its scalar carrier. PurRDF does not mint or guess a datatype IRI, so format validation is widened and recorded."
+  },
+  {
+    "code": "multiple-of-validation-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A numeric multipleOf assertion has no SHACL Core numeric facet. Datatype and range bounds remain while divisibility validation is omitted."
+  },
+  {
+    "code": "non-object-definition-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A top-level schema definition describes a scalar, array, finite value set, or alias rather than a class-shaped object. Without a caller-supplied class/property use site it cannot become a top-level SHACL node shape and is omitted."
+  },
+  {
+    "code": "numeric-lexical-form-normalized",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A JSON/native numeric value carries numeric value but not the original RDF literal lexical form or derived XSD datatype. The importer uses the canonical configured numeric carrier, so that lexical distinction is normalized."
+  },
+  {
+    "code": "object-key-validation-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "patternProperties/propertyNames or an equivalent native dynamic-key rule constrains JSON member names. Direct SHACL predicate paths retain named properties, but the dynamic key-space rule is omitted."
+  },
+  {
+    "code": "property-count-validation-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "minProperties/maxProperties counts JSON object members independently of named predicates. SHACL property shapes retain named requiredness but cannot bound the total predicate count with a Core constraint."
+  },
+  {
+    "code": "schema-applicator-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema logical applicator cannot be lowered to an equivalent finite SHACL and/or/xone/not shape at its position. Independently representable constraints remain and the applicator is omitted."
+  },
+  {
+    "code": "schema-identity-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema document identifier, anchor, dialect declaration, generated package identity, or native module identity is not a SHACL vocabulary term. Caller-owned class and property IRIs remain; the carrier identity is omitted."
+  },
+  {
+    "code": "tuple-validation-widened",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "Position-specific prefixItems/additionalItems or an equivalent tuple type has no direct RDF multi-value ordering contract on one predicate. Common item/cardinality constraints remain and positional validation is widened."
+  },
+  {
+    "code": "unevaluated-validation-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "unevaluatedProperties/unevaluatedItems depends on schema-applicator evaluation state that SHACL Core does not expose. Local closure, named properties, and item constraints remain while the evaluation-state assertion is omitted."
+  },
+  {
+    "code": "unique-items-validation-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "uniqueItems constrains duplicate JSON array members. RDF predicate values are a set in the data model, so the serialized-array assertion has no distinct imported SHACL constraint and is omitted."
+  },
+  {
+    "code": "unknown-keyword-dropped",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A valid extension or assertion outside the fixed importer capability table has no reviewed SHACL interpretation. It is omitted with a located entry rather than silently ignored or guessed."
+  },
+  {
+    "code": "value-term-kind-widened",
+    "from": "pydantic-v2",
+    "to": "shacl",
+    "intentional": true,
+    "note": "The schema carrier admits values whose RDF term kind or exact datatype cannot be recovered uniquely. The importer retains the representable scalar/node carrier and records the unresolved term-kind distinction."
   },
   {
     "code": "research-object-annotation-dropped",
@@ -2154,6 +2742,153 @@
     "to": "rdfxml",
     "intentional": true,
     "note": "RDF/XML has no triple-term (RDF-1.2 quoted triple) syntax; reifying triples and their annotations are dropped."
+  },
+  {
+    "code": "additional-properties-schema-widened",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema-valued additionalProperties assertion constrains arbitrary object members, while SHACL Core closure can only reject unlisted direct predicates. Named properties remain constrained and the arbitrary-value schema is widened."
+  },
+  {
+    "code": "annotation-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema title, description, comment, example, default, deprecation marker, or native documentation annotation has no exact validation meaning in the imported SHACL shape and is omitted."
+  },
+  {
+    "code": "array-contains-validation-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "Schema contains/minContains/maxContains assertions quantify matching array members; the imported SHACL property retains item and total-cardinality constraints but cannot express that independent match count exactly."
+  },
+  {
+    "code": "boolean-schema-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A standalone true or false schema has no class-targeted SHACL shape identity. The definition is omitted rather than inventing a caller vocabulary term."
+  },
+  {
+    "code": "conditional-validation-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "Schema if/then/else validation chooses constraints from runtime object content. SHACL Core has no equivalent conditional constraint, so independently representable constraints remain and the conditional relationship is omitted."
+  },
+  {
+    "code": "content-validation-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "String contentEncoding/contentMediaType/contentSchema assertions describe or validate an embedded representation. SHACL Core constrains the RDF literal itself and cannot reproduce that nested content contract."
+  },
+  {
+    "code": "dependency-validation-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "dependentRequired/dependentSchemas or an equivalent native cross-field dependency has no exact SHACL Core property-shape expression. Individual properties remain while the dependency is omitted."
+  },
+  {
+    "code": "enum-metadata-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema enum member's generated symbol, title, description, or other parallel metadata is not part of SHACL membership semantics and is omitted while the finite values remain."
+  },
+  {
+    "code": "format-validation-widened",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A string format without one exact caller-identifiable RDF datatype is imported as its scalar carrier. PurRDF does not mint or guess a datatype IRI, so format validation is widened and recorded."
+  },
+  {
+    "code": "multiple-of-validation-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A numeric multipleOf assertion has no SHACL Core numeric facet. Datatype and range bounds remain while divisibility validation is omitted."
+  },
+  {
+    "code": "non-object-definition-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A top-level schema definition describes a scalar, array, finite value set, or alias rather than a class-shaped object. Without a caller-supplied class/property use site it cannot become a top-level SHACL node shape and is omitted."
+  },
+  {
+    "code": "numeric-lexical-form-normalized",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A JSON/native numeric value carries numeric value but not the original RDF literal lexical form or derived XSD datatype. The importer uses the canonical configured numeric carrier, so that lexical distinction is normalized."
+  },
+  {
+    "code": "object-key-validation-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "patternProperties/propertyNames or an equivalent native dynamic-key rule constrains JSON member names. Direct SHACL predicate paths retain named properties, but the dynamic key-space rule is omitted."
+  },
+  {
+    "code": "property-count-validation-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "minProperties/maxProperties counts JSON object members independently of named predicates. SHACL property shapes retain named requiredness but cannot bound the total predicate count with a Core constraint."
+  },
+  {
+    "code": "schema-applicator-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema logical applicator cannot be lowered to an equivalent finite SHACL and/or/xone/not shape at its position. Independently representable constraints remain and the applicator is omitted."
+  },
+  {
+    "code": "schema-identity-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A schema document identifier, anchor, dialect declaration, generated package identity, or native module identity is not a SHACL vocabulary term. Caller-owned class and property IRIs remain; the carrier identity is omitted."
+  },
+  {
+    "code": "tuple-validation-widened",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "Position-specific prefixItems/additionalItems or an equivalent tuple type has no direct RDF multi-value ordering contract on one predicate. Common item/cardinality constraints remain and positional validation is widened."
+  },
+  {
+    "code": "unevaluated-validation-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "unevaluatedProperties/unevaluatedItems depends on schema-applicator evaluation state that SHACL Core does not expose. Local closure, named properties, and item constraints remain while the evaluation-state assertion is omitted."
+  },
+  {
+    "code": "unique-items-validation-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "uniqueItems constrains duplicate JSON array members. RDF predicate values are a set in the data model, so the serialized-array assertion has no distinct imported SHACL constraint and is omitted."
+  },
+  {
+    "code": "unknown-keyword-dropped",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "A valid extension or assertion outside the fixed importer capability table has no reviewed SHACL interpretation. It is omitted with a located entry rather than silently ignored or guessed."
+  },
+  {
+    "code": "value-term-kind-widened",
+    "from": "typescript-7.0",
+    "to": "shacl",
+    "intentional": true,
+    "note": "The schema carrier admits values whose RDF term kind or exact datatype cannot be recovered uniquely. The importer retains the representable scalar/node carrier and records the unresolved term-kind distinction."
   },
   {
     "code": "canonical-rdf12-projection",


### PR DESCRIPTION
Closes #112.

## Outcome

PurRDF now imports the complete schema-projection family back into SHACL:

- JSON Schema draft 2020-12 and LinkML 1.11 have native document readers.
- Deterministic PurRDF-emitted Pydantic v2, TypeScript 7.0, and GraphQL September 2025 packages have verified reverse readers over their exact retained schema contracts.
- Every reader returns typed `Shapes` plus an always-computed, located reverse `LossLedger` from one closed 21-code profile.

No language is deferred. Arbitrary Python, TypeScript declarations, and GraphQL SDL are explicitly outside the inverse contract because they do not define a unique JSON acceptance relation; accepting them would invent semantics. The fixed emitted-package readers verify exact artifacts, maps/identity, source schema, and forward ledger before importing.

## Implementation

- Adds mandatory caller-owned `SchemaImportConfig`, bounded JSON Schema parsing, deterministic SHACL lowering, local-reference validation, identity-collision checks, and typed import errors.
- Adds a native LinkML adapter for classes, slots/attributes, types, enums, inheritance/mixins, ranges, cardinality/list semantics, facets, finite values, closure, and boolean expressions.
- Adds verified reverse functions for `PydanticPackage`, `TypeScriptPackage`, and `GraphqlPackage`; package drift and dialect mismatch fail closed.
- Registers all five schema-to-SHACL pairs in the canonical loss registry and regenerates the transcode-loss matrix from source.
- Exposes the readers from `purrdf-shapes` and `purrdf::shapes`, adds an all-five runnable example, expands docs/conformance/provenance, and adds a report-only importer benchmark.

PurRDF does not retain gmeow’s legacy models or defaults. Those models are disposable migration material; the downstream deletion/cutover remains tracked by gmeow-ontology#1571 while this PR supplies their replacement surface.

## Acceptance evidence

- Supported SHACL → schema → SHACL → schema paths are byte-exact; lossy native inputs prove stable output plus exact located ledger coverage.
- Every valid accepted omission maps to the closed profile; malformed values, external/dynamic/dangling/rebased references, collisions, resource exhaustion, and coordinated package corruption fail closed.
- Every vocabulary and datatype IRI is caller supplied. No gmeow dependency, fabricated namespace, filesystem/network/clock/RNG behavior, Cargo feature, optional dependency, or wasm-host divergence was introduced.
- Public production examples and four live locked-language oracles exercise all reverse APIs.

## Validation

- `UV_CACHE_DIR=/tmp/purrdf-112-uv-cache make check`
- `make metadata`
- `make doc`
- all 17 release crates checked for `wasm32-unknown-unknown` by the full gate
- `make pydantic-oracle`
- `make linkml-oracle`
- `make typescript-oracle` (TypeScript 7.0.2)
- `make graphql-oracle` (GraphQL.js 16.14)
- all-five `schema_reverse` example twice with identical output
- mdBook 0.5.3 SHACL book build
- warning-denied workspace Clippy/rustdoc
- exact whitespace, generated-artifact, feature, dependency, vocabulary, issue-reference, and deferral scans
- all five commits verify with the repository signing key; the worktree is clean and synchronized

The 128-class/1,024-property report-only Criterion probe measured 2.7285–2.7465 ms (372.84–375.29 Kelem/s), 89,825 allocations, and 6,507,870 requested bytes. This is evidence only, not a performance claim or gate.

## Deferrals

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON Schema-to-SHACL importing with configurable namespaces and datatype mappings.
  * Added reverse import support for LinkML, Pydantic v2, TypeScript 7.0, and GraphQL.
  * Added deterministic package verification, artifact integrity checks, and located loss reporting.
  * Added namespace and schema identity validation for safer imports.

* **Bug Fixes**
  * Improved handling of malformed, ambiguous, dangling, or tampered schema artifacts.
  * Prevented expected broken-pipe conditions from causing test failures.

* **Documentation**
  * Added usage guidance, reverse-import examples, conformance details, and schema-import benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->