### PR TITLE
shapes: make LinkML slot lowering deterministic and reversible

### DIFF
--- a/crates/purrdf/src/lib.rs
+++ b/crates/purrdf/src/lib.rs
@@ -178,6 +178,7 @@ mod tests {
     fn facade_exposes_rdf_slice_shapes_and_shex() {
         let _ = RdfDatasetBuilder::new();
         let _ = slice::rdf_query::DatasetAccumulator::new();
+        let _ = shapes::SanitizePolicy::Rename;
         let _ = shapes::report::ValidationReport {
             conforms: true,
             results: Vec::new(),

--- a/crates/rdf-core/src/loss.rs
+++ b/crates/rdf-core/src/loss.rs
@@ -1121,6 +1121,18 @@ const JSON_SCHEMA_LINKML_PROFILE: &[(&str, &str)] = &[
          validation is omitted.",
     ),
     (
+        "slot-identity-rehomed",
+        "A source JSON property token without a caller-resolvable RDF identity is assigned to a \
+         concrete URI under the caller's configured LinkML default prefix. The source token, \
+         generated slot name, and assigned identity remain explicit in the projection report.",
+    ),
+    (
+        "slot-name-policy-dropped",
+        "The caller selected LinkML slot-name skipping for a JSON property whose spelling \
+         cannot be emitted directly. The single property is omitted and its exact source \
+         location remains explicit in the projection diagnostic.",
+    ),
+    (
         "string-length-validation-dropped",
         "JSON Schema minLength/maxLength assertions have no LinkML 1.11 slot expression. The \
          string carrier and representable pattern remain, while code-point length validation is \

--- a/crates/shapes/README.md
+++ b/crates/shapes/README.md
@@ -217,8 +217,10 @@ description, default prefix, and complete prefix map; there is deliberately no
 `Default` configuration.
 
 ```rust,ignore
-use std::collections::BTreeMap;
-use purrdf_shapes::{LinkmlConfig, emit_linkml, parse_linkml, write_linkml};
+use std::collections::{BTreeMap, BTreeSet};
+use purrdf_shapes::{
+    LinkmlConfig, SanitizePolicy, emit_linkml, parse_linkml, write_linkml,
+};
 
 let config = LinkmlConfig::new(
     "https://example.org/schema/linkml",
@@ -229,7 +231,12 @@ let config = LinkmlConfig::new(
         ("ex".into(), "https://example.org/".into()),
         ("linkml".into(), "https://w3id.org/linkml/".into()),
     ]),
-)?;
+)?
+.with_sanitize_policy(SanitizePolicy::Rename)
+.with_slot_rehomes(BTreeSet::from([
+    // This exact undeclared token is caller-owned shorthand, not a custom IRI.
+    "skos:definition".to_owned(),
+]))?;
 let package = emit_linkml(&compiled_schema, &config)?;
 
 let parsed = parse_linkml(&package.yaml)?;
@@ -238,12 +245,17 @@ assert_eq!(
     package.element_names.get("Person").map(String::as_str),
     Some("Person"),
 );
+for rename in &package.slot_renames {
+    let (class, old_slot_uri, new_slot_name) = rename.audit_tuple();
+    println!("{class}: {old_slot_uri:?} -> {new_slot_name}");
+}
 ```
 
 `LinkmlPackage` returns the validated document tree, canonical YAML, a
-reversible source-`$defs`-key to LinkML-element map, and the always-computed
-`json-schema` → `linkml-1.11` loss ledger. The YAML writer sorts every mapping
-and emits exactly one trailing newline. The reader preserves every
+reversible source-`$defs`-key to LinkML-element map, ordered slot rename and
+skip-diagnostic reports, and the always-computed `json-schema` → `linkml-1.11`
+loss ledger. The YAML writer sorts every mapping and emits exactly one trailing
+newline. The reader preserves every
 JSON-compatible LinkML field, including metamodel extensions PurRDF does not
 author, while rejecting duplicate keys, YAML tags, non-string mapping keys,
 non-finite numbers, and resource-limit violations. Thus read → write and write
@@ -252,9 +264,49 @@ language-neutral boundary.
 
 `import_linkml` interprets any validated native `LinkmlDocument` through the
 shared SHACL import model. `import_linkml_package` additionally verifies that an
-emitted package's canonical YAML and reversible element map still match its
-typed document. Native metamodel annotations and schema identity are ledgered
+emitted package's canonical YAML, element map, slot reports, policy losses,
+aliases, and `slot_uri` values still agree. A declared CURIE or absolute IRI
+therefore reverses to its original predicate even when its LinkML attribute name
+was changed. Native metamodel annotations and schema identity are ledgered
 instead of being mistaken for SHACL validation terms.
+
+`LinkmlConfig::new` selects `SanitizePolicy::Rename`. The renderer plans every
+class before emitting it, so an unsafe property cannot consume an already-safe
+name and insertion order cannot change collision ownership:
+
+- `Rename` emits a deterministic caller-prefixed NCName, retains the exact
+  source spelling in `alias`, and appends a `LinkmlSlotRename`. For a declared
+  CURIE only the local spelling changes; its exact original CURIE remains in
+  `slot_uri`. Every parser-valid absolute IRI (`http`, `https`, `urn`, `did`,
+  `mailto`, or another scheme) likewise remains byte-exact in `slot_uri`.
+- `Skip` omits only the unsafe property, appends a located
+  `LinkmlSlotDiagnostic`, and records `slot-name-policy-dropped`.
+- `Fail` rejects the projection with the source class, emitted class, property,
+  and JSON Pointer.
+
+An unmatched absolute IRI uses its trailing local segment under the caller's
+default prefix only for the generated attribute name; its absolute semantic
+identity is preserved. An unsafe bare token has no pre-existing RDF identity
+and is explicitly assigned one under the caller's default prefix, recorded as
+`slot-identity-rehomed`. `with_slot_rehomes` provides the same explicit
+assignment for exact unresolved tokens such as an undeclared `skos:definition`.
+Valid custom-scheme IRIs are never guessed to be unresolved CURIEs. Hints that
+target declared prefixes or the five supported JSON-LD carriers (`@annotation`,
+`@id`, `@language`, `@type`, and `@value`) are rejected, and every configured
+hint must occur in the source.
+
+Generated-name collisions receive a fixed hash suffix and bounded ordinal
+fallback. Semantic `slot_uri` collisions fail unless the colliding identity is
+being explicitly re-homed, in which case allocation chooses another reported
+caller-default identity. Source schema bytes, source-key bytes, slots per class,
+total slots, report rows, generated-name bytes, and collision attempts all have
+fixed fail-closed limits.
+
+Code that previously rewrote `properties` and `required` keys before LinkML
+emission should remove that pre-pass. Pass the shared `CompiledSchema` unchanged,
+configure any exact semantic re-homes on `LinkmlConfig`, and use
+`package.slot_renames` as the reversible migration record. This keeps every
+other emitter on the same deterministic schema carrier.
 
 The projection grammar is:
 
@@ -263,7 +315,7 @@ The projection grammar is:
 | object `$defs` | named `classes` with caller-prefix-derived `class_uri` |
 | scalar `$defs` | named `types` |
 | string and `{"@id": ...}` enum `$defs` | named `enums` and `permissible_values` |
-| `properties` | class-scoped `attributes`; the exact JSON key remains the attribute key and `alias` |
+| `properties` | class-scoped `attributes`; safe keys remain exact, while unsafe keys use the selected policy and always retain the source key in `alias` when emitted |
 | local `$ref` | class, type, or enum `range`; class aliases use `is_a` |
 | inline object | deterministic synthesized class with `inlined: true` |
 | `required` | attribute `required` |
@@ -280,15 +332,16 @@ conditional/dependency/contains/unevaluated rules, tuple widening, string and
 property counts, exclusive and multiple-of bounds, format differences,
 non-scalar enum carriers, and a closed catch-all. Malformed values,
 external/dynamic/dangling references, inconsistent `required` declarations,
-unknown caller prefixes, reserved names, and normalized-name collisions hard
-fail instead of entering the ledger. Source SHACL → JSON Schema losses remain
-separate on `CompiledSchema::losses`.
+stale/ambiguous re-home hints, semantic identity collisions, and fixed-limit
+breaches hard fail instead of entering the ledger. Source SHACL → JSON Schema
+losses remain separate on `CompiledSchema::losses`.
 
 The production emitter has no Python dependency and remains wasm-clean. The
 dev-only oracle pins the official `linkml` and `linkml-runtime` packages to
 1.11.1, loads the emitted YAML through `SchemaDefinition` and `SchemaView`,
 regenerates JSON Schema, compares the exact fixture's `$defs` and accept/reject
-corpus, and probes every lossy family:
+corpus, verifies renamed aliases and `slot_uri` values across seven identity
+forms, checks reverse predicates, and probes every lossy family:
 
 ```bash
 make linkml-oracle

--- a/crates/shapes/benches/validate.rs
+++ b/crates/shapes/benches/validate.rs
@@ -18,8 +18,10 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 
-use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use purrdf::loss::LossLedger;
 use purrdf_shapes::engine::validate_graphs;
+use purrdf_shapes::json_schema::CompiledSchema;
 use purrdf_shapes::{
     LinkmlConfig, LinkmlDocument, Namespaces, SchemaDatatypeMap, SchemaImportConfig, emit_linkml,
     import_json_schema, import_linkml,
@@ -60,6 +62,7 @@ const IMPORT_CLASSES: usize = 128;
 const IMPORT_PROPERTIES_PER_CLASS: usize = 8;
 const LINKML: &str = "https://w3id.org/linkml/";
 const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+const LINKML_EMIT_SIZES: &[usize] = &[32, 1_024, 60_000];
 
 /// Read every `corpus/<case>/{data.nt, shapes.ttl}` pair, sorted by case name.
 fn corpus_cases() -> Vec<(String, String, String)> {
@@ -345,11 +348,160 @@ fn bench_linkml_import(c: &mut Criterion) {
     group.finish();
 }
 
+#[derive(Debug, Clone, Copy)]
+enum SlotEmissionMode {
+    Safe,
+    Rename,
+    Collision,
+}
+
+impl SlotEmissionMode {
+    const ALL: [Self; 3] = [Self::Safe, Self::Rename, Self::Collision];
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Safe => "safe",
+            Self::Rename => "rename",
+            Self::Collision => "collision",
+        }
+    }
+}
+
+fn linkml_emit_fixture(
+    slots: usize,
+    mode: SlotEmissionMode,
+) -> (CompiledSchema, LinkmlConfig, usize, usize) {
+    assert!(slots > 0, "benchmark fixture requires slots");
+    let mut properties = Map::new();
+    let mut required = Vec::new();
+    for index in 0..slots {
+        let name = match mode {
+            SlotEmissionMode::Safe => format!("ex:slot{index:05}"),
+            SlotEmissionMode::Rename => format!("ex:slot/{index:05}"),
+            SlotEmissionMode::Collision if index == 0 => "ex:collision_".to_owned(),
+            SlotEmissionMode::Collision => {
+                let scalar = u32::try_from(index).expect("benchmark index fits u32");
+                let marker = char::from_u32(0x0f_0000 + scalar)
+                    .expect("plane-15 private-use benchmark marker");
+                format!("ex:collision{marker}")
+            }
+        };
+        if index % 4 == 0 {
+            required.push(Value::String(name.clone()));
+        }
+        properties.insert(
+            name,
+            json!({
+                "type": "string",
+                "pattern": "^[A-Z]"
+            }),
+        );
+    }
+    let schema = json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "Carrier": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": properties,
+                "required": required
+            }
+        }
+    });
+    let compiled = CompiledSchema {
+        schema_json: format!(
+            "{}\n",
+            serde_json::to_string_pretty(&schema).expect("benchmark schema serializes")
+        ),
+        openapi_json: "{}\n".to_owned(),
+        losses: LossLedger::new(),
+    };
+    let config = LinkmlConfig::new(
+        "https://example.org/bench/linkml-emission",
+        "LinkmlEmissionBench",
+        "Matched safe, rename, and collision-heavy LinkML emission fixture.",
+        "ex",
+        BTreeMap::from([
+            ("ex".to_owned(), "https://example.org/bench/".to_owned()),
+            ("linkml".to_owned(), LINKML.to_owned()),
+        ]),
+    )
+    .expect("benchmark LinkML configuration");
+    let expected_renames = match mode {
+        SlotEmissionMode::Safe => 0,
+        SlotEmissionMode::Rename => slots,
+        SlotEmissionMode::Collision => slots - 1,
+    };
+    let expected_collisions = match mode {
+        SlotEmissionMode::Collision => slots - 1,
+        SlotEmissionMode::Safe | SlotEmissionMode::Rename => 0,
+    };
+    (compiled, config, expected_renames, expected_collisions)
+}
+
+fn bench_linkml_slot_emission(c: &mut Criterion) {
+    let mut group = c.benchmark_group("linkml_slot_emission");
+    group.sample_size(10);
+    for &slots in LINKML_EMIT_SIZES {
+        for mode in SlotEmissionMode::ALL {
+            let (compiled, config, expected_renames, expected_collisions) =
+                linkml_emit_fixture(slots, mode);
+            let assert_output = |output: &purrdf_shapes::LinkmlPackage| {
+                assert_eq!(output.slot_renames.len(), expected_renames);
+                assert_eq!(
+                    output
+                        .slot_renames
+                        .iter()
+                        .filter(|rename| rename.reasons.iter().any(|reason| {
+                            *reason == purrdf_shapes::linkml::LinkmlSlotReason::Collision
+                        }))
+                        .count(),
+                    expected_collisions
+                );
+            };
+
+            let warm = emit_linkml(&compiled, &config).expect("benchmark fixture emits");
+            assert_output(&warm);
+            drop(warm);
+
+            let before = allocation_snapshot();
+            let observed = emit_linkml(&compiled, &config).expect("allocation probe emits");
+            let after = allocation_snapshot();
+            assert_output(&observed);
+            println!(
+                "[linkml_slot_emission] mode={} slots={slots} renames={expected_renames} collisions={expected_collisions} allocations={} allocated_bytes={}",
+                mode.label(),
+                after.0 - before.0,
+                after.1 - before.1
+            );
+            black_box(observed);
+
+            group.throughput(Throughput::Elements(
+                u64::try_from(slots).expect("benchmark slot count fits u64"),
+            ));
+            group.bench_with_input(
+                BenchmarkId::new(mode.label(), slots),
+                &slots,
+                |bencher, _| {
+                    bencher.iter(|| {
+                        let output = emit_linkml(black_box(&compiled), black_box(&config))
+                            .expect("benchmark fixture emits");
+                        assert_output(&output);
+                        black_box(output);
+                    });
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_validate,
     bench_validate_large,
     bench_schema_import,
-    bench_linkml_import
+    bench_linkml_import,
+    bench_linkml_slot_emission
 );
 criterion_main!(benches);

--- a/crates/shapes/examples/linkml_oracle_fixture.rs
+++ b/crates/shapes/examples/linkml_oracle_fixture.rs
@@ -192,13 +192,42 @@ fn lossy_schema() -> Value {
     })
 }
 
+fn renamed_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "Carrier": {
+                "type": "object",
+                "title": "Renamed identity carrier",
+                "description": "A caller-described slot-lowering oracle fixture.",
+                "additionalProperties": false,
+                "properties": {
+                    "custom:alpha/beta": { "type": "boolean" },
+                    "did:example:123": { "type": "string" },
+                    "ex:a/b": { "type": "string", "pattern": "^A" },
+                    "https://outside.example/path/external": { "type": "string" },
+                    "mailto:cat@example.org": { "type": "string" },
+                    "skos:definition": { "type": "string" },
+                    "urn:example:part": { "type": "integer" }
+                },
+                "required": ["ex:a/b"]
+            }
+        }
+    })
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     let config = config()?;
+    let renamed_config = config
+        .clone()
+        .with_slot_rehomes(BTreeSet::from(["skos:definition".to_owned()]))?;
     let import_config = import_config()?;
     let exact_schema = exact_schema();
     let lossy_schema = lossy_schema();
+    let renamed_schema = renamed_schema();
     let exact = emit_linkml(&compiled(&exact_schema)?, &config)?;
     let lossy = emit_linkml(&compiled(&lossy_schema)?, &config)?;
+    let renamed = emit_linkml(&compiled(&renamed_schema)?, &renamed_config)?;
 
     if !exact.losses.is_empty() {
         return Err(format!(
@@ -299,7 +328,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .into());
     }
 
-    for package in [&exact, &lossy] {
+    for package in [&exact, &lossy, &renamed] {
         let reparsed = parse_linkml(&package.yaml)?;
         if reparsed != package.document || write_linkml(&reparsed)? != package.yaml {
             return Err("LinkML fixture did not survive canonical read/write".into());
@@ -319,6 +348,15 @@ fn main() -> Result<(), Box<dyn Error>> {
             "reverse": reverse_payload(&lossy, &import_config)?,
             "schema": lossy_schema,
             "yaml": lossy.yaml,
+        },
+        "renamed": {
+            "element_names": renamed.element_names,
+            "losses": serde_json::from_str::<Value>(&renamed.losses.render_json())?,
+            "reverse": reverse_payload(&renamed, &import_config)?,
+            "schema": renamed_schema,
+            "slot_diagnostics": renamed.slot_diagnostics,
+            "slot_renames": renamed.slot_renames,
+            "yaml": renamed.yaml,
         }
     });
     println!("{}", serde_json::to_string(&output)?);

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -64,8 +64,9 @@ pub use json_schema::{
     SchemaSurfaceMode, ValueVocab, ValueVocabProjection, compile_schema, compile_with_value_vocab,
 };
 pub use linkml::{
-    LinkmlConfig, LinkmlDocument, LinkmlError, LinkmlPackage, emit_linkml, import_linkml,
-    import_linkml_package, parse_linkml, write_linkml,
+    LinkmlConfig, LinkmlDocument, LinkmlError, LinkmlPackage, LinkmlSlotDiagnostic,
+    LinkmlSlotDisposition, LinkmlSlotReason, LinkmlSlotRename, SanitizePolicy, emit_linkml,
+    import_linkml, import_linkml_package, parse_linkml, write_linkml,
 };
 pub use pydantic::{
     PYDANTIC_DIALECT, PydanticConfig, PydanticError, PydanticPackage, emit_pydantic,

--- a/crates/shapes/src/linkml.rs
+++ b/crates/shapes/src/linkml.rs
@@ -364,6 +364,9 @@ pub struct LinkmlPackage {
     pub slot_diagnostics: Vec<LinkmlSlotDiagnostic>,
     canonical_yaml: String,
     canonical_element_names: BTreeMap<String, String>,
+    canonical_losses: LossLedger,
+    canonical_slot_renames: Vec<LinkmlSlotRename>,
+    canonical_slot_diagnostics: Vec<LinkmlSlotDiagnostic>,
 }
 
 /// A malformed LinkML configuration, document, or projection input.

--- a/crates/shapes/src/linkml.rs
+++ b/crates/shapes/src/linkml.rs
@@ -42,7 +42,7 @@ pub(super) const MAX_LINKML_SOURCE_KEY_BYTES: usize = 1024 * 1024;
 const RESERVED_JSONLD_SLOTS: &[&str] = &["@annotation", "@id", "@language", "@type", "@value"];
 
 /// Policy for a JSON property that cannot be used directly as a LinkML slot name.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum SanitizePolicy {
     /// Emit a deterministic NCName-safe slot and report the mapping.
@@ -54,7 +54,7 @@ pub enum SanitizePolicy {
 }
 
 /// Semantic effect of a LinkML slot-name policy decision.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum LinkmlSlotDisposition {
     /// Only the LinkML attribute spelling changes; RDF identity is preserved.
@@ -358,6 +358,10 @@ pub struct LinkmlPackage {
     pub element_names: BTreeMap<String, String>,
     /// JSON Schema assertions not represented exactly in LinkML 1.11.
     pub losses: LossLedger,
+    /// Ordered source-slot to emitted-name mappings.
+    pub slot_renames: Vec<LinkmlSlotRename>,
+    /// Ordered located diagnostics for slots omitted by [`SanitizePolicy::Skip`].
+    pub slot_diagnostics: Vec<LinkmlSlotDiagnostic>,
     canonical_yaml: String,
     canonical_element_names: BTreeMap<String, String>,
 }

--- a/crates/shapes/src/linkml.rs
+++ b/crates/shapes/src/linkml.rs
@@ -11,12 +11,15 @@
 //! not author.
 
 use std::borrow::Cow;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
 
 use ::purrdf::loss::LossLedger;
-use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
+use serde::{
+    Serialize,
+    de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor},
+};
 use serde_json::{Map, Number, Value};
 use serde_yaml::Value as YamlValue;
 
@@ -34,6 +37,113 @@ const MAX_LINKML_YAML_BYTES: usize = 16 * 1024 * 1024;
 const MAX_LINKML_YAML_DEPTH: usize = 256;
 const MAX_LINKML_YAML_NODES: usize = 1_000_000;
 const MAX_LINKML_STRING_BYTES: usize = 16 * 1024 * 1024;
+pub(super) const MAX_LINKML_SOURCE_KEY_BYTES: usize = 1024 * 1024;
+
+const RESERVED_JSONLD_SLOTS: &[&str] = &["@annotation", "@id", "@language", "@type", "@value"];
+
+/// Policy for a JSON property that cannot be used directly as a LinkML slot name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SanitizePolicy {
+    /// Emit a deterministic NCName-safe slot and report the mapping.
+    Rename,
+    /// Omit only the unsafe slot and return a located diagnostic and loss.
+    Skip,
+    /// Reject the projection with a contextual error.
+    Fail,
+}
+
+/// Semantic effect of a LinkML slot-name policy decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LinkmlSlotDisposition {
+    /// Only the LinkML attribute spelling changes; RDF identity is preserved.
+    IdentityPreserved,
+    /// Caller configuration assigns an unresolved source token a new RDF identity.
+    IdentityRehomed,
+    /// The selected policy omits the source property.
+    Skipped,
+}
+
+/// Deterministic reason contributing to a slot rename or diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LinkmlSlotReason {
+    /// The source local part contains a character outside LinkML's NCName grammar.
+    InvalidCharacter,
+    /// The source local part does not begin with an NCName start character.
+    InvalidInitialCharacter,
+    /// No caller prefix namespace can provide a directly usable source name.
+    UnmatchedNamespace,
+    /// An exact caller hint requests assignment under the default prefix.
+    CallerRehome,
+    /// A non-IRI source name requires caller-default RDF identity.
+    BareName,
+    /// The direct candidate exceeds the fixed generated-name byte limit.
+    LengthBound,
+    /// Another source slot already owns the direct candidate.
+    Collision,
+}
+
+/// One deterministic source-slot to emitted-LinkML rename record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LinkmlSlotRename {
+    /// Source `$defs` key, or the inline-class JSON Pointer.
+    pub source_class: String,
+    /// Emitted LinkML class name.
+    pub emitted_class: String,
+    /// Exact source property JSON Pointer.
+    pub source_path: String,
+    /// Exact source JSON property spelling.
+    pub source_name: String,
+    /// Resolvable source URI/CURIE before emission, when one exists.
+    pub old_slot_uri: Option<String>,
+    /// NCName-safe emitted LinkML attribute name.
+    pub new_slot_name: String,
+    /// Concrete URI/CURIE carried by the emitted `slot_uri`.
+    pub emitted_slot_uri: String,
+    /// Whether RDF identity was preserved or explicitly re-homed.
+    pub disposition: LinkmlSlotDisposition,
+    /// Ordered causes for the generated spelling.
+    pub reasons: Vec<LinkmlSlotReason>,
+}
+
+impl LinkmlSlotRename {
+    /// Required `(class, old_slot_uri, new_slot_name)` audit view.
+    #[must_use]
+    pub fn audit_tuple(&self) -> (&str, Option<&str>, &str) {
+        (
+            &self.source_class,
+            self.old_slot_uri.as_deref(),
+            &self.new_slot_name,
+        )
+    }
+}
+
+/// One located slot omitted by [`SanitizePolicy::Skip`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LinkmlSlotDiagnostic {
+    /// Source `$defs` key, or the inline-class JSON Pointer.
+    pub source_class: String,
+    /// Emitted LinkML class name.
+    pub emitted_class: String,
+    /// Exact source property JSON Pointer.
+    pub source_path: String,
+    /// Exact source JSON property spelling.
+    pub source_name: String,
+    /// Resolvable source URI/CURIE before omission, when one exists.
+    pub old_slot_uri: Option<String>,
+    /// No emitted name exists for a skipped slot.
+    pub new_slot_name: Option<String>,
+    /// No emitted URI exists for a skipped slot.
+    pub emitted_slot_uri: Option<String>,
+    /// Always [`LinkmlSlotDisposition::Skipped`].
+    pub disposition: LinkmlSlotDisposition,
+    /// Ordered causes that made the source name unsafe.
+    pub reasons: Vec<LinkmlSlotReason>,
+    /// Stable human-readable policy result.
+    pub detail: String,
+}
 
 /// Caller-owned identity and vocabulary configuration for LinkML emission.
 ///
@@ -48,6 +158,8 @@ pub struct LinkmlConfig {
     description: String,
     default_prefix: String,
     prefixes: BTreeMap<String, String>,
+    sanitize_policy: SanitizePolicy,
+    slot_rehomes: BTreeSet<String>,
 }
 
 impl LinkmlConfig {
@@ -100,6 +212,8 @@ impl LinkmlConfig {
             description,
             default_prefix,
             prefixes,
+            sanitize_policy: SanitizePolicy::Rename,
+            slot_rehomes: BTreeSet::new(),
         })
     }
 
@@ -131,6 +245,67 @@ impl LinkmlConfig {
     #[must_use]
     pub fn prefixes(&self) -> &BTreeMap<String, String> {
         &self.prefixes
+    }
+
+    /// Policy applied to a source property without a directly usable LinkML name.
+    #[must_use]
+    pub const fn sanitize_policy(&self) -> SanitizePolicy {
+        self.sanitize_policy
+    }
+
+    /// Select the unsafe-slot policy while retaining the caller-owned identity config.
+    #[must_use]
+    pub fn with_sanitize_policy(mut self, policy: SanitizePolicy) -> Self {
+        self.sanitize_policy = policy;
+        self
+    }
+
+    /// Assign exact unresolved source tokens to the caller's default prefix.
+    ///
+    /// A hint cannot target a declared CURIE or reserved JSON-LD carrier. During
+    /// emission every configured token must occur at least once; stale hints
+    /// fail closed instead of silently changing classification intent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LinkmlError`] for an empty/oversized source token, a reserved
+    /// JSON-LD carrier, or a CURIE whose prefix is already declared.
+    pub fn with_slot_rehomes(
+        mut self,
+        slot_rehomes: BTreeSet<String>,
+    ) -> Result<Self, LinkmlError> {
+        for source in &slot_rehomes {
+            if source.is_empty() {
+                return Err(LinkmlError::new(
+                    "LinkML slot re-home source token cannot be empty",
+                ));
+            }
+            if source.len() > MAX_LINKML_SOURCE_KEY_BYTES {
+                return Err(LinkmlError::new(format!(
+                    "LinkML slot re-home source token exceeds {MAX_LINKML_SOURCE_KEY_BYTES} bytes"
+                )));
+            }
+            if is_reserved_jsonld_slot(source) {
+                return Err(LinkmlError::new(format!(
+                    "LinkML slot re-home source token {source:?} is a reserved JSON-LD carrier"
+                )));
+            }
+            if let Some((prefix, _)) = source.split_once(':')
+                && self.prefixes.contains_key(prefix)
+            {
+                return Err(LinkmlError::new(format!(
+                    "LinkML slot re-home source token {source:?} uses declared prefix {prefix:?}"
+                )));
+            }
+        }
+        self.slot_rehomes = slot_rehomes;
+        Ok(self)
+    }
+
+    /// Exact source tokens assigned to the caller's default prefix.
+    #[must_use]
+    pub fn slot_rehomes(&self) -> &BTreeSet<String> {
+        &self.slot_rehomes
     }
 }
 
@@ -541,6 +716,10 @@ fn is_linkml_identifier(value: &str) -> bool {
         })
 }
 
