### PR TITLE
fix(gts): make zstd encode total against huff0 encoder panics

### DIFF
--- a/crates/gts/src/codec.rs
+++ b/crates/gts/src/codec.rs
@@ -11,8 +11,9 @@
 use std::borrow::Cow;
 use std::fmt;
 use std::io::{Read, Write};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 
-use structured_zstd::decoding::{FrameDecoder, errors::FrameDecoderError};
+use structured_zstd::decoding::{FrameDecoder, errors::FrameDecoderError, read_frame_header_info};
 use structured_zstd::encoding::{CompressionLevel, StreamingEncoder, compress_to_vec};
 
 /// A catalog entry (§5, §8.5).
@@ -139,8 +140,32 @@ fn decode_one(codec: &Codec, data: &[u8]) -> Result<Vec<u8>, CodecError> {
 
 const RSYNCABLE_BLOCK_SIZE: usize = 65_536;
 
+/// Run a zstd encode that may panic on an internal encoder invariant
+/// (structured-zstd `huff0_encoder.rs` "internal error"); on unwind, degrade
+/// per the caller. Deterministic: a given input either always encodes or
+/// always degrades. Mirrors the panic-totalization pattern in
+/// `crates/rdf/src/native_codecs/parse.rs`.
+///
+/// `AssertUnwindSafe` is sound here: the input slice is untouched by the
+/// encode, and the poisoned encoder/buffers are dropped on unwind, so no
+/// shared mutable state crosses the catch boundary. On `wasm32` (panic=abort)
+/// `catch_unwind` compiles cleanly but does not catch — the guard is a
+/// compile-clean no-op there; the panic is a native-producer concern.
+fn guarded_encode<T>(f: impl FnOnce() -> T, on_panic: impl FnOnce() -> T) -> T {
+    match catch_unwind(AssertUnwindSafe(f)) {
+        Ok(v) => v,
+        Err(_) => on_panic(),
+    }
+}
+
 fn encode_zstd(data: &[u8], level: Option<i32>) -> Vec<u8> {
-    compress_to_vec(data, zstd_level(level))
+    // `Uncompressed` produces a valid Zstandard frame the existing
+    // `FrameDecoder` already round-trips, and it cannot itself build a
+    // Huffman table — so the fallback can never re-trip this guard.
+    guarded_encode(
+        || compress_to_vec(data, zstd_level(level)),
+        || compress_to_vec(data, CompressionLevel::Uncompressed),
+    )
 }
 
 fn encode_zstd_with_dict(
@@ -151,10 +176,27 @@ fn encode_zstd_with_dict(
     let mut enc = StreamingEncoder::new(Vec::<u8>::new(), zstd_level(level));
     enc.set_dictionary_from_bytes(dict)
         .map_err(|e| CodecError::Failed(format!("zstd dictionary load failed: {e}")))?;
-    Write::write_all(&mut enc, data)
-        .map_err(|e| CodecError::Failed(format!("zstd dict encode failed: {e}")))?;
-    enc.finish()
-        .map_err(|e| CodecError::Failed(format!("zstd dict encode failed: {e}")))
+    // Unlike `encode_zstd`, a dict-primed encode has no safe raw-literals
+    // degrade: the reader registers this dictionary against the frame, and
+    // the mismatch test (`zstd_dict_codec_rejects_a_mismatched_dictionary`)
+    // shows the decoder refuses a dict/frame mismatch outright — a
+    // dict-less fallback frame could be silently undecodable, strictly
+    // worse than the panic it would replace. Returning `Err` keeps encoding
+    // total (no panic escapes this function) without ever emitting
+    // undecodable bytes.
+    guarded_encode(
+        move || {
+            Write::write_all(&mut enc, data)
+                .map_err(|e| CodecError::Failed(format!("zstd dict encode failed: {e}")))?;
+            enc.finish()
+                .map_err(|e| CodecError::Failed(format!("zstd dict encode failed: {e}")))
+        },
+        || {
+            Err(CodecError::Failed(
+                "zstd dict encode aborted (huff0 internal error)".into(),
+            ))
+        },
+    )
 }
 
 fn encode_zstd_rsyncable(data: &[u8], level: Option<i32>) -> Vec<u8> {
@@ -266,6 +308,70 @@ pub fn decode_chain_with_decrypt(
         }
     }
     Ok(current.into_owned())
+}
+
+/// A zstd block's on-wire kind, read from its 3-byte `Block_Header` (RFC 8878
+/// §3.1.1.2) without decompressing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockKind {
+    /// `Block_Type` 0: the block body is the literal, uncompressed bytes.
+    Raw,
+    /// `Block_Type` 1: the block body is a single byte repeated `Block_Size` times.
+    Rle,
+    /// `Block_Type` 2: the block body is Huffman/FSE-compressed (the normal path).
+    Compressed,
+}
+
+/// The block types in a zstd frame, read from block headers WITHOUT
+/// decompressing. Lets a caller distinguish a natively-compressed frame from a
+/// raw-literals degrade. A test/inspection utility (no production degradation
+/// logging is wired in this change).
+///
+/// Parses per RFC 8878: the frame header (magic + descriptor, read via
+/// `structured_zstd::decoding::read_frame_header_info` so the magic/flag
+/// decoding never drifts from the crate's own decoder), then a sequence of
+/// 3-byte `Block_Header`s (bit0 `Last_Block`, bits1-2 `Block_Type`, bits3-23
+/// `Block_Size`) until `Last_Block`. The trailing content checksum, if any,
+/// is not consumed — it is not needed to classify block kinds.
+///
+/// # Errors
+/// `CodecError::Failed` on a malformed/truncated frame header, a truncated
+/// block, or a block declaring the reserved `Block_Type`; never panics (every
+/// slice access is checked).
+pub fn frame_block_kinds(frame: &[u8]) -> Result<Vec<BlockKind>, CodecError> {
+    let info = read_frame_header_info(frame, false)
+        .map_err(|e| CodecError::Failed(format!("zstd frame header read failed: {e}")))?;
+    let mut offset = info.header_size;
+    let mut kinds = Vec::new();
+    loop {
+        // 3-byte Block_Header (RFC 8878 §3.1.1.2), little-endian: bit0 =
+        // Last_Block, bits1-2 = Block_Type, bits3-23 = Block_Size.
+        let header = frame
+            .get(offset..offset + 3)
+            .ok_or_else(|| CodecError::Failed("zstd frame block header truncated".into()))?;
+        let raw = u32::from(header[0]) | (u32::from(header[1]) << 8) | (u32::from(header[2]) << 16);
+        let last_block = raw & 1 != 0;
+        let block_size = (raw >> 3) as usize;
+        let (kind, on_disk) = match (raw >> 1) & 0b11 {
+            0 => (BlockKind::Raw, block_size),
+            1 => (BlockKind::Rle, 1),
+            2 => (BlockKind::Compressed, block_size),
+            _ => {
+                return Err(CodecError::Failed(
+                    "zstd frame block has reserved Block_Type".into(),
+                ));
+            }
+        };
+        kinds.push(kind);
+        offset = offset
+            .checked_add(3 + on_disk)
+            .filter(|end| *end <= frame.len())
+            .ok_or_else(|| CodecError::Failed("zstd frame block body truncated".into()))?;
+        if last_block {
+            break;
+        }
+    }
+    Ok(kinds)
 }
 
 #[cfg(test)]
