### PR TITLE
shapes: compile ontology-complete developer schema surfaces

### DIFF
--- a/crates/purrdf/src/lib.rs
+++ b/crates/purrdf/src/lib.rs
@@ -27,7 +27,9 @@
 //!
 //! Consumer-config types are surfaced at the root ([`SliceVocab`],
 //! [`Namespaces`], [`StatementMetadataVocab`]) and unified behind a single
-//! [`OntologyProfile`] a downstream builds once (see [`profile`]).
+//! [`OntologyProfile`] a downstream builds once (see [`profile`]). The explicit
+//! ontology-aware developer-schema contract ([`SchemaCompileRequest`],
+//! [`SchemaSurfaceMode`], and [`compile_schema`]) is also available at the root.
 //!
 //! # Example
 //!
@@ -83,7 +85,12 @@ pub mod columnar {
 // ── consumer-config types, surfaced directly ────────────────────────────────
 // A consumer parameterizes an emitter without reaching into a sub-crate.
 pub use purrdf_rdf::native_codecs::jsonld::StatementMetadataVocab;
-pub use purrdf_shapes::json_schema::Namespaces;
+pub use purrdf_shapes::json_schema::{
+    Namespaces, SchemaClassPropertyCoverage, SchemaCompilation, SchemaCompilationInput,
+    SchemaCompilationKey, SchemaCompileError, SchemaCompileRequest, SchemaCoveragePrecision,
+    SchemaCoverageProvenance, SchemaCoverageReport, SchemaCoverageStatus, SchemaPropertyCoverage,
+    SchemaSurfaceMode, compile_schema,
+};
 pub use purrdf_slice::SliceVocab;
 
 /// GTS: the container engine ([`purrdf_gts`]) plus the RDF-level GTS adapter
@@ -244,6 +251,16 @@ mod tests {
             &shapes::GraphqlPackage,
             &shapes::SchemaImportConfig,
         ) -> Result<shapes::ImportedShapes, shapes::GraphqlError> = shapes::import_graphql_package;
+    }
+
+    #[test]
+    fn facade_exposes_ontology_schema_compilation_contract() {
+        let _: fn(&SchemaCompileRequest<'_>) -> Result<SchemaCompilation, SchemaCompileError> =
+            compile_schema;
+        let mode = SchemaSurfaceMode::OntologyComplete;
+        assert!(matches!(mode, SchemaSurfaceMode::OntologyComplete));
+        let _: Option<SchemaCoverageReport> = None;
+        let _: Option<SchemaCompilationKey> = None;
     }
 
     #[test]

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -87,3 +87,7 @@ harness = false
 [[bench]]
 name = "canonical_sort"
 harness = false
+
+[[bench]]
+name = "schema_surface"
+harness = false

--- a/crates/shapes/README.md
+++ b/crates/shapes/README.md
@@ -58,6 +58,72 @@ cargo build -p purrdf-shapes
 cargo test -p purrdf-shapes
 ```
 
+## Ontology-complete developer schemas
+
+`compile_schema` makes the developer-schema surface an explicit choice.
+`SchemaSurfaceMode::ShapedOnly` preserves the existing active
+`sh:targetClass` union. `SchemaSurfaceMode::OntologyComplete` also emits
+caller-vocabulary classes and optional properties justified by a bounded,
+deterministic OWL/RDFS schema theory. Both modes return the same JSON Schema
+draft 2020-12 and OpenAPI 3.1 carrier, plus a coverage manifest and cache key.
+The resulting `CompiledSchema` can be passed unchanged to the LinkML 1.11,
+TypeScript 7.0, GraphQL September 2025, and Pydantic v2 emitters.
+
+The request binds parsed SHACL, the exact ontology dataset, caller-owned
+`Namespaces`, and the mode. The compiler never discovers or invents a
+vocabulary. Only IRIs under prefixes explicitly supplied to `Namespaces::new`
+are eligible for synthesized definitions and fields; builtin prefixes known for
+compaction do not become caller-owned implicitly.
+
+The supported schema theory is deliberately finite:
+
+- the property catalog is formed from direct IRI `sh:path` predicates,
+  `rdf:Property` and OWL property types, `rdfs:domain`/`rdfs:range`, and both
+  endpoints of `rdfs:subPropertyOf`, `owl:equivalentProperty`, and
+  `owl:inverseOf`; predicates seen only in instance assertions are not schema
+  declarations;
+- named classes come from class declarations, named domain/range members,
+  direct SHACL target classes, `rdfs:subClassOf`, and `owl:equivalentClass`;
+- subclass and equivalent-class closure drives domain membership. Multiple
+  effective domain axioms are conjunctive, while an `owl:unionOf` domain matches
+  any member and an `owl:intersectionOf` domain matches every member. A
+  domainless property applies to every eligible class;
+- subproperties inherit superproperty domains, ranges, and forward
+  functionality; equivalent properties propagate both ways; inverse properties
+  swap domain and range. Legal cycles are condensed before propagation;
+- multiple effective ranges are conjunctive. Union ranges become `anyOf`,
+  intersection ranges become `allOf`, and contradictory object/datatype
+  declarations fail with `SchemaCompileError`;
+- direct SHACL constraints remain authoritative. Unshaped ontology properties
+  are optional, `owl:FunctionalProperty` is represented as a scalar and marked
+  as a representation approximation, and `owl:InverseFunctionalProperty` never
+  implies scalar cardinality. An active `sh:closed` shape excludes an unshaped
+  property unless the shape or its ignored-properties list admits it;
+- an ontology class without a target shape receives an open carrier definition.
+  It is never made closed merely because PurRDF synthesized it.
+
+This is schema projection, not ABox entailment or unrestricted OWL reasoning.
+Property chains and axioms outside the fragment do not drive fields. Malformed
+union/intersection RDF lists, namespace/key collisions, incompatible property
+kinds or ranges, and fixed limit breaches fail with typed errors. The fixed
+ceilings are 65,536 properties, 65,536 classes, 1,048,576 relation or coverage
+cells, and OWL expression depth 64.
+
+Every catalogued property appears exactly once in `SchemaCoverageReport`, with
+sorted class decisions, inclusion/exclusion reasons, precision, and source
+axiom provenance. `SchemaCompileRequest::coverage_report` computes that audit
+surface without serializing language artifacts. `compilation_key` hashes the
+RDFC-1.0 identities of both input graphs together with declared namespaces,
+mode, value-vocabulary marker, compiler/policy salts, and fixed limits, so the
+key can be computed before expensive emission and used directly for caching.
+
+The runnable example compares both modes, prints the report and cache key, and
+passes the complete result through all four language emitters:
+
+```bash
+cargo run -p purrdf-shapes --example ontology_schema_surface --locked
+```
+
 ## Schema → SHACL imports
 
 The schema-projection family is bidirectional. `SchemaImportConfig` requires a

--- a/crates/shapes/benches/schema_surface.rs
+++ b/crates/shapes/benches/schema_surface.rs
@@ -3,11 +3,9 @@
 
 //! Report-only scale instrument for ontology-aware schema compilation.
 
-#![allow(missing_docs)]
-
 use std::fmt::Write as _;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, black_box, criterion_main};
 use purrdf_shapes::json_schema::{
     Namespaces, SchemaCompileRequest, SchemaSurfaceMode, compile_schema,
 };
@@ -134,5 +132,10 @@ fn bench_schema_surface(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_schema_surface);
+/// Run the schema-surface benchmark group.
+pub fn benches() {
+    let mut criterion = Criterion::default().configure_from_args();
+    bench_schema_surface(&mut criterion);
+}
+
 criterion_main!(benches);

--- a/crates/shapes/benches/schema_surface.rs
+++ b/crates/shapes/benches/schema_surface.rs
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Report-only scale instrument for ontology-aware schema compilation.
+
+#![allow(missing_docs)]
+
+use std::fmt::Write as _;
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use purrdf_shapes::json_schema::{
+    Namespaces, SchemaCompileRequest, SchemaSurfaceMode, compile_schema,
+};
+use purrdf_shapes::shapes::{Shapes, from_dataset};
+
+const PREFIXES: &str = r"
+@prefix ex: <https://example.org/schema-bench/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+";
+
+struct Fixture {
+    shapes: Shapes,
+    ontology: std::sync::Arc<purrdf::RdfDataset>,
+    namespaces: Namespaces,
+}
+
+#[derive(Clone, Copy)]
+enum Density {
+    Sparse,
+    Dense,
+}
+
+fn fixture(
+    classes: usize,
+    properties: usize,
+    density: Density,
+    shape_every_class: bool,
+) -> Fixture {
+    let mut shapes_turtle = String::from(PREFIXES);
+    if shape_every_class {
+        for class in 0..classes {
+            let _ = writeln!(
+                shapes_turtle,
+                "ex:Shape{class:04} a sh:NodeShape ; sh:targetClass ex:Class{class:04} ."
+            );
+        }
+    }
+    let shapes_dataset = purrdf_shapes::text_ingest::parse_turtle_to_dataset(&shapes_turtle)
+        .expect("benchmark shapes Turtle");
+    let shapes = from_dataset(&shapes_dataset).expect("benchmark shapes graph");
+
+    let mut ontology_turtle = String::from(PREFIXES);
+    for class in 0..classes {
+        let _ = writeln!(ontology_turtle, "ex:Class{class:04} a owl:Class .");
+    }
+    for property in 0..properties {
+        match density {
+            Density::Sparse => {
+                let domain = property % classes;
+                let _ = writeln!(
+                    ontology_turtle,
+                    "ex:property{property:04} a owl:DatatypeProperty ; rdfs:domain ex:Class{domain:04} ; rdfs:range xsd:string ."
+                );
+            }
+            Density::Dense => {
+                let _ = writeln!(
+                    ontology_turtle,
+                    "ex:property{property:04} a owl:DatatypeProperty ; rdfs:range xsd:string ."
+                );
+            }
+        }
+    }
+    let ontology = purrdf_shapes::text_ingest::parse_turtle_to_dataset(&ontology_turtle)
+        .expect("benchmark ontology Turtle");
+    let namespaces = Namespaces::new(
+        "ex",
+        &[(
+            "ex".to_owned(),
+            "https://example.org/schema-bench/".to_owned(),
+        )],
+    )
+    .expect("benchmark namespaces");
+    Fixture {
+        shapes,
+        ontology,
+        namespaces,
+    }
+}
+
+fn bench_schema_surface(c: &mut Criterion) {
+    let shaped = fixture(128, 128, Density::Sparse, true);
+    let sparse = fixture(256, 256, Density::Sparse, false);
+    let dense = fixture(128, 256, Density::Dense, false);
+    let mut group = c.benchmark_group("shacl_schema_surface");
+    group.sample_size(10);
+
+    group.bench_function("shaped_only_128_classes_128_properties", |bencher| {
+        bencher.iter(|| {
+            let request = SchemaCompileRequest::new(
+                &shaped.shapes,
+                &shaped.namespaces,
+                shaped.ontology.as_ref(),
+                SchemaSurfaceMode::ShapedOnly,
+            );
+            black_box(compile_schema(&request).expect("shaped-only compilation"));
+        });
+    });
+    group.bench_function("ontology_sparse_256_classes_256_properties", |bencher| {
+        bencher.iter(|| {
+            let request = SchemaCompileRequest::new(
+                &sparse.shapes,
+                &sparse.namespaces,
+                sparse.ontology.as_ref(),
+                SchemaSurfaceMode::OntologyComplete,
+            );
+            black_box(compile_schema(&request).expect("sparse ontology compilation"));
+        });
+    });
+    group.bench_function("ontology_dense_128_classes_256_properties", |bencher| {
+        bencher.iter(|| {
+            let request = SchemaCompileRequest::new(
+                &dense.shapes,
+                &dense.namespaces,
+                dense.ontology.as_ref(),
+                SchemaSurfaceMode::OntologyComplete,
+            );
+            black_box(compile_schema(&request).expect("dense ontology compilation"));
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_schema_surface);
+criterion_main!(benches);

--- a/crates/shapes/examples/ontology_schema_surface.rs
+++ b/crates/shapes/examples/ontology_schema_surface.rs
@@ -8,8 +8,8 @@ use std::error::Error;
 
 use purrdf_shapes::{
     GraphqlConfig, LinkmlConfig, Namespaces, PydanticConfig, SchemaCompileRequest,
-    SchemaSurfaceMode, TypeScriptConfig, compile_schema, emit_graphql, emit_linkml, emit_pydantic,
-    emit_typescript,
+    SchemaSurfaceMode, TYPESCRIPT_DECLARATION_PATH, TypeScriptConfig, compile_schema, emit_graphql,
+    emit_linkml, emit_pydantic, emit_typescript,
 };
 
 const EX: &str = "https://example.org/schema/";
@@ -22,12 +22,13 @@ const PREFIXES: &str = r"
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 ";
 
-fn artifact_contains(artifacts: &BTreeMap<String, Vec<u8>>, needle: &[u8]) -> bool {
-    artifacts.values().any(|artifact| {
-        artifact
-            .windows(needle.len())
-            .any(|window| window == needle)
-    })
+fn generated_definition_block<'a>(source: &'a str, start: &str, next: &str) -> Option<&'a str> {
+    let offset = source.find(start)?;
+    let tail = &source[offset..];
+    let end = tail[start.len()..]
+        .find(next)
+        .map_or(tail.len(), |next_offset| start.len() + next_offset);
+    Some(&tail[..end])
 }
 
 fn definition_keys(schema: &str) -> Result<BTreeSet<String>, Box<dyn Error>> {
@@ -123,19 +124,47 @@ ex:resentMessageId a owl:DatatypeProperty ;
         )?,
     )?;
 
-    let property = b"ex:resentMessageId";
-    let reaches_every_carrier = linkml
-        .yaml
-        .as_bytes()
-        .windows(property.len())
-        .any(|w| w == property)
-        && artifact_contains(&typescript.artifacts, property)
-        && graphql
-            .names
-            .fields
-            .values()
-            .any(|fields| fields.contains_key("ex:resentMessageId"))
-        && artifact_contains(&pydantic.artifacts, property);
+    let declarations = std::str::from_utf8(
+        typescript
+            .artifacts
+            .get(TYPESCRIPT_DECLARATION_PATH)
+            .ok_or("TypeScript declaration artifact is missing")?,
+    )?;
+    let email_type = typescript
+        .type_names
+        .get("EmailMessage")
+        .ok_or("TypeScript EmailMessage type is missing")?;
+    let email_declaration = generated_definition_block(
+        declarations,
+        &format!("export type {email_type} = "),
+        "\nexport type ",
+    )
+    .ok_or("TypeScript EmailMessage declaration is missing")?;
+    let email_fields = graphql
+        .names
+        .fields
+        .get("#/$defs/EmailMessage")
+        .ok_or("GraphQL EmailMessage field map is missing")?;
+    let models = std::str::from_utf8(
+        pydantic
+            .artifacts
+            .get("example_ontology/models.py")
+            .ok_or("Pydantic models artifact is missing")?,
+    )?;
+    let email_model = pydantic
+        .model_paths
+        .get("EmailMessage")
+        .and_then(|path| path.rsplit('.').next())
+        .ok_or("Pydantic EmailMessage model is missing")?;
+    let email_model =
+        generated_definition_block(models, &format!("class {email_model}("), "\nclass ")
+            .ok_or("Pydantic EmailMessage definition is missing")?;
+    let reaches_every_carrier = linkml.document.as_value()["classes"]["EmailMessage"]["attributes"]
+        ["ex:resentMessageId"]
+        .is_object()
+        && email_declaration.contains("ex:resentMessageId")
+        && email_fields.contains_key("ex:resentMessageId")
+        && email_model.contains("alias=\"ex:resentMessageId\"");
     if !reaches_every_carrier {
         return Err("ontology-only property did not reach every language carrier".into());
     }

--- a/crates/shapes/examples/ontology_schema_surface.rs
+++ b/crates/shapes/examples/ontology_schema_surface.rs
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Compare shaped-only and ontology-complete schema surfaces and emit every carrier.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+
+use purrdf_shapes::{
+    GraphqlConfig, LinkmlConfig, Namespaces, PydanticConfig, SchemaCompileRequest,
+    SchemaSurfaceMode, TypeScriptConfig, compile_schema, emit_graphql, emit_linkml, emit_pydantic,
+    emit_typescript,
+};
+
+const EX: &str = "https://example.org/schema/";
+const LINKML: &str = "https://w3id.org/linkml/";
+const PREFIXES: &str = r"
+@prefix ex: <https://example.org/schema/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+";
+
+fn artifact_contains(artifacts: &BTreeMap<String, Vec<u8>>, needle: &[u8]) -> bool {
+    artifacts.values().any(|artifact| {
+        artifact
+            .windows(needle.len())
+            .any(|window| window == needle)
+    })
+}
+
+fn definition_keys(schema: &str) -> Result<BTreeSet<String>, Box<dyn Error>> {
+    let document: serde_json::Value = serde_json::from_str(schema)?;
+    let definitions = document["$defs"]
+        .as_object()
+        .ok_or("compiled schema has no $defs object")?;
+    Ok(definitions.keys().cloned().collect())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let shapes_dataset = purrdf_shapes::text_ingest::parse_turtle_to_dataset(&format!(
+        "{PREFIXES}
+ex:PersonShape a sh:NodeShape ;
+    sh:targetClass ex:Person ;
+    sh:property [ sh:path ex:name ; sh:minCount 1 ; sh:datatype xsd:string ] ."
+    ))
+    .map_err(|errors| std::io::Error::other(errors.join("\n")))?;
+    let shapes = purrdf_shapes::shapes::from_dataset(&shapes_dataset)?;
+    let ontology = purrdf_shapes::text_ingest::parse_turtle_to_dataset(&format!(
+        "{PREFIXES}
+ex:Person a owl:Class .
+ex:EmailMessage a owl:Class .
+ex:name a owl:DatatypeProperty ; rdfs:domain ex:Person ; rdfs:range xsd:string .
+ex:latestMessage a owl:ObjectProperty, owl:FunctionalProperty ;
+    rdfs:domain ex:Person ; rdfs:range ex:EmailMessage .
+ex:resentDate a owl:DatatypeProperty ;
+    rdfs:domain ex:EmailMessage ; rdfs:range xsd:dateTime .
+ex:resentMessageId a owl:DatatypeProperty ;
+    rdfs:domain ex:EmailMessage ; rdfs:range rdfs:Literal ."
+    ))
+    .map_err(|errors| std::io::Error::other(errors.join("\n")))?;
+    let namespaces = Namespaces::new("ex", &[("ex".to_owned(), EX.to_owned())])?;
+
+    let shaped = compile_schema(&SchemaCompileRequest::new(
+        &shapes,
+        &namespaces,
+        ontology.as_ref(),
+        SchemaSurfaceMode::ShapedOnly,
+    ))?;
+    let complete = compile_schema(&SchemaCompileRequest::new(
+        &shapes,
+        &namespaces,
+        ontology.as_ref(),
+        SchemaSurfaceMode::OntologyComplete,
+    ))?;
+    let shaped_defs = definition_keys(&shaped.compiled.schema_json)?;
+    let complete_defs = definition_keys(&complete.compiled.schema_json)?;
+    println!("shaped-only definitions: {shaped_defs:?}");
+    println!("ontology-complete definitions: {complete_defs:?}");
+    println!("ontology-complete cache key: {}", complete.key);
+    println!("coverage manifest:\n{}", complete.coverage.to_json());
+    if shaped_defs.contains("EmailMessage") || !complete_defs.contains("EmailMessage") {
+        return Err("surface-mode comparison did not expose the ontology-only class".into());
+    }
+
+    let linkml = emit_linkml(
+        &complete.compiled,
+        &LinkmlConfig::new(
+            "https://example.org/schema/generated",
+            "ExampleSchema",
+            "Ontology-complete schema owned by the example.org caller.",
+            "ex",
+            BTreeMap::from([
+                ("ex".to_owned(), EX.to_owned()),
+                ("linkml".to_owned(), LINKML.to_owned()),
+            ]),
+        )?,
+    )?;
+    let typescript = emit_typescript(
+        &complete.compiled,
+        &TypeScriptConfig::new(
+            "example-ontology-types",
+            "Types owned by the example.org caller.",
+            "Ontology-complete TypeScript declarations.",
+        )?,
+    )?;
+    let graphql = emit_graphql(
+        &complete.compiled,
+        &GraphqlConfig::new(
+            "ExampleOntology",
+            "GraphQL package owned by the example.org caller.",
+            "Ontology-complete GraphQL types.",
+            "RdfValue",
+        )?,
+    )?;
+    let pydantic = emit_pydantic(
+        &complete.compiled,
+        &PydanticConfig::new(
+            "example_ontology",
+            "Models owned by the example.org caller.",
+            "Ontology-complete Pydantic models.",
+        )?,
+    )?;
+
+    let property = b"ex:resentMessageId";
+    let reaches_every_carrier = linkml
+        .yaml
+        .as_bytes()
+        .windows(property.len())
+        .any(|w| w == property)
+        && artifact_contains(&typescript.artifacts, property)
+        && graphql
+            .names
+            .fields
+            .values()
+            .any(|fields| fields.contains_key("ex:resentMessageId"))
+        && artifact_contains(&pydantic.artifacts, property);
+    if !reaches_every_carrier {
+        return Err("ontology-only property did not reach every language carrier".into());
+    }
+    println!(
+        "emitted LinkML YAML plus {} TypeScript, {} GraphQL, and {} Pydantic artifact(s)",
+        typescript.artifacts.len(),
+        graphql.artifacts.len(),
+        pydantic.artifacts.len()
+    );
+    Ok(())
+}

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -56,6 +56,9 @@ use serde_json::{Map, Value, json};
 
 use crate::data::{GraphFilter, native_quads};
 use crate::model::{rdf, rdfs};
+use crate::schema_surface::{
+    OntologyExpression, OntologyPropertyKind, SchemaSurface, SurfaceClass, SurfaceProperty,
+};
 use crate::shapes::{Constraint, NodeKindValue, Path, Shape, Shapes, Target};
 use crate::term::{NamedNode, Term};
 
@@ -866,7 +869,7 @@ struct Ctx<'ns> {
     /// Predicate IRIs whose `rdfs:range` is a value-vocabulary class → that
     /// class's `{Local}Enum` `$def` key. Drives the enum `$ref` for OPEN
     /// vocabularies that carry no `sh:class`. Empty unless a projection is active.
-    predicate_ranges: BTreeMap<String, String>,
+    predicate_ranges: BTreeMap<String, Vec<String>>,
     /// The namespace table driving ALL compaction / keying decisions.
     ns: &'ns Namespaces,
 }
@@ -875,7 +878,7 @@ impl<'ns> Ctx<'ns> {
     fn new(
         emitted_defs: BTreeSet<String>,
         value_vocab_enums: BTreeMap<String, String>,
-        predicate_ranges: BTreeMap<String, String>,
+        predicate_ranges: BTreeMap<String, Vec<String>>,
         ns: &'ns Namespaces,
     ) -> Self {
         Self {
@@ -925,6 +928,45 @@ impl<'ns> Ctx<'ns> {
 /// would share a `$defs` key — see [`Namespaces::def_key`].
 pub fn compile(shapes: &Shapes, ns: &Namespaces) -> CompiledSchema {
     compile_with_value_vocab(shapes, ns, None)
+}
+
+/// Compile an explicit ontology-aware schema request.
+///
+/// [`SchemaSurfaceMode::ShapedOnly`] delegates to the legacy emitter and is
+/// byte-identical for the same shapes/value-vocabulary inputs. The
+/// ontology-complete mode injects optional OWL/RDFS properties and synthesized
+/// open carrier classes from the same relation returned in
+/// [`SchemaCompilation::coverage`].
+///
+/// # Errors
+///
+/// Returns a typed error for unsafe canonicalization, malformed/contradictory
+/// ontology axioms, fixed resource ceiling breaches, or schema key collisions.
+pub fn compile_schema(
+    request: &SchemaCompileRequest<'_>,
+) -> Result<SchemaCompilation, SchemaCompileError> {
+    let key = request.compilation_key()?;
+    let surface = crate::schema_surface::build(request)?;
+    let projection = request.value_vocab().map(|vocab| ValueVocabProjection {
+        vocab,
+        ontology: request.ontology(),
+    });
+    let compiled = match request.mode() {
+        SchemaSurfaceMode::ShapedOnly => {
+            compile_with_value_vocab(request.shapes(), request.namespaces(), projection.as_ref())
+        }
+        SchemaSurfaceMode::OntologyComplete => compile_with_surface(
+            request.shapes(),
+            request.namespaces(),
+            projection.as_ref(),
+            &surface,
+        )?,
+    };
+    Ok(SchemaCompilation {
+        compiled,
+        coverage: surface.report,
+        key,
+    })
 }
 
 /// Compile a parsed [`Shapes`] graph, optionally projecting *value vocabularies*
@@ -1131,6 +1173,346 @@ pub fn compile_with_value_vocab(
     }
 }
 
+fn compile_with_surface(
+    shapes: &Shapes,
+    ns: &Namespaces,
+    projection: Option<&ValueVocabProjection<'_>>,
+    surface: &SchemaSurface,
+) -> Result<CompiledSchema, SchemaCompileError> {
+    let (vocab_enums, vocab_losses) = value_vocab_enum_defs(shapes, ns, projection);
+    validate_surface_keys(surface, ns, &vocab_enums)?;
+
+    let mut emitted_defs: BTreeSet<String> = surface
+        .classes
+        .keys()
+        .map(|class_iri| ns.def_key(class_iri))
+        .collect();
+    for (key, _definition) in vocab_enums.values() {
+        emitted_defs.insert(key.clone());
+    }
+    let value_vocab_enums: BTreeMap<String, String> = vocab_enums
+        .iter()
+        .map(|(class_iri, (key, _definition))| (class_iri.clone(), key.clone()))
+        .collect();
+    let predicate_ranges = value_vocab_predicate_ranges(shapes, projection, &vocab_enums);
+    let mut ctx = Ctx::new(emitted_defs, value_vocab_enums, predicate_ranges, ns);
+    ctx.record_entries(vocab_losses);
+
+    let mut defs: Map<String, Value> = Map::new();
+    for shape in &shapes.node_shapes {
+        if shape.deactivated {
+            continue;
+        }
+        let body = compile_object_schema(shape, &mut ctx);
+        let shape_iri = shape.id.to_string();
+        for target in &shape.targets {
+            match target {
+                Target::Class(class) => {
+                    let class_iri = class.as_str();
+                    let name = ns.def_key(class_iri);
+                    let augmented =
+                        augment_object_schema(body.clone(), surface.classes.get(class_iri), &ctx);
+                    defs.entry(name).or_insert(augmented);
+                }
+                Target::ImplicitClass(term) => {
+                    let class_iri = implicit_class_iri(term);
+                    let name = ns.def_key(class_iri);
+                    let augmented =
+                        augment_object_schema(body.clone(), surface.classes.get(class_iri), &ctx);
+                    defs.entry(name).or_insert(augmented);
+                }
+                Target::Sparql { .. } => ctx.record(
+                    "sh:SPARQLTarget",
+                    &shape_iri,
+                    "SHACL-AF SPARQL target (sh:target/sh:SPARQLTarget) selects focus \
+                     nodes via an arbitrary SPARQL query with no closed-world JSON \
+                     Schema equivalent; the shape's SPARQL-selected instances are not \
+                     enforced by the emitted schema",
+                ),
+                Target::Node(_) => ctx.record(
+                    "sh:targetNode",
+                    &shape_iri,
+                    "A shape targeted only via sh:targetNode selects specific focus \
+                     nodes, not a class extension; it has no closed-world JSON Schema \
+                     $def and its constraints are not enforced by the emitted schema.",
+                ),
+                Target::SubjectsOf(_) => ctx.record(
+                    "sh:targetSubjectsOf",
+                    &shape_iri,
+                    "A shape targeted only via sh:targetSubjectsOf selects focus nodes \
+                     by a predicate's subject position, not a class extension; no \
+                     closed-world JSON Schema $def can be keyed and its constraints are \
+                     not enforced.",
+                ),
+                Target::ObjectsOf(_) => ctx.record(
+                    "sh:targetObjectsOf",
+                    &shape_iri,
+                    "A shape targeted only via sh:targetObjectsOf selects focus nodes \
+                     by a predicate's object position, not a class extension; no \
+                     closed-world JSON Schema $def can be keyed and its constraints are \
+                     not enforced.",
+                ),
+            }
+        }
+    }
+
+    for (class_iri, class) in &surface.classes {
+        let key = ns.def_key(class_iri);
+        if class.synthesized_open {
+            defs.entry(key)
+                .or_insert_with(|| open_surface_class_schema(class, &ctx));
+        } else {
+            debug_assert!(
+                defs.contains_key(&key),
+                "every non-synthesized surface class has an active SHACL target"
+            );
+        }
+    }
+
+    defs.insert("Annotation".to_owned(), annotation_def());
+    let class_names: Vec<String> = defs
+        .keys()
+        .filter(|key| *key != "Annotation")
+        .cloned()
+        .collect();
+    defs.insert("Node".to_owned(), node_def(&class_names, ns));
+    for (key, definition) in vocab_enums.values() {
+        defs.insert(key.clone(), definition.clone());
+    }
+
+    Ok(CompiledSchema {
+        schema_json: to_pretty(&root_schema(&defs, ns)),
+        openapi_json: to_pretty(&openapi_doc(&defs)),
+        losses: ctx.ledger,
+    })
+}
+
+fn validate_surface_keys(
+    surface: &SchemaSurface,
+    ns: &Namespaces,
+    vocab_enums: &BTreeMap<String, (String, Value)>,
+) -> Result<(), SchemaCompileError> {
+    let mut keys: BTreeMap<String, String> = BTreeMap::new();
+    keys.insert(
+        "Annotation".to_owned(),
+        "JSON Schema reserved definition".to_owned(),
+    );
+    keys.insert(
+        "Node".to_owned(),
+        "JSON Schema reserved definition".to_owned(),
+    );
+    for class_iri in surface.classes.keys() {
+        if !ns.is_known(class_iri) {
+            return Err(SchemaCompileError::Namespace {
+                iri: class_iri.clone(),
+                reason: "class has no caller-declared prefix for discriminator/key emission"
+                    .to_owned(),
+            });
+        }
+        insert_definition_key(&mut keys, ns.def_key(class_iri), class_iri)?;
+    }
+    for (class_iri, (key, _definition)) in vocab_enums {
+        if !ns.is_known(class_iri) {
+            return Err(SchemaCompileError::Namespace {
+                iri: class_iri.clone(),
+                reason: "value-vocabulary class has no caller-declared prefix".to_owned(),
+            });
+        }
+        insert_definition_key(&mut keys, key.clone(), class_iri)?;
+    }
+    for (class_iri, class) in &surface.classes {
+        let mut property_keys: BTreeMap<String, String> = BTreeMap::new();
+        for property_iri in class.properties.keys() {
+            let key = ns.compact_iri(property_iri);
+            if let Some(first) = property_keys.insert(key.clone(), property_iri.clone())
+                && first != *property_iri
+            {
+                return Err(SchemaCompileError::DefinitionCollision {
+                    key: format!("{}::{key}", ns.def_key(class_iri)),
+                    first,
+                    second: property_iri.clone(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn insert_definition_key(
+    keys: &mut BTreeMap<String, String>,
+    key: String,
+    resource: &str,
+) -> Result<(), SchemaCompileError> {
+    if let Some(first) = keys.insert(key.clone(), resource.to_owned())
+        && first != resource
+    {
+        return Err(SchemaCompileError::DefinitionCollision {
+            key,
+            first,
+            second: resource.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn augment_object_schema(mut body: Value, class: Option<&SurfaceClass>, ctx: &Ctx<'_>) -> Value {
+    let Some(class) = class else {
+        return body;
+    };
+    let properties = body
+        .as_object_mut()
+        .and_then(|object| object.get_mut("properties"))
+        .and_then(Value::as_object_mut)
+        .expect("compiled class object always has a properties map");
+    for property in class.properties.values() {
+        properties
+            .entry(ctx.ns.compact_iri(&property.iri))
+            .or_insert_with(|| ontology_property_schema(property, ctx));
+    }
+    body
+}
+
+fn open_surface_class_schema(class: &SurfaceClass, ctx: &Ctx<'_>) -> Value {
+    let body = json!({
+        "type": "object",
+        "properties": {
+            "@id": { "type": "string" },
+            "@type": {
+                "anyOf": [
+                    { "type": "string" },
+                    { "type": "array", "items": { "type": "string" } }
+                ]
+            },
+            "@annotation": { "$ref": "#/$defs/Annotation" }
+        }
+    });
+    augment_object_schema(body, Some(class), ctx)
+}
+
+fn ontology_property_schema(property: &SurfaceProperty, ctx: &Ctx<'_>) -> Value {
+    let mut single = if property.ranges.is_empty() {
+        match property.kind {
+            OntologyPropertyKind::Object => node_ref_schema(),
+            OntologyPropertyKind::Datatype => general_literal_schema(),
+            OntologyPropertyKind::Generic | OntologyPropertyKind::Annotation => {
+                general_rdf_value_schema()
+            }
+        }
+    } else {
+        let mut conjuncts: Vec<Value> = property
+            .ranges
+            .iter()
+            .map(|range| range_expression_schema(range, property.kind, ctx))
+            .collect();
+        if conjuncts.len() == 1 {
+            conjuncts.pop().expect("one range expression")
+        } else {
+            json!({ "allOf": conjuncts })
+        }
+    };
+    if let Value::Object(schema) = &mut single {
+        schema.insert(
+            "$comment".to_owned(),
+            Value::String(if property.functional {
+                "Optional OWL/RDFS-derived property; owl:FunctionalProperty is represented as a scalar approximation."
+                    .to_owned()
+            } else {
+                "Optional OWL/RDFS-derived property; multiple values remain permitted.".to_owned()
+            }),
+        );
+    }
+    if property.functional {
+        single
+    } else {
+        json!({
+            "anyOf": [
+                single.clone(),
+                { "type": "array", "items": single }
+            ]
+        })
+    }
+}
+
+fn range_expression_schema(
+    expression: &OntologyExpression,
+    kind: OntologyPropertyKind,
+    ctx: &Ctx<'_>,
+) -> Value {
+    match expression {
+        OntologyExpression::Named(iri) => named_range_schema(iri, kind, ctx),
+        OntologyExpression::Union(members) => json!({
+            "anyOf": members
+                .iter()
+                .map(|member| range_expression_schema(member, kind, ctx))
+                .collect::<Vec<_>>()
+        }),
+        OntologyExpression::Intersection(members) => json!({
+            "allOf": members
+                .iter()
+                .map(|member| range_expression_schema(member, kind, ctx))
+                .collect::<Vec<_>>()
+        }),
+    }
+}
+
+fn named_range_schema(iri: &str, kind: OntologyPropertyKind, ctx: &Ctx<'_>) -> Value {
+    if let Some(enum_key) = ctx.value_vocab_enums.get(iri) {
+        return json!({ "$ref": format!("#/$defs/{enum_key}") });
+    }
+    if iri == "http://www.w3.org/2000/01/rdf-schema#Literal" {
+        return general_literal_schema();
+    }
+    if iri == RDF_LANG_STRING {
+        return json!({
+            "type": "object",
+            "properties": {
+                "@value": { "type": "string" },
+                "@language": { "type": "string" }
+            },
+            "required": ["@value", "@language"]
+        });
+    }
+    if kind == OntologyPropertyKind::Datatype || iri.starts_with(XSD_NS) {
+        return datatype_value_schema(iri);
+    }
+    let key = ctx.ns.def_key(iri);
+    if ctx.emitted_defs.contains(&key) {
+        json!({ "$ref": format!("#/$defs/{key}") })
+    } else if kind == OntologyPropertyKind::Annotation {
+        general_rdf_value_schema()
+    } else {
+        node_ref_schema()
+    }
+}
+
+fn general_literal_schema() -> Value {
+    json!({
+        "anyOf": [
+            { "type": "string" },
+            { "type": "number" },
+            { "type": "boolean" },
+            typed_literal_schema(),
+            {
+                "type": "object",
+                "properties": {
+                    "@value": { "type": "string" },
+                    "@language": { "type": "string" }
+                },
+                "required": ["@value", "@language"]
+            }
+        ]
+    })
+}
+
+fn general_rdf_value_schema() -> Value {
+    json!({
+        "anyOf": [
+            general_literal_schema(),
+            node_ref_schema()
+        ]
+    })
+}
+
 /// A single value-vocabulary member: its compacted CURIE (the `enum` value id),
 /// its identifier-safe symbol name (`x-enum-varnames`), and its doc string
 /// (`x-enum-descriptions`, empty when the member carries neither `rdfs:comment`
@@ -1210,26 +1592,23 @@ fn value_vocab_enum_defs(
 ///
 /// A single `(?P, rdfs:range, ?O)` scan per dataset is performed — O(1) queries
 /// in the number of vocab classes, rather than one scan per class — filtering
-/// each matched object against `vocab_enums` by IRI string. When a predicate's
-/// `rdfs:range` is declared over multiple distinct vocab classes, the class
-/// with the lexicographically largest IRI wins, matching the deterministic
-/// last-write-wins tiebreak of a sorted-by-`class_iri` resolution.
+/// each matched object against `vocab_enums` by IRI string. Multiple ranges are
+/// retained in lexical class-IRI order because RDFS range axioms are
+/// conjunctive; discarding all but one would weaken the ontology.
 fn value_vocab_predicate_ranges(
     shapes: &Shapes,
     projection: Option<&ValueVocabProjection<'_>>,
     vocab_enums: &BTreeMap<String, (String, Value)>,
-) -> BTreeMap<String, String> {
-    let mut out: BTreeMap<String, String> = BTreeMap::new();
+) -> BTreeMap<String, Vec<String>> {
+    let mut out: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
     let Some(proj) = projection else {
-        return out;
+        return BTreeMap::new();
     };
     if vocab_enums.is_empty() {
-        return out;
+        return BTreeMap::new();
     }
     let datasets: [&RdfDataset; 2] = [proj.ontology, shapes.shapes_dataset.as_ref()];
     let range_term = Term::NamedNode(NamedNode::from(rdfs::RANGE));
-    // predicate -> (winning class_iri, enum_key); on conflict the larger class_iri wins.
-    let mut winners: BTreeMap<String, (&str, &str)> = BTreeMap::new();
     for ds in datasets {
         for (subject, _pred, object) in
             native_quads(ds, None, Some(&range_term), None, GraphFilter::AnyGraph)
@@ -1243,20 +1622,14 @@ fn value_vocab_predicate_ranges(
             let Some((class_iri, (enum_key, _def))) = vocab_enums.get_key_value(o.as_str()) else {
                 continue;
             };
-            winners
-                .entry(p.as_str().to_owned())
-                .and_modify(|winner| {
-                    if class_iri.as_str() > winner.0 {
-                        *winner = (class_iri.as_str(), enum_key.as_str());
-                    }
-                })
-                .or_insert((class_iri.as_str(), enum_key.as_str()));
+            out.entry(p.as_str().to_owned())
+                .or_default()
+                .insert(class_iri.clone(), enum_key.clone());
         }
     }
-    for (predicate, (_class_iri, enum_key)) in winners {
-        out.insert(predicate, enum_key.to_owned());
-    }
-    out
+    out.into_iter()
+        .map(|(predicate, ranges)| (predicate, ranges.into_values().collect()))
+        .collect()
 }
 
 /// Enumerate the named individuals of `class_iri` (`?x rdf:type class_iri`) across
@@ -2260,18 +2633,19 @@ fn compile_property(
     // always wins. Only a property with NO `sh:class` takes the range-derived enum
     // `$ref`; a `sh:class` that coexists with a value-vocabulary range records a
     // conflict loss (the range enum is suppressed).
-    if let Some(range_key) = ctx.predicate_ranges.get(pred_iri).cloned() {
+    if let Some(range_keys) = ctx.predicate_ranges.get(pred_iri).cloned() {
         match (&class_enum_key, had_any_class) {
             (Some(class_key), _) => {
                 // A vocab `sh:class` already emitted its enum `$ref`; it wins.
-                if *class_key != range_key {
+                if range_keys.iter().any(|range_key| range_key != class_key) {
                     ctx.record(
                         "rdfs:range",
                         shape_iri,
                         &format!(
                             "predicate {pred_iri} has a value-vocabulary sh:class ({class_key}) \
-                             and a conflicting value-vocabulary rdfs:range ({range_key}); \
-                             sh:class wins, range enum suppressed"
+                             and conflicting value-vocabulary rdfs:ranges ({}); \
+                             sh:class wins, range enum suppressed",
+                            range_keys.join(", ")
                         ),
                     );
                 }
@@ -2283,13 +2657,22 @@ fn compile_property(
                     shape_iri,
                     &format!(
                         "predicate {pred_iri} has a sh:class and a value-vocabulary \
-                         rdfs:range ({range_key}); sh:class wins, range enum suppressed"
+                         rdfs:range ({}); sh:class wins, range enum suppressed",
+                        range_keys.join(", ")
                     ),
                 );
             }
             (None, false) => {
-                // Open vocabulary (no sh:class): the enum `$ref` is the value schema.
-                alts.push(json!({ "$ref": format!("#/$defs/{range_key}") }));
+                // Open vocabulary (no sh:class): every range is conjunctive.
+                let mut refs: Vec<Value> = range_keys
+                    .into_iter()
+                    .map(|range_key| json!({ "$ref": format!("#/$defs/{range_key}") }))
+                    .collect();
+                alts.push(if refs.len() == 1 {
+                    refs.pop().expect("one range ref")
+                } else {
+                    json!({ "allOf": refs })
+                });
             }
         }
     }
@@ -2545,6 +2928,29 @@ mod tests {
         let dataset = crate::text_ingest::parse_turtle_to_dataset(&ttl).expect("Turtle parse");
         let shapes = from_dataset(&dataset).expect("shape parse");
         compile(&shapes, &fixture_ns())
+    }
+
+    fn compile_ontology(
+        shapes_body: &str,
+        ontology_body: &str,
+        mode: SchemaSurfaceMode,
+    ) -> SchemaCompilation {
+        let shapes_dataset = crate::text_ingest::parse_turtle_to_dataset(&format!(
+            "{PREFIXES}@prefix owl: <http://www.w3.org/2002/07/owl#> .\n{shapes_body}"
+        ))
+        .expect("shapes Turtle");
+        let shapes = from_dataset(&shapes_dataset).expect("shapes graph");
+        let ontology = crate::text_ingest::parse_turtle_to_dataset(&format!(
+            "{PREFIXES}@prefix owl: <http://www.w3.org/2002/07/owl#> .\n{ontology_body}"
+        ))
+        .expect("ontology Turtle");
+        compile_schema(&SchemaCompileRequest::new(
+            &shapes,
+            &fixture_ns(),
+            ontology.as_ref(),
+            mode,
+        ))
+        .expect("ontology schema compilation")
     }
 
     fn schema_of(c: &CompiledSchema) -> Value {
@@ -2912,6 +3318,187 @@ mod tests {
         };
         assert_eq!(forward.to_json(), reverse.to_json());
         assert!(forward.to_json().ends_with('\n'));
+    }
+
+    #[test]
+    fn ontology_complete_compilation_emits_optional_open_carriers() {
+        let compilation = compile_ontology(
+            r"
+                meta:PersonShape a sh:NodeShape ; sh:targetClass meta:Person ;
+                    sh:property [ sh:path meta:name ; sh:minCount 1 ; sh:datatype xsd:string ] .
+            ",
+            r"
+                meta:Person a owl:Class .
+                meta:EmailMessage a owl:Class .
+                meta:resentDate a owl:DatatypeProperty ;
+                    rdfs:domain meta:EmailMessage ; rdfs:range xsd:dateTime .
+                meta:resentMessageId a owl:DatatypeProperty ;
+                    rdfs:domain meta:EmailMessage ; rdfs:range rdfs:Literal .
+                meta:messageCode a owl:DatatypeProperty, owl:FunctionalProperty ;
+                    rdfs:domain meta:EmailMessage ; rdfs:range xsd:string .
+                meta:latestMessage a owl:ObjectProperty ;
+                    rdfs:domain meta:Person ; rdfs:range meta:EmailMessage .
+            ",
+            SchemaSurfaceMode::OntologyComplete,
+        );
+        let schema = schema_of(&compilation.compiled);
+        let email = def(&schema, "EmailMessage");
+        assert!(
+            email.is_object(),
+            "unshaped ontology class gets a carrier $def"
+        );
+        assert!(
+            email.get("additionalProperties").is_none(),
+            "carrier remains open"
+        );
+        assert!(
+            email.get("required").is_none(),
+            "ontology properties stay optional"
+        );
+        for property in [
+            "meta:resentDate",
+            "meta:resentMessageId",
+            "meta:messageCode",
+        ] {
+            assert!(
+                email["properties"][property].is_object(),
+                "{property} must be present on the synthesized carrier"
+            );
+        }
+        assert!(
+            email["properties"]["meta:resentDate"]["anyOf"]
+                .as_array()
+                .is_some_and(|forms| forms.iter().any(|form| form["type"] == "array")),
+            "non-functional property accepts multiple values"
+        );
+        assert_eq!(
+            email["properties"]["meta:messageCode"]["$comment"],
+            "Optional OWL/RDFS-derived property; owl:FunctionalProperty is represented as a scalar approximation."
+        );
+        assert_eq!(
+            def(&schema, "Person")["properties"]["meta:latestMessage"]["anyOf"][0]["$ref"],
+            "#/$defs/EmailMessage"
+        );
+
+        let openapi: Value =
+            serde_json::from_str(&compilation.compiled.openapi_json).expect("OpenAPI is JSON");
+        assert_eq!(
+            openapi["components"]["schemas"]["EmailMessage"], schema["$defs"]["EmailMessage"],
+            "OpenAPI embeds the exact shared carrier definition"
+        );
+        assert!(validates(
+            &compilation.compiled.schema_json,
+            &json!({
+                "@type": "meta:EmailMessage",
+                "meta:resentDate": ["2026-07-17T00:00:00Z"],
+                "meta:resentMessageId": "message-1",
+                "meta:messageCode": "code-1"
+            })
+        ));
+    }
+
+    #[test]
+    fn ontology_request_shaped_only_is_legacy_byte_exact() {
+        let shapes_dataset = crate::text_ingest::parse_turtle_to_dataset(&format!(
+            "{PREFIXES}meta:PersonShape a sh:NodeShape ; sh:targetClass meta:Person ; \
+             sh:property [ sh:path meta:name ; sh:datatype xsd:string ] ."
+        ))
+        .expect("shapes Turtle");
+        let shapes = from_dataset(&shapes_dataset).expect("shapes graph");
+        let ontology = crate::text_ingest::parse_turtle_to_dataset(&format!(
+            "{PREFIXES}@prefix owl: <http://www.w3.org/2002/07/owl#> . \
+             meta:extra a owl:DatatypeProperty ."
+        ))
+        .expect("ontology Turtle");
+        let legacy = compile(&shapes, &fixture_ns());
+        let requested = compile_schema(&SchemaCompileRequest::new(
+            &shapes,
+            &fixture_ns(),
+            ontology.as_ref(),
+            SchemaSurfaceMode::ShapedOnly,
+        ))
+        .expect("shaped-only request");
+        assert_eq!(legacy.schema_json, requested.compiled.schema_json);
+        assert_eq!(legacy.openapi_json, requested.compiled.openapi_json);
+        assert_eq!(
+            legacy.losses.render_json(),
+            requested.compiled.losses.render_json()
+        );
+    }
+
+    #[test]
+    fn ontology_surface_preserves_direct_shacl_and_closed_shape_authority() {
+        let compilation = compile_ontology(
+            r"
+                meta:PersonShape a sh:NodeShape ; sh:targetClass meta:Person ;
+                    sh:closed true ; sh:ignoredProperties ( meta:allowed ) ;
+                    sh:property [ sh:path meta:name ; sh:minCount 1 ; sh:datatype xsd:string ] .
+            ",
+            r"
+                meta:Person a owl:Class .
+                meta:name a owl:DatatypeProperty ; rdfs:domain meta:Person ; rdfs:range rdfs:Literal .
+                meta:blocked a owl:DatatypeProperty ; rdfs:domain meta:Person .
+                meta:allowed a owl:DatatypeProperty ; rdfs:domain meta:Person .
+            ",
+            SchemaSurfaceMode::OntologyComplete,
+        );
+        let schema = schema_of(&compilation.compiled);
+        let person = def(&schema, "Person");
+        assert_eq!(person["additionalProperties"], false);
+        assert!(person["properties"]["meta:blocked"].is_null());
+        assert_eq!(person["properties"]["meta:allowed"], true);
+        assert!(
+            person["required"]
+                .as_array()
+                .is_some_and(|required| required.contains(&json!("meta:name"))),
+            "direct SHACL minCount remains authoritative"
+        );
+    }
+
+    #[test]
+    fn ontology_range_union_and_conjunction_remain_load_bearing() {
+        let compilation = compile_ontology(
+            "",
+            r"
+                meta:A a owl:Class .
+                meta:B a owl:Class .
+                meta:Holder a owl:Class .
+                meta:choice a owl:ObjectProperty ; rdfs:domain meta:Holder ;
+                    rdfs:range [ owl:unionOf ( meta:A meta:B ) ] .
+                meta:both a owl:ObjectProperty ; rdfs:domain meta:Holder ;
+                    rdfs:range meta:A, meta:B .
+            ",
+            SchemaSurfaceMode::OntologyComplete,
+        );
+        let schema = schema_of(&compilation.compiled);
+        let holder = def(&schema, "Holder");
+        let choice = &holder["properties"]["meta:choice"]["anyOf"][0];
+        assert_eq!(choice["anyOf"].as_array().map(Vec::len), Some(2));
+        let both = &holder["properties"]["meta:both"]["anyOf"][0];
+        assert_eq!(both["allOf"].as_array().map(Vec::len), Some(2));
+    }
+
+    #[test]
+    fn ontology_class_collision_is_a_typed_error() {
+        let shapes_dataset =
+            crate::text_ingest::parse_turtle_to_dataset(PREFIXES).expect("empty shapes Turtle");
+        let shapes = from_dataset(&shapes_dataset).expect("empty shapes graph");
+        let ontology = crate::text_ingest::parse_turtle_to_dataset(&format!(
+            "{PREFIXES}@prefix owl: <http://www.w3.org/2002/07/owl#> . \
+             meta:Node a owl:Class ."
+        ))
+        .expect("ontology Turtle");
+        let error = compile_schema(&SchemaCompileRequest::new(
+            &shapes,
+            &fixture_ns(),
+            ontology.as_ref(),
+            SchemaSurfaceMode::OntologyComplete,
+        ))
+        .expect_err("reserved Node definition must collide");
+        assert!(matches!(
+            error,
+            SchemaCompileError::DefinitionCollision { key, .. } if key == "Node"
+        ));
     }
 
     #[test]
@@ -5123,10 +5710,9 @@ mod tests {
     }
 
     #[test]
-    fn value_vocab_multi_range_picks_largest_class_iri_deterministically() {
-        // When ONE predicate declares rdfs:range over TWO distinct value-vocab
-        // classes, the winner is the class with the lexicographically LARGEST
-        // class IRI (".../logic/Beta" > ".../logic/Alpha"), not load order.
+    fn value_vocab_multi_range_is_conjunctive_and_deterministic() {
+        // Multiple rdfs:range axioms are a conjunction, retained in stable
+        // class-IRI order rather than reduced to one lexical winner.
         let forward = schema_of(&compile_vocab(
             r"
             logic:Alpha a logic:AbstractIndividualType .
@@ -5141,8 +5727,13 @@ mod tests {
         ));
         assert_eq!(
             def(&forward, "Thing")["properties"]["meta:choice"],
-            json!({ "$ref": "#/$defs/BetaEnum" }),
-            "the larger class IRI (logic:Beta) wins the multi-range tiebreak"
+            json!({
+                "allOf": [
+                    { "$ref": "#/$defs/AlphaEnum" },
+                    { "$ref": "#/$defs/BetaEnum" }
+                ]
+            }),
+            "both declared ranges remain load-bearing"
         );
 
         // Reversed triple order (Beta declared before Alpha) must yield the
@@ -5161,8 +5752,8 @@ mod tests {
         ));
         assert_eq!(
             def(&reversed, "Thing")["properties"]["meta:choice"],
-            json!({ "$ref": "#/$defs/BetaEnum" }),
-            "the winner is order-independent: still logic:Beta when declared first"
+            def(&forward, "Thing")["properties"]["meta:choice"],
+            "the conjunctive range order is independent of triple load order"
         );
     }
 

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -1488,7 +1488,12 @@ fn named_range_schema(iri: &str, kind: OntologyPropertyKind, ctx: &Ctx<'_>) -> V
     }
     let key = ctx.ns.def_key(iri);
     if ctx.emitted_defs.contains(&key) {
-        json!({ "$ref": format!("#/$defs/{key}") })
+        json!({
+            "anyOf": [
+                node_ref_schema(),
+                { "$ref": format!("#/$defs/{key}") }
+            ]
+        })
     } else if kind == OntologyPropertyKind::Annotation {
         general_rdf_value_schema()
     } else {
@@ -3423,9 +3428,16 @@ mod tests {
             email["properties"]["meta:messageCode"]["$comment"],
             "Optional OWL/RDFS-derived property; owl:FunctionalProperty is represented as a scalar approximation."
         );
-        assert_eq!(
-            def(&schema, "Person")["properties"]["meta:latestMessage"]["anyOf"][0]["$ref"],
-            "#/$defs/EmailMessage"
+        let latest_message =
+            &def(&schema, "Person")["properties"]["meta:latestMessage"]["anyOf"][0]["anyOf"];
+        assert!(
+            latest_message
+                .as_array()
+                .is_some_and(|forms| forms.iter().any(|form| {
+                    form["$ref"] == "#/$defs/EmailMessage"
+                        && form.as_object().is_some_and(|object| object.len() == 1)
+                })),
+            "ontology class range retains the direct class definition reference"
         );
 
         let openapi: Value =
@@ -3524,6 +3536,53 @@ mod tests {
         assert_eq!(choice["anyOf"].as_array().map(Vec::len), Some(2));
         let both = &holder["properties"]["meta:both"]["anyOf"][0];
         assert_eq!(both["allOf"].as_array().map(Vec::len), Some(2));
+    }
+
+    #[test]
+    fn ontology_class_range_accepts_identifier_only_or_full_class_values() {
+        let compilation = compile_ontology(
+            r"
+                meta:HolderShape a sh:NodeShape ; sh:targetClass meta:Holder .
+                meta:RequiredShape a sh:NodeShape ; sh:targetClass meta:Required ;
+                    sh:property [ sh:path meta:name ; sh:minCount 1 ; sh:datatype xsd:string ] .
+            ",
+            r"
+                meta:Holder a owl:Class .
+                meta:Required a owl:Class .
+                meta:target a owl:ObjectProperty, owl:FunctionalProperty ;
+                    rdfs:domain meta:Holder ; rdfs:range meta:Required .
+            ",
+            SchemaSurfaceMode::OntologyComplete,
+        );
+        let schema = schema_of(&compilation.compiled);
+        let target = &def(&schema, "Holder")["properties"]["meta:target"];
+        let alternatives = target["anyOf"].as_array().expect("node or class value");
+        assert!(
+            alternatives
+                .iter()
+                .any(|form| form["$ref"] == "#/$defs/Required"),
+            "the full class definition remains directly referenced"
+        );
+        assert!(
+            alternatives
+                .iter()
+                .any(|form| form["properties"]["@id"].is_object()),
+            "the normal identifier-only node carrier remains available"
+        );
+        assert!(validates(
+            &compilation.compiled.schema_json,
+            &json!({
+                "@type": "meta:Holder",
+                "meta:target": { "@id": "https://example.org/meta/required-1" }
+            })
+        ));
+        assert!(validates(
+            &compilation.compiled.schema_json,
+            &json!({
+                "@type": "meta:Holder",
+                "meta:target": { "meta:name": "complete value" }
+            })
+        ));
     }
 
     #[test]

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -51,6 +51,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use ::purrdf::RdfDataset;
 use ::purrdf::RdfLocation;
 use ::purrdf::loss::{LossEntry, LossLedger};
+use serde::Serialize;
 use serde_json::{Map, Value, json};
 
 use crate::data::{GraphFilter, native_quads};
@@ -125,6 +126,12 @@ pub struct Namespaces {
     primary_prefix: String,
     /// The namespace `primary_prefix` resolves to.
     primary_ns: String,
+    /// Caller-declared `(prefix, namespace)` pairs in lexical prefix order.
+    /// Builtins appear here only when the caller explicitly declared or
+    /// rebound them. Ontology-complete schema projection uses this set as its
+    /// vocabulary boundary; merely knowing a W3C builtin for compaction must
+    /// never make that vocabulary caller-owned.
+    declared_prefixes: Vec<(String, String)>,
 }
 
 impl Namespaces {
@@ -139,6 +146,7 @@ impl Namespaces {
     /// Returns `Err` when `primary_prefix` resolves in neither `doc_prefixes`
     /// nor the builtins.
     pub fn new(primary_prefix: &str, doc_prefixes: &[(String, String)]) -> Result<Self, String> {
+        let declared: BTreeMap<String, String> = doc_prefixes.iter().cloned().collect();
         let mut merged: BTreeMap<String, String> = BUILTIN_PREFIXES
             .iter()
             .map(|(p, n)| ((*p).to_owned(), (*n).to_owned()))
@@ -161,6 +169,7 @@ impl Namespaces {
             prefixes,
             primary_prefix: primary_prefix.to_owned(),
             primary_ns,
+            declared_prefixes: declared.into_iter().collect(),
         })
     }
 
@@ -290,6 +299,18 @@ impl Namespaces {
     fn is_known(&self, iri: &str) -> bool {
         self.compact_iri(iri) != iri
     }
+
+    /// Whether `iri` belongs to a namespace explicitly declared by the caller.
+    ///
+    /// This deliberately differs from [`Self::is_known`]: W3C builtins are
+    /// always known for compaction, but are not caller-owned ontology surface
+    /// unless the caller explicitly supplied their prefix declaration.
+    #[must_use]
+    pub fn is_caller_owned(&self, iri: &str) -> bool {
+        self.declared_prefixes
+            .iter()
+            .any(|(_, namespace)| iri.starts_with(namespace))
+    }
 }
 
 /// The bare local name of an IRI: the substring after the last `#` or `/`.
@@ -329,6 +350,418 @@ pub struct CompiledSchema {
     /// runtime [`LossLedger`] built via [`LossLedger::record`], one entry per
     /// occurrence (codes from `SHACL_JSON_SCHEMA_PROFILE`).
     pub losses: LossLedger,
+}
+
+// ── Ontology-complete schema compilation contract ──────────────────────────
+
+/// Selects the property/class surface projected into developer schemas.
+///
+/// The legacy [`compile`] and [`compile_with_value_vocab`] entry points always
+/// use [`Self::ShapedOnly`]. Ontology-aware callers must choose explicitly;
+/// there is intentionally no `Default` implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SchemaSurfaceMode {
+    /// Emit exactly the active SHACL target-class union.
+    ShapedOnly,
+    /// Also project caller-vocabulary OWL/RDFS properties and open carrier
+    /// classes according to the bounded theory documented by this module.
+    OntologyComplete,
+}
+
+impl SchemaSurfaceMode {
+    const fn key_byte(self) -> u8 {
+        match self {
+            Self::ShapedOnly => 0,
+            Self::OntologyComplete => 1,
+        }
+    }
+}
+
+/// Stable reason attached to one property/class coverage decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SchemaCoverageStatus {
+    /// A direct SHACL predicate shape supplies the emitted property.
+    HasShape,
+    /// An ontology-declared property was emitted without a direct SHACL shape.
+    IncludedUnshaped,
+    /// The property is catalogued but shaped-only mode does not admit it.
+    ExcludedShapedOnly,
+    /// The property is outside the caller-declared vocabulary boundary.
+    ExcludedNamespace,
+    /// The class does not satisfy every effective `rdfs:domain` expression.
+    ExcludedDomain,
+    /// An authoritative `sh:closed` shape excludes the ontology-only property.
+    ExcludedClosedShape,
+}
+
+/// Precision of a schema-surface decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SchemaCoveragePrecision {
+    /// The emitted structure follows a direct SHACL or exact RDF/RDFS rule.
+    Exact,
+    /// The representation is deliberately useful but weaker than the source
+    /// semantics, such as projecting forward functionality as a scalar field.
+    RepresentationApproximation,
+}
+
+/// One source axiom supporting a schema-surface decision.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct SchemaCoverageProvenance {
+    /// Subject IRI in the source axiom.
+    pub subject: String,
+    /// Predicate IRI in the source axiom.
+    pub predicate: String,
+    /// Canonical source-object rendering.
+    pub object: String,
+}
+
+/// One catalogued property's decision for one eligible class.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SchemaClassPropertyCoverage {
+    /// Existing caller-owned class IRI.
+    pub class_iri: String,
+    /// Whether ontology-complete compilation created an open carrier `$def`
+    /// because no active SHACL target shape existed for this class.
+    pub synthesized_open_class: bool,
+    /// Inclusion or exclusion reason.
+    pub status: SchemaCoverageStatus,
+    /// Semantic precision of the emitted representation or exclusion proof.
+    pub precision: SchemaCoveragePrecision,
+    /// Canonically sorted source axioms supporting this decision.
+    pub provenance: Vec<SchemaCoverageProvenance>,
+}
+
+/// Aggregate coverage for one ontology-declared property.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SchemaPropertyCoverage {
+    /// Full property IRI.
+    pub property_iri: String,
+    /// Canonically sorted RDF/OWL declaration or relationship kinds that made
+    /// the property a catalog entry.
+    pub declarations: Vec<String>,
+    /// Canonically sorted per-class decisions. The aggregate property appears
+    /// exactly once in a report even when this vector is empty.
+    pub classes: Vec<SchemaClassPropertyCoverage>,
+}
+
+/// Deterministic audit manifest for ontology property coverage.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SchemaCoverageReport {
+    /// Surface mode used by the compilation.
+    pub mode: SchemaSurfaceMode,
+    /// Every catalogued property exactly once, sorted by full IRI.
+    pub properties: Vec<SchemaPropertyCoverage>,
+}
+
+impl SchemaCoverageReport {
+    /// Render canonical, pretty JSON with one trailing newline.
+    ///
+    /// Struct field order is fixed and every collection is sorted before the
+    /// report is constructed, so repeated rendering is byte-identical.
+    #[must_use]
+    pub fn to_json(&self) -> String {
+        let mut canonical = self.clone();
+        canonical
+            .properties
+            .sort_by(|left, right| left.property_iri.cmp(&right.property_iri));
+        for property in &mut canonical.properties {
+            property.declarations.sort();
+            property.declarations.dedup();
+            property.classes.sort_by(|left, right| {
+                left.class_iri
+                    .cmp(&right.class_iri)
+                    .then_with(|| left.status.cmp(&right.status))
+                    .then_with(|| left.precision.cmp(&right.precision))
+            });
+            for class in &mut property.classes {
+                class.provenance.sort();
+                class.provenance.dedup();
+            }
+        }
+        let value = serde_json::to_value(canonical)
+            .expect("SchemaCoverageReport contains only serializable values");
+        to_pretty(&value)
+    }
+}
+
+/// Compiler-owned cache identity for one complete schema request.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SchemaCompilationKey(String);
+
+impl SchemaCompilationKey {
+    /// Lowercase SHA-256 cache-key text.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for SchemaCompilationKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Which graph failed canonicalization while deriving a schema cache key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaCompilationInput {
+    /// Parsed SHACL shapes graph retained by [`Shapes`].
+    Shapes,
+    /// Caller-supplied ontology graph.
+    Ontology,
+}
+
+/// Typed failures from ontology-aware schema compilation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SchemaCompileError {
+    /// RDFC-1.0 canonicalization exceeded its fixed safety budget.
+    Canonicalization {
+        /// Graph that could not be canonicalized.
+        input: SchemaCompilationInput,
+        /// Stable diagnostic from the canonicalizer.
+        message: String,
+    },
+    /// A fixed schema-surface resource ceiling was exceeded.
+    LimitExceeded {
+        /// Resource whose ceiling was exceeded.
+        resource: &'static str,
+        /// Fixed implementation ceiling.
+        limit: usize,
+        /// Observed input size.
+        observed: usize,
+    },
+    /// An OWL/RDFS axiom is structurally invalid for the supported expression
+    /// fragment.
+    InvalidOntology {
+        /// Canonical subject rendering or IRI.
+        subject: String,
+        /// Explanation of the structural violation.
+        reason: String,
+    },
+    /// An eligible class/property cannot be represented under caller namespace
+    /// and `$defs` keying rules.
+    Namespace {
+        /// Offending IRI.
+        iri: String,
+        /// Explanation of the keying/admission violation.
+        reason: String,
+    },
+    /// Two distinct ontology resources map to the same emitted key.
+    DefinitionCollision {
+        /// Colliding `$defs` key.
+        key: String,
+        /// First resource IRI.
+        first: String,
+        /// Second resource IRI.
+        second: String,
+    },
+}
+
+impl std::fmt::Display for SchemaCompileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Canonicalization { input, message } => {
+                write!(f, "failed to canonicalize {input:?} graph: {message}")
+            }
+            Self::LimitExceeded {
+                resource,
+                limit,
+                observed,
+            } => write!(
+                f,
+                "schema surface {resource} limit exceeded: observed {observed}, limit {limit}"
+            ),
+            Self::InvalidOntology { subject, reason } => {
+                write!(f, "invalid ontology expression at {subject}: {reason}")
+            }
+            Self::Namespace { iri, reason } => {
+                write!(f, "cannot project ontology resource {iri}: {reason}")
+            }
+            Self::DefinitionCollision { key, first, second } => write!(
+                f,
+                "distinct ontology resources {first} and {second} share schema definition key {key:?}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SchemaCompileError {}
+
+/// Complete input contract for ontology-aware schema compilation.
+///
+/// Every request owns one ontology graph and one explicit mode. Value-vocabulary
+/// projection can only be enabled through [`Self::from_value_vocab_projection`],
+/// which reuses that projection's ontology and makes a mismatched pair
+/// unrepresentable.
+#[derive(Debug, Clone, Copy)]
+pub struct SchemaCompileRequest<'a> {
+    shapes: &'a Shapes,
+    namespaces: &'a Namespaces,
+    ontology: &'a RdfDataset,
+    mode: SchemaSurfaceMode,
+    value_vocab: Option<&'a ValueVocab>,
+}
+
+impl<'a> SchemaCompileRequest<'a> {
+    /// Construct a request without value-vocabulary enum projection.
+    #[must_use]
+    pub fn new(
+        shapes: &'a Shapes,
+        namespaces: &'a Namespaces,
+        ontology: &'a RdfDataset,
+        mode: SchemaSurfaceMode,
+    ) -> Self {
+        Self {
+            shapes,
+            namespaces,
+            ontology,
+            mode,
+            value_vocab: None,
+        }
+    }
+
+    /// Construct a request using an existing co-bound value-vocabulary marker
+    /// and ontology graph.
+    #[must_use]
+    pub fn from_value_vocab_projection(
+        shapes: &'a Shapes,
+        namespaces: &'a Namespaces,
+        projection: &'a ValueVocabProjection<'a>,
+        mode: SchemaSurfaceMode,
+    ) -> Self {
+        Self {
+            shapes,
+            namespaces,
+            ontology: projection.ontology,
+            mode,
+            value_vocab: Some(projection.vocab),
+        }
+    }
+
+    /// Parsed SHACL shapes.
+    #[must_use]
+    pub fn shapes(&self) -> &Shapes {
+        self.shapes
+    }
+
+    /// Caller namespace configuration.
+    #[must_use]
+    pub fn namespaces(&self) -> &Namespaces {
+        self.namespaces
+    }
+
+    /// Exact ontology graph used for surface derivation.
+    #[must_use]
+    pub fn ontology(&self) -> &RdfDataset {
+        self.ontology
+    }
+
+    /// Explicit surface mode.
+    #[must_use]
+    pub const fn mode(&self) -> SchemaSurfaceMode {
+        self.mode
+    }
+
+    /// Caller marker used for value-vocabulary projection, when active.
+    #[must_use]
+    pub fn value_vocab(&self) -> Option<&ValueVocab> {
+        self.value_vocab
+    }
+
+    /// Derive the exact pre-compilation cache key for this request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchemaCompileError::Canonicalization`] if either graph exceeds
+    /// the canonicalizer's fixed safety budget.
+    pub fn compilation_key(&self) -> Result<SchemaCompilationKey, SchemaCompileError> {
+        schema_compilation_key(self)
+    }
+}
+
+/// Ontology-aware compilation output.
+#[derive(Debug, Clone)]
+pub struct SchemaCompilation {
+    /// Existing schema/OpenAPI/loss artifacts.
+    pub compiled: CompiledSchema,
+    /// Complete deterministic property coverage manifest.
+    pub coverage: SchemaCoverageReport,
+    /// Exact identity of every compilation input and policy constant.
+    pub key: SchemaCompilationKey,
+}
+
+const SCHEMA_KEY_SALT: &str = "purrdf-shapes/schema-compilation-key/v1";
+const SCHEMA_POLICY_SALT: &str =
+    "rdf12;json-schema-2020-12;openapi-3.1;surface-limits-v1;owl-rdfs-fragment-v1";
+const MAX_SCHEMA_PROPERTIES: usize = 65_536;
+const MAX_SCHEMA_CLASSES: usize = 65_536;
+const MAX_SCHEMA_RELATIONS: usize = 1_048_576;
+const MAX_OWL_EXPRESSION_DEPTH: usize = 64;
+
+fn schema_compilation_key(
+    request: &SchemaCompileRequest<'_>,
+) -> Result<SchemaCompilationKey, SchemaCompileError> {
+    let shapes =
+        ::purrdf::try_canonicalize(request.shapes.shapes_dataset.as_ref()).map_err(|error| {
+            SchemaCompileError::Canonicalization {
+                input: SchemaCompilationInput::Shapes,
+                message: error.to_string(),
+            }
+        })?;
+    let ontology = ::purrdf::try_canonicalize(request.ontology).map_err(|error| {
+        SchemaCompileError::Canonicalization {
+            input: SchemaCompilationInput::Ontology,
+            message: error.to_string(),
+        }
+    })?;
+
+    let mut bytes = Vec::with_capacity(
+        shapes.nquads.len() + ontology.nquads.len() + request.namespaces.prefixes.len() * 64 + 256,
+    );
+    append_key_part(&mut bytes, "key-salt", SCHEMA_KEY_SALT.as_bytes());
+    append_key_part(&mut bytes, "policy", SCHEMA_POLICY_SALT.as_bytes());
+    append_key_part(&mut bytes, "crate-version", crate::VERSION.as_bytes());
+    append_key_part(&mut bytes, "shapes-rdfc", shapes.nquads.as_bytes());
+    append_key_part(&mut bytes, "ontology-rdfc", ontology.nquads.as_bytes());
+    append_key_part(
+        &mut bytes,
+        "primary-prefix",
+        request.namespaces.primary_prefix.as_bytes(),
+    );
+    for (prefix, namespace) in &request.namespaces.declared_prefixes {
+        append_key_part(&mut bytes, "namespace-prefix", prefix.as_bytes());
+        append_key_part(&mut bytes, "namespace-iri", namespace.as_bytes());
+    }
+    append_key_part(&mut bytes, "surface-mode", &[request.mode.key_byte()]);
+    append_key_part(
+        &mut bytes,
+        "value-vocab-marker",
+        request
+            .value_vocab
+            .map_or(&[][..], |vocab| vocab.abstract_individual_type().as_bytes()),
+    );
+    for limit in [
+        MAX_SCHEMA_PROPERTIES,
+        MAX_SCHEMA_CLASSES,
+        MAX_SCHEMA_RELATIONS,
+        MAX_OWL_EXPRESSION_DEPTH,
+    ] {
+        append_key_part(&mut bytes, "fixed-limit", &limit.to_be_bytes());
+    }
+    Ok(SchemaCompilationKey(
+        ::purrdf::ContentDigest::of(&bytes).to_hex(),
+    ))
+}
+
+fn append_key_part(bytes: &mut Vec<u8>, label: &str, value: &[u8]) {
+    bytes.extend_from_slice(&(label.len() as u64).to_be_bytes());
+    bytes.extend_from_slice(label.as_bytes());
+    bytes.extend_from_slice(&(value.len() as u64).to_be_bytes());
+    bytes.extend_from_slice(value);
 }
 
 // ── Value-vocabulary projection config ───────────────────────────────────────