+pub(super) fn is_reserved_jsonld_slot(value: &str) -> bool {
+    RESERVED_JSONLD_SLOTS.binary_search(&value).is_ok()
+}
+
 fn validate_yaml_value(
     value: &YamlValue,
     depth: usize,
@@ -754,6 +933,34 @@ mod tests {
         assert_eq!(config.description(), "Caller schema.");
         assert_eq!(config.default_prefix(), "ex");
         assert_eq!(config.prefixes(), &prefixes());
+        assert_eq!(config.sanitize_policy(), SanitizePolicy::Rename);
+        assert!(config.slot_rehomes().is_empty());
+
+        let configured = config
+            .clone()
+            .with_sanitize_policy(SanitizePolicy::Skip)
+            .with_slot_rehomes(BTreeSet::from(["skos:definition".to_owned()]))
+            .expect("unresolved source token is caller-owned");
+        assert_eq!(configured.sanitize_policy(), SanitizePolicy::Skip);
+        assert_eq!(
+            configured.slot_rehomes(),
+            &BTreeSet::from(["skos:definition".to_owned()])
+        );
+        assert!(
+            config
+                .clone()
+                .with_slot_rehomes(BTreeSet::from(["ex:name".to_owned()]))
+                .expect_err("declared CURIE cannot be re-homed")
+                .detail()
+                .contains("declared prefix")
+        );
+        assert!(
+            config
+                .with_slot_rehomes(BTreeSet::from(["@id".to_owned()]))
+                .expect_err("reserved carrier cannot be re-homed")
+                .detail()
+                .contains("reserved JSON-LD")
+        );
 
         assert!(LinkmlConfig::new("/relative", "Schema", "docs", "ex", prefixes()).is_err());
         assert!(

--- a/crates/shapes/src/linkml/importer.rs
+++ b/crates/shapes/src/linkml/importer.rs
@@ -10,8 +10,8 @@ use ::purrdf::loss::{LossEntry, LossLedger, check_ledger_sound, schema_to_shacl_
 use serde_json::{Map, Value};
 
 use super::{
-    LinkmlDocument, LinkmlError, LinkmlPackage, parse_linkml, pointer_escape, projection,
-    write_linkml,
+    LinkmlDocument, LinkmlError, LinkmlPackage, LinkmlSlotDiagnostic, LinkmlSlotDisposition,
+    LinkmlSlotRename, is_linkml_identifier, parse_linkml, pointer_escape, projection, write_linkml,
 };
 use crate::schema_import::{ImportedShapes, SchemaImportConfig, import_schema_value_from};
 use crate::term::Term;
@@ -45,6 +45,7 @@ pub(super) fn import_package(
         ));
     }
     let visible = verify_element_names(package)?;
+    verify_slot_reports(package)?;
     import_document(&package.document, config, Some(&visible))
 }
 
@@ -142,6 +143,314 @@ fn verify_element_names(package: &LinkmlPackage) -> Result<BTreeSet<String>, Lin
         }
     }
     Ok(reverse.into_keys().collect())