@@ -470,5 +576,162 @@ mod tests {
         )
         .expect_err("zstd-rsyncable + dict must be a hard error");
         assert!(matches!(err, CodecError::Failed(_)));
+    }
+
+    #[test]
+    fn guarded_encode_falls_back_to_raw_on_injected_panic() {
+        let payload = b"stable payload for the huff0 panic-fallback guard".repeat(8);
+        let encoded: Vec<u8> = guarded_encode(
+            || -> Vec<u8> { panic!("simulated huff0 internal error") },
+            || compress_to_vec(payload.as_slice(), CompressionLevel::Uncompressed),
+        );
+
+        let decoded = decode_chain(&[Codec::new("zstd", "compress")], &encoded)
+            .expect("fallback frame must decode");
+        assert_eq!(decoded, payload);
+
+        let kinds = frame_block_kinds(&encoded).expect("fallback frame block kinds parse");
+        assert!(
+            kinds.iter().all(|k| *k == BlockKind::Raw),
+            "an Uncompressed-level fallback frame must be all Raw blocks, got {kinds:?}"
+        );
+    }
+
+    #[test]
+    fn guarded_encode_is_deterministic() {
+        let payload = b"deterministic payload for the zstd encode guard".repeat(8);
+
+        // Normal success path.
+        let a = encode_zstd(&payload, None);
+        let b = encode_zstd(&payload, None);
+        assert_eq!(a, b, "the normal success path must be deterministic");
+
+        // Forced-fallback path.
+        let fallback_a: Vec<u8> = guarded_encode(
+            || -> Vec<u8> { panic!("simulated huff0 internal error") },
+            || compress_to_vec(payload.as_slice(), CompressionLevel::Uncompressed),
+        );
+        let fallback_b: Vec<u8> = guarded_encode(
+            || -> Vec<u8> { panic!("simulated huff0 internal error") },
+            || compress_to_vec(payload.as_slice(), CompressionLevel::Uncompressed),
+        );
+        assert_eq!(
+            fallback_a, fallback_b,
+            "a forced fallback must be deterministic"
+        );
+    }
+
+    #[test]
+    fn guarded_rsyncable_falls_back_per_block() {
+        // Positive path: a multi-block rsyncable payload round-trips through decode.
+        let payload = vec![b'r'; RSYNCABLE_BLOCK_SIZE * 3 + 17];
+        let encoded = encode_chain(&["zstd-rsyncable".to_string()], &payload)
+            .expect("large rsyncable payload encodes");
+        let decoded = decode_chain(&[Codec::new("zstd-rsyncable", "compress")], &encoded)
+            .expect("large rsyncable payload decodes");
+        assert_eq!(decoded, payload);
+
+        // Direct per-block fallback: `encode_zstd_rsyncable` calls `encode_zstd` (which
+        // itself routes through `guarded_encode`) once per `RSYNCABLE_BLOCK_SIZE` chunk,
+        // so one block's guard can independently fall back without disturbing its
+        // neighbours. There is no production seam to inject a panic into one specific
+        // block without polluting the public API, so this exercises `guarded_encode`'s
+        // per-block fallback directly — the same call shape `encode_zstd_rsyncable`
+        // makes for each block — and checks that two independently-guarded blocks
+        // (one normal, one forced to fall back) still concatenate into a valid
+        // multi-frame zstd stream, exactly like `zstd_rsyncable_decodes_concatenated_frames`.
+        let block_a = b"first independent rsyncable block".repeat(4);
+        let block_b = b"second independent rsyncable block".repeat(4);
+        let encoded_a = guarded_encode(
+            || compress_to_vec(block_a.as_slice(), zstd_level(None)),
+            || compress_to_vec(block_a.as_slice(), CompressionLevel::Uncompressed),
+        );
+        let encoded_b: Vec<u8> = guarded_encode(
+            || -> Vec<u8> { panic!("simulated huff0 internal error in one block") },
+            || compress_to_vec(block_b.as_slice(), CompressionLevel::Uncompressed),
+        );
+
+        let mut concatenated = encoded_a;
+        concatenated.extend(encoded_b);
+        let decoded = decode_one(&Codec::new("zstd-rsyncable", "compress"), &concatenated)
+            .expect("concatenated normal + fallback blocks decode");
+
+        let mut expected = block_a;
+        expected.extend_from_slice(&block_b);
+        assert_eq!(decoded, expected);
+    }
+
+    #[test]
+    fn dict_encode_aborts_to_err_not_undecodable_frame() {
+        // Positive control: a normal dict-primed encode round-trips through decode
+        // with the same dictionary.
+        let owned = dict_corpus();
+        let corpus: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+        let payload = dict_payload();
+        let dict = crate::dict::raw_content_dict(&corpus, 4096).expect("dict builds");
+
+        let encoded = encode_chain_with_options(
+            &["zstd".to_string()],
+            &payload,
+            EncodeOptions {
+                zstd_level: None,
+                dict: Some(&dict),
+            },
+        )
+        .expect("dict-primed zstd encodes");
+        let mut codec = Codec::new("zstd", "compress");
+        codec.dct = Some(dict);
+        let decoded = decode_chain(&[codec], &encoded).expect("dict-primed zstd decodes");
+        assert_eq!(decoded, payload);
+
+        // There is no production seam to inject a panic into `encode_zstd_with_dict`'s
+        // guarded region without adding a test-only parameter to a public function, so
+        // the panic branch is exercised at the `guarded_encode` level directly, using
+        // the SAME `on_panic` closure shape `encode_zstd_with_dict` installs: on unwind
+        // it must return `Err`, never synthesize a dict-less frame the reader could
+        // silently misdecode (see `zstd_dict_codec_rejects_a_mismatched_dictionary`
+        // above for why a dict/frame mismatch is dangerous, not just inconvenient).
+        let result: Result<Vec<u8>, CodecError> = guarded_encode(
+            || -> Result<Vec<u8>, CodecError> {
+                panic!("simulated huff0 internal error during dict encode")
+            },
+            || {
+                Err(CodecError::Failed(
+                    "zstd dict encode aborted (huff0 internal error)".into(),
+                ))
+            },
+        );
+        match result {
+            Err(CodecError::Failed(msg)) => {
+                assert!(msg.contains("huff0 internal error"));
+            }
+            other => panic!("expected Err(CodecError::Failed(_)), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn frame_block_kinds_reads_compressed_and_raw() {
+        let compressible = b"abababababababababababababababababababababababab".repeat(64);
+
+        let compressed = encode_chain(&["zstd".to_string()], &compressible).expect("zstd encodes");
+        let kinds = frame_block_kinds(&compressed).expect("compressed frame parses");
+        assert!(
+            kinds.contains(&BlockKind::Compressed),
+            "a compressible payload must produce at least one Compressed block, got {kinds:?}"
+        );
+
+        let raw = compress_to_vec(compressible.as_slice(), CompressionLevel::Uncompressed);
+        let raw_kinds = frame_block_kinds(&raw).expect("uncompressed frame parses");
+        assert!(
+            raw_kinds.iter().all(|k| *k == BlockKind::Raw),
+            "an Uncompressed-level frame must be all Raw blocks, got {raw_kinds:?}"
+        );
+
+        let err = frame_block_kinds(&[0xde, 0xad, 0xbe, 0xef])
+            .expect_err("garbage input must error, not panic");
+        assert!(matches!(err, CodecError::Failed(_)));
+
+        let err_empty = frame_block_kinds(&[]).expect_err("empty input must error, not panic");
+        assert!(matches!(err_empty, CodecError::Failed(_)));
     }
 }

--- a/crates/gts/tests/encode_never_panics.rs
+++ b/crates/gts/tests/encode_never_panics.rs
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Standing "never panics" guard for the GTS codec (§8) transform chain.
+//!
+//! Task 1 (commit fd1e5f2) made the zstd encode path total against an
+//! internal huff0-encoder panic (`guarded_encode` in `crates/gts/src/codec.rs`).
+//! This file is the permanent regression guard that huff0 panic motivated: it
+//! sweeps a broad, deterministic spread of generated inputs through
+//! `encode_chain`, and a broad spread of arbitrary/truncated/garbage bytes
+//! through `decode_chain` and `frame_block_kinds`, and asserts none of them
+//! ever unwinds — encode and decode are both TOTAL over their input domains
+//! (`Result`, never a panic).
+//!
+//! All inputs below are built with a fixed-seed LCG (never `rand`/time), so a
+//! failing case reproduces byte-for-byte on every run.
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use purrdf_gts::codec::{Codec, decode_chain, encode_chain, frame_block_kinds};
+
+/// A tiny deterministic linear congruential generator (Numerical Recipes
+/// constants) — no `rand`, no time, fully reproducible across runs.
+struct Lcg(u64);
+
+impl Lcg {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    fn next_u32(&mut self) -> u32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        (self.0 >> 32) as u32
+    }
+
+    fn bytes(&mut self, len: usize) -> Vec<u8> {
+        let mut out = Vec::with_capacity(len);
+        while out.len() < len {
+            out.extend_from_slice(&self.next_u32().to_le_bytes());
+        }
+        out.truncate(len);
+        out
+    }
+}
+
+/// A broad, deterministic spread of byte inputs covering: empty, tiny,
+/// medium, and large (> 64 KiB, crossing the rsyncable block boundary and
+/// forcing multiple blocks); all-same-byte, small-alphabet, high-entropy
+/// LCG, real-ish repeated text, and skewed-histogram distributions.
+fn generated_inputs() -> Vec<Vec<u8>> {
+    let mut inputs = vec![
+        Vec::new(),   // empty
+        vec![0u8],    // single byte, minimum
+        vec![0xFFu8], // single byte, maximum
+    ];
+
+    // Tiny inputs (1..16 bytes) over a couple of deterministic seeds.
+    for seed in [1u64, 7u64] {
+        let mut lcg = Lcg::new(seed);
+        for len in 1..16usize {
+            inputs.push(lcg.bytes(len));
+        }
+    }
+
+    // All-same-byte inputs at a few sizes.
+    for &byte in &[0x00u8, 0xFFu8, 0x41u8] {
+        for &len in &[16usize, 4096, 70_000] {
+            inputs.push(vec![byte; len]);
+        }
+    }
+
+    // Small-alphabet inputs (2-symbol and 4-symbol) at medium size.
+    {
+        let mut lcg = Lcg::new(11);
+        let mut two_symbol = Vec::with_capacity(8192);
+        for _ in 0..8192 {
+            two_symbol.push(if lcg.next_u32() & 1 == 0 { b'a' } else { b'b' });
+        }
+        inputs.push(two_symbol);
+
+        let mut lcg = Lcg::new(13);
+        let alphabet = [b'w', b'x', b'y', b'z'];
+        let mut four_symbol = Vec::with_capacity(8192);
+        for _ in 0..8192 {
+            four_symbol.push(alphabet[(lcg.next_u32() % 4) as usize]);
+        }
+        inputs.push(four_symbol);
+    }
+
+    // High-entropy LCG bytes, medium and large (crosses the 64 KiB rsyncable
+    // block boundary and forces multiple blocks).
+    inputs.push(Lcg::new(101).bytes(4096));
+    inputs.push(Lcg::new(103).bytes(70_000));
+    inputs.push(Lcg::new(107).bytes(200_000));
+
+    // Real-ish repeated text, a size that does not evenly divide the
+    // rsyncable block size, to exercise a ragged final block.
+    let text = b"<https://example.org/s> <https://example.org/p> \"claim about cats\" .\n";
+    inputs.push(text.repeat(1200));
+
+    // Skewed histogram: mostly one byte, with rare other bytes scattered in
+    // (a realistic "mostly-zero padding with sparse structure" shape).
+    {
+        let mut lcg = Lcg::new(211);
+        let mut skewed = vec![0u8; 20_000];
+        for _ in 0..200 {
+            let idx = (lcg.next_u32() as usize) % skewed.len();
+            skewed[idx] = (lcg.next_u32() % 256) as u8;
+        }
+        inputs.push(skewed);
+    }
+
+    inputs
+}
+
+/// Run `f` under `catch_unwind`, asserting it never unwinds. Returns the
+/// value on success (never returns on panic — the test fails first).
+fn assert_no_panic<T>(label: &str, f: impl FnOnce() -> T + std::panic::UnwindSafe) -> T {
+    catch_unwind(f).unwrap_or_else(|_| panic!("{label} panicked instead of returning a Result"))
+}
+
+#[test]
+fn encode_chain_never_panics_over_generated_inputs() {
+    let inputs = generated_inputs();
+    assert!(inputs.len() >= 20, "expected a broad generated spread");
+
+    for (i, input) in inputs.iter().enumerate() {
+        for chain_name in ["zstd", "zstd-rsyncable"] {
+            let chain = vec![chain_name.to_string()];
+            let label = format!(
+                "encode_chain([{chain_name}]) on input #{i} (len {})",
+                input.len()
+            );
+            let input_ref = input.as_slice();
+            let result =
+                assert_no_panic(&label, AssertUnwindSafe(|| encode_chain(&chain, input_ref)));
+            let encoded = result.unwrap_or_else(|e| panic!("{label} must succeed, got {e}"));
+
+            // Round-trip a sampling back through decode_chain to prove the
+            // output is a genuinely valid, decodable frame — not just "some
+            // bytes came out".
+            let codec = Codec::new(chain_name, "compress");
+            let decoded = decode_chain(std::slice::from_ref(&codec), &encoded)
+                .unwrap_or_else(|e| panic!("{label}: round-trip decode must succeed, got {e}"));
+            assert_eq!(
+                &decoded, input,
+                "{label}: round-trip must reproduce the original bytes exactly"
+            );
+        }
+    }
+}
+
+/// Arbitrary/truncated/garbage byte inputs that need NOT be valid zstd
+/// frames — the decoder must stay total (`Ok`/`Err`, never a panic) over
+/// this untrusted-input surface.
+fn arbitrary_decode_inputs() -> Vec<Vec<u8>> {
+    let mut inputs = vec![
+        Vec::new(),
+        vec![0x00u8],
+        vec![0xFFu8],
+        vec![0x28u8, 0xB5u8], // partial zstd magic
+    ];
+
+    // All-0x00 and all-0xFF buffers at a few sizes.
+    for &len in &[1usize, 8, 64, 4096] {
+        inputs.push(vec![0x00u8; len]);
+        inputs.push(vec![0xFFu8; len]);
+    }
+
+    // Random-ish (LCG) bytes at a few sizes.
+    for (seed, len) in [(31u64, 8usize), (37, 64), (41, 4096)] {
+        inputs.push(Lcg::new(seed).bytes(len));
+    }
+
+    // Truncated valid zstd frames: compress something real, then cut it at
+    // several lengths, including mid-header and mid-block-body cuts.
+    let payload =
+        b"real payload with enough structure to build a multi-block zstd frame".repeat(4000);
+    let full_frame = encode_chain(&["zstd".to_string()], &payload).expect("zstd encodes");
+    for &cut in &[0usize, 1, 2, 3, 4, 5, 8, 16, 32, 64] {
+        if cut <= full_frame.len() {
+            inputs.push(full_frame[..cut].to_vec());
+        }
+    }
+    // A handful of cuts spread across the rest of the frame, including one
+    // that lands just short of the end (truncated checksum/trailer).
+    let frame_len = full_frame.len();
+    for frac in [4usize, 3, 2] {
+        let cut = frame_len / frac;
+        inputs.push(full_frame[..cut].to_vec());
+    }
+    if frame_len > 1 {
+        inputs.push(full_frame[..frame_len - 1].to_vec());
+    }
+
+    // Same treatment for a rsyncable (multi-frame) encode.
+    let rsync_payload = vec![b'q'; 200_000];
+    let full_rsync = encode_chain(&["zstd-rsyncable".to_string()], &rsync_payload)
+        .expect("zstd-rsyncable encodes");
+    let rsync_len = full_rsync.len();
+    for frac in [8usize, 4, 2] {
+        let cut = rsync_len / frac;
+        inputs.push(full_rsync[..cut].to_vec());
+    }
+
+    inputs
+}
+
+#[test]
+fn decode_chain_never_panics_over_arbitrary_bytes() {
+    let inputs = arbitrary_decode_inputs();
+    assert!(inputs.len() >= 15, "expected a broad arbitrary-byte spread");
+
+    let chain = [Codec::new("zstd", "compress")];
+    for (i, input) in inputs.iter().enumerate() {
+        let label = format!("decode_chain on arbitrary input #{i} (len {})", input.len());
+        let input_ref = input.as_slice();
+        let chain_ref = &chain;
+        // The point of this assertion is totality, not success: garbage
+        // bytes are expected to yield `Err`, never an unwind.
+        let _ = assert_no_panic(
+            &label,
+            AssertUnwindSafe(|| decode_chain(chain_ref, input_ref)),
+        );
+    }
+}
+
+#[test]
+fn frame_block_kinds_never_panics_over_arbitrary_bytes() {
+    let inputs = arbitrary_decode_inputs();
+    assert!(inputs.len() >= 15, "expected a broad arbitrary-byte spread");
+
+    for (i, input) in inputs.iter().enumerate() {
+        let label = format!(
+            "frame_block_kinds on arbitrary input #{i} (len {})",
+            input.len()
+        );
+        let input_ref = input.as_slice();
+        let _ = assert_no_panic(&label, AssertUnwindSafe(|| frame_block_kinds(input_ref)));
+    }
+}


