### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,174 @@ All notable changes to the PurRDF crate suite are recorded here. The suite
 ships one lockstep version across crates.io, PyPI, and npm; pre-1.0, a minor
 bump may carry breaking changes and a patch bump is bugfix-only.
 
+## [0.7.0] - 2026-07-17
+
+### Benchmarks
+
+- **core:** Measure wavelet indexes against pack FoQ
+- **shapes:** Measure LinkML imports
+
+### Bug Fixes
+
+- **shapes:** Record losses for non-class shape targets instead of dropping silently
+- **capi:** Regenerate the ABI header for the 0.6 version bump
+- **rdf:** Skip triple-term self-reifier sentinels in the JSON-LD reifier index
+- **rdf:** Graph-scope reifier/annotation identity end-to-end
+- **rdf:** Record TriX/HexTuples base-direction drop in the loss ledger
+- **cli:** Reach reason stdin/stdout via --from/--to + fail-fast format resolve
+- **cli:** Treat stdout BrokenPipe as a clean exit, not a runtime error
+- **wasm,playground:** Honest size re-baseline + JSON-LD bidirectional round-trip
+- **rdf-core:** Keep page planning metadata-only
+- **rdf-core:** Make paged view debug inert
+- **columnar:** Support published loss ledger API
+- **columnar:** Bound untrusted decode allocations
+- **rdf:** Scan escaped OKF link destinations
+- **rdf:** Normalize exponent-form OKF decimals
+- **shapes:** Enforce constrained schema unions
+- **shapes:** Align Pydantic loss contracts
+- **shapes:** Enforce JSON carrier fidelity
+- **shapes:** Harden TypeScript reference closure
+- **shapes:** Close TypeScript loss-audit gaps
+- **shapes:** Bound TypeScript alias-cycle scans
+- **shapes:** Describe GraphQL key validation bidirectionally
+- **capi:** Restrict projection output permissions
+- **rdf:** Honor CSVW record dialects
+- **rdf:** Validate CSVW BCP 47 tags
+
+### CI & Build
+
+- **wasm:** Raise size budget for packed-dataset restoration
+- **wasm:** Raise npm tarball size ceiling for packed-dataset restoration
+
+### Documentation
+
+- **core:** Drop stale issue-number token from loss_matrix_json doc comment
+- **core:** Unlink private registry_entries from public loss_matrix_json doc
+- **rdf:** Unlink classify from the private FORMATS table for rustdoc
+- **cli:** Add the purrdf CLI README; fix a private intra-doc link
+- **query:** Define paged completeness contract
+- **shapes:** Document Pydantic projection
+- **shapes:** Document LinkML projection
+- **shapes:** Define TypeScript projection contract
+- **shapes:** Define the GraphQL carrier boundary
+- **rdf:** Complete projection adoption surface
+- **conformance:** Refresh projection parity count
+- Refresh conformance parity count
+- **shapes:** Complete schema reverse surface
+- Keep issue tracking out of provenance
+
+### Features
+
+- **core:** Unify the runtime loss ledger and add an enumerable codec-pair registry
+- **shapes:** Record schema-projection losses on the unified LossLedger
+- **core:** Add reusable ledger soundness + completeness verification helpers
+- **core:** Enumerate the codec-pair registry and pin the runtime-ledger schema
+- **core:** Make loss_matrix_json the enumerable codec-pair registry
+- **core:** Unified loss-ledger surface for all codecs
+- **rdf:** Register JSON-LD/YAML-LD as first-class native format variants
+- **rdf:** Lossless JSON-LD-star triple-term encoding + orphan-reifier fix
+- **rdf:** Lossless nested triple terms + reject annotations inside a @triple
+- **rdf:** Unify JSON-LD/YAML-LD into the native format registry
+- **rdf:** Make the native serializer generic over DatasetView
+- **rdf-core:** Public DatasetView-generic pack reconstructor
+- **cli:** Add the purrdf CLI crate (convert/query/reason core)
+- **cli:** Convert --base/--entailment/--canonical + full matrix tests
+- **cli:** Query --base/--entailment + CONSTRUCT/DESCRIBE RDF sink
+- **cli:** Reason --base + per-regime boundary diagnostics + tests
+- **cli:** The purrdf CLI — convert / query / reason
+- **rdf:** Expose packed dataset restoration
+- **rdf-core:** Certify paged provider snapshots
+- **rdf-core:** Add fallible paged query views
+- **sparql:** Certify complete fallible query results
+- Certify fallible paged SPARQL execution
+- **columnar:** Define five-table Parquet contract
+- **columnar:** Implement deterministic Parquet kernel
+- **columnar:** Project RDF datasets to five tables
+- **columnar:** Reconstruct RDF from five tables
+- **columnar:** Add deterministic bidirectional Parquet codec
+- **rdf:** Define OKF loss contracts
+- **rdf:** Lift OKF bundles into event sinks
+- **rdf:** Write deterministic OKF bundles
+- **rdf:** Add native bidirectional OKF codec
+- **core:** Register Pydantic projection losses
+- **shapes:** Emit Pydantic v2 packages
+- **core:** Register LinkML loss profile
+- **shapes:** Add canonical LinkML codec
+- **shapes:** Project schemas to LinkML
+- **shapes:** Add canonical LinkML 1.11 projection
+- **core:** Register TypeScript projection losses
+- **shapes:** Emit TypeScript declarations
+- **shapes:** Emit deterministic TypeScript declarations
+- **core:** Register GraphQL loss profile
+- **shapes:** Emit deterministic GraphQL SDL
+- **shapes:** Emit deterministic GraphQL SDL
+- **rdf:** Add projection carrier foundations
+- **rdf:** Add canonical LPG mapping
+- **rdf:** Add LPG CSV adapters
+- **rdf:** Add LPG graph carriers
+- **rdf:** Add bidirectional CSVW projections
+- **rdf:** Add OBO Graphs projection
+- **rdf:** Add deterministic SKOS projection
+- **projections:** Expose deterministic carrier surfaces
+- **rdf:** Add graph and tabular projections
+- **rdf:** Add research-object semantic pivot
+- **rdf:** Add Croissant 1.1 codec
+- **rdf:** Add RO-Crate 1.3 codec
+- **rdf:** Add DataCite 4.6 codec
+- **rdf:** Add DCAT 3 codec
+- **rdf:** Add Frictionless Data Package codec
+- **rdf:** Expose research-object carrier surfaces
+- **rdf:** Complete research-object carrier integration
+- **rdf:** Add bidirectional research-object codecs
+- **core:** Register schema to SHACL loss profiles
+- **shapes:** Import JSON Schema as SHACL
+- **shapes:** Import LinkML as SHACL
+- **shapes:** Import generated schema packages
+- **shapes:** Import schemas as SHACL
+
+### Other
+
+- Expose packed dataset restoration
+- Emit caller-configured Pydantic v2 packages
+
+### Performance
+
+- **core:** Memoize the codec-pair loss registry behind OnceLock
+- **cli:** Mmap-borrow disk pack→pack passthrough instead of heap-buffering
+- **shapes:** Avoid duplicate Pydantic schema work
+- **shapes:** Avoid LinkML projection allocations
+- **shapes:** Avoid TypeScript render copies
+- **shapes:** Avoid redundant GraphQL oracle escaping
+- **rdf:** Avoid clean JSON pointer allocation
+- **rdf:** Avoid DataCite XML uppercase copy
+- **shapes:** Reduce schema import allocations
+
+### Refactor
+
+- **core:** Remove the dead RdfLoss diagnostic type
+- **core:** Derive loss-entry intentional from profile membership
+- **rdf:** Single FormatDescriptor table as the format metadata source of truth
+- **wasm:** Route the wasm format resolver through the one core registry
+- **shapes:** Share compiled schema catalog
+
+### Testing
+
+- **rdf:** Assert bnode-scope-flatten is an in-profile loss
+- **rdf:** Production-surface tests for JSON-LD/YAML-LD + named-graph reifier fix
+- **rdf:** Pin YAML-LD adversarial-scalar literals against the Norway problem
+- **wasm:** Assert isomorphism on the JSON-LD/YAML-LD round-trip + fix stale docs
+- **cli:** Pin --loss-ledger surfacing tri-state + universal-sink invariant
+- **cli,rdf:** Pin query --entailment exit-3 boundary + dedup pack test fixture
+- **sparql:** Cover fallible query guarantees
+- **columnar:** Prove backend and DuckDB interoperability
+- **columnar:** Cover empty files in DuckDB oracle
+- **shapes:** Execute Pydantic schema oracle
+- **shapes:** Exercise recursive Pydantic refs
+- **shapes:** Add official LinkML oracle
+- **shapes:** Add TypeScript compiler oracle
+- **shapes:** Verify GraphQL coercion with GraphQL.js
+- **cli:** Tolerate early stdin closure
+
 ## [0.6.0] - 2026-07-14
 
 ### Bug Fixes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,8 +21,8 @@ authors:
   - family-names: "Audley"
     given-names: "Patrick"
     orcid: "https://orcid.org/0000-0003-4382-7625"
