### PR TITLE
shapes: emit deterministic rich Pydantic packages

### DIFF
--- a/crates/purrdf/src/lib.rs
+++ b/crates/purrdf/src/lib.rs
@@ -252,6 +252,37 @@ mod tests {
             &shapes::GraphqlPackage,
             &shapes::SchemaImportConfig,
         ) -> Result<shapes::ImportedShapes, shapes::GraphqlError> = shapes::import_graphql_package;
+
+        let module = shapes::PydanticModuleConfig::new(
+            "domain.people",
+            "Caller-owned facade module documentation.",
+        )
+        .expect("module");
+        let class = shapes::PydanticClassConfig::new(
+            "Person",
+            "domain.people",
+            "Caller-owned facade class documentation.",
+            std::collections::BTreeMap::new(),
+        )
+        .expect("class");
+        let topology = shapes::PydanticPackageTopology::new([module], [class])
+            .expect("topology through facade");
+        let stamp = shapes::PydanticVersionStamp::new(
+            "1.2.3+facade.1",
+            "Caller-owned facade version documentation.",
+        )
+        .expect("version through facade");
+        let config = shapes::PydanticConfig::new(
+            "facade_models",
+            "Caller-owned facade package documentation.",
+            "Caller-owned facade support documentation.",
+        )
+        .expect("config through facade")
+        .with_topology(topology)
+        .expect("topology config through facade")
+        .with_version_stamp(stamp)
+        .expect("version config through facade");
+        assert_eq!(config.package_name(), "facade_models");
     }
 
     #[test]

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -91,3 +91,7 @@ harness = false
 [[bench]]
 name = "schema_surface"
 harness = false
+
+[[bench]]
+name = "pydantic_package"
+harness = false

--- a/crates/shapes/README.md
+++ b/crates/shapes/README.md
@@ -186,6 +186,57 @@ assert_eq!(
 );
 ```
 
+Callers that need a distribution-ready package can supply a total topology,
+class documentation and arbitrary sorted JSON linkage metadata, plus an exact
+PEP 440 version. Every `$defs` key must occur exactly once and every declared
+leaf module must own a class:
+
+```rust,ignore
+use std::collections::BTreeMap;
+use purrdf_shapes::{
+    PydanticClassConfig, PydanticModuleConfig, PydanticPackageTopology,
+    PydanticVersionStamp,
+};
+use serde_json::json;
+
+let topology = PydanticPackageTopology::new(
+    [PydanticModuleConfig::new(
+        "domain.people",
+        "Caller-owned people module.",
+    )?],
+    [PydanticClassConfig::new(
+        "Person",
+        "domain.people",
+        "Caller-owned Person documentation.",
+        BTreeMap::from([
+            ("definitionDigest".to_owned(), json!("sha256:...")),
+            ("docs".to_owned(), json!("https://example.org/docs/person")),
+        ]),
+    )?],
+)?;
+let config = config
+    .with_topology(topology)?
+    .with_version_stamp(PydanticVersionStamp::new(
+        "1.2.3+portable.1",
+        "Caller-owned version module.",
+    )?)?;
+let package = emit_pydantic(&compiled_schema, &config)?;
+
+assert!(package.artifacts.contains_key("example_models/domain/people.py"));
+assert_eq!(
+    package.model_paths.get("Person").map(String::as_str),
+    Some("example_models.domain.people.Person"),
+);
+```
+
+Routed packages share one schema table and one runtime base, create required
+intermediate `__init__.py` files, rebuild cross-module references once at the
+package root, and export explicit symbol maps. Missing or stale routes,
+path/symbol collisions, malformed versions, and fixed schema/config/output
+resource-limit violations fail before any artifacts are returned. Omitting the
+topology retains the original single `models.py` layout byte-for-byte; version
+stamping is independently optional in either layout.
+
 Generated classes validate the representable JSON Schema subset and expose the
 originating definition through Pydantic v2's standard
 `model_json_schema(by_alias=True)` surface. Assertions without an exact
@@ -194,12 +245,22 @@ pointer locations, in `package.losses`; the source SHACL-to-JSON-Schema losses
 remain separately available on `CompiledSchema::losses`. The checked
 `json-schema` → `pydantic-v2` loss profile makes every widening auditable.
 
-The dev-only executable oracle imports an emitted package, compares its live
-`model_json_schema()` output with the source definitions, and probes validation
-and alias round trips:
+The dev-only executable oracle imports both flat and routed packages, runs
+strict mypy over the routed package, compares live `model_json_schema()` output
+with the source definitions, and probes validation, metadata/version linkage,
+aliases, and verified reverse round trips:
 
 ```bash
 make pydantic-oracle