+}
+
+fn verify_slot_reports(package: &LinkmlPackage) -> Result<(), LinkmlError> {
+    if package.losses != package.canonical_losses {
+        return Err(LinkmlError::new(
+            "LinkML package loss ledger differs from its retained emitted ledger",
+        ));
+    }
+    if package.slot_renames != package.canonical_slot_renames {
+        return Err(LinkmlError::new(
+            "LinkML package slot-rename report differs from its retained emitted report",
+        ));
+    }
+    if package.slot_diagnostics != package.canonical_slot_diagnostics {
+        return Err(LinkmlError::new(
+            "LinkML package slot diagnostic report differs from its retained emitted report",
+        ));
+    }
+    check_ledger_sound(&package.losses, "json-schema", "linkml-1.11").map_err(LinkmlError::new)?;
+
+    verify_report_order(&package.slot_renames, |row| {
+        (
+            row.source_class.as_str(),
+            row.source_path.as_str(),
+            row.source_name.as_str(),
+        )
+    })?;
+    verify_report_order(&package.slot_diagnostics, |row| {
+        (
+            row.source_class.as_str(),
+            row.source_path.as_str(),
+            row.source_name.as_str(),
+        )
+    })?;
+
+    let root = package
+        .document
+        .as_value()
+        .as_object()
+        .expect("LinkmlDocument validates an object root");
+    let prefixes = document_prefixes(root)?;
+    let mut report_paths = BTreeSet::new();
+    let mut expected_losses = BTreeSet::new();
+
+    for rename in &package.slot_renames {
+        if !report_paths.insert(rename.source_path.clone()) {
+            return Err(LinkmlError::new(format!(
+                "LinkML package repeats slot report location {:?}",
+                rename.source_path
+            )));
+        }
+        let class = verify_report_context(package, rename, root)?;
+        let attribute = class
+            .get("attributes")
+            .and_then(Value::as_object)
+            .and_then(|attributes| attributes.get(&rename.new_slot_name))
+            .and_then(Value::as_object)
+            .ok_or_else(|| {
+                LinkmlError::new(format!(
+                    "LinkML package rename at {:?} targets missing attribute {:?} on class {:?}",
+                    rename.source_path, rename.new_slot_name, rename.emitted_class
+                ))
+            })?;
+        if rename.source_name == rename.new_slot_name {
+            return Err(LinkmlError::new(format!(
+                "LinkML package rename at {:?} does not change the source spelling",
+                rename.source_path
+            )));
+        }
+        verify_generated_slot_name(&rename.new_slot_name, &prefixes, &rename.source_path)?;
+        if attribute.get("alias").and_then(Value::as_str) != Some(rename.source_name.as_str()) {
+            return Err(LinkmlError::new(format!(
+                "LinkML package rename at {:?} does not retain source alias {:?}",
+                rename.source_path, rename.source_name
+            )));
+        }
+        if attribute.get("slot_uri").and_then(Value::as_str)
+            != Some(rename.emitted_slot_uri.as_str())
+        {
+            return Err(LinkmlError::new(format!(
+                "LinkML package rename at {:?} disagrees with emitted slot_uri {:?}",
+                rename.source_path, rename.emitted_slot_uri
+            )));
+        }
+        if rename.reasons.is_empty() {
+            return Err(LinkmlError::new(format!(
+                "LinkML package rename at {:?} has no naming reason",
+                rename.source_path
+            )));
+        }
+        match rename.disposition {
+            LinkmlSlotDisposition::IdentityPreserved => {
+                if rename.old_slot_uri.as_deref() != Some(rename.emitted_slot_uri.as_str()) {
+                    return Err(LinkmlError::new(format!(
+                        "LinkML package identity-preserving rename at {:?} does not retain its exact source slot URI",
+                        rename.source_path
+                    )));
+                }
+            }
+            LinkmlSlotDisposition::IdentityRehomed => {
+                if rename.old_slot_uri.is_some() || rename.emitted_slot_uri != rename.new_slot_name
+                {
+                    return Err(LinkmlError::new(format!(
+                        "LinkML package identity re-home at {:?} is not explicit in its generated name and URI",
+                        rename.source_path
+                    )));
+                }
+                expected_losses.insert((
+                    "slot-identity-rehomed".to_owned(),
+                    rename.source_path.clone(),
+                ));
+            }
+            LinkmlSlotDisposition::Skipped => {
+                return Err(LinkmlError::new(format!(
+                    "LinkML package rename at {:?} has skipped disposition",
+                    rename.source_path
+                )));
+            }
+        }
+    }
+
+    for diagnostic in &package.slot_diagnostics {
+        if !report_paths.insert(diagnostic.source_path.clone()) {
+            return Err(LinkmlError::new(format!(
+                "LinkML package repeats slot report location {:?}",
+                diagnostic.source_path
+            )));
+        }
+        let class = verify_diagnostic_context(package, diagnostic, root)?;
+        if diagnostic.disposition != LinkmlSlotDisposition::Skipped
+            || diagnostic.new_slot_name.is_some()
+            || diagnostic.emitted_slot_uri.is_some()
+            || diagnostic.reasons.is_empty()
+            || diagnostic.detail.trim().is_empty()
+        {
+            return Err(LinkmlError::new(format!(
+                "LinkML package diagnostic at {:?} is not a complete skipped-slot record",
+                diagnostic.source_path
+            )));
+        }
+        if class
+            .get("attributes")
+            .and_then(Value::as_object)
+            .is_some_and(|attributes| {
+                attributes.values().any(|attribute| {
+                    attribute
+                        .as_object()
+                        .and_then(|slot| slot.get("alias"))
+                        .and_then(Value::as_str)
+                        == Some(diagnostic.source_name.as_str())
+                })
+            })
+        {
+            return Err(LinkmlError::new(format!(
+                "LinkML package diagnostic at {:?} names a slot that is still emitted",
+                diagnostic.source_path
+            )));
+        }
+        expected_losses.insert((
+            "slot-name-policy-dropped".to_owned(),
+            diagnostic.source_path.clone(),
+        ));
+    }
+
+    let mut observed_losses = BTreeMap::<(String, String), usize>::new();
+    for entry in package.losses.entries() {
+        if !matches!(
+            entry.code.as_ref(),
+            "slot-identity-rehomed" | "slot-name-policy-dropped"
+        ) {
+            continue;
+        }
+        let location = entry.location.as_deref().ok_or_else(|| {
+            LinkmlError::new(format!(
+                "LinkML package loss {:?} lacks its source location",
+                entry.code
+            ))
+        })?;
+        if location.logical.as_deref() != Some("shapes:linkml") {
+            return Err(LinkmlError::new(format!(
+                "LinkML package loss {:?} has the wrong logical source",
+                entry.code
+            )));
+        }
+        let subject = location.subject.as_deref().ok_or_else(|| {
+            LinkmlError::new(format!(
+                "LinkML package loss {:?} lacks its source JSON Pointer",
+                entry.code
+            ))
+        })?;
+        *observed_losses
+            .entry((entry.code.to_string(), subject.to_owned()))
+            .or_default() += 1;
+    }
+    if observed_losses.len() != expected_losses.len()
+        || observed_losses
+            .iter()
+            .any(|(entry, count)| *count != 1 || !expected_losses.contains(entry))
+    {
+        return Err(LinkmlError::new(
+            "LinkML package slot reports disagree with the retained slot-policy loss entries",
+        ));
+    }
+    Ok(())
+}
+
+fn verify_report_order<T, F>(rows: &[T], key: F) -> Result<(), LinkmlError>
+where
+    F: for<'a> Fn(&'a T) -> (&'a str, &'a str, &'a str),
+{
+    for pair in rows.windows(2) {
+        if key(&pair[0]) >= key(&pair[1]) {
+            return Err(LinkmlError::new(
+                "LinkML package slot report is duplicated or out of canonical order",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn verify_report_context<'a>(
+    package: &LinkmlPackage,
+    rename: &LinkmlSlotRename,
+    root: &'a Map<String, Value>,
+) -> Result<&'a Map<String, Value>, LinkmlError> {
+    verify_source_context(
+        package,
+        &rename.source_class,
+        &rename.emitted_class,
+        &rename.source_path,
+        &rename.source_name,
+        root,
+    )
+}
+
+fn verify_diagnostic_context<'a>(
+    package: &LinkmlPackage,
+    diagnostic: &LinkmlSlotDiagnostic,
+    root: &'a Map<String, Value>,
+) -> Result<&'a Map<String, Value>, LinkmlError> {
+    verify_source_context(
+        package,
+        &diagnostic.source_class,
+        &diagnostic.emitted_class,
+        &diagnostic.source_path,
+        &diagnostic.source_name,
+        root,
+    )
+}
+
+fn verify_source_context<'a>(
+    package: &LinkmlPackage,
+    source_class: &str,
+    emitted_class: &str,
+    source_path: &str,
+    source_name: &str,
+    root: &'a Map<String, Value>,
+) -> Result<&'a Map<String, Value>, LinkmlError> {
+    let suffix = format!("/properties/{}", pointer_escape(source_name));
+    if !source_path.ends_with(&suffix) {
+        return Err(LinkmlError::new(format!(
+            "LinkML package slot report path {source_path:?} does not name source property {source_name:?}"
+        )));
+    }
+    if let Some(mapped_class) = package.element_names.get(source_class) {
+        let prefix = definition_path(source_class);
+        if mapped_class != emitted_class || !source_path.starts_with(&format!("{prefix}/")) {
+            return Err(LinkmlError::new(format!(
+                "LinkML package slot report at {source_path:?} disagrees with source class {source_class:?}"
+            )));
+        }
+    } else if !source_class.starts_with("#/")
+        || !source_path.starts_with(&format!("{source_class}/"))
+    {
+        return Err(LinkmlError::new(format!(
+            "LinkML package slot report at {source_path:?} has unknown source class {source_class:?}"
+        )));
+    }
+    root.get("classes")
+        .and_then(Value::as_object)
+        .and_then(|classes| classes.get(emitted_class))
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            LinkmlError::new(format!(
+                "LinkML package slot report targets missing emitted class {emitted_class:?}"
+            ))
+        })
+}
+
+fn verify_generated_slot_name(
+    name: &str,
+    prefixes: &BTreeMap<String, String>,
+    source_path: &str,
+) -> Result<(), LinkmlError> {
+    let Some((prefix, local)) = name.split_once(':') else {
+        return Err(LinkmlError::new(format!(
+            "LinkML package generated slot name {name:?} at {source_path:?} lacks a prefix"
+        )));
+    };
+    if !prefixes.contains_key(prefix)
+        || !is_linkml_identifier(prefix)
+        || !is_linkml_identifier(local)
+    {
+        return Err(LinkmlError::new(format!(
+            "LinkML package generated slot name {name:?} at {source_path:?} is not a declared-prefix NCName"
+        )));
+    }
+    Ok(())
 }
 
 struct NativeImporter {
@@ -1915,6 +2224,105 @@ mod tests {
             .next()
             .expect("element map") = "MissingElement".to_owned();
         assert!(import_package(&bad_map, &config()).is_err());
+    }
+
+    #[test]
+    fn renamed_package_verifies_reports_and_reconstructs_source_predicates() {
+        let schema = json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "Carrier": {
+                    "type": "object",
+                    "properties": {
+                        "ex:a/b": { "type": "string" },
+                        "https://outside.example/path/value": { "type": "integer" },
+                        "custom:value/path": { "type": "boolean" },
+                        "skos:definition": { "type": "string" }
+                    },
+                    "required": ["ex:a/b"]
+                }
+            }
+        });
+        let compiled = CompiledSchema {
+            schema_json: format!(
+                "{}\n",
+                serde_json::to_string_pretty(&schema).expect("schema serializes")
+            ),
+            openapi_json: "{}\n".to_owned(),
+            losses: LossLedger::new(),
+        };
+        let linkml = linkml_config()
+            .with_slot_rehomes(BTreeSet::from(["skos:definition".to_owned()]))
+            .expect("exact re-home config");
+        let package = emit_linkml(&compiled, &linkml).expect("renamed package");
+        assert_eq!(package.slot_renames.len(), 4);
+
+        let imported = import_package(&package, &config()).expect("verified reverse import");
+        let predicates = imported
+            .shapes
+            .node_shapes
+            .iter()
+            .flat_map(|shape| &shape.property_shapes)
+            .filter_map(|property| match &property.path {
+                Path::Predicate(predicate) => Some(predicate.as_str()),
+                _ => None,
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            predicates,
+            BTreeSet::from([
+                "custom:value/path",
+                "https://example.org/a/b",
+                "https://example.org/definition",
+                "https://outside.example/path/value",
+            ])
+        );
+
+        let mut bad_report = package.clone();
+        bad_report.slot_renames[0].new_slot_name.push_str("_drift");
+        assert!(
+            import_package(&bad_report, &config())
+                .expect_err("public report drift rejected")
+                .detail()
+                .contains("retained emitted report")
+        );
+
+        let mut bad_order = package.clone();
+        bad_order.slot_renames.swap(0, 1);
+        assert!(import_package(&bad_order, &config()).is_err());
+
+        let mut bad_losses = package.clone();
+        bad_losses.losses = LossLedger::new();
+        assert!(
+            import_package(&bad_losses, &config())
+                .expect_err("loss drift rejected")
+                .detail()
+                .contains("retained emitted ledger")
+        );
+
+        let mut bad_document = package;
+        let renamed = bad_document.slot_renames[0].clone();
+        let mut value = bad_document.document.as_value().clone();
+        value["classes"][&renamed.emitted_class]["attributes"][&renamed.new_slot_name]["slot_uri"] =
+            Value::String("ex:tampered".to_owned());
+        bad_document.document = LinkmlDocument::from_value(value).expect("valid tampered document");
+        bad_document.yaml = write_linkml(&bad_document.document).expect("tampered YAML");
+        bad_document.canonical_yaml.clone_from(&bad_document.yaml);
+        assert!(
+            import_package(&bad_document, &config())
+                .expect_err("slot identity drift rejected")
+                .detail()
+                .contains("disagrees with emitted slot_uri")
+        );
+
+        let skipped = emit_linkml(
+            &compiled,
+            &linkml.with_sanitize_policy(super::super::SanitizePolicy::Skip),
+        )
+        .expect("skip package");
+        let mut bad_diagnostic = skipped;
+        bad_diagnostic.slot_diagnostics[0].detail.push_str(" drift");
+        assert!(import_package(&bad_diagnostic, &config()).is_err());
     }
 
     #[test]

--- a/crates/shapes/src/linkml/projection.rs
+++ b/crates/shapes/src/linkml/projection.rs
@@ -140,9 +140,12 @@ pub(super) fn emit(
         yaml,
         canonical_element_names: element_names.clone(),
         element_names,
-        losses: renderer.ledger,
-        slot_renames: renderer.slot_renames,
-        slot_diagnostics: renderer.slot_diagnostics,
+        losses: renderer.ledger.clone(),
+        slot_renames: renderer.slot_renames.clone(),
+        slot_diagnostics: renderer.slot_diagnostics.clone(),
+        canonical_losses: renderer.ledger,
+        canonical_slot_renames: renderer.slot_renames,
+        canonical_slot_diagnostics: renderer.slot_diagnostics,
     })
 }
 