@@ -2273,6 +2706,191 @@ mod tests {
         );
         assert_eq!(ctx.get("xsd"), Some(&json!(XSD_NS)));
         assert_eq!(ctx.get("sh"), Some(&json!(SH_NS)));
+    }
+
+    #[test]
+    fn caller_owned_namespaces_exclude_implicit_builtins() {
+        let ns = fixture_ns();
+        assert!(ns.is_caller_owned("https://example.org/meta/Person"));
+        assert!(ns.is_caller_owned("https://blackcatinformatics.ca/logic/Claim"));
+        assert!(!ns.is_caller_owned("http://www.w3.org/2002/07/owl#DatatypeProperty"));
+
+        let explicit = Namespaces::new(
+            "meta",
+            &[
+                ("meta".to_owned(), "https://example.org/meta/".to_owned()),
+                ("owl".to_owned(), OWL_NS.to_owned()),
+            ],
+        )
+        .expect("explicit builtin declaration is valid");
+        assert!(explicit.is_caller_owned("http://www.w3.org/2002/07/owl#DatatypeProperty"));
+    }
+
+    #[test]
+    fn schema_compilation_key_covers_every_request_input() {
+        let shapes_a_dataset = crate::text_ingest::parse_turtle_to_dataset(&format!(
+            "{PREFIXES}\nmeta:ThingShape a sh:NodeShape ; sh:targetClass meta:Thing ."
+        ))
+        .expect("shape graph A");
+        let shapes_b_dataset = crate::text_ingest::parse_turtle_to_dataset(&format!(
+            "{PREFIXES}\nmeta:ThingShape a sh:NodeShape ; sh:targetClass meta:Thing ; sh:closed true ."
+        ))
+        .expect("shape graph B");
+        let shapes_a = from_dataset(&shapes_a_dataset).expect("parse shape graph A");
+        let shapes_b = from_dataset(&shapes_b_dataset).expect("parse shape graph B");
+
+        let ontology_a = crate::text_ingest::parse_turtle_to_dataset(
+            r"
+                @prefix owl: <http://www.w3.org/2002/07/owl#> .
+                @prefix meta: <https://example.org/meta/> .
+                meta:p a owl:DatatypeProperty .
+            ",
+        )
+        .expect("ontology A");
+        let ontology_a_shuffled = crate::text_ingest::parse_turtle_to_dataset(
+            r"
+                @prefix meta: <https://example.org/meta/> .
+                @prefix owl: <http://www.w3.org/2002/07/owl#> .
+                meta:p a owl:DatatypeProperty .
+            ",
+        )
+        .expect("shuffled ontology A");
+        let ontology_b = crate::text_ingest::parse_turtle_to_dataset(
+            r"
+                @prefix owl: <http://www.w3.org/2002/07/owl#> .
+                @prefix meta: <https://example.org/meta/> .
+                meta:q a owl:DatatypeProperty .
+            ",
+        )
+        .expect("ontology B");
+
+        let shaped = SchemaCompileRequest::new(
+            &shapes_a,
+            &fixture_ns(),
+            ontology_a.as_ref(),
+            SchemaSurfaceMode::ShapedOnly,
+        )
+        .compilation_key()
+        .expect("shaped key");
+        let shuffled = SchemaCompileRequest::new(
+            &shapes_a,
+            &fixture_ns(),
+            ontology_a_shuffled.as_ref(),
+            SchemaSurfaceMode::ShapedOnly,
+        )
+        .compilation_key()
+        .expect("shuffled key");
+        assert_eq!(shaped, shuffled, "RDF load order is not key material");
+        assert_eq!(shaped.as_str().len(), 64);
+        assert!(shaped.as_str().bytes().all(|byte| byte.is_ascii_hexdigit()));
+
+        let complete = SchemaCompileRequest::new(
+            &shapes_a,
+            &fixture_ns(),
+            ontology_a.as_ref(),
+            SchemaSurfaceMode::OntologyComplete,
+        )
+        .compilation_key()
+        .expect("complete key");
+        assert_ne!(shaped, complete, "surface mode is key material");
+
+        let changed_ontology = SchemaCompileRequest::new(
+            &shapes_a,
+            &fixture_ns(),
+            ontology_b.as_ref(),
+            SchemaSurfaceMode::ShapedOnly,
+        )
+        .compilation_key()
+        .expect("changed ontology key");
+        assert_ne!(
+            shaped, changed_ontology,
+            "ontology identity is key material"
+        );
+
+        let changed_shapes = SchemaCompileRequest::new(
+            &shapes_b,
+            &fixture_ns(),
+            ontology_a.as_ref(),
+            SchemaSurfaceMode::ShapedOnly,
+        )
+        .compilation_key()
+        .expect("changed shapes key");
+        assert_ne!(shaped, changed_shapes, "shapes identity is key material");
+
+        let alternate_ns = Namespaces::new(
+            "meta",
+            &[
+                ("meta".to_owned(), "https://example.org/meta/".to_owned()),
+                ("extra".to_owned(), "https://example.org/extra/".to_owned()),
+            ],
+        )
+        .expect("alternate namespaces");
+        let changed_namespaces = SchemaCompileRequest::new(
+            &shapes_a,
+            &alternate_ns,
+            ontology_a.as_ref(),
+            SchemaSurfaceMode::ShapedOnly,
+        )
+        .compilation_key()
+        .expect("changed namespace key");
+        assert_ne!(
+            shaped, changed_namespaces,
+            "namespace config is key material"
+        );
+
+        let vocab = ValueVocab::new("https://example.org/meta/ValueVocabulary");
+        let projection = ValueVocabProjection {
+            vocab: &vocab,
+            ontology: ontology_a.as_ref(),
+        };
+        let with_vocab = SchemaCompileRequest::from_value_vocab_projection(
+            &shapes_a,
+            &fixture_ns(),
+            &projection,
+            SchemaSurfaceMode::ShapedOnly,
+        )
+        .compilation_key()
+        .expect("value-vocabulary key");
+        assert_ne!(
+            shaped, with_vocab,
+            "value-vocabulary marker is key material"
+        );
+    }
+
+    #[test]
+    fn coverage_report_json_canonicalizes_public_collection_order() {
+        let provenance = SchemaCoverageProvenance {
+            subject: "https://example.org/meta/p".to_owned(),
+            predicate: rdfs::RANGE.to_owned(),
+            object: "<http://www.w3.org/2001/XMLSchema#string>".to_owned(),
+        };
+        let property = |iri: &str| SchemaPropertyCoverage {
+            property_iri: iri.to_owned(),
+            declarations: vec!["rdfs:range".to_owned(), "owl:DatatypeProperty".to_owned()],
+            classes: vec![SchemaClassPropertyCoverage {
+                class_iri: "https://example.org/meta/Thing".to_owned(),
+                synthesized_open_class: false,
+                status: SchemaCoverageStatus::IncludedUnshaped,
+                precision: SchemaCoveragePrecision::Exact,
+                provenance: vec![provenance.clone()],
+            }],
+        };
+        let forward = SchemaCoverageReport {
+            mode: SchemaSurfaceMode::OntologyComplete,
+            properties: vec![
+                property("https://example.org/meta/a"),
+                property("https://example.org/meta/z"),
+            ],
+        };
+        let reverse = SchemaCoverageReport {
+            mode: SchemaSurfaceMode::OntologyComplete,
+            properties: vec![
+                property("https://example.org/meta/z"),
+                property("https://example.org/meta/a"),
+            ],
+        };
+        assert_eq!(forward.to_json(), reverse.to_json());
+        assert!(forward.to_json().ends_with('\n'));
     }
 
     #[test]

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -1413,7 +1413,7 @@ fn ontology_property_schema(property: &SurfaceProperty, ctx: &Ctx<'_>) -> Value 
         let mut conjuncts: Vec<Value> = property
             .ranges
             .iter()
-            .map(|range| range_expression_schema(range, property.kind, ctx))
+            .map(|range| range_expression_schema(range, property, ctx))
             .collect();
         if conjuncts.len() == 1 {
             conjuncts.pop().expect("one range expression")
@@ -1446,27 +1446,27 @@ fn ontology_property_schema(property: &SurfaceProperty, ctx: &Ctx<'_>) -> Value 
 
 fn range_expression_schema(
     expression: &OntologyExpression,
-    kind: OntologyPropertyKind,
+    property: &SurfaceProperty,
     ctx: &Ctx<'_>,
 ) -> Value {
     match expression {
-        OntologyExpression::Named(iri) => named_range_schema(iri, kind, ctx),
+        OntologyExpression::Named(iri) => named_range_schema(iri, property, ctx),
         OntologyExpression::Union(members) => json!({
             "anyOf": members
                 .iter()
-                .map(|member| range_expression_schema(member, kind, ctx))
+                .map(|member| range_expression_schema(member, property, ctx))
                 .collect::<Vec<_>>()
         }),
         OntologyExpression::Intersection(members) => json!({
             "allOf": members
                 .iter()
-                .map(|member| range_expression_schema(member, kind, ctx))
+                .map(|member| range_expression_schema(member, property, ctx))
                 .collect::<Vec<_>>()
         }),
     }
 }
 
-fn named_range_schema(iri: &str, kind: OntologyPropertyKind, ctx: &Ctx<'_>) -> Value {
+fn named_range_schema(iri: &str, property: &SurfaceProperty, ctx: &Ctx<'_>) -> Value {
     if let Some(enum_key) = ctx.value_vocab_enums.get(iri) {
         return json!({ "$ref": format!("#/$defs/{enum_key}") });
     }
@@ -1483,7 +1483,10 @@ fn named_range_schema(iri: &str, kind: OntologyPropertyKind, ctx: &Ctx<'_>) -> V
             "required": ["@value", "@language"]
         });
     }
-    if kind == OntologyPropertyKind::Datatype || iri.starts_with(XSD_NS) {
+    if property.kind == OntologyPropertyKind::Datatype
+        || property.datatype_iris.contains(iri)
+        || iri.starts_with(XSD_NS)
+    {
         return datatype_value_schema(iri);
     }
     let key = ctx.ns.def_key(iri);
@@ -1494,7 +1497,7 @@ fn named_range_schema(iri: &str, kind: OntologyPropertyKind, ctx: &Ctx<'_>) -> V
                 { "$ref": format!("#/$defs/{key}") }
             ]
         })
-    } else if kind == OntologyPropertyKind::Annotation {
+    } else if property.kind == OntologyPropertyKind::Annotation {
         general_rdf_value_schema()
     } else {
         node_ref_schema()
@@ -3581,6 +3584,53 @@ mod tests {
             &json!({
                 "@type": "meta:Holder",
                 "meta:target": { "meta:name": "complete value" }
+            })
+        ));
+    }
+
+    #[test]
+    fn generic_properties_preserve_declared_custom_datatype_ranges() {
+        let compilation = compile_ontology(
+            "",
+            r"
+                meta:Holder a owl:Class .
+                meta:Related a owl:Class .
+                meta:Code a rdfs:Datatype .
+                meta:Token a owl:DataRange .
+                meta:code a rdf:Property ;
+                    rdfs:domain meta:Holder ; rdfs:range meta:Code .
+                meta:token a rdf:Property ;
+                    rdfs:domain meta:Holder ; rdfs:range meta:Token .
+                meta:mixed a rdf:Property ;
+                    rdfs:domain meta:Holder ;
+                    rdfs:range [ owl:unionOf ( meta:Code meta:Related ) ] .
+            ",
+            SchemaSurfaceMode::OntologyComplete,
+        );
+        let schema = schema_of(&compilation.compiled);
+        let holder = def(&schema, "Holder");
+        for property in ["meta:code", "meta:token"] {
+            assert!(
+                holder["properties"][property]
+                    .to_string()
+                    .contains("string"),
+                "{property} retains its declared literal carrier"
+            );
+        }
+        assert!(validates(
+            &compilation.compiled.schema_json,
+            &json!({
+                "@type": "meta:Holder",
+                "meta:code": "C-1",
+                "meta:token": "T-1",
+                "meta:mixed": "literal branch"
+            })
+        ));
+        assert!(validates(
+            &compilation.compiled.schema_json,
+            &json!({
+                "@type": "meta:Holder",
+                "meta:mixed": { "@id": "https://example.org/meta/related-1" }
             })
         ));
     }

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -305,7 +305,7 @@ impl Namespaces {
 
     /// Whether `iri` belongs to a namespace explicitly declared by the caller.
     ///
-    /// This deliberately differs from [`Self::is_known`]: W3C builtins are
+    /// This deliberately differs from the internal compaction test: W3C builtins are
     /// always known for compaction, but are not caller-owned ontology surface
     /// unless the caller explicitly supplied their prefix declaration.
     #[must_use]

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -952,9 +952,11 @@ pub fn compile_schema(
         ontology: request.ontology(),
     });
     let compiled = match request.mode() {
-        SchemaSurfaceMode::ShapedOnly => {
-            compile_with_value_vocab(request.shapes(), request.namespaces(), projection.as_ref())
-        }
+        SchemaSurfaceMode::ShapedOnly => try_compile_with_value_vocab(
+            request.shapes(),
+            request.namespaces(),
+            projection.as_ref(),
+        )?,
         SchemaSurfaceMode::OntologyComplete => compile_with_surface(
             request.shapes(),
             request.namespaces(),
@@ -995,6 +997,15 @@ pub fn compile_with_value_vocab(
     ns: &Namespaces,
     projection: Option<&ValueVocabProjection<'_>>,
 ) -> CompiledSchema {
+    try_compile_with_value_vocab(shapes, ns, projection)
+        .unwrap_or_else(|error| panic!("json_schema: {error}"))
+}
+
+fn try_compile_with_value_vocab(
+    shapes: &Shapes,
+    ns: &Namespaces,
+    projection: Option<&ValueVocabProjection<'_>>,
+) -> Result<CompiledSchema, SchemaCompileError> {
     // Keying invariant (Gap D, fail-closed): every primary-namespace `$def`
     // is keyed by the class LOCAL NAME and the `@type` discriminator is
     // `<primary_prefix>:<LocalName>`. That is sound ONLY while every target
@@ -1004,13 +1015,13 @@ pub fn compile_with_value_vocab(
     // guard protects the precondition rather than widening the keys. A target
     // class from an undeclared namespace or a colliding key HARD-fails the
     // build here instead of silently mis-discriminating or clobbering a `$def`.
-    assert_target_class_keys_are_unambiguous(shapes, ns);
+    validate_target_class_keys(shapes, ns)?;
 
     // Value-vocabulary enum `$defs` (projection-only): class IRI → (enum key,
     // `$def` body). Empty when `projection` is `None`. Enum keys are guarded for
     // collisions against each other and the class `$def` keys before use.
-    let (vocab_enums, vocab_losses) = value_vocab_enum_defs(shapes, ns, projection);
-    assert_value_vocab_enum_keys_unambiguous(shapes, ns, &vocab_enums);
+    let (vocab_enums, vocab_losses) = value_vocab_enum_defs(shapes, ns, projection)?;
+    validate_value_vocab_enum_keys(shapes, ns, &vocab_enums)?;
 
     // PASS 1: compute the set of `def_key`s that WILL receive a `$def`, using
     // the EXACT same iteration AND the EXACT same key function (`ns.def_key`)
@@ -1166,11 +1177,11 @@ pub fn compile_with_value_vocab(
     let schema = root_schema(&defs, ns);
     let openapi = openapi_doc(&defs);
 
-    CompiledSchema {
+    Ok(CompiledSchema {
         schema_json: to_pretty(&schema),
         openapi_json: to_pretty(&openapi),
         losses: ctx.ledger,
-    }
+    })
 }
 
 fn compile_with_surface(
@@ -1179,7 +1190,7 @@ fn compile_with_surface(
     projection: Option<&ValueVocabProjection<'_>>,
     surface: &SchemaSurface,
 ) -> Result<CompiledSchema, SchemaCompileError> {
-    let (vocab_enums, vocab_losses) = value_vocab_enum_defs(shapes, ns, projection);
+    let (vocab_enums, vocab_losses) = value_vocab_enum_defs(shapes, ns, projection)?;
     validate_surface_keys(surface, ns, &vocab_enums)?;
 
     let mut emitted_defs: BTreeSet<String> = surface
@@ -1523,6 +1534,9 @@ struct VocabMember {
     description: String,
 }
 
+type ValueVocabDefinitions = BTreeMap<String, (String, Value)>;
+type ValueVocabDerivation = (ValueVocabDefinitions, Vec<LossEntry>);
+
 /// Derive the value-vocabulary enum `$defs`: `class IRI → (enum key, $def body)`.
 ///
 /// Enumerates value-vocabulary classes (`?V rdf:type <marker>`) and each one's
@@ -1534,11 +1548,11 @@ fn value_vocab_enum_defs(
     shapes: &Shapes,
     ns: &Namespaces,
     projection: Option<&ValueVocabProjection<'_>>,
-) -> (BTreeMap<String, (String, Value)>, Vec<LossEntry>) {
+) -> Result<ValueVocabDerivation, SchemaCompileError> {
     let mut out: BTreeMap<String, (String, Value)> = BTreeMap::new();
     let mut losses: Vec<LossEntry> = Vec::new();
     let Some(proj) = projection else {
-        return (out, losses);
+        return Ok((out, losses));
     };
 
     let datasets: [&RdfDataset; 2] = [proj.ontology, shapes.shapes_dataset.as_ref()];
@@ -1563,12 +1577,13 @@ fn value_vocab_enum_defs(
     }
 
     for class_iri in &class_iris {
-        assert!(
-            ns.is_known(class_iri),
-            "json_schema: value-vocabulary class {class_iri:?} has no declared namespace \
-             prefix — its `{{Local}}Enum` `$def` key and members derive from a prefix CURIE; \
-             declare its prefix in the shapes document / Namespaces before marking it"
-        );
+        if !ns.is_known(class_iri) {
+            return Err(SchemaCompileError::Namespace {
+                iri: class_iri.clone(),
+                reason: "value-vocabulary class has no declared namespace prefix for its enum definition key"
+                    .to_owned(),
+            });
+        }
         let key = format!("{}Enum", local_name(class_iri));
         let (members, member_losses) = members_of(&datasets, class_iri, ns);
         losses.extend(member_losses);
@@ -1582,7 +1597,7 @@ fn value_vocab_enum_defs(
         out.insert(class_iri.clone(), (key, build_enum_def(&members)));
     }
 
-    (out, losses)
+    Ok((out, losses))
 }
 
 /// Map each predicate whose `rdfs:range` is a value-vocabulary class to that
@@ -1762,40 +1777,27 @@ fn build_enum_def(members: &[VocabMember]) -> Value {
 /// (build-time, fail-closed): no two value-vocabulary classes share a
 /// `{Local}Enum` key (cross-namespace local-name twins), and no enum key clashes
 /// with a class `$def` key.
-fn assert_value_vocab_enum_keys_unambiguous(
+fn validate_value_vocab_enum_keys(
     shapes: &Shapes,
     ns: &Namespaces,
     vocab_enums: &BTreeMap<String, (String, Value)>,
-) {
+) -> Result<(), SchemaCompileError> {
     // The class `$def` keys (every active target class, explicit or implicit),
     // which enum keys must not clash with.
-    let mut class_keys: BTreeSet<String> = BTreeSet::new();
-    for shape in &shapes.node_shapes {
-        if shape.deactivated {
-            continue;
-        }
-        for target in &shape.targets {
-            if let Some(iri) = class_def_target_iri(target) {
-                class_keys.insert(ns.def_key(iri));
-            }
-        }
-    }
+    let class_keys = target_definition_keys(shapes, ns)?;
 
     let mut key_to_class: BTreeMap<String, String> = BTreeMap::new();
     for (class_iri, (key, _def)) in vocab_enums {
-        assert!(
-            !class_keys.contains(key),
-            "json_schema: value-vocabulary enum key {key:?} (from {class_iri}) collides with a \
-             class `$def` key — disambiguate before projecting"
-        );
-        if let Some(prev) = key_to_class.insert(key.clone(), class_iri.clone()) {
-            panic!(
-                "json_schema: distinct value-vocabulary classes share the enum `$def` key \
-                 {key:?} ({prev} vs {class_iri}) — cross-namespace local-name twins; \
-                 disambiguate before projecting"
-            );
+        if let Some(first) = class_keys.get(key) {
+            return Err(SchemaCompileError::DefinitionCollision {
+                key: key.clone(),
+                first: first.clone(),
+                second: class_iri.clone(),
+            });
         }
+        insert_definition_key(&mut key_to_class, key.clone(), class_iri)?;
     }
+    Ok(())
 }
 
 /// The class IRI a `Target::ImplicitClass` carries. [`Shapes::parse_targets`]
@@ -1831,35 +1833,44 @@ fn class_def_target_iri(target: &Target) -> Option<&str> {
 /// Enforce the keying precondition (Gap D): every active `sh:targetClass` /
 /// implicit-class target is in a DECLARED namespace (so [`Namespaces::def_key`]
 /// yields a stable `$defs` key and [`node_def`] can rebuild its `@type` const)
-/// and those keys are collision-free. Panics with a descriptive message
-/// otherwise (build-time, fail-closed).
-fn assert_target_class_keys_are_unambiguous(shapes: &Shapes, ns: &Namespaces) {
-    let mut key_to_iri: BTreeMap<String, String> = BTreeMap::new();
+/// and those keys are collision-free. Returns the public typed compilation
+/// error so ontology-aware callers never cross a panic boundary.
+fn validate_target_class_keys(shapes: &Shapes, ns: &Namespaces) -> Result<(), SchemaCompileError> {
+    target_definition_keys(shapes, ns).map(drop)
+}
+
+fn target_definition_keys(
+    shapes: &Shapes,
+    ns: &Namespaces,
+) -> Result<BTreeMap<String, String>, SchemaCompileError> {
+    let mut key_to_iri = BTreeMap::from([
+        (
+            "Annotation".to_owned(),
+            "JSON Schema reserved definition".to_owned(),
+        ),
+        (
+            "Node".to_owned(),
+            "JSON Schema reserved definition".to_owned(),
+        ),
+    ]);
     for shape in &shapes.node_shapes {
         if shape.deactivated {
             continue;
         }
         for target in &shape.targets {
             if let Some(iri) = class_def_target_iri(target) {
-                assert!(
-                    ns.is_known(iri),
-                    "json_schema: target class {iri:?} has no declared namespace prefix — \
-                     the @type discriminator and `$defs` keys derive from a prefix CURIE; \
-                     declare its prefix in the shapes document / Namespaces (and confirm \
-                     OpenAPI key encoding) before introducing target classes from it"
-                );
-                let key = ns.def_key(iri);
-                if let Some(prev) = key_to_iri.insert(key.clone(), iri.to_owned()) {
-                    assert_eq!(
-                        prev, iri,
-                        "json_schema: distinct target classes share the `$defs` key \
-                         {key:?} ({prev} vs {iri}) — their `$defs`/OpenAPI keys would \
-                         collide; disambiguate before keying"
-                    );
+                if !ns.is_known(iri) {
+                    return Err(SchemaCompileError::Namespace {
+                        iri: iri.to_owned(),
+                        reason: "target class has no declared namespace prefix for its discriminator and definition key"
+                            .to_owned(),
+                    });
                 }
+                insert_definition_key(&mut key_to_iri, ns.def_key(iri), iri)?;
             }
         }
     }
+    Ok(key_to_iri)
 }
 
 // ── Root envelope ────────────────────────────────────────────────────────────
@@ -2996,7 +3007,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "declare its prefix in the shapes document / Namespaces")]
+    #[should_panic(expected = "target class has no declared namespace prefix")]
     fn unknown_namespace_target_class_hard_fails() {
         // A target class from an UNDECLARED namespace has no prefix CURIE to key
         // its `$defs`/discriminator by; the keying guard must reject it loudly
@@ -3010,6 +3021,36 @@ mod tests {
                 sh:property [ sh:path meta:name ; sh:minCount 1 ] .
         ",
         );
+    }
+
+    #[test]
+    fn ontology_request_returns_typed_target_key_errors_in_both_modes() {
+        let shapes_dataset = crate::text_ingest::parse_turtle_to_dataset(&format!(
+            "{PREFIXES}@prefix und: <https://undeclared.example/> .
+             meta:Shape a sh:NodeShape ; sh:targetClass und:Person ."
+        ))
+        .expect("shapes Turtle");
+        let shapes = from_dataset(&shapes_dataset).expect("shapes graph");
+        let ontology =
+            crate::text_ingest::parse_turtle_to_dataset(PREFIXES).expect("ontology Turtle");
+
+        for mode in [
+            SchemaSurfaceMode::ShapedOnly,
+            SchemaSurfaceMode::OntologyComplete,
+        ] {
+            let error = compile_schema(&SchemaCompileRequest::new(
+                &shapes,
+                &fixture_ns(),
+                ontology.as_ref(),
+                mode,
+            ))
+            .expect_err("unknown target namespace must be typed");
+            assert!(matches!(
+                error,
+                SchemaCompileError::Namespace { iri, .. }
+                    if iri == "https://undeclared.example/Person"
+            ));
+        }
     }
 
     #[test]
@@ -5562,7 +5603,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "cross-namespace local-name twins")]
+    #[should_panic(expected = "share schema definition key")]
     fn value_vocab_local_name_twins_hard_fail() {
         // Two vocab classes with the same local name in different declared
         // namespaces both key to `ColorEnum` — the collision guard must reject it.
@@ -5589,7 +5630,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "collides with a class `$def` key")]
+    #[should_panic(expected = "share schema definition key")]
     fn value_vocab_enum_key_class_def_key_clash_hard_fails() {
         // A vocab class `logic:Color` enum-keys to `ColorEnum`, which is the SAME
         // `$def` key a primary-namespace target class `meta:ColorEnum` receives
@@ -5606,6 +5647,82 @@ mod tests {
                 sh:property [ sh:path meta:name ; sh:minCount 1 ] .
         ",
         );
+    }
+
+    #[test]
+    fn ontology_request_returns_typed_value_vocab_key_errors_in_both_modes() {
+        const MARKER_IRI: &str = "https://example.org/marker/AbstractIndividualType";
+
+        let shapes_dataset =
+            crate::text_ingest::parse_turtle_to_dataset(PREFIXES).expect("empty shapes Turtle");
+        let shapes = from_dataset(&shapes_dataset).expect("empty shapes graph");
+        let vocab = ValueVocab::new(MARKER_IRI);
+
+        let unknown = crate::text_ingest::parse_turtle_to_dataset(&format!(
+            "{PREFIXES}
+             @prefix marker: <https://example.org/marker/> .
+             @prefix und: <https://undeclared.example/> .
+             und:Color a marker:AbstractIndividualType ."
+        ))
+        .expect("unknown-namespace vocabulary Turtle");
+        let unknown_projection = ValueVocabProjection {
+            vocab: &vocab,
+            ontology: unknown.as_ref(),
+        };
+        for mode in [
+            SchemaSurfaceMode::ShapedOnly,
+            SchemaSurfaceMode::OntologyComplete,
+        ] {
+            let error = compile_schema(&SchemaCompileRequest::from_value_vocab_projection(
+                &shapes,
+                &fixture_ns(),
+                &unknown_projection,
+                mode,
+            ))
+            .expect_err("unknown vocabulary namespace must be typed");
+            assert!(matches!(
+                error,
+                SchemaCompileError::Namespace { iri, .. }
+                    if iri == "https://undeclared.example/Color"
+            ));
+        }
+
+        let collision = crate::text_ingest::parse_turtle_to_dataset(&format!(
+            "{PREFIXES}
+             @prefix marker: <https://example.org/marker/> .
+             @prefix aux: <https://example.org/aux/> .
+             meta:Color a marker:AbstractIndividualType .
+             aux:Color a marker:AbstractIndividualType ."
+        ))
+        .expect("colliding vocabulary Turtle");
+        let collision_namespaces = Namespaces::new(
+            "meta",
+            &[
+                ("meta".to_owned(), "https://example.org/meta/".to_owned()),
+                ("aux".to_owned(), "https://example.org/aux/".to_owned()),
+            ],
+        )
+        .expect("collision namespace config");
+        let collision_projection = ValueVocabProjection {
+            vocab: &vocab,
+            ontology: collision.as_ref(),
+        };
+        for mode in [
+            SchemaSurfaceMode::ShapedOnly,
+            SchemaSurfaceMode::OntologyComplete,
+        ] {
+            let error = compile_schema(&SchemaCompileRequest::from_value_vocab_projection(
+                &shapes,
+                &collision_namespaces,
+                &collision_projection,
+                mode,
+            ))
+            .expect_err("colliding vocabulary keys must be typed");
+            assert!(matches!(
+                error,
+                SchemaCompileError::DefinitionCollision { key, .. } if key == "ColorEnum"
+            ));
+        }
     }
 
     // ── Referencing $ref (Task 3) ────────────────────────────────────────────

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -442,6 +442,10 @@ pub struct SchemaPropertyCoverage {
     /// Canonically sorted RDF/OWL declaration or relationship kinds that made
     /// the property a catalog entry.
     pub declarations: Vec<String>,
+    /// Distinct inclusion/exclusion outcomes represented by the class rows.
+    /// A property with no eligible class still carries one aggregate exclusion
+    /// outcome, so its absence is always explained.
+    pub outcomes: Vec<SchemaCoverageStatus>,
     /// Canonically sorted per-class decisions. The aggregate property appears
     /// exactly once in a report even when this vector is empty.
     pub classes: Vec<SchemaClassPropertyCoverage>,
@@ -470,6 +474,8 @@ impl SchemaCoverageReport {
         for property in &mut canonical.properties {
             property.declarations.sort();
             property.declarations.dedup();
+            property.outcomes.sort();
+            property.outcomes.dedup();
             property.classes.sort_by(|left, right| {
                 left.class_iri
                     .cmp(&right.class_iri)
@@ -681,6 +687,20 @@ impl<'a> SchemaCompileRequest<'a> {
     pub fn compilation_key(&self) -> Result<SchemaCompilationKey, SchemaCompileError> {
         schema_compilation_key(self)
     }
+
+    /// Derive the deterministic ontology property coverage manifest without
+    /// serializing any developer-schema artifact.
+    ///
+    /// This uses the same internal relation consumed by full compilation, so a
+    /// cache planner can inspect both the key and coverage before emission.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed error for malformed OWL/RDFS expressions, contradictory
+    /// property kinds/ranges, or a fixed resource ceiling breach.
+    pub fn coverage_report(&self) -> Result<SchemaCoverageReport, SchemaCompileError> {
+        Ok(crate::schema_surface::build(self)?.report)
+    }
 }
 
 /// Ontology-aware compilation output.
@@ -697,10 +717,10 @@ pub struct SchemaCompilation {
 const SCHEMA_KEY_SALT: &str = "purrdf-shapes/schema-compilation-key/v1";
 const SCHEMA_POLICY_SALT: &str =
     "rdf12;json-schema-2020-12;openapi-3.1;surface-limits-v1;owl-rdfs-fragment-v1";
-const MAX_SCHEMA_PROPERTIES: usize = 65_536;
-const MAX_SCHEMA_CLASSES: usize = 65_536;
-const MAX_SCHEMA_RELATIONS: usize = 1_048_576;
-const MAX_OWL_EXPRESSION_DEPTH: usize = 64;
+pub(crate) const MAX_SCHEMA_PROPERTIES: usize = 65_536;
+pub(crate) const MAX_SCHEMA_CLASSES: usize = 65_536;
+pub(crate) const MAX_SCHEMA_RELATIONS: usize = 1_048_576;
+pub(crate) const MAX_OWL_EXPRESSION_DEPTH: usize = 64;
 
 fn schema_compilation_key(
     request: &SchemaCompileRequest<'_>,
@@ -2867,6 +2887,7 @@ mod tests {
         let property = |iri: &str| SchemaPropertyCoverage {
             property_iri: iri.to_owned(),
             declarations: vec!["rdfs:range".to_owned(), "owl:DatatypeProperty".to_owned()],
+            outcomes: vec![SchemaCoverageStatus::IncludedUnshaped],
             classes: vec![SchemaClassPropertyCoverage {
                 class_iri: "https://example.org/meta/Thing".to_owned(),
                 synthesized_open_class: false,

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -3136,9 +3136,16 @@ mod tests {
 
     #[test]
     fn caller_owned_namespaces_exclude_implicit_builtins() {
-        let ns = fixture_ns();
+        let ns = Namespaces::new(
+            "meta",
+            &[
+                ("meta".to_owned(), "https://example.org/meta/".to_owned()),
+                ("aux".to_owned(), "https://example.org/aux/".to_owned()),
+            ],
+        )
+        .expect("caller namespace declarations are valid");
         assert!(ns.is_caller_owned("https://example.org/meta/Person"));
-        assert!(ns.is_caller_owned("https://blackcatinformatics.ca/logic/Claim"));
+        assert!(ns.is_caller_owned("https://example.org/aux/Claim"));
         assert!(!ns.is_caller_owned("http://www.w3.org/2002/07/owl#DatatypeProperty"));
 
         let explicit = Namespaces::new(

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -58,7 +58,7 @@ pub use json_schema::{
     Namespaces, SchemaClassPropertyCoverage, SchemaCompilation, SchemaCompilationInput,
     SchemaCompilationKey, SchemaCompileError, SchemaCompileRequest, SchemaCoveragePrecision,
     SchemaCoverageProvenance, SchemaCoverageReport, SchemaCoverageStatus, SchemaPropertyCoverage,
-    SchemaSurfaceMode, ValueVocab, ValueVocabProjection, compile_with_value_vocab,
+    SchemaSurfaceMode, ValueVocab, ValueVocabProjection, compile_schema, compile_with_value_vocab,
 };
 pub use linkml::{
     LinkmlConfig, LinkmlDocument, LinkmlError, LinkmlPackage, emit_linkml, import_linkml,

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -41,6 +41,7 @@ pub mod report;
 pub mod rules;
 mod schema_catalog;
 pub mod schema_import;
+mod schema_surface;
 pub mod shape_union;
 pub mod shapes;
 pub mod sparql;

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -11,12 +11,15 @@
 //! implemented in the [`sparql`] module on the native `purrdf-sparql-eval`
 //! engine.
 //!
-//! The crate also owns the bidirectional schema boundary. [`import_json_schema`]
-//! and [`import_linkml`] read native documents; [`import_pydantic_package`],
-//! [`import_typescript_package`], and [`import_graphql_package`] verify intact
-//! PurRDF-generated packages before lowering through the same deterministic
-//! schema-import engine. Every reader requires caller-owned namespace and
-//! datatype configuration and returns an always-computed reverse loss ledger.
+//! The crate also owns the bidirectional schema boundary. [`compile_schema`]
+//! explicitly selects shaped-only or ontology-complete developer-schema
+//! projection and returns a deterministic coverage manifest plus cache key.
+//! [`import_json_schema`] and [`import_linkml`] read native documents;
+//! [`import_pydantic_package`], [`import_typescript_package`], and
+//! [`import_graphql_package`] verify intact PurRDF-generated packages before
+//! lowering through the same deterministic schema-import engine. Every reader
+//! requires caller-owned namespace and datatype configuration and returns an
+//! always-computed reverse loss ledger.
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/Blackcat-Informatics/purrdf/main/docs/purrdf-logo.svg"
 )]

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -53,7 +53,12 @@ pub use graphql::{
     GraphqlDefinitionMap, GraphqlEnumValueMap, GraphqlError, GraphqlNameMap, GraphqlPackage,
     emit_graphql, import_graphql_package,
 };
-pub use json_schema::{Namespaces, ValueVocab, ValueVocabProjection, compile_with_value_vocab};
+pub use json_schema::{
+    Namespaces, SchemaClassPropertyCoverage, SchemaCompilation, SchemaCompilationInput,
+    SchemaCompilationKey, SchemaCompileError, SchemaCompileRequest, SchemaCoveragePrecision,
+    SchemaCoverageProvenance, SchemaCoverageReport, SchemaCoverageStatus, SchemaPropertyCoverage,
+    SchemaSurfaceMode, ValueVocab, ValueVocabProjection, compile_with_value_vocab,
+};
 pub use linkml::{
     LinkmlConfig, LinkmlDocument, LinkmlError, LinkmlPackage, emit_linkml, import_linkml,
     import_linkml_package, parse_linkml, write_linkml,

--- a/crates/shapes/src/schema_surface.rs
+++ b/crates/shapes/src/schema_surface.rs
@@ -269,8 +269,8 @@ struct PropertyRelation {
 pub(crate) fn build(
     request: &SchemaCompileRequest<'_>,
 ) -> Result<SchemaSurface, SchemaCompileError> {
-    let mut rows = dataset_rows(request.ontology());
-    rows.extend(dataset_rows(request.shapes().shapes_dataset.as_ref()));
+    let union = RdfDataset::union(&[request.ontology(), request.shapes().shapes_dataset.as_ref()]);
+    let mut rows = dataset_rows(&union);
     rows.sort_by(|left, right| {
         left.subject_key
             .cmp(&right.subject_key)
@@ -1494,6 +1494,37 @@ mod tests {
         )
         .expect_err("cyclic RDF list must fail");
         assert!(matches!(cyclic, SchemaCompileError::InvalidOntology { .. }));
+    }
+
+    #[test]
+    fn ontology_and_shapes_blank_nodes_are_standardized_apart() {
+        let surface = surface(
+            r"
+                _:shared rdf:first ex:ShapeOnly ; rdf:rest rdf:nil .
+            ",
+            r"
+                ex:A a owl:Class .
+                ex:B a owl:Class .
+                ex:Holder a owl:Class .
+                ex:choice a owl:ObjectProperty ;
+                    rdfs:domain ex:Holder ;
+                    rdfs:range [ owl:unionOf _:shared ] .
+                _:shared rdf:first ex:A ; rdf:rest _:tail .
+                _:tail rdf:first ex:B ; rdf:rest rdf:nil .
+            ",
+            SchemaSurfaceMode::OntologyComplete,
+        )
+        .expect("same-label blanks from separate datasets remain independent");
+
+        assert_eq!(
+            surface.classes["https://example.org/schema/Holder"].properties
+                ["https://example.org/schema/choice"]
+                .ranges,
+            vec![OntologyExpression::Union(vec![
+                OntologyExpression::Named("https://example.org/schema/A".to_owned()),
+                OntologyExpression::Named("https://example.org/schema/B".to_owned()),
+            ])]
+        );
     }
 
     #[test]

--- a/crates/shapes/src/schema_surface.rs
+++ b/crates/shapes/src/schema_surface.rs
@@ -165,6 +165,7 @@ pub(crate) struct SurfaceProperty {
     pub(crate) iri: String,
     pub(crate) kind: OntologyPropertyKind,
     pub(crate) ranges: Vec<OntologyExpression>,
+    pub(crate) datatype_iris: BTreeSet<String>,
     pub(crate) functional: bool,
     pub(crate) provenance: Vec<SchemaCoverageProvenance>,
 }
@@ -451,6 +452,7 @@ pub(crate) fn build(
         properties,
         &shape_classes,
         explicit_classes,
+        &datatypes,
         &supertypes,
     )
 }
@@ -977,6 +979,7 @@ fn assemble_surface(
     properties: BTreeMap<String, PropertyFacts>,
     shape_classes: &BTreeMap<String, ShapeClassInfo>,
     explicit_classes: BTreeSet<String>,
+    datatypes: &BTreeSet<String>,
     supertypes: &BTreeMap<String, BTreeSet<String>>,
 ) -> Result<SchemaSurface, SchemaCompileError> {
     let eligible_classes: Vec<String> = explicit_classes
@@ -1016,6 +1019,11 @@ fn assemble_surface(
 
     for (property_iri, facts) in properties {
         let kind = facts.kind(&property_iri)?;
+        let mut datatype_iris = BTreeSet::new();
+        for range in &facts.ranges {
+            range.expression.named_members(&mut datatype_iris);
+        }
+        datatype_iris.retain(|iri| datatypes.contains(iri));
         let mut class_rows = Vec::new();
         let mut outcomes = BTreeSet::new();
         let base_provenance: Vec<SchemaCoverageProvenance> = facts
@@ -1081,6 +1089,7 @@ fn assemble_surface(
                             .iter()
                             .map(|range| range.expression.clone())
                             .collect(),
+                        datatype_iris: datatype_iris.clone(),
                         functional: !facts.functional.is_empty(),
                         provenance: base_provenance.clone(),
                     },

--- a/crates/shapes/src/schema_surface.rs
+++ b/crates/shapes/src/schema_surface.rs
@@ -545,6 +545,20 @@ fn enforce_limit(
     }
 }
 
+fn coverage_cell_count(
+    property_count: usize,
+    eligible_class_count: usize,
+    external_shaped_cells: usize,
+    limit: usize,
+) -> Result<usize, SchemaCompileError> {
+    let observed = property_count
+        .checked_mul(eligible_class_count)
+        .and_then(|cells| cells.checked_add(external_shaped_cells))
+        .unwrap_or(usize::MAX);
+    enforce_limit("class/property coverage cells", observed, limit)?;
+    Ok(observed)
+}
+
 fn parse_expression(
     term: &Term,
     objects: &ObjectIndex,
@@ -759,17 +773,31 @@ fn propagate_property_facts(
         expression_seeds[index * 2 + 1].clone_from(&facts.ranges);
         functional_seeds[index].clone_from(&facts.functional);
     }
-    let effective_expressions = propagate_sets(&expression_graph, expression_seeds);
-    let effective_functionality = propagate_sets(&functional_graph, functional_seeds);
-    for (index, name) in names.iter().enumerate() {
+    let effective_expressions = propagate_sets(
+        &expression_graph,
+        expression_seeds,
+        "propagated ontology expressions",
+    )?;
+    let effective_functionality = propagate_sets(
+        &functional_graph,
+        functional_seeds,
+        "propagated functionality facts",
+    )?;
+    let mut effective_expressions = effective_expressions.into_iter();
+    let mut effective_functionality = effective_functionality.into_iter();
+    for name in &names {
         let facts = properties
             .get_mut(name)
             .expect("property index was built from this map");
-        facts.domains.clone_from(&effective_expressions[index * 2]);
-        facts
-            .ranges
-            .clone_from(&effective_expressions[index * 2 + 1]);
-        facts.functional.clone_from(&effective_functionality[index]);
+        facts.domains = effective_expressions
+            .next()
+            .expect("each property has one propagated domain set");
+        facts.ranges = effective_expressions
+            .next()
+            .expect("each property has one propagated range set");
+        facts.functional = effective_functionality
+            .next()
+            .expect("each property has one propagated functionality set");
     }
     Ok(())
 }
@@ -863,7 +891,7 @@ fn class_supertypes(
         .iter()
         .map(|name| BTreeSet::from([name.clone()]))
         .collect();
-    let effective = propagate_sets(&graph, seeds);
+    let effective = propagate_sets(&graph, seeds, "propagated class memberships")?;
     Ok(names.into_iter().zip(effective).collect())
 }
 
@@ -872,16 +900,35 @@ fn class_supertypes(
 fn propagate_sets<T: Clone + Ord>(
     graph: &[BTreeSet<usize>],
     seeds: Vec<BTreeSet<T>>,
-) -> Vec<BTreeSet<T>> {
+    resource: &'static str,
+) -> Result<Vec<BTreeSet<T>>, SchemaCompileError> {
+    propagate_sets_with_limit(graph, seeds, resource, MAX_SCHEMA_RELATIONS)
+}
+
+fn propagate_sets_with_limit<T: Clone + Ord>(
+    graph: &[BTreeSet<usize>],
+    seeds: Vec<BTreeSet<T>>,
+    resource: &'static str,
+    limit: usize,
+) -> Result<Vec<BTreeSet<T>>, SchemaCompileError> {
     debug_assert_eq!(graph.len(), seeds.len());
     if graph.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
     let components = strongly_connected_components(graph);
     let component_count = components.iter().copied().max().map_or(0, |max| max + 1);
     let mut values = vec![BTreeSet::new(); component_count];
+    let mut materialized = 0_usize;
     for (node, facts) in seeds.into_iter().enumerate() {
-        values[components[node]].extend(facts);
+        for fact in facts {
+            insert_propagated_fact(
+                &mut values[components[node]],
+                fact,
+                &mut materialized,
+                resource,
+                limit,
+            )?;
+        }
     }
 
     let mut dag = vec![BTreeSet::new(); component_count];
@@ -906,9 +953,17 @@ fn propagate_sets<T: Clone + Ord>(
     let mut visited = 0_usize;
     while let Some(component) = ready.pop_first() {
         visited += 1;
-        let inherited = values[component].clone();
+        let inherited: Vec<T> = values[component].iter().cloned().collect();
         for &destination in &dag[component] {
-            values[destination].extend(inherited.iter().cloned());
+            for fact in &inherited {
+                insert_propagated_fact(
+                    &mut values[destination],
+                    fact.clone(),
+                    &mut materialized,
+                    resource,
+                    limit,
+                )?;
+            }
             indegree[destination] -= 1;
             if indegree[destination] == 0 {
                 ready.insert(destination);
@@ -916,10 +971,30 @@ fn propagate_sets<T: Clone + Ord>(
         }
     }
     debug_assert_eq!(visited, component_count, "component graph is acyclic");
-    components
+    let output_entries = components.iter().fold(0_usize, |total, &component| {
+        total.saturating_add(values[component].len())
+    });
+    enforce_limit(resource, output_entries, limit)?;
+    Ok(components
         .into_iter()
         .map(|component| values[component].clone())
-        .collect()
+        .collect())
+}
+
+fn insert_propagated_fact<T: Ord>(
+    destination: &mut BTreeSet<T>,
+    fact: T,
+    materialized: &mut usize,
+    resource: &'static str,
+    limit: usize,
+) -> Result<(), SchemaCompileError> {
+    if destination.get(&fact).is_none() {
+        let observed = materialized.saturating_add(1);
+        enforce_limit(resource, observed, limit)?;
+        destination.insert(fact);
+        *materialized = observed;
+    }
+    Ok(())
 }
 
 /// Iterative Kosaraju decomposition. Iteration avoids recursion depth depending
@@ -987,6 +1062,12 @@ fn assemble_surface(
         .filter(|class| request.namespaces().is_caller_owned(class))
         .collect();
     let shaped_classes: BTreeSet<String> = shape_classes.keys().cloned().collect();
+    let eligible_class_set: BTreeSet<&str> = eligible_classes.iter().map(String::as_str).collect();
+    let external_shaped_classes: Vec<&str> = shaped_classes
+        .iter()
+        .map(String::as_str)
+        .filter(|class| !eligible_class_set.contains(class))
+        .collect();
     let represented_classes: BTreeSet<String> = match request.mode() {
         SchemaSurfaceMode::ShapedOnly => shaped_classes.clone(),
         SchemaSurfaceMode::OntologyComplete => eligible_classes
@@ -1010,10 +1091,14 @@ fn assemble_surface(
         })
         .collect();
     let mut report_properties = Vec::with_capacity(properties.len());
-    let potential_cells = properties.len().saturating_mul(eligible_classes.len());
-    enforce_limit(
-        "class/property coverage cells",
-        potential_cells,
+    let external_shaped_cells = external_shaped_classes
+        .iter()
+        .map(|class| shape_classes[*class].direct_properties.len())
+        .fold(0_usize, usize::saturating_add);
+    coverage_cell_count(
+        properties.len(),
+        eligible_classes.len(),
+        external_shaped_cells,
         MAX_SCHEMA_RELATIONS,
     )?;
 
@@ -1111,16 +1196,14 @@ fn assemble_surface(
         // A shaped class may intentionally live outside the caller-owned
         // ontology boundary; retain its direct-shape audit row because legacy
         // compilation still emits it.
-        for class_iri in
-            shaped_classes.difference(&eligible_classes.iter().cloned().collect::<BTreeSet<_>>())
-        {
+        for &class_iri in &external_shaped_classes {
             if shape_classes[class_iri]
                 .direct_properties
                 .contains(&property_iri)
             {
                 outcomes.insert(SchemaCoverageStatus::HasShape);
                 class_rows.push(SchemaClassPropertyCoverage {
-                    class_iri: class_iri.clone(),
+                    class_iri: class_iri.to_owned(),
                     synthesized_open_class: false,
                     status: SchemaCoverageStatus::HasShape,
                     precision: SchemaCoveragePrecision::Exact,
@@ -1534,6 +1617,62 @@ mod tests {
                 OntologyExpression::Named("https://example.org/schema/B".to_owned()),
             ])]
         );
+    }
+
+    #[test]
+    fn propagation_and_coverage_preflights_enforce_exact_small_limits() {
+        let chain = vec![
+            BTreeSet::from([1_usize]),
+            BTreeSet::from([2_usize]),
+            BTreeSet::new(),
+        ];
+        let seeds = vec![
+            BTreeSet::from([0_u8]),
+            BTreeSet::from([1_u8]),
+            BTreeSet::from([2_u8]),
+        ];
+        let transitive = propagate_sets_with_limit(&chain, seeds, "test facts", 5)
+            .expect_err("transitive extension must stop at the limit");
+        assert!(matches!(
+            transitive,
+            SchemaCompileError::LimitExceeded {
+                resource: "test facts",
+                limit: 5,
+                observed: 6
+            }
+        ));
+
+        let cycle = vec![
+            BTreeSet::from([1_usize]),
+            BTreeSet::from([2_usize]),
+            BTreeSet::from([0_usize]),
+        ];
+        let seeds = vec![
+            BTreeSet::from([0_u8]),
+            BTreeSet::from([1_u8]),
+            BTreeSet::from([2_u8]),
+        ];
+        let output = propagate_sets_with_limit(&cycle, seeds, "test facts", 8)
+            .expect_err("per-node output cloning must stop at the limit");
+        assert!(matches!(
+            output,
+            SchemaCompileError::LimitExceeded {
+                resource: "test facts",
+                limit: 8,
+                observed: 9
+            }
+        ));
+
+        let coverage = coverage_cell_count(2, 3, 1, 6)
+            .expect_err("external shaped rows count toward coverage");
+        assert!(matches!(
+            coverage,
+            SchemaCompileError::LimitExceeded {
+                resource: "class/property coverage cells",
+                limit: 6,
+                observed: 7
+            }
+        ));
     }
 
     #[test]

--- a/crates/shapes/src/schema_surface.rs
+++ b/crates/shapes/src/schema_surface.rs
@@ -1,0 +1,1545 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Deterministic OWL/RDFS property-surface derivation for developer schemas.
+//!
+//! This is deliberately a bounded schema theory, not an instance reasoner. It
+//! computes one sparse class/property relation with source-axiom provenance;
+//! every schema emitter and the public coverage manifest project from that
+//! relation. Unsupported or malformed structures fail with a typed error.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use ::purrdf::RdfDataset;
+
+use crate::data::{GraphFilter, native_quads};
+use crate::json_schema::{
+    MAX_OWL_EXPRESSION_DEPTH, MAX_SCHEMA_CLASSES, MAX_SCHEMA_PROPERTIES, MAX_SCHEMA_RELATIONS,
+    SchemaClassPropertyCoverage, SchemaCompileError, SchemaCompileRequest, SchemaCoveragePrecision,
+    SchemaCoverageProvenance, SchemaCoverageReport, SchemaCoverageStatus, SchemaPropertyCoverage,
+    SchemaSurfaceMode,
+};
+use crate::model::{rdf, rdfs};
+use crate::shapes::{Constraint, Path, Shape, Target};
+use crate::term::Term;
+
+const RDF_PROPERTY: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property";
+const RDF_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
+const RDFS_DOMAIN: &str = "http://www.w3.org/2000/01/rdf-schema#domain";
+const RDFS_SUB_PROPERTY_OF: &str = "http://www.w3.org/2000/01/rdf-schema#subPropertyOf";
+const RDFS_DATATYPE: &str = "http://www.w3.org/2000/01/rdf-schema#Datatype";
+const RDFS_LITERAL: &str = "http://www.w3.org/2000/01/rdf-schema#Literal";
+const OWL_CLASS: &str = "http://www.w3.org/2002/07/owl#Class";
+const OWL_DATA_RANGE: &str = "http://www.w3.org/2002/07/owl#DataRange";
+const OWL_OBJECT_PROPERTY: &str = "http://www.w3.org/2002/07/owl#ObjectProperty";
+const OWL_DATATYPE_PROPERTY: &str = "http://www.w3.org/2002/07/owl#DatatypeProperty";
+const OWL_ANNOTATION_PROPERTY: &str = "http://www.w3.org/2002/07/owl#AnnotationProperty";
+const OWL_FUNCTIONAL_PROPERTY: &str = "http://www.w3.org/2002/07/owl#FunctionalProperty";
+const OWL_INVERSE_FUNCTIONAL_PROPERTY: &str =
+    "http://www.w3.org/2002/07/owl#InverseFunctionalProperty";
+const OWL_EQUIVALENT_PROPERTY: &str = "http://www.w3.org/2002/07/owl#equivalentProperty";
+const OWL_INVERSE_OF: &str = "http://www.w3.org/2002/07/owl#inverseOf";
+const OWL_EQUIVALENT_CLASS: &str = "http://www.w3.org/2002/07/owl#equivalentClass";
+const OWL_UNION_OF: &str = "http://www.w3.org/2002/07/owl#unionOf";
+const OWL_INTERSECTION_OF: &str = "http://www.w3.org/2002/07/owl#intersectionOf";
+
+/// Exact bounded class expression supported for ontology domains and ranges.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum OntologyExpression {
+    Named(String),
+    Union(Vec<Self>),
+    Intersection(Vec<Self>),
+}
+
+impl OntologyExpression {
+    fn canonical(&self) -> String {
+        match self {
+            Self::Named(iri) => format!("<{iri}>"),
+            Self::Union(members) => format!(
+                "union({})",
+                members
+                    .iter()
+                    .map(Self::canonical)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ),
+            Self::Intersection(members) => format!(
+                "intersection({})",
+                members
+                    .iter()
+                    .map(Self::canonical)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ),
+        }
+    }
+
+    fn named_members(&self, out: &mut BTreeSet<String>) {
+        match self {
+            Self::Named(iri) => {
+                out.insert(iri.clone());
+            }
+            Self::Union(members) | Self::Intersection(members) => {
+                for member in members {
+                    member.named_members(out);
+                }
+            }
+        }
+    }
+
+    fn matches_class(&self, supertypes: &BTreeSet<String>) -> bool {
+        match self {
+            Self::Named(iri) => supertypes.contains(iri),
+            Self::Union(members) => members
+                .iter()
+                .any(|member| member.matches_class(supertypes)),
+            Self::Intersection(members) => members
+                .iter()
+                .all(|member| member.matches_class(supertypes)),
+        }
+    }
+
+    fn all_named_members_match(&self, predicate: &impl Fn(&str) -> bool) -> bool {
+        match self {
+            Self::Named(iri) => predicate(iri),
+            Self::Union(members) | Self::Intersection(members) => members
+                .iter()
+                .all(|member| member.all_named_members_match(predicate)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OntologyPropertyKind {
+    Generic,
+    Object,
+    Datatype,
+    Annotation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct SourcedExpression {
+    expression: OntologyExpression,
+    provenance: SchemaCoverageProvenance,
+}
+
+#[derive(Debug, Clone, Default)]
+struct PropertyFacts {
+    declarations: BTreeSet<String>,
+    provenance: BTreeSet<SchemaCoverageProvenance>,
+    object_property: bool,
+    datatype_property: bool,
+    annotation_property: bool,
+    domains: BTreeSet<SourcedExpression>,
+    ranges: BTreeSet<SourcedExpression>,
+    functional: BTreeSet<SchemaCoverageProvenance>,
+}
+
+impl PropertyFacts {
+    fn kind(&self, property_iri: &str) -> Result<OntologyPropertyKind, SchemaCompileError> {
+        let specialized = usize::from(self.object_property)
+            + usize::from(self.datatype_property)
+            + usize::from(self.annotation_property);
+        if specialized > 1 {
+            return Err(SchemaCompileError::InvalidOntology {
+                subject: property_iri.to_owned(),
+                reason: "property has incompatible object, datatype, or annotation declarations"
+                    .to_owned(),
+            });
+        }
+        Ok(if self.object_property {
+            OntologyPropertyKind::Object
+        } else if self.datatype_property {
+            OntologyPropertyKind::Datatype
+        } else if self.annotation_property {
+            OntologyPropertyKind::Annotation
+        } else {
+            OntologyPropertyKind::Generic
+        })
+    }
+}
+
+/// One unshaped property admitted into a class definition.
+#[derive(Debug, Clone)]
+pub(crate) struct SurfaceProperty {
+    pub(crate) iri: String,
+    pub(crate) kind: OntologyPropertyKind,
+    pub(crate) ranges: Vec<OntologyExpression>,
+    pub(crate) functional: bool,
+    pub(crate) provenance: Vec<SchemaCoverageProvenance>,
+}
+
+/// One existing named class represented by a schema `$def`.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SurfaceClass {
+    pub(crate) synthesized_open: bool,
+    pub(crate) properties: BTreeMap<String, SurfaceProperty>,
+}
+
+/// Single source of truth for ontology-aware schema definitions and coverage.
+#[derive(Debug, Clone)]
+pub(crate) struct SchemaSurface {
+    pub(crate) classes: BTreeMap<String, SurfaceClass>,
+    pub(crate) report: SchemaCoverageReport,
+}
+
+impl SchemaSurface {
+    fn assert_conservation(&self) {
+        let report_properties: BTreeSet<&str> = self
+            .report
+            .properties
+            .iter()
+            .map(|property| property.property_iri.as_str())
+            .collect();
+        debug_assert_eq!(report_properties.len(), self.report.properties.len());
+        let mut emitted = 0_usize;
+        let mut range_expressions = 0_usize;
+        let mut provenance_records = 0_usize;
+        for class in self.classes.values() {
+            for (property_iri, property) in &class.properties {
+                debug_assert_eq!(property_iri, &property.iri);
+                debug_assert!(report_properties.contains(property_iri.as_str()));
+                match property.kind {
+                    OntologyPropertyKind::Generic
+                    | OntologyPropertyKind::Object
+                    | OntologyPropertyKind::Datatype
+                    | OntologyPropertyKind::Annotation => {}
+                }
+                if property.functional {
+                    debug_assert!(!property.provenance.is_empty());
+                }
+                emitted += 1;
+                range_expressions += property.ranges.len();
+                provenance_records += property.provenance.len();
+            }
+        }
+        debug_assert!(emitted <= MAX_SCHEMA_RELATIONS);
+        debug_assert!(range_expressions <= MAX_SCHEMA_RELATIONS);
+        debug_assert!(provenance_records <= MAX_SCHEMA_RELATIONS * 8);
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct ShapeClassInfo {
+    direct_properties: BTreeSet<String>,
+    closed_surfaces: Vec<ClosedSurface>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ClosedSurface {
+    direct_properties: BTreeSet<String>,
+    ignored_properties: BTreeSet<String>,
+}
+
+impl ShapeClassInfo {
+    fn closed_allows(&self, property: &str) -> bool {
+        self.closed_surfaces.iter().all(|closed| {
+            closed.direct_properties.contains(property)
+                || closed.ignored_properties.contains(property)
+        })
+    }
+}
+
+type ObjectIndex = BTreeMap<String, BTreeMap<String, Vec<Term>>>;
+
+#[derive(Debug, Clone)]
+struct TripleRow {
+    subject: Term,
+    predicate: String,
+    object: Term,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PropertyRelationKind {
+    SubProperty,
+    Equivalent,
+    Inverse,
+}
+
+#[derive(Debug, Clone)]
+struct PropertyRelation {
+    left: String,
+    right: String,
+    kind: PropertyRelationKind,
+}
+
+/// Build the deterministic class/property relation for one request.
+pub(crate) fn build(
+    request: &SchemaCompileRequest<'_>,
+) -> Result<SchemaSurface, SchemaCompileError> {
+    let mut rows = dataset_rows(request.ontology());
+    rows.extend(dataset_rows(request.shapes().shapes_dataset.as_ref()));
+    rows.sort_by(|left, right| {
+        left.subject
+            .to_string()
+            .cmp(&right.subject.to_string())
+            .then_with(|| left.predicate.cmp(&right.predicate))
+            .then_with(|| left.object.to_string().cmp(&right.object.to_string()))
+    });
+    rows.dedup_by(|left, right| {
+        left.subject == right.subject
+            && left.predicate == right.predicate
+            && left.object == right.object
+    });
+    let objects = object_index(&rows);
+
+    let shape_classes = shape_class_info(request.shapes());
+    let mut properties: BTreeMap<String, PropertyFacts> = BTreeMap::new();
+    let mut explicit_classes = BTreeSet::new();
+    let mut datatypes = BTreeSet::new();
+    let mut subclass_relations = Vec::new();
+    let mut equivalent_class_relations = Vec::new();
+    let mut property_relations = Vec::new();
+
+    for (class, info) in &shape_classes {
+        explicit_classes.insert(class.clone());
+        for property in &info.direct_properties {
+            let facts = property_entry(&mut properties, property)?;
+            facts.declarations.insert("sh:path".to_owned());
+            facts.provenance.insert(SchemaCoverageProvenance {
+                subject: class.clone(),
+                predicate: crate::model::sh::PATH.to_owned(),
+                object: format!("<{property}>"),
+            });
+        }
+    }
+
+    for row in &rows {
+        let Some(subject_iri) = named_iri(&row.subject) else {
+            continue;
+        };
+        match row.predicate.as_str() {
+            rdf::TYPE => {
+                let Some(type_iri) = named_iri(&row.object) else {
+                    continue;
+                };
+                match type_iri {
+                    RDF_PROPERTY
+                    | OWL_OBJECT_PROPERTY
+                    | OWL_DATATYPE_PROPERTY
+                    | OWL_ANNOTATION_PROPERTY
+                    | OWL_FUNCTIONAL_PROPERTY
+                    | OWL_INVERSE_FUNCTIONAL_PROPERTY => {
+                        let facts = property_entry(&mut properties, subject_iri)?;
+                        facts.declarations.insert(type_iri.to_owned());
+                        let provenance = axiom_provenance(subject_iri, rdf::TYPE, type_iri);
+                        facts.provenance.insert(provenance.clone());
+                        match type_iri {
+                            OWL_OBJECT_PROPERTY => facts.object_property = true,
+                            OWL_DATATYPE_PROPERTY => facts.datatype_property = true,
+                            OWL_ANNOTATION_PROPERTY => facts.annotation_property = true,
+                            OWL_FUNCTIONAL_PROPERTY => {
+                                facts.functional.insert(provenance);
+                            }
+                            _ => {}
+                        }
+                    }
+                    rdfs::CLASS | OWL_CLASS => {
+                        explicit_classes.insert(subject_iri.to_owned());
+                    }
+                    RDFS_DATATYPE | OWL_DATA_RANGE => {
+                        datatypes.insert(subject_iri.to_owned());
+                    }
+                    _ => {}
+                }
+            }
+            rdfs::SUB_CLASS_OF => {
+                let Some(parent) = named_iri(&row.object) else {
+                    return Err(invalid_relation(subject_iri, rdfs::SUB_CLASS_OF));
+                };
+                explicit_classes.insert(subject_iri.to_owned());
+                explicit_classes.insert(parent.to_owned());
+                subclass_relations.push((subject_iri.to_owned(), parent.to_owned()));
+            }
+            OWL_EQUIVALENT_CLASS => {
+                let Some(equivalent) = named_iri(&row.object) else {
+                    return Err(invalid_relation(subject_iri, OWL_EQUIVALENT_CLASS));
+                };
+                explicit_classes.insert(subject_iri.to_owned());
+                explicit_classes.insert(equivalent.to_owned());
+                equivalent_class_relations.push((subject_iri.to_owned(), equivalent.to_owned()));
+            }
+            RDFS_SUB_PROPERTY_OF | OWL_EQUIVALENT_PROPERTY | OWL_INVERSE_OF => {
+                let Some(right) = named_iri(&row.object) else {
+                    return Err(invalid_relation(subject_iri, &row.predicate));
+                };
+                let left_facts = property_entry(&mut properties, subject_iri)?;
+                left_facts
+                    .declarations
+                    .insert(format!("{}:subject", row.predicate));
+                left_facts
+                    .provenance
+                    .insert(axiom_provenance(subject_iri, &row.predicate, right));
+                let right_facts = property_entry(&mut properties, right)?;
+                right_facts
+                    .declarations
+                    .insert(format!("{}:object", row.predicate));
+                right_facts
+                    .provenance
+                    .insert(axiom_provenance(subject_iri, &row.predicate, right));
+                property_relations.push(PropertyRelation {
+                    left: subject_iri.to_owned(),
+                    right: right.to_owned(),
+                    kind: match row.predicate.as_str() {
+                        RDFS_SUB_PROPERTY_OF => PropertyRelationKind::SubProperty,
+                        OWL_EQUIVALENT_PROPERTY => PropertyRelationKind::Equivalent,
+                        OWL_INVERSE_OF => PropertyRelationKind::Inverse,
+                        _ => unreachable!("matched relation predicate"),
+                    },
+                });
+            }
+            RDFS_DOMAIN | rdfs::RANGE => {
+                let expression = parse_expression(&row.object, &objects, 0)?;
+                let predicate = row.predicate.as_str();
+                let provenance = SchemaCoverageProvenance {
+                    subject: subject_iri.to_owned(),
+                    predicate: predicate.to_owned(),
+                    object: expression.canonical(),
+                };
+                let sourced = SourcedExpression {
+                    expression,
+                    provenance: provenance.clone(),
+                };
+                let facts = property_entry(&mut properties, subject_iri)?;
+                facts.declarations.insert(predicate.to_owned());
+                facts.provenance.insert(provenance);
+                if predicate == RDFS_DOMAIN {
+                    facts.domains.insert(sourced);
+                } else {
+                    facts.ranges.insert(sourced);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    enforce_limit("properties", properties.len(), MAX_SCHEMA_PROPERTIES)?;
+    propagate_property_facts(&mut properties, &property_relations)?;
+    validate_property_ranges(&properties, &datatypes)?;
+
+    for facts in properties.values() {
+        for domain in &facts.domains {
+            domain.expression.named_members(&mut explicit_classes);
+        }
+        let kind = facts.kind("range class discovery")?;
+        if matches!(
+            kind,
+            OntologyPropertyKind::Object | OntologyPropertyKind::Generic
+        ) {
+            for range in &facts.ranges {
+                let mut named = BTreeSet::new();
+                range.expression.named_members(&mut named);
+                for iri in named {
+                    if !is_builtin_datatype(&iri) && !datatypes.contains(&iri) {
+                        explicit_classes.insert(iri);
+                    }
+                }
+            }
+        }
+    }
+    explicit_classes.extend(shape_classes.keys().cloned());
+    enforce_limit("classes", explicit_classes.len(), MAX_SCHEMA_CLASSES)?;
+    let supertypes = class_supertypes(
+        &explicit_classes,
+        &subclass_relations,
+        &equivalent_class_relations,
+    )?;
+
+    assemble_surface(
+        request,
+        properties,
+        &shape_classes,
+        explicit_classes,
+        &supertypes,
+    )
+}
+
+fn dataset_rows(dataset: &RdfDataset) -> Vec<TripleRow> {
+    native_quads(dataset, None, None, None, GraphFilter::AnyGraph)
+        .into_iter()
+        .map(|(subject, predicate, object)| TripleRow {
+            subject,
+            predicate: predicate.into_string(),
+            object,
+        })
+        .collect()
+}
+
+fn object_index(rows: &[TripleRow]) -> ObjectIndex {
+    let mut index: ObjectIndex = BTreeMap::new();
+    for row in rows {
+        index
+            .entry(row.subject.to_string())
+            .or_default()
+            .entry(row.predicate.clone())
+            .or_default()
+            .push(row.object.clone());
+    }
+    for predicates in index.values_mut() {
+        for values in predicates.values_mut() {
+            values.sort_by_cached_key(ToString::to_string);
+            values.dedup();
+        }
+    }
+    index
+}
+
+fn named_iri(term: &Term) -> Option<&str> {
+    match term {
+        Term::NamedNode(node) => Some(node.as_str()),
+        _ => None,
+    }
+}
+
+fn property_entry<'a>(
+    properties: &'a mut BTreeMap<String, PropertyFacts>,
+    iri: &str,
+) -> Result<&'a mut PropertyFacts, SchemaCompileError> {
+    if !properties.contains_key(iri) && properties.len() == MAX_SCHEMA_PROPERTIES {
+        return Err(SchemaCompileError::LimitExceeded {
+            resource: "properties",
+            limit: MAX_SCHEMA_PROPERTIES,
+            observed: MAX_SCHEMA_PROPERTIES + 1,
+        });
+    }
+    Ok(properties.entry(iri.to_owned()).or_default())
+}
+
+fn axiom_provenance(subject: &str, predicate: &str, object_iri: &str) -> SchemaCoverageProvenance {
+    SchemaCoverageProvenance {
+        subject: subject.to_owned(),
+        predicate: predicate.to_owned(),
+        object: format!("<{object_iri}>"),
+    }
+}
+
+fn invalid_relation(subject: &str, predicate: &str) -> SchemaCompileError {
+    SchemaCompileError::InvalidOntology {
+        subject: subject.to_owned(),
+        reason: format!("{predicate} requires a named IRI object in the schema fragment"),
+    }
+}
+
+fn enforce_limit(
+    resource: &'static str,
+    observed: usize,
+    limit: usize,
+) -> Result<(), SchemaCompileError> {
+    if observed > limit {
+        Err(SchemaCompileError::LimitExceeded {
+            resource,
+            limit,
+            observed,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn parse_expression(
+    term: &Term,
+    objects: &ObjectIndex,
+    depth: usize,
+) -> Result<OntologyExpression, SchemaCompileError> {
+    if depth > MAX_OWL_EXPRESSION_DEPTH {
+        return Err(SchemaCompileError::LimitExceeded {
+            resource: "OWL expression depth",
+            limit: MAX_OWL_EXPRESSION_DEPTH,
+            observed: depth,
+        });
+    }
+    match term {
+        Term::NamedNode(node) => Ok(OntologyExpression::Named(node.as_str().to_owned())),
+        Term::BlankNode(_) => {
+            let key = term.to_string();
+            let unions = indexed_objects(objects, &key, OWL_UNION_OF);
+            let intersections = indexed_objects(objects, &key, OWL_INTERSECTION_OF);
+            match (unions.len(), intersections.len()) {
+                (1, 0) => Ok(OntologyExpression::Union(parse_expression_list(
+                    &unions[0],
+                    objects,
+                    depth + 1,
+                    &key,
+                )?)),
+                (0, 1) => Ok(OntologyExpression::Intersection(parse_expression_list(
+                    &intersections[0],
+                    objects,
+                    depth + 1,
+                    &key,
+                )?)),
+                (0, 0) => Err(SchemaCompileError::InvalidOntology {
+                    subject: key,
+                    reason: "anonymous domain/range expression must declare exactly one owl:unionOf or owl:intersectionOf"
+                        .to_owned(),
+                }),
+                _ => Err(SchemaCompileError::InvalidOntology {
+                    subject: key,
+                    reason: "anonymous domain/range expression has ambiguous union/intersection declarations"
+                        .to_owned(),
+                }),
+            }
+        }
+        _ => Err(SchemaCompileError::InvalidOntology {
+            subject: term.to_string(),
+            reason: "domain/range expression must be a named class/datatype or an anonymous union/intersection"
+                .to_owned(),
+        }),
+    }
+}
+
+fn parse_expression_list(
+    head: &Term,
+    objects: &ObjectIndex,
+    depth: usize,
+    owner: &str,
+) -> Result<Vec<OntologyExpression>, SchemaCompileError> {
+    let mut cursor = head.clone();
+    let mut visited = BTreeSet::new();
+    let mut members = Vec::new();
+    loop {
+        if matches!(&cursor, Term::NamedNode(node) if node.as_str() == rdf::NIL) {
+            break;
+        }
+        let Term::BlankNode(_) = &cursor else {
+            return Err(SchemaCompileError::InvalidOntology {
+                subject: owner.to_owned(),
+                reason: format!("OWL expression list must terminate at rdf:nil; found {cursor}"),
+            });
+        };
+        let key = cursor.to_string();
+        if !visited.insert(key.clone()) {
+            return Err(SchemaCompileError::InvalidOntology {
+                subject: owner.to_owned(),
+                reason: format!("OWL expression list contains a cycle at {key}"),
+            });
+        }
+        enforce_limit(
+            "OWL expression list members",
+            visited.len(),
+            MAX_SCHEMA_CLASSES,
+        )?;
+        let first = indexed_objects(objects, &key, rdf::FIRST);
+        let rest = indexed_objects(objects, &key, rdf::REST);
+        if first.len() != 1 || rest.len() != 1 {
+            return Err(SchemaCompileError::InvalidOntology {
+                subject: key,
+                reason: format!(
+                    "RDF list cell requires exactly one rdf:first and rdf:rest; found {} and {}",
+                    first.len(),
+                    rest.len()
+                ),
+            });
+        }
+        members.push(parse_expression(&first[0], objects, depth)?);
+        cursor = rest[0].clone();
+    }
+    if members.len() < 2 {
+        return Err(SchemaCompileError::InvalidOntology {
+            subject: owner.to_owned(),
+            reason: "owl:unionOf/owl:intersectionOf requires at least two members".to_owned(),
+        });
+    }
+    members.sort();
+    members.dedup();
+    if members.len() < 2 {
+        return Err(SchemaCompileError::InvalidOntology {
+            subject: owner.to_owned(),
+            reason: "owl:unionOf/owl:intersectionOf must contain two distinct members".to_owned(),
+        });
+    }
+    Ok(members)
+}
+
+fn indexed_objects<'a>(objects: &'a ObjectIndex, subject: &str, predicate: &str) -> &'a [Term] {
+    objects
+        .get(subject)
+        .and_then(|predicates| predicates.get(predicate))
+        .map_or(&[], Vec::as_slice)
+}
+
+fn shape_class_info(shapes: &crate::shapes::Shapes) -> BTreeMap<String, ShapeClassInfo> {
+    let mut classes = BTreeMap::new();
+    for shape in &shapes.node_shapes {
+        if shape.deactivated {
+            continue;
+        }
+        for target in &shape.targets {
+            let class = match target {
+                Target::Class(node) => Some(node.as_str()),
+                Target::ImplicitClass(Term::NamedNode(node)) => Some(node.as_str()),
+                _ => None,
+            };
+            if let Some(class) = class {
+                merge_shape_info(classes.entry(class.to_owned()).or_default(), shape);
+            }
+        }
+    }
+    classes
+}
+
+fn merge_shape_info(info: &mut ShapeClassInfo, shape: &Shape) {
+    let direct = direct_shape_properties(shape);
+    info.direct_properties.extend(direct.iter().cloned());
+    for constraint in &shape.constraints {
+        if let Constraint::Closed { ignored } = constraint {
+            info.closed_surfaces.push(ClosedSurface {
+                direct_properties: direct.clone(),
+                ignored_properties: ignored
+                    .iter()
+                    .map(|node| node.as_str().to_owned())
+                    .collect(),
+            });
+        }
+    }
+}
+
+fn direct_shape_properties(shape: &Shape) -> BTreeSet<String> {
+    shape
+        .property_shapes
+        .iter()
+        .filter(|property| !property.deactivated)
+        .filter_map(|property| match &property.path {
+            Path::Predicate(node) => Some(node.as_str().to_owned()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn propagate_property_facts(
+    properties: &mut BTreeMap<String, PropertyFacts>,
+    relations: &[PropertyRelation],
+) -> Result<(), SchemaCompileError> {
+    let names: Vec<String> = properties.keys().cloned().collect();
+    let indices: BTreeMap<&str, usize> = names
+        .iter()
+        .enumerate()
+        .map(|(index, name)| (name.as_str(), index))
+        .collect();
+    let mut expression_graph = vec![BTreeSet::new(); names.len() * 2];
+    let mut functional_graph = vec![BTreeSet::new(); names.len()];
+
+    for relation in relations {
+        let left = indices[relation.left.as_str()];
+        let right = indices[relation.right.as_str()];
+        match relation.kind {
+            PropertyRelationKind::SubProperty => {
+                add_edge(&mut expression_graph, right * 2, left * 2);
+                add_edge(&mut expression_graph, right * 2 + 1, left * 2 + 1);
+                add_edge(&mut functional_graph, right, left);
+            }
+            PropertyRelationKind::Equivalent => {
+                add_bidirectional_edge(&mut expression_graph, left * 2, right * 2);
+                add_bidirectional_edge(&mut expression_graph, left * 2 + 1, right * 2 + 1);
+                add_bidirectional_edge(&mut functional_graph, left, right);
+            }
+            PropertyRelationKind::Inverse => {
+                add_bidirectional_edge(&mut expression_graph, left * 2, right * 2 + 1);
+                add_bidirectional_edge(&mut expression_graph, left * 2 + 1, right * 2);
+            }
+        }
+    }
+    let edge_count = expression_graph.iter().map(BTreeSet::len).sum::<usize>()
+        + functional_graph.iter().map(BTreeSet::len).sum::<usize>();
+    enforce_limit("ontology relation edges", edge_count, MAX_SCHEMA_RELATIONS)?;
+
+    let mut expression_seeds = vec![BTreeSet::new(); names.len() * 2];
+    let mut functional_seeds = vec![BTreeSet::new(); names.len()];
+    for (index, name) in names.iter().enumerate() {
+        let facts = &properties[name];
+        expression_seeds[index * 2].clone_from(&facts.domains);
+        expression_seeds[index * 2 + 1].clone_from(&facts.ranges);
+        functional_seeds[index].clone_from(&facts.functional);
+    }
+    let effective_expressions = propagate_sets(&expression_graph, expression_seeds);
+    let effective_functionality = propagate_sets(&functional_graph, functional_seeds);
+    for (index, name) in names.iter().enumerate() {
+        let facts = properties
+            .get_mut(name)
+            .expect("property index was built from this map");
+        facts.domains.clone_from(&effective_expressions[index * 2]);
+        facts
+            .ranges
+            .clone_from(&effective_expressions[index * 2 + 1]);
+        facts.functional.clone_from(&effective_functionality[index]);
+    }
+    Ok(())
+}
+
+fn add_edge(graph: &mut [BTreeSet<usize>], source: usize, destination: usize) {
+    graph[source].insert(destination);
+}
+
+fn add_bidirectional_edge(graph: &mut [BTreeSet<usize>], left: usize, right: usize) {
+    add_edge(graph, left, right);
+    add_edge(graph, right, left);
+}
+
+fn validate_property_ranges(
+    properties: &BTreeMap<String, PropertyFacts>,
+    datatypes: &BTreeSet<String>,
+) -> Result<(), SchemaCompileError> {
+    for (property, facts) in properties {
+        let kind = facts.kind(property)?;
+        for range in &facts.ranges {
+            match kind {
+                OntologyPropertyKind::Datatype
+                    if !range.expression.all_named_members_match(&|iri| {
+                        is_builtin_datatype(iri) || datatypes.contains(iri)
+                    }) =>
+                {
+                    return Err(SchemaCompileError::InvalidOntology {
+                        subject: property.clone(),
+                        reason: format!(
+                            "owl:DatatypeProperty has non-datatype range {}",
+                            range.expression.canonical()
+                        ),
+                    });
+                }
+                OntologyPropertyKind::Object
+                    if !range.expression.all_named_members_match(&|iri| {
+                        !is_builtin_datatype(iri) && !datatypes.contains(iri)
+                    }) =>
+                {
+                    return Err(SchemaCompileError::InvalidOntology {
+                        subject: property.clone(),
+                        reason: format!(
+                            "owl:ObjectProperty has datatype range {}",
+                            range.expression.canonical()
+                        ),
+                    });
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+fn is_builtin_datatype(iri: &str) -> bool {
+    iri.starts_with(crate::model::xsd::BASE) || iri == RDFS_LITERAL || iri == RDF_LANG_STRING
+}
+
+fn class_supertypes(
+    classes: &BTreeSet<String>,
+    subclasses: &[(String, String)],
+    equivalents: &[(String, String)],
+) -> Result<BTreeMap<String, BTreeSet<String>>, SchemaCompileError> {
+    let names: Vec<String> = classes.iter().cloned().collect();
+    let indices: BTreeMap<&str, usize> = names
+        .iter()
+        .enumerate()
+        .map(|(index, name)| (name.as_str(), index))
+        .collect();
+    let mut graph = vec![BTreeSet::new(); names.len()];
+    for (child, parent) in subclasses {
+        if let (Some(&child), Some(&parent)) =
+            (indices.get(child.as_str()), indices.get(parent.as_str()))
+        {
+            add_edge(&mut graph, parent, child);
+        }
+    }
+    for (left, right) in equivalents {
+        if let (Some(&left), Some(&right)) =
+            (indices.get(left.as_str()), indices.get(right.as_str()))
+        {
+            add_bidirectional_edge(&mut graph, left, right);
+        }
+    }
+    enforce_limit(
+        "class hierarchy edges",
+        graph.iter().map(BTreeSet::len).sum(),
+        MAX_SCHEMA_RELATIONS,
+    )?;
+    let seeds: Vec<BTreeSet<String>> = names
+        .iter()
+        .map(|name| BTreeSet::from([name.clone()]))
+        .collect();
+    let effective = propagate_sets(&graph, seeds);
+    Ok(names.into_iter().zip(effective).collect())
+}
+
+/// Propagate ordered fact sets through a directed graph after condensing every
+/// legal cycle into one strongly connected component.
+fn propagate_sets<T: Clone + Ord>(
+    graph: &[BTreeSet<usize>],
+    seeds: Vec<BTreeSet<T>>,
+) -> Vec<BTreeSet<T>> {
+    debug_assert_eq!(graph.len(), seeds.len());
+    if graph.is_empty() {
+        return Vec::new();
+    }
+    let components = strongly_connected_components(graph);
+    let component_count = components.iter().copied().max().map_or(0, |max| max + 1);
+    let mut values = vec![BTreeSet::new(); component_count];
+    for (node, facts) in seeds.into_iter().enumerate() {
+        values[components[node]].extend(facts);
+    }
+
+    let mut dag = vec![BTreeSet::new(); component_count];
+    let mut indegree = vec![0_usize; component_count];
+    for (source, destinations) in graph.iter().enumerate() {
+        let source_component = components[source];
+        for &destination in destinations {
+            let destination_component = components[destination];
+            if source_component != destination_component
+                && dag[source_component].insert(destination_component)
+            {
+                indegree[destination_component] += 1;
+            }
+        }
+    }
+
+    let mut ready: BTreeSet<usize> = indegree
+        .iter()
+        .enumerate()
+        .filter_map(|(component, &degree)| (degree == 0).then_some(component))
+        .collect();
+    let mut visited = 0_usize;
+    while let Some(component) = ready.pop_first() {
+        visited += 1;
+        let inherited = values[component].clone();
+        for &destination in &dag[component] {
+            values[destination].extend(inherited.iter().cloned());
+            indegree[destination] -= 1;
+            if indegree[destination] == 0 {
+                ready.insert(destination);
+            }
+        }
+    }
+    debug_assert_eq!(visited, component_count, "component graph is acyclic");
+    components
+        .into_iter()
+        .map(|component| values[component].clone())
+        .collect()
+}
+
+/// Iterative Kosaraju decomposition. Iteration avoids recursion depth depending
+/// on caller graph shape; lexical node/edge order keeps component assignment
+/// deterministic even though only membership affects semantics.
+fn strongly_connected_components(graph: &[BTreeSet<usize>]) -> Vec<usize> {
+    let mut seen = vec![false; graph.len()];
+    let mut finish = Vec::with_capacity(graph.len());
+    for root in 0..graph.len() {
+        if seen[root] {
+            continue;
+        }
+        seen[root] = true;
+        let mut stack = vec![(root, graph[root].iter())];
+        while let Some((node, edges)) = stack.last_mut() {
+            if let Some(&next) = edges.next() {
+                if !seen[next] {
+                    seen[next] = true;
+                    stack.push((next, graph[next].iter()));
+                }
+            } else {
+                finish.push(*node);
+                stack.pop();
+            }
+        }
+    }
+
+    let mut reverse = vec![BTreeSet::new(); graph.len()];
+    for (source, destinations) in graph.iter().enumerate() {
+        for &destination in destinations {
+            reverse[destination].insert(source);
+        }
+    }
+    let mut components = vec![usize::MAX; graph.len()];
+    let mut component = 0_usize;
+    while let Some(root) = finish.pop() {
+        if components[root] != usize::MAX {
+            continue;
+        }
+        components[root] = component;
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            for &next in reverse[node].iter().rev() {
+                if components[next] == usize::MAX {
+                    components[next] = component;
+                    stack.push(next);
+                }
+            }
+        }
+        component += 1;
+    }
+    components
+}
+
+fn assemble_surface(
+    request: &SchemaCompileRequest<'_>,
+    properties: BTreeMap<String, PropertyFacts>,
+    shape_classes: &BTreeMap<String, ShapeClassInfo>,
+    explicit_classes: BTreeSet<String>,
+    supertypes: &BTreeMap<String, BTreeSet<String>>,
+) -> Result<SchemaSurface, SchemaCompileError> {
+    let eligible_classes: Vec<String> = explicit_classes
+        .into_iter()
+        .filter(|class| request.namespaces().is_caller_owned(class))
+        .collect();
+    let shaped_classes: BTreeSet<String> = shape_classes.keys().cloned().collect();
+    let represented_classes: BTreeSet<String> = match request.mode() {
+        SchemaSurfaceMode::ShapedOnly => shaped_classes.clone(),
+        SchemaSurfaceMode::OntologyComplete => eligible_classes
+            .iter()
+            .cloned()
+            .chain(shaped_classes.iter().cloned())
+            .collect(),
+    };
+    enforce_limit("classes", represented_classes.len(), MAX_SCHEMA_CLASSES)?;
+
+    let mut classes: BTreeMap<String, SurfaceClass> = represented_classes
+        .iter()
+        .map(|class| {
+            (
+                class.clone(),
+                SurfaceClass {
+                    synthesized_open: !shaped_classes.contains(class),
+                    properties: BTreeMap::new(),
+                },
+            )
+        })
+        .collect();
+    let mut report_properties = Vec::with_capacity(properties.len());
+    let potential_cells = properties.len().saturating_mul(eligible_classes.len());
+    enforce_limit(
+        "class/property coverage cells",
+        potential_cells,
+        MAX_SCHEMA_RELATIONS,
+    )?;
+
+    for (property_iri, facts) in properties {
+        let kind = facts.kind(&property_iri)?;
+        let mut class_rows = Vec::new();
+        let mut outcomes = BTreeSet::new();
+        let base_provenance: Vec<SchemaCoverageProvenance> = facts
+            .provenance
+            .iter()
+            .chain(facts.domains.iter().map(|domain| &domain.provenance))
+            .chain(facts.ranges.iter().map(|range| &range.provenance))
+            .chain(facts.functional.iter())
+            .cloned()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+
+        for class_iri in &eligible_classes {
+            let shape_info = shape_classes.get(class_iri);
+            let has_shape = shape_info
+                .is_some_and(|info| info.direct_properties.contains(property_iri.as_str()));
+            let (status, precision) = if has_shape {
+                (
+                    SchemaCoverageStatus::HasShape,
+                    SchemaCoveragePrecision::Exact,
+                )
+            } else if request.mode() == SchemaSurfaceMode::ShapedOnly {
+                (
+                    SchemaCoverageStatus::ExcludedShapedOnly,
+                    SchemaCoveragePrecision::Exact,
+                )
+            } else if !request.namespaces().is_caller_owned(&property_iri) {
+                (
+                    SchemaCoverageStatus::ExcludedNamespace,
+                    SchemaCoveragePrecision::Exact,
+                )
+            } else if !facts.domains.iter().all(|domain| {
+                supertypes
+                    .get(class_iri)
+                    .is_some_and(|types| domain.expression.matches_class(types))
+            }) {
+                (
+                    SchemaCoverageStatus::ExcludedDomain,
+                    SchemaCoveragePrecision::Exact,
+                )
+            } else if shape_info.is_some_and(|info| !info.closed_allows(&property_iri)) {
+                (
+                    SchemaCoverageStatus::ExcludedClosedShape,
+                    SchemaCoveragePrecision::Exact,
+                )
+            } else {
+                let precision = if facts.functional.is_empty() {
+                    SchemaCoveragePrecision::Exact
+                } else {
+                    SchemaCoveragePrecision::RepresentationApproximation
+                };
+                let class = classes
+                    .get_mut(class_iri)
+                    .expect("eligible complete-mode class has a surface entry");
+                class.properties.insert(
+                    property_iri.clone(),
+                    SurfaceProperty {
+                        iri: property_iri.clone(),
+                        kind,
+                        ranges: facts
+                            .ranges
+                            .iter()
+                            .map(|range| range.expression.clone())
+                            .collect(),
+                        functional: !facts.functional.is_empty(),
+                        provenance: base_provenance.clone(),
+                    },
+                );
+                (SchemaCoverageStatus::IncludedUnshaped, precision)
+            };
+            outcomes.insert(status);
+            class_rows.push(SchemaClassPropertyCoverage {
+                class_iri: class_iri.clone(),
+                synthesized_open_class: classes
+                    .get(class_iri)
+                    .is_some_and(|class| class.synthesized_open),
+                status,
+                precision,
+                provenance: base_provenance.clone(),
+            });
+        }
+
+        // A shaped class may intentionally live outside the caller-owned
+        // ontology boundary; retain its direct-shape audit row because legacy
+        // compilation still emits it.
+        for class_iri in
+            shaped_classes.difference(&eligible_classes.iter().cloned().collect::<BTreeSet<_>>())
+        {
+            if shape_classes[class_iri]
+                .direct_properties
+                .contains(&property_iri)
+            {
+                outcomes.insert(SchemaCoverageStatus::HasShape);
+                class_rows.push(SchemaClassPropertyCoverage {
+                    class_iri: class_iri.clone(),
+                    synthesized_open_class: false,
+                    status: SchemaCoverageStatus::HasShape,
+                    precision: SchemaCoveragePrecision::Exact,
+                    provenance: base_provenance.clone(),
+                });
+            }
+        }
+        if outcomes.is_empty() {
+            outcomes.insert(if !request.namespaces().is_caller_owned(&property_iri) {
+                SchemaCoverageStatus::ExcludedNamespace
+            } else if request.mode() == SchemaSurfaceMode::ShapedOnly {
+                SchemaCoverageStatus::ExcludedShapedOnly
+            } else {
+                SchemaCoverageStatus::ExcludedDomain
+            });
+        }
+        class_rows.sort_by(|left, right| left.class_iri.cmp(&right.class_iri));
+        report_properties.push(SchemaPropertyCoverage {
+            property_iri,
+            declarations: facts.declarations.into_iter().collect(),
+            outcomes: outcomes.into_iter().collect(),
+            classes: class_rows,
+        });
+    }
+
+    let surface = SchemaSurface {
+        classes,
+        report: SchemaCoverageReport {
+            mode: request.mode(),
+            properties: report_properties,
+        },
+    };
+    surface.assert_conservation();
+    Ok(surface)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::json_schema::Namespaces;
+    use crate::shapes::from_dataset;
+
+    const PREFIXES: &str = r"
+        @prefix ex: <https://example.org/schema/> .
+        @prefix ext: <https://external.example/vocab/> .
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    ";
+
+    fn namespaces() -> Namespaces {
+        Namespaces::new(
+            "ex",
+            &[("ex".to_owned(), "https://example.org/schema/".to_owned())],
+        )
+        .expect("test namespace")
+    }
+
+    fn surface(
+        shapes_body: &str,
+        ontology_body: &str,
+        mode: SchemaSurfaceMode,
+    ) -> Result<SchemaSurface, SchemaCompileError> {
+        let shape_dataset =
+            crate::text_ingest::parse_turtle_to_dataset(&format!("{PREFIXES}{shapes_body}"))
+                .expect("shape Turtle");
+        let shapes = from_dataset(&shape_dataset).expect("shape graph");
+        let ontology =
+            crate::text_ingest::parse_turtle_to_dataset(&format!("{PREFIXES}{ontology_body}"))
+                .expect("ontology Turtle");
+        build(&SchemaCompileRequest::new(
+            &shapes,
+            &namespaces(),
+            ontology.as_ref(),
+            mode,
+        ))
+    }
+
+    fn property<'a>(surface: &'a SchemaSurface, iri: &str) -> &'a SchemaPropertyCoverage {
+        surface
+            .report
+            .properties
+            .iter()
+            .find(|property| property.property_iri == iri)
+            .expect("catalogued property")
+    }
+
+    fn class_status(
+        surface: &SchemaSurface,
+        property_iri: &str,
+        class_iri: &str,
+    ) -> SchemaCoverageStatus {
+        property(surface, property_iri)
+            .classes
+            .iter()
+            .find(|row| row.class_iri == class_iri)
+            .expect("class coverage row")
+            .status
+    }
+
+    #[test]
+    fn full_surface_catalogs_only_schema_properties_and_applies_domains() {
+        let surface = surface(
+            r"
+                ex:PersonShape a sh:NodeShape ;
+                    sh:targetClass ex:Person ;
+                    sh:property [ sh:path ex:name ; sh:datatype xsd:string ] .
+            ",
+            r#"
+                ex:Agent a owl:Class .
+                ex:Person a owl:Class ; rdfs:subClassOf ex:Agent .
+                ex:Message a owl:Class .
+
+                ex:resentDate a owl:DatatypeProperty ;
+                    rdfs:domain ex:Message ; rdfs:range xsd:dateTime .
+                ex:identifier a owl:DatatypeProperty, owl:FunctionalProperty ;
+                    rdfs:domain ex:Agent ; rdfs:range rdfs:Literal .
+                ex:tag a rdf:Property .
+                ext:externalOnly a owl:DatatypeProperty ; rdfs:range xsd:string .
+
+                ex:instance ex:incidental "not a declaration" .
+            "#,
+            SchemaSurfaceMode::OntologyComplete,
+        )
+        .expect("complete surface");
+
+        let catalog: BTreeSet<&str> = surface
+            .report
+            .properties
+            .iter()
+            .map(|property| property.property_iri.as_str())
+            .collect();
+        assert!(catalog.contains("https://example.org/schema/resentDate"));
+        assert!(catalog.contains("https://example.org/schema/identifier"));
+        assert!(catalog.contains("https://example.org/schema/tag"));
+        assert!(catalog.contains("https://example.org/schema/name"));
+        assert!(catalog.contains("https://external.example/vocab/externalOnly"));
+        assert!(!catalog.contains("https://example.org/schema/incidental"));
+
+        assert_eq!(
+            class_status(
+                &surface,
+                "https://example.org/schema/resentDate",
+                "https://example.org/schema/Message"
+            ),
+            SchemaCoverageStatus::IncludedUnshaped
+        );
+        assert_eq!(
+            class_status(
+                &surface,
+                "https://example.org/schema/resentDate",
+                "https://example.org/schema/Person"
+            ),
+            SchemaCoverageStatus::ExcludedDomain
+        );
+        assert_eq!(
+            class_status(
+                &surface,
+                "https://example.org/schema/identifier",
+                "https://example.org/schema/Person"
+            ),
+            SchemaCoverageStatus::IncludedUnshaped,
+            "subclasses satisfy inherited domain membership"
+        );
+        assert_eq!(
+            class_status(
+                &surface,
+                "https://example.org/schema/name",
+                "https://example.org/schema/Person"
+            ),
+            SchemaCoverageStatus::HasShape
+        );
+        assert_eq!(
+            property(&surface, "https://external.example/vocab/externalOnly").outcomes,
+            vec![SchemaCoverageStatus::ExcludedNamespace]
+        );
+
+        assert!(!surface.classes["https://example.org/schema/Person"].synthesized_open);
+        assert!(surface.classes["https://example.org/schema/Agent"].synthesized_open);
+        assert!(surface.classes["https://example.org/schema/Message"].synthesized_open);
+        let identifier = &surface.classes["https://example.org/schema/Person"].properties["https://example.org/schema/identifier"];
+        assert!(identifier.functional);
+        assert_eq!(identifier.kind, OntologyPropertyKind::Datatype);
+    }
+
+    #[test]
+    fn shaped_only_reports_exclusion_and_creates_no_carrier_classes() {
+        let surface = surface(
+            r"
+                ex:PersonShape a sh:NodeShape ; sh:targetClass ex:Person ;
+                    sh:property [ sh:path ex:name ] .
+            ",
+            r"
+                ex:Person a owl:Class .
+                ex:Message a owl:Class .
+                ex:resentMessageId a owl:DatatypeProperty ;
+                    rdfs:domain ex:Message ; rdfs:range rdfs:Literal .
+            ",
+            SchemaSurfaceMode::ShapedOnly,
+        )
+        .expect("shaped surface");
+        assert_eq!(
+            surface.classes.keys().cloned().collect::<Vec<_>>(),
+            vec!["https://example.org/schema/Person"]
+        );
+        assert_eq!(
+            property(&surface, "https://example.org/schema/resentMessageId").outcomes,
+            vec![SchemaCoverageStatus::ExcludedShapedOnly]
+        );
+    }
+
+    #[test]
+    fn closed_shape_excludes_unshaped_property_but_ignored_property_is_admitted() {
+        let surface = surface(
+            r"
+                ex:PersonShape a sh:NodeShape ; sh:targetClass ex:Person ;
+                    sh:closed true ; sh:ignoredProperties ( ex:allowed ) ;
+                    sh:property [ sh:path ex:name ] .
+            ",
+            r"
+                ex:Person a owl:Class .
+                ex:blocked a owl:DatatypeProperty ; rdfs:domain ex:Person .
+                ex:allowed a owl:DatatypeProperty ; rdfs:domain ex:Person .
+            ",
+            SchemaSurfaceMode::OntologyComplete,
+        )
+        .expect("closed surface");
+        assert_eq!(
+            class_status(
+                &surface,
+                "https://example.org/schema/blocked",
+                "https://example.org/schema/Person"
+            ),
+            SchemaCoverageStatus::ExcludedClosedShape
+        );
+        assert_eq!(
+            class_status(
+                &surface,
+                "https://example.org/schema/allowed",
+                "https://example.org/schema/Person"
+            ),
+            SchemaCoverageStatus::IncludedUnshaped
+        );
+    }
+
+    #[test]
+    fn subproperty_equivalence_and_inverse_propagate_in_defined_directions() {
+        let surface = surface(
+            "",
+            r"
+                ex:Agent a owl:Class .
+                ex:Document a owl:Class .
+                ex:parent a owl:ObjectProperty, owl:FunctionalProperty ;
+                    rdfs:domain ex:Agent ; rdfs:range ex:Document .
+                ex:child a owl:ObjectProperty ; rdfs:subPropertyOf ex:parent .
+                ex:alias a owl:ObjectProperty ; owl:equivalentProperty ex:child .
+                ex:inverse a owl:ObjectProperty ; owl:inverseOf ex:parent .
+                ex:reverseUnique a owl:InverseFunctionalProperty ;
+                    rdfs:domain ex:Agent ; rdfs:range ex:Document .
+            ",
+            SchemaSurfaceMode::OntologyComplete,
+        )
+        .expect("relation surface");
+        for property_iri in [
+            "https://example.org/schema/parent",
+            "https://example.org/schema/child",
+            "https://example.org/schema/alias",
+        ] {
+            assert!(
+                surface.classes["https://example.org/schema/Agent"].properties[property_iri]
+                    .functional
+            );
+        }
+        assert!(
+            surface.classes["https://example.org/schema/Document"]
+                .properties
+                .contains_key("https://example.org/schema/inverse"),
+            "inverse swaps the parent's range into its domain"
+        );
+        assert!(
+            !surface.classes["https://example.org/schema/Agent"].properties
+                ["https://example.org/schema/reverseUnique"]
+                .functional,
+            "inverse-functional does not select a scalar value representation"
+        );
+    }
+
+    #[test]
+    fn multiple_domains_are_conjunctive_and_union_domain_is_disjunctive() {
+        let surface = surface(
+            "",
+            r"
+                ex:A a owl:Class .
+                ex:B a owl:Class .
+                ex:AB a owl:Class ; rdfs:subClassOf ex:A, ex:B .
+                ex:both a rdf:Property ; rdfs:domain ex:A, ex:B .
+                ex:either a rdf:Property ; rdfs:domain [
+                    owl:unionOf ( ex:A ex:B )
+                ] .
+            ",
+            SchemaSurfaceMode::OntologyComplete,
+        )
+        .expect("expression surface");
+        assert_eq!(
+            class_status(
+                &surface,
+                "https://example.org/schema/both",
+                "https://example.org/schema/A"
+            ),
+            SchemaCoverageStatus::ExcludedDomain
+        );
+        assert_eq!(
+            class_status(
+                &surface,
+                "https://example.org/schema/both",
+                "https://example.org/schema/AB"
+            ),
+            SchemaCoverageStatus::IncludedUnshaped
+        );
+        for class in ["A", "B", "AB"] {
+            assert_eq!(
+                class_status(
+                    &surface,
+                    "https://example.org/schema/either",
+                    &format!("https://example.org/schema/{class}")
+                ),
+                SchemaCoverageStatus::IncludedUnshaped
+            );
+        }
+    }
+
+    #[test]
+    fn hierarchy_cycles_are_legal_and_preserve_domain_membership() {
+        let surface = surface(
+            "",
+            r"
+                ex:A a owl:Class ; rdfs:subClassOf ex:B .
+                ex:B a owl:Class ; rdfs:subClassOf ex:A .
+                ex:p a rdf:Property ; rdfs:domain ex:A .
+            ",
+            SchemaSurfaceMode::OntologyComplete,
+        )
+        .expect("cyclic hierarchy");
+        assert_eq!(
+            class_status(
+                &surface,
+                "https://example.org/schema/p",
+                "https://example.org/schema/B"
+            ),
+            SchemaCoverageStatus::IncludedUnshaped
+        );
+    }
+
+    #[test]
+    fn malformed_and_cyclic_expression_lists_fail_with_typed_errors() {
+        let malformed = surface(
+            "",
+            r"
+                ex:p a rdf:Property ; rdfs:domain [ owl:unionOf _:list ] .
+                _:list rdf:first ex:A ; rdf:first ex:B ; rdf:rest rdf:nil .
+            ",
+            SchemaSurfaceMode::OntologyComplete,
+        )
+        .expect_err("multiple rdf:first values must fail");
+        assert!(matches!(
+            malformed,
+            SchemaCompileError::InvalidOntology { .. }
+        ));
+
+        let cyclic = surface(
+            "",
+            r"
+                ex:p a rdf:Property ; rdfs:domain [ owl:intersectionOf _:list ] .
+                _:list rdf:first ex:A ; rdf:rest _:tail .
+                _:tail rdf:first ex:B ; rdf:rest _:list .
+            ",
+            SchemaSurfaceMode::OntologyComplete,
+        )
+        .expect_err("cyclic RDF list must fail");
+        assert!(matches!(cyclic, SchemaCompileError::InvalidOntology { .. }));
+    }
+
+    #[test]
+    fn incompatible_property_kind_and_range_fail_with_typed_error() {
+        let error = surface(
+            "",
+            r"
+                ex:Person a owl:Class .
+                ex:p a owl:DatatypeProperty ; rdfs:range ex:Person .
+            ",
+            SchemaSurfaceMode::OntologyComplete,
+        )
+        .expect_err("datatype property with class range must fail");
+        assert!(matches!(
+            error,
+            SchemaCompileError::InvalidOntology { subject, .. }
+                if subject == "https://example.org/schema/p"
+        ));
+    }
+
+    #[test]
+    fn report_and_surface_are_permutation_deterministic_and_conservative() {
+        let first = surface(
+            "",
+            r"
+                ex:C a owl:Class .
+                ex:b a owl:DatatypeProperty ; rdfs:domain ex:C ; rdfs:range xsd:string .
+                ex:a a owl:DatatypeProperty ; rdfs:domain ex:C ; rdfs:range xsd:dateTime .
+            ",
+            SchemaSurfaceMode::OntologyComplete,
+        )
+        .expect("first surface");
+        let second = surface(
+            "",
+            r"
+                ex:a rdfs:range xsd:dateTime ; rdfs:domain ex:C ; a owl:DatatypeProperty .
+                ex:b rdfs:range xsd:string ; a owl:DatatypeProperty ; rdfs:domain ex:C .
+                ex:C a owl:Class .
+            ",
+            SchemaSurfaceMode::OntologyComplete,
+        )
+        .expect("permuted surface");
+        assert_eq!(first.report.to_json(), second.report.to_json());
+        let catalog: Vec<&str> = first
+            .report
+            .properties
+            .iter()
+            .map(|property| property.property_iri.as_str())
+            .collect();
+        assert_eq!(
+            catalog.len(),
+            catalog.iter().copied().collect::<BTreeSet<_>>().len()
+        );
+        assert_eq!(first.classes.len(), second.classes.len());
+    }
+}

--- a/crates/shapes/src/schema_surface.rs
+++ b/crates/shapes/src/schema_surface.rs
@@ -245,8 +245,10 @@ type ObjectIndex = BTreeMap<String, BTreeMap<String, Vec<Term>>>;
 #[derive(Debug, Clone)]
 struct TripleRow {
     subject: Term,
+    subject_key: String,
     predicate: String,
     object: Term,
+    object_key: String,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -270,11 +272,10 @@ pub(crate) fn build(
     let mut rows = dataset_rows(request.ontology());
     rows.extend(dataset_rows(request.shapes().shapes_dataset.as_ref()));
     rows.sort_by(|left, right| {
-        left.subject
-            .to_string()
-            .cmp(&right.subject.to_string())
+        left.subject_key
+            .cmp(&right.subject_key)
             .then_with(|| left.predicate.cmp(&right.predicate))
-            .then_with(|| left.object.to_string().cmp(&right.object.to_string()))
+            .then_with(|| left.object_key.cmp(&right.object_key))
     });
     rows.dedup_by(|left, right| {
         left.subject == right.subject
@@ -457,10 +458,16 @@ pub(crate) fn build(
 fn dataset_rows(dataset: &RdfDataset) -> Vec<TripleRow> {
     native_quads(dataset, None, None, None, GraphFilter::AnyGraph)
         .into_iter()
-        .map(|(subject, predicate, object)| TripleRow {
-            subject,
-            predicate: predicate.into_string(),
-            object,
+        .map(|(subject, predicate, object)| {
+            let subject_key = subject.to_string();
+            let object_key = object.to_string();
+            TripleRow {
+                subject,
+                subject_key,
+                predicate: predicate.into_string(),
+                object,
+                object_key,
+            }
         })
         .collect()
 }
@@ -469,7 +476,7 @@ fn object_index(rows: &[TripleRow]) -> ObjectIndex {
     let mut index: ObjectIndex = BTreeMap::new();
     for row in rows {
         index
-            .entry(row.subject.to_string())
+            .entry(row.subject_key.clone())
             .or_default()
             .entry(row.predicate.clone())
             .or_default()

--- a/crates/shapes/tests/ontology_schema_surface.rs
+++ b/crates/shapes/tests/ontology_schema_surface.rs
@@ -100,6 +100,15 @@ fn pydantic_config() -> PydanticConfig {
     .expect("Pydantic config")
 }
 
+fn generated_definition_block<'a>(source: &'a str, start: &str, next: &str) -> &'a str {
+    let offset = source.find(start).expect("generated definition start");
+    let tail = &source[offset..];
+    let end = tail[start.len()..]
+        .find(next)
+        .map_or(tail.len(), |next_offset| start.len() + next_offset);
+    &tail[..end]
+}
+
 #[test]
 fn ontology_property_surface_reaches_every_language_emitter() {
     let compilation = compiled_surface();
@@ -120,24 +129,32 @@ fn ontology_property_surface_reaches_every_language_emitter() {
     let typescript = emit_typescript(compiled, &typescript_config()).expect("TypeScript emission");
     let declarations = std::str::from_utf8(&typescript.artifacts[TYPESCRIPT_DECLARATION_PATH])
         .expect("UTF-8 TypeScript");
-    assert!(declarations.contains("ex:resentDate"));
-    assert!(declarations.contains("ex:resentMessageId"));
+    let email_type = &typescript.type_names["EmailMessage"];
+    let email_declaration = generated_definition_block(
+        declarations,
+        &format!("export type {email_type} = "),
+        "\nexport type ",
+    );
+    assert!(email_declaration.contains("ex:resentDate"));
+    assert!(email_declaration.contains("ex:resentMessageId"));
 
     let graphql = emit_graphql(compiled, &graphql_config()).expect("GraphQL emission");
     assert!(graphql.artifacts[GRAPHQL_SCHEMA_PATH].is_ascii());
-    assert!(graphql.names.fields.values().any(|fields| {
-        fields.contains_key("ex:resentDate") && fields.contains_key("ex:resentMessageId")
-    }));
+    let email_fields = &graphql.names.fields["#/$defs/EmailMessage"];
+    assert!(email_fields.contains_key("ex:resentDate"));
+    assert!(email_fields.contains_key("ex:resentMessageId"));
 
     let pydantic = emit_pydantic(compiled, &pydantic_config()).expect("Pydantic emission");
-    let python = pydantic
-        .artifacts
-        .values()
-        .filter_map(|artifact| std::str::from_utf8(artifact).ok())
-        .collect::<Vec<_>>()
-        .join("\n");
-    assert!(python.contains("ex:resentDate"));
-    assert!(python.contains("ex:resentMessageId"));
+    let models = std::str::from_utf8(&pydantic.artifacts["example_ontology/models.py"])
+        .expect("UTF-8 Pydantic models");
+    let email_model = pydantic.model_paths["EmailMessage"]
+        .rsplit('.')
+        .next()
+        .expect("generated model name");
+    let email_model =
+        generated_definition_block(models, &format!("class {email_model}("), "\nclass ");
+    assert!(email_model.contains("alias=\"ex:resentDate\""));
+    assert!(email_model.contains("alias=\"ex:resentMessageId\""));
 
     assert_eq!(
         compilation.coverage.properties.len(),

--- a/crates/shapes/tests/ontology_schema_surface.rs
+++ b/crates/shapes/tests/ontology_schema_surface.rs
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Cross-emitter proofs for ontology-complete developer-schema surfaces.
+
+use std::collections::BTreeMap;
+
+use purrdf_shapes::json_schema::{
+    Namespaces, SchemaCompileRequest, SchemaSurfaceMode, compile_schema,
+};
+use purrdf_shapes::shapes::from_dataset;
+use purrdf_shapes::{
+    GRAPHQL_SCHEMA_PATH, GraphqlConfig, LinkmlConfig, PydanticConfig, TYPESCRIPT_DECLARATION_PATH,
+    TypeScriptConfig, emit_graphql, emit_linkml, emit_pydantic, emit_typescript,
+};
+
+const PREFIXES: &str = r"
+    @prefix ex: <https://example.org/schema/> .
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+";
+
+fn compiled_surface() -> purrdf_shapes::SchemaCompilation {
+    let shapes_dataset = purrdf_shapes::text_ingest::parse_turtle_to_dataset(&format!(
+        "{PREFIXES}
+        ex:PersonShape a sh:NodeShape ; sh:targetClass ex:Person ;
+            sh:property [ sh:path ex:name ; sh:minCount 1 ; sh:datatype xsd:string ] ."
+    ))
+    .expect("shapes Turtle");
+    let shapes = from_dataset(&shapes_dataset).expect("shapes graph");
+    let ontology = purrdf_shapes::text_ingest::parse_turtle_to_dataset(&format!(
+        "{PREFIXES}
+        ex:Person a owl:Class .
+        ex:EmailMessage a owl:Class .
+        ex:name a owl:DatatypeProperty ; rdfs:domain ex:Person ; rdfs:range rdfs:Literal .
+        ex:resentDate a owl:DatatypeProperty ;
+            rdfs:domain ex:EmailMessage ; rdfs:range xsd:dateTime .
+        ex:resentMessageId a owl:DatatypeProperty ;
+            rdfs:domain ex:EmailMessage ; rdfs:range rdfs:Literal .
+        ex:latestMessage a owl:ObjectProperty ;
+            rdfs:domain ex:Person ; rdfs:range ex:EmailMessage ."
+    ))
+    .expect("ontology Turtle");
+    let namespaces = Namespaces::new(
+        "ex",
+        &[("ex".to_owned(), "https://example.org/schema/".to_owned())],
+    )
+    .expect("namespace config");
+    compile_schema(&SchemaCompileRequest::new(
+        &shapes,
+        &namespaces,
+        ontology.as_ref(),
+        SchemaSurfaceMode::OntologyComplete,
+    ))
+    .expect("ontology-complete compilation")
+}
+
+fn linkml_config() -> LinkmlConfig {
+    LinkmlConfig::new(
+        "https://example.org/schema/generated",
+        "ExampleSchema",
+        "Example ontology-complete schema.",
+        "ex",
+        BTreeMap::from([
+            ("ex".to_owned(), "https://example.org/schema/".to_owned()),
+            ("linkml".to_owned(), "https://w3id.org/linkml/".to_owned()),
+        ]),
+    )
+    .expect("LinkML config")
+}
+
+fn typescript_config() -> TypeScriptConfig {
+    TypeScriptConfig::new(
+        "example-ontology-types",
+        "Example ontology package.",
+        "Example ontology declarations.",
+    )
+    .expect("TypeScript config")
+}
+
+fn graphql_config() -> GraphqlConfig {
+    GraphqlConfig::new(
+        "ExampleOntology",
+        "Example GraphQL package.",
+        "Example GraphQL module.",
+        "RdfValue",
+    )
+    .expect("GraphQL config")
+}
+
+fn pydantic_config() -> PydanticConfig {
+    PydanticConfig::new(
+        "example_ontology",
+        "Example Pydantic package.",
+        "Example Pydantic models.",
+    )
+    .expect("Pydantic config")
+}
+
+#[test]
+fn ontology_property_surface_reaches_every_language_emitter() {
+    let compilation = compiled_surface();
+    let compiled = &compilation.compiled;
+
+    let linkml = emit_linkml(compiled, &linkml_config()).expect("LinkML emission");
+    let linkml_classes = &linkml.document.as_value()["classes"];
+    assert!(linkml_classes["EmailMessage"].is_object());
+    assert!(
+        linkml_classes["EmailMessage"]["attributes"]["ex:resentDate"].is_object(),
+        "LinkML must retain the ontology-only resentDate attribute"
+    );
+    assert!(
+        linkml_classes["EmailMessage"]["attributes"]["ex:resentMessageId"].is_object(),
+        "LinkML must retain the ontology-only resentMessageId attribute"
+    );
+
+    let typescript = emit_typescript(compiled, &typescript_config()).expect("TypeScript emission");
+    let declarations = std::str::from_utf8(&typescript.artifacts[TYPESCRIPT_DECLARATION_PATH])
+        .expect("UTF-8 TypeScript");
+    assert!(declarations.contains("ex:resentDate"));
+    assert!(declarations.contains("ex:resentMessageId"));
+
+    let graphql = emit_graphql(compiled, &graphql_config()).expect("GraphQL emission");
+    assert!(graphql.artifacts[GRAPHQL_SCHEMA_PATH].is_ascii());
+    assert!(graphql.names.fields.values().any(|fields| {
+        fields.contains_key("ex:resentDate") && fields.contains_key("ex:resentMessageId")
+    }));
+
+    let pydantic = emit_pydantic(compiled, &pydantic_config()).expect("Pydantic emission");
+    let python = pydantic
+        .artifacts
+        .values()
+        .filter_map(|artifact| std::str::from_utf8(artifact).ok())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(python.contains("ex:resentDate"));
+    assert!(python.contains("ex:resentMessageId"));
+
+    assert_eq!(
+        compilation.coverage.properties.len(),
+        compilation
+            .coverage
+            .properties
+            .iter()
+            .map(|property| property.property_iri.as_str())
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        "coverage catalog has one aggregate row per property"
+    );
+}
+
+#[test]
+fn all_language_emitter_outputs_are_byte_deterministic() {
+    let first = compiled_surface();
+    let second = compiled_surface();
+    assert_eq!(first.compiled.schema_json, second.compiled.schema_json);
+    assert_eq!(first.compiled.openapi_json, second.compiled.openapi_json);
+    assert_eq!(first.coverage.to_json(), second.coverage.to_json());
+    assert_eq!(first.key, second.key);
+    assert_eq!(
+        emit_linkml(&first.compiled, &linkml_config()).expect("first LinkML"),
+        emit_linkml(&second.compiled, &linkml_config()).expect("second LinkML")
+    );
+    assert_eq!(
+        emit_typescript(&first.compiled, &typescript_config()).expect("first TypeScript"),
+        emit_typescript(&second.compiled, &typescript_config()).expect("second TypeScript")
+    );
+    assert_eq!(
+        emit_graphql(&first.compiled, &graphql_config()).expect("first GraphQL"),
+        emit_graphql(&second.compiled, &graphql_config()).expect("second GraphQL")
+    );
+    assert_eq!(
+        emit_pydantic(&first.compiled, &pydantic_config()).expect("first Pydantic"),
+        emit_pydantic(&second.compiled, &pydantic_config()).expect("second Pydantic")
+    );
+}

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -57,6 +57,8 @@ They live under `crates/*/benches/`:
   `SERVICE ?g` evaluated as a LATERAL join vs. a fixed-IRI `SERVICE <ep>`.
 - `crates/shapes/benches/validate.rs` — SHACL validation plus JSON Schema and
   LinkML import/lowering throughput and one-operation allocation traffic.
+- `crates/shapes/benches/schema_surface.rs` — complete ontology-aware schema
+  compilation for shaped-only, sparse, and dense property surfaces.
 - `crates/entail/benches/chase.rs` — RDFS forward-materialization chase scaling.
 - `crates/gts/benches/authoring.rs` — GTS container authoring.
 - `crates/rdf-wasm/benches/query_engine_reuse.rs` — package-root
@@ -90,6 +92,7 @@ Additional benches are run package-by-package, e.g.
 | `crates/sparql-eval/benches/exists_decorrelation.rs` | `FILTER NOT EXISTS` inner-pattern re-evaluation and index-rebuild cost with/without memoization. |
 | `crates/sparql-eval/benches/lateral_service.rs` | `SERVICE ?g` LATERAL substitute-and-forward cost as the number of distinct endpoint bindings grows. |
 | `crates/shapes/benches/validate.rs` | SHACL Core validation latency plus JSON Schema/LinkML → SHACL import/lowering throughput and allocation traffic on deterministic fixtures. |
+| `crates/shapes/benches/schema_surface.rs` | RDFC-keyed shaped-only compilation and sparse/dense ontology-complete class/property relation plus JSON Schema/OpenAPI emission. |
 | `crates/entail/benches/chase.rs` | RDFS semi-naive materialization scaling on subclass chains. |
 | `crates/gts/benches/authoring.rs` | GTS container authoring: append, hash, and CBOR-log construction throughput. |
 | `crates/rdf-wasm/benches/query_engine_reuse.rs` | Binding-level SELECT overhead for reused package-root `QueryEngine` instances vs. fresh construction. |
@@ -234,6 +237,24 @@ cargo bench -p purrdf-shapes --bench validate --locked -- shacl_schema_import
 cargo bench -p purrdf-shapes --bench validate --locked -- shacl_schema_import --quick
 cargo bench -p purrdf-shapes --bench validate --locked -- shacl_linkml_import
 cargo bench -p purrdf-shapes --bench validate --locked -- shacl_linkml_import --quick
+```
+
+### SHACL ontology schema surface
+
+The `shacl_schema_surface` group keeps namespace configuration and parsed RDF
+fixtures outside the timed loop. Each iteration measures the complete public
+compilation contract: RDFC-1.0 input identities, property catalog, SCC-condensed
+OWL/RDFS propagation, coverage manifest, JSON Schema, and OpenAPI. Three fixed
+fixtures distinguish 128 shaped classes with 128 properties, a sparse 256 by
+256 ontology relation, and a dense domainless 128 by 256 relation. Inputs are
+generated deterministically without RNG, time, or filesystem data.
+
+The suite is report-only and carries no latency threshold. Run its compile and
+single-sample smoke forms with:
+
+```sh
+cargo bench -p purrdf-shapes --bench schema_surface --locked --no-run
+cargo bench -p purrdf-shapes --bench schema_surface --locked -- --test
 ```
 
 ### Graph, tabular, and research-object projections

--- a/docs/book/src/validation/shacl.md
+++ b/docs/book/src/validation/shacl.md
@@ -44,6 +44,56 @@ so shapes can constrain the RDF 1.2 reifier metadata attached to statements
 draft is dated 2026-06-02. **This is not a claim of full SHACL 1.2
 conformance** — it is one draft feature, explicitly scoped and tested.
 
+## Ontology-complete developer schemas
+
+The public `compile_schema` boundary accepts a `SchemaCompileRequest` that binds
+the parsed shapes, exact ontology dataset, caller-owned `Namespaces`, and an
+explicit `SchemaSurfaceMode`. `ShapedOnly` retains the active SHACL
+target-class surface. `OntologyComplete` adds existing caller-vocabulary
+classes and optional OWL/RDFS-derived properties. The result carries JSON
+Schema draft 2020-12, OpenAPI 3.1, the normal forward loss ledger, a canonical
+property-coverage report, and a deterministic pre-compilation cache key. Its
+`CompiledSchema` feeds the LinkML, TypeScript, GraphQL, and Pydantic emitters
+without a second schema-discovery pass.
+
+The bounded theory catalogs only schema evidence: direct IRI `sh:path`, RDF/OWL
+property declarations, domain/range declarations, and both endpoints of
+subproperty, equivalent-property, and inverse-property relations. A predicate
+seen only on an instance is not promoted. Class admission is likewise explicit,
+and synthesized definitions are limited to namespaces the caller supplied;
+PurRDF does not turn builtin compaction prefixes into an ontology boundary.
+
+Subclass/equivalent-class closure determines domain membership. Multiple
+domains are conjunctive; OWL union members are alternatives and intersection
+members are conjunctive. Subproperties inherit superproperty domains, ranges,
+and forward functionality, equivalent properties propagate bidirectionally,
+and inverse properties exchange domain and range. Strongly connected cycles
+are condensed deterministically. Multiple ranges remain conjunctive in emitted
+JSON Schema; union and intersection expressions map to `anyOf` and `allOf`.
+
+Direct SHACL remains authoritative. Ontology-only fields are optional;
+`owl:FunctionalProperty` gives a scalar representation with approximation
+provenance, while inverse functionality does not. Closed shapes reject
+unshaped fields unless they are directly present or ignored. Classes without a
+target shape are emitted as open carriers, never as fabricated closed models.
+This is not ABox materialization or unrestricted OWL: property chains and
+axioms outside the fragment do not create fields.
+
+`SchemaCoverageReport` accounts for every catalogued property once, including
+exclusions, with sorted per-class outcomes and source-axiom provenance.
+`SchemaCompileRequest::coverage_report` can produce it before emission. The
+request cache key binds RDFC-1.0 identities for the shapes and ontology graphs,
+caller namespaces, mode, value-vocabulary marker, compiler/policy salts, and
+the fixed ceilings: 65,536 properties, 65,536 classes, 1,048,576 relation or
+coverage cells, and expression depth 64. Malformed OWL lists, contradictory
+property kinds/ranges, key collisions, and limit exhaustion are typed failures.
+
+Run the complete two-mode and four-emitter example with:
+
+```bash
+cargo run -p purrdf-shapes --example ontology_schema_surface --locked
+```
+
 ## Schema → SHACL imports
 
 The schema-projection surface is bidirectional. `SchemaImportConfig` requires


### PR DESCRIPTION
## Summary

- add an explicit shaped-only or ontology-complete schema compilation contract with deterministic cache identity and a complete property coverage manifest
- derive a bounded OWL/RDFS class-property surface through SCC-condensed subclass, subproperty, equivalent-property, inverse-property, domain, range, and forward-functionality propagation
- preserve direct SHACL authority, closed-shape exclusions, caller namespace ownership, typed resource limits, and open synthesized carrier classes
- feed one compiled JSON Schema/OpenAPI carrier into LinkML, TypeScript, GraphQL, and Pydantic without per-emitter property discovery
- expose the contract through the PurRDF facade and add cross-emitter proofs, scale benchmarks, an executable two-mode example, and user documentation

## Deterministic contract

SchemaCompileRequest binds the parsed shapes graph, exact ontology graph, caller-supplied Namespaces, explicit surface mode, and optional co-bound value-vocabulary marker. SchemaCompilation returns the existing CompiledSchema plus a canonical SchemaCoverageReport and a pre-compilation SchemaCompilationKey. The key folds RDFC-1.0 identities for both graphs, namespace declarations, mode, value marker, compiler and policy salts, crate version, and fixed limits.

The property catalog admits only schema evidence: direct IRI sh:path predicates, RDF/OWL property types, domain and range declarations, and both endpoints of subproperty, equivalent-property, and inverse-property relations. ABox-only predicates are not promoted. Multiple domains and ranges are conjunctive; OWL unions and intersections preserve their Boolean structure. Inverse functionality never implies scalar cardinality, while forward functionality is reported as a representation approximation.

## Compatibility and emitted bytes

Existing compile and compile_with_value_vocab entry points and the CompiledSchema layout remain source-compatible. ShapedOnly delegates to the prior emitter and remains byte-identical for equal inputs. OntologyComplete is opt-in.

One deliberate emitted-byte correction is included: multiple value-vocabulary rdfs:range axioms now emit conjunctive allOf constraints instead of selecting one lexical winner. RDF Schema defines multiple ranges conjunctively. No frozen GTS vector or generated projection changed.

## Validation

- make metadata
- make check on final commit, including full workspace tests and doctests, all-target clippy, hygiene, ring-fence checks, and all 17 wasm release crates
- make doc with rustdoc warnings denied
- make wasm-pkg-size: 6,048,309 / 6,225,000 bytes; 40,329 SIMD opcodes verified
- cargo bench -p purrdf-shapes --bench schema_surface --locked --no-run
- cargo bench -p purrdf-shapes --bench schema_surface --locked -- --test
- cargo run -p purrdf-shapes --example ontology_schema_surface --locked
- Pydantic, LinkML, TypeScript 7.0.2, and GraphQL.js 16.14.0 differential oracles
- clean worktree, remote parity 0/0, good signatures on all six commits, and clean whitespace/reference/deferral/vocabulary scans

Closes #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ontology-aware developer schema compilation with shaped-only vs ontology-complete modes.
  - Exposed a typed compilation request, deterministic cache keys, and structured coverage reporting.
  - Re-exported the full set of schema compilation/coverage types and the `compile_schema` entry point.
- **Bug Fixes**
  - Improved multi-range value-vocabulary handling with deterministic constraint generation.
- **Documentation**
  - Documented ontology-complete developer schemas, coverage behavior, and runnable examples; updated benchmark docs.
- **Tests & Benchmarks**
  - Added compile-time API reachability checks, ontology-complete multi-emitter integration tests, determinism validation, and a new schema surface benchmark.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->