### PR DESCRIPTION
Refs #142

## Context
A downstream consumer (`gmeow-ontology`, generating `gmeow.gts`) hit a deterministic panic — `structured-zstd-0.0.40 huff0_encoder.rs "This is an internal error"` — inside PurRDF's GTS composer (`emit_gts`) during final zstd compression of a large multi-blob bundle. The workspace dep was already bumped `0.0.40 → 0.0.49` on main (commit 80aebbc), but (a) the fix was **unverified** and (b) the encode path had **zero fault tolerance**: `compress_to_vec` returns `Vec<u8>` (not `Result`), so an internal encoder invariant violation could only surface as a panic that unwinds through `emit_gts`.

The huff0 panic guard is **still compiled in 0.0.49** (moved to `huff0_encoder.rs:746`); the real fix is behavioral — upstream PR #424 ("skip FSE weight description for streams it cannot encode", released 0.0.41) — which changes *which* streams reach the guard.

## What this PR does
Makes GTS zstd encoding **total** — `encode : Bytes → Bytes` was a partial function (undefined on huff0-degenerate inputs); a `catch_unwind` guard closes it into a total function whose bottom element is a raw-literals zstd frame (a valid instance of the codec's own output space, so `decode ∘ encode = id` with no new wire concept).

- `crates/gts/src/codec.rs`: `guarded_encode` combinator; plain/rsyncable encode degrades to a `CompressionLevel::Uncompressed` (raw-literals) frame on an internal panic — decode-compatible and deterministic. The **dict path returns `CodecError::Failed`** rather than a dict-less frame, because the reader registers the dict and the existing mismatch test shows the decoder refuses dict mismatches (a dict-less fallback could be silently *undecodable* — strictly worse than the panic).
- `frame_block_kinds`/`BlockKind`: read a zstd frame's block types without decompressing (distinguishes native compression from a degraded fallback).
- `crates/gts/tests/encode_never_panics.rs`: standing class-of-bugs guarantee — `encode_chain` (zstd + zstd-rsyncable) never unwinds over a generated input spread (with decode round-trip byte-identity); `decode_chain` and `frame_block_kinds` never panic on arbitrary/truncated bytes (guards the untrusted-reader surface against a structured-zstd internal panic becoming a DoS).

## Verification
Clippy `--workspace --all-targets -D warnings`, **3693 tests / 139 suites, 0 failed**, all six hygiene checks, `make wasm`, and `make doc` — all green. Determinism preserved (`snapshot_content_id_is_order_independent`, `codec_recompression_preserves_refold_equivalence`, dict compaction round-trips).

## Honest limitation on requirement 3
The issue asked to *verify the bump against a bundle large enough to actually trip the 0.0.40 panic*. **This could not be independently reproduced.** The =0.0.40 trigger did NOT reproduce from 25 MB of diverse real repo bytes (198,184 windows, sizes 1 KiB–1 MiB, levels 3/12/19 + the DIST-profile rsyncable 64 KiB path) nor from theory-driven synthetics targeting PR #424's degenerate weight histograms (`max_count==1` / `max_count==len`). The real gmeow bundle was unavailable and the maintainer authorized skipping the reproduction. Verification of the 0.0.49 fix therefore rests on **upstream PR #424 + the generic `catch_unwind` guard added here**, not on a committed regression test that reproduces the specific input. Recorded in `.deficiencies`.

## Out of scope (maintainer-directed)
Version bump / changelog / `rust-v0.7.x` release tag are **batched across open tickets** and cut later — not in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added frame inspection support to identify whether compressed data blocks are raw, run-length encoded, or compressed.
  - Added clear error reporting for malformed or truncated compression frames.

- **Bug Fixes**
  - Compression now avoids unexpected crashes and safely falls back when standard encoding encounters an internal failure.
  - Dictionary-based compression reports an error instead of producing unusable output.

- **Tests**
  - Expanded coverage for compression round trips, malformed input, truncated frames, and panic-free processing across varied data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->