--- a/crates/shapes/src/linkml/projection.rs
+++ b/crates/shapes/src/linkml/projection.rs
@@ -11,8 +11,9 @@ use serde_json::{Map, Value};
 
 use super::{
     LINKML_METAMODEL_VERSION, LinkmlConfig, LinkmlDocument, LinkmlError, LinkmlPackage,
-    LinkmlSlotDisposition, LinkmlSlotReason, MAX_LINKML_SOURCE_KEY_BYTES, is_linkml_identifier,
-    is_reserved_jsonld_slot, write_linkml,
+    LinkmlSlotDiagnostic, LinkmlSlotDisposition, LinkmlSlotReason, LinkmlSlotRename,
+    MAX_LINKML_SOURCE_KEY_BYTES, SanitizePolicy, is_linkml_identifier, is_reserved_jsonld_slot,
+    write_linkml,
 };
 use crate::json_schema::CompiledSchema;
 use crate::schema_catalog::{
@@ -23,7 +24,12 @@ use crate::schema_catalog::{
 const LOSS_FROM: &str = "json-schema";
 const LOSS_TO: &str = "linkml-1.11";
 const LOSS_CONTEXT: &str = "shapes:linkml";
+const MAX_LINKML_SOURCE_SCHEMA_BYTES: usize = 16 * 1024 * 1024;
+const MAX_LINKML_SLOTS_PER_CLASS: usize = 65_536;
+const MAX_LINKML_TOTAL_SLOTS: usize = 1_000_000;
+const MAX_LINKML_REPORT_ROWS: usize = 1_000_000;
 const MAX_GENERATED_SLOT_NAME_BYTES: usize = 255;
+const MAX_SLOT_COLLISION_ATTEMPTS: usize = 1_024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ElementKind {
@@ -42,6 +48,11 @@ pub(super) fn emit(
     compiled: &CompiledSchema,
     config: &LinkmlConfig,
 ) -> Result<LinkmlPackage, LinkmlError> {
+    if compiled.schema_json.len() > MAX_LINKML_SOURCE_SCHEMA_BYTES {
+        return Err(LinkmlError::new(format!(
+            "JSON Schema source exceeds the {MAX_LINKML_SOURCE_SCHEMA_BYTES}-byte LinkML projection limit"
+        )));
+    }
     let catalog = CompiledSchemaCatalog::parse(compiled)
         .map_err(|error| LinkmlError::new(error.to_string()))?;
     let definitions = catalog.definitions();
@@ -62,6 +73,19 @@ pub(super) fn emit(
             .clone();
         renderer.render_definition(key, &info, definition)?;
     }
+    renderer.verify_rehome_hints()?;
+    renderer.slot_renames.sort_by(|left, right| {
+        left.source_class
+            .cmp(&right.source_class)
+            .then_with(|| left.source_path.cmp(&right.source_path))
+            .then_with(|| left.source_name.cmp(&right.source_name))
+    });
+    renderer.slot_diagnostics.sort_by(|left, right| {
+        left.source_class
+            .cmp(&right.source_class)
+            .then_with(|| left.source_path.cmp(&right.source_path))
+            .then_with(|| left.source_name.cmp(&right.source_name))
+    });
 
     let mut root = Map::new();
     root.insert(
@@ -117,6 +141,8 @@ pub(super) fn emit(
         canonical_element_names: element_names.clone(),
         element_names,
         losses: renderer.ledger,
+        slot_renames: renderer.slot_renames,
+        slot_diagnostics: renderer.slot_diagnostics,
     })
 }
 
@@ -317,6 +343,14 @@ struct SlotNameSeed {
     emitted_slot_uri: Option<String>,
     disposition: LinkmlSlotDisposition,
     reasons: Vec<LinkmlSlotReason>,
+}
+
+#[derive(Debug, Clone)]
+struct PlannedSlot {
+    source_name: String,
+    source_path: String,
+    emitted_name: String,
+    emitted_slot_uri: Option<String>,
 }
 
 impl SlotNameSeed {
@@ -520,6 +554,46 @@ fn bounded_curie(
     Ok(hashed)
 }
 
+fn collision_name(base: &str, source: &str, ordinal: usize) -> Result<String, LinkmlError> {
+    let (prefix, local) = base.split_once(':').ok_or_else(|| {
+        LinkmlError::new(format!(
+            "generated LinkML slot candidate {base:?} lacks a caller prefix"
+        ))
+    })?;
+    let suffix = if ordinal == 0 {
+        format!("_{:016x}", fnv1a(source.as_bytes()))
+    } else {
+        format!("_{:016x}_{ordinal}", fnv1a(source.as_bytes()))
+    };
+    let fixed = prefix
+        .len()
+        .checked_add(1)
+        .and_then(|length| length.checked_add(suffix.len()))
+        .ok_or_else(|| LinkmlError::new("generated LinkML slot-name length overflow"))?;
+    let local_budget = MAX_GENERATED_SLOT_NAME_BYTES.checked_sub(fixed).ok_or_else(|| {
+        LinkmlError::new(format!(
+            "LinkML prefix {prefix:?} leaves no room for a collision suffix within the {MAX_GENERATED_SLOT_NAME_BYTES}-byte generated slot-name limit"
+        ))
+    })?;
+    if local_budget == 0 {
+        return Err(LinkmlError::new(format!(
+            "LinkML prefix {prefix:?} leaves no local-name byte within the {MAX_GENERATED_SLOT_NAME_BYTES}-byte generated slot-name limit"
+        )));
+    }
+    let mut end = local.len().min(local_budget);
+    while !local.is_char_boundary(end) {
+        end -= 1;
+    }
+    if end == 0 {
+        return Err(LinkmlError::new(format!(
+            "LinkML prefix {prefix:?} leaves no complete local-name character within the {MAX_GENERATED_SLOT_NAME_BYTES}-byte generated slot-name limit"
+        )));
+    }
+    let candidate = format!("{prefix}:{}{suffix}", &local[..end]);
+    debug_assert!(candidate.len() <= MAX_GENERATED_SLOT_NAME_BYTES);
+    Ok(candidate)
+}
+
 fn push_reason(reasons: &mut Vec<LinkmlSlotReason>, reason: LinkmlSlotReason) {
     if !reasons.contains(&reason) {
         reasons.push(reason);
@@ -553,6 +627,10 @@ struct Renderer<'a> {
     used_names: BTreeMap<String, String>,
     inline_classes: BTreeMap<String, String>,
     inline_enums: BTreeMap<String, String>,
+    slot_renames: Vec<LinkmlSlotRename>,
+    slot_diagnostics: Vec<LinkmlSlotDiagnostic>,
+    used_rehome_hints: BTreeSet<String>,
+    total_slots: usize,
 }
 
 impl<'a> Renderer<'a> {
@@ -575,6 +653,26 @@ impl<'a> Renderer<'a> {
             used_names,
             inline_classes: BTreeMap::new(),
             inline_enums: BTreeMap::new(),
+            slot_renames: Vec::new(),
+            slot_diagnostics: Vec::new(),
+            used_rehome_hints: BTreeSet::new(),
+            total_slots: 0,
+        }
+    }
+
+    fn verify_rehome_hints(&self) -> Result<(), LinkmlError> {
+        let unused = self
+            .config
+            .slot_rehomes()
+            .difference(&self.used_rehome_hints)
+            .cloned()
+            .collect::<Vec<_>>();
+        if unused.is_empty() {
+            Ok(())
+        } else {
+            Err(LinkmlError::new(format!(
+                "LinkML slot re-home hints were not used by any source class: {unused:?}"
+            )))
         }
     }
 
@@ -1041,25 +1139,27 @@ impl Renderer<'_> {
         let properties = object_map(object, "properties", path)?;
         let required = required_names(object, properties, path)?;
         if !properties.is_empty() {
+            let source_class = source_key.unwrap_or(path);
+            let slot_plan = self.plan_class_slots(name, source_class, properties, path)?;
             let mut attributes = Map::new();
-            let mut slot_uris = BTreeMap::<String, String>::new();
-            for (property, property_schema) in properties {
-                let property_path = format!("{path}/properties/{}", pointer_escape(property));
-                let mut slot = self.render_slot_expression(property_schema, &property_path)?;
-                slot.insert("alias".to_owned(), Value::String(property.clone()));
-                if let Some(slot_uri) = self.slot_uri(property)? {
-                    if let Some(previous) = slot_uris.insert(slot_uri.clone(), property.clone()) {
-                        return Err(LinkmlError::new(format!(
-                            "{path}/properties keys {previous:?} and {property:?} derive the same caller-vocabulary slot URI {slot_uri:?}"
-                        )));
-                    }
+            for planned in slot_plan {
+                let property_schema = properties
+                    .get(&planned.source_name)
+                    .expect("class slot plan covers source properties");
+                let mut slot =
+                    self.render_slot_expression(property_schema, &planned.source_path)?;
+                slot.insert(
+                    "alias".to_owned(),
+                    Value::String(planned.source_name.clone()),
+                );
+                if let Some(slot_uri) = planned.emitted_slot_uri {
                     slot.insert("slot_uri".to_owned(), Value::String(slot_uri));
                 }
                 slot.insert(
                     "required".to_owned(),
-                    Value::Bool(required.contains(property.as_str())),
+                    Value::Bool(required.contains(planned.source_name.as_str())),
                 );
-                attributes.insert(property.clone(), Value::Object(slot));
+                attributes.insert(planned.emitted_name, Value::Object(slot));
             }
             class.insert("attributes".to_owned(), Value::Object(attributes));
         }
@@ -1207,37 +1307,243 @@ impl Renderer<'_> {
         Ok(name)
     }
 
-    fn slot_uri(&self, property: &str) -> Result<Option<String>, LinkmlError> {
-        let seed = slot_name_seed(self.config, property)?;
-        match seed.source_kind {
-            SlotSourceKind::Reserved => Ok(None),
-            SlotSourceKind::RegisteredCurie => {
-                if seed.requires_rename() {
+    fn plan_class_slots(
+        &mut self,
+        emitted_class: &str,
+        source_class: &str,
+        properties: &Map<String, Value>,
+        path: &str,
+    ) -> Result<Vec<PlannedSlot>, LinkmlError> {
+        if properties.len() > MAX_LINKML_SLOTS_PER_CLASS {
+            return Err(LinkmlError::new(format!(
+                "{path}/properties contains {} slots, exceeding the per-class limit of {MAX_LINKML_SLOTS_PER_CLASS}",
+                properties.len()
+            )));
+        }
+        self.total_slots = self
+            .total_slots
+            .checked_add(properties.len())
+            .ok_or_else(|| LinkmlError::new("LinkML source slot count overflow"))?;
+        if self.total_slots > MAX_LINKML_TOTAL_SLOTS {
+            return Err(LinkmlError::new(format!(
+                "{path}/properties raises the document slot count above the {MAX_LINKML_TOTAL_SLOTS}-slot limit"
+            )));
+        }
+
+        let mut classified = Vec::with_capacity(properties.len());
+        for source_name in properties.keys() {
+            let source_path = format!("{path}/properties/{}", pointer_escape(source_name));
+            let seed = slot_name_seed(self.config, source_name).map_err(|error| {
+                LinkmlError::new(format!(
+                    "{source_path} in source class {source_class:?}: {error}"
+                ))
+            })?;
+            if self.config.slot_rehomes().contains(source_name) {
+                self.used_rehome_hints.insert(source_name.clone());
+            }
+            debug_assert!(
+                seed.source_kind != SlotSourceKind::Reserved || !seed.requires_rename(),
+                "reserved JSON-LD slots never enter naming policy"
+            );
+            classified.push((source_name.clone(), source_path, seed));
+        }
+
+        // Safe source spellings and their resolved identities win before any
+        // generated name is allocated. This makes the relation independent of
+        // source-object traversal order and protects byte-stable safe output.
+        let mut used_names = BTreeMap::<String, String>::new();
+        let mut used_identities = BTreeMap::<String, String>::new();
+        for (source_name, source_path, seed) in &classified {
+            if seed.requires_rename() {
+                continue;
+            }
+            if let Some(previous) = used_names.insert(seed.direct_name.clone(), source_name.clone())
+            {
+                return Err(LinkmlError::new(format!(
+                    "{path}/properties keys {previous:?} and {source_name:?} use the same LinkML slot name {:?}",
+                    seed.direct_name
+                )));
+            }
+            if let Some(slot_uri) = seed.emitted_slot_uri.as_deref() {
+                let identity = self.expanded_slot_identity(slot_uri);
+                if let Some(previous) =
+                    used_identities.insert(identity.clone(), source_name.clone())
+                {
                     return Err(LinkmlError::new(format!(
-                        "JSON property {property:?} has a non-NCName CURIE local part"
+                        "{source_path} and source property {previous:?} resolve to the same caller-vocabulary slot identity {identity:?}"
                     )));
                 }
-                Ok(seed.emitted_slot_uri)
-            }
-            SlotSourceKind::AbsoluteIri => {
-                if seed.requires_rename() {
-                    return Err(LinkmlError::new(format!(
-                        "absolute JSON property {property:?} is outside every caller-supplied LinkML prefix namespace"
-                    )));
-                }
-                Ok(seed.emitted_slot_uri)
-            }
-            SlotSourceKind::Bare => {
-                // Bare source identity follows the caller-default prefix rule;
-                // attribute-name allocation is class-scoped.
-                let local = if is_linkml_identifier(property) {
-                    property.to_owned()
-                } else {
-                    element_name(property)
-                };
-                Ok(Some(format!("{}:{local}", self.config.default_prefix())))
             }
         }
+
+        let mut planned = Vec::with_capacity(properties.len());
+        for (source_name, source_path, mut seed) in classified {
+            if !seed.requires_rename() {
+                planned.push(PlannedSlot {
+                    source_name,
+                    source_path,
+                    emitted_name: seed.direct_name,
+                    emitted_slot_uri: seed.emitted_slot_uri,
+                });
+                continue;
+            }
+
+            match self.config.sanitize_policy() {
+                SanitizePolicy::Fail => {
+                    return Err(LinkmlError::new(format!(
+                        "{source_path} in source class {source_class:?} (emitted class {emitted_class:?}) has unsafe LinkML slot name {source_name:?} under SanitizePolicy::Fail"
+                    )));
+                }
+                SanitizePolicy::Skip => {
+                    self.ensure_report_capacity(&source_path)?;
+                    self.slot_diagnostics.push(LinkmlSlotDiagnostic {
+                        source_class: source_class.to_owned(),
+                        emitted_class: emitted_class.to_owned(),
+                        source_path: source_path.clone(),
+                        source_name,
+                        old_slot_uri: seed.old_slot_uri,
+                        new_slot_name: None,
+                        emitted_slot_uri: None,
+                        disposition: LinkmlSlotDisposition::Skipped,
+                        reasons: seed.reasons,
+                        detail: "unsafe LinkML slot omitted by caller-selected sanitize policy"
+                            .to_owned(),
+                    });
+                    self.record(
+                        "slot-name-policy-dropped",
+                        &source_path,
+                        "An unsafe JSON property is omitted by the caller-selected LinkML slot-name policy",
+                    );
+                }
+                SanitizePolicy::Rename => {
+                    if seed.disposition == LinkmlSlotDisposition::IdentityPreserved
+                        && let Some(slot_uri) = seed.emitted_slot_uri.as_deref()
+                    {
+                        let identity = self.expanded_slot_identity(slot_uri);
+                        if let Some(previous) = used_identities.get(&identity) {
+                            return Err(LinkmlError::new(format!(
+                                "{source_path} and source property {previous:?} resolve to the same caller-vocabulary slot identity {identity:?}"
+                            )));
+                        }
+                    }
+
+                    let (emitted_name, emitted_slot_uri) = self.allocate_slot_name(
+                        &mut seed,
+                        &used_names,
+                        &used_identities,
+                        &source_path,
+                    )?;
+                    used_names.insert(emitted_name.clone(), source_name.clone());
+                    if let Some(slot_uri) = emitted_slot_uri.as_deref() {
+                        used_identities
+                            .insert(self.expanded_slot_identity(slot_uri), source_name.clone());
+                    }
+
+                    let emitted_slot_uri = emitted_slot_uri.ok_or_else(|| {
+                        LinkmlError::new(format!(
+                            "{source_path} generated a renamed slot without a semantic identity"
+                        ))
+                    })?;
+                    self.ensure_report_capacity(&source_path)?;
+                    self.slot_renames.push(LinkmlSlotRename {
+                        source_class: source_class.to_owned(),
+                        emitted_class: emitted_class.to_owned(),
+                        source_path: source_path.clone(),
+                        source_name: source_name.clone(),
+                        old_slot_uri: seed.old_slot_uri,
+                        new_slot_name: emitted_name.clone(),
+                        emitted_slot_uri: emitted_slot_uri.clone(),
+                        disposition: seed.disposition,
+                        reasons: seed.reasons,
+                    });
+                    if seed.disposition == LinkmlSlotDisposition::IdentityRehomed {
+                        self.record(
+                            "slot-identity-rehomed",
+                            &source_path,
+                            "An unresolved source property token is assigned to the caller's default LinkML vocabulary",
+                        );
+                    }
+                    planned.push(PlannedSlot {
+                        source_name,
+                        source_path,
+                        emitted_name,
+                        emitted_slot_uri: Some(emitted_slot_uri),
+                    });
+                }
+            }
+        }
+        Ok(planned)
+    }
+
+    fn allocate_slot_name(
+        &self,
+        seed: &mut SlotNameSeed,
+        used_names: &BTreeMap<String, String>,
+        used_identities: &BTreeMap<String, String>,
+        source_path: &str,
+    ) -> Result<(String, Option<String>), LinkmlError> {
+        for attempt in 0..=MAX_SLOT_COLLISION_ATTEMPTS {
+            let candidate = if attempt == 0 {
+                seed.direct_name.clone()
+            } else {
+                push_reason(&mut seed.reasons, LinkmlSlotReason::Collision);
+                collision_name(&seed.direct_name, &seed.source_name, attempt - 1)?
+            };
+            if used_names.contains_key(&candidate) {
+                continue;
+            }
+            let slot_uri = if seed.disposition == LinkmlSlotDisposition::IdentityRehomed {
+                Some(candidate.clone())
+            } else {
+                seed.emitted_slot_uri.clone()
+            };
+            if slot_uri.as_deref().is_some_and(|slot_uri| {
+                used_identities.contains_key(&self.expanded_slot_identity(slot_uri))
+            }) {
+                if seed.disposition == LinkmlSlotDisposition::IdentityRehomed {
+                    continue;
+                }
+                let identity = self.expanded_slot_identity(
+                    slot_uri
+                        .as_deref()
+                        .expect("identity collision checked Some"),
+                );
+                let previous = used_identities
+                    .get(&identity)
+                    .expect("identity collision checked present");
+                return Err(LinkmlError::new(format!(
+                    "{source_path} and source property {previous:?} resolve to the same caller-vocabulary slot identity {identity:?}"
+                )));
+            }
+            return Ok((candidate, slot_uri));
+        }
+        Err(LinkmlError::new(format!(
+            "{source_path} exceeds the bounded {MAX_SLOT_COLLISION_ATTEMPTS}-attempt LinkML slot-name collision allocator"
+        )))
+    }
+
+    fn expanded_slot_identity(&self, slot_uri: &str) -> String {
+        if let Some((prefix, local)) = slot_uri.split_once(':')
+            && let Some(namespace) = self.config.prefixes().get(prefix)
+        {
+            return format!("{namespace}{local}");
+        }
+        slot_uri.to_owned()
+    }
+
+    fn ensure_report_capacity(&self, source_path: &str) -> Result<(), LinkmlError> {
+        let rows = self
+            .slot_renames
+            .len()
+            .checked_add(self.slot_diagnostics.len())
+            .and_then(|count| count.checked_add(1))
+            .ok_or_else(|| LinkmlError::new("LinkML slot-report row count overflow"))?;
+        if rows > MAX_LINKML_REPORT_ROWS {
+            return Err(LinkmlError::new(format!(
+                "{source_path} raises the slot-report count above the {MAX_LINKML_REPORT_ROWS}-row limit"
+            )));
+        }
+        Ok(())
     }
 
     fn element_curie(&self, name: &str) -> String {
@@ -2508,7 +2814,7 @@ mod tests {
                 .contains("absent")
         );
 
-        let unknown_prefix = json!({
+        let custom_scheme = json!({
             "$defs": {
                 "Broken": {
                     "type": "object",
@@ -2516,12 +2822,12 @@ mod tests {
                 }
             }
         });
-        assert!(
-            emit(&compiled(&unknown_prefix), &config())
-                .unwrap_err()
-                .to_string()
-                .contains("prefix")
+        let custom = emit(&compiled(&custom_scheme), &config()).expect("custom IRI scheme emits");
+        assert_eq!(
+            custom.document.as_value()["classes"]["Broken"]["attributes"]["ex:value"]["slot_uri"],
+            "other:value"
         );
+        assert_eq!(custom.slot_renames.len(), 1);
 
         let malformed_type = json!({ "$defs": { "Broken": { "type": [] } } });
         assert!(
@@ -2566,5 +2872,204 @@ mod tests {
                 ["slot_uri"],
             "people:name"
         );
+    }
+
+    #[test]
+    fn unsafe_slots_follow_rename_skip_and_fail_policies() {
+        let schema = json!({
+            "$defs": {
+                "Person": {
+                    "type": "object",
+                    "properties": {
+                        "ex:a/b": { "type": "string", "pattern": "^A" },
+                        "ex:safe": { "type": "integer" }
+                    },
+                    "required": ["ex:a/b"]
+                }
+            }
+        });
+
+        let renamed = emit(&compiled(&schema), &config()).expect("default rename emits");
+        let attributes = &renamed.document.as_value()["classes"]["Person"]["attributes"];
+        assert_eq!(attributes["ex:a_b"]["alias"], "ex:a/b");
+        assert_eq!(attributes["ex:a_b"]["slot_uri"], "ex:a/b");
+        assert_eq!(attributes["ex:a_b"]["required"], true);
+        assert_eq!(attributes["ex:a_b"]["pattern"], "^A");
+        assert_eq!(renamed.slot_renames.len(), 1);
+        assert_eq!(
+            renamed.slot_renames[0].audit_tuple(),
+            ("Person", Some("ex:a/b"), "ex:a_b")
+        );
+        assert_eq!(
+            renamed.slot_renames[0].disposition,
+            LinkmlSlotDisposition::IdentityPreserved
+        );
+        assert!(renamed.slot_diagnostics.is_empty());
+
+        let skipped = emit(
+            &compiled(&schema),
+            &config().with_sanitize_policy(SanitizePolicy::Skip),
+        )
+        .expect("skip emits remaining schema");
+        let attributes = &skipped.document.as_value()["classes"]["Person"]["attributes"];
+        assert!(attributes.get("ex:a_b").is_none());
+        assert_eq!(attributes["ex:safe"]["slot_uri"], "ex:safe");
+        assert!(skipped.slot_renames.is_empty());
+        assert_eq!(skipped.slot_diagnostics.len(), 1);
+        assert_eq!(
+            skipped.slot_diagnostics[0].source_path,
+            "#/$defs/Person/properties/ex:a~1b"
+        );
+        assert_eq!(
+            skipped.slot_diagnostics[0].disposition,
+            LinkmlSlotDisposition::Skipped
+        );
+        assert_eq!(
+            skipped
+                .losses
+                .entries()
+                .iter()
+                .map(|entry| entry.code.as_ref())
+                .collect::<Vec<_>>(),
+            vec!["slot-name-policy-dropped"]
+        );
+        check_ledger_sound(&skipped.losses, LOSS_FROM, LOSS_TO).expect("skip loss is registered");
+
+        let error = emit(
+            &compiled(&schema),
+            &config().with_sanitize_policy(SanitizePolicy::Fail),
+        )
+        .expect_err("fail policy rejects unsafe source");
+        assert!(error.detail().contains("source class \"Person\""));
+        assert!(error.detail().contains("ex:a/b"));
+        assert!(error.detail().contains("#/$defs/Person/properties/ex:a~1b"));
+    }
+
+    #[test]
+    fn class_planning_reserves_safe_names_and_bounds_collision_fallback() {
+        let direct = "ex:a_b";
+        let hash_candidate = collision_name(direct, "ex:a/b", 0).expect("hash candidate");
+        let ordinal_candidate = collision_name(direct, "ex:a/b", 1).expect("ordinal candidate");
+        let schema = json!({
+            "$defs": {
+                "Collision": {
+                    "type": "object",
+                    "properties": {
+                        direct: { "type": "string" },
+                        hash_candidate.clone(): { "type": "string" },
+                        "ex:a/b": { "type": "string" }
+                    }
+                }
+            }
+        });
+
+        let output = emit(&compiled(&schema), &config()).expect("collision plan emits");
+        let attributes = output.document.as_value()["classes"]["Collision"]["attributes"]
+            .as_object()
+            .expect("attributes");
+        assert!(attributes.contains_key(direct));
+        assert!(attributes.contains_key(&hash_candidate));
+        assert_eq!(attributes[&ordinal_candidate]["alias"], "ex:a/b");
+        assert_eq!(attributes[&ordinal_candidate]["slot_uri"], "ex:a/b");
+        assert_eq!(output.slot_renames[0].new_slot_name, ordinal_candidate);
+        assert!(
+            output.slot_renames[0]
+                .reasons
+                .contains(&LinkmlSlotReason::Collision)
+        );
+    }
+
+    #[test]
+    fn rehomes_are_exact_loss_accounted_and_stale_hints_fail_closed() {
+        let configured = config()
+            .with_slot_rehomes(BTreeSet::from(["skos:definition".to_owned()]))
+            .expect("valid exact re-home hint");
+        let schema = json!({
+            "$defs": {
+                "Term": {
+                    "type": "object",
+                    "properties": {
+                        "@id": { "type": "string" },
+                        "@unknown": { "type": "string" },
+                        "skos:definition": { "type": "string" }
+                    }
+                }
+            }
+        });
+        let output = emit(&compiled(&schema), &configured).expect("configured re-home emits");
+        let attributes = &output.document.as_value()["classes"]["Term"]["attributes"];
+        assert!(attributes["@id"].get("slot_uri").is_none());
+        assert_eq!(attributes["ex:definition"]["alias"], "skos:definition");
+        assert_eq!(attributes["ex:definition"]["slot_uri"], "ex:definition");
+        assert_eq!(attributes["ex:_unknown"]["alias"], "@unknown");
+        assert_eq!(output.slot_renames.len(), 2);
+        assert!(
+            output
+                .slot_renames
+                .iter()
+                .all(|rename| { rename.disposition == LinkmlSlotDisposition::IdentityRehomed })
+        );
+        assert_eq!(
+            output
+                .losses
+                .entries()
+                .iter()
+                .map(|entry| entry.code.as_ref())
+                .collect::<Vec<_>>(),
+            vec!["slot-identity-rehomed", "slot-identity-rehomed"]
+        );
+        check_ledger_sound(&output.losses, LOSS_FROM, LOSS_TO)
+            .expect("re-home losses are registered");
+
+        let stale = config()
+            .with_slot_rehomes(BTreeSet::from(["skos:definition".to_owned()]))
+            .expect("valid stale hint configuration");
+        let error = emit(
+            &compiled(&json!({
+                "$defs": {
+                    "Term": {
+                        "type": "object",
+                        "properties": { "ex:name": { "type": "string" } }
+                    }
+                }
+            })),
+            &stale,
+        )
+        .expect_err("unused re-home hint fails closed");
+        assert!(error.detail().contains("skos:definition"));
+    }
+
+    #[test]
+    fn nested_unsafe_slots_keep_requiredness_and_use_the_same_planner() {
+        let schema = json!({
+            "$defs": {
+                "Outer": {
+                    "type": "object",
+                    "properties": {
+                        "ex:child/value": {
+                            "type": "object",
+                            "properties": {
+                                "ex:nested/value": { "type": "integer" }
+                            },
+                            "required": ["ex:nested/value"]
+                        }
+                    },
+                    "required": ["ex:child/value"]
+                }
+            }
+        });
+        let output = emit(&compiled(&schema), &config()).expect("nested rename emits");
+        let outer = &output.document.as_value()["classes"]["Outer"]["attributes"]["ex:child_value"];
+        assert_eq!(outer["required"], true);
+        let nested_report = output
+            .slot_renames
+            .iter()
+            .find(|rename| rename.source_name == "ex:nested/value")
+            .expect("nested report");
+        let nested = &output.document.as_value()["classes"][&nested_report.emitted_class]["attributes"]
+            ["ex:nested_value"];
+        assert_eq!(nested["alias"], "ex:nested/value");
+        assert_eq!(nested["required"], true);
+        assert_eq!(nested["slot_uri"], "ex:nested/value");
     }
 }

--- a/crates/shapes/src/linkml/projection.rs
+++ b/crates/shapes/src/linkml/projection.rs
@@ -3,6 +3,7 @@
 
 //! Capability-driven JSON Schema to LinkML 1.11 projection.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 
 use ::purrdf::RdfLocation;
@@ -383,7 +384,12 @@ fn slot_name_seed(config: &LinkmlConfig, source: &str) -> Result<SlotNameSeed, L
     if config.slot_rehomes().contains(source) {
         let mut reasons = vec![LinkmlSlotReason::CallerRehome];
         let local = sanitized_local(trailing_local(source), &mut reasons);
-        let direct_name = bounded_curie(config.default_prefix(), &local, source, &mut reasons)?;
+        let direct_name = bounded_curie(
+            config.default_prefix(),
+            local.as_ref(),
+            source,
+            &mut reasons,
+        )?;
         return Ok(SlotNameSeed {
             source_kind: SlotSourceKind::Bare,
             source_name: source.to_owned(),
@@ -411,7 +417,7 @@ fn slot_name_seed(config: &LinkmlConfig, source: &str) -> Result<SlotNameSeed, L
         }
         let mut reasons = Vec::new();
         let local = sanitized_local(local, &mut reasons);
-        let direct_name = bounded_curie(prefix, &local, source, &mut reasons)?;
+        let direct_name = bounded_curie(prefix, local.as_ref(), source, &mut reasons)?;
         return Ok(SlotNameSeed {
             source_kind: SlotSourceKind::RegisteredCurie,
             source_name: source.to_owned(),
@@ -448,7 +454,7 @@ fn slot_name_seed(config: &LinkmlConfig, source: &str) -> Result<SlotNameSeed, L
             (config.default_prefix(), trailing_local(source))
         };
         let local = sanitized_local(local, &mut reasons);
-        let direct_name = bounded_curie(prefix, &local, source, &mut reasons)?;
+        let direct_name = bounded_curie(prefix, local.as_ref(), source, &mut reasons)?;
         return Ok(SlotNameSeed {
             source_kind: SlotSourceKind::AbsoluteIri,
             source_name: source.to_owned(),
@@ -474,7 +480,12 @@ fn slot_name_seed(config: &LinkmlConfig, source: &str) -> Result<SlotNameSeed, L
 
     let mut reasons = vec![LinkmlSlotReason::BareName];
     let local = sanitized_local(trailing_local(source), &mut reasons);
-    let direct_name = bounded_curie(config.default_prefix(), &local, source, &mut reasons)?;
+    let direct_name = bounded_curie(
+        config.default_prefix(),
+        local.as_ref(),
+        source,
+        &mut reasons,
+    )?;
     Ok(SlotNameSeed {
         source_kind: SlotSourceKind::Bare,
         source_name: source.to_owned(),
@@ -507,12 +518,16 @@ fn trailing_local(source: &str) -> &str {
     source.rsplit(['#', '/', ':']).next().unwrap_or(source)
 }
 
-fn sanitized_local(source: &str, reasons: &mut Vec<LinkmlSlotReason>) -> String {
+fn sanitized_local<'a>(source: &'a str, reasons: &mut Vec<LinkmlSlotReason>) -> Cow<'a, str> {
+    if is_linkml_identifier(source) {
+        return Cow::Borrowed(source);
+    }
+
     let mut output = String::with_capacity(source.len().saturating_add(1));
     let mut characters = source.chars();
     let Some(first) = characters.next() else {
         push_reason(reasons, LinkmlSlotReason::InvalidInitialCharacter);
-        return "_".to_owned();
+        return Cow::Owned("_".to_owned());
     };
 
     if is_linkml_start(first) {
@@ -534,7 +549,7 @@ fn sanitized_local(source: &str, reasons: &mut Vec<LinkmlSlotReason>) -> String 
         }
     }
     debug_assert!(is_linkml_identifier(&output));
-    output
+    Cow::Owned(output)
 }
 
 fn bounded_curie(
@@ -2435,6 +2450,33 @@ mod tests {
             ]),
         )
         .expect("valid config")
+    }
+
+    #[test]
+    fn sanitizer_borrows_valid_locals_and_owns_replacements() {
+        let mut valid_reasons = Vec::new();
+        let valid = sanitized_local("already_valid", &mut valid_reasons);
+        assert!(matches!(valid, Cow::Borrowed("already_valid")));
+        assert!(valid_reasons.is_empty());
+
+        let mut invalid_reasons = Vec::new();
+        let invalid = sanitized_local("9 bad", &mut invalid_reasons);
+        assert!(matches!(invalid, Cow::Owned(ref value) if value == "_9_bad"));
+        assert_eq!(
+            invalid_reasons,
+            vec![
+                LinkmlSlotReason::InvalidCharacter,
+                LinkmlSlotReason::InvalidInitialCharacter,
+            ]
+        );
+
+        let mut empty_reasons = Vec::new();
+        let empty = sanitized_local("", &mut empty_reasons);
+        assert!(matches!(empty, Cow::Owned(ref value) if value == "_"));
+        assert_eq!(
+            empty_reasons,
+            vec![LinkmlSlotReason::InvalidInitialCharacter]
+        );
     }
 
     #[test]

--- a/crates/shapes/src/linkml/projection.rs
+++ b/crates/shapes/src/linkml/projection.rs
@@ -11,7 +11,8 @@ use serde_json::{Map, Value};
 
 use super::{
     LINKML_METAMODEL_VERSION, LinkmlConfig, LinkmlDocument, LinkmlError, LinkmlPackage,
-    is_linkml_identifier, write_linkml,
+    LinkmlSlotDisposition, LinkmlSlotReason, MAX_LINKML_SOURCE_KEY_BYTES, is_linkml_identifier,
+    is_reserved_jsonld_slot, write_linkml,
 };
 use crate::json_schema::CompiledSchema;
 use crate::schema_catalog::{
@@ -22,6 +23,7 @@ use crate::schema_catalog::{
 const LOSS_FROM: &str = "json-schema";
 const LOSS_TO: &str = "linkml-1.11";
 const LOSS_CONTEXT: &str = "shapes:linkml";
+const MAX_GENERATED_SLOT_NAME_BYTES: usize = 255;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ElementKind {
@@ -296,6 +298,248 @@ fn fnv1a(bytes: &[u8]) -> u64 {
         hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
     }
     hash
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SlotSourceKind {
+    Reserved,
+    RegisteredCurie,
+    AbsoluteIri,
+    Bare,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SlotNameSeed {
+    source_kind: SlotSourceKind,
+    source_name: String,
+    direct_name: String,
+    old_slot_uri: Option<String>,
+    emitted_slot_uri: Option<String>,
+    disposition: LinkmlSlotDisposition,
+    reasons: Vec<LinkmlSlotReason>,
+}
+
+impl SlotNameSeed {
+    fn requires_rename(&self) -> bool {
+        self.direct_name != self.source_name
+    }
+}
+
+fn slot_name_seed(config: &LinkmlConfig, source: &str) -> Result<SlotNameSeed, LinkmlError> {
+    if source.len() > MAX_LINKML_SOURCE_KEY_BYTES {
+        return Err(LinkmlError::new(format!(
+            "JSON property name exceeds {MAX_LINKML_SOURCE_KEY_BYTES} bytes"
+        )));
+    }
+    if is_reserved_jsonld_slot(source) {
+        return Ok(SlotNameSeed {
+            source_kind: SlotSourceKind::Reserved,
+            source_name: source.to_owned(),
+            direct_name: source.to_owned(),
+            old_slot_uri: None,
+            emitted_slot_uri: None,
+            disposition: LinkmlSlotDisposition::IdentityPreserved,
+            reasons: Vec::new(),
+        });
+    }
+
+    if config.slot_rehomes().contains(source) {
+        let mut reasons = vec![LinkmlSlotReason::CallerRehome];
+        let local = sanitized_local(trailing_local(source), &mut reasons);
+        let direct_name = bounded_curie(config.default_prefix(), &local, source, &mut reasons)?;
+        return Ok(SlotNameSeed {
+            source_kind: SlotSourceKind::Bare,
+            source_name: source.to_owned(),
+            old_slot_uri: None,
+            emitted_slot_uri: Some(direct_name.clone()),
+            direct_name,
+            disposition: LinkmlSlotDisposition::IdentityRehomed,
+            reasons,
+        });
+    }
+
+    if let Some((prefix, local)) = source.split_once(':')
+        && config.prefixes().contains_key(prefix)
+    {
+        if is_linkml_identifier(local) && source.len() <= MAX_GENERATED_SLOT_NAME_BYTES {
+            return Ok(SlotNameSeed {
+                source_kind: SlotSourceKind::RegisteredCurie,
+                source_name: source.to_owned(),
+                direct_name: source.to_owned(),
+                old_slot_uri: Some(source.to_owned()),
+                emitted_slot_uri: Some(source.to_owned()),
+                disposition: LinkmlSlotDisposition::IdentityPreserved,
+                reasons: Vec::new(),
+            });
+        }
+        let mut reasons = Vec::new();
+        let local = sanitized_local(local, &mut reasons);
+        let direct_name = bounded_curie(prefix, &local, source, &mut reasons)?;
+        return Ok(SlotNameSeed {
+            source_kind: SlotSourceKind::RegisteredCurie,
+            source_name: source.to_owned(),
+            direct_name,
+            old_slot_uri: Some(source.to_owned()),
+            emitted_slot_uri: Some(source.to_owned()),
+            disposition: LinkmlSlotDisposition::IdentityPreserved,
+            reasons,
+        });
+    }
+
+    if purrdf_iri::parse(source).is_ok_and(|iri| iri.has_scheme()) {
+        let matched = longest_namespace_match(config, source);
+        if let Some((prefix, local)) = matched
+            && is_linkml_identifier(local)
+            && source.len() <= MAX_GENERATED_SLOT_NAME_BYTES
+        {
+            return Ok(SlotNameSeed {
+                source_kind: SlotSourceKind::AbsoluteIri,
+                source_name: source.to_owned(),
+                direct_name: source.to_owned(),
+                old_slot_uri: Some(source.to_owned()),
+                emitted_slot_uri: Some(format!("{prefix}:{local}")),
+                disposition: LinkmlSlotDisposition::IdentityPreserved,
+                reasons: Vec::new(),
+            });
+        }
+
+        let mut reasons = Vec::new();
+        let (prefix, local) = if let Some((prefix, local)) = matched {
+            (prefix, local)
+        } else {
+            reasons.push(LinkmlSlotReason::UnmatchedNamespace);
+            (config.default_prefix(), trailing_local(source))
+        };
+        let local = sanitized_local(local, &mut reasons);
+        let direct_name = bounded_curie(prefix, &local, source, &mut reasons)?;
+        return Ok(SlotNameSeed {
+            source_kind: SlotSourceKind::AbsoluteIri,
+            source_name: source.to_owned(),
+            direct_name,
+            old_slot_uri: Some(source.to_owned()),
+            emitted_slot_uri: Some(source.to_owned()),
+            disposition: LinkmlSlotDisposition::IdentityPreserved,
+            reasons,
+        });
+    }
+
+    if is_linkml_identifier(source) && source.len() <= MAX_GENERATED_SLOT_NAME_BYTES {
+        return Ok(SlotNameSeed {
+            source_kind: SlotSourceKind::Bare,
+            source_name: source.to_owned(),
+            direct_name: source.to_owned(),
+            old_slot_uri: None,
+            emitted_slot_uri: Some(format!("{}:{source}", config.default_prefix())),
+            disposition: LinkmlSlotDisposition::IdentityPreserved,
+            reasons: Vec::new(),
+        });
+    }
+
+    let mut reasons = vec![LinkmlSlotReason::BareName];
+    let local = sanitized_local(trailing_local(source), &mut reasons);
+    let direct_name = bounded_curie(config.default_prefix(), &local, source, &mut reasons)?;
+    Ok(SlotNameSeed {
+        source_kind: SlotSourceKind::Bare,
+        source_name: source.to_owned(),
+        old_slot_uri: None,
+        emitted_slot_uri: Some(direct_name.clone()),
+        direct_name,
+        disposition: LinkmlSlotDisposition::IdentityRehomed,
+        reasons,
+    })
+}
+
+fn longest_namespace_match<'a>(
+    config: &'a LinkmlConfig,
+    source: &'a str,
+) -> Option<(&'a str, &'a str)> {
+    config
+        .prefixes()
+        .iter()
+        .filter_map(|(prefix, namespace)| {
+            source
+                .strip_prefix(namespace)
+                .filter(|local| !local.is_empty())
+                .map(|local| (namespace.len(), prefix.as_str(), local))
+        })
+        .min_by(|left, right| right.0.cmp(&left.0).then_with(|| left.1.cmp(right.1)))
+        .map(|(_, prefix, local)| (prefix, local))
+}
+
+fn trailing_local(source: &str) -> &str {
+    source.rsplit(['#', '/', ':']).next().unwrap_or(source)
+}
+
+fn sanitized_local(source: &str, reasons: &mut Vec<LinkmlSlotReason>) -> String {
+    let mut output = String::with_capacity(source.len().saturating_add(1));
+    let mut characters = source.chars();
+    let Some(first) = characters.next() else {
+        push_reason(reasons, LinkmlSlotReason::InvalidInitialCharacter);
+        return "_".to_owned();
+    };
+
+    if is_linkml_start(first) {
+        output.push(first);
+    } else if is_linkml_continue(first) {
+        push_reason(reasons, LinkmlSlotReason::InvalidInitialCharacter);
+        output.push('_');
+        output.push(first);
+    } else {
+        push_reason(reasons, LinkmlSlotReason::InvalidCharacter);
+        output.push('_');
+    }
+    for character in characters {
+        if is_linkml_continue(character) {
+            output.push(character);
+        } else {
+            push_reason(reasons, LinkmlSlotReason::InvalidCharacter);
+            output.push('_');
+        }
+    }
+    debug_assert!(is_linkml_identifier(&output));
+    output
+}
+
+fn bounded_curie(
+    prefix: &str,
+    local: &str,
+    source: &str,
+    reasons: &mut Vec<LinkmlSlotReason>,
+) -> Result<String, LinkmlError> {
+    let direct = format!("{prefix}:{local}");
+    if direct.len() <= MAX_GENERATED_SLOT_NAME_BYTES {
+        return Ok(direct);
+    }
+    push_reason(reasons, LinkmlSlotReason::LengthBound);
+    let hashed = format!("{prefix}:Slot{:016x}", fnv1a(source.as_bytes()));
+    if hashed.len() > MAX_GENERATED_SLOT_NAME_BYTES {
+        return Err(LinkmlError::new(format!(
+            "LinkML prefix {prefix:?} leaves no room within the {MAX_GENERATED_SLOT_NAME_BYTES}-byte generated slot-name limit"
+        )));
+    }
+    Ok(hashed)
+}
+
+fn push_reason(reasons: &mut Vec<LinkmlSlotReason>, reason: LinkmlSlotReason) {
+    if !reasons.contains(&reason) {
+        reasons.push(reason);
+        reasons.sort_unstable();
+    }
+}
+
+fn is_linkml_start(character: char) -> bool {
+    character == '_' || character.is_alphabetic()
+}
+
+fn is_linkml_continue(character: char) -> bool {
+    character == '_'
+        || character == '-'
+        || character == '.'
+        || character.is_alphanumeric()
+        || matches!(
+            character,
+            '\u{300}'..='\u{36f}' | '\u{203f}'..='\u{2040}' | '\u{b7}'
+        )
 }
 
 struct Renderer<'a> {
@@ -964,48 +1208,36 @@ impl Renderer<'_> {
     }
 
     fn slot_uri(&self, property: &str) -> Result<Option<String>, LinkmlError> {
-        if property.starts_with('@') {
-            return Ok(None);
-        }
-
-        if let Some((prefix, local)) = property.split_once(':')
-            && self.config.prefixes().contains_key(prefix)
-        {
-            if !is_linkml_identifier(local) {
-                return Err(LinkmlError::new(format!(
-                    "JSON property {property:?} has a non-NCName CURIE local part"
-                )));
+        let seed = slot_name_seed(self.config, property)?;
+        match seed.source_kind {
+            SlotSourceKind::Reserved => Ok(None),
+            SlotSourceKind::RegisteredCurie => {
+                if seed.requires_rename() {
+                    return Err(LinkmlError::new(format!(
+                        "JSON property {property:?} has a non-NCName CURIE local part"
+                    )));
+                }
+                Ok(seed.emitted_slot_uri)
             }
-            return Ok(Some(property.to_owned()));
-        }
-
-        if purrdf_iri::parse(property).is_ok_and(|iri| iri.has_scheme()) {
-            let compacted = self
-                .config
-                .prefixes()
-                .iter()
-                .filter_map(|(prefix, namespace)| {
-                    property
-                        .strip_prefix(namespace)
-                        .filter(|local| is_linkml_identifier(local))
-                        .map(|local| (namespace.len(), prefix, local))
-                })
-                .max_by_key(|(length, _, _)| *length)
-                .map(|(_, prefix, local)| format!("{prefix}:{local}"))
-                .ok_or_else(|| {
-                    LinkmlError::new(format!(
+            SlotSourceKind::AbsoluteIri => {
+                if seed.requires_rename() {
+                    return Err(LinkmlError::new(format!(
                         "absolute JSON property {property:?} is outside every caller-supplied LinkML prefix namespace"
-                    ))
-                })?;
-            return Ok(Some(compacted));
+                    )));
+                }
+                Ok(seed.emitted_slot_uri)
+            }
+            SlotSourceKind::Bare => {
+                // Bare source identity follows the caller-default prefix rule;
+                // attribute-name allocation is class-scoped.
+                let local = if is_linkml_identifier(property) {
+                    property.to_owned()
+                } else {
+                    element_name(property)
+                };
+                Ok(Some(format!("{}:{local}", self.config.default_prefix())))
+            }
         }
-
-        let local = if is_linkml_identifier(property) {
-            property.to_owned()
-        } else {
-            element_name(property)
-        };
-        Ok(Some(format!("{}:{local}", self.config.default_prefix())))
     }
 
     fn element_curie(&self, name: &str) -> String {
@@ -1851,6 +2083,8 @@ fn conjoin_expression(target: &mut Map<String, Value>, key: &str, values: Vec<Va
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use super::*;
     use ::purrdf::loss::check_ledger_sound;
     use serde_json::json;
@@ -1878,6 +2112,108 @@ mod tests {
             ]),
         )
         .expect("valid config")
+    }
+
+    #[test]
+    fn slot_name_seed_separates_syntax_identity_and_caller_rehomes() {
+        let config = config();
+
+        let registered = slot_name_seed(&config, "ex:a/b").expect("registered CURIE seed");
+        assert_eq!(registered.direct_name, "ex:a_b");
+        assert_eq!(registered.old_slot_uri.as_deref(), Some("ex:a/b"));
+        assert_eq!(registered.emitted_slot_uri.as_deref(), Some("ex:a/b"));
+        assert_eq!(
+            registered.disposition,
+            LinkmlSlotDisposition::IdentityPreserved
+        );
+        assert_eq!(registered.reasons, vec![LinkmlSlotReason::InvalidCharacter]);
+
+        let matched =
+            slot_name_seed(&config, "https://example.org/name").expect("matched absolute IRI seed");
+        assert!(!matched.requires_rename());
+        assert_eq!(matched.emitted_slot_uri.as_deref(), Some("ex:name"));
+
+        let unmatched = slot_name_seed(&config, "https://outside.example/definition")
+            .expect("unmatched absolute IRI seed");
+        assert_eq!(unmatched.direct_name, "ex:definition");
+        assert_eq!(
+            unmatched.emitted_slot_uri.as_deref(),
+            Some("https://outside.example/definition")
+        );
+        assert_eq!(
+            unmatched.reasons,
+            vec![LinkmlSlotReason::UnmatchedNamespace]
+        );
+
+        for (source, expected) in [
+            ("urn:example:part", "ex:part"),
+            ("did:example:123", "ex:_123"),
+            ("mailto:cat@example.org", "ex:cat_example.org"),
+            ("custom:alpha/beta", "ex:beta"),
+        ] {
+            let seed = slot_name_seed(&config, source).expect("non-HTTP absolute IRI seed");
+            assert_eq!(seed.direct_name, expected);
+            assert_eq!(seed.old_slot_uri.as_deref(), Some(source));
+            assert_eq!(seed.emitted_slot_uri.as_deref(), Some(source));
+            assert_eq!(seed.disposition, LinkmlSlotDisposition::IdentityPreserved);
+        }
+
+        let bare = slot_name_seed(&config, "9 bad").expect("bare source seed");
+        assert_eq!(bare.direct_name, "ex:_9_bad");
+        assert_eq!(bare.old_slot_uri, None);
+        assert_eq!(bare.emitted_slot_uri.as_deref(), Some("ex:_9_bad"));
+        assert_eq!(bare.disposition, LinkmlSlotDisposition::IdentityRehomed);
+        assert_eq!(
+            bare.reasons,
+            vec![
+                LinkmlSlotReason::InvalidCharacter,
+                LinkmlSlotReason::InvalidInitialCharacter,
+                LinkmlSlotReason::BareName,
+            ]
+        );
+
+        let reserved = slot_name_seed(&config, "@id").expect("reserved source seed");
+        assert_eq!(reserved.source_kind, SlotSourceKind::Reserved);
+        assert_eq!(reserved.emitted_slot_uri, None);
+        let unknown = slot_name_seed(&config, "@unknown").expect("unknown at-name seed");
+        assert_eq!(unknown.direct_name, "ex:_unknown");
+        assert_eq!(unknown.disposition, LinkmlSlotDisposition::IdentityRehomed);
+
+        let rehome_config = config
+            .with_slot_rehomes(BTreeSet::from(["skos:definition".to_owned()]))
+            .expect("caller re-home config");
+        let rehomed =
+            slot_name_seed(&rehome_config, "skos:definition").expect("re-homed source seed");
+        assert_eq!(rehomed.direct_name, "ex:definition");
+        assert_eq!(rehomed.old_slot_uri, None);
+        assert_eq!(rehomed.emitted_slot_uri.as_deref(), Some("ex:definition"));
+        assert_eq!(rehomed.disposition, LinkmlSlotDisposition::IdentityRehomed);
+        assert_eq!(rehomed.reasons, vec![LinkmlSlotReason::CallerRehome]);
+    }
+
+    #[test]
+    fn slot_name_seed_has_lexical_namespace_ties_and_bounded_names() {
+        let tied = LinkmlConfig::new(
+            "https://example.org/schema",
+            "Example-Schema",
+            "Caller-owned tie fixture.",
+            "zz",
+            BTreeMap::from([
+                ("aa".to_owned(), "https://example.org/".to_owned()),
+                ("linkml".to_owned(), "https://w3id.org/linkml/".to_owned()),
+                ("zz".to_owned(), "https://example.org/".to_owned()),
+            ]),
+        )
+        .expect("valid tied config");
+        let seed = slot_name_seed(&tied, "https://example.org/name").expect("tied seed");
+        assert_eq!(seed.emitted_slot_uri.as_deref(), Some("aa:name"));
+
+        let source = format!("ex:{}", "x".repeat(MAX_GENERATED_SLOT_NAME_BYTES));
+        let bounded = slot_name_seed(&config(), &source).expect("bounded seed");
+        assert!(bounded.direct_name.len() <= MAX_GENERATED_SLOT_NAME_BYTES);
+        assert!(bounded.direct_name.starts_with("ex:Slot"));
+        assert!(bounded.reasons.contains(&LinkmlSlotReason::LengthBound));
+        assert_eq!(bounded.old_slot_uri.as_deref(), Some(source.as_str()));
     }
 
     fn exact_schema() -> Value {

--- a/crates/shapes/src/linkml/projection.rs
+++ b/crates/shapes/src/linkml/projection.rs
@@ -1317,21 +1317,7 @@ impl Renderer<'_> {
         properties: &Map<String, Value>,
         path: &str,
     ) -> Result<Vec<PlannedSlot>, LinkmlError> {
-        if properties.len() > MAX_LINKML_SLOTS_PER_CLASS {
-            return Err(LinkmlError::new(format!(
-                "{path}/properties contains {} slots, exceeding the per-class limit of {MAX_LINKML_SLOTS_PER_CLASS}",
-                properties.len()
-            )));
-        }
-        self.total_slots = self
-            .total_slots
-            .checked_add(properties.len())
-            .ok_or_else(|| LinkmlError::new("LinkML source slot count overflow"))?;
-        if self.total_slots > MAX_LINKML_TOTAL_SLOTS {
-            return Err(LinkmlError::new(format!(
-                "{path}/properties raises the document slot count above the {MAX_LINKML_TOTAL_SLOTS}-slot limit"
-            )));
-        }
+        self.total_slots = checked_slot_total(self.total_slots, properties.len(), path)?;
 
         let mut classified = Vec::with_capacity(properties.len());
         for source_name in properties.keys() {
@@ -1535,18 +1521,12 @@ impl Renderer<'_> {
     }
 
     fn ensure_report_capacity(&self, source_path: &str) -> Result<(), LinkmlError> {
-        let rows = self
+        let current = self
             .slot_renames
             .len()
             .checked_add(self.slot_diagnostics.len())
-            .and_then(|count| count.checked_add(1))
             .ok_or_else(|| LinkmlError::new("LinkML slot-report row count overflow"))?;
-        if rows > MAX_LINKML_REPORT_ROWS {
-            return Err(LinkmlError::new(format!(
-                "{source_path} raises the slot-report count above the {MAX_LINKML_REPORT_ROWS}-row limit"
-            )));
-        }
-        Ok(())
+        checked_report_rows(current, source_path).map(|_| ())
     }
 
     fn element_curie(&self, name: &str) -> String {
@@ -2200,6 +2180,39 @@ impl Renderer<'_> {
     }
 }
 
+fn checked_slot_total(
+    current: usize,
+    class_slots: usize,
+    path: &str,
+) -> Result<usize, LinkmlError> {
+    if class_slots > MAX_LINKML_SLOTS_PER_CLASS {
+        return Err(LinkmlError::new(format!(
+            "{path}/properties contains {class_slots} slots, exceeding the per-class limit of {MAX_LINKML_SLOTS_PER_CLASS}"
+        )));
+    }
+    let total = current
+        .checked_add(class_slots)
+        .ok_or_else(|| LinkmlError::new("LinkML source slot count overflow"))?;
+    if total > MAX_LINKML_TOTAL_SLOTS {
+        return Err(LinkmlError::new(format!(
+            "{path}/properties raises the document slot count above the {MAX_LINKML_TOTAL_SLOTS}-slot limit"
+        )));
+    }
+    Ok(total)
+}
+
+fn checked_report_rows(current: usize, source_path: &str) -> Result<usize, LinkmlError> {
+    let rows = current
+        .checked_add(1)
+        .ok_or_else(|| LinkmlError::new("LinkML slot-report row count overflow"))?;
+    if rows > MAX_LINKML_REPORT_ROWS {
+        return Err(LinkmlError::new(format!(
+            "{source_path} raises the slot-report count above the {MAX_LINKML_REPORT_ROWS}-row limit"
+        )));
+    }
+    Ok(rows)
+}
+
 fn extra_slots(allowed: bool, range_expression: Option<Map<String, Value>>) -> Value {
     let mut extra = Map::new();
     extra.insert("allowed".to_owned(), Value::Bool(allowed));
@@ -2396,6 +2409,7 @@ mod tests {
 
     use super::*;
     use ::purrdf::loss::check_ledger_sound;
+    use proptest::prelude::*;
     use serde_json::json;
 
     fn compiled(schema: &Value) -> CompiledSchema {
@@ -2455,6 +2469,7 @@ mod tests {
         );
 
         for (source, expected) in [
+            ("http://outside.example/name", "ex:name"),
             ("urn:example:part", "ex:part"),
             ("did:example:123", "ex:_123"),
             ("mailto:cat@example.org", "ex:cat_example.org"),
@@ -2487,6 +2502,25 @@ mod tests {
         let unknown = slot_name_seed(&config, "@unknown").expect("unknown at-name seed");
         assert_eq!(unknown.direct_name, "ex:_unknown");
         assert_eq!(unknown.disposition, LinkmlSlotDisposition::IdentityRehomed);
+
+        for (source, expected) in [
+            ("", "ex:_"),
+            ("ex:9 cats", "ex:_9_cats"),
+            ("ex:cat🐈", "ex:cat_"),
+            ("https://outside.example/", "ex:_"),
+        ] {
+            assert_eq!(
+                slot_name_seed(&config, source)
+                    .expect("edge-case seed")
+                    .direct_name,
+                expected
+            );
+        }
+        assert!(
+            !slot_name_seed(&config, "ex:Δelta")
+                .expect("Unicode NCName seed")
+                .requires_rename()
+        );
 
         let rehome_config = config
             .with_slot_rehomes(BTreeSet::from(["skos:definition".to_owned()]))
@@ -2909,6 +2943,11 @@ mod tests {
         );
         assert!(renamed.slot_diagnostics.is_empty());
 
+        let source = compiled(&schema);
+        let source_bytes = source.schema_json.clone();
+        let _ = emit(&source, &config()).expect("source immutability probe emits");
+        assert_eq!(source.schema_json, source_bytes);
+
         let skipped = emit(
             &compiled(&schema),
             &config().with_sanitize_policy(SanitizePolicy::Skip),
@@ -3043,6 +3082,94 @@ mod tests {
     }
 
     #[test]
+    fn reserved_carriers_and_semantic_identity_collisions_are_explicit() {
+        for reserved in ["@annotation", "@id", "@language", "@type", "@value"] {
+            let seed = slot_name_seed(&config(), reserved).expect("reserved seed");
+            assert_eq!(seed.source_kind, SlotSourceKind::Reserved);
+            assert!(!seed.requires_rename());
+            assert_eq!(seed.emitted_slot_uri, None);
+        }
+
+        for properties in [
+            json!({
+                "name": { "type": "string" },
+                "ex:name": { "type": "string" }
+            }),
+            json!({
+                "ex:name": { "type": "string" },
+                "https://example.org/name": { "type": "string" }
+            }),
+        ] {
+            let schema = json!({
+                "$defs": {
+                    "Collision": {
+                        "type": "object",
+                        "properties": properties
+                    }
+                }
+            });
+            assert!(
+                emit(&compiled(&schema), &config())
+                    .expect_err("semantic identity collision")
+                    .detail()
+                    .contains("same caller-vocabulary slot identity")
+            );
+        }
+
+        let rehome = config()
+            .with_slot_rehomes(BTreeSet::from(["skos:definition".to_owned()]))
+            .expect("re-home config");
+        let schema = json!({
+            "$defs": {
+                "Collision": {
+                    "type": "object",
+                    "properties": {
+                        "definition": { "type": "string" },
+                        "skos:definition": { "type": "string" }
+                    }
+                }
+            }
+        });
+        let output = emit(&compiled(&schema), &rehome).expect("re-home collision allocates");
+        let renamed = output
+            .slot_renames
+            .iter()
+            .find(|row| row.source_name == "skos:definition")
+            .expect("re-home report");
+        assert!(renamed.reasons.contains(&LinkmlSlotReason::Collision));
+        assert_ne!(renamed.emitted_slot_uri, "ex:definition");
+    }
+
+    #[test]
+    fn sanitizer_collisions_have_one_lexical_direct_owner() {
+        let schema = json!({
+            "$defs": {
+                "Collision": {
+                    "type": "object",
+                    "properties": {
+                        "ex:a/b": { "type": "string" },
+                        "ex:a?b": { "type": "string" }
+                    }
+                }
+            }
+        });
+        let output = emit(&compiled(&schema), &config()).expect("sanitizer collision emits");
+        assert_eq!(output.slot_renames.len(), 2);
+        let slash = output
+            .slot_renames
+            .iter()
+            .find(|row| row.source_name == "ex:a/b")
+            .expect("slash row");
+        let question = output
+            .slot_renames
+            .iter()
+            .find(|row| row.source_name == "ex:a?b")
+            .expect("question row");
+        assert_eq!(slash.new_slot_name, "ex:a_b");
+        assert!(question.reasons.contains(&LinkmlSlotReason::Collision));
+    }
+
+    #[test]
     fn nested_unsafe_slots_keep_requiredness_and_use_the_same_planner() {
         let schema = json!({
             "$defs": {
@@ -3074,5 +3201,142 @@ mod tests {
         assert_eq!(nested["alias"], "ex:nested/value");
         assert_eq!(nested["required"], true);
         assert_eq!(nested["slot_uri"], "ex:nested/value");
+    }
+
+    #[test]
+    fn every_slot_resource_limit_fails_before_unbounded_work() {
+        let oversized_schema = CompiledSchema {
+            schema_json: " ".repeat(MAX_LINKML_SOURCE_SCHEMA_BYTES + 1),
+            openapi_json: "{}\n".to_owned(),
+            losses: LossLedger::new(),
+        };
+        assert!(
+            emit(&oversized_schema, &config())
+                .expect_err("source byte bound")
+                .detail()
+                .contains("source exceeds")
+        );
+
+        let oversized_key = "x".repeat(MAX_LINKML_SOURCE_KEY_BYTES + 1);
+        assert!(
+            slot_name_seed(&config(), &oversized_key)
+                .expect_err("source key bound")
+                .detail()
+                .contains("property name exceeds")
+        );
+        assert!(
+            checked_slot_total(0, MAX_LINKML_SLOTS_PER_CLASS + 1, "#/$defs/Large")
+                .expect_err("per-class bound")
+                .detail()
+                .contains("per-class limit")
+        );
+        assert!(
+            checked_slot_total(MAX_LINKML_TOTAL_SLOTS, 1, "#/$defs/Large")
+                .expect_err("total bound")
+                .detail()
+                .contains("document slot count")
+        );
+        assert!(
+            checked_report_rows(MAX_LINKML_REPORT_ROWS, "#/$defs/Large/properties/ex:x")
+                .expect_err("report bound")
+                .detail()
+                .contains("slot-report count")
+        );
+
+        let config = config();
+        let elements = BTreeMap::new();
+        let renderer = Renderer::new(&config, &elements);
+        let mut seed = slot_name_seed(&config, "ex:a/b").expect("unsafe seed");
+        let mut used_names =
+            BTreeMap::from([(seed.direct_name.clone(), "safe direct owner".to_owned())]);
+        for ordinal in 0..MAX_SLOT_COLLISION_ATTEMPTS {
+            used_names.insert(
+                collision_name(&seed.direct_name, &seed.source_name, ordinal)
+                    .expect("bounded collision candidate"),
+                format!("candidate {ordinal}"),
+            );
+        }
+        assert!(
+            renderer
+                .allocate_slot_name(
+                    &mut seed,
+                    &used_names,
+                    &BTreeMap::new(),
+                    "#/$defs/Large/properties/ex:a~1b",
+                )
+                .expect_err("collision bound")
+                .detail()
+                .contains("collision allocator")
+        );
+    }
+
+    #[test]
+    fn safe_input_matches_the_committed_byte_golden() {
+        let schema = json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "Safe": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "@id": { "type": "string" },
+                        "ex:name": { "type": "string", "pattern": "^[A-Z]" }
+                    },
+                    "required": ["ex:name"]
+                }
+            }
+        });
+        let output = emit(&compiled(&schema), &config()).expect("safe fixture emits");
+        assert!(output.slot_renames.is_empty());
+        assert!(output.slot_diagnostics.is_empty());
+        assert!(output.losses.is_empty());
+        assert_eq!(
+            output.element_names,
+            BTreeMap::from([("Safe".to_owned(), "Safe".to_owned())])
+        );
+        assert_eq!(
+            output.yaml,
+            include_str!("../../tests/linkml_safe.golden.yaml")
+        );
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(128))]
+
+        #[test]
+        fn ncname_sanitizer_is_total_valid_and_deterministic(source in any::<String>()) {
+            let mut first_reasons = Vec::new();
+            let first = sanitized_local(&source, &mut first_reasons);
+            let mut second_reasons = Vec::new();
+            let second = sanitized_local(&source, &mut second_reasons);
+            prop_assert!(is_linkml_identifier(&first));
+            prop_assert_eq!(first, second);
+            prop_assert_eq!(first_reasons, second_reasons);
+        }
+
+        #[test]
+        fn slot_planning_is_independent_of_property_insertion_order(
+            names in proptest::collection::btree_set("[A-Za-z0-9_ /?.-]{1,24}", 1..24)
+        ) {
+            let mut forward = Map::new();
+            for name in &names {
+                forward.insert(format!("ex:{name}"), json!({ "type": "string" }));
+            }
+            let mut reverse = Map::new();
+            for name in names.iter().rev() {
+                reverse.insert(format!("ex:{name}"), json!({ "type": "string" }));
+            }
+            let source = |properties| json!({
+                "$defs": {
+                    "Order": {
+                        "type": "object",
+                        "properties": properties
+                    }
+                }
+            });
+            let left = emit(&compiled(&source(forward)), &config());
+            let right = emit(&compiled(&source(reverse)), &config());
+            prop_assert_eq!(left, right);
+        }
     }
 }

--- a/crates/shapes/tests/linkml_oracle.py
+++ b/crates/shapes/tests/linkml_oracle.py
@@ -308,6 +308,99 @@ def _assert_lossy(payload: dict[str, Any]) -> None:
     _assert_reverse(payload, ["<https://example.org/Lossy>"])
 
 
+def _assert_renamed(payload: dict[str, Any]) -> None:
+    schema = _load(payload["yaml"])
+    view = SchemaView(schema)
+    if sorted(view.all_classes()) != ["Carrier"]:
+        raise AssertionError(f"unexpected renamed classes: {sorted(view.all_classes())}")
+
+    reports = payload["slot_renames"]
+    if len(reports) != 7:
+        raise AssertionError(f"unexpected rename report size: {len(reports)}")
+    ordered = sorted(
+        reports,
+        key=lambda row: (row["source_class"], row["source_path"], row["source_name"]),
+    )
+    if reports != ordered:
+        raise AssertionError("rename report is not in canonical source order")
+    if payload["slot_diagnostics"]:
+        raise AssertionError("default rename fixture unexpectedly returned skip diagnostics")
+
+    by_source = {row["source_name"]: row for row in reports}
+    for source, row in by_source.items():
+        slot = view.induced_slot(row["new_slot_name"], "Carrier")
+        if str(slot.slot_uri) != row["emitted_slot_uri"]:
+            raise AssertionError(
+                f"{source!r} slot_uri drifted: {slot.slot_uri!r} != "
+                f"{row['emitted_slot_uri']!r}"
+            )
+        if row["disposition"] == "identity-preserved":
+            if row["old_slot_uri"] != row["emitted_slot_uri"]:
+                raise AssertionError(f"{source!r} lost its original semantic identity")
+        elif row["disposition"] == "identity-rehomed":
+            if row["old_slot_uri"] is not None:
+                raise AssertionError(f"{source!r} falsely claims a source semantic identity")
+            if row["new_slot_name"] != row["emitted_slot_uri"]:
+                raise AssertionError(f"{source!r} re-home is not explicit")
+        else:
+            raise AssertionError(f"unexpected rename disposition: {row!r}")
+
+    expected_uris = {
+        "custom:alpha/beta": "custom:alpha/beta",
+        "did:example:123": "did:example:123",
+        "ex:a/b": "ex:a/b",
+        "https://outside.example/path/external": (
+            "https://outside.example/path/external"
+        ),
+        "mailto:cat@example.org": "mailto:cat@example.org",
+        "skos:definition": "ex:definition",
+        "urn:example:part": "urn:example:part",
+    }
+    observed_uris = {
+        source: row["emitted_slot_uri"] for source, row in by_source.items()
+    }
+    if observed_uris != expected_uris:
+        raise AssertionError(f"renamed identity map drifted: {observed_uris!r}")
+
+    generated = _generate(schema)
+    _assert_reference_closure(generated)
+    properties = generated["$defs"]["Carrier"]["properties"]
+    expected_names = set(by_source)
+    if set(properties) != expected_names:
+        raise AssertionError(
+            f"official generator slot names drifted: {sorted(properties)!r}"
+        )
+    if generated["$defs"]["Carrier"].get("required") != ["ex:a/b"]:
+        raise AssertionError("renamed required slot drifted")
+
+    losses = payload["losses"]["losses"]
+    if len(losses) != 1 or losses[0]["code"] != "slot-identity-rehomed":
+        raise AssertionError(f"unexpected renamed losses: {losses!r}")
+    if not losses[0]["intentional"]:
+        raise AssertionError("identity re-home is not registered")
+
+    reverse_properties = payload["reverse"]["schema"]["$defs"]["Carrier"][
+        "properties"
+    ]
+    expected_reverse = {
+        "@annotation",
+        "@id",
+        "@type",
+        "custom:alpha/beta",
+        "did:example:123",
+        "ex:a/b",
+        "ex:definition",
+        "https://outside.example/path/external",
+        "mailto:cat@example.org",
+        "urn:example:part",
+    }
+    if set(reverse_properties) != expected_reverse:
+        raise AssertionError(
+            f"reverse predicate identities drifted: {sorted(reverse_properties)!r}"
+        )
+    _assert_reverse(payload, ["<https://example.org/Carrier>"])
+
+
 def main() -> None:
     if importlib.metadata.version("linkml") != LINKML_PACKAGE_VERSION:
         raise AssertionError("linkml package version is not locked to 1.11.1")
@@ -317,9 +410,11 @@ def main() -> None:
     payload = _fixture()
     _assert_exact(payload["exact"])
     _assert_lossy(payload["lossy"])
+    _assert_renamed(payload["renamed"])
     print(
         "LinkML oracle: exact $defs and 16 instance probes agree; "
-        "18 located losses, reverse SHACL imports, and representable widening probes pass"
+        "18 located losses, 7 verified slot renames, reverse SHACL imports, "
+        "and representable widening probes pass"
     )
 
 

--- a/crates/shapes/tests/linkml_safe.golden.yaml
+++ b/crates/shapes/tests/linkml_safe.golden.yaml
@@ -1,0 +1,26 @@
+classes:
+  Safe:
+    attributes:
+      '@id':
+        alias: '@id'
+        range: string
+        required: false
+      ex:name:
+        alias: ex:name
+        pattern: ^[A-Z]
+        range: string
+        required: true
+        slot_uri: ex:name
+    class_uri: ex:Safe
+    extra_slots:
+      allowed: false
+default_prefix: ex
+description: Caller-owned exact projection fixture.
+id: https://example.org/schema
+imports:
+- linkml:types
+metamodel_version: 1.11.0
+name: Example-Schema
+prefixes:
+  ex: https://example.org/
+  linkml: https://w3id.org/linkml/

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -232,11 +232,24 @@ warmed import. Those counters represent cumulative allocation traffic, not
 retained or peak memory, and the benchmark is report-only: neither timing nor
 allocation output is a CI threshold or performance promise.
 
+The `linkml_slot_emission` group measures the forward name-planning boundary on
+matched fixtures with the same class, slot count, requiredness, and constraint
+payload. `safe` uses directly representable names, `rename` uses distinct unsafe
+locals, and `collision` gives every unsafe local one sanitized stem while a safe
+slot owns that stem. Each mode runs at 32, 1,024, and 60,000 slots (near the
+65,536 per-class limit). Schema/config construction stays outside the timed
+loop; warmup, one-operation allocation probe, and measured loop all assert the
+expected rename and collision counts. Throughput is total source slots. The
+printed allocation calls/requested bytes are traffic, not retained or peak
+memory, and no speedup claim or gate is attached to them.
+
 ```sh
 cargo bench -p purrdf-shapes --bench validate --locked -- shacl_schema_import
 cargo bench -p purrdf-shapes --bench validate --locked -- shacl_schema_import --quick
 cargo bench -p purrdf-shapes --bench validate --locked -- shacl_linkml_import
 cargo bench -p purrdf-shapes --bench validate --locked -- shacl_linkml_import --quick
+cargo bench -p purrdf-shapes --bench validate --locked -- linkml_slot_emission
+cargo bench -p purrdf-shapes --bench validate --locked -- linkml_slot_emission --quick
 ```
 
 ### SHACL ontology schema surface

--- a/docs/book/src/validation/shacl.md
+++ b/docs/book/src/validation/shacl.md
@@ -148,24 +148,40 @@ with `emit_linkml`. `LinkmlConfig` requires the caller's schema IRI, name,
 description, default prefix, and complete prefix map, so PurRDF never mints a
 consumer vocabulary or identity. The returned `LinkmlPackage` includes the
 typed document, deterministic YAML, a reversible `$defs`-key mapping, and a
-located `json-schema` → `linkml-1.11` loss ledger.
+located `json-schema` → `linkml-1.11` loss ledger. It also carries ordered,
+integrity-checked slot rename and skip-diagnostic reports.
 
 Classes and exact property aliases, types, enums, local references, inline
 objects, requiredness, homogeneous arrays, patterns, inclusive bounds, and
-LinkML boolean expressions are represented directly. Every unsupported
-assertion is classified by a closed capability table; malformed inputs,
-external/dynamic/dangling references, prefix mistakes, and deterministic-name
-collisions fail closed. `parse_linkml` and `write_linkml` preserve all
+LinkML boolean expressions are represented directly. An unsafe LinkML slot name
+uses `SanitizePolicy::Rename` by default; `Skip` omits only that slot with a
+located diagnostic/loss, and `Fail` returns a contextual error. Rename preserves
+declared CURIE and absolute-IRI identity byte-exactly in `slot_uri`; an unsafe
+bare token or exact caller re-home receives a reported identity under the
+caller-supplied default prefix. All valid IRI schemes remain absolute unless
+the caller marks that exact token, so custom schemes are not guessed from their
+spelling. Safe names reserve first and hash-plus-ordinal collision allocation is
+bounded and deterministic.
+
+Every unsupported assertion is classified by a closed capability table;
+malformed inputs, external/dynamic/dangling references, stale re-home hints,
+semantic identity collisions, and fixed-limit breaches fail closed.
+`parse_linkml` and `write_linkml` preserve all
 JSON-compatible metamodel fields and provide byte-stable read/write round trips
 while rejecting YAML-only tags, duplicate keys, non-string keys, and non-finite
 numbers.
 
 `import_linkml` consumes that validated native document; the emitted-package
 variant `import_linkml_package` first verifies canonical YAML and the reversible
-element map. Both use the same caller-owned SHACL import configuration.
+element map, slot reports, policy losses, aliases, and emitted identities. Both
+use the same caller-owned SHACL import configuration. Migration adapters should
+pass `CompiledSchema` unchanged, configure exact re-homes, and consume
+`slot_renames`; rewriting shared property/required keys is unnecessary.
 
 The Rust production path has no LinkML-toolkit dependency. CI uses the locked
-official LinkML 1.11.1 Python packages only as a differential oracle:
+official LinkML 1.11.1 Python packages only as a differential oracle. It loads
+safe, lossy, and renamed fixtures through `SchemaDefinition` and `SchemaView`,
+regenerates JSON Schema, and verifies reverse predicates:
 
 ```bash
 make linkml-oracle

--- a/generated/transcode-loss-matrix.json
+++ b/generated/transcode-loss-matrix.json
@@ -665,6 +665,20 @@
     "note": "JSON Schema minProperties/maxProperties assertions have no LinkML 1.11 class expression. Named attributes and their requiredness remain, while total property-count validation is omitted."
   },
   {
+    "code": "slot-identity-rehomed",
+    "from": "json-schema",
+    "to": "linkml-1.11",
+    "intentional": true,
+    "note": "A source JSON property token without a caller-resolvable RDF identity is assigned to a concrete URI under the caller's configured LinkML default prefix. The source token, generated slot name, and assigned identity remain explicit in the projection report."
+  },
+  {
+    "code": "slot-name-policy-dropped",
+    "from": "json-schema",
+    "to": "linkml-1.11",
+    "intentional": true,
+    "note": "The caller selected LinkML slot-name skipping for a JSON property whose spelling cannot be emitted directly. The single property is omitted and its exact source location remains explicit in the projection diagnostic."
+  },
+  {
     "code": "string-length-validation-dropped",
     "from": "json-schema",
     "to": "linkml-1.11",


### PR DESCRIPTION
Closes #132

## Outcome

LinkML emission now separates source property spelling, RDF identity, emitted slot name, policy disposition, and source location. A single NCName-unsafe property no longer aborts the default document: `LinkmlConfig::new` selects deterministic `SanitizePolicy::Rename`, while callers can explicitly select `Skip` or `Fail`.

## Behavior

- Plans every class before rendering so unchanged names and semantic identities reserve first and allocation is independent of source-object insertion order.
- Keeps a declared CURIE prefix and sanitizes only its local spelling; the exact original CURIE remains in `slot_uri`.
- Preserves every parser-valid absolute IRI byte-exactly in `slot_uri`, including HTTP(S), `urn`, `did`, `mailto`, and custom schemes.
- Uses the caller's default prefix for generated names of unmatched absolute IRIs while preserving their absolute identity.
- Assigns unsafe bare names and exact caller-marked unresolved tokens to the caller-default vocabulary, with an explicit `slot-identity-rehomed` loss.
- Returns ordered typed rename rows containing source/emitted class, JSON Pointer, source spelling, optional old URI, new name, emitted URI, disposition, and reasons; `audit_tuple()` exposes `(class, old_slot_uri, new_slot_name)`.
- `Skip` omits only the unsafe slot, returns a located typed diagnostic, and records `slot-name-policy-dropped`; `Fail` returns a contextual class/property/pointer error.
- Preserves `alias`, requiredness, constraints, and nested inline-class behavior without mutating `CompiledSchema`.
- Resolves spelling and re-home collisions through bounded hash-plus-ordinal allocation; hard-fails duplicate preserved semantic identities.
- Verifies report contents/order, policy losses, aliases, and emitted identities before package reverse import.
- Enforces fixed bounds on source bytes, source-key bytes, per-class and total slots, report rows, generated names, and collision attempts.

## Proof

- 29 focused LinkML tests, including 128-case property tests and a byte-exact safe-input golden.
- Locked official LinkML 1.11.1 oracle loads the renamed document through `SchemaDefinition` and `SchemaView`, regenerates the original aliased JSON properties, and verifies seven identity forms plus PurRDF reverse predicates.
- Criterion covers matched safe, rename-heavy, and one-stem collision-heavy workloads at 32, 1,024, and 60,000 slots, with asserted report cardinality and one-operation allocation traffic.
- The public types are exposed through `purrdf-shapes` and `purrdf::shapes`; crate/book/benchmark documentation describes policy selection and migration without a schema-rewrite pass.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache make metadata`
- `UV_CACHE_DIR=/tmp/uv-cache make doc`
- `UV_CACHE_DIR=/tmp/uv-cache make check`
- `UV_CACHE_DIR=/tmp/uv-cache make linkml-oracle`
- `cargo bench -p purrdf-shapes --bench validate --locked --no-run`
- `cargo bench -p purrdf-shapes --bench validate --locked -- linkml_slot_emission --quick`
- repo-pinned mdBook 0.5.3 `mdbook build docs/book`
- `UV_CACHE_DIR=/tmp/uv-cache make wasm-pkg-size` — 6,047,425 / 6,225,000 bytes; ceiling unchanged
- workspace-aware whitespace check and prohibited-marker scan
- all branch commits signature-verified; clean worktree; local/remote parity

## Residual risk

No known correctness gap remains. Exact semantic re-homing is intentionally non-invertible to the unresolved source token and is therefore represented in both the typed report and closed loss ledger. Criterion results are report-only observations, not latency or allocation thresholds.