+```
+
+Report-only timing and allocation instruments share the same deterministic
+32/1,024/16,384-definition fixture family across flat, rich single-module,
+40-module, and one-module-per-definition layouts:
+
+```bash
+cargo bench -p purrdf-shapes --bench pydantic_package --locked -- --noplot
+cargo run --release -p purrdf-shapes --example pydantic_allocations --locked
 ```
 
 `import_pydantic_package` is the schema reverse API. It verifies the fixed

--- a/crates/shapes/README.md
+++ b/crates/shapes/README.md
@@ -233,9 +233,10 @@ Routed packages share one schema table and one runtime base, create required
 intermediate `__init__.py` files, rebuild cross-module references once at the
 package root, and export explicit symbol maps. Missing or stale routes,
 path/symbol collisions, malformed versions, and fixed schema/config/output
-resource-limit violations fail before any artifacts are returned. Omitting the
-topology retains the original single `models.py` layout byte-for-byte; version
-stamping is independently optional in either layout.
+resource-limit violations fail before any artifacts are returned. Omitting both
+the topology and version stamp retains the original flat package byte-for-byte.
+Version stamping is independently available in either layout; in the flat
+layout it adds `__about__.py` and updates the `__init__.py` exports.
 
 Generated classes validate the representable JSON Schema subset and expose the
 originating definition through Pydantic v2's standard

--- a/crates/shapes/benches/pydantic_package.rs
+++ b/crates/shapes/benches/pydantic_package.rs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Standard-allocator Criterion instrument for deterministic Pydantic emission.
+
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_main};
+
+#[path = "support/pydantic.rs"]
+mod pydantic_support;
+use pydantic_support::{Fixture, Mode, SIZES};
+
+fn bench_pydantic_package(c: &mut Criterion) {
+    let fixtures = SIZES
+        .into_iter()
+        .flat_map(|definitions| {
+            Mode::ALL
+                .into_iter()
+                .map(move |mode| Fixture::new(definitions, mode))
+        })
+        .collect::<Vec<_>>();
+    let mut group = c.benchmark_group("pydantic_package_emission");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(3));
+    group.warm_up_time(Duration::from_secs(1));
+
+    for fixture in &fixtures {
+        black_box(fixture.emit());
+        group.throughput(Throughput::Elements(
+            fixture
+                .definitions
+                .try_into()
+                .expect("definition count fits u64"),
+        ));
+        group.bench_with_input(
+            BenchmarkId::new(fixture.mode.label(), fixture.definitions),
+            fixture,
+            |bencher, fixture| {
+                bencher.iter(|| black_box(fixture.emit()));
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Run the Pydantic package benchmark group.
+pub fn benches() {
+    let mut criterion = Criterion::default().configure_from_args();
+    bench_pydantic_package(&mut criterion);
+}
+
+criterion_main!(benches);

--- a/crates/shapes/benches/pydantic_package.rs
+++ b/crates/shapes/benches/pydantic_package.rs
@@ -12,7 +12,7 @@ mod pydantic_support;
 use pydantic_support::{Fixture, Mode, SIZES};
 
 fn bench_pydantic_package(c: &mut Criterion) {
-    let fixtures = SIZES
+    let mut fixtures = SIZES
         .into_iter()
         .flat_map(|definitions| {
             Mode::ALL
@@ -20,6 +20,7 @@ fn bench_pydantic_package(c: &mut Criterion) {
                 .map(move |mode| Fixture::new(definitions, mode))
         })
         .collect::<Vec<_>>();
+    fixtures.push(Fixture::maximum_high_fanout());
     let mut group = c.benchmark_group("pydantic_package_emission");
     group.sample_size(10);
     group.measurement_time(Duration::from_secs(3));

--- a/crates/shapes/benches/support/pydantic.rs
+++ b/crates/shapes/benches/support/pydantic.rs
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Shared deterministic fixtures for Pydantic emission instruments.
+
+use std::collections::BTreeMap;
+
+use purrdf::loss::LossLedger;
+use purrdf_shapes::json_schema::CompiledSchema;
+use purrdf_shapes::{
+    PydanticClassConfig, PydanticConfig, PydanticModuleConfig, PydanticPackage,
+    PydanticPackageTopology, PydanticVersionStamp, emit_pydantic,
+};
+use serde_json::{Map, Value, json};
+
+pub(crate) const SIZES: [usize; 3] = [32, 1_024, 16_384];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Mode {
+    Flat,
+    RichSingleModule,
+    GroupedFortyModules,
+    HighFanout,
+}
+
+impl Mode {
+    pub(crate) const ALL: [Self; 4] = [
+        Self::Flat,
+        Self::RichSingleModule,
+        Self::GroupedFortyModules,
+        Self::HighFanout,
+    ];
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Flat => "flat",
+            Self::RichSingleModule => "rich_single_module",
+            Self::GroupedFortyModules => "grouped_40_modules",
+            Self::HighFanout => "high_fanout",
+        }
+    }
+}
+
+pub(crate) struct Fixture {
+    pub(crate) definitions: usize,
+    pub(crate) mode: Mode,
+    compiled: CompiledSchema,
+    config: PydanticConfig,
+}
+
+impl Fixture {
+    pub(crate) fn new(definitions: usize, mode: Mode) -> Self {
+        assert!(definitions >= 4, "fixture needs every schema shape");
+        let compiled = compiled_schema(definitions);
+        let config = config(definitions, mode);
+        let fixture = Self {
+            definitions,
+            mode,
+            compiled,
+            config,
+        };
+        let package = fixture.emit();
+        assert_eq!(package.model_paths.len(), definitions);
+        assert_eq!(package.source_schema_json(), fixture.compiled.schema_json);
+        match mode {
+            Mode::Flat => assert_eq!(package.artifacts.len(), 4),
+            Mode::RichSingleModule => assert_eq!(package.artifacts.len(), 6),
+            Mode::GroupedFortyModules => {
+                assert_eq!(package.artifacts.len(), definitions.min(40) + 6);
+            }
+            Mode::HighFanout => assert_eq!(package.artifacts.len(), definitions + 6),
+        }
+        fixture
+    }
+
+    pub(crate) fn emit(&self) -> PydanticPackage {
+        emit_pydantic(&self.compiled, &self.config).expect("validated benchmark fixture emits")
+    }
+}
+
+fn compiled_schema(definitions: usize) -> CompiledSchema {
+    let mut defs = Map::new();
+    for index in 0..definitions {
+        let name = definition_name(index);
+        let next = definition_name((index + 1) % definitions);
+        let definition = if index == 3 {
+            high_fanout_definition(definitions)
+        } else {
+            match index % 4 {
+                0 => json!({
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "inline": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "label": { "type": "string", "minLength": 1 }
+                            },
+                            "required": ["label"]
+                        },
+                        "next": { "$ref": format!("#/$defs/{next}") },
+                        "self": { "$ref": format!("#/$defs/{name}") }
+                    }
+                }),
+                1 => json!({
+                    "enum": [format!("value:{index}:a"), format!("value:{index}:b")]
+                }),
+                2 => json!({ "$ref": format!("#/$defs/{next}") }),
+                _ => json!({
+                    "type": "object",
+                    "properties": {
+                        "members": {
+                            "type": "array",
+                            "items": { "$ref": format!("#/$defs/{next}") },
+                            "minItems": 1
+                        },
+                        "name": { "type": "string", "pattern": "^[A-Z]" }
+                    },
+                    "required": ["name"]
+                }),
+            }
+        };
+        defs.insert(name, definition);
+    }
+    let schema = json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": Value::Object(defs),
+    });
+    CompiledSchema {
+        schema_json: serde_json::to_string(&schema).expect("benchmark schema serializes"),
+        openapi_json: "{}\n".to_owned(),
+        losses: LossLedger::new(),
+    }
+}
+
+fn high_fanout_definition(definitions: usize) -> Value {
+    let properties = (0..definitions)
+        .map(|index| {
+            let target = definition_name(index);
+            (
+                format!("target_{index:05}"),
+                json!({ "$ref": format!("#/$defs/{target}") }),
+            )
+        })
+        .collect::<Map<_, _>>();
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": properties,
+    })
+}
+
+fn config(definitions: usize, mode: Mode) -> PydanticConfig {
+    let base = PydanticConfig::new(
+        "benchmark_models",
+        "Caller-owned benchmark package documentation.",
+        "Caller-owned benchmark support documentation.",
+    )
+    .expect("benchmark base config");
+    if mode == Mode::Flat {
+        return base;
+    }
+
+    let module_count = match mode {
+        Mode::Flat => unreachable!("flat returned above"),
+        Mode::RichSingleModule => 1,
+        Mode::GroupedFortyModules => definitions.min(40),
+        Mode::HighFanout => definitions,
+    };
+    let modules = (0..module_count).map(|module| {
+        let path = module_path(mode, module);
+        PydanticModuleConfig::new(
+            path.clone(),
+            format!("Caller-owned benchmark module {path}."),
+        )
+        .expect("benchmark module")
+    });
+    let classes = (0..definitions).map(|index| {
+        let key = definition_name(index);
+        PydanticClassConfig::new(
+            key.clone(),
+            module_path(mode, index % module_count),
+            format!("Caller-owned documentation for {key}."),
+            BTreeMap::from([
+                (
+                    "definitionDigest".to_owned(),
+                    json!(format!("sha256:benchmark-{index:05}")),
+                ),
+                (
+                    "docs".to_owned(),
+                    json!(format!("https://example.org/docs/{key}")),
+                ),
+            ]),
+        )
+        .expect("benchmark class route")
+    });
+    base.with_topology(PydanticPackageTopology::new(modules, classes).expect("benchmark topology"))
+        .expect("benchmark topology config")
+        .with_version_stamp(
+            PydanticVersionStamp::new(
+                "1.2.3+benchmark.1",
+                "Caller-owned benchmark version documentation.",
+            )
+            .expect("benchmark version"),
+        )
+        .expect("benchmark version config")
+}
+
+fn definition_name(index: usize) -> String {
+    format!("Model{index:05}")
+}
+
+fn module_path(mode: Mode, module: usize) -> String {
+    match mode {
+        Mode::Flat => unreachable!("flat packages have no topology"),
+        Mode::RichSingleModule => "models".to_owned(),
+        Mode::GroupedFortyModules => format!("group.module_{module:03}"),
+        Mode::HighFanout => format!("fanout.module_{module:05}"),
+    }
+}

--- a/crates/shapes/benches/support/pydantic.rs
+++ b/crates/shapes/benches/support/pydantic.rs
@@ -14,6 +14,7 @@ use purrdf_shapes::{
 use serde_json::{Map, Value, json};
 
 pub(crate) const SIZES: [usize; 3] = [32, 1_024, 16_384];
+pub(crate) const MAXIMUM_DEFINITIONS: usize = 65_536;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Mode {
@@ -51,8 +52,29 @@ pub(crate) struct Fixture {
 impl Fixture {
     pub(crate) fn new(definitions: usize, mode: Mode) -> Self {
         assert!(definitions >= 4, "fixture needs every schema shape");
-        let compiled = compiled_schema(definitions);
-        let config = config(definitions, mode);
+        Self::from_parts(
+            definitions,
+            mode,
+            compiled_schema(definitions),
+            config(definitions, mode),
+        )
+    }
+
+    pub(crate) fn maximum_high_fanout() -> Self {
+        Self::from_parts(
+            MAXIMUM_DEFINITIONS,
+            Mode::HighFanout,
+            compact_high_fanout_schema(MAXIMUM_DEFINITIONS),
+            compact_high_fanout_config(MAXIMUM_DEFINITIONS),
+        )
+    }
+
+    fn from_parts(
+        definitions: usize,
+        mode: Mode,
+        compiled: CompiledSchema,
+        config: PydanticConfig,
+    ) -> Self {
         let fixture = Self {
             definitions,
             mode,
@@ -76,6 +98,21 @@ impl Fixture {
     pub(crate) fn emit(&self) -> PydanticPackage {
         emit_pydantic(&self.compiled, &self.config).expect("validated benchmark fixture emits")
     }
+}
+
+fn compact_high_fanout_schema(definitions: usize) -> CompiledSchema {
+    let mut defs = Map::new();
+    for index in 0..definitions {
+        defs.insert(
+            definition_name(index),
+            if index == 3 {
+                high_fanout_definition(definitions)
+            } else {
+                json!({})
+            },
+        );
+    }
+    compiled(defs)
 }
 
 fn compiled_schema(definitions: usize) -> CompiledSchema {
@@ -123,6 +160,10 @@ fn compiled_schema(definitions: usize) -> CompiledSchema {
         };
         defs.insert(name, definition);
     }
+    compiled(defs)
+}
+
+fn compiled(defs: Map<String, Value>) -> CompiledSchema {
     let schema = json!({
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "$defs": Value::Object(defs),
@@ -132,6 +173,37 @@ fn compiled_schema(definitions: usize) -> CompiledSchema {
         openapi_json: "{}\n".to_owned(),
         losses: LossLedger::new(),
     }
+}
+
+fn compact_high_fanout_config(definitions: usize) -> PydanticConfig {
+    let base = PydanticConfig::new(
+        "benchmark_models",
+        "Caller-owned benchmark package documentation.",
+        "Caller-owned benchmark support documentation.",
+    )
+    .expect("benchmark base config");
+    let modules = (0..definitions).map(|index| {
+        PydanticModuleConfig::new(compact_module_path(index), "d").expect("benchmark module")
+    });
+    let classes = (0..definitions).map(|index| {
+        PydanticClassConfig::new(
+            definition_name(index),
+            compact_module_path(index),
+            "d",
+            BTreeMap::new(),
+        )
+        .expect("benchmark class route")
+    });
+    base.with_topology(PydanticPackageTopology::new(modules, classes).expect("benchmark topology"))
+        .expect("benchmark topology config")
+        .with_version_stamp(
+            PydanticVersionStamp::new(
+                "1.2.3+benchmark.1",
+                "Caller-owned benchmark version documentation.",
+            )
+            .expect("benchmark version"),
+        )
+        .expect("benchmark version config")
 }
 
 fn high_fanout_definition(definitions: usize) -> Value {
@@ -218,4 +290,8 @@ fn module_path(mode: Mode, module: usize) -> String {
         Mode::GroupedFortyModules => format!("group.module_{module:03}"),
         Mode::HighFanout => format!("fanout.module_{module:05}"),
     }
+}
+
+fn compact_module_path(module: usize) -> String {
+    format!("m.m{module:05}")
 }

--- a/crates/shapes/examples/pydantic_allocations.rs
+++ b/crates/shapes/examples/pydantic_allocations.rs
@@ -85,24 +85,28 @@ fn main() {
     );
     for definitions in SIZES {
         for mode in Mode::ALL {
-            let fixture = Fixture::new(definitions, mode);
-            black_box(fixture.emit());
-            reset();
-            let package = black_box(fixture.emit());
-            let allocations = ALLOCATIONS.load(Ordering::Relaxed);
-            let requested_bytes = REQUESTED_BYTES.load(Ordering::Relaxed);
-            let retained_bytes = LIVE_BYTES.load(Ordering::Relaxed);
-            let peak_live_bytes = PEAK_LIVE_BYTES.load(Ordering::Relaxed);
-            ACTIVE.store(false, Ordering::Relaxed);
-            let artifact_bytes = package.artifacts.values().map(Vec::len).sum::<usize>();
-            let files = package.artifacts.len();
-            println!(
-                "{},{},{allocations},{requested_bytes},{retained_bytes},{peak_live_bytes},{artifact_bytes},{files}",
-                fixture.mode.label(),
-                fixture.definitions
-            );
-            black_box(&package);
-            drop(package);
+            measure(&Fixture::new(definitions, mode));
         }
     }
+    measure(&Fixture::maximum_high_fanout());
+}
+
+fn measure(fixture: &Fixture) {
+    black_box(fixture.emit());
+    reset();
+    let package = black_box(fixture.emit());
+    let allocations = ALLOCATIONS.load(Ordering::Relaxed);
+    let requested_bytes = REQUESTED_BYTES.load(Ordering::Relaxed);
+    let retained_bytes = LIVE_BYTES.load(Ordering::Relaxed);
+    let peak_live_bytes = PEAK_LIVE_BYTES.load(Ordering::Relaxed);
+    ACTIVE.store(false, Ordering::Relaxed);
+    let artifact_bytes = package.artifacts.values().map(Vec::len).sum::<usize>();
+    let files = package.artifacts.len();
+    println!(
+        "{},{},{allocations},{requested_bytes},{retained_bytes},{peak_live_bytes},{artifact_bytes},{files}",
+        fixture.mode.label(),
+        fixture.definitions
+    );
+    black_box(&package);
+    drop(package);
 }

--- a/crates/shapes/examples/pydantic_allocations.rs
+++ b/crates/shapes/examples/pydantic_allocations.rs
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! One-shot allocation instrument for deterministic Pydantic emission.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+#[path = "../benches/support/pydantic.rs"]
+mod pydantic_support;
+use pydantic_support::{Fixture, Mode, SIZES};
+
+struct CountingAllocator;
+
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+static REQUESTED_BYTES: AtomicUsize = AtomicUsize::new(0);
+static LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+static PEAK_LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+
+fn record_allocation(bytes: usize) {
+    if !ACTIVE.load(Ordering::Relaxed) {
+        return;
+    }
+    ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+    REQUESTED_BYTES.fetch_add(bytes, Ordering::Relaxed);
+    let live = LIVE_BYTES.fetch_add(bytes, Ordering::Relaxed) + bytes;
+    PEAK_LIVE_BYTES.fetch_max(live, Ordering::Relaxed);
+}
+
+fn record_deallocation(bytes: usize) {
+    if ACTIVE.load(Ordering::Relaxed) {
+        LIVE_BYTES.fetch_sub(bytes, Ordering::Relaxed);
+    }
+}
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let pointer = unsafe { System.alloc(layout) };
+        if !pointer.is_null() {
+            record_allocation(layout.size());
+        }
+        pointer
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let pointer = unsafe { System.alloc_zeroed(layout) };
+        if !pointer.is_null() {
+            record_allocation(layout.size());
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        record_deallocation(layout.size());
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let replacement = unsafe { System.realloc(pointer, layout, new_size) };
+        if !replacement.is_null() {
+            record_deallocation(layout.size());
+            record_allocation(new_size);
+        }
+        replacement
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn reset() {
+    ACTIVE.store(false, Ordering::Relaxed);
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    REQUESTED_BYTES.store(0, Ordering::Relaxed);
+    LIVE_BYTES.store(0, Ordering::Relaxed);
+    PEAK_LIVE_BYTES.store(0, Ordering::Relaxed);
+    ACTIVE.store(true, Ordering::Relaxed);
+}
+
+fn main() {
+    println!(
+        "mode,definitions,allocations,requested_bytes,retained_bytes,peak_live_bytes,artifact_bytes,files"
+    );
+    for definitions in SIZES {
+        for mode in Mode::ALL {
+            let fixture = Fixture::new(definitions, mode);
+            black_box(fixture.emit());
+            reset();
+            let package = black_box(fixture.emit());
+            let allocations = ALLOCATIONS.load(Ordering::Relaxed);
+            let requested_bytes = REQUESTED_BYTES.load(Ordering::Relaxed);
+            let retained_bytes = LIVE_BYTES.load(Ordering::Relaxed);
+            let peak_live_bytes = PEAK_LIVE_BYTES.load(Ordering::Relaxed);
+            ACTIVE.store(false, Ordering::Relaxed);
+            let artifact_bytes = package.artifacts.values().map(Vec::len).sum::<usize>();
+            let files = package.artifacts.len();
+            println!(
+                "{},{},{allocations},{requested_bytes},{retained_bytes},{peak_live_bytes},{artifact_bytes},{files}",
+                fixture.mode.label(),
+                fixture.definitions
+            );
+            black_box(&package);
+            drop(package);
+        }
+    }
+}

--- a/crates/shapes/examples/pydantic_oracle_fixture.rs
+++ b/crates/shapes/examples/pydantic_oracle_fixture.rs
@@ -9,8 +9,8 @@ use std::error::Error;
 use purrdf::loss::{LossLedger, check_ledger_sound};
 use purrdf_shapes::json_schema::{CompiledSchema, Namespaces};
 use purrdf_shapes::{
-    PYDANTIC_DIALECT, PydanticConfig, PydanticPackage, SchemaDatatypeMap, SchemaImportConfig,
-    emit_pydantic, import_pydantic_package,
+    PYDANTIC_DIALECT, PydanticConfig, PydanticPackage, PydanticVersionStamp, SchemaDatatypeMap,
+    SchemaImportConfig, emit_pydantic, import_pydantic_package,
 };
 use serde_json::{Value, json};
 
@@ -58,6 +58,83 @@ fn reverse_evidence(
             .map(|shape| shape.id.to_string())
             .collect::<Vec<_>>(),
     }))
+}
+
+fn version_oracle() -> Value {
+    let candidates = [
+        "0",
+        "v1.2",
+        "1!2.0",
+        "1.0a1",
+        "1.0-alpha",
+        "1.0beta2",
+        "1.0b3",
+        "1.0preview2",
+        "1.0pre4",
+        "1.0c5",
+        "1.0RC1",
+        "1.0rc_",
+        "1.0-1",
+        "1.0-post2",
+        "1.0post-",
+        "1.0_post_7",
+        "1.0rev",
+        "1.0r8",
+        "1.0.dev3",
+        "1.0dev-",
+        "1.0_dev_9",
+        "1.0rc1.post2.dev3",
+        "01.002",
+        "1.0+abc.1",
+        "1.0+Ubuntu-1",
+        " \tv1.0RC1+LOCAL_1\n",
+        "",
+        "v",
+        "1..0",
+        "1.0+",
+        "1.0+abc+def",
+        "1.0++x",
+        "1.0+abc_",
+        "1.0-",
+        "1.0_",
+        "1.0..post1",
+        "1.0a..1",
+        "1!",
+        "1.0foo",
+        "1.0+naïve",
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .chain([
+        format!("1.{}", "7".repeat(510)),
+        format!("1.{}", "7".repeat(511)),
+    ]);
+
+    Value::Array(
+        candidates
+            .into_iter()
+            .map(|candidate| {
+                let outcome = PydanticVersionStamp::new(
+                    candidate.clone(),
+                    "Caller-owned version oracle documentation.",
+                );
+                match outcome {
+                    Ok(stamp) => json!({
+                        "accepted": true,
+                        "is_local": stamp.is_local(),
+                        "raw": candidate,
+                        "resource_error": false,
+                    }),
+                    Err(error) => json!({
+                        "accepted": false,
+                        "error": error.to_string(),
+                        "raw": candidate,
+                        "resource_error": error.to_string().contains("limit is 512"),
+                    }),
+                }
+            })
+            .collect(),
+    )
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -222,6 +299,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         "model_paths": package.model_paths,
         "reverse": reverse,
         "schema": schema,
+        "version_oracle": version_oracle(),
     });
     println!("{}", serde_json::to_string(&output)?);
     Ok(())

--- a/crates/shapes/examples/pydantic_oracle_fixture.rs
+++ b/crates/shapes/examples/pydantic_oracle_fixture.rs
@@ -9,8 +9,9 @@ use std::error::Error;
 use purrdf::loss::{LossLedger, check_ledger_sound};
 use purrdf_shapes::json_schema::{CompiledSchema, Namespaces};
 use purrdf_shapes::{
-    PYDANTIC_DIALECT, PydanticConfig, PydanticPackage, PydanticVersionStamp, SchemaDatatypeMap,
-    SchemaImportConfig, emit_pydantic, import_pydantic_package,
+    PYDANTIC_DIALECT, PydanticClassConfig, PydanticConfig, PydanticModuleConfig, PydanticPackage,
+    PydanticPackageTopology, PydanticVersionStamp, SchemaDatatypeMap, SchemaImportConfig,
+    emit_pydantic, import_pydantic_package,
 };
 use serde_json::{Value, json};
 
@@ -137,6 +138,67 @@ fn version_oracle() -> Value {
     )
 }
 
+fn routed_config(include_empty: bool) -> Result<PydanticConfig, Box<dyn Error>> {
+    let mut routes = vec![
+        ("Color", "catalog.enums"),
+        ("CycleLeft", "cycles.left"),
+        ("CycleRight", "cycles.right"),
+        ("Person", "domain.people"),
+        ("PersonAlias", "domain.people"),
+        ("State", "catalog.enums"),
+        ("path/with~token", "common.paths"),
+    ];
+    if include_empty {
+        routes.push(("Empty", "catalog.enums"));
+    }
+    let classes = routes
+        .into_iter()
+        .map(|(key, module)| {
+            PydanticClassConfig::new(
+                key,
+                module,
+                format!("Caller documentation for {key}."),
+                BTreeMap::from([
+                    (
+                        "definitionDigest".to_owned(),
+                        json!(format!("sha256:oracle-{key}")),
+                    ),
+                    (
+                        "docs".to_owned(),
+                        json!(format!("https://example.org/docs/{key}")),
+                    ),
+                ]),
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let topology = PydanticPackageTopology::new(
+        [
+            PydanticModuleConfig::new(
+                "catalog.enums",
+                "Caller-owned enumeration module documentation.",
+            )?,
+            PydanticModuleConfig::new("common.paths", "Caller-owned path module documentation.")?,
+            PydanticModuleConfig::new("cycles.left", "Caller-owned left-cycle documentation.")?,
+            PydanticModuleConfig::new("cycles.right", "Caller-owned right-cycle documentation.")?,
+            PydanticModuleConfig::new(
+                "domain.people",
+                "Caller-owned people module documentation.",
+            )?,
+        ],
+        classes,
+    )?;
+    Ok(PydanticConfig::new(
+        "routed_oracle_models",
+        "Caller-owned routed oracle package documentation.",
+        "Caller-owned routed oracle support documentation.",
+    )?
+    .with_topology(topology)?
+    .with_version_stamp(PydanticVersionStamp::new(
+        "1.2.3+oracle.1",
+        "Caller-owned routed oracle version documentation.",
+    )?)?)
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     let schema = json!({
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -236,12 +298,42 @@ fn main() -> Result<(), Box<dyn Error>> {
         openapi_json: "{}\n".to_owned(),
         losses: LossLedger::new(),
     };
+    let mut routed_schema = schema.clone();
+    let routed_definitions = routed_schema["$defs"]
+        .as_object_mut()
+        .ok_or("oracle schema has no $defs")?;
+    routed_definitions.insert(
+        "CycleLeft".to_owned(),
+        json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ex:right": { "$ref": "#/$defs/CycleRight" }
+            }
+        }),
+    );
+    routed_definitions.insert(
+        "CycleRight".to_owned(),
+        json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "ex:left": { "$ref": "#/$defs/CycleLeft" }
+            }
+        }),
+    );
+    let routed_compiled = CompiledSchema {
+        schema_json: format!("{}\n", serde_json::to_string_pretty(&routed_schema)?),
+        openapi_json: "{}\n".to_owned(),
+        losses: LossLedger::new(),
+    };
     let config = PydanticConfig::new(
         "oracle_models",
         "Caller-owned oracle package documentation.",
         "Caller-owned oracle model documentation.",
     )?;
     let package = emit_pydantic(&compiled, &config)?;
+    let routed_package = emit_pydantic(&routed_compiled, &routed_config(true)?)?;
     let mut reverse_schema = schema.clone();
     reverse_schema["$defs"]
         .as_object_mut()
@@ -256,6 +348,23 @@ fn main() -> Result<(), Box<dyn Error>> {
         &config,
     )?;
     let reverse = reverse_evidence(&reverse_package, &import_config()?)?;
+    let mut routed_reverse_schema = routed_schema.clone();
+    routed_reverse_schema["$defs"]
+        .as_object_mut()
+        .ok_or("routed oracle schema has no $defs")?
+        .remove("Empty");
+    let routed_reverse_package = emit_pydantic(
+        &CompiledSchema {
+            schema_json: format!(
+                "{}\n",
+                serde_json::to_string_pretty(&routed_reverse_schema)?
+            ),
+            openapi_json: "{}\n".to_owned(),
+            losses: LossLedger::new(),
+        },
+        &routed_config(false)?,
+    )?;
+    let routed_reverse = reverse_evidence(&routed_reverse_package, &import_config()?)?;
     let observed_losses: BTreeSet<(&str, &str)> = package
         .losses
         .entries()
@@ -294,10 +403,36 @@ fn main() -> Result<(), Box<dyn Error>> {
         .into_iter()
         .map(|(path, bytes)| String::from_utf8(bytes).map(|text| (path, text)))
         .collect::<Result<_, _>>()?;
+    let routed_artifacts: BTreeMap<String, String> = routed_package
+        .artifacts
+        .into_iter()
+        .map(|(path, bytes)| String::from_utf8(bytes).map(|text| (path, text)))
+        .collect::<Result<_, _>>()?;
+    let routed_metadata = routed_package
+        .model_paths
+        .keys()
+        .map(|key| {
+            (
+                key.clone(),
+                json!({
+                    "definitionDigest": format!("sha256:oracle-{key}"),
+                    "docs": format!("https://example.org/docs/{key}"),
+                }),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
     let output = json!({
         "artifacts": artifacts,
         "model_paths": package.model_paths,
         "reverse": reverse,
+        "routed": {
+            "artifacts": routed_artifacts,
+            "metadata": routed_metadata,
+            "model_paths": routed_package.model_paths,
+            "reverse": routed_reverse,
+            "schema": routed_schema,
+            "version": "1.2.3+oracle.1",
+        },
         "schema": schema,
         "version_oracle": version_oracle(),
     });

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -69,7 +69,8 @@ pub use linkml::{
     import_linkml, import_linkml_package, parse_linkml, write_linkml,
 };
 pub use pydantic::{
-    PYDANTIC_DIALECT, PydanticConfig, PydanticError, PydanticPackage, emit_pydantic,
+    PYDANTIC_DIALECT, PydanticClassConfig, PydanticConfig, PydanticError, PydanticModuleConfig,
+    PydanticPackage, PydanticPackageTopology, PydanticVersionStamp, emit_pydantic,
     import_pydantic_package,
 };
 pub use rules::{apply_rules, entail_dataset};

--- a/crates/shapes/src/pydantic.rs
+++ b/crates/shapes/src/pydantic.rs
@@ -9,6 +9,16 @@
 //! are caller configuration; PurRDF neither mints vocabulary nor fabricates a
 //! downstream brand.
 //!
+//! With only [`PydanticConfig::new`], emission retains the byte-stable flat
+//! `models.py` layout. A caller may instead attach a total
+//! [`PydanticPackageTopology`] that routes every `$defs` entry to one portable
+//! dotted leaf module, supplies its class documentation and sorted JSON metadata,
+//! and optionally attach a [`PydanticVersionStamp`]. Routed packages share one
+//! schema table and runtime base, emit intermediate initializers, and resolve the
+//! complete cross-module reference graph through explicit symbol tables. Missing,
+//! stale, unused, colliding, or over-limit configuration fails before a package is
+//! returned; PurRDF never infers ownership or assigns semantics to metadata keys.
+//!
 //! Generated models use strict Pydantic scalar carriers, aliases matching the
 //! JSON property names, and a class-owned schema hook taken from the same `$defs`
 //! input. Consequently `model_json_schema(by_alias=True)`
@@ -34,16 +44,18 @@ use serde_json::{Map, Value};
 
 use crate::json_schema::CompiledSchema;
 use crate::schema_catalog::{
-    CompiledSchemaCatalog, definition_path, pointer_escape, reference_key, schema_array_keywords,
-    schema_map_keywords, schema_single_keywords,
+    CompiledSchemaCatalog, SchemaCatalogLimits, definition_path, pointer_escape, reference_key,
+    schema_array_keywords, schema_map_keywords, schema_single_keywords,
 };
 use crate::schema_import::{ImportedShapes, SchemaImportConfig, import_json_schema_from};
 
 mod config;
+mod linker;
 
 pub use self::config::{
     PydanticClassConfig, PydanticModuleConfig, PydanticPackageTopology, PydanticVersionStamp,
 };
+use self::linker::{LinkedHelper, LinkedModule, RoutedPackagePlan, relative_root_import};
 
 const MODELS_MODULE: &str = "models";
 const BASE_MODULE: &str = "_base";
@@ -174,6 +186,10 @@ impl PydanticConfig {
 }
 
 /// Deterministic generated Pydantic package and its runtime-projection losses.
+///
+/// Artifact paths are always package-relative and sorted. [`Self::model_paths`]
+/// is the authoritative source-definition-to-import map for both flat and routed
+/// layouts; consumers do not need to reproduce name or topology normalization.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PydanticPackage {
     /// Fixed generated-package dialect.
@@ -186,6 +202,7 @@ pub struct PydanticPackage {
     /// enforced by Pydantic runtime annotations.
     pub losses: LossLedger,
     source_schema_json: String,
+    source_schema_fingerprint: u64,
     config: PydanticConfig,
 }
 
@@ -220,6 +237,90 @@ impl fmt::Display for PydanticError {
 
 impl Error for PydanticError {}
 
+struct ArtifactAccumulator {
+    artifacts: BTreeMap<String, Vec<u8>>,
+    total_bytes: usize,
+    limits: ArtifactLimits,
+}
+
+#[derive(Clone, Copy)]
+struct ArtifactLimits {
+    artifact_bytes: usize,
+    output_bytes: usize,
+    artifacts: usize,
+}
+
+impl ArtifactAccumulator {
+    fn new() -> Self {
+        Self::with_limits(ArtifactLimits {
+            artifact_bytes: config::MAX_ARTIFACT_BYTES,
+            output_bytes: config::MAX_OUTPUT_BYTES,
+            artifacts: config::MAX_OUTPUT_ARTIFACTS,
+        })
+    }
+
+    fn with_limits(limits: ArtifactLimits) -> Self {
+        Self {
+            artifacts: BTreeMap::new(),
+            total_bytes: 0,
+            limits,
+        }
+    }
+
+    fn insert(&mut self, path: String, bytes: Vec<u8>) -> Result<(), PydanticError> {
+        if bytes.len() > self.limits.artifact_bytes {
+            return Err(PydanticError::new(format!(
+                "Pydantic artifact {path:?} uses {} bytes; limit is {}",
+                bytes.len(),
+                self.limits.artifact_bytes
+            )));
+        }
+        let total_bytes = self.total_bytes.checked_add(bytes.len()).ok_or_else(|| {
+            PydanticError::new("Pydantic artifact bytes exceed the platform usize range")
+        })?;
+        if total_bytes > self.limits.output_bytes {
+            return Err(PydanticError::new(format!(
+                "Pydantic artifacts use {total_bytes} bytes; limit is {}",
+                self.limits.output_bytes
+            )));
+        }
+        if self.artifacts.len() == self.limits.artifacts {
+            return Err(PydanticError::new(format!(
+                "Pydantic package exceeds the {}-artifact limit",
+                self.limits.artifacts
+            )));
+        }
+        if self.artifacts.contains_key(&path) {
+            return Err(PydanticError::new(format!(
+                "Pydantic artifact path {path:?} was emitted more than once"
+            )));
+        }
+        self.artifacts.insert(path, bytes);
+        self.total_bytes = total_bytes;
+        Ok(())
+    }
+
+    fn finish(self) -> BTreeMap<String, Vec<u8>> {
+        self.artifacts
+    }
+
+    fn relative_paths(&self, package_path: &str) -> Result<BTreeSet<String>, PydanticError> {
+        let prefix = format!("{package_path}/");
+        self.artifacts
+            .keys()
+            .map(|path| {
+                path.strip_prefix(&prefix)
+                    .map(str::to_owned)
+                    .ok_or_else(|| {
+                        PydanticError::new(format!(
+                            "Pydantic artifact path {path:?} is outside package {package_path:?}"
+                        ))
+                    })
+            })
+            .collect()
+    }
+}
+
 /// Emit a deterministic, filesystem-free Pydantic v2 package from one compiled
 /// SHACL-derived JSON Schema.
 ///
@@ -230,36 +331,34 @@ impl Error for PydanticError {}
 ///
 /// Returns [`PydanticError`] when `schema_json` is malformed, `$defs` is absent
 /// or malformed, a reference is external/dangling, required/property declarations
-/// disagree, or two source names collide after Python identifier normalization.
+/// disagree, two source names collide after Python identifier normalization, a
+/// routed topology is not an exact total partition, or a fixed input/configuration/
+/// output resource ceiling is exceeded. The function returns no partial package.
 pub fn emit_pydantic(
     compiled: &CompiledSchema,
     config: &PydanticConfig,
 ) -> Result<PydanticPackage, PydanticError> {
-    let catalog = CompiledSchemaCatalog::parse(compiled)
-        .map_err(|error| PydanticError::new(error.to_string()))?;
+    let catalog = CompiledSchemaCatalog::parse_with_limits(
+        compiled,
+        SchemaCatalogLimits {
+            input_bytes: config::MAX_SCHEMA_BYTES,
+            definitions: config::MAX_DEFINITIONS,
+            depth: config::MAX_SCHEMA_DEPTH,
+            nodes: config::MAX_SCHEMA_NODES,
+            string_bytes: config::MAX_SCHEMA_STRING_BYTES,
+        },
+    )
+    .map_err(|error| PydanticError::new(error.to_string()))?;
     let defs = catalog.definitions();
 
-    let names = definition_names(defs)?;
+    let routed = config.topology().is_some();
+    let names = definition_names(defs, routed)?;
 
-    let mut renderer = Renderer::new(&names);
+    let mut renderer = Renderer::new(&names, routed);
     for (key, definition) in defs {
         renderer.audit_schema(definition, &definition_path(key));
     }
 
-    let mut definitions = Vec::with_capacity(defs.len());
-    let mut exports = Vec::with_capacity(defs.len());
-    let mut model_paths = BTreeMap::new();
-    for (key, definition) in defs {
-        let class_name = names
-            .get(key)
-            .expect("definition_names covers every $defs key");
-        definitions.push(renderer.render_definition(key, class_name, definition)?);
-        exports.push(class_name.clone());
-        model_paths.insert(
-            key.clone(),
-            format!("{}.{}.{}", config.package_name, MODELS_MODULE, class_name),
-        );
-    }
     let rewritten_defs = defs
         .iter()
         .map(|(key, definition)| {
@@ -273,34 +372,147 @@ pub fn emit_pydantic(
     let defs_literal = python_value(&Value::Object(rewritten_defs));
 
     let package_path = config.package_name.replace('.', "/");
-    let mut artifacts = BTreeMap::new();
-    artifacts.insert(
-        format!("{package_path}/{BASE_MODULE}.py"),
-        render_base(config.models_docstring()).into_bytes(),
-    );
-    artifacts.insert(
-        format!("{package_path}/{MODELS_MODULE}.py"),
-        renderer
-            .finish_models(
-                config.models_docstring(),
-                &defs_literal,
-                &definitions,
-                &exports,
+    let mut artifacts = ArtifactAccumulator::new();
+    let model_paths = if let Some(topology) = config.topology() {
+        let mut plan = RoutedPackagePlan::compile(
+            defs,
+            &names,
+            topology,
+            config.package_name(),
+            config.version_stamp().is_some(),
+        )?;
+        for (key, definition) in defs {
+            let class_name = names
+                .get(key)
+                .expect("definition_names covers every $defs key");
+            let class_config = topology
+                .classes()
+                .get(key)
+                .expect("the linker validated exact topology coverage");
+            let helper_start = renderer.helpers.len();
+            let source =
+                renderer.render_definition(key, class_name, definition, Some(class_config))?;
+            let helpers = renderer.helpers[helper_start..]
+                .iter()
+                .map(|(name, source)| LinkedHelper {
+                    name: name.clone(),
+                    source: source.clone(),
+                })
+                .collect();
+            let mut private_symbols = BTreeSet::new();
+            let is_record = definition.as_object().is_some_and(is_record_definition);
+            if !is_record
+                && definition
+                    .get("enum")
+                    .and_then(Value::as_array)
+                    .is_some_and(|values| values.iter().all(Value::is_string))
+            {
+                private_symbols.insert(format!("_{class_name}Value"));
+            }
+            if !is_record {
+                private_symbols.insert(format!("_{class_name}Root"));
+            }
+            plan.attach_definition(key, source, helpers, private_symbols)?;
+        }
+        plan.validate_complete()?;
+
+        artifacts.insert(
+            format!("{package_path}/{BASE_MODULE}.py"),
+            render_routed_base(config.models_docstring()).into_bytes(),
+        )?;
+        artifacts.insert(
+            format!("{package_path}/_schema.py"),
+            render_schema_module(config.models_docstring(), &defs_literal).into_bytes(),
+        )?;
+        for path in &plan.intermediate_packages {
+            artifacts.insert(format!("{package_path}/{path}"), Vec::new())?;
+        }
+        for module in plan.modules.values() {
+            artifacts.insert(
+                format!("{package_path}/{}", module.artifact_path),
+                render_routed_module(module).into_bytes(),
+            )?;
+        }
+        artifacts.insert(
+            format!("{package_path}/__init__.py"),
+            render_routed_init(
+                config.package_docstring(),
+                &plan,
+                config.version_stamp().is_some(),
             )
             .into_bytes(),
-    );
-    artifacts.insert(
-        format!("{package_path}/__init__.py"),
-        render_init(config.package_docstring(), &exports).into_bytes(),
-    );
-    artifacts.insert(format!("{package_path}/py.typed"), Vec::new());
+        )?;
+        if let Some(version) = config.version_stamp() {
+            artifacts.insert(
+                format!("{package_path}/__about__.py"),
+                render_about(version).into_bytes(),
+            )?;
+        }
+        artifacts.insert(format!("{package_path}/py.typed"), Vec::new())?;
+
+        let emitted_paths = artifacts.relative_paths(&package_path)?;
+        if emitted_paths != plan.artifact_paths {
+            return Err(PydanticError::new(format!(
+                "Pydantic routed artifact plan drifted: planned={:?}, emitted={emitted_paths:?}",
+                plan.artifact_paths
+            )));
+        }
+        plan.model_paths
+    } else {
+        let mut definitions = Vec::with_capacity(defs.len());
+        let mut exports = Vec::with_capacity(defs.len());
+        let mut model_paths = BTreeMap::new();
+        for (key, definition) in defs {
+            let class_name = names
+                .get(key)
+                .expect("definition_names covers every $defs key");
+            definitions.push(renderer.render_definition(key, class_name, definition, None)?);
+            exports.push(class_name.clone());
+            model_paths.insert(
+                key.clone(),
+                format!("{}.{}.{}", config.package_name, MODELS_MODULE, class_name),
+            );
+        }
+        artifacts.insert(
+            format!("{package_path}/{BASE_MODULE}.py"),
+            render_base(config.models_docstring()).into_bytes(),
+        )?;
+        artifacts.insert(
+            format!("{package_path}/{MODELS_MODULE}.py"),
+            renderer
+                .finish_models(
+                    config.models_docstring(),
+                    &defs_literal,
+                    &definitions,
+                    &exports,
+                )
+                .into_bytes(),
+        )?;
+        artifacts.insert(
+            format!("{package_path}/__init__.py"),
+            if config.version_stamp().is_some() {
+                render_versioned_init(config.package_docstring(), &exports).into_bytes()
+            } else {
+                render_init(config.package_docstring(), &exports).into_bytes()
+            },
+        )?;
+        if let Some(version) = config.version_stamp() {
+            artifacts.insert(
+                format!("{package_path}/__about__.py"),
+                render_about(version).into_bytes(),
+            )?;
+        }
+        artifacts.insert(format!("{package_path}/py.typed"), Vec::new())?;
+        model_paths
+    };
 
     Ok(PydanticPackage {
         dialect: PYDANTIC_DIALECT.to_owned(),
-        artifacts,
+        artifacts: artifacts.finish(),
         model_paths,
         losses: renderer.ledger,
         source_schema_json: compiled.schema_json.clone(),
+        source_schema_fingerprint: fnv1a(compiled.schema_json.as_bytes()),
         config: config.clone(),
     })
 }
@@ -327,6 +539,11 @@ pub fn import_pydantic_package(
             "Pydantic package dialect must be {PYDANTIC_DIALECT:?}, got {:?}",
             package.dialect
         )));
+    }
+    if fnv1a(package.source_schema_json.as_bytes()) != package.source_schema_fingerprint {
+        return Err(PydanticError::new(
+            "Pydantic package retained source schema differs from its emission fingerprint",
+        ));
     }
     {
         let retained = CompiledSchema {
@@ -355,12 +572,15 @@ pub fn import_pydantic_package(
         .map_err(|error| PydanticError::new(format!("Pydantic package import: {error}")))
 }
 
-fn definition_names(defs: &Map<String, Value>) -> Result<BTreeMap<String, String>, PydanticError> {
+fn definition_names(
+    defs: &Map<String, Value>,
+    routed: bool,
+) -> Result<BTreeMap<String, String>, PydanticError> {
     let mut names = BTreeMap::new();
     let mut reverse = BTreeMap::<String, String>::new();
     for key in defs.keys() {
         let name = python_type_name(key, "SchemaModel");
-        if reserved_type_names().contains(name.as_str()) {
+        if reserved_type_names().contains(name.as_str()) || routed && name == "TypeAlias" {
             return Err(PydanticError::new(format!(
                 "$defs key {key:?} normalizes to reserved generated/import name {name:?}"
             )));
@@ -377,18 +597,20 @@ fn definition_names(defs: &Map<String, Value>) -> Result<BTreeMap<String, String
 
 struct Renderer<'a> {
     names: &'a BTreeMap<String, String>,
+    routed: bool,
     ledger: LossLedger,
-    helpers: Vec<String>,
+    helpers: Vec<(String, String)>,
     helper_by_path: BTreeMap<String, String>,
     used_names: BTreeSet<String>,
 }
 
 impl<'a> Renderer<'a> {
-    fn new(names: &'a BTreeMap<String, String>) -> Self {
+    fn new(names: &'a BTreeMap<String, String>, routed: bool) -> Self {
         let mut used_names: BTreeSet<String> = names.values().cloned().collect();
         used_names.extend(reserved_type_names().into_iter().map(str::to_owned));
         Self {
             names,
+            routed,
             ledger: LossLedger::new(),
             helpers: Vec::new(),
             helper_by_path: BTreeMap::new(),
@@ -401,6 +623,7 @@ impl<'a> Renderer<'a> {
         key: &str,
         class_name: &str,
         definition: &Value,
+        class_config: Option<&PydanticClassConfig>,
     ) -> Result<String, PydanticError> {
         let path = format!("#/$defs/{}", pointer_escape(key));
         let rewritten = rewrite_references(definition, self.names)?;
@@ -409,10 +632,10 @@ impl<'a> Renderer<'a> {
         if let Some(object) = definition.as_object()
             && is_record_definition(object)
         {
-            return self.render_record(class_name, object, &path, &schema_literal);
+            return self.render_record(class_name, object, &path, &schema_literal, class_config);
         }
 
-        self.render_root(class_name, definition, &path, &schema_literal)
+        self.render_root(class_name, definition, &path, &schema_literal, class_config)
     }
 
     fn render_record(
@@ -421,6 +644,7 @@ impl<'a> Renderer<'a> {
         definition: &Map<String, Value>,
         path: &str,
         schema_literal: &str,
+        class_config: Option<&PydanticClassConfig>,
     ) -> Result<String, PydanticError> {
         let properties = properties(definition, path)?;
         let required = required_names(definition, properties, path)?;
@@ -452,7 +676,11 @@ impl<'a> Renderer<'a> {
             let runtime_type = self.resolve_type(schema, &property_path)?;
             let mut field_args = Vec::new();
             if !required.contains(property.as_str()) {
-                field_args.push("default=None".to_owned());
+                field_args.push(if self.routed {
+                    "default=cast(Any, None)".to_owned()
+                } else {
+                    "default=None".to_owned()
+                });
             }
             if let Some(description) = schema.get("description").and_then(Value::as_str) {
                 field_args.push(format!("description={}", python_string(description)));
@@ -467,15 +695,26 @@ impl<'a> Renderer<'a> {
         }
 
         let mut out = format!("class {class_name}({BASE_CLASS}):\n");
-        if let Some(description) = definition.get("description").and_then(Value::as_str) {
+        if let Some(class_config) = class_config {
+            writeln!(out, "    {}", python_string(class_config.docstring()))
+                .expect("writing generated Python to a String cannot fail");
+        } else if let Some(description) = definition.get("description").and_then(Value::as_str) {
             writeln!(out, "    {}", python_string(description))
                 .expect("writing generated Python to a String cannot fail");
         }
         out.push_str("    model_config = ConfigDict(\n");
         writeln!(out, "        extra=\"{extra}\",")
             .expect("writing generated Python to a String cannot fail");
+        if let Some(class_config) = class_config {
+            writeln!(
+                out,
+                "        json_schema_extra={},",
+                python_mapping(class_config.json_schema_extra())
+            )
+            .expect("writing generated Python to a String cannot fail");
+        }
         out.push_str("    )\n");
-        append_schema_surface(&mut out, schema_literal);
+        append_schema_surface(&mut out, schema_literal, self.routed);
         out.push('\n');
         if !fields.is_empty() {
             out.push_str(&fields);
@@ -490,6 +729,7 @@ impl<'a> Renderer<'a> {
         definition: &Value,
         path: &str,
         schema_literal: &str,
+        class_config: Option<&PydanticClassConfig>,
     ) -> Result<String, PydanticError> {
         let mut out = String::new();
         let root_type = if let Some(values) = definition.get("enum").and_then(Value::as_array)
@@ -506,17 +746,45 @@ impl<'a> Renderer<'a> {
             self.resolve_type(definition, path)?
         };
 
-        writeln!(
-            out,
-            "class {class_name}(RootModel[ForwardRef({})]):",
-            python_string(&root_type)
-        )
-        .expect("writing generated Python to a String cannot fail");
-        if let Some(description) = definition.get("description").and_then(Value::as_str) {
+        if self.routed {
+            let root_alias = format!("_{class_name}Root");
+            writeln!(out, "if TYPE_CHECKING:")
+                .expect("writing generated Python to a String cannot fail");
+            writeln!(out, "    {root_alias}: TypeAlias = RootModel[{root_type}]")
+                .expect("writing generated Python to a String cannot fail");
+            writeln!(out, "else:").expect("writing generated Python to a String cannot fail");
+            writeln!(
+                out,
+                "    {root_alias} = RootModel[ForwardRef({})]\n",
+                python_string(&root_type)
+            )
+            .expect("writing generated Python to a String cannot fail");
+            writeln!(out, "class {class_name}({root_alias}):")
+                .expect("writing generated Python to a String cannot fail");
+        } else {
+            writeln!(
+                out,
+                "class {class_name}(RootModel[ForwardRef({})]):",
+                python_string(&root_type)
+            )
+            .expect("writing generated Python to a String cannot fail");
+        }
+        if let Some(class_config) = class_config {
+            writeln!(out, "    {}", python_string(class_config.docstring()))
+                .expect("writing generated Python to a String cannot fail");
+            out.push_str("    model_config = ConfigDict(\n");
+            writeln!(
+                out,
+                "        json_schema_extra={},",
+                python_mapping(class_config.json_schema_extra())
+            )
+            .expect("writing generated Python to a String cannot fail");
+            out.push_str("    )\n");
+        } else if let Some(description) = definition.get("description").and_then(Value::as_str) {
             writeln!(out, "    {}", python_string(description))
                 .expect("writing generated Python to a String cannot fail");
         }
-        append_schema_surface(&mut out, schema_literal);
+        append_schema_surface(&mut out, schema_literal, self.routed);
         out.push('\n');
         Ok(out)
     }
@@ -673,7 +941,8 @@ impl<'a> Renderer<'a> {
 
         let properties = properties(object, path)?;
         let required = required_names(object, properties, path)?;
-        let mut fields = Vec::with_capacity(properties.len());
+        let mut runtime_fields = Vec::with_capacity(properties.len());
+        let mut static_fields = Vec::with_capacity(properties.len());
         for (property, schema) in properties {
             let child_path = format!("{path}/properties/{}", pointer_escape(property));
             let child_type = self.resolve_type(schema, &child_path)?;
@@ -682,10 +951,14 @@ impl<'a> Renderer<'a> {
             } else {
                 "NotRequired"
             };
-            fields.push(format!(
+            runtime_fields.push(format!(
                 "{}: {marker}[ForwardRef({})]",
                 python_string(property),
                 python_string(&child_type)
+            ));
+            static_fields.push(format!(
+                "{}: {marker}[{child_type}]",
+                python_string(property)
             ));
         }
         let policy = extra_policy(object, path)?;
@@ -699,13 +972,25 @@ impl<'a> Renderer<'a> {
             );
         }
 
-        let declaration = format!(
-            "{name} = TypedDict({}, {{{}}})\n{name}.__pydantic_config__ = \
-             ConfigDict(extra=\"{policy}\")\n",
-            python_string(&name),
-            fields.join(", ")
-        );
-        self.helpers.push(declaration);
+        let declaration = if self.routed {
+            format!(
+                "if TYPE_CHECKING:\n    {name} = TypedDict({}, {{{}}})\nelse:\n    {name} = \
+                 TypedDict({}, {{{}}})\nsetattr({name}, \"__pydantic_config__\", \
+                 ConfigDict(extra=\"{policy}\"))\n",
+                python_string(&name),
+                static_fields.join(", "),
+                python_string(&name),
+                runtime_fields.join(", ")
+            )
+        } else {
+            format!(
+                "{name} = TypedDict({}, {{{}}})\n{name}.__pydantic_config__ = \
+                 ConfigDict(extra=\"{policy}\")\n",
+                python_string(&name),
+                runtime_fields.join(", ")
+            )
+        };
+        self.helpers.push((name.clone(), declaration));
         Ok(name)
     }
 
@@ -1055,7 +1340,7 @@ impl<'a> Renderer<'a> {
         writeln!(out, "_PURRDF_DEFS = {defs_literal}\n")
             .expect("writing generated Python to a String cannot fail");
 
-        for helper in &self.helpers {
+        for (_, helper) in &self.helpers {
             out.push_str(helper);
             out.push_str("\n\n");
         }
@@ -1080,14 +1365,18 @@ impl<'a> Renderer<'a> {
     }
 }
 
-fn append_schema_surface(out: &mut String, schema_literal: &str) {
+fn append_schema_surface(out: &mut String, schema_literal: &str, routed: bool) {
     writeln!(
         out,
         "    __purrdf_schema__: ClassVar[Any] = {schema_literal}"
     )
     .expect("writing generated Python to a String cannot fail");
     out.push_str("\n    @classmethod\n");
-    out.push_str("    def model_json_schema(cls, **kwargs: Any) -> Any:\n");
+    if routed {
+        out.push_str("    def model_json_schema(cls, *args: Any, **kwargs: Any) -> Any:\n");
+    } else {
+        out.push_str("    def model_json_schema(cls, **kwargs: Any) -> Any:\n");
+    }
     out.push_str("        schema = deepcopy(cls.__purrdf_schema__)\n");
     out.push_str("        if isinstance(schema, dict):\n");
     out.push_str("            schema[\"$defs\"] = deepcopy(_PURRDF_DEFS)\n");
@@ -1342,6 +1631,217 @@ fn render_base(docstring: &str) -> String {
     finish_text(out)
 }
 
+fn render_routed_base(docstring: &str) -> String {
+    let mut out = String::new();
+    out.push_str(&python_string(docstring));
+    out.push_str("\nfrom __future__ import annotations\n\n");
+    out.push_str("from datetime import date, datetime, time\n");
+    out.push_str("from enum import StrEnum\n");
+    out.push_str(
+        "from typing import Annotated, Any, ClassVar, ForwardRef, Literal, Never, TypeAlias, cast\n\n",
+    );
+    out.push_str("from pydantic import (\n");
+    out.push_str(
+        "    BaseModel,\n    BeforeValidator,\n    ConfigDict,\n    Field,\n    RootModel,\n",
+    );
+    out.push_str("    StrictBool,\n    StrictFloat,\n    StrictInt,\n    StrictStr,\n");
+    out.push_str(")\n");
+    out.push_str("from typing_extensions import NotRequired, Required, TypedDict\n\n\n");
+    writeln!(out, "class {BASE_CLASS}(BaseModel):")
+        .expect("writing generated Python to a String cannot fail");
+    out.push_str("    model_config = ConfigDict(\n");
+    out.push_str("        populate_by_name=False,\n");
+    out.push_str("    )\n\n\n");
+    out.push_str("def _purrdf_temporal_input(value: Any) -> Any:\n");
+    out.push_str("    if not isinstance(value, str):\n");
+    out.push_str("        raise ValueError(\"temporal values require a JSON string carrier\")\n");
+    out.push_str("    return value\n\n\n");
+    out.push_str("_PURRDF_RUNTIME_TYPES: dict[str, Any] = {\n");
+    for name in routed_runtime_names() {
+        writeln!(out, "    {}: {name},", python_string(name))
+            .expect("writing generated Python to a String cannot fail");
+    }
+    out.push_str("}\n\n");
+    out.push_str("__all__ = (\n");
+    for name in routed_runtime_names() {
+        writeln!(out, "    {},", python_string(name))
+            .expect("writing generated Python to a String cannot fail");
+    }
+    out.push_str("    \"_PURRDF_RUNTIME_TYPES\",\n");
+    out.push_str(")\n");
+    finish_text(out)
+}
+
+fn routed_runtime_names() -> &'static [&'static str] {
+    &[
+        BASE_CLASS,
+        "Annotated",
+        "Any",
+        "BeforeValidator",
+        "ClassVar",
+        "ConfigDict",
+        "Field",
+        "ForwardRef",
+        "Literal",
+        "Never",
+        "NotRequired",
+        "Required",
+        "RootModel",
+        "StrEnum",
+        "StrictBool",
+        "StrictFloat",
+        "StrictInt",
+        "StrictStr",
+        "TypeAlias",
+        "TypedDict",
+        "_purrdf_temporal_input",
+        "cast",
+        "date",
+        "datetime",
+        "time",
+    ]
+}
+
+fn render_schema_module(docstring: &str, defs_literal: &str) -> String {
+    let mut out = String::new();
+    out.push_str(&python_string(docstring));
+    out.push_str("\nfrom __future__ import annotations\n\n");
+    writeln!(out, "_PURRDF_DEFS = {defs_literal}")
+        .expect("writing generated Python to a String cannot fail");
+    finish_text(out)
+}
+
+fn render_routed_module(module: &LinkedModule) -> String {
+    let mut out = String::new();
+    out.push_str(&python_string(&module.docstring));
+    out.push_str("\nfrom __future__ import annotations\n\n");
+    out.push_str("from copy import deepcopy\n");
+    out.push_str("from typing import TYPE_CHECKING\n\n");
+    writeln!(
+        out,
+        "from {} import (",
+        relative_root_import(&module.path, BASE_MODULE)
+    )
+    .expect("writing generated Python to a String cannot fail");
+    for name in routed_runtime_names() {
+        writeln!(out, "    {name},").expect("writing generated Python to a String cannot fail");
+    }
+    out.push_str(")\n");
+    writeln!(
+        out,
+        "from {} import _PURRDF_DEFS\n",
+        relative_root_import(&module.path, "_schema")
+    )
+    .expect("writing generated Python to a String cannot fail");
+
+    if !module.dependencies.is_empty() {
+        out.push_str("if TYPE_CHECKING:\n");
+        for (target, symbols) in &module.dependencies {
+            writeln!(
+                out,
+                "    from {} import (",
+                relative_root_import(&module.path, target)
+            )
+            .expect("writing generated Python to a String cannot fail");
+            for symbol in symbols {
+                writeln!(out, "        {symbol},")
+                    .expect("writing generated Python to a String cannot fail");
+            }
+            out.push_str("    )\n");
+        }
+        out.push('\n');
+    }
+
+    for helper in &module.helpers {
+        out.push_str(&helper.source);
+        out.push_str("\n\n");
+    }
+    for definition in module.definitions.values() {
+        out.push_str(
+            definition
+                .source
+                .as_deref()
+                .expect("a complete linker plan has rendered definition source"),
+        );
+        out.push('\n');
+    }
+
+    let symbols = module
+        .public_symbols
+        .union(&module.private_symbols)
+        .collect::<BTreeSet<_>>();
+    out.push_str("_PURRDF_TYPES: dict[str, Any] = {\n");
+    for symbol in symbols {
+        writeln!(out, "    {}: {symbol},", python_string(symbol))
+            .expect("writing generated Python to a String cannot fail");
+    }
+    out.push_str("}\n\n");
+    out.push_str("__all__ = (\n");
+    for symbol in &module.public_symbols {
+        writeln!(out, "    {},", python_string(symbol))
+            .expect("writing generated Python to a String cannot fail");
+    }
+    out.push_str(")\n");
+    finish_text(out)
+}
+
+fn render_routed_init(docstring: &str, plan: &RoutedPackagePlan, include_version: bool) -> String {
+    let mut out = String::new();
+    out.push_str(&python_string(docstring));
+    out.push_str("\nfrom __future__ import annotations\n\n");
+    out.push_str("from typing import Any\n\n");
+    out.push_str("from ._base import _PURRDF_RUNTIME_TYPES\n");
+    if include_version {
+        out.push_str("from .__about__ import __version__\n");
+    }
+    for module in plan.modules.values() {
+        writeln!(out, "from .{} import (", module.path)
+            .expect("writing generated Python to a String cannot fail");
+        for symbol in &module.public_symbols {
+            writeln!(out, "    {symbol},")
+                .expect("writing generated Python to a String cannot fail");
+        }
+        writeln!(out, "    _PURRDF_TYPES as {},", module.namespace_alias)
+            .expect("writing generated Python to a String cannot fail");
+        out.push_str(")\n");
+    }
+
+    out.push_str("\n_REBUILD_NAMESPACE: dict[str, Any] = dict(_PURRDF_RUNTIME_TYPES)\n");
+    out.push_str("for _namespace in (\n");
+    for module in plan.modules.values() {
+        writeln!(out, "    {},", module.namespace_alias)
+            .expect("writing generated Python to a String cannot fail");
+    }
+    out.push_str("):\n");
+    out.push_str("    for _name, _symbol in _namespace.items():\n");
+    out.push_str("        if _name in _REBUILD_NAMESPACE:\n");
+    out.push_str(
+        "            raise RuntimeError(f\"duplicate generated Pydantic type symbol: {_name}\")\n",
+    );
+    out.push_str("        _REBUILD_NAMESPACE[_name] = _symbol\n");
+    out.push_str("for _model in (\n");
+    for module in plan.modules.values() {
+        for symbol in &module.public_symbols {
+            writeln!(out, "    {symbol},")
+                .expect("writing generated Python to a String cannot fail");
+        }
+    }
+    out.push_str("):\n");
+    out.push_str("    _model.model_rebuild(force=True, _types_namespace=_REBUILD_NAMESPACE)\n\n");
+    out.push_str("__all__ = (\n");
+    for module in plan.modules.values() {
+        for symbol in &module.public_symbols {
+            writeln!(out, "    {},", python_string(symbol))
+                .expect("writing generated Python to a String cannot fail");
+        }
+    }
+    if include_version {
+        out.push_str("    \"__version__\",\n");
+    }
+    out.push_str(")\n");
+    finish_text(out)
+}
+
 fn render_init(docstring: &str, exports: &[String]) -> String {
     let mut out = String::new();
     out.push_str(&python_string(docstring));
@@ -1360,6 +1860,38 @@ fn render_init(docstring: &str, exports: &[String]) -> String {
             .expect("writing generated Python to a String cannot fail");
     }
     out.push_str(")\n");
+    finish_text(out)
+}
+
+fn render_versioned_init(docstring: &str, exports: &[String]) -> String {
+    let mut out = String::new();
+    out.push_str(&python_string(docstring));
+    out.push_str("\nfrom __future__ import annotations\n\n");
+    out.push_str("from .__about__ import __version__\n\n");
+    if !exports.is_empty() {
+        writeln!(out, "from .{MODELS_MODULE} import (")
+            .expect("writing generated Python to a String cannot fail");
+        for name in exports {
+            writeln!(out, "    {name},").expect("writing generated Python to a String cannot fail");
+        }
+        out.push_str(")\n\n");
+    }
+    out.push_str("__all__ = (\n");
+    for name in exports {
+        writeln!(out, "    {},", python_string(name))
+            .expect("writing generated Python to a String cannot fail");
+    }
+    out.push_str("    \"__version__\",\n");
+    out.push_str(")\n");
+    finish_text(out)
+}
+
+fn render_about(version: &PydanticVersionStamp) -> String {
+    let mut out = String::new();
+    out.push_str(&python_string(version.module_docstring()));
+    out.push_str("\nfrom __future__ import annotations\n\n");
+    writeln!(out, "__version__ = {}", python_string(version.version()))
+        .expect("writing generated Python to a String cannot fail");
     finish_text(out)
 }
 
@@ -1440,6 +1972,17 @@ fn python_value(value: &Value) -> String {
                 .join(", ")
         ),
     }
+}
+
+fn python_mapping(values: &BTreeMap<String, Value>) -> String {
+    format!(
+        "{{{}}}",
+        values
+            .iter()
+            .map(|(key, value)| format!("{}: {}", python_string(key), python_value(value)))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
 }
 
 fn python_string(value: &str) -> String {
@@ -1706,6 +2249,79 @@ mod tests {
         .expect("valid config")
     }
 
+    fn routed_config_with(
+        people_module_docstring: &str,
+        person_docstring: &str,
+        person_digest: &str,
+        version: Option<(&str, &str)>,
+        swap_routes: bool,
+    ) -> PydanticConfig {
+        let person_module = if swap_routes {
+            "vocab"
+        } else {
+            "domain.people"
+        };
+        let color_module = if swap_routes {
+            "domain.people"
+        } else {
+            "vocab"
+        };
+        let topology = PydanticPackageTopology::new(
+            [
+                PydanticModuleConfig::new("domain.people", people_module_docstring)
+                    .expect("people module"),
+                PydanticModuleConfig::new("vocab", "Caller vocabulary module documentation.")
+                    .expect("vocabulary module"),
+            ],
+            [
+                PydanticClassConfig::new(
+                    "Person",
+                    person_module,
+                    person_docstring,
+                    BTreeMap::from([
+                        ("definitionDigest".to_owned(), json!(person_digest)),
+                        ("docs".to_owned(), json!("https://example.org/docs/person")),
+                    ]),
+                )
+                .expect("Person route"),
+                PydanticClassConfig::new(
+                    "Color",
+                    color_module,
+                    "Caller Color documentation.",
+                    BTreeMap::from([
+                        ("definitionDigest".to_owned(), json!("sha256:color")),
+                        ("docs".to_owned(), json!("https://example.org/docs/color")),
+                    ]),
+                )
+                .expect("Color route"),
+            ],
+        )
+        .expect("routed topology");
+        let config = config().with_topology(topology).expect("routed config");
+        if let Some((version, module_docstring)) = version {
+            config
+                .with_version_stamp(
+                    PydanticVersionStamp::new(version, module_docstring).expect("version"),
+                )
+                .expect("versioned routed config")
+        } else {
+            config
+        }
+    }
+
+    fn routed_config(include_version: bool) -> PydanticConfig {
+        routed_config_with(
+            "Caller people module documentation.",
+            "Caller Person documentation.",
+            "sha256:person",
+            include_version.then_some((
+                "2!3.4rc1+portable.7",
+                "Caller-owned version module documentation.",
+            )),
+            false,
+        )
+    }
+
     fn import_config() -> SchemaImportConfig {
         let namespaces = Namespaces::new(
             "ex",
@@ -1789,6 +2405,222 @@ mod tests {
         assert!(PydanticConfig::new("pkg", " ", "models").is_err());
         assert!(PydanticConfig::new("pkg", "package", "\n").is_err());
         assert!(PydanticConfig::new("org.example_models", "p", "m").is_ok());
+    }
+
+    #[test]
+    fn caller_version_emits_about_and_root_export_exactly() {
+        let version = PydanticVersionStamp::new(
+            "2!3.4rc1+portable.7",
+            "Caller-owned version module documentation.",
+        )
+        .expect("version");
+        let config = config()
+            .with_version_stamp(version)
+            .expect("versioned config");
+        let package = emit_pydantic(&compiled(&lossless_schema()), &config).expect("emit");
+
+        assert_eq!(package.artifacts.len(), 5);
+        let about = std::str::from_utf8(&package.artifacts["example_models/__about__.py"])
+            .expect("about UTF-8");
+        let init = std::str::from_utf8(&package.artifacts["example_models/__init__.py"])
+            .expect("init UTF-8");
+        assert!(about.starts_with("\"Caller-owned version module documentation.\"\n"));
+        assert!(about.contains("__version__ = \"2!3.4rc1+portable.7\""));
+        assert!(init.contains("from .__about__ import __version__"));
+        assert!(init.contains("    \"__version__\","));
+        assert_eq!(
+            package.model_paths["Person"],
+            "example_models.models.Person"
+        );
+        import_pydantic_package(&package, &import_config()).expect("verified import");
+    }
+
+    #[test]
+    fn routed_package_owns_modules_metadata_symbols_and_version() {
+        let package = emit_pydantic(&compiled(&lossless_schema()), &routed_config(true))
+            .expect("emit routed package");
+        assert_eq!(
+            package
+                .artifacts
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            [
+                "example_models/__about__.py",
+                "example_models/__init__.py",
+                "example_models/_base.py",
+                "example_models/_schema.py",
+                "example_models/domain/__init__.py",
+                "example_models/domain/people.py",
+                "example_models/py.typed",
+                "example_models/vocab.py",
+            ]
+        );
+        assert_eq!(
+            package.model_paths,
+            BTreeMap::from([
+                ("Color".to_owned(), "example_models.vocab.Color".to_owned(),),
+                (
+                    "Person".to_owned(),
+                    "example_models.domain.people.Person".to_owned(),
+                ),
+            ])
+        );
+
+        let schema = std::str::from_utf8(&package.artifacts["example_models/_schema.py"])
+            .expect("schema UTF-8");
+        let people = std::str::from_utf8(&package.artifacts["example_models/domain/people.py"])
+            .expect("people UTF-8");
+        let vocab = std::str::from_utf8(&package.artifacts["example_models/vocab.py"])
+            .expect("vocab UTF-8");
+        let init = std::str::from_utf8(&package.artifacts["example_models/__init__.py"])
+            .expect("init UTF-8");
+        let about = std::str::from_utf8(&package.artifacts["example_models/__about__.py"])
+            .expect("about UTF-8");
+
+        assert!(schema.contains("_PURRDF_DEFS ="));
+        assert!(!people.contains("_PURRDF_DEFS ="));
+        assert!(!vocab.contains("_PURRDF_DEFS ="));
+        assert!(people.starts_with("\"Caller people module documentation.\""));
+        assert!(people.contains("    \"Caller Person documentation.\""));
+        assert!(people.contains(
+            "json_schema_extra={\"definitionDigest\": \"sha256:person\", \"docs\": \"https://example.org/docs/person\"}"
+        ));
+        assert!(people.contains("if TYPE_CHECKING:\n    from ..vocab import (\n        Color,"));
+        assert!(people.contains("_PURRDF_TYPES: dict[str, Any] = {"));
+        assert!(vocab.contains("class _ColorValue(StrEnum):"));
+        assert!(vocab.contains("    \"Caller Color documentation.\""));
+        assert!(vocab.contains("\"_ColorValue\": _ColorValue"));
+        assert!(!people.contains("dict(globals())"));
+        assert!(!vocab.contains("dict(globals())"));
+        assert!(init.contains("from .__about__ import __version__"));
+        assert!(init.contains("_model.model_rebuild("));
+        assert!(about.contains("__version__ = \"2!3.4rc1+portable.7\""));
+        import_pydantic_package(&package, &import_config()).expect("verified routed import");
+    }
+
+    #[test]
+    fn routed_topology_requires_exact_schema_coverage() {
+        let schema = compiled(&lossless_schema());
+        let missing = PydanticPackageTopology::new(
+            [PydanticModuleConfig::new("models", "Caller models.").expect("module")],
+            [
+                PydanticClassConfig::new("Person", "models", "Caller Person.", BTreeMap::new())
+                    .expect("route"),
+            ],
+        )
+        .expect("missing topology is structurally valid");
+        let error = emit_pydantic(&schema, &config().with_topology(missing).expect("config"))
+            .expect_err("missing route");
+        assert!(error.to_string().contains("missing routes=[\"Color\"]"));
+
+        let stale = PydanticPackageTopology::new(
+            [PydanticModuleConfig::new("models", "Caller models.").expect("module")],
+            [
+                PydanticClassConfig::new("Color", "models", "Caller Color.", BTreeMap::new())
+                    .expect("route"),
+                PydanticClassConfig::new("Person", "models", "Caller Person.", BTreeMap::new())
+                    .expect("route"),
+                PydanticClassConfig::new("Stale", "models", "Caller stale class.", BTreeMap::new())
+                    .expect("route"),
+            ],
+        )
+        .expect("stale topology is structurally valid");
+        let error = emit_pydantic(&schema, &config().with_topology(stale).expect("config"))
+            .expect_err("stale route");
+        assert!(error.to_string().contains("stale routes=[\"Stale\"]"));
+    }
+
+    #[test]
+    fn routed_only_runtime_names_do_not_narrow_flat_compatibility() {
+        let schema = compiled(&json!({ "$defs": { "TypeAlias": { "type": "string" } } }));
+        emit_pydantic(&schema, &config()).expect("flat TypeAlias remains valid");
+        let topology = PydanticPackageTopology::new(
+            [PydanticModuleConfig::new("models", "Caller module.").expect("module")],
+            [
+                PydanticClassConfig::new("TypeAlias", "models", "Caller class.", BTreeMap::new())
+                    .expect("route"),
+            ],
+        )
+        .expect("topology");
+        assert!(
+            emit_pydantic(&schema, &config().with_topology(topology).expect("config")).is_err()
+        );
+    }
+
+    #[test]
+    fn routed_output_is_order_independent_and_helpers_stay_with_owners() {
+        let schema = json!({
+            "$defs": {
+                "Color": { "enum": ["red", "blue"] },
+                "Person": {
+                    "type": "object",
+                    "properties": {
+                        "color": { "$ref": "#/$defs/Color" },
+                        "address": {
+                            "type": "object",
+                            "properties": { "city": { "type": "string" } }
+                        }
+                    }
+                }
+            }
+        });
+        let first = emit_pydantic(&compiled(&schema), &routed_config(false)).expect("first");
+
+        let topology = PydanticPackageTopology::new(
+            [
+                PydanticModuleConfig::new("vocab", "Caller vocabulary module documentation.")
+                    .expect("module"),
+                PydanticModuleConfig::new("domain.people", "Caller people module documentation.")
+                    .expect("module"),
+            ],
+            [
+                routed_config(false).topology().expect("topology").classes()["Color"].clone(),
+                routed_config(false).topology().expect("topology").classes()["Person"].clone(),
+            ],
+        )
+        .expect("reordered topology");
+        let second = emit_pydantic(
+            &compiled(&schema),
+            &config().with_topology(topology).expect("config"),
+        )
+        .expect("second");
+        assert_eq!(first, second);
+
+        let people = std::str::from_utf8(&first.artifacts["example_models/domain/people.py"])
+            .expect("people UTF-8");
+        let vocab =
+            std::str::from_utf8(&first.artifacts["example_models/vocab.py"]).expect("vocab UTF-8");
+        assert!(people.contains("TypedDict("));
+        assert!(!vocab.contains("TypedDict("));
+        assert!(vocab.contains("class _ColorValue(StrEnum):"));
+        assert!(!people.contains("class _ColorValue(StrEnum):"));
+    }
+
+    #[test]
+    fn artifact_limits_accept_boundaries_and_reject_each_one_over() {
+        let limits = ArtifactLimits {
+            artifact_bytes: 4,
+            output_bytes: 6,
+            artifacts: 2,
+        };
+        let mut accepted = ArtifactAccumulator::with_limits(limits);
+        accepted
+            .insert("a.py".to_owned(), vec![0; 4])
+            .expect("artifact boundary");
+        accepted
+            .insert("b.py".to_owned(), vec![0; 2])
+            .expect("output boundary");
+        assert!(accepted.insert("c.py".to_owned(), Vec::new()).is_err());
+
+        let mut artifact_over = ArtifactAccumulator::with_limits(limits);
+        assert!(artifact_over.insert("a.py".to_owned(), vec![0; 5]).is_err());
+
+        let mut output_over = ArtifactAccumulator::with_limits(limits);
+        output_over
+            .insert("a.py".to_owned(), vec![0; 4])
+            .expect("first artifact");
+        assert!(output_over.insert("b.py".to_owned(), vec![0; 3]).is_err());
     }
 
     #[test]
@@ -1888,6 +2720,122 @@ mod tests {
     }
 
     #[test]
+    fn retained_source_and_emission_configuration_tampering_fail_closed() {
+        let package =
+            emit_pydantic(&compiled(&lossless_schema()), &routed_config(true)).expect("emit");
+
+        let mut bad_source = package.clone();
+        bad_source.source_schema_json.push('\n');
+        let error = import_pydantic_package(&bad_source, &import_config())
+            .expect_err("retained source mutation");
+        assert!(error.to_string().contains("emission fingerprint"));
+
+        let topology = routed_config(true)
+            .topology()
+            .expect("routed topology")
+            .clone();
+        let version = routed_config(true)
+            .version_stamp()
+            .expect("version stamp")
+            .clone();
+        let changed_base_configs = [
+            PydanticConfig::new(
+                "changed_models",
+                "Caller package documentation.",
+                "Caller model documentation.",
+            )
+            .expect("changed package name"),
+            PydanticConfig::new(
+                "example_models",
+                "Changed package documentation.",
+                "Caller model documentation.",
+            )
+            .expect("changed package docstring"),
+            PydanticConfig::new(
+                "example_models",
+                "Caller package documentation.",
+                "Changed support documentation.",
+            )
+            .expect("changed models docstring"),
+        ]
+        .into_iter()
+        .map(|config| {
+            config
+                .with_topology(topology.clone())
+                .expect("same topology")
+                .with_version_stamp(version.clone())
+                .expect("same version")
+        });
+        let changed_routed_configs = [
+            routed_config_with(
+                "Changed people module documentation.",
+                "Caller Person documentation.",
+                "sha256:person",
+                Some((
+                    "2!3.4rc1+portable.7",
+                    "Caller-owned version module documentation.",
+                )),
+                false,
+            ),
+            routed_config_with(
+                "Caller people module documentation.",
+                "Changed Person documentation.",
+                "sha256:person",
+                Some((
+                    "2!3.4rc1+portable.7",
+                    "Caller-owned version module documentation.",
+                )),
+                false,
+            ),
+            routed_config_with(
+                "Caller people module documentation.",
+                "Caller Person documentation.",
+                "sha256:changed",
+                Some((
+                    "2!3.4rc1+portable.7",
+                    "Caller-owned version module documentation.",
+                )),
+                false,
+            ),
+            routed_config_with(
+                "Caller people module documentation.",
+                "Caller Person documentation.",
+                "sha256:person",
+                Some((
+                    "2!3.4rc2+portable.7",
+                    "Caller-owned version module documentation.",
+                )),
+                false,
+            ),
+            routed_config_with(
+                "Caller people module documentation.",
+                "Caller Person documentation.",
+                "sha256:person",
+                Some(("2!3.4rc1+portable.7", "Changed version documentation.")),
+                false,
+            ),
+            routed_config_with(
+                "Caller people module documentation.",
+                "Caller Person documentation.",
+                "sha256:person",
+                Some((
+                    "2!3.4rc1+portable.7",
+                    "Caller-owned version module documentation.",
+                )),
+                true,
+            ),
+        ];
+        for changed in changed_base_configs.chain(changed_routed_configs) {
+            let mut bad = package.clone();
+            bad.config = changed;
+            assert!(
+                import_pydantic_package(&bad, &import_config()).is_err(),
+                "changed retained configuration must fail closed"
+            );
+        }
+    }
+
+    #[test]
     fn verified_package_imports_recursive_nullable_and_finite_schema() {
         let schema = json!({
             "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1934,14 +2882,12 @@ mod tests {
             losses: LossLedger::new(),
         };
 
-        let package = emit_pydantic(&compiled, &config()).expect("Pydantic emits annotation");
         assert!(
-            import_pydantic_package(&package, &import_config())
-                .expect_err("Pydantic shared node limit")
+            emit_pydantic(&compiled, &config())
+                .expect_err("Pydantic forward node limit")
                 .to_string()
-                .contains("node limit")
+                .contains("JSON nodes")
         );
-        drop(package);
 
         let typescript_config = crate::typescript::TypeScriptConfig::new(
             "@example/resource-probe",

--- a/crates/shapes/src/pydantic.rs
+++ b/crates/shapes/src/pydantic.rs
@@ -39,6 +39,12 @@ use crate::schema_catalog::{
 };
 use crate::schema_import::{ImportedShapes, SchemaImportConfig, import_json_schema_from};
 
+mod config;
+
+pub use self::config::{
+    PydanticClassConfig, PydanticModuleConfig, PydanticPackageTopology, PydanticVersionStamp,
+};
+
 const MODELS_MODULE: &str = "models";
 const BASE_MODULE: &str = "_base";
 const BASE_CLASS: &str = "PurrdfBaseModel";
@@ -55,14 +61,17 @@ pub struct PydanticConfig {
     package_name: String,
     package_docstring: String,
     models_docstring: String,
+    topology: Option<PydanticPackageTopology>,
+    version_stamp: Option<PydanticVersionStamp>,
 }
 
 impl PydanticConfig {
     /// Validate and construct an emitter configuration.
     ///
     /// `package_name` may be a dotted Python package path. Every component must
-    /// be a non-keyword ASCII Python identifier. Both docstrings must contain
-    /// non-whitespace caller text.
+    /// be a portable, non-keyword ASCII Python identifier. Both docstrings must
+    /// contain non-whitespace caller text and all values must satisfy the fixed
+    /// generated-package resource ceilings.
     ///
     /// # Errors
     ///
@@ -76,32 +85,61 @@ impl PydanticConfig {
         let package_docstring = package_docstring.into();
         let models_docstring = models_docstring.into();
 
-        if package_name.is_empty()
-            || package_name
-                .split('.')
-                .any(|part| !is_python_identifier(part) || is_python_keyword(part))
-        {
-            return Err(PydanticError::new(format!(
-                "Pydantic package name {package_name:?} is not a dotted sequence of non-keyword \
-                 ASCII Python identifiers"
-            )));
-        }
-        if package_docstring.trim().is_empty() {
-            return Err(PydanticError::new(
-                "Pydantic package docstring must be caller-supplied non-whitespace text",
-            ));
-        }
-        if models_docstring.trim().is_empty() {
-            return Err(PydanticError::new(
-                "Pydantic models-module docstring must be caller-supplied non-whitespace text",
-            ));
-        }
+        config::validate_base_config(&package_name, &package_docstring, &models_docstring)?;
 
         Ok(Self {
             package_name,
             package_docstring,
             models_docstring,
+            topology: None,
+            version_stamp: None,
         })
+    }
+
+    /// Attach a validated, total caller-owned package topology.
+    ///
+    /// Exact coverage of the emitted schema's `$defs` is checked by
+    /// [`emit_pydantic`]. This builder validates package-relative artifact paths
+    /// and aggregate configuration resources immediately.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PydanticError`] when the combined package configuration exceeds
+    /// a fixed resource or portable-path ceiling.
+    pub fn with_topology(
+        mut self,
+        topology: PydanticPackageTopology,
+    ) -> Result<Self, PydanticError> {
+        config::validate_full_config(
+            &self.package_name,
+            &self.package_docstring,
+            &self.models_docstring,
+            Some(&topology),
+            self.version_stamp.as_ref(),
+        )?;
+        self.topology = Some(topology);
+        Ok(self)
+    }
+
+    /// Attach a caller-owned PEP 440 version source.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PydanticError`] when the combined package configuration exceeds
+    /// a fixed resource or portable-path ceiling.
+    pub fn with_version_stamp(
+        mut self,
+        version_stamp: PydanticVersionStamp,
+    ) -> Result<Self, PydanticError> {
+        config::validate_full_config(
+            &self.package_name,
+            &self.package_docstring,
+            &self.models_docstring,
+            self.topology.as_ref(),
+            Some(&version_stamp),
+        )?;
+        self.version_stamp = Some(version_stamp);
+        Ok(self)
     }
 
     /// The dotted Python package name.