-version: "0.6.0"
-date-released: "2026-07-13"
+version: "0.7.0"
+date-released: "2026-07-17"
 license:
   - Apache-2.0
   - MIT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "purrdf-columnar",
  "purrdf-entail",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap",
  "memmap2",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-columnar"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1344,11 +1344,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "purrdf-gts"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "ciborium",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "boon",
  "criterion",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "hex",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -45,22 +45,22 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "0.6.0" }
-purrdf-columnar = { path = "crates/columnar", version = "0.6.0" }
-purrdf-core = { path = "crates/rdf-core", version = "0.6.0" }
-purrdf-entail = { path = "crates/entail", version = "0.6.0" }
-purrdf-events = { path = "crates/rdf-events", version = "0.6.0" }
-purrdf-gts = { path = "crates/gts", version = "0.6.0" }
-purrdf-iri = { path = "crates/iri", version = "0.6.0" }
-purrdf-rdf = { path = "crates/rdf", version = "0.6.0" }
-purrdf-shapes = { path = "crates/shapes", version = "0.6.0" }
-purrdf-shex = { path = "crates/shex", version = "0.6.0" }
-purrdf-slice = { path = "crates/slice", version = "0.6.0" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.6.0" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.6.0" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "0.6.0" }
-purrdf-validate = { path = "crates/validate", version = "0.6.0" }
-purrdf-xsd = { path = "crates/xsd", version = "0.6.0" }
+purrdf = { path = "crates/purrdf", version = "0.7.0" }
+purrdf-columnar = { path = "crates/columnar", version = "0.7.0" }
+purrdf-core = { path = "crates/rdf-core", version = "0.7.0" }
+purrdf-entail = { path = "crates/entail", version = "0.7.0" }
+purrdf-events = { path = "crates/rdf-events", version = "0.7.0" }
+purrdf-gts = { path = "crates/gts", version = "0.7.0" }
+purrdf-iri = { path = "crates/iri", version = "0.7.0" }
+purrdf-rdf = { path = "crates/rdf", version = "0.7.0" }
+purrdf-shapes = { path = "crates/shapes", version = "0.7.0" }
+purrdf-shex = { path = "crates/shex", version = "0.7.0" }
+purrdf-slice = { path = "crates/slice", version = "0.7.0" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.7.0" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.7.0" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "0.7.0" }
+purrdf-validate = { path = "crates/validate", version = "0.7.0" }
+purrdf-xsd = { path = "crates/xsd", version = "0.7.0" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "0.6.0"
+version = "0.7.0"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.6.0" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.7.0" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -78,4 +78,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "0.6.0"
+version = "0.7.0"

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -58,7 +58,7 @@ purrdf-iri = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.6.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.7.0" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.6.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.7.0" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.


### PR DESCRIPTION
## Outcome

Prepare the coherent PurRDF 0.7.0 release across crates.io, PyPI, and npm.

## Changes

- Bump the workspace, every internal path dependency pin, PyPI metadata, npm package, C ABI metadata, citation metadata, and development locks to 0.7.0.
- Keep the external Cargo dependency graph unchanged; only PurRDF workspace package versions move in `Cargo.lock`.
- Regenerate `CHANGELOG.md` deterministically from the conventional-commit history with the pinned git-cliff version.

## Validation

- `UV_CACHE_DIR=/tmp/purrdf-release-uv-cache CARGO_BUILD_JOBS=2 make check`
- `python3 scripts/check-versions.py`
- `git -c core.whitespace=trailing-space,space-before-tab diff --check`
- Good repository signature on the release commit and a clean synchronized worktree.

After this commit reaches `main`, the guarded `make release-tags VERSION=0.7.0` command will atomically push `rust-v0.7.0`, `py-v0.7.0`, and `npm-v0.7.0`.