@@ -120,6 +158,18 @@ impl PydanticConfig {
     #[must_use]
     pub fn models_docstring(&self) -> &str {
         &self.models_docstring
+    }
+
+    /// Caller-owned routed package topology, when configured.
+    #[must_use]
+    pub const fn topology(&self) -> Option<&PydanticPackageTopology> {
+        self.topology.as_ref()
+    }
+
+    /// Caller-owned package version source, when configured.
+    #[must_use]
+    pub const fn version_stamp(&self) -> Option<&PydanticVersionStamp> {
+        self.version_stamp.as_ref()
     }
 }
 

--- a/crates/shapes/src/pydantic.rs
+++ b/crates/shapes/src/pydantic.rs
@@ -580,7 +580,7 @@ fn definition_names(
     let mut reverse = BTreeMap::<String, String>::new();
     for key in defs.keys() {
         let name = python_type_name(key, "SchemaModel");
-        if reserved_type_names().contains(name.as_str()) || routed && name == "TypeAlias" {
+        if reserved_type_names().contains(name.as_str()) || (routed && name == "TypeAlias") {
             return Err(PydanticError::new(format!(
                 "$defs key {key:?} normalizes to reserved generated/import name {name:?}"
             )));

--- a/crates/shapes/src/pydantic/config.rs
+++ b/crates/shapes/src/pydantic/config.rs
@@ -480,14 +480,14 @@ fn validate_dotted_path(value: &str, role: &str) -> Result<(), PydanticError> {
             value.len()
         )));
     }
-    let components = value.split('.').collect::<Vec<_>>();
-    if components.len() > MAX_DOTTED_PATH_COMPONENTS {
+    let component_count = value.bytes().filter(|byte| *byte == b'.').count() + 1;
+    if component_count > MAX_DOTTED_PATH_COMPONENTS {
         return Err(PydanticError::new(format!(
-            "{role} {value:?} has {} components; limit is {MAX_DOTTED_PATH_COMPONENTS}",
-            components.len()
+            "{role} {value:?} has {component_count} components; limit is \
+             {MAX_DOTTED_PATH_COMPONENTS}"
         )));
     }
-    for component in components {
+    for component in value.split('.') {
         if !is_python_identifier(component) || is_python_keyword(component) {
             return Err(PydanticError::new(format!(
                 "{role} {value:?} contains invalid or keyword component {component:?}"
@@ -520,19 +520,18 @@ fn validate_module_prefixes(
         .keys()
         .map(|path| path.to_ascii_lowercase())
         .collect::<BTreeSet<_>>();
+    let mut prefix = String::new();
     for path in modules.keys() {
-        let parts = path
-            .split('.')
-            .map(str::to_ascii_lowercase)
-            .collect::<Vec<_>>();
-        for length in 1..parts.len() {
-            let prefix = parts[..length].join(".");
-            if folded.contains(&prefix) {
+        prefix.clear();
+        prefix.reserve(path.len());
+        for byte in path.bytes() {
+            if byte == b'.' && folded.contains(prefix.as_str()) {
                 return Err(PydanticError::new(format!(
                     "Pydantic module path {path:?} requires {prefix:?} to be a package, but it \
                      is also declared as a module file"
                 )));
             }
+            prefix.push(char::from(byte.to_ascii_lowercase()));
         }
     }
     Ok(())
@@ -556,16 +555,23 @@ fn validate_relative_artifacts(
         insert_artifact("__about__.py".to_owned(), &mut paths, &mut folded)?;
     }
     if let Some(modules) = modules {
+        let mut current_path = String::new();
         for module in modules.keys() {
-            let parts = module.split('.').collect::<Vec<_>>();
-            for length in 1..parts.len() {
-                insert_artifact(
-                    format!("{}/__init__.py", parts[..length].join("/")),
-                    &mut paths,
-                    &mut folded,
-                )?;
+            current_path.clear();
+            current_path.reserve(module.len());
+            for byte in module.bytes() {
+                if byte == b'.' {
+                    insert_artifact(
+                        format!("{current_path}/__init__.py"),
+                        &mut paths,
+                        &mut folded,
+                    )?;
+                    current_path.push('/');
+                } else {
+                    current_path.push(char::from(byte));
+                }
             }
-            insert_artifact(format!("{}.py", parts.join("/")), &mut paths, &mut folded)?;
+            insert_artifact(format!("{current_path}.py"), &mut paths, &mut folded)?;
         }
     }
     Ok(paths)

--- a/crates/shapes/src/pydantic/config.rs
+++ b/crates/shapes/src/pydantic/config.rs
@@ -9,7 +9,8 @@ use serde_json::Value;
 
 use super::{PydanticError, is_python_identifier, is_python_keyword};
 
-const MAX_CLASSES: usize = 65_536;
+pub(super) const MAX_DEFINITIONS: usize = 65_536;
+const MAX_CLASSES: usize = MAX_DEFINITIONS;
 const MAX_MODULES: usize = 65_536;
 const MAX_DOTTED_PATH_BYTES: usize = 255;
 const MAX_DOTTED_PATH_COMPONENTS: usize = 32;
@@ -20,6 +21,13 @@ const MAX_CONFIG_BYTES: usize = 16 * 1024 * 1024;
 const MAX_METADATA_DEPTH: usize = 128;
 const MAX_METADATA_NODES: usize = 1_000_000;
 const MAX_ARTIFACTS: usize = 131_072;
+pub(super) const MAX_SCHEMA_BYTES: usize = 16 * 1024 * 1024;
+pub(super) const MAX_SCHEMA_DEPTH: usize = 128;
+pub(super) const MAX_SCHEMA_NODES: usize = 1_000_000;
+pub(super) const MAX_SCHEMA_STRING_BYTES: usize = 16 * 1024 * 1024;
+pub(super) const MAX_ARTIFACT_BYTES: usize = 256 * 1024 * 1024;
+pub(super) const MAX_OUTPUT_BYTES: usize = 512 * 1024 * 1024;
+pub(super) const MAX_OUTPUT_ARTIFACTS: usize = MAX_ARTIFACTS;
 
 const GENERATED_ROOT_MODULES: &[&str] = &["_base", "_schema", "__about__", "__init__"];
 
@@ -560,12 +568,6 @@ fn validate_relative_artifacts(
             insert_artifact(format!("{}.py", parts.join("/")), &mut paths, &mut folded)?;
         }
     }
-    if paths.len() > MAX_ARTIFACTS {
-        return Err(PydanticError::new(format!(
-            "Pydantic package requires {} artifacts; limit is {MAX_ARTIFACTS}",
-            paths.len()
-        )));
-    }
     Ok(paths)
 }
 
@@ -576,6 +578,11 @@ fn insert_artifact(
 ) -> Result<(), PydanticError> {
     if paths.contains(&path) {
         return Ok(());
+    }
+    if paths.len() == MAX_ARTIFACTS {
+        return Err(PydanticError::new(format!(
+            "Pydantic package exceeds the {MAX_ARTIFACTS}-artifact limit"
+        )));
     }
     if path.len() > MAX_ARTIFACT_PATH_BYTES {
         return Err(PydanticError::new(format!(
@@ -961,6 +968,24 @@ mod tests {
         .expect("shared intermediate package");
         validate_relative_artifacts(Some(topology.modules()), false)
             .expect("shared initializer is emitted once");
+    }
+
+    #[test]
+    fn artifact_count_fails_before_inserting_the_first_one_over() {
+        let mut paths = (0..MAX_ARTIFACTS)
+            .map(|index| format!("path-{index}"))
+            .collect::<BTreeSet<_>>();
+        let mut folded = paths
+            .iter()
+            .map(|path| (path.to_ascii_lowercase(), path.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let existing = paths.first().expect("full path set has an entry").clone();
+        insert_artifact(existing, &mut paths, &mut folded).expect("duplicate is not a new file");
+        let error = insert_artifact("one-over".to_owned(), &mut paths, &mut folded)
+            .expect_err("new artifact beyond the ceiling");
+        assert!(error.to_string().contains("131072-artifact limit"));
+        assert_eq!(paths.len(), MAX_ARTIFACTS);
+        assert!(!paths.contains("one-over"));
     }
 
     #[test]

--- a/crates/shapes/src/pydantic/config.rs
+++ b/crates/shapes/src/pydantic/config.rs
@@ -52,6 +52,14 @@ impl PydanticModuleConfig {
         let path = path.into();
         let docstring = docstring.into();
         validate_dotted_path(&path, "Pydantic module path")?;
+        if path
+            .split('.')
+            .any(|component| component.eq_ignore_ascii_case("__init__"))
+        {
+            return Err(PydanticError::new(format!(
+                "Pydantic module path {path:?} contains reserved package initializer component \"__init__\""
+            )));
+        }
         let root = path
             .split('.')
             .next()
@@ -1019,6 +1027,25 @@ mod tests {
             .join(".");
         assert!(PydanticModuleConfig::new(deep, "docs").is_err());
         assert!(PydanticConfig::new("con", "package docs", "model docs").is_err());
+    }
+
+    #[test]
+    fn module_paths_reject_initializer_components_at_every_position() {
+        for path in [
+            "__init__",
+            "__INIT__.models",
+            "domain.__init__.people",
+            "domain.people.__INIT__",
+        ] {
+            let error = PydanticModuleConfig::new(path, "docs")
+                .expect_err("package initializer component must be reserved");
+            assert!(
+                error
+                    .to_string()
+                    .contains("reserved package initializer component"),
+                "{path}: {error}"
+            );
+        }
     }
 
     #[test]

--- a/crates/shapes/src/pydantic/config.rs
+++ b/crates/shapes/src/pydantic/config.rs
@@ -1,0 +1,1094 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Validated caller-owned configuration for deterministic Pydantic packages.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::Value;
+
+use super::{PydanticError, is_python_identifier, is_python_keyword};
+
+const MAX_CLASSES: usize = 65_536;
+const MAX_MODULES: usize = 65_536;
+const MAX_DOTTED_PATH_BYTES: usize = 255;
+const MAX_DOTTED_PATH_COMPONENTS: usize = 32;
+const MAX_ARTIFACT_PATH_BYTES: usize = 4_096;
+const MAX_DOCSTRING_BYTES: usize = 1024 * 1024;
+const MAX_VERSION_BYTES: usize = 512;
+const MAX_CONFIG_BYTES: usize = 16 * 1024 * 1024;
+const MAX_METADATA_DEPTH: usize = 128;
+const MAX_METADATA_NODES: usize = 1_000_000;
+const MAX_ARTIFACTS: usize = 131_072;
+
+const GENERATED_ROOT_MODULES: &[&str] = &["_base", "_schema", "__about__", "__init__"];
+
+/// One caller-declared Python module in a routed Pydantic package.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PydanticModuleConfig {
+    path: String,
+    docstring: String,
+}
+
+impl PydanticModuleConfig {
+    /// Validate a relative dotted Python module path and its caller documentation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PydanticError`] when the path is not portable Python syntax,
+    /// collides with a generated root module, or the documentation is invalid.
+    pub fn new(
+        path: impl Into<String>,
+        docstring: impl Into<String>,
+    ) -> Result<Self, PydanticError> {
+        let path = path.into();
+        let docstring = docstring.into();
+        validate_dotted_path(&path, "Pydantic module path")?;
+        let root = path
+            .split('.')
+            .next()
+            .expect("a validated dotted path has one component");
+        if GENERATED_ROOT_MODULES
+            .iter()
+            .any(|generated| root.eq_ignore_ascii_case(generated))
+        {
+            return Err(PydanticError::new(format!(
+                "Pydantic module path {path:?} collides with generated root module {root:?}"
+            )));
+        }
+        validate_docstring(&docstring, "Pydantic module docstring")?;
+        Ok(Self { path, docstring })
+    }
+
+    /// Relative dotted module path within the configured package.
+    #[must_use]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Caller-supplied module docstring.
+    #[must_use]
+    pub fn docstring(&self) -> &str {
+        &self.docstring
+    }
+}
+
+/// One source `$defs` entry's caller-owned route and class metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PydanticClassConfig {
+    definition_key: String,
+    module_path: String,
+    docstring: String,
+    json_schema_extra: BTreeMap<String, Value>,
+    resource_bytes: usize,
+    metadata_nodes: usize,
+}
+
+impl PydanticClassConfig {
+    /// Validate one definition route, class docstring, and deterministic metadata.
+    ///
+    /// `json_schema_extra` is deliberately vocabulary-neutral. PurRDF preserves
+    /// the caller's sorted JSON map without assigning meaning to any key.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PydanticError`] for an invalid module path, blank or oversized
+    /// documentation, or metadata beyond the fixed depth, node, or byte ceilings.
+    pub fn new(
+        definition_key: impl Into<String>,
+        module_path: impl Into<String>,
+        docstring: impl Into<String>,
+        json_schema_extra: BTreeMap<String, Value>,
+    ) -> Result<Self, PydanticError> {
+        let definition_key = definition_key.into();
+        let module_path = module_path.into();
+        let docstring = docstring.into();
+        validate_dotted_path(&module_path, "Pydantic class module path")?;
+        validate_docstring(&docstring, "Pydantic class docstring")?;
+
+        let (metadata_bytes, metadata_nodes) =
+            measure_metadata(&json_schema_extra, &definition_key)?;
+        let resource_bytes = checked_sum(
+            [
+                definition_key.len(),
+                module_path.len(),
+                docstring.len(),
+                metadata_bytes,
+            ],
+            "Pydantic class configuration byte count",
+        )?;
+        if resource_bytes > MAX_CONFIG_BYTES {
+            return Err(PydanticError::new(format!(
+                "Pydantic class route {definition_key:?} uses {resource_bytes} configuration \
+                 bytes; limit is {MAX_CONFIG_BYTES}"
+            )));
+        }
+
+        Ok(Self {
+            definition_key,
+            module_path,
+            docstring,
+            json_schema_extra,
+            resource_bytes,
+            metadata_nodes,
+        })
+    }
+
+    /// Exact source `$defs` key routed by this declaration.
+    #[must_use]
+    pub fn definition_key(&self) -> &str {
+        &self.definition_key
+    }
+
+    /// Relative dotted module path for the generated class.
+    #[must_use]
+    pub fn module_path(&self) -> &str {
+        &self.module_path
+    }
+
+    /// Caller-supplied generated-class docstring.
+    #[must_use]
+    pub fn docstring(&self) -> &str {
+        &self.docstring
+    }
+
+    /// Sorted caller-owned Pydantic `json_schema_extra` map.
+    #[must_use]
+    pub fn json_schema_extra(&self) -> &BTreeMap<String, Value> {
+        &self.json_schema_extra
+    }
+}
+
+/// A total, deterministic caller-owned partition of schema definitions into modules.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PydanticPackageTopology {
+    modules: BTreeMap<String, PydanticModuleConfig>,
+    classes: BTreeMap<String, PydanticClassConfig>,
+    resource_bytes: usize,
+    metadata_nodes: usize,
+}
+
+impl PydanticPackageTopology {
+    /// Validate and canonicalize module declarations and definition routes.
+    ///
+    /// Constructors accept iterators so duplicate declarations are diagnosed
+    /// before storage in sorted maps. Every declared leaf module must own at
+    /// least one class, and every class must name a declared module. Exact
+    /// coverage of a concrete schema's `$defs` is checked by the emitter.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PydanticError`] for duplicates, missing/unused modules,
+    /// case-folded or file/package collisions, or resource-limit exhaustion.
+    pub fn new(
+        modules: impl IntoIterator<Item = PydanticModuleConfig>,
+        classes: impl IntoIterator<Item = PydanticClassConfig>,
+    ) -> Result<Self, PydanticError> {
+        let mut module_map = BTreeMap::new();
+        let mut folded_modules = BTreeMap::<String, String>::new();
+        for module in modules {
+            if module_map.len() == MAX_MODULES {
+                return Err(PydanticError::new(format!(
+                    "Pydantic topology exceeds the {MAX_MODULES}-module limit"
+                )));
+            }
+            let path = module.path.clone();
+            if module_map.insert(path.clone(), module).is_some() {
+                return Err(PydanticError::new(format!(
+                    "Pydantic topology declares module {path:?} more than once"
+                )));
+            }
+            let folded = path.to_ascii_lowercase();
+            if let Some(previous) = folded_modules.insert(folded, path.clone()) {
+                return Err(PydanticError::new(format!(
+                    "Pydantic modules {previous:?} and {path:?} collide on a \
+                     case-insensitive filesystem"
+                )));
+            }
+        }
+        validate_module_prefixes(&module_map)?;
+
+        let mut class_map = BTreeMap::new();
+        let mut used_modules = BTreeSet::new();
+        for class in classes {
+            if class_map.len() == MAX_CLASSES {
+                return Err(PydanticError::new(format!(
+                    "Pydantic topology exceeds the {MAX_CLASSES}-class limit"
+                )));
+            }
+            if !module_map.contains_key(class.module_path()) {
+                return Err(PydanticError::new(format!(
+                    "Pydantic class route {:?} names undeclared module {:?}",
+                    class.definition_key(),
+                    class.module_path()
+                )));
+            }
+            used_modules.insert(class.module_path.clone());
+            let key = class.definition_key.clone();
+            if class_map.insert(key.clone(), class).is_some() {
+                return Err(PydanticError::new(format!(
+                    "Pydantic topology routes $defs key {key:?} more than once"
+                )));
+            }
+        }
+        if let Some(unused) = module_map.keys().find(|path| !used_modules.contains(*path)) {
+            return Err(PydanticError::new(format!(
+                "Pydantic topology declares leaf module {unused:?} with no routed class"
+            )));
+        }
+
+        let mut resource_bytes = 0usize;
+        for module in module_map.values() {
+            resource_bytes = checked_add(
+                resource_bytes,
+                checked_add(
+                    module.path.len(),
+                    module.docstring.len(),
+                    "Pydantic module configuration byte count",
+                )?,
+                "Pydantic topology byte count",
+            )?;
+        }
+        let mut metadata_nodes = 0usize;
+        for class in class_map.values() {
+            resource_bytes = checked_add(
+                resource_bytes,
+                class.resource_bytes,
+                "Pydantic topology byte count",
+            )?;
+            metadata_nodes = checked_add(
+                metadata_nodes,
+                class.metadata_nodes,
+                "Pydantic topology metadata node count",
+            )?;
+        }
+        if resource_bytes > MAX_CONFIG_BYTES {
+            return Err(PydanticError::new(format!(
+                "Pydantic topology uses {resource_bytes} configuration bytes; limit is \
+                 {MAX_CONFIG_BYTES}"
+            )));
+        }
+        if metadata_nodes > MAX_METADATA_NODES {
+            return Err(PydanticError::new(format!(
+                "Pydantic topology contains {metadata_nodes} metadata nodes; limit is \
+                 {MAX_METADATA_NODES}"
+            )));
+        }
+
+        validate_relative_artifacts(Some(&module_map), false)?;
+        Ok(Self {
+            modules: module_map,
+            classes: class_map,
+            resource_bytes,
+            metadata_nodes,
+        })
+    }
+
+    /// Sorted relative module path to declaration map.
+    #[must_use]
+    pub fn modules(&self) -> &BTreeMap<String, PydanticModuleConfig> {
+        &self.modules
+    }
+
+    /// Sorted source `$defs` key to class route map.
+    #[must_use]
+    pub fn classes(&self) -> &BTreeMap<String, PydanticClassConfig> {
+        &self.classes
+    }
+}
+
+/// A caller-owned version source for an emitted Pydantic package.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PydanticVersionStamp {
+    version: String,
+    module_docstring: String,
+    local: bool,
+}
+
+impl PydanticVersionStamp {
+    /// Validate an exact PEP 440 package version and `__about__.py` docstring.
+    ///
+    /// The version is retained byte-for-byte, including accepted leading/trailing
+    /// ASCII whitespace and spelling aliases. Consumers that require a normalized
+    /// distribution identifier can apply their own release policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PydanticError`] when the version exceeds 512 ASCII bytes, does
+    /// not match the complete PEP 440 grammar, or the docstring is invalid.
+    pub fn new(
+        version: impl Into<String>,
+        module_docstring: impl Into<String>,
+    ) -> Result<Self, PydanticError> {
+        let version = version.into();
+        let module_docstring = module_docstring.into();
+        if version.len() > MAX_VERSION_BYTES {
+            return Err(PydanticError::new(format!(
+                "Pydantic package version uses {} bytes; limit is {MAX_VERSION_BYTES}",
+                version.len()
+            )));
+        }
+        if !version.is_ascii() {
+            return Err(PydanticError::new(
+                "Pydantic package version must contain only ASCII PEP 440 syntax",
+            ));
+        }
+        let local = validate_pep440(&version).ok_or_else(|| {
+            PydanticError::new(format!(
+                "Pydantic package version {version:?} is not a PEP 440 version"
+            ))
+        })?;
+        validate_docstring(&module_docstring, "Pydantic version-module docstring")?;
+        Ok(Self {
+            version,
+            module_docstring,
+            local,
+        })
+    }
+
+    /// Exact caller-supplied PEP 440 version text.
+    #[must_use]
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    /// Caller-supplied `__about__.py` docstring.
+    #[must_use]
+    pub fn module_docstring(&self) -> &str {
+        &self.module_docstring
+    }
+
+    /// Whether the version contains a PEP 440 local-version identifier.
+    #[must_use]
+    pub const fn is_local(&self) -> bool {
+        self.local
+    }
+}
+
+pub(super) fn validate_base_config(
+    package_name: &str,
+    package_docstring: &str,
+    models_docstring: &str,
+) -> Result<(), PydanticError> {
+    validate_dotted_path(package_name, "Pydantic package name")?;
+    validate_docstring(package_docstring, "Pydantic package docstring")?;
+    validate_docstring(models_docstring, "Pydantic models-module docstring")?;
+    validate_full_config(
+        package_name,
+        package_docstring,
+        models_docstring,
+        None,
+        None,
+    )
+}
+
+pub(super) fn validate_full_config(
+    package_name: &str,
+    package_docstring: &str,
+    models_docstring: &str,
+    topology: Option<&PydanticPackageTopology>,
+    version: Option<&PydanticVersionStamp>,
+) -> Result<(), PydanticError> {
+    let mut config_bytes = checked_sum(
+        [
+            package_name.len(),
+            package_docstring.len(),
+            models_docstring.len(),
+        ],
+        "Pydantic configuration byte count",
+    )?;
+    if let Some(topology) = topology {
+        config_bytes = checked_add(
+            config_bytes,
+            topology.resource_bytes,
+            "Pydantic configuration byte count",
+        )?;
+        if topology.metadata_nodes > MAX_METADATA_NODES {
+            return Err(PydanticError::new(format!(
+                "Pydantic configuration contains {} metadata nodes; limit is \
+                 {MAX_METADATA_NODES}",
+                topology.metadata_nodes
+            )));
+        }
+    }
+    if let Some(version) = version {
+        config_bytes = checked_sum(
+            [
+                config_bytes,
+                version.version.len(),
+                version.module_docstring.len(),
+            ],
+            "Pydantic configuration byte count",
+        )?;
+    }
+    if config_bytes > MAX_CONFIG_BYTES {
+        return Err(PydanticError::new(format!(
+            "Pydantic configuration uses {config_bytes} bytes; limit is {MAX_CONFIG_BYTES}"
+        )));
+    }
+
+    let relative =
+        validate_relative_artifacts(topology.map(|value| &value.modules), version.is_some())?;
+    let package_path = package_name.replace('.', "/");
+    for path in &relative {
+        let full_len = checked_sum(
+            [package_path.len(), 1, path.len()],
+            "Pydantic generated artifact path byte count",
+        )?;
+        if full_len > MAX_ARTIFACT_PATH_BYTES {
+            return Err(PydanticError::new(format!(
+                "Pydantic generated artifact path {package_path}/{path} uses {full_len} bytes; \
+                 limit is {MAX_ARTIFACT_PATH_BYTES}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_docstring(value: &str, role: &str) -> Result<(), PydanticError> {
+    if value.trim().is_empty() {
+        return Err(PydanticError::new(format!(
+            "{role} must be caller-supplied non-whitespace text"
+        )));
+    }
+    if value.len() > MAX_DOCSTRING_BYTES {
+        return Err(PydanticError::new(format!(
+            "{role} uses {} bytes; limit is {MAX_DOCSTRING_BYTES}",
+            value.len()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_dotted_path(value: &str, role: &str) -> Result<(), PydanticError> {
+    if value.is_empty() || !value.is_ascii() {
+        return Err(PydanticError::new(format!(
+            "{role} {value:?} must be a non-empty dotted sequence of ASCII Python identifiers"
+        )));
+    }
+    if value.len() > MAX_DOTTED_PATH_BYTES {
+        return Err(PydanticError::new(format!(
+            "{role} {value:?} uses {} bytes; limit is {MAX_DOTTED_PATH_BYTES}",
+            value.len()
+        )));
+    }
+    let components = value.split('.').collect::<Vec<_>>();
+    if components.len() > MAX_DOTTED_PATH_COMPONENTS {
+        return Err(PydanticError::new(format!(
+            "{role} {value:?} has {} components; limit is {MAX_DOTTED_PATH_COMPONENTS}",
+            components.len()
+        )));
+    }
+    for component in components {
+        if !is_python_identifier(component) || is_python_keyword(component) {
+            return Err(PydanticError::new(format!(
+                "{role} {value:?} contains invalid or keyword component {component:?}"
+            )));
+        }
+        if is_windows_device_stem(component) {
+            return Err(PydanticError::new(format!(
+                "{role} {value:?} contains Windows-reserved device component {component:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn is_windows_device_stem(component: &str) -> bool {
+    let folded = component.to_ascii_lowercase();
+    matches!(folded.as_str(), "con" | "prn" | "aux" | "nul")
+        || folded.strip_prefix("com").is_some_and(|suffix| {
+            matches!(suffix, "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9")
+        })
+        || folded.strip_prefix("lpt").is_some_and(|suffix| {
+            matches!(suffix, "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9")
+        })
+}
+
+fn validate_module_prefixes(
+    modules: &BTreeMap<String, PydanticModuleConfig>,
+) -> Result<(), PydanticError> {
+    let folded = modules
+        .keys()
+        .map(|path| path.to_ascii_lowercase())
+        .collect::<BTreeSet<_>>();
+    for path in modules.keys() {
+        let parts = path
+            .split('.')
+            .map(str::to_ascii_lowercase)
+            .collect::<Vec<_>>();
+        for length in 1..parts.len() {
+            let prefix = parts[..length].join(".");
+            if folded.contains(&prefix) {
+                return Err(PydanticError::new(format!(
+                    "Pydantic module path {path:?} requires {prefix:?} to be a package, but it \
+                     is also declared as a module file"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_relative_artifacts(
+    modules: Option<&BTreeMap<String, PydanticModuleConfig>>,
+    include_version: bool,
+) -> Result<BTreeSet<String>, PydanticError> {
+    let mut paths = BTreeSet::new();
+    let mut folded = BTreeMap::<String, String>::new();
+    let generated = if modules.is_some() {
+        ["_base.py", "_schema.py", "__init__.py", "py.typed"]
+    } else {
+        ["_base.py", "models.py", "__init__.py", "py.typed"]
+    };
+    for path in generated {
+        insert_artifact(path.to_owned(), &mut paths, &mut folded)?;
+    }
+    if include_version {
+        insert_artifact("__about__.py".to_owned(), &mut paths, &mut folded)?;
+    }
+    if let Some(modules) = modules {
+        for module in modules.keys() {
+            let parts = module.split('.').collect::<Vec<_>>();
+            for length in 1..parts.len() {
+                insert_artifact(
+                    format!("{}/__init__.py", parts[..length].join("/")),
+                    &mut paths,
+                    &mut folded,
+                )?;
+            }
+            insert_artifact(format!("{}.py", parts.join("/")), &mut paths, &mut folded)?;
+        }
+    }
+    if paths.len() > MAX_ARTIFACTS {
+        return Err(PydanticError::new(format!(
+            "Pydantic package requires {} artifacts; limit is {MAX_ARTIFACTS}",
+            paths.len()
+        )));
+    }
+    Ok(paths)
+}
+
+fn insert_artifact(
+    path: String,
+    paths: &mut BTreeSet<String>,
+    folded: &mut BTreeMap<String, String>,
+) -> Result<(), PydanticError> {
+    if paths.contains(&path) {
+        return Ok(());
+    }
+    if path.len() > MAX_ARTIFACT_PATH_BYTES {
+        return Err(PydanticError::new(format!(
+            "Pydantic relative artifact path {path:?} uses {} bytes; limit is \
+             {MAX_ARTIFACT_PATH_BYTES}",
+            path.len()
+        )));
+    }
+    let key = path.to_ascii_lowercase();
+    if let Some(previous) = folded.insert(key, path.clone()) {
+        return Err(PydanticError::new(format!(
+            "Pydantic artifact paths {previous:?} and {path:?} collide on a \
+             case-insensitive filesystem"
+        )));
+    }
+    paths.insert(path);
+    Ok(())
+}
+
+fn measure_metadata(
+    metadata: &BTreeMap<String, Value>,
+    definition_key: &str,
+) -> Result<(usize, usize), PydanticError> {
+    let mut bytes = 1usize;
+    let mut nodes = 1usize;
+    let mut stack = metadata
+        .iter()
+        .rev()
+        .map(|(key, value)| (Some(key.as_str()), value, 1usize))
+        .collect::<Vec<_>>();
+    while let Some((key, value, depth)) = stack.pop() {
+        if depth > MAX_METADATA_DEPTH {
+            return Err(PydanticError::new(format!(
+                "Pydantic class route {definition_key:?} metadata exceeds depth limit \
+                 {MAX_METADATA_DEPTH}"
+            )));
+        }
+        nodes = checked_add(nodes, 1, "Pydantic metadata node count")?;
+        if nodes > MAX_METADATA_NODES {
+            return Err(PydanticError::new(format!(
+                "Pydantic class route {definition_key:?} metadata exceeds node limit \
+                 {MAX_METADATA_NODES}"
+            )));
+        }
+        if let Some(key) = key {
+            bytes = checked_add(bytes, key.len(), "Pydantic metadata byte count")?;
+        }
+        bytes = checked_add(bytes, 1, "Pydantic metadata byte count")?;
+        match value {
+            Value::Null | Value::Bool(_) => {}
+            Value::Number(number) => {
+                bytes = checked_add(
+                    bytes,
+                    number.to_string().len(),
+                    "Pydantic metadata byte count",
+                )?;
+            }
+            Value::String(text) => {
+                bytes = checked_add(bytes, text.len(), "Pydantic metadata byte count")?;
+            }
+            Value::Array(values) => {
+                for child in values.iter().rev() {
+                    stack.push((None, child, depth + 1));
+                }
+            }
+            Value::Object(object) => {
+                for (child_key, child) in object.iter().rev() {
+                    stack.push((Some(child_key), child, depth + 1));
+                }
+            }
+        }
+        if bytes > MAX_CONFIG_BYTES {
+            return Err(PydanticError::new(format!(
+                "Pydantic class route {definition_key:?} metadata exceeds byte limit \
+                 {MAX_CONFIG_BYTES}"
+            )));
+        }
+    }
+    Ok((bytes, nodes))
+}
+
+fn checked_sum(
+    values: impl IntoIterator<Item = usize>,
+    role: &str,
+) -> Result<usize, PydanticError> {
+    values
+        .into_iter()
+        .try_fold(0usize, |sum, value| checked_add(sum, value, role))
+}
+
+fn checked_add(left: usize, right: usize, role: &str) -> Result<usize, PydanticError> {
+    left.checked_add(right)
+        .ok_or_else(|| PydanticError::new(format!("{role} exceeds the platform usize range")))
+}
+
+/// Validate PEP 440 without normalizing or parsing numeric fields into integers.
+///
+/// Returns whether the accepted identifier contains a local-version segment.
+fn validate_pep440(raw: &str) -> Option<bool> {
+    let bytes = raw.as_bytes();
+    let mut start = 0usize;
+    let mut end = bytes.len();
+    while start < end && bytes[start].is_ascii_whitespace() {
+        start += 1;
+    }
+    while end > start && bytes[end - 1].is_ascii_whitespace() {
+        end -= 1;
+    }
+    let bytes = &bytes[start..end];
+    if bytes.is_empty() {
+        return None;
+    }
+    let mut index = 0usize;
+
+    if bytes
+        .get(index)
+        .is_some_and(|byte| byte.eq_ignore_ascii_case(&b'v'))
+    {
+        index += 1;
+    }
+
+    let epoch_start = index;
+    consume_digits(bytes, &mut index);
+    if bytes.get(index) == Some(&b'!') && index > epoch_start {
+        index += 1;
+    } else {
+        index = epoch_start;
+    }
+
+    if !consume_digits(bytes, &mut index) {
+        return None;
+    }
+    loop {
+        let checkpoint = index;
+        if bytes.get(index) == Some(&b'.') {
+            index += 1;
+            if consume_digits(bytes, &mut index) {
+                continue;
+            }
+        }
+        index = checkpoint;
+        break;
+    }
+
+    let checkpoint = index;
+    let mut candidate = index;
+    consume_separator(bytes, &mut candidate);
+    if consume_tag(
+        bytes,
+        &mut candidate,
+        &["preview", "alpha", "beta", "pre", "rc", "a", "b", "c"],
+    ) {
+        consume_optional_number(bytes, &mut candidate);
+        index = candidate;
+    } else {
+        index = checkpoint;
+    }
+
+    let checkpoint = index;
+    let mut matched_post = false;
+    if bytes.get(index) == Some(&b'-') {
+        let mut candidate = index + 1;
+        if consume_digits(bytes, &mut candidate) {
+            index = candidate;
+            matched_post = true;
+        }
+    }
+    if !matched_post {
+        let mut candidate = checkpoint;
+        consume_separator(bytes, &mut candidate);
+        if consume_tag(bytes, &mut candidate, &["post", "rev", "r"]) {
+            consume_optional_number(bytes, &mut candidate);
+            index = candidate;
+        } else {
+            index = checkpoint;
+        }
+    }
+
+    let checkpoint = index;
+    let mut candidate = index;
+    consume_separator(bytes, &mut candidate);
+    if consume_tag(bytes, &mut candidate, &["dev"]) {
+        consume_optional_number(bytes, &mut candidate);
+        index = candidate;
+    } else {
+        index = checkpoint;
+    }
+
+    let mut local = false;
+    if bytes.get(index) == Some(&b'+') {
+        local = true;
+        index += 1;
+        if !consume_ascii_alphanumeric(bytes, &mut index) {
+            return None;
+        }
+        loop {
+            let checkpoint = index;
+            if bytes
+                .get(index)
+                .is_some_and(|byte| matches!(byte, b'-' | b'_' | b'.'))
+            {
+                index += 1;
+                if consume_ascii_alphanumeric(bytes, &mut index) {
+                    continue;
+                }
+            }
+            index = checkpoint;
+            break;
+        }
+    }
+
+    (index == bytes.len()).then_some(local)
+}
+
+fn consume_digits(bytes: &[u8], index: &mut usize) -> bool {
+    let start = *index;
+    while bytes.get(*index).is_some_and(u8::is_ascii_digit) {
+        *index += 1;
+    }
+    *index > start
+}
+
+fn consume_ascii_alphanumeric(bytes: &[u8], index: &mut usize) -> bool {
+    let start = *index;
+    while bytes.get(*index).is_some_and(u8::is_ascii_alphanumeric) {
+        *index += 1;
+    }
+    *index > start
+}
+
+fn consume_separator(bytes: &[u8], index: &mut usize) {
+    if bytes
+        .get(*index)
+        .is_some_and(|byte| matches!(byte, b'-' | b'_' | b'.'))
+    {
+        *index += 1;
+    }
+}
+
+fn consume_optional_number(bytes: &[u8], index: &mut usize) {
+    consume_separator(bytes, index);
+    consume_digits(bytes, index);
+}
+
+fn consume_tag(bytes: &[u8], index: &mut usize, tags: &[&str]) -> bool {
+    for tag in tags {
+        let end = *index + tag.len();
+        if bytes
+            .get(*index..end)
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(tag.as_bytes()))
+        {
+            *index = end;
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PydanticConfig;
+    use serde_json::json;
+
+    fn module(path: &str) -> PydanticModuleConfig {
+        PydanticModuleConfig::new(path, format!("Caller docs for {path}.")).expect("module")
+    }
+
+    fn class(key: &str, module: &str) -> PydanticClassConfig {
+        PydanticClassConfig::new(
+            key,
+            module,
+            format!("Caller docs for {key}."),
+            BTreeMap::from([
+                (
+                    "definitionDigest".to_owned(),
+                    json!(format!("sha256:{key}")),
+                ),
+                (
+                    "docs".to_owned(),
+                    json!(format!("https://example.org/docs/{key}")),
+                ),
+            ]),
+        )
+        .expect("class")
+    }
+
+    #[test]
+    fn topology_is_total_over_declared_modules_and_canonical() {
+        let topology = PydanticPackageTopology::new(
+            [module("zeta"), module("alpha.people")],
+            [class("Person", "alpha.people"), class("Thing", "zeta")],
+        )
+        .expect("topology");
+        assert_eq!(
+            topology
+                .modules()
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            ["alpha.people", "zeta"]
+        );
+        assert_eq!(
+            topology
+                .classes()
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            ["Person", "Thing"]
+        );
+    }
+
+    #[test]
+    fn config_builders_retain_validated_topology_and_version() {
+        let topology = PydanticPackageTopology::new(
+            [module("domain.people")],
+            [class("Person", "domain.people")],
+        )
+        .expect("topology");
+        let version = PydanticVersionStamp::new(
+            "2!3.4rc1+portable.7",
+            "Caller-owned package version documentation.",
+        )
+        .expect("version");
+        let config = PydanticConfig::new(
+            "example_models",
+            "Caller package documentation.",
+            "Caller base-model documentation.",
+        )
+        .expect("base config")
+        .with_version_stamp(version)
+        .expect("version config")
+        .with_topology(topology)
+        .expect("topology config");
+
+        assert_eq!(
+            config.topology().expect("topology").classes()["Person"].json_schema_extra()["definitionDigest"],
+            json!("sha256:Person")
+        );
+        assert_eq!(
+            config.version_stamp().expect("version").version(),
+            "2!3.4rc1+portable.7"
+        );
+        assert!(config.version_stamp().expect("version").is_local());
+    }
+
+    #[test]
+    fn topology_rejects_duplicate_unknown_unused_and_prefix_routes() {
+        assert!(PydanticPackageTopology::new([module("a"), module("a")], []).is_err());
+        assert!(PydanticPackageTopology::new([module("a")], [class("A", "b")]).is_err());
+        assert!(
+            PydanticPackageTopology::new([module("a"), module("b")], [class("A", "a")]).is_err()
+        );
+        assert!(
+            PydanticPackageTopology::new(
+                [module("a"), module("a.b")],
+                [class("A", "a"), class("B", "a.b")]
+            )
+            .is_err()
+        );
+        assert!(
+            PydanticPackageTopology::new(
+                [module("Case"), module("case")],
+                [class("A", "Case"), class("B", "case")]
+            )
+            .is_err()
+        );
+        assert!(
+            PydanticPackageTopology::new([module("a")], [class("A", "a"), class("A", "a")])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn shared_intermediate_package_initializers_are_valid() {
+        let topology = PydanticPackageTopology::new(
+            [module("domain.people"), module("domain.places")],
+            [
+                class("Person", "domain.people"),
+                class("Place", "domain.places"),
+            ],
+        )
+        .expect("shared intermediate package");
+        validate_relative_artifacts(Some(topology.modules()), false)
+            .expect("shared initializer is emitted once");
+    }
+
+    #[test]
+    fn paths_reject_keywords_generated_names_devices_and_limits() {
+        for path in [
+            "",
+            "bad-name",
+            "class",
+            "naïve",
+            "con",
+            "COM9",
+            "_base",
+            "_SCHEMA.child",
+            "__about__.x",
+        ] {
+            assert!(PydanticModuleConfig::new(path, "docs").is_err(), "{path}");
+        }
+        let max = format!("a{}", "b".repeat(MAX_DOTTED_PATH_BYTES - 1));
+        assert_eq!(max.len(), MAX_DOTTED_PATH_BYTES);
+        assert!(PydanticModuleConfig::new(max, "docs").is_ok());
+        let over = format!("a{}", "b".repeat(MAX_DOTTED_PATH_BYTES));
+        assert!(PydanticModuleConfig::new(over, "docs").is_err());
+        let deep = std::iter::repeat_n("a", MAX_DOTTED_PATH_COMPONENTS + 1)
+            .collect::<Vec<_>>()
+            .join(".");
+        assert!(PydanticModuleConfig::new(deep, "docs").is_err());
+        assert!(PydanticConfig::new("con", "package docs", "model docs").is_err());
+    }
+
+    #[test]
+    fn docs_and_metadata_fail_at_fixed_boundaries() {
+        assert!(PydanticModuleConfig::new("models", " ").is_err());
+        assert!(PydanticModuleConfig::new("models", "x".repeat(MAX_DOCSTRING_BYTES)).is_ok());
+        assert!(PydanticModuleConfig::new("models", "x".repeat(MAX_DOCSTRING_BYTES + 1)).is_err());
+
+        let mut accepted = Value::Null;
+        for _ in 1..MAX_METADATA_DEPTH {
+            accepted = Value::Array(vec![accepted]);
+        }
+        assert!(
+            PydanticClassConfig::new(
+                "Deep",
+                "models",
+                "docs",
+                BTreeMap::from([("value".to_owned(), accepted)]),
+            )
+            .is_ok()
+        );
+
+        let mut rejected = Value::Null;
+        for _ in 0..MAX_METADATA_DEPTH {
+            rejected = Value::Array(vec![rejected]);
+        }
+        assert!(
+            PydanticClassConfig::new(
+                "TooDeep",
+                "models",
+                "docs",
+                BTreeMap::from([("value".to_owned(), rejected)]),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn pep440_accepts_complete_public_and_local_grammar() {
+        for version in [
+            "0",
+            "v1.2",
+            "1!2.0",
+            "1.0a1",
+            "1.0-alpha",
+            "1.0beta2",
+            "1.0b3",
+            "1.0preview2",
+            "1.0pre4",
+            "1.0c5",
+            "1.0RC1",
+            "1.0-1",
+            "1.0-post2",
+            "1.0rev",
+            "1.0post-",
+            "1.0_post_7",
+            "1.0rc_",
+            "1.0dev-",
+            "1.0_dev_9",
+            "1.0.dev3",
+            "1.0rc1.post2.dev3",
+            "1.0+abc.1",
+            "1.0+Ubuntu-1",
+            " \tv1.0RC1+LOCAL_1\n",
+        ] {
+            let stamp = PydanticVersionStamp::new(version, "Caller version docs.")
+                .unwrap_or_else(|error| panic!("{version:?}: {error}"));
+            assert_eq!(stamp.version(), version);
+            assert_eq!(stamp.is_local(), version.contains('+'));
+        }
+    }
+
+    #[test]
+    fn pep440_rejects_malformed_non_ascii_and_over_limit_versions() {
+        for version in [
+            "",
+            "v",
+            "1..0",
+            "1.0+",
+            "1.0+abc+def",
+            "1.0++x",
+            "1.0+abc_",
+            "1.0-",
+            "1.0_",
+            "1.0..post1",
+            "1.0a..1",
+            "1!",
+            "1.0foo",
+            "1.0+naïve",
+        ] {
+            assert!(
+                PydanticVersionStamp::new(version, "Caller version docs.").is_err(),
+                "{version:?}"
+            );
+        }
+        let accepted = format!("1.{}", "7".repeat(MAX_VERSION_BYTES - 2));
+        assert_eq!(accepted.len(), MAX_VERSION_BYTES);
+        assert!(PydanticVersionStamp::new(accepted, "docs").is_ok());
+        let rejected = format!("1.{}", "7".repeat(MAX_VERSION_BYTES - 1));
+        assert_eq!(rejected.len(), MAX_VERSION_BYTES + 1);
+        let error = PydanticVersionStamp::new(rejected, "docs").expect_err("version limit");
+        assert!(error.to_string().contains("512"));
+    }
+}

--- a/crates/shapes/src/pydantic/linker.rs
+++ b/crates/shapes/src/pydantic/linker.rs
@@ -45,6 +45,7 @@ pub(super) struct RoutedPackagePlan {
     pub(super) model_paths: BTreeMap<String, String>,
     pub(super) artifact_paths: BTreeSet<String>,
     pub(super) intermediate_packages: BTreeSet<String>,
+    definition_modules: BTreeMap<String, String>,
     symbol_owners: BTreeMap<String, String>,
 }
 
@@ -121,6 +122,7 @@ impl RoutedPackagePlan {
         }
 
         let mut model_paths = BTreeMap::new();
+        let mut definition_modules = BTreeMap::new();
         let mut symbol_owners = BTreeMap::new();
         for (key, class_config) in topology.classes() {
             let class_name = names.get(key).ok_or_else(|| {
@@ -155,6 +157,7 @@ impl RoutedPackagePlan {
                     source: None,
                 },
             );
+            definition_modules.insert(key.clone(), class_config.module_path().to_owned());
             model_paths.insert(
                 key.clone(),
                 format!(
@@ -202,6 +205,7 @@ impl RoutedPackagePlan {
             model_paths,
             artifact_paths,
             intermediate_packages,
+            definition_modules,
             symbol_owners,
         })
     }
@@ -213,22 +217,13 @@ impl RoutedPackagePlan {
         helpers: Vec<LinkedHelper>,
         private_symbols: BTreeSet<String>,
     ) -> Result<(), PydanticError> {
-        let module_path = self
-            .modules
-            .values()
-            .find_map(|module| {
-                module
-                    .definitions
-                    .contains_key(key)
-                    .then(|| module.path.clone())
-            })
-            .ok_or_else(|| {
-                PydanticError::new(format!(
-                    "Pydantic linker cannot attach unknown $defs key {key:?}"
-                ))
-            })?;
+        let module_path = self.definition_modules.get(key).ok_or_else(|| {
+            PydanticError::new(format!(
+                "Pydantic linker cannot attach unknown $defs key {key:?}"
+            ))
+        })?;
 
-        if self.modules[&module_path].definitions[key].source.is_some() {
+        if self.modules[module_path].definitions[key].source.is_some() {
             return Err(PydanticError::new(format!(
                 "Pydantic linker attached $defs key {key:?} more than once"
             )));
@@ -265,7 +260,7 @@ impl RoutedPackagePlan {
 
         let module = self
             .modules
-            .get_mut(&module_path)
+            .get_mut(module_path)
             .expect("located module remains present");
         module
             .definitions
@@ -439,6 +434,8 @@ mod tests {
             plan.model_paths["Person"],
             "example_models.domain.people.Person"
         );
+        assert_eq!(plan.definition_modules["Person"], "domain.people");
+        assert_eq!(plan.definition_modules["Color"], "vocab");
         assert!(plan.artifact_paths.contains("domain/__init__.py"));
         assert!(plan.artifact_paths.contains("__about__.py"));
         assert_eq!(

--- a/crates/shapes/src/pydantic/linker.rs
+++ b/crates/shapes/src/pydantic/linker.rs
@@ -1,0 +1,488 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Crate-private attributed package linker for routed Pydantic emission.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::{Map, Value};
+
+use super::{
+    PydanticClassConfig, PydanticError, PydanticPackageTopology, reference_key,
+    schema_array_keywords, schema_map_keywords, schema_single_keywords,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct LinkedHelper {
+    pub(super) name: String,
+    pub(super) source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct LinkedDefinition {
+    pub(super) key: String,
+    pub(super) class_name: String,
+    pub(super) config: PydanticClassConfig,
+    pub(super) source: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct LinkedModule {
+    pub(super) path: String,
+    pub(super) docstring: String,
+    pub(super) artifact_path: String,
+    pub(super) namespace_alias: String,
+    pub(super) definitions: BTreeMap<String, LinkedDefinition>,
+    pub(super) dependencies: BTreeMap<String, BTreeSet<String>>,
+    pub(super) helpers: Vec<LinkedHelper>,
+    pub(super) public_symbols: BTreeSet<String>,
+    pub(super) private_symbols: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RoutedPackagePlan {
+    pub(super) modules: BTreeMap<String, LinkedModule>,
+    pub(super) model_paths: BTreeMap<String, String>,
+    pub(super) artifact_paths: BTreeSet<String>,
+    pub(super) intermediate_packages: BTreeSet<String>,
+    symbol_owners: BTreeMap<String, String>,
+}
+
+impl RoutedPackagePlan {
+    pub(super) fn compile(
+        definitions: &Map<String, Value>,
+        names: &BTreeMap<String, String>,
+        topology: &PydanticPackageTopology,
+        package_name: &str,
+        include_version: bool,
+    ) -> Result<Self, PydanticError> {
+        let schema_keys = definitions.keys().cloned().collect::<BTreeSet<_>>();
+        let route_keys = topology.classes().keys().cloned().collect::<BTreeSet<_>>();
+        let missing = schema_keys
+            .difference(&route_keys)
+            .cloned()
+            .collect::<Vec<_>>();
+        let stale = route_keys
+            .difference(&schema_keys)
+            .cloned()
+            .collect::<Vec<_>>();
+        if !missing.is_empty() || !stale.is_empty() {
+            return Err(PydanticError::new(format!(
+                "Pydantic topology must cover $defs exactly; missing routes={missing:?}, stale \
+                 routes={stale:?}"
+            )));
+        }
+
+        let mut modules = BTreeMap::new();
+        let mut artifact_paths = BTreeSet::from([
+            "_base.py".to_owned(),
+            "_schema.py".to_owned(),
+            "__init__.py".to_owned(),
+            "py.typed".to_owned(),
+        ]);
+        if include_version {
+            artifact_paths.insert("__about__.py".to_owned());
+        }
+        let mut intermediate_packages = BTreeSet::new();
+        for (index, module) in topology.modules().values().enumerate() {
+            let parts = module.path().split('.').collect::<Vec<_>>();
+            for length in 1..parts.len() {
+                let path = format!("{}/__init__.py", parts[..length].join("/"));
+                artifact_paths.insert(path.clone());
+                intermediate_packages.insert(path);
+            }
+            let artifact_path = format!("{}.py", parts.join("/"));
+            if !artifact_paths.insert(artifact_path.clone()) {
+                return Err(PydanticError::new(format!(
+                    "Pydantic linker artifact path {artifact_path:?} is not unique"
+                )));
+            }
+            modules.insert(
+                module.path().to_owned(),
+                LinkedModule {
+                    path: module.path().to_owned(),
+                    docstring: module.docstring().to_owned(),
+                    artifact_path,
+                    namespace_alias: format!("_PURRDF_TYPES_{index}"),
+                    definitions: BTreeMap::new(),
+                    dependencies: BTreeMap::new(),
+                    helpers: Vec::new(),
+                    public_symbols: BTreeSet::new(),
+                    private_symbols: BTreeSet::new(),
+                },
+            );
+        }
+
+        let mut model_paths = BTreeMap::new();
+        let mut symbol_owners = BTreeMap::new();
+        for (key, class_config) in topology.classes() {
+            let class_name = names.get(key).ok_or_else(|| {
+                PydanticError::new(format!(
+                    "Pydantic linker has no normalized class name for $defs key {key:?}"
+                ))
+            })?;
+            let module = modules.get_mut(class_config.module_path()).ok_or_else(|| {
+                PydanticError::new(format!(
+                    "Pydantic linker has no declared module {:?} for $defs key {key:?}",
+                    class_config.module_path()
+                ))
+            })?;
+            if !module.public_symbols.insert(class_name.clone()) {
+                return Err(PydanticError::new(format!(
+                    "Pydantic module {:?} exports class {class_name:?} more than once",
+                    module.path
+                )));
+            }
+            if let Some(previous) = symbol_owners.insert(class_name.clone(), key.clone()) {
+                return Err(PydanticError::new(format!(
+                    "Pydantic definitions {previous:?} and {key:?} both own symbol \
+                     {class_name:?}"
+                )));
+            }
+            module.definitions.insert(
+                key.clone(),
+                LinkedDefinition {
+                    key: key.clone(),
+                    class_name: class_name.clone(),
+                    config: class_config.clone(),
+                    source: None,
+                },
+            );
+            model_paths.insert(
+                key.clone(),
+                format!(
+                    "{package_name}.{}.{}",
+                    class_config.module_path(),
+                    class_name
+                ),
+            );
+        }
+
+        for (key, definition) in definitions {
+            let source_config = topology
+                .classes()
+                .get(key)
+                .expect("exact topology coverage was validated");
+            let mut references = BTreeSet::new();
+            collect_references(definition, &mut references)?;
+            for target_key in references {
+                let target_config = topology.classes().get(&target_key).ok_or_else(|| {
+                    PydanticError::new(format!(
+                        "Pydantic $defs key {key:?} references missing routed definition \
+                         {target_key:?}"
+                    ))
+                })?;
+                if target_config.module_path() == source_config.module_path() {
+                    continue;
+                }
+                let target_name = names.get(&target_key).ok_or_else(|| {
+                    PydanticError::new(format!(
+                        "Pydantic linker has no class name for referenced $defs key {target_key:?}"
+                    ))
+                })?;
+                modules
+                    .get_mut(source_config.module_path())
+                    .expect("topology module exists")
+                    .dependencies
+                    .entry(target_config.module_path().to_owned())
+                    .or_default()
+                    .insert(target_name.clone());
+            }
+        }
+
+        Ok(Self {
+            modules,
+            model_paths,
+            artifact_paths,
+            intermediate_packages,
+            symbol_owners,
+        })
+    }
+
+    pub(super) fn attach_definition(
+        &mut self,
+        key: &str,
+        source: String,
+        helpers: Vec<LinkedHelper>,
+        private_symbols: BTreeSet<String>,
+    ) -> Result<(), PydanticError> {
+        let module_path = self
+            .modules
+            .values()
+            .find_map(|module| {
+                module
+                    .definitions
+                    .contains_key(key)
+                    .then(|| module.path.clone())
+            })
+            .ok_or_else(|| {
+                PydanticError::new(format!(
+                    "Pydantic linker cannot attach unknown $defs key {key:?}"
+                ))
+            })?;
+
+        if self.modules[&module_path].definitions[key].source.is_some() {
+            return Err(PydanticError::new(format!(
+                "Pydantic linker attached $defs key {key:?} more than once"
+            )));
+        }
+
+        let mut new_symbols = BTreeSet::new();
+        for helper in &helpers {
+            if !new_symbols.insert(helper.name.clone()) {
+                return Err(PydanticError::new(format!(
+                    "Pydantic definition {key:?} declares generated symbol {:?} more than once",
+                    helper.name
+                )));
+            }
+        }
+        for symbol in &private_symbols {
+            if !new_symbols.insert(symbol.clone()) {
+                return Err(PydanticError::new(format!(
+                    "Pydantic definition {key:?} declares generated symbol {symbol:?} more than \
+                     once"
+                )));
+            }
+        }
+        for symbol in &new_symbols {
+            if let Some(previous) = self.symbol_owners.get(symbol) {
+                return Err(PydanticError::new(format!(
+                    "Pydantic definitions {previous:?} and {key:?} both own generated symbol \
+                     {symbol:?}"
+                )));
+            }
+        }
+        for symbol in &new_symbols {
+            self.symbol_owners.insert(symbol.clone(), key.to_owned());
+        }
+
+        let module = self
+            .modules
+            .get_mut(&module_path)
+            .expect("located module remains present");
+        module
+            .definitions
+            .get_mut(key)
+            .expect("located definition remains present")
+            .source = Some(source);
+        for helper in helpers {
+            if !module.private_symbols.insert(helper.name.clone()) {
+                return Err(PydanticError::new(format!(
+                    "Pydantic module {module_path:?} declares private helper {:?} more than once",
+                    helper.name
+                )));
+            }
+            module.helpers.push(helper);
+        }
+        for symbol in private_symbols {
+            if !module.private_symbols.insert(symbol.clone()) {
+                return Err(PydanticError::new(format!(
+                    "Pydantic module {module_path:?} declares private symbol {symbol:?} more than \
+                     once"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn validate_complete(&self) -> Result<(), PydanticError> {
+        for module in self.modules.values() {
+            if module.definitions.is_empty() {
+                return Err(PydanticError::new(format!(
+                    "Pydantic linked leaf module {:?} has no definitions",
+                    module.path
+                )));
+            }
+            for definition in module.definitions.values() {
+                if definition.config.definition_key() != definition.key
+                    || definition.config.module_path() != module.path
+                    || !module.public_symbols.contains(&definition.class_name)
+                {
+                    return Err(PydanticError::new(format!(
+                        "Pydantic linker attribution drifted for $defs key {:?}",
+                        definition.key
+                    )));
+                }
+                if definition.source.is_none() {
+                    return Err(PydanticError::new(format!(
+                        "Pydantic linker has no rendered source for $defs key {:?}",
+                        definition.key
+                    )));
+                }
+            }
+            for symbols in module.dependencies.values() {
+                for symbol in symbols {
+                    if !self.symbol_owners.contains_key(symbol) {
+                        return Err(PydanticError::new(format!(
+                            "Pydantic linker dependency symbol {symbol:?} has no owner"
+                        )));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn relative_root_import(module_path: &str, target: &str) -> String {
+    format!("{}{}", ".".repeat(module_path.split('.').count()), target)
+}
+
+fn collect_references(
+    value: &Value,
+    references: &mut BTreeSet<String>,
+) -> Result<(), PydanticError> {
+    let Value::Object(object) = value else {
+        return Ok(());
+    };
+    if let Some(reference) = object.get("$ref") {
+        let reference = reference.as_str().ok_or_else(|| {
+            PydanticError::new("Pydantic linker encountered a non-string schema $ref")
+        })?;
+        let key = reference_key(reference).ok_or_else(|| {
+            PydanticError::new(format!(
+                "Pydantic linker cannot route external/non-$defs reference {reference:?}"
+            ))
+        })?;
+        references.insert(key);
+    }
+    for keyword in schema_map_keywords() {
+        if let Some(children) = object.get(*keyword).and_then(Value::as_object) {
+            for child in children.values() {
+                collect_references(child, references)?;
+            }
+        }
+    }
+    for keyword in schema_array_keywords() {
+        if let Some(children) = object.get(*keyword).and_then(Value::as_array) {
+            for child in children {
+                collect_references(child, references)?;
+            }
+        }
+    }
+    for keyword in schema_single_keywords() {
+        if let Some(child) = object.get(*keyword) {
+            collect_references(child, references)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{PydanticClassConfig, PydanticModuleConfig};
+    use serde_json::json;
+
+    fn topology() -> PydanticPackageTopology {
+        PydanticPackageTopology::new(
+            [
+                PydanticModuleConfig::new("domain.people", "People module.").expect("module"),
+                PydanticModuleConfig::new("vocab", "Vocabulary module.").expect("module"),
+            ],
+            [
+                PydanticClassConfig::new(
+                    "Person",
+                    "domain.people",
+                    "Person docs.",
+                    BTreeMap::new(),
+                )
+                .expect("class"),
+                PydanticClassConfig::new("Color", "vocab", "Color docs.", BTreeMap::new())
+                    .expect("class"),
+            ],
+        )
+        .expect("topology")
+    }
+
+    fn definitions() -> Map<String, Value> {
+        json!({
+            "Person": {
+                "type": "object",
+                "properties": {
+                    "$ref": {"type": "string"},
+                    "color": {"$ref": "#/$defs/Color"},
+                    "data": {"enum": [{"$ref": "literal-data"}]}
+                }
+            },
+            "Color": {"enum": ["red", "blue"]}
+        })
+        .as_object()
+        .expect("object")
+        .clone()
+    }
+
+    #[test]
+    fn compiles_reference_edges_paths_and_intermediate_packages() {
+        let definitions = definitions();
+        let names = BTreeMap::from([
+            ("Color".to_owned(), "Color".to_owned()),
+            ("Person".to_owned(), "Person".to_owned()),
+        ]);
+        let plan =
+            RoutedPackagePlan::compile(&definitions, &names, &topology(), "example_models", true)
+                .expect("plan");
+        assert_eq!(
+            plan.model_paths["Person"],
+            "example_models.domain.people.Person"
+        );
+        assert!(plan.artifact_paths.contains("domain/__init__.py"));
+        assert!(plan.artifact_paths.contains("__about__.py"));
+        assert_eq!(
+            plan.modules["domain.people"].dependencies["vocab"],
+            BTreeSet::from(["Color".to_owned()])
+        );
+        assert!(!plan.modules["domain.people"].dependencies["vocab"].contains("literal-data"));
+    }
+
+    #[test]
+    fn exact_coverage_and_complete_attachments_fail_closed() {
+        let definitions = definitions();
+        let names = BTreeMap::from([
+            ("Color".to_owned(), "Color".to_owned()),
+            ("Person".to_owned(), "Person".to_owned()),
+        ]);
+        let mut missing = definitions.clone();
+        missing.remove("Color");
+        assert!(
+            RoutedPackagePlan::compile(&missing, &names, &topology(), "example_models", false)
+                .is_err()
+        );
+
+        let mut plan =
+            RoutedPackagePlan::compile(&definitions, &names, &topology(), "example_models", false)
+                .expect("plan");
+        assert!(plan.validate_complete().is_err());
+        plan.attach_definition(
+            "Color",
+            "class Color: pass\n".to_owned(),
+            Vec::new(),
+            BTreeSet::new(),
+        )
+        .expect("attach Color");
+        plan.attach_definition(
+            "Person",
+            "class Person: pass\n".to_owned(),
+            vec![LinkedHelper {
+                name: "_PersonData".to_owned(),
+                source: "_PersonData = object\n".to_owned(),
+            }],
+            BTreeSet::new(),
+        )
+        .expect("attach Person");
+        plan.validate_complete().expect("complete");
+        assert!(
+            plan.attach_definition("Person", "again\n".to_owned(), Vec::new(), BTreeSet::new())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn relative_imports_reach_the_package_root() {
+        assert_eq!(relative_root_import("people", "vocab"), ".vocab");
+        assert_eq!(
+            relative_root_import("domain.people", "vocab.colors"),
+            "..vocab.colors"
+        );
+    }
+}

--- a/crates/shapes/src/pydantic/linker.rs
+++ b/crates/shapes/src/pydantic/linker.rs
@@ -84,14 +84,21 @@ impl RoutedPackagePlan {
             artifact_paths.insert("__about__.py".to_owned());
         }
         let mut intermediate_packages = BTreeSet::new();
+        let mut current_path = String::new();
         for (index, module) in topology.modules().values().enumerate() {
-            let parts = module.path().split('.').collect::<Vec<_>>();
-            for length in 1..parts.len() {
-                let path = format!("{}/__init__.py", parts[..length].join("/"));
-                artifact_paths.insert(path.clone());
-                intermediate_packages.insert(path);
+            current_path.clear();
+            current_path.reserve(module.path().len());
+            for byte in module.path().bytes() {
+                if byte == b'.' {
+                    let path = format!("{current_path}/__init__.py");
+                    artifact_paths.insert(path.clone());
+                    intermediate_packages.insert(path);
+                    current_path.push('/');
+                } else {
+                    current_path.push(char::from(byte));
+                }
             }
-            let artifact_path = format!("{}.py", parts.join("/"));
+            let artifact_path = format!("{current_path}.py");
             if !artifact_paths.insert(artifact_path.clone()) {
                 return Err(PydanticError::new(format!(
                     "Pydantic linker artifact path {artifact_path:?} is not unique"
@@ -325,7 +332,13 @@ impl RoutedPackagePlan {
 }
 
 pub(super) fn relative_root_import(module_path: &str, target: &str) -> String {
-    format!("{}{}", ".".repeat(module_path.split('.').count()), target)
+    let depth = module_path.bytes().filter(|byte| *byte == b'.').count() + 1;
+    let mut import = String::with_capacity(depth + target.len());
+    for _ in 0..depth {
+        import.push('.');
+    }
+    import.push_str(target);
+    import
 }
 
 fn collect_references(

--- a/crates/shapes/src/schema_catalog.rs
+++ b/crates/shapes/src/schema_catalog.rs
@@ -41,8 +41,40 @@ pub(crate) struct CompiledSchemaCatalog {
     document: Value,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SchemaCatalogLimits {
+    pub(crate) input_bytes: usize,
+    pub(crate) definitions: usize,
+    pub(crate) depth: usize,
+    pub(crate) nodes: usize,
+    pub(crate) string_bytes: usize,
+}
+
 impl CompiledSchemaCatalog {
     pub(crate) fn parse(compiled: &CompiledSchema) -> Result<Self, SchemaCatalogError> {
+        Self::parse_inner(compiled, None)
+    }
+
+    pub(crate) fn parse_with_limits(
+        compiled: &CompiledSchema,
+        limits: SchemaCatalogLimits,
+    ) -> Result<Self, SchemaCatalogError> {
+        Self::parse_inner(compiled, Some(limits))
+    }
+
+    fn parse_inner(
+        compiled: &CompiledSchema,
+        limits: Option<SchemaCatalogLimits>,
+    ) -> Result<Self, SchemaCatalogError> {
+        if let Some(limits) = limits
+            && compiled.schema_json.len() > limits.input_bytes
+        {
+            return Err(SchemaCatalogError::new(format!(
+                "CompiledSchema.schema_json uses {} bytes; limit is {}",
+                compiled.schema_json.len(),
+                limits.input_bytes
+            )));
+        }
         let document: Value = serde_json::from_str(&compiled.schema_json).map_err(|error| {
             SchemaCatalogError::new(format!(
                 "CompiledSchema.schema_json is not valid JSON: {error}"
@@ -60,6 +92,10 @@ impl CompiledSchemaCatalog {
                 )
             })?;
 
+        if let Some(limits) = limits {
+            validate_document_limits(&document, definitions.len(), limits)?;
+        }
+
         for (key, definition) in definitions {
             validate_schema(definition, definitions, &definition_path(key))?;
         }
@@ -74,6 +110,65 @@ impl CompiledSchemaCatalog {
             .and_then(Value::as_object)
             .expect("a compiled schema catalog always has validated object-valued `$defs`")
     }
+}
+
+fn validate_document_limits(
+    document: &Value,
+    definitions: usize,
+    limits: SchemaCatalogLimits,
+) -> Result<(), SchemaCatalogError> {
+    if definitions > limits.definitions {
+        return Err(SchemaCatalogError::new(format!(
+            "CompiledSchema contains {definitions} definitions; limit is {}",
+            limits.definitions
+        )));
+    }
+
+    let mut nodes = 0usize;
+    let mut stack = vec![(document, 0usize)];
+    while let Some((value, depth)) = stack.pop() {
+        if depth > limits.depth {
+            return Err(SchemaCatalogError::new(format!(
+                "CompiledSchema exceeds JSON nesting limit {}",
+                limits.depth
+            )));
+        }
+        nodes = nodes.checked_add(1).ok_or_else(|| {
+            SchemaCatalogError::new("CompiledSchema JSON node count exceeds usize")
+        })?;
+        if nodes > limits.nodes {
+            return Err(SchemaCatalogError::new(format!(
+                "CompiledSchema contains more than {} JSON nodes",
+                limits.nodes
+            )));
+        }
+        match value {
+            Value::String(text) if text.len() > limits.string_bytes => {
+                return Err(SchemaCatalogError::new(format!(
+                    "CompiledSchema contains a {}-byte string; limit is {}",
+                    text.len(),
+                    limits.string_bytes
+                )));
+            }
+            Value::Array(values) => {
+                stack.extend(values.iter().rev().map(|child| (child, depth + 1)));
+            }
+            Value::Object(object) => {
+                for (key, child) in object.iter().rev() {
+                    if key.len() > limits.string_bytes {
+                        return Err(SchemaCatalogError::new(format!(
+                            "CompiledSchema contains a {}-byte object key; limit is {}",
+                            key.len(),
+                            limits.string_bytes
+                        )));
+                    }
+                    stack.push((child, depth + 1));
+                }
+            }
+            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn definition_path(key: &str) -> String {
@@ -355,6 +450,45 @@ mod tests {
                     .contains("$id cannot rebase a closed generated package"),
                 "{error}"
             );
+        }
+    }
+
+    #[test]
+    fn bounded_catalog_accepts_limits_and_rejects_each_one_over() {
+        let fixture = compiled(&json!({ "$defs": { "A": { "description": "xy" } } }));
+        let accepted = SchemaCatalogLimits {
+            input_bytes: fixture.schema_json.len(),
+            definitions: 1,
+            depth: 3,
+            nodes: 4,
+            string_bytes: 11,
+        };
+        CompiledSchemaCatalog::parse_with_limits(&fixture, accepted).expect("exact boundaries");
+
+        for limits in [
+            SchemaCatalogLimits {
+                input_bytes: fixture.schema_json.len() - 1,
+                ..accepted
+            },
+            SchemaCatalogLimits {
+                definitions: 0,
+                ..accepted
+            },
+            SchemaCatalogLimits {
+                depth: 2,
+                ..accepted
+            },
+            SchemaCatalogLimits {
+                nodes: 3,
+                ..accepted
+            },
+            SchemaCatalogLimits {
+                string_bytes: 10,
+                ..accepted
+            },
+        ] {
+            CompiledSchemaCatalog::parse_with_limits(&fixture, limits)
+                .expect_err("one-over limit must fail");
         }
     }
 }

--- a/crates/shapes/src/schema_catalog.rs
+++ b/crates/shapes/src/schema_catalog.rs
@@ -11,7 +11,8 @@
 use std::error::Error;
 use std::fmt;
 
-use serde_json::{Map, Value};
+use serde::de::{self, DeserializeSeed, MapAccess, SeqAccess, Visitor};
+use serde_json::{Map, Number, Value};
 
 use crate::json_schema::CompiledSchema;
 
@@ -75,11 +76,12 @@ impl CompiledSchemaCatalog {
                 limits.input_bytes
             )));
         }
-        let document: Value = serde_json::from_str(&compiled.schema_json).map_err(|error| {
-            SchemaCatalogError::new(format!(
-                "CompiledSchema.schema_json is not valid JSON: {error}"
-            ))
-        })?;
+        let document = if let Some(limits) = limits {
+            parse_bounded_document(&compiled.schema_json, limits)?
+        } else {
+            serde_json::from_str(&compiled.schema_json)
+                .map_err(|error| invalid_json_error(&error))?
+        };
         let root = document.as_object().ok_or_else(|| {
             SchemaCatalogError::new("CompiledSchema.schema_json root must be a JSON object")
         })?;
@@ -109,6 +111,233 @@ impl CompiledSchemaCatalog {
             .and_then(|root| root.get("$defs"))
             .and_then(Value::as_object)
             .expect("a compiled schema catalog always has validated object-valued `$defs`")
+    }
+}
+
+fn invalid_json_error(error: &serde_json::Error) -> SchemaCatalogError {
+    SchemaCatalogError::new(format!(
+        "CompiledSchema.schema_json is not valid JSON: {error}"
+    ))
+}
+
+fn parse_bounded_document(
+    input: &str,
+    limits: SchemaCatalogLimits,
+) -> Result<Value, SchemaCatalogError> {
+    let mut state = BoundedParseState {
+        limits,
+        nodes: 0,
+        violation: None,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(input);
+    let document = match (BoundedValueSeed {
+        state: &mut state,
+        depth: 0,
+    })
+    .deserialize(&mut deserializer)
+    {
+        Ok(document) => document,
+        Err(error) => {
+            return Err(state
+                .violation
+                .map_or_else(|| invalid_json_error(&error), SchemaCatalogError::new));
+        }
+    };
+    deserializer
+        .end()
+        .map_err(|error| invalid_json_error(&error))?;
+    Ok(document)
+}
+
+struct BoundedParseState {
+    limits: SchemaCatalogLimits,
+    nodes: usize,
+    violation: Option<String>,
+}
+
+impl BoundedParseState {
+    fn enter_node<E: de::Error>(&mut self, depth: usize) -> Result<(), E> {
+        if depth > self.limits.depth {
+            return self.reject(format!(
+                "CompiledSchema exceeds JSON nesting limit {}",
+                self.limits.depth
+            ));
+        }
+        let Some(nodes) = self.nodes.checked_add(1) else {
+            return self.reject("CompiledSchema JSON node count exceeds usize".to_owned());
+        };
+        if nodes > self.limits.nodes {
+            return self.reject(format!(
+                "CompiledSchema contains more than {} JSON nodes",
+                self.limits.nodes
+            ));
+        }
+        self.nodes = nodes;
+        Ok(())
+    }
+
+    fn check_string<E: de::Error>(&mut self, bytes: usize) -> Result<(), E> {
+        if bytes > self.limits.string_bytes {
+            return self.reject(format!(
+                "CompiledSchema contains a {bytes}-byte string; limit is {}",
+                self.limits.string_bytes
+            ));
+        }
+        Ok(())
+    }
+
+    fn reject<T, E: de::Error>(&mut self, message: String) -> Result<T, E> {
+        self.violation = Some(message.clone());
+        Err(E::custom(message))
+    }
+}
+
+struct BoundedValueSeed<'a> {
+    state: &'a mut BoundedParseState,
+    depth: usize,
+}
+
+impl<'de> DeserializeSeed<'de> for BoundedValueSeed<'_> {
+    type Value = Value;
+
+    fn deserialize<D: de::Deserializer<'de>>(
+        self,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error> {
+        self.state.enter_node::<D::Error>(self.depth)?;
+        deserializer.deserialize_any(BoundedValueVisitor {
+            state: self.state,
+            depth: self.depth,
+        })
+    }
+}
+
+struct BoundedValueVisitor<'a> {
+    state: &'a mut BoundedParseState,
+    depth: usize,
+}
+
+impl<'de> Visitor<'de> for BoundedValueVisitor<'_> {
+    type Value = Value;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON value within the configured structural limits")
+    }
+
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_bool<E: de::Error>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(Value::Bool(value))
+    }
+
+    fn visit_i64<E: de::Error>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(Value::Number(value.into()))
+    }
+
+    fn visit_i128<E: de::Error>(self, value: i128) -> Result<Self::Value, E> {
+        Number::from_i128(value)
+            .map(Value::Number)
+            .ok_or_else(|| E::custom("JSON integer is out of range"))
+    }
+
+    fn visit_u64<E: de::Error>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(Value::Number(value.into()))
+    }
+
+    fn visit_u128<E: de::Error>(self, value: u128) -> Result<Self::Value, E> {
+        Number::from_u128(value)
+            .map(Value::Number)
+            .ok_or_else(|| E::custom("JSON integer is out of range"))
+    }
+
+    fn visit_f64<E: de::Error>(self, value: f64) -> Result<Self::Value, E> {
+        Number::from_f64(value)
+            .map(Value::Number)
+            .ok_or_else(|| E::custom("JSON number is not finite"))
+    }
+
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+        self.state.check_string::<E>(value.len())?;
+        Ok(Value::String(value.to_owned()))
+    }
+
+    fn visit_borrowed_str<E: de::Error>(self, value: &'de str) -> Result<Self::Value, E> {
+        self.state.check_string::<E>(value.len())?;
+        Ok(Value::String(value.to_owned()))
+    }
+
+    fn visit_string<E: de::Error>(self, value: String) -> Result<Self::Value, E> {
+        self.state.check_string::<E>(value.len())?;
+        Ok(Value::String(value))
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, mut sequence: A) -> Result<Self::Value, A::Error> {
+        let mut values = Vec::new();
+        while let Some(value) = sequence.next_element_seed(BoundedValueSeed {
+            state: &mut *self.state,
+            depth: self.depth + 1,
+        })? {
+            values.push(value);
+        }
+        Ok(Value::Array(values))
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+        let mut object = Map::new();
+        while let Some(key) = map.next_key_seed(BoundedStringSeed {
+            state: &mut *self.state,
+        })? {
+            let value = map.next_value_seed(BoundedValueSeed {
+                state: &mut *self.state,
+                depth: self.depth + 1,
+            })?;
+            object.insert(key, value);
+        }
+        Ok(Value::Object(object))
+    }
+}
+
+struct BoundedStringSeed<'a> {
+    state: &'a mut BoundedParseState,
+}
+
+impl<'de> DeserializeSeed<'de> for BoundedStringSeed<'_> {
+    type Value = String;
+
+    fn deserialize<D: de::Deserializer<'de>>(
+        self,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_string(BoundedStringVisitor { state: self.state })
+    }
+}
+
+struct BoundedStringVisitor<'a> {
+    state: &'a mut BoundedParseState,
+}
+
+impl<'de> Visitor<'de> for BoundedStringVisitor<'_> {
+    type Value = String;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON object key within the configured string limit")
+    }
+
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+        self.state.check_string::<E>(value.len())?;
+        Ok(value.to_owned())
+    }
+
+    fn visit_borrowed_str<E: de::Error>(self, value: &'de str) -> Result<Self::Value, E> {
+        self.state.check_string::<E>(value.len())?;
+        Ok(value.to_owned())
+    }
+
+    fn visit_string<E: de::Error>(self, value: String) -> Result<Self::Value, E> {
+        self.state.check_string::<E>(value.len())?;
+        Ok(value)
     }
 }
 
@@ -489,6 +718,86 @@ mod tests {
         ] {
             CompiledSchemaCatalog::parse_with_limits(&fixture, limits)
                 .expect_err("one-over limit must fail");
+        }
+    }
+
+    #[test]
+    fn bounded_parser_rejects_structural_limits_before_malformed_tail() {
+        let cases = [
+            (
+                r#"{"$defs":{"A":{"description":"xy"}} trailing"#,
+                SchemaCatalogLimits {
+                    input_bytes: 1_024,
+                    definitions: 10,
+                    depth: 10,
+                    nodes: 3,
+                    string_bytes: 100,
+                },
+                "more than 3 JSON nodes",
+            ),
+            (
+                r#"{"$defs":{"longer" trailing"#,
+                SchemaCatalogLimits {
+                    input_bytes: 1_024,
+                    definitions: 10,
+                    depth: 10,
+                    nodes: 10,
+                    string_bytes: 5,
+                },
+                "6-byte string; limit is 5",
+            ),
+            (
+                r#"{"$defs":{"A":{"properties":{"x":{ trailing"#,
+                SchemaCatalogLimits {
+                    input_bytes: 1_024,
+                    definitions: 10,
+                    depth: 3,
+                    nodes: 10,
+                    string_bytes: 100,
+                },
+                "JSON nesting limit 3",
+            ),
+        ];
+        for (schema_json, limits, expected) in cases {
+            let error = CompiledSchemaCatalog::parse_with_limits(
+                &CompiledSchema {
+                    schema_json: schema_json.to_owned(),
+                    openapi_json: "{}\n".to_owned(),
+                    losses: LossLedger::new(),
+                },
+                limits,
+            )
+            .expect_err("construction limit must fire before the malformed suffix");
+            assert!(error.to_string().contains(expected), "{error}");
+            assert!(!error.to_string().contains("not valid JSON"), "{error}");
+        }
+    }
+
+    #[test]
+    fn bounded_parser_matches_serde_json_value_semantics() {
+        for source in [
+            "null",
+            "true",
+            "-9223372036854775808",
+            "18446744073709551615",
+            "1.25e-7",
+            r#""escaped\nvalue""#,
+            r#"[null,true,-1,2.5,"x"]"#,
+            r#"{"a":1,"a":2,"nested":{"items":[false,"z"]}}"#,
+        ] {
+            let expected = serde_json::from_str::<Value>(source).expect("serde JSON fixture");
+            let actual = parse_bounded_document(
+                source,
+                SchemaCatalogLimits {
+                    input_bytes: source.len(),
+                    definitions: 100,
+                    depth: 10,
+                    nodes: 100,
+                    string_bytes: 100,
+                },
+            )
+            .expect("bounded parser accepts the same JSON value");
+            assert_eq!(actual, expected, "{source}");
         }
     }
 }

--- a/crates/shapes/src/schema_catalog.rs
+++ b/crates/shapes/src/schema_catalog.rs
@@ -95,7 +95,7 @@ impl CompiledSchemaCatalog {
             })?;
 
         if let Some(limits) = limits {
-            validate_document_limits(&document, definitions.len(), limits)?;
+            validate_definition_limit(definitions.len(), limits)?;
         }
 
         for (key, definition) in definitions {
@@ -274,7 +274,8 @@ impl<'de> Visitor<'de> for BoundedValueVisitor<'_> {
     }
 
     fn visit_seq<A: SeqAccess<'de>>(self, mut sequence: A) -> Result<Self::Value, A::Error> {
-        let mut values = Vec::new();
+        let remaining_nodes = self.state.limits.nodes.saturating_sub(self.state.nodes);
+        let mut values = Vec::with_capacity(sequence.size_hint().unwrap_or(0).min(remaining_nodes));
         while let Some(value) = sequence.next_element_seed(BoundedValueSeed {
             state: &mut *self.state,
             depth: self.depth + 1,
@@ -285,7 +286,8 @@ impl<'de> Visitor<'de> for BoundedValueVisitor<'_> {
     }
 
     fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-        let mut object = Map::new();
+        let remaining_nodes = self.state.limits.nodes.saturating_sub(self.state.nodes);
+        let mut object = Map::with_capacity(map.size_hint().unwrap_or(0).min(remaining_nodes));
         while let Some(key) = map.next_key_seed(BoundedStringSeed {
             state: &mut *self.state,
         })? {
@@ -341,8 +343,7 @@ impl<'de> Visitor<'de> for BoundedStringVisitor<'_> {
     }
 }
 
-fn validate_document_limits(
-    document: &Value,
+fn validate_definition_limit(
     definitions: usize,
     limits: SchemaCatalogLimits,
 ) -> Result<(), SchemaCatalogError> {
@@ -353,50 +354,6 @@ fn validate_document_limits(
         )));
     }
 
-    let mut nodes = 0usize;
-    let mut stack = vec![(document, 0usize)];
-    while let Some((value, depth)) = stack.pop() {
-        if depth > limits.depth {
-            return Err(SchemaCatalogError::new(format!(
-                "CompiledSchema exceeds JSON nesting limit {}",
-                limits.depth
-            )));
-        }
-        nodes = nodes.checked_add(1).ok_or_else(|| {
-            SchemaCatalogError::new("CompiledSchema JSON node count exceeds usize")
-        })?;
-        if nodes > limits.nodes {
-            return Err(SchemaCatalogError::new(format!(
-                "CompiledSchema contains more than {} JSON nodes",
-                limits.nodes
-            )));
-        }
-        match value {
-            Value::String(text) if text.len() > limits.string_bytes => {
-                return Err(SchemaCatalogError::new(format!(
-                    "CompiledSchema contains a {}-byte string; limit is {}",
-                    text.len(),
-                    limits.string_bytes
-                )));
-            }
-            Value::Array(values) => {
-                stack.extend(values.iter().rev().map(|child| (child, depth + 1)));
-            }
-            Value::Object(object) => {
-                for (key, child) in object.iter().rev() {
-                    if key.len() > limits.string_bytes {
-                        return Err(SchemaCatalogError::new(format!(
-                            "CompiledSchema contains a {}-byte object key; limit is {}",
-                            key.len(),
-                            limits.string_bytes
-                        )));
-                    }
-                    stack.push((child, depth + 1));
-                }
-            }
-            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
-        }
-    }
     Ok(())
 }
 

--- a/crates/shapes/tests/pydantic_oracle.py
+++ b/crates/shapes/tests/pydantic_oracle.py
@@ -13,6 +13,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from packaging.version import InvalidVersion, Version
 from pydantic import ValidationError
 
 
@@ -123,8 +124,33 @@ def _normalize_inferred_types(actual: Any, expected: Any) -> Any:
     return normalized
 
 
+def _assert_version_oracle(cases: list[dict[str, Any]]) -> None:
+    for case in cases:
+        raw = case["raw"]
+        try:
+            parsed = Version(raw)
+            packaging_accepts = True
+        except InvalidVersion:
+            parsed = None
+            packaging_accepts = False
+        over_limit = len(raw.encode("utf-8")) > 512
+        expected = packaging_accepts and not over_limit
+        if case["accepted"] != expected:
+            raise AssertionError(
+                f"PEP 440 differential mismatch for {raw!r}: "
+                f"packaging={packaging_accepts}, purrdf={case}"
+            )
+        if case["resource_error"] != (packaging_accepts and over_limit):
+            raise AssertionError(f"version resource classification mismatch: {case}")
+        if expected:
+            assert parsed is not None
+            if case["is_local"] != (parsed.local is not None):
+                raise AssertionError(f"local-version classification mismatch: {case}")
+
+
 def main() -> None:
     payload = _fixture()
+    _assert_version_oracle(payload["version_oracle"])
     reverse = payload["reverse"]
     if reverse["shape_ids"] != ["<https://example.org/Person>"]:
         raise AssertionError(f"unexpected reverse SHACL shapes: {reverse['shape_ids']!r}")
@@ -297,8 +323,9 @@ def main() -> None:
             sys.path.remove(str(root))
 
     print(
-        "Pydantic oracle: 6 live model schemas agree; validation/alias probes and "
-        "verified reverse SHACL import pass"
+        f"Pydantic oracle: {len(payload['version_oracle'])} PEP 440 differential cases "
+        "agree; 6 live model schemas, validation/alias probes, and verified reverse "
+        "SHACL import pass"
     )
 
 

--- a/crates/shapes/tests/pydantic_oracle.py
+++ b/crates/shapes/tests/pydantic_oracle.py
@@ -5,8 +5,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -18,6 +20,7 @@ from pydantic import ValidationError
 
 
 REPO = Path(__file__).resolve().parents[3]
+FLAT_BASELINE_SHA256 = "a89d78ba9be04d5d10be8709ea81da938176e5c678920c09007c3b94d60d3625"
 SCHEMA_MAP_KEYWORDS = (
     "$defs",
     "properties",
@@ -148,11 +151,8 @@ def _assert_version_oracle(cases: list[dict[str, Any]]) -> None:
                 raise AssertionError(f"local-version classification mismatch: {case}")
 
 
-def main() -> None:
-    payload = _fixture()
-    _assert_version_oracle(payload["version_oracle"])
-    reverse = payload["reverse"]
-    if reverse["shape_ids"] != ["<https://example.org/Person>"]:
+def _assert_reverse(reverse: dict[str, Any], expected_shape_ids: list[str]) -> None:
+    if reverse["shape_ids"] != expected_shape_ids:
         raise AssertionError(f"unexpected reverse SHACL shapes: {reverse['shape_ids']!r}")
     reverse_losses = reverse["losses"]["losses"]
     if not all(
@@ -163,169 +163,289 @@ def main() -> None:
         for entry in reverse_losses
     ):
         raise AssertionError("Pydantic reverse package has an unsound or unlocated loss")
-    with tempfile.TemporaryDirectory(prefix="purrdf-pydantic-oracle-") as directory:
-        root = Path(directory)
-        for relative, text in payload["artifacts"].items():
-            destination = root / relative
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            destination.write_text(text, encoding="utf-8", newline="\n")
 
-        sys.path.insert(0, str(root))
-        try:
-            models = importlib.import_module("oracle_models.models")
-            source_defs = payload["schema"]["$defs"]
-            model_paths = payload["model_paths"]
-            expected_defs = {
-                import_path.rsplit(".", 1)[1]: _rewrite_refs(
-                    source_defs[source_key], model_paths
-                )
-                for source_key, import_path in model_paths.items()
-            }
-            for source_key, import_path in model_paths.items():
-                class_name = import_path.rsplit(".", 1)[1]
-                model = getattr(models, class_name)
-                native_schema = super(model, model).model_json_schema(by_alias=True)
-                if not isinstance(native_schema, dict):
+
+def _load_models(model_paths: dict[str, str]) -> dict[str, type[Any]]:
+    models: dict[str, type[Any]] = {}
+    for source_key, import_path in model_paths.items():
+        module_name, class_name = import_path.rsplit(".", 1)
+        module = importlib.import_module(module_name)
+        model = getattr(module, class_name)
+        if not isinstance(model, type):
+            raise AssertionError(f"{import_path} is not a generated model type")
+        models[source_key] = model
+    return models
+
+
+def _assert_package_runtime(
+    schema: dict[str, Any],
+    model_paths: dict[str, str],
+    metadata: dict[str, dict[str, Any]] | None,
+) -> None:
+    source_defs = schema["$defs"]
+    models = _load_models(model_paths)
+    expected_defs = {
+        import_path.rsplit(".", 1)[1]: _rewrite_refs(source_defs[source_key], model_paths)
+        for source_key, import_path in model_paths.items()
+    }
+    for source_key, model in models.items():
+        expected_module = model_paths[source_key].rsplit(".", 1)[0]
+        if model.__module__ != expected_module:
+            raise AssertionError(
+                f"{source_key} module drifted: {model.__module__!r} != {expected_module!r}"
+            )
+        native_schema = super(model, model).model_json_schema(by_alias=True)
+        if not isinstance(native_schema, dict):
+            raise AssertionError(
+                f"{source_key} cannot produce a native Pydantic JSON Schema"
+            )
+        if metadata is not None:
+            if model.__doc__ != f"Caller documentation for {source_key}.":
+                raise AssertionError(f"{source_key} lost its caller class documentation")
+            if model.model_config.get("json_schema_extra") != metadata[source_key]:
+                raise AssertionError(f"{source_key} lost caller metadata linkage")
+            native_metadata = native_schema.get("$defs", {}).get(
+                model.__name__, native_schema
+            )
+            for key, value in metadata[source_key].items():
+                if native_metadata.get(key) != value:
                     raise AssertionError(
-                        f"{source_key} cannot produce a native Pydantic JSON Schema"
+                        f"{source_key} native schema lost metadata key {key!r}"
                     )
-                live_schema = model.model_json_schema(by_alias=True)
-                if live_schema.get("$defs") != expected_defs:
-                    raise AssertionError(
-                        f"{source_key} model_json_schema() has a divergent $defs table:\n"
-                        f"expected={json.dumps(expected_defs, indent=2, sort_keys=True)}\n"
-                        f"actual={json.dumps(live_schema.get('$defs'), indent=2, sort_keys=True)}"
-                    )
-                actual = _definition_surface(live_schema)
-                expected = _rewrite_refs(source_defs[source_key], model_paths)
-                actual = _normalize_inferred_types(actual, expected)
-                if actual != expected:
-                    raise AssertionError(
-                        f"{source_key} model_json_schema() disagrees with CompiledSchema:\n"
-                        f"expected={json.dumps(expected, indent=2, sort_keys=True)}\n"
-                        f"actual={json.dumps(actual, indent=2, sort_keys=True)}"
-                    )
+        live_schema = model.model_json_schema(by_alias=True)
+        if live_schema.get("$defs") != expected_defs:
+            raise AssertionError(
+                f"{source_key} model_json_schema() has a divergent $defs table:\n"
+                f"expected={json.dumps(expected_defs, indent=2, sort_keys=True)}\n"
+                f"actual={json.dumps(live_schema.get('$defs'), indent=2, sort_keys=True)}"
+            )
+        actual = _definition_surface(live_schema)
+        expected = _rewrite_refs(source_defs[source_key], model_paths)
+        actual = _normalize_inferred_types(actual, expected)
+        if actual != expected:
+            raise AssertionError(
+                f"{source_key} model_json_schema() disagrees with CompiledSchema:\n"
+                f"expected={json.dumps(expected, indent=2, sort_keys=True)}\n"
+                f"actual={json.dumps(actual, indent=2, sort_keys=True)}"
+            )
 
-            color = models.Color.model_validate("ex:red")
-            assert color.model_dump(mode="json") == "ex:red"
-            _assert_rejects(models.Color, "ex:green")
-            _assert_rejects(models.Empty, "anything")
+    color = models["Color"].model_validate("ex:red")
+    assert color.model_dump(mode="json") == "ex:red"
+    _assert_rejects(models["Color"], "ex:green")
+    _assert_rejects(models["Empty"], "anything")
 
-            state = models.State.model_validate({"@id": "ex:open"})
-            assert state.model_dump(mode="json") == {"@id": "ex:open"}
-            _assert_rejects(models.State, {"@id": "ex:unknown"})
+    state = models["State"].model_validate({"@id": "ex:open"})
+    assert state.model_dump(mode="json") == {"@id": "ex:open"}
+    _assert_rejects(models["State"], {"@id": "ex:unknown"})
 
-            person_payload = {
-                "@id": "ex:alice",
-                "ex:active": True,
-                "ex:address": {"ex:city": "E", "ex:postalCode": "A1"},
-                "ex:age": 42,
-                "ex:color": "ex:red",
-                "ex:friend": {"ex:age": 39, "ex:name": "Bob"},
-                "ex:label": "Al",
-                "ex:lookahead": "A",
-                "ex:name": "Alice",
-                "ex:nullableCount": 2,
-                "ex:nullableName": "Name",
-                "ex:nullableTags": ["one"],
-                "ex:path": "mapped:value",
-                "ex:score": 0.75,
-                "ex:tags": ["one", "two"],
-                "ex:when": "2026-07-15T12:00:00Z",
-            }
-            person = models.Person.model_validate(person_payload)
-            dumped = person.model_dump(mode="json", by_alias=True, exclude_none=True)
-            assert dumped == person_payload
-            alias = models.PersonAlias.model_validate(person_payload)
-            assert alias.model_dump(mode="json", by_alias=True, exclude_none=True) == person_payload
+    if "CycleLeft" in models:
+        cycle = models["CycleLeft"].model_validate({"ex:right": {"ex:left": {}}})
+        assert cycle.model_dump(mode="json", by_alias=True, exclude_none=True) == {
+            "ex:right": {"ex:left": {}}
+        }
 
-            nullable_payload = dict(person_payload)
-            nullable_payload.update(
-                {
-                    "ex:nullableCount": None,
-                    "ex:nullableName": None,
-                    "ex:nullableTags": None,
-                }
-            )
-            nullable_person = models.Person.model_validate(nullable_payload)
-            nullable_dump = nullable_person.model_dump(mode="json", by_alias=True)
-            assert nullable_dump["ex:nullableCount"] is None
-            assert nullable_dump["ex:nullableName"] is None
-            assert nullable_dump["ex:nullableTags"] is None
+    person_payload = {
+        "@id": "ex:alice",
+        "ex:active": True,
+        "ex:address": {"ex:city": "E", "ex:postalCode": "A1"},
+        "ex:age": 42,
+        "ex:color": "ex:red",
+        "ex:friend": {"ex:age": 39, "ex:name": "Bob"},
+        "ex:label": "Al",
+        "ex:lookahead": "A",
+        "ex:name": "Alice",
+        "ex:nullableCount": 2,
+        "ex:nullableName": "Name",
+        "ex:nullableTags": ["one"],
+        "ex:path": "mapped:value",
+        "ex:score": 0.75,
+        "ex:tags": ["one", "two"],
+        "ex:when": "2026-07-15T12:00:00Z",
+    }
+    person = models["Person"].model_validate(person_payload)
+    dumped = person.model_dump(mode="json", by_alias=True, exclude_none=True)
+    assert dumped == person_payload
+    alias = models["PersonAlias"].model_validate(person_payload)
+    assert alias.model_dump(mode="json", by_alias=True, exclude_none=True) == person_payload
 
-            _assert_rejects(models.Person, {"ex:age": -1, "ex:name": "Alice"})
-            _assert_rejects(models.Person, {"ex:age": 1, "ex:name": ""})
-            _assert_rejects(models.Person, {"ex:age": 1, "name": "Alice"})
-            for non_json_number in [float("nan"), float("inf"), float("-inf")]:
-                _assert_rejects(
-                    models.Person,
-                    {
-                        "ex:age": 1,
-                        "ex:name": "Alice",
-                        "ex:score": non_json_number,
-                    },
-                )
-            _assert_rejects(
-                models.Person,
-                {"ex:age": 1, "ex:name": "Alice", "ex:nullableCount": -1},
-            )
-            _assert_rejects(
-                models.Person,
-                {"ex:age": 1, "ex:name": "Alice", "ex:nullableName": "n"},
-            )
-            _assert_rejects(
-                models.Person,
-                {"ex:age": 1, "ex:name": "Alice", "ex:nullableTags": []},
-            )
-            _assert_rejects(
-                models.Person,
-                {"ex:age": 1, "ex:name": "Alice", "ex:when": 0},
-            )
-            _assert_rejects(
-                models.Person,
-                {"ex:age": 1, "ex:name": "Alice", "ex:path": "wrong"},
-            )
-            _assert_rejects(
-                models.Person,
-                {"ex:age": 1, "ex:name": "Alice", "ex:label": "A"},
-            )
-            typed_label = models.Person.model_validate(
-                {
-                    "ex:age": 1,
-                    "ex:name": "Alice",
-                    "ex:label": {
-                        "@value": "A",
-                        "@type": "xsd:string",
-                        "@language": "en",
-                    },
-                }
-            )
-            assert typed_label.model_dump(
-                mode="json", by_alias=True, exclude_none=True
-            )["ex:label"] == {
+    nullable_payload = dict(person_payload)
+    nullable_payload.update(
+        {
+            "ex:nullableCount": None,
+            "ex:nullableName": None,
+            "ex:nullableTags": None,
+        }
+    )
+    nullable_person = models["Person"].model_validate(nullable_payload)
+    nullable_dump = nullable_person.model_dump(mode="json", by_alias=True)
+    assert nullable_dump["ex:nullableCount"] is None
+    assert nullable_dump["ex:nullableName"] is None
+    assert nullable_dump["ex:nullableTags"] is None
+
+    _assert_rejects(models["Person"], {"ex:age": -1, "ex:name": "Alice"})
+    _assert_rejects(models["Person"], {"ex:age": 1, "ex:name": ""})
+    _assert_rejects(models["Person"], {"ex:age": 1, "name": "Alice"})
+    for non_json_number in [float("nan"), float("inf"), float("-inf")]:
+        _assert_rejects(
+            models["Person"],
+            {"ex:age": 1, "ex:name": "Alice", "ex:score": non_json_number},
+        )
+    _assert_rejects(
+        models["Person"],
+        {"ex:age": 1, "ex:name": "Alice", "ex:nullableCount": -1},
+    )
+    _assert_rejects(
+        models["Person"],
+        {"ex:age": 1, "ex:name": "Alice", "ex:nullableName": "n"},
+    )
+    _assert_rejects(
+        models["Person"],
+        {"ex:age": 1, "ex:name": "Alice", "ex:nullableTags": []},
+    )
+    _assert_rejects(
+        models["Person"], {"ex:age": 1, "ex:name": "Alice", "ex:when": 0}
+    )
+    _assert_rejects(
+        models["Person"], {"ex:age": 1, "ex:name": "Alice", "ex:path": "wrong"}
+    )
+    _assert_rejects(
+        models["Person"], {"ex:age": 1, "ex:name": "Alice", "ex:label": "A"}
+    )
+    typed_label = models["Person"].model_validate(
+        {
+            "ex:age": 1,
+            "ex:name": "Alice",
+            "ex:label": {
                 "@value": "A",
                 "@type": "xsd:string",
                 "@language": "en",
-            }
-            _assert_rejects(
-                models.Person,
-                {"ex:age": 1, "ex:name": "Alice", "ex:unexpected": True},
+            },
+        }
+    )
+    assert typed_label.model_dump(mode="json", by_alias=True, exclude_none=True)[
+        "ex:label"
+    ] == {
+        "@value": "A",
+        "@type": "xsd:string",
+        "@language": "en",
+    }
+    _assert_rejects(
+        models["Person"],
+        {"ex:age": 1, "ex:name": "Alice", "ex:unexpected": True},
+    )
+    _assert_rejects(
+        models["Person"],
+        {
+            "ex:age": 1,
+            "ex:name": "Alice",
+            "ex:address": {"ex:postalCode": "bad"},
+        },
+    )
+
+
+def _assert_strict_routed_types(root: Path) -> None:
+    consumer = root / "routed_consumer.py"
+    consumer.write_text(
+        """# SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+from routed_oracle_models.catalog.enums import Color, Empty, State
+from routed_oracle_models.common.paths import PathWithToken
+from routed_oracle_models.cycles.left import CycleLeft
+from routed_oracle_models.cycles.right import CycleRight
+from routed_oracle_models.domain.people import Person, PersonAlias
+
+def compose(
+    person: Person,
+    alias: PersonAlias,
+    color: Color,
+    empty: Empty,
+    state: State,
+    path: PathWithToken,
+    cycle_left: CycleLeft,
+    cycle_right: CycleRight,
+) -> tuple[Person, PersonAlias, Color, Empty, State, PathWithToken, CycleLeft, CycleRight]:
+    return person, alias, color, empty, state, path, cycle_left, cycle_right
+""",
+        encoding="utf-8",
+        newline="\n",
+    )
+    env = dict(os.environ)
+    env["MYPYPATH"] = str(root)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mypy",
+            "--strict",
+            "--no-incremental",
+            "routed_oracle_models",
+            "routed_consumer.py",
+        ],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            "strict mypy rejected the routed generated package:\n"
+            f"{completed.stdout}{completed.stderr}"
+        )
+
+
+def main() -> None:
+    payload = _fixture()
+    flat_baseline = json.dumps(
+        [payload["artifacts"], payload["model_paths"], payload["reverse"]["losses"]],
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ) + "\n"
+    flat_digest = hashlib.sha256(flat_baseline.encode()).hexdigest()
+    if flat_digest != FLAT_BASELINE_SHA256:
+        raise AssertionError(
+            f"flat Pydantic package baseline drifted: {flat_digest} != "
+            f"{FLAT_BASELINE_SHA256}"
+        )
+    _assert_version_oracle(payload["version_oracle"])
+    _assert_reverse(payload["reverse"], ["<https://example.org/Person>"])
+    _assert_reverse(
+        payload["routed"]["reverse"],
+        [
+            "<https://example.org/CycleLeft>",
+            "<https://example.org/CycleRight>",
+            "<https://example.org/Person>",
+        ],
+    )
+    with tempfile.TemporaryDirectory(prefix="purrdf-pydantic-oracle-") as directory:
+        root = Path(directory)
+        for artifacts in [payload["artifacts"], payload["routed"]["artifacts"]]:
+            for relative, text in artifacts.items():
+                destination = root / relative
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_text(text, encoding="utf-8", newline="\n")
+
+        _assert_strict_routed_types(root)
+
+        sys.path.insert(0, str(root))
+        try:
+            _assert_package_runtime(payload["schema"], payload["model_paths"], None)
+            _assert_package_runtime(
+                payload["routed"]["schema"],
+                payload["routed"]["model_paths"],
+                payload["routed"]["metadata"],
             )
-            _assert_rejects(
-                models.Person,
-                {
-                    "ex:age": 1,
-                    "ex:name": "Alice",
-                    "ex:address": {"ex:postalCode": "bad"},
-                },
-            )
+            routed_root = importlib.import_module("routed_oracle_models")
+            if routed_root.__version__ != payload["routed"]["version"]:
+                raise AssertionError("routed package version export drifted")
         finally:
             sys.path.remove(str(root))
 
     print(
         f"Pydantic oracle: {len(payload['version_oracle'])} PEP 440 differential cases "
-        "agree; 6 live model schemas, validation/alias probes, and verified reverse "
-        "SHACL import pass"
+        "agree; flat 6-model and routed 8-model packages pass strict typing, live schemas, "
+        "validation/alias probes, metadata/version linkage, and verified reverse SHACL import"
     )
 
 

--- a/docs/book/src/validation/shacl.md
+++ b/docs/book/src/validation/shacl.md
@@ -141,6 +141,17 @@ generated code and checks the live reverse/schema surface.
 `import_pydantic_package` separately verifies the retained source schema,
 generated files, model map, dialect, and forward ledger before importing SHACL.
 
+The optional caller-owned `PydanticPackageTopology` is a total partition of
+`$defs` entries into portable dotted leaf modules. Each route carries the class
+docstring and a sorted, vocabulary-neutral `json_schema_extra` map suitable for
+documentation URLs, content digests, and other caller-defined linkage. An
+optional `PydanticVersionStamp` adds an exact PEP 440 `__version__` export.
+Routed packages share schema/runtime support modules, generate intermediate
+package initializers, use explicit symbol tables for one root-level rebuild,
+and pass the executable runtime oracle plus strict mypy. Exact route coverage,
+portable path/symbol uniqueness, and fixed input/config/output limits all fail
+closed. Without a topology, the original flat package bytes remain unchanged.
+
 ## LinkML 1.11 projection
 
 The same `CompiledSchema` carrier can be projected to canonical LinkML 1.11

--- a/docs/book/src/validation/shacl.md
+++ b/docs/book/src/validation/shacl.md
@@ -150,7 +150,9 @@ Routed packages share schema/runtime support modules, generate intermediate
 package initializers, use explicit symbol tables for one root-level rebuild,
 and pass the executable runtime oracle plus strict mypy. Exact route coverage,
 portable path/symbol uniqueness, and fixed input/config/output limits all fail
-closed. Without a topology, the original flat package bytes remain unchanged.
+closed. When both topology and version stamping are omitted, the original flat
+package bytes remain unchanged. A flat version stamp adds `__about__.py` and
+updates the `__init__.py` exports.
 
 ## LinkML 1.11 projection
 


### PR DESCRIPTION
Closes #130

## What changed

- Adds a validated caller-owned `PydanticPackageTopology` that totally partitions schema definitions into portable dotted Python modules.
- Carries caller-authored module/class documentation and vocabulary-neutral sorted `json_schema_extra` linkage metadata.
- Adds exact caller-owned PEP 440 package version stamping through `__about__.py` and root `__version__`.
- Compiles schema references, module dependencies, helper ownership, explicit symbol maps, imports, artifacts, and rebuild membership into one deterministic linker plan.
- Emits shared `_base.py` and `_schema.py` support, intermediate package initializers, strict-typing imports, and one root rebuild sweep for recursive cross-module models.
- Bounds schema, configuration, metadata, artifact count/paths/bytes, and aggregate output; incomplete, ambiguous, stale, colliding, corrupted, or over-limit inputs fail closed.
- Strengthens reverse verification with retained-source fingerprinting and deterministic re-emission of every artifact, model path, loss entry, and retained configuration value.

## Completeness and compatibility

The routed package exercises per-module ownership, per-class documentation, definition-digest/docs linkage, version stamping, nested modules, inline/enum helpers, and live cross-module recursion. The no-topology/no-version path retains its original four artifacts, exact bytes, model paths, and loss ledger; the independent oracle freezes that surface at SHA-256 `a89d78ba9be04d5d10be8709ea81da938176e5c678920c09007c3b94d60d3625`.

PurRDF assigns no semantics to metadata keys, infers no slice ownership, emits no ontology vocabulary, and adds no Cargo feature or optional dependency.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo +1.96 check --workspace --lib --locked`
- `UV_CACHE_DIR=/tmp/uv-cache make pydantic-oracle`
- `make metadata`
- `make doc`
- `make book`
- `make book-samples`
- `make check`
- `make wasm`
- `make wasm-pkg-size`
- complete `pydantic_package` Criterion target
- complete `pydantic_allocations` instrument
- whitespace, issue-reference, namespace/feature, and mechanical deferral scans

The oracle passes 42 PEP 440 differential cases; flat 6-model and routed 8-model packages pass strict mypy, live schemas and validation, a real `CycleLeft`/`CycleRight` module cycle, metadata/version linkage, and verified reverse import. The optimized wasm is 6,047,463 bytes against the 6,225,000-byte budget with 40,329 SIMD opcodes verified.

## Performance evidence

At 16,384 definitions, median emission time is 335.65 ms flat, 479.61 ms rich single-module, 488.45 ms grouped across 40 modules, and 1.6276 s for one module per model with true all-definition graph fanout. Retained/peak allocation bytes are 33,098,044/121,550,276; 51,309,097/149,617,929; 59,291,494/159,163,587; and 83,166,256/245,840,046 respectively.

## Risk controls

The richer topology is opt-in and validated as a total declaration. Every output is sorted and filesystem-free; no time, randomness, hash iteration, repository state, or caller vocabulary enters emitted bytes. Fixed ceilings make hostile inputs deterministic errors, and the independent Python/type oracle tests the generated distribution as consumers load it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generate distribution-ready Pydantic packages across multiple routed modules with package initializers, cross-module references, metadata, and optional version information.
  * Preserve the existing flat single-module output when routing is not configured.
  * Add stronger validation for package topology, schema size, metadata, paths, symbols, and version formats.
  * Detect tampered or mismatched source schemas during package import.

* **Documentation**
  * Expanded guidance for routed Pydantic packages, versioning, validation, and type-checking workflows.

* **Tests**
  * Extended coverage for flat and routed package generation, runtime behavior, metadata, reverse conversion, and strict type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->