### PR TITLE
jsonld: add deterministic context compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,6 +1393,7 @@ dependencies = [
  "purrdf-validate",
  "purrdf-xsd",
  "pyo3",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,6 +1474,7 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
+ "serde_json",
  "sha2",
  "tempfile",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,6 +1401,7 @@ name = "purrdf-rdf"
 version = "0.7.0"
 dependencies = [
  "ahash",
+ "boon",
  "ciborium",
  "criterion",
  "csv",

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,10 @@ BINARYEN_VERSION := 130
 # artifact grew: a new capability or dependency, or a routine rustc-stable /
 # binaryen bump (a valid, must-be-explained reason). Never raise it merely to
 # turn a red gate green.
-WASM_SIZE_BUDGET_BYTES := 6225000
+# Measured 6,418,213 bytes after exposing the full compiled JSON-LD context
+# engine to JavaScript (strict options/registry decoding plus reusable contexts).
+# 6,610,000 leaves 2.99% headroom for reproducible toolchain variation.
+WASM_SIZE_BUDGET_BYTES := 6610000
 
 help: ## Show this help.
 	@grep -E '^[a-zA-Z_-]+:.*## ' $(MAKEFILE_LIST) | awk -F':.*## ' '{printf "  %-18s %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,11 @@ BINARYEN_VERSION := 130
 # artifact exceeds this. The shipped bundle — RDF 1.2 model, SPARQL/SHACL/ShEx
 # engines, the native format registry (now including JSON-LD/YAML-LD),
 # deterministic layout, SVG export, and all twelve graph/tabular/research-object
-# projection profiles — measures 6_042_985 bytes; 6_225_000 keeps about 3%
-# headroom. The five strict bidirectional research-object codecs are the
-# capability responsible for this reviewed increase. The artifact's size is a
-# joint function of
+# projection profiles and the compiled JSON-LD context/options/registry engine
+# — measures 6_418_213 bytes; 6_610_000 keeps 2.99% headroom. Exposing reusable
+# configured JSON-LD/YAML-LD serialization to JavaScript is the capability
+# responsible for the latest reviewed increase. The artifact's size is a joint
+# function of
 # rustc (tracks stable), wasm-bindgen (pinned in Cargo.toml), and binaryen
 # (pinned via BINARYEN_VERSION), so a moved number is attributable.
 #
@@ -39,9 +40,6 @@ BINARYEN_VERSION := 130
 # artifact grew: a new capability or dependency, or a routine rustc-stable /
 # binaryen bump (a valid, must-be-explained reason). Never raise it merely to
 # turn a red gate green.
-# Measured 6,418,213 bytes after exposing the full compiled JSON-LD context
-# engine to JavaScript (strict options/registry decoding plus reusable contexts).
-# 6,610,000 leaves 2.99% headroom for reproducible toolchain variation.
 WASM_SIZE_BUDGET_BYTES := 6610000
 
 help: ## Show this help.

--- a/Makefile
+++ b/Makefile
@@ -311,8 +311,8 @@ playground: wasm-pkg ## Assemble the standalone RDF-1.2 console into $(CARGO_TAR
 	@echo "OK: console assembled at $(PLAYGROUND_OUT)"
 	@echo "    preview: (cd $(PLAYGROUND_OUT) && python3 -m http.server 8080) then open http://localhost:8080/"
 
-playground-smoke: wasm-pkg ## Smoke the console's engine calls (every pane's package call, Node-side; a CI gate).
-	node --test docs/playground/smoke/*.test.mjs
+playground-smoke: playground ## Smoke the assembled console's worker dispatch and every pane's package calls (Node-side; a CI gate).
+	PLAYGROUND_OUT="$(abspath $(PLAYGROUND_OUT))" node --test docs/playground/smoke/*.test.mjs
 
 capi-build: ## Build libpurrdf (cdylib + staticlib + header + pkg-config) via cargo-c.
 	cargo capi build -p purrdf-capi

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -32,3 +32,4 @@ purrdf-sparql-eval = { workspace = true }
 purrdf-validate = { workspace = true }
 purrdf-xsd = { workspace = true }
 pyo3 = { workspace = true }
+serde_json = { workspace = true }

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -42,6 +42,30 @@ quads = purrdf.parse(
 `purrdf.to_rdf_xml` converters. All codecs are first-party with
 byte-deterministic output.
 
+Configured JSON-LD and YAML-LD use one strict versioned options document. Compile
+a reusable context when serializing several datasets:
+
+```python
+import json
+import purrdf
+
+options = json.dumps({
+    "version": 1,
+    "mode": "context",
+    "prefixes": {"ex": "https://example.org/", "schema": "https://schema.org/"},
+})
+context = purrdf.CompiledJsonLdContext(options)
+jsonld = purrdf.serialize_jsonld(
+    nquads,
+    format=purrdf.RdfFormat.N_QUADS,
+    output_format="jsonld",
+    context=context,
+)
+```
+
+`expanded`, `context`, and deterministic dataset-IRI `derived` modes are
+explicit. PurRDF never infers a caller vocabulary or fetches a remote context.
+
 ## Project graph, tabular, and research-object carriers
 
 `purrdf.project` and `purrdf.lift` are thin calls into the same Rust projection

--- a/bindings/python/python/src/purrdf/__init__.pyi
+++ b/bindings/python/python/src/purrdf/__init__.pyi
@@ -103,6 +103,14 @@ class RdfFormat:
     TRIG: RdfFormat
     TRIX: RdfFormat
     HEXTUPLES: RdfFormat
+    JSON_LD: RdfFormat
+    YAML_LD: RdfFormat
+
+class CompiledJsonLdContext:
+    def __init__(self, options_json: str) -> None: ...
+    @staticmethod
+    def from_prefixes(prefixes: dict[str, str]) -> CompiledJsonLdContext: ...
+    def canonical_context_json(self) -> str: ...
 
 class CanonicalizationAlgorithm:
     RDFC_1_0: CanonicalizationAlgorithm
@@ -269,6 +277,9 @@ class Store:
         format: RdfFormat,
         *,
         from_graph: NamedNode | BlankNode | DefaultGraph | None = ...,
+        jsonld_options: str | None = ...,
+        jsonld_context: CompiledJsonLdContext | None = ...,
+        yaml_schema_url: str | None = ...,
     ) -> None: ...
     @overload
     def dump(
@@ -277,6 +288,9 @@ class Store:
         *,
         format: RdfFormat,
         from_graph: NamedNode | BlankNode | DefaultGraph | None = ...,
+        jsonld_options: str | None = ...,
+        jsonld_context: CompiledJsonLdContext | None = ...,
+        yaml_schema_url: str | None = ...,
     ) -> bytes: ...
     def __len__(self) -> int: ...
 
@@ -309,6 +323,9 @@ class MutableDataset:
         format: RdfFormat,
         *,
         from_graph: NamedNode | BlankNode | DefaultGraph | None = ...,
+        jsonld_options: str | None = ...,
+        jsonld_context: CompiledJsonLdContext | None = ...,
+        yaml_schema_url: str | None = ...,
     ) -> None: ...
     @overload
     def dump(
@@ -317,6 +334,9 @@ class MutableDataset:
         *,
         format: RdfFormat,
         from_graph: NamedNode | BlankNode | DefaultGraph | None = ...,
+        jsonld_options: str | None = ...,
+        jsonld_context: CompiledJsonLdContext | None = ...,
+        yaml_schema_url: str | None = ...,
     ) -> bytes: ...
     # Engine configuration kwargs: as on `Store.query` / `Store.update`.
     def query(
@@ -429,7 +449,23 @@ def snapshot_content_id_native(data: bytes, *, format: RdfFormat) -> str: ...
 # RDF bytes ↔ JSON-LD-star / RDF/XML through the purrdf-gts codec set. The compat
 # `Graph.serialize`/`parse` route these formats here; serialize takes RDF bytes in
 # `format` and returns the text form, parse takes the text and returns N-Quads bytes.
-def to_json_ld(data: bytes, *, format: RdfFormat) -> str: ...
+def to_json_ld(
+    data: bytes,
+    *,
+    format: RdfFormat,
+    options_json: str | None = ...,
+    context: CompiledJsonLdContext | None = ...,
+) -> str: ...
+
+def serialize_jsonld(
+    data: bytes,
+    *,
+    format: RdfFormat,
+    output_format: str,
+    options_json: str | None = ...,
+    context: CompiledJsonLdContext | None = ...,
+    yaml_schema_url: str | None = ...,
+) -> str: ...
 
 # `statement_vocab` is the caller-supplied statement-metadata vocabulary
 # (keys: class/subject/predicate/object/objectLiteral, each an absolute IRI).
@@ -544,6 +580,14 @@ class RdfDataset:
     def quad_count(self) -> int: ...
     def term_count(self) -> int: ...
     def __len__(self) -> int: ...
+    def serialize_jsonld(
+        self,
+        output_format: str,
+        *,
+        options_json: str | None = ...,
+        context: CompiledJsonLdContext | None = ...,
+        yaml_schema_url: str | None = ...,
+    ) -> str: ...
     def to_gts(self, profile: str = ...) -> bytes: ...
 
 # ── Native SSSOM codec (bindings/python/src/py_sssom.rs, #848) ──────────────────

--- a/bindings/python/python/src/purrdf/compat/rdflib/graph.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/graph.py
@@ -1018,7 +1018,7 @@ class Graph:
             return src_str
         return Path(src_str).absolute().as_uri()
 
-    def _dump_bytes(self, fmt: str | None) -> bytes:
+    def _dump_bytes(self, fmt: str | None, **kwargs: object) -> bytes:
         """Serialize the store to bytes in the requested format.
 
         The format name is resolved to a serializer class through the plugin
@@ -1037,7 +1037,7 @@ class Graph:
         except plugin.PluginException as exc:
             raise ValueError(f"unsupported RDF format: {fmt!r}") from exc
         buffer = io.BytesIO()
-        serializer_cls(self).serialize(buffer)
+        serializer_cls(self).serialize(buffer, **kwargs)
         return buffer.getvalue()
 
     @overload
@@ -1079,7 +1079,7 @@ class Graph:
         **kwargs: object,
     ) -> str | bytes | None:
         """Serialize the graph; return ``str``/``bytes`` or write to ``destination``."""
-        out = self._dump_bytes(format)
+        out = self._dump_bytes(format, **kwargs)
         if destination is None:
             return out if encoding is not None else out.decode("utf-8")
         writer = getattr(destination, "write", None)

--- a/bindings/python/python/src/purrdf/compat/rdflib/namespace.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/namespace.py
@@ -516,6 +516,7 @@ class NamespaceManager:
                         break
                     num += 1
                 self.bind(prefix, namespace)
+                self._caller_prefixes.discard(prefix)
             self.__cache[uri] = (prefix, URIRef(namespace), name)
         return self.__cache[uri]
 
@@ -552,6 +553,7 @@ class NamespaceManager:
                         break
                     num += 1
                 self.bind(prefix, namespace)
+                self._caller_prefixes.discard(prefix)
             self.__cache_strict[uri] = (prefix, URIRef(namespace), name)
         cached = self.__cache_strict[uri]
         return cached[0], str(cached[1]), cached[2]

--- a/bindings/python/python/src/purrdf/compat/rdflib/namespace.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/namespace.py
@@ -411,6 +411,8 @@ class NamespaceManager:
         self.__cache_strict: dict[str, tuple[str, URIRef, str]] = {}
         self.__strie: dict[str, Any] = {}
         self.__trie: dict[str, Any] = {}
+        self._caller_prefixes: set[str] = set()
+        self._record_caller_prefixes = False
         if bind_namespaces == "none":
             pass
         elif bind_namespaces == "core":
@@ -423,6 +425,7 @@ class NamespaceManager:
                 self.bind(prefix, ns)
         else:
             raise ValueError(f"unsupported namespace set {bind_namespaces}")
+        self._record_caller_prefixes = True
 
     @property
     def store(self) -> _SupportsStore:
@@ -592,6 +595,7 @@ class NamespaceManager:
             if replace:
                 self.store.bind(prefix, namespace, override=override)
                 insert_trie(self.__trie, str(namespace))
+                self._record_jsonld_prefix(namespace)
                 return
             if not prefix:
                 prefix = "default"
@@ -600,6 +604,7 @@ class NamespaceManager:
                 new_prefix = f"{prefix}{num}"
                 tnamespace = self.store.namespace(new_prefix)
                 if tnamespace and namespace == URIRef(tnamespace):
+                    self._record_jsonld_prefix(namespace)
                     return  # already bound to the right namespace
                 if not self.store.namespace(new_prefix):
                     break
@@ -614,6 +619,23 @@ class NamespaceManager:
             elif override or bound_prefix.startswith("_"):
                 self.store.bind(prefix, namespace, override=override)
         insert_trie(self.__trie, str(namespace))
+        self._record_jsonld_prefix(namespace)
+
+    def _record_jsonld_prefix(self, namespace: URIRef) -> None:
+        """Remember caller/document bindings separately from shipped defaults."""
+        if not self._record_caller_prefixes:
+            return
+        prefix = self.store.prefix(namespace)
+        if prefix:
+            self._caller_prefixes.add(prefix)
+
+    def jsonld_prefixes(self) -> dict[str, str]:
+        """Return caller/document prefix mappings for explicit JSON-LD compaction."""
+        return {
+            prefix: str(namespace)
+            for prefix in sorted(self._caller_prefixes)
+            if (namespace := self.store.namespace(prefix)) is not None
+        }
 
     def namespaces(self) -> list[tuple[str, URIRef]]:
         """Return the bound ``(prefix, namespace)`` pairs."""

--- a/bindings/python/python/src/purrdf/compat/rdflib/plugins/parsers.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/plugins/parsers.py
@@ -163,10 +163,17 @@ class JsonLDParser(Parser):
             for prefix, value in ctx.items():
                 if prefix in self._RESERVED_CONTEXT_KEYS:
                     continue
-                if not isinstance(value, str):
-                    continue
-                if value.endswith(("/", "#", ":")):
-                    sink.bind(prefix, URIRef(value))
+                namespace: str | None = None
+                if isinstance(value, str):
+                    namespace = value
+                elif (
+                    isinstance(value, dict)
+                    and value.get("@prefix") is True
+                    and isinstance(value.get("@id"), str)
+                ):
+                    namespace = value["@id"]
+                if namespace is not None and namespace.endswith(("/", "#", ":")):
+                    sink.bind(prefix, URIRef(namespace))
 
 
 class RDFXMLParser(Parser):

--- a/bindings/python/python/src/purrdf/compat/rdflib/plugins/serializers/__init__.py
+++ b/bindings/python/python/src/purrdf/compat/rdflib/plugins/serializers/__init__.py
@@ -17,6 +17,7 @@ emit deterministic quad documents.
 
 from __future__ import annotations
 
+import json
 from typing import IO, Any
 
 import purrdf
@@ -118,9 +119,31 @@ class JsonLDSerializer(Serializer):
         encoding: str | None = None,
         **args: Any,
     ) -> None:
-        """Emit JSON-LD (store → N-Quads → ``to_json_ld``)."""
+        """Emit JSON-LD through the shared configured context engine."""
         nquads = self.store._store.dump(format=_NQ)
-        stream.write(purrdf.to_json_ld(nquads, format=_NQ).encode("utf-8"))
+        options = args.get("jsonld_options")
+        context = args.get("jsonld_context")
+        if options is not None and not isinstance(options, str):
+            options = json.dumps(options, sort_keys=True, separators=(",", ":"))
+        if options is None and context is None:
+            prefixes = self.store._nsm.jsonld_prefixes()
+            if prefixes:
+                options = json.dumps(
+                    {"version": 1, "mode": "context", "prefixes": prefixes},
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+        if options is None and context is None:
+            rendered = purrdf.to_json_ld(nquads, format=_NQ)
+        else:
+            rendered = purrdf.serialize_jsonld(
+                nquads,
+                format=_NQ,
+                output_format="jsonld",
+                options_json=options,
+                context=context,
+            )
+        stream.write(rendered.encode("utf-8"))
 
 
 class XMLSerializer(Serializer):

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -21,6 +21,7 @@ pub use purrdf::*;
 mod py_gts;
 mod py_gts_dataset;
 mod py_gts_view;
+mod py_jsonld;
 mod py_projection;
 mod py_shex;
 mod py_slice;

--- a/bindings/python/src/py_gts.rs
+++ b/bindings/python/src/py_gts.rs
@@ -37,6 +37,7 @@ use crate::bundle::{RdfBundle, UnitMetadata};
 use crate::gts_compose::{BlobRow, DEFAULT_RSYNCABLE_THRESHOLD, SnapshotBuilder, emit_gts};
 use crate::ir::RdfDataset;
 use crate::provenance::{DatasetProvenance, OriginKind};
+use crate::py_jsonld::{PyCompiledJsonLdContext, options_from_inputs};
 use crate::py_store::{PyRdfFormat, parse_quads};
 use crate::{NativeRdfFormat, RdfQuad, flat_dataset_from_quads};
 
@@ -303,13 +304,32 @@ fn gts_from_rdf12_bytes(
 /// in-repo `native_codecs::jsonld` serializer — no longer the external purrdf-gts JSON-LD
 /// codec. This is the RDF-1.2-first JSON-LD form the published `*.jsonld` artifacts emit.
 #[pyfunction]
-#[pyo3(signature = (data, *, format))]
-fn to_json_ld(py: Python<'_>, data: &Bound<'_, PyBytes>, format: PyRdfFormat) -> PyResult<String> {
+#[pyo3(signature = (data, *, format, options_json=None, context=None))]
+fn to_json_ld(
+    py: Python<'_>,
+    data: &Bound<'_, PyBytes>,
+    format: PyRdfFormat,
+    options_json: Option<&str>,
+    context: Option<&PyCompiledJsonLdContext>,
+) -> PyResult<String> {
     let raw = data.as_bytes();
+    let configured = if options_json.is_some() || context.is_some() {
+        Some(options_from_inputs(options_json, context, None)?)
+    } else {
+        None
+    };
     py.detach(|| {
         let dataset = parse_rdf_dataset(raw, format)?;
-        crate::native_codecs::jsonld::serialize_dataset_to_jsonld(&dataset)
+        if let Some(options) = &configured {
+            crate::native_codecs::jsonld::serialize_dataset_to_jsonld_with_options(
+                &dataset, options,
+            )
             .map_err(|e| PyValueError::new_err(format!("json-ld-star serialization error: {e}")))
+        } else {
+            crate::native_codecs::jsonld::serialize_dataset_to_jsonld(&dataset).map_err(|e| {
+                PyValueError::new_err(format!("json-ld-star serialization error: {e}"))
+            })
+        }
     })
 }
 

--- a/bindings/python/src/py_gts_dataset.rs
+++ b/bindings/python/src/py_gts_dataset.rs
@@ -20,6 +20,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};
 
+use crate::py_jsonld::{PyCompiledJsonLdContext, options_from_inputs, serialize_frozen};
 use crate::py_store::PyRdfFormat;
 use crate::{NativeRdfFormat, RdfDataset, RdfLookaside, dataset_from_bytes, gts_write};
 
@@ -62,6 +63,20 @@ impl PyRdfDataset {
 
     fn __len__(&self) -> usize {
         self.inner.quad_count()
+    }
+
+    /// Serialize this immutable dataset as configured JSON-LD or YAML-LD.
+    #[pyo3(signature = (output_format, *, options_json=None, context=None, yaml_schema_url=None))]
+    fn serialize_jsonld(
+        &self,
+        py: Python<'_>,
+        output_format: &str,
+        options_json: Option<&str>,
+        context: Option<&PyCompiledJsonLdContext>,
+        yaml_schema_url: Option<&str>,
+    ) -> PyResult<String> {
+        let options = options_from_inputs(options_json, context, yaml_schema_url)?;
+        py.detach(|| serialize_frozen(&self.inner, output_format, &options))
     }
 
     /// Emit a GTS byte stream for this dataset under `profile`. Uses the

--- a/bindings/python/src/py_jsonld.rs
+++ b/bindings/python/src/py_jsonld.rs
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Configured JSON-LD/YAML-LD Python surface over the shared Rust context engine.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+
+use crate::py_store::PyRdfFormat;
+use crate::{
+    CompiledJsonLdContext as EngineContext, JsonLdSerializeMode, JsonLdSerializeOptions,
+    RdfDataset, classify, parse_dataset, serialize_dataset_to_format_with_jsonld_options,
+};
+
+/// An immutable compiled JSON-LD 1.1 context reusable across datasets.
+#[pyclass(name = "CompiledJsonLdContext", frozen, skip_from_py_object)]
+#[derive(Debug, Clone)]
+pub(crate) struct PyCompiledJsonLdContext {
+    pub(crate) inner: Arc<EngineContext>,
+}
+
+#[pymethods]
+impl PyCompiledJsonLdContext {
+    /// Compile the context-mode branch of a versioned JSON-LD options document.
+    #[new]
+    fn new(options_json: &str) -> PyResult<Self> {
+        let options = decode_options(options_json)?;
+        let JsonLdSerializeMode::Context(context) = options.mode() else {
+            return Err(PyValueError::new_err(
+                "CompiledJsonLdContext requires JSON-LD options with mode `context`",
+            ));
+        };
+        Ok(Self {
+            inner: Arc::clone(context),
+        })
+    }
+
+    /// Compile a deterministic prefix map without constructing JSON in Python.
+    #[staticmethod]
+    fn from_prefixes(prefixes: BTreeMap<String, String>) -> PyResult<Self> {
+        let context = EngineContext::from_prefixes(prefixes)
+            .map_err(|error| PyValueError::new_err(error.to_string()))?;
+        Ok(Self {
+            inner: Arc::new(context),
+        })
+    }
+
+    /// Return the recursively canonicalized context document as JSON.
+    fn canonical_context_json(&self) -> PyResult<String> {
+        serde_json::to_string(self.inner.canonical_context())
+            .map_err(|error| PyValueError::new_err(error.to_string()))
+    }
+}
+
+/// Format-selecting configured JSON-LD/YAML-LD serializer.
+#[pyfunction]
+#[pyo3(signature = (data, *, format, output_format, options_json=None, context=None, yaml_schema_url=None))]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the Python API names each explicit serialization input"
+)]
+fn serialize_jsonld(
+    py: Python<'_>,
+    data: &Bound<'_, PyBytes>,
+    format: PyRdfFormat,
+    output_format: &str,
+    options_json: Option<&str>,
+    context: Option<&PyCompiledJsonLdContext>,
+    yaml_schema_url: Option<&str>,
+) -> PyResult<String> {
+    let input = data.as_bytes().to_vec();
+    let options = options_from_inputs(options_json, context, yaml_schema_url)?;
+    py.detach(|| {
+        let dataset = parse_dataset(&input, format.to_native().media_type(), None)
+            .map_err(|error| PyValueError::new_err(error.to_string()))?;
+        serialize_frozen(&dataset, output_format, &options)
+    })
+}
+
+pub(crate) fn decode_options(options_json: &str) -> PyResult<JsonLdSerializeOptions> {
+    JsonLdSerializeOptions::from_json(options_json.as_bytes())
+        .map_err(|error| PyValueError::new_err(error.to_string()))
+}
+
+pub(crate) fn options_from_inputs(
+    options_json: Option<&str>,
+    context: Option<&PyCompiledJsonLdContext>,
+    yaml_schema_url: Option<&str>,
+) -> PyResult<JsonLdSerializeOptions> {
+    let mut options = match (options_json, context) {
+        (Some(_), Some(_)) => {
+            return Err(PyValueError::new_err(
+                "provide exactly one of options_json or context",
+            ));
+        }
+        (Some(json), None) => decode_options(json)?,
+        (None, Some(context)) => JsonLdSerializeOptions::compiled(Arc::clone(&context.inner)),
+        (None, None) => {
+            return Err(PyValueError::new_err(
+                "configured JSON-LD serialization requires options_json or context",
+            ));
+        }
+    };
+    if let Some(schema_url) = yaml_schema_url {
+        options = options
+            .with_yaml_schema_url(schema_url)
+            .map_err(|error| PyValueError::new_err(error.to_string()))?;
+    }
+    Ok(options)
+}
+
+pub(crate) fn serialize_frozen(
+    dataset: &RdfDataset,
+    output_format: &str,
+    options: &JsonLdSerializeOptions,
+) -> PyResult<String> {
+    let format =
+        classify(output_format).map_err(|error| PyValueError::new_err(error.to_string()))?;
+    let outcome = serialize_dataset_to_format_with_jsonld_options(dataset, format, None, options)
+        .map_err(|error| PyValueError::new_err(error.to_string()))?;
+    String::from_utf8(outcome.bytes).map_err(|error| {
+        PyValueError::new_err(format!("serialization produced non-UTF-8: {error}"))
+    })
+}
+
+pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<PyCompiledJsonLdContext>()?;
+    module.add_function(wrap_pyfunction!(serialize_jsonld, module)?)?;
+    Ok(())
+}

--- a/bindings/python/src/py_store/io.rs
+++ b/bindings/python/src/py_store/io.rs
@@ -43,6 +43,8 @@ pub(crate) enum PyRdfFormat {
     TRIG,
     TRIX,
     HEXTUPLES,
+    JSON_LD,
+    YAML_LD,
 }
 
 impl PyRdfFormat {
@@ -56,6 +58,8 @@ impl PyRdfFormat {
             Self::TRIG => NativeRdfFormat::TriG,
             Self::TRIX => NativeRdfFormat::TriX,
             Self::HEXTUPLES => NativeRdfFormat::HexTuples,
+            Self::JSON_LD => NativeRdfFormat::JsonLd,
+            Self::YAML_LD => NativeRdfFormat::YamlLd,
         }
     }
 }
@@ -297,5 +301,7 @@ mod tests {
             PyRdfFormat::HEXTUPLES.to_native(),
             NativeRdfFormat::HexTuples
         );
+        assert_eq!(PyRdfFormat::JSON_LD.to_native(), NativeRdfFormat::JsonLd);
+        assert_eq!(PyRdfFormat::YAML_LD.to_native(), NativeRdfFormat::YamlLd);
     }
 }

--- a/bindings/python/src/py_store/mutable.rs
+++ b/bindings/python/src/py_store/mutable.rs
@@ -16,9 +16,11 @@ use super::io::{PyRdfFormat, dataset_from_quads_verbatim, parse_quads, read_inpu
 use super::query::{build_engine, materialize_results};
 use super::store::PyQuadIter;
 use super::term::{PyQuad, PyVariable, extract_graph_name, extract_term};
+use crate::py_jsonld::{PyCompiledJsonLdContext, options_from_inputs};
 use crate::{
     BlankScope, DatasetMut, GraphMatchValue, RdfDatasetBuilder, RdfLiteral, RdfQuad, RdfTerm,
     RdfTriple, SerializeGraph, SparqlEngine, SparqlRequest, TermValue, serialize_dataset,
+    serialize_dataset_with_jsonld_options,
 };
 
 const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
@@ -123,13 +125,20 @@ impl PyMutableDataset {
     }
 
     /// Dump the effective dataset (or one graph) in `format`.
-    #[pyo3(signature = (output=None, format=None, *, from_graph=None))]
+    #[pyo3(signature = (output=None, format=None, *, from_graph=None, jsonld_options=None, jsonld_context=None, yaml_schema_url=None))]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "Python dump names graph selection and JSON-LD configuration explicitly"
+    )]
     fn dump(
         &self,
         py: Python<'_>,
         output: Option<&Bound<'_, PyAny>>,
         format: Option<PyRdfFormat>,
         from_graph: Option<&Bound<'_, PyAny>>,
+        jsonld_options: Option<&str>,
+        jsonld_context: Option<&PyCompiledJsonLdContext>,
+        yaml_schema_url: Option<&str>,
     ) -> PyResult<Option<Py<PyBytes>>> {
         let format = format.ok_or_else(|| PyValueError::new_err("dump: format is required"))?;
         let native = format.to_native();
@@ -139,6 +148,16 @@ impl PyMutableDataset {
             None => None,
         };
         let explicit_from_graph = from_graph.is_some();
+        let configured =
+            if jsonld_options.is_some() || jsonld_context.is_some() || yaml_schema_url.is_some() {
+                Some(options_from_inputs(
+                    jsonld_options,
+                    jsonld_context,
+                    yaml_schema_url,
+                )?)
+            } else {
+                None
+            };
         let inner = &self.inner;
         // Materialize the effective set into the IR verbatim, then serialize through
         // the native codec — literal lexical forms are preserved. Both steps
@@ -157,8 +176,18 @@ impl PyMutableDataset {
                 (None, false) if native.supports_datasets() => SerializeGraph::Dataset,
                 (None, false) => SerializeGraph::DefaultGraph,
             };
-            serialize_dataset(&dataset, native.media_type(), selection)
+            if let Some(options) = &configured {
+                serialize_dataset_with_jsonld_options(
+                    &dataset,
+                    native.media_type(),
+                    selection,
+                    options,
+                )
                 .map_err(|e| PyValueError::new_err(format!("dump error: {e}")))
+            } else {
+                serialize_dataset(&dataset, native.media_type(), selection)
+                    .map_err(|e| PyValueError::new_err(format!("dump error: {e}")))
+            }
         })?;
         match output {
             Some(output) => {

--- a/bindings/python/src/py_store/store.rs
+++ b/bindings/python/src/py_store/store.rs
@@ -26,9 +26,11 @@ use super::canon::PyCanonicalizationAlgorithm;
 use super::io::{PyRdfFormat, dataset_from_quads_verbatim, parse_quads, read_input};
 use super::query::{build_engine, materialize_results};
 use super::term::{PyQuad, PyVariable, extract_graph_name, extract_term};
+use crate::py_jsonld::{PyCompiledJsonLdContext, options_from_inputs};
 use crate::{
     BlankScope, DatasetMut, GraphMatchValue, RdfDataset, RdfDatasetBuilder, RdfLiteral, RdfQuad,
     RdfTerm, RdfTriple, SerializeGraph, SparqlEngine, SparqlRequest, TermValue, serialize_dataset,
+    serialize_dataset_with_jsonld_options,
 };
 
 /// An in-memory RDF 1.2 quad store with SPARQL. Mirrors the oxigraph Python `Store`.
@@ -197,13 +199,20 @@ impl PyStore {
     /// the oxigraph Python `Store.dump`: when `output` (a file-like with `.write`) is given
     /// the bytes are written to it and `None` is returned; otherwise the bytes are
     /// returned directly.
-    #[pyo3(signature = (output=None, format=None, *, from_graph=None))]
+    #[pyo3(signature = (output=None, format=None, *, from_graph=None, jsonld_options=None, jsonld_context=None, yaml_schema_url=None))]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "Python dump names graph selection and JSON-LD configuration explicitly"
+    )]
     fn dump(
         &self,
         py: Python<'_>,
         output: Option<&Bound<'_, PyAny>>,
         format: Option<PyRdfFormat>,
         from_graph: Option<&Bound<'_, PyAny>>,
+        jsonld_options: Option<&str>,
+        jsonld_context: Option<&PyCompiledJsonLdContext>,
+        yaml_schema_url: Option<&str>,
     ) -> PyResult<Option<Py<PyBytes>>> {
         let format = format.ok_or_else(|| PyValueError::new_err("dump: format is required"))?;
         let native = format.to_native();
@@ -218,6 +227,16 @@ impl PyStore {
                 // default graph). Project its triples into the default graph.
                 Some(extract_graph_name(from_graph)?)
             };
+        let configured =
+            if jsonld_options.is_some() || jsonld_context.is_some() || yaml_schema_url.is_some() {
+                Some(options_from_inputs(
+                    jsonld_options,
+                    jsonld_context,
+                    yaml_schema_url,
+                )?)
+            } else {
+                None
+            };
         let buf: Vec<u8> = py.detach(|| {
             // Serialize natively: materialize the store's quads into the IR
             // verbatim (preserving literal lexical forms) and dispatch to the codec.
@@ -230,8 +249,18 @@ impl PyStore {
             };
             let dataset = dataset_from_quads_verbatim(&quads)
                 .map_err(|e| PyValueError::new_err(format!("dump error: {e}")))?;
-            serialize_dataset(&dataset, native.media_type(), selection)
+            if let Some(options) = &configured {
+                serialize_dataset_with_jsonld_options(
+                    &dataset,
+                    native.media_type(),
+                    selection,
+                    options,
+                )
                 .map_err(|e| PyValueError::new_err(format!("dump error: {e}")))
+            } else {
+                serialize_dataset(&dataset, native.media_type(), selection)
+                    .map_err(|e| PyValueError::new_err(format!("dump error: {e}")))
+            }
         })?;
         match output {
             Some(output) => {

--- a/bindings/python/src/rdf.rs
+++ b/bindings/python/src/rdf.rs
@@ -86,6 +86,7 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(loss_matrix_json, m)?)?;
     m.add_function(wrap_pyfunction!(rdf_gts_loss_matrix_json, m)?)?;
     m.add_function(wrap_pyfunction!(canonicalize_turtle, m)?)?;
+    crate::py_jsonld::register(m)?;
     // The native oxigraph Store / SPARQL / parse / canonicalize surface that
     // replaces the external `pyoxigraph` package.
     crate::py_store::register(m)?;

--- a/bindings/python/tests/test_jsonld_baseline.py
+++ b/bindings/python/tests/test_jsonld_baseline.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Byte-compatibility baseline for the Python JSON-LD codec surface."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import purrdf
+
+
+SOURCE = b'<https://example.org/alice> <https://schema.org/name> "Alice" .\n'
+EXPANDED = """{
+  "@context": {},
+  "@graph": [
+    {
+      "@id": "https://example.org/alice",
+      "https://schema.org/name": {
+        "@value": "Alice"
+      }
+    }
+  ]
+}"""
+
+
+def test_to_json_ld_expanded_bytes_are_frozen() -> None:
+    """The no-options Python helper remains the exact expanded compatibility route."""
+    assert purrdf.to_json_ld(SOURCE, format=purrdf.RdfFormat.N_QUADS) == EXPANDED
+
+
+def test_rdflib_graph_json_ld_expanded_bytes_are_frozen(compat: ModuleType) -> None:
+    """The RDFLib-compatible plugin reaches the same exact expanded Rust bytes."""
+    graph = compat.Graph()
+    graph.parse(data=SOURCE, format="nquads")
+    assert graph.serialize(format="json-ld") == EXPANDED

--- a/bindings/python/tests/test_jsonld_configured.py
+++ b/bindings/python/tests/test_jsonld_configured.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Configured JSON-LD/YAML-LD Python surfaces use the shared Rust context lens."""
+
+from __future__ import annotations
+
+import json
+from types import ModuleType
+
+import pytest
+
+import purrdf
+
+
+SOURCE = b'<https://example.org/alice> <https://schema.org/name> "Alice" .\n'
+PREFIX_OPTIONS = json.dumps(
+    {
+        "version": 1,
+        "mode": "context",
+        "prefixes": {
+            "ex": "https://example.org/",
+            "schema": "https://schema.org/",
+        },
+    },
+    sort_keys=True,
+    separators=(",", ":"),
+)
+
+
+def _assert_compacted(text: str) -> None:
+    document = json.loads(text)
+    assert document["@context"] == {
+        "ex": {"@id": "https://example.org/", "@prefix": True},
+        "schema": {"@id": "https://schema.org/", "@prefix": True},
+    }
+    assert document["@graph"][0]["@id"] == "ex:alice"
+    assert document["@graph"][0]["schema:name"] == {"@value": "Alice"}
+
+
+def test_direct_serializer_options_and_compiled_context_are_byte_identical() -> None:
+    """The versioned decoder and reusable handle reach one deterministic engine."""
+    direct = purrdf.serialize_jsonld(
+        SOURCE,
+        format=purrdf.RdfFormat.N_QUADS,
+        output_format="jsonld",
+        options_json=PREFIX_OPTIONS,
+    )
+    context = purrdf.CompiledJsonLdContext(PREFIX_OPTIONS)
+    reused = purrdf.serialize_jsonld(
+        SOURCE,
+        format=purrdf.RdfFormat.N_QUADS,
+        output_format="application/ld+json",
+        context=context,
+    )
+    assert direct == reused
+    _assert_compacted(direct)
+    assert json.loads(context.canonical_context_json()) == json.loads(direct)["@context"]
+
+
+def test_yaml_schema_and_immutable_dataset_surface() -> None:
+    """YAML-LD keeps the configured schema header and compiled-context bytes."""
+    context = purrdf.CompiledJsonLdContext.from_prefixes(
+        {"ex": "https://example.org/", "schema": "https://schema.org/"}
+    )
+    dataset = purrdf.RdfDataset(SOURCE, purrdf.RdfFormat.N_QUADS)
+    rendered = dataset.serialize_jsonld(
+        "yamlld",
+        context=context,
+        yaml_schema_url="https://example.org/purrdf.schema.json",
+    )
+    assert rendered.startswith(
+        "# yaml-language-server: $schema=https://example.org/purrdf.schema.json\n"
+    )
+    assert "ex:alice" in rendered
+    assert "schema:name" in rendered
+
+
+@pytest.mark.parametrize("store_type", [purrdf.Store, purrdf.MutableDataset])
+def test_store_surfaces_accept_reusable_context(store_type: type[object]) -> None:
+    """Both mutable store implementations accept the same immutable handle."""
+    store = store_type()
+    store.load(SOURCE, format=purrdf.RdfFormat.N_QUADS)
+    context = purrdf.CompiledJsonLdContext(PREFIX_OPTIONS)
+    rendered = store.dump(
+        format=purrdf.RdfFormat.JSON_LD,
+        jsonld_context=context,
+    )
+    assert isinstance(rendered, bytes)
+    _assert_compacted(rendered.decode())
+
+
+def test_rdflib_graph_bound_prefixes_are_an_explicit_context(
+    compat: ModuleType,
+) -> None:
+    """Caller-bound namespaces compact output without changing default bytes."""
+    graph = compat.Graph()
+    graph.parse(data=SOURCE, format="nquads")
+    graph.bind("ex", compat.Namespace("https://example.org/"))
+    graph.bind("schema", compat.Namespace("https://schema.org/"))
+    _assert_compacted(graph.serialize(format="json-ld"))
+
+
+def test_configured_inputs_are_closed_and_mutually_exclusive() -> None:
+    """Malformed, unknown, and conflicting inputs hard-fail before output."""
+    context = purrdf.CompiledJsonLdContext(PREFIX_OPTIONS)
+    with pytest.raises(ValueError, match="exactly one"):
+        purrdf.serialize_jsonld(
+            SOURCE,
+            format=purrdf.RdfFormat.N_QUADS,
+            output_format="jsonld",
+            options_json=PREFIX_OPTIONS,
+            context=context,
+        )
+    with pytest.raises(ValueError, match="unknown"):
+        purrdf.serialize_jsonld(
+            SOURCE,
+            format=purrdf.RdfFormat.N_QUADS,
+            output_format="jsonld",
+            options_json='{"version":1,"mode":"expanded","unknown":true}',
+        )
+    with pytest.raises(ValueError, match="requires JSON-LD options"):
+        purrdf.CompiledJsonLdContext('{"version":1,"mode":"derived"}')

--- a/bindings/python/tests/test_namespaces.py
+++ b/bindings/python/tests/test_namespaces.py
@@ -242,6 +242,19 @@ def test_parse_binds_jsonld_context_prefixes(compat: ModuleType) -> None:
     assert ("ex", "http://example.org/") in {(p, str(n)) for p, n in g.namespaces()}
 
 
+def test_parse_binds_expanded_jsonld_prefix_definitions(compat: ModuleType) -> None:
+    """Expanded ``@id``/``@prefix`` definitions are rebound on the graph."""
+    jsonld = (
+        '{"@context": {"ex": {"@id": "http://example.org/", "@prefix": true}}, '
+        '"@id": "ex:s", "ex:p": {"@id": "ex:o"}}'
+    )
+    graph = compat.Graph()
+    graph.parse(data=jsonld, format="json-ld")
+    assert ("ex", "http://example.org/") in {
+        (prefix, str(namespace)) for prefix, namespace in graph.namespaces()
+    }
+
+
 def test_parse_binds_rdfxml_xmlns_prefixes(compat: ModuleType) -> None:
     """RDF/XML ``xmlns:`` prefixes are recorded on the graph (rdflib parity)."""
     rdfxml = (

--- a/bindings/python/tests/test_namespaces.py
+++ b/bindings/python/tests/test_namespaces.py
@@ -131,6 +131,18 @@ def test_compute_qname_generates_ns_prefixes(
         assert (cp, cl) == (op, ol)
 
 
+def test_generated_qname_prefixes_are_not_caller_jsonld_context(
+    compat: ModuleType,
+) -> None:
+    """Internal qname aliases stay out of caller-controlled JSON-LD compaction."""
+    manager = _nsm(compat)
+    generated, _namespace, _local = manager.compute_qname(f"{EX}generated")
+    assert generated not in manager.jsonld_prefixes()
+
+    manager.bind("explicit", "http://explicit.example/")
+    assert manager.jsonld_prefixes() == {"explicit": "http://explicit.example/"}
+
+
 def test_qname_and_curie(compat: ModuleType, oracle: ModuleType) -> None:
     """``qname`` and ``curie`` render identical CURIEs for bound IRIs."""
     uri = "http://xmlns.com/foaf/0.1/knows"

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -60,6 +60,12 @@ pub(crate) struct Cli {
         require_equals = true
     )]
     pub(crate) loss_ledger: Option<Option<PathBuf>>,
+
+    /// Versioned JSON options document for configured JSON-LD/YAML-LD output.
+    /// The selected output must be JSON-LD or YAML-LD; otherwise the option is
+    /// rejected instead of ignored.
+    #[arg(long, global = true, value_name = "PATH")]
+    pub(crate) jsonld_options: Option<PathBuf>,
 }
 
 /// Where (if anywhere) the loss ledger should be surfaced — the decoded form of

--- a/crates/cli/src/convert.rs
+++ b/crates/cli/src/convert.rs
@@ -28,6 +28,7 @@ use std::sync::Arc;
 
 use purrdf_core::{DatasetView, LossLedger, RdfDataset, verify_pack};
 use purrdf_entail::materialize;
+use purrdf_rdf::JsonLdSerializeOptions;
 use purrdf_rdf::canonical_flat_nquads;
 
 use crate::cli::{CliRdfFormat, CliRegime, LedgerTarget};
@@ -45,13 +46,21 @@ struct ConvertOp<'a> {
     target: CliFormat,
     base: Option<&'a str>,
     src_codec: Option<&'a str>,
+    jsonld_options: Option<&'a JsonLdSerializeOptions>,
 }
 
 impl ViewOp for ConvertOp<'_> {
     type Output = LossLedger;
 
     fn run<D: DatasetView + Sync>(self, view: &D) -> Result<LossLedger, CliError> {
-        sink::write_rdf(view, self.out, self.target, self.base, self.src_codec)
+        sink::write_rdf(
+            view,
+            self.out,
+            self.target,
+            self.base,
+            self.src_codec,
+            self.jsonld_options,
+        )
     }
 }
 
@@ -69,6 +78,8 @@ pub(crate) struct ConvertOptions<'a> {
     pub(crate) entailment: Option<CliRegime>,
     /// Whether `--canonical` was set (emit RDFC-1.0 canonical N-Quads).
     pub(crate) canonical: bool,
+    /// Explicit JSON-LD/YAML-LD serialization configuration.
+    pub(crate) jsonld_options: Option<&'a JsonLdSerializeOptions>,
 }
 
 /// Run the `convert` subcommand.
@@ -79,6 +90,11 @@ pub(crate) fn run(
     ledger_target: &LedgerTarget,
 ) -> Result<(), CliError> {
     let source_format = format::resolve(options.from, input)?;
+    if options.canonical && options.jsonld_options.is_some() {
+        return Err(CliError::Usage(
+            "--jsonld-options cannot be combined with --canonical".to_owned(),
+        ));
+    }
 
     // The transform lane: either `--entailment` or `--canonical` needs a concrete
     // owned dataset, so reconstruct one and apply the transforms in order.
@@ -90,6 +106,7 @@ pub(crate) fn run(
     // pack is mmap-borrowed (no `Vec<u8>` copy of the pack contents); stdin has no
     // file to map, so it still buffers into a `Vec`.
     let target_format = format::resolve(options.to, output)?;
+    sink::validate_jsonld_options(target_format, options.jsonld_options)?;
     if matches!(source_format, CliFormat::Pack) && matches!(target_format, CliFormat::Pack) {
         if input == "-" {
             let bytes = source::read_bytes(input)?;
@@ -112,6 +129,7 @@ pub(crate) fn run(
             target: target_format,
             base: options.base,
             src_codec,
+            jsonld_options: options.jsonld_options,
         },
     )?;
     ledger::surface(ledger_target, &ledger)
@@ -127,6 +145,13 @@ fn run_with_transforms(
     output: &str,
     ledger_target: &LedgerTarget,
 ) -> Result<(), CliError> {
+    let target_format = if options.canonical {
+        None
+    } else {
+        let target = format::resolve(options.to, output)?;
+        sink::validate_jsonld_options(target, options.jsonld_options)?;
+        Some(target)
+    };
     let dataset = source::load_dataset(input, source_format, options.base)?;
 
     // Entail first: materialize the regime's closure (rejecting the
@@ -149,8 +174,15 @@ fn run_with_transforms(
     }
 
     // No `--canonical`: serialize the (possibly entailed) closure to `--to`.
-    let target_format = format::resolve(options.to, output)?;
+    let target_format = target_format.expect("non-canonical branch resolved a target format");
     let src_codec = source_format.loss_codec_name();
-    let ledger = sink::write_rdf(&*dataset, output, target_format, options.base, src_codec)?;
+    let ledger = sink::write_rdf(
+        &*dataset,
+        output,
+        target_format,
+        options.base,
+        src_codec,
+        options.jsonld_options,
+    )?;
     ledger::surface(ledger_target, &ledger)
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -31,8 +31,11 @@ mod reason;
 mod sink;
 mod source;
 
+use std::fs::File;
+use std::io::Read as _;
+
 use clap::Parser;
-use purrdf_rdf::JsonLdSerializeOptions;
+use purrdf_rdf::{JsonLdContextLimits, JsonLdSerializeOptions};
 
 use crate::cli::{Cli, Command};
 use crate::error::CliError;
@@ -53,7 +56,16 @@ fn dispatch(cli: &Cli) -> Result<(), CliError> {
         .jsonld_options
         .as_ref()
         .map(|path| {
-            let bytes = std::fs::read(path)?;
+            let limit = JsonLdContextLimits::default().max_options_bytes();
+            let mut bytes = Vec::new();
+            File::open(path)?
+                .take(u64::try_from(limit).expect("options byte limit fits u64") + 1)
+                .read_to_end(&mut bytes)?;
+            if bytes.len() > limit {
+                return Err(CliError::Runtime(format!(
+                    "JSON-LD options document exceeds the {limit}-byte limit"
+                )));
+            }
             JsonLdSerializeOptions::from_json(&bytes).map_err(CliError::from)
         })
         .transpose()?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -32,6 +32,7 @@ mod sink;
 mod source;
 
 use clap::Parser;
+use purrdf_rdf::JsonLdSerializeOptions;
 
 use crate::cli::{Cli, Command};
 use crate::error::CliError;
@@ -48,6 +49,14 @@ fn main() {
 /// `--loss-ledger` target through.
 fn dispatch(cli: &Cli) -> Result<(), CliError> {
     let ledger_target = cli.ledger_target();
+    let jsonld_options = cli
+        .jsonld_options
+        .as_ref()
+        .map(|path| {
+            let bytes = std::fs::read(path)?;
+            JsonLdSerializeOptions::from_json(&bytes).map_err(CliError::from)
+        })
+        .transpose()?;
     match &cli.cmd {
         Command::Convert {
             from,
@@ -64,6 +73,7 @@ fn dispatch(cli: &Cli) -> Result<(), CliError> {
                 base: base.as_deref(),
                 entailment: *entailment,
                 canonical: *canonical,
+                jsonld_options: jsonld_options.as_ref(),
             },
             input,
             output,
@@ -81,6 +91,7 @@ fn dispatch(cli: &Cli) -> Result<(), CliError> {
             *entailment,
             *results_format,
             query,
+            jsonld_options.as_ref(),
             &ledger_target,
         ),
         Command::Reason {
@@ -97,6 +108,7 @@ fn dispatch(cli: &Cli) -> Result<(), CliError> {
             base.as_deref(),
             input,
             output,
+            jsonld_options.as_ref(),
             &ledger_target,
         ),
         Command::Project {
@@ -113,6 +125,7 @@ fn dispatch(cli: &Cli) -> Result<(), CliError> {
             base.as_deref(),
             input,
             output,
+            jsonld_options.as_ref(),
             &ledger_target,
         ),
         Command::Lift {
@@ -129,6 +142,7 @@ fn dispatch(cli: &Cli) -> Result<(), CliError> {
             base.as_deref(),
             input,
             output,
+            jsonld_options.as_ref(),
             &ledger_target,
         ),
     }

--- a/crates/cli/src/projection.rs
+++ b/crates/cli/src/projection.rs
@@ -4,6 +4,7 @@
 //! `project` and `lift` graph, tabular, and research-object carrier pipelines.
 
 use purrdf_core::{DatasetView, LossLedger};
+use purrdf_rdf::JsonLdSerializeOptions;
 use purrdf_rdf::{ProjectionArchive, ProjectionConfig, lift_archive, project_archive};
 
 use crate::cli::{
@@ -44,8 +45,14 @@ pub(crate) fn run_project(
     base: Option<&str>,
     input: &str,
     output: &str,
+    jsonld_options: Option<&JsonLdSerializeOptions>,
     ledger_target: &LedgerTarget,
 ) -> Result<(), CliError> {
+    if jsonld_options.is_some() {
+        return Err(CliError::Usage(
+            "--jsonld-options cannot be used with projection carrier output".to_owned(),
+        ));
+    }
     let config = read_config(config_path, input)?;
     let source_format = format::resolve(from, input)?;
     let outcome = source::run_over_input(
@@ -73,8 +80,10 @@ pub(crate) fn run_lift(
     base: Option<&str>,
     input: &str,
     output: &str,
+    jsonld_options: Option<&JsonLdSerializeOptions>,
     ledger_target: &LedgerTarget,
 ) -> Result<(), CliError> {
+    sink::validate_jsonld_options(CliFormat::Rdf(to.to_native()), jsonld_options)?;
     let config = read_config(config_path, input)?;
     let archive = source::read_bytes(input)?;
     let mut outcome = lift_archive(&archive, profile.to_profile(), &config)?;
@@ -84,6 +93,7 @@ pub(crate) fn run_lift(
         CliFormat::Rdf(to.to_native()),
         base,
         None,
+        jsonld_options,
     )?;
     merge_ledger(&mut outcome.loss_ledger, &serialization_ledger);
     ledger::surface(ledger_target, &outcome.loss_ledger)

--- a/crates/cli/src/query.rs
+++ b/crates/cli/src/query.rs
@@ -34,6 +34,7 @@
 
 use purrdf_core::{DatasetView, LossLedger, SparqlResult};
 use purrdf_entail::materialize;
+use purrdf_rdf::JsonLdSerializeOptions;
 use purrdf_sparql_eval::{NativeSparqlEngine, PreparedQuery};
 use purrdf_sparql_results::{ResultProvenance, serialize};
 
@@ -70,10 +71,17 @@ fn emit_result(
     result: &SparqlResult,
     results_format: QueryFormat,
     base: Option<&str>,
+    jsonld_options: Option<&JsonLdSerializeOptions>,
     ledger_target: &LedgerTarget,
 ) -> Result<(), CliError> {
     match result {
         SparqlResult::Solutions { .. } | SparqlResult::Boolean(_) => {
+            if jsonld_options.is_some() {
+                return Err(CliError::Usage(
+                    "--jsonld-options requires an RDF graph result serialized as JSON-LD or YAML-LD"
+                        .to_owned(),
+                ));
+            }
             let Some(fmt) = results_format.to_results_format() else {
                 let kind = match result {
                     SparqlResult::Boolean(_) => "an ASK boolean",
@@ -106,7 +114,14 @@ fn emit_result(
             // projects the RDF-1.2 statement layer and records the drop in the ledger.
             // The graph is freshly constructed, so there is no source codec to seed the
             // contract-loss half (`None`); only the realized dropped-row counts appear.
-            let ledger = sink::write_rdf(&**graph, "-", CliFormat::Rdf(fmt), base, None)?;
+            let ledger = sink::write_rdf(
+                &**graph,
+                "-",
+                CliFormat::Rdf(fmt),
+                base,
+                None,
+                jsonld_options,
+            )?;
             ledger::surface(ledger_target, &ledger)
         }
     }
@@ -119,6 +134,7 @@ pub(crate) fn run(
     entailment: Option<CliRegime>,
     results_format: QueryFormat,
     query: &str,
+    jsonld_options: Option<&JsonLdSerializeOptions>,
     ledger_target: &LedgerTarget,
 ) -> Result<(), CliError> {
     let data_format = format::resolve(None, data)?;
@@ -147,5 +163,5 @@ pub(crate) fn run(
         )?,
     };
 
-    emit_result(&result, results_format, base, ledger_target)
+    emit_result(&result, results_format, base, jsonld_options, ledger_target)
 }

--- a/crates/cli/src/reason.rs
+++ b/crates/cli/src/reason.rs
@@ -15,6 +15,7 @@
 //! is surfaced under `--loss-ledger`.
 
 use purrdf_entail::{Regime, materialize};
+use purrdf_rdf::JsonLdSerializeOptions;
 
 use crate::cli::{CliRdfFormat, CliRegime, LedgerTarget};
 use crate::error::CliError;
@@ -51,6 +52,10 @@ pub(crate) fn resolve_materializable_regime(regime: CliRegime) -> Result<Regime,
 }
 
 /// Run the `reason` subcommand.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the CLI dispatcher passes the command fields and shared sink configuration explicitly"
+)]
 pub(crate) fn run(
     regime: CliRegime,
     from: Option<CliRdfFormat>,
@@ -58,6 +63,7 @@ pub(crate) fn run(
     base: Option<&str>,
     input: &str,
     output: &str,
+    jsonld_options: Option<&JsonLdSerializeOptions>,
     ledger_target: &LedgerTarget,
 ) -> Result<(), CliError> {
     let regime = resolve_materializable_regime(regime)?;
@@ -67,12 +73,20 @@ pub(crate) fn run(
     // expensive) load + materialize work has already run.
     let source_format = format::resolve(from, input)?;
     let target_format = format::resolve(to, output)?;
+    sink::validate_jsonld_options(target_format, jsonld_options)?;
 
     let dataset = source::load_dataset(input, source_format, base)?;
 
     let closure = materialize(&dataset, regime)?;
 
     let src_codec = source_format.loss_codec_name();
-    let ledger = sink::write_rdf(&*closure, output, target_format, base, src_codec)?;
+    let ledger = sink::write_rdf(
+        &*closure,
+        output,
+        target_format,
+        base,
+        src_codec,
+        jsonld_options,
+    )?;
     ledger::surface(ledger_target, &ledger)
 }

--- a/crates/cli/src/sink.rs
+++ b/crates/cli/src/sink.rs
@@ -23,7 +23,10 @@ use std::io::Write;
 use purrdf_core::{
     DatasetView, LossEntry, LossLedger, PackBuilder, dataset_from_view, pair_loss_ledger,
 };
-use purrdf_rdf::serialize_dataset_to_format;
+use purrdf_rdf::{
+    JsonLdSerializeOptions, NativeRdfFormat, serialize_dataset_to_format,
+    serialize_dataset_to_format_with_jsonld_options,
+};
 
 use crate::error::CliError;
 use crate::format::CliFormat;
@@ -70,10 +73,16 @@ pub(crate) fn write_rdf<D: DatasetView>(
     target: CliFormat,
     base: Option<&str>,
     src_codec: Option<&str>,
+    jsonld_options: Option<&JsonLdSerializeOptions>,
 ) -> Result<LossLedger, CliError> {
+    validate_jsonld_options(target, jsonld_options)?;
     match target {
         CliFormat::Rdf(format) => {
-            let outcome = serialize_dataset_to_format(view, format, base)?;
+            let outcome = if let Some(options) = jsonld_options {
+                serialize_dataset_to_format_with_jsonld_options(view, format, base, options)?
+            } else {
+                serialize_dataset_to_format(view, format, base)?
+            };
             write_out(out, &outcome.bytes)?;
             Ok(build_ledger(
                 src_codec,
@@ -90,6 +99,24 @@ pub(crate) fn write_rdf<D: DatasetView>(
             Ok(LossLedger::new())
         }
     }
+}
+
+/// Reject a JSON-LD options document unless the selected sink is JSON-LD/YAML-LD.
+pub(crate) fn validate_jsonld_options(
+    target: CliFormat,
+    options: Option<&JsonLdSerializeOptions>,
+) -> Result<(), CliError> {
+    if options.is_some()
+        && !matches!(
+            target,
+            CliFormat::Rdf(NativeRdfFormat::JsonLd | NativeRdfFormat::YamlLd)
+        )
+    {
+        return Err(CliError::Usage(
+            "--jsonld-options requires a JSON-LD or YAML-LD RDF output".to_owned(),
+        ));
+    }
+    Ok(())
 }
 
 /// Combine the contract losses for `(src_codec → dst_codec)` with the realized

--- a/crates/cli/tests/convert_cli.rs
+++ b/crates/cli/tests/convert_cli.rs
@@ -341,6 +341,224 @@ fn expanded_jsonld_and_yamlld_cli_bytes_are_frozen() {
     }
 }
 
+#[test]
+fn configured_jsonld_cli_modes_registry_yaml_and_errors_share_one_schema() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let input = write_file(
+        dir,
+        "configured.nq",
+        "<https://example.org/alice> <https://schema.org/name> \"Alice\" .\n",
+    );
+    let expanded = write_file(
+        dir,
+        "expanded-options.json",
+        r#"{"version":1,"mode":"expanded"}"#,
+    );
+    let registry = write_file(
+        dir,
+        "registry-options.json",
+        r#"{
+  "version": 1,
+  "mode": "context",
+  "context": "https://example.org/context",
+  "registry": {
+    "https://example.org/context": {
+      "@context": {
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "schema": {"@id": "https://schema.org/", "@prefix": true}
+      }
+    }
+  },
+  "yaml_schema_url": "https://example.org/purrdf.schema.json"
+}"#,
+    );
+    let prefixes = write_file(
+        dir,
+        "prefix-options.json",
+        r#"{
+  "version": 1,
+  "mode": "context",
+  "prefixes": {
+    "ex": "https://example.org/",
+    "schema": "https://schema.org/"
+  },
+  "yaml_schema_url": "https://example.org/purrdf.schema.json"
+}"#,
+    );
+    let derived = write_file(
+        dir,
+        "derived-options.json",
+        r#"{"version":1,"mode":"derived"}"#,
+    );
+
+    let legacy_path = path(dir, "legacy.jsonld");
+    let expanded_path = path(dir, "expanded.jsonld");
+    assert!(
+        run(&[
+            "convert",
+            "--from",
+            "nquads",
+            "--to",
+            "jsonld",
+            &input,
+            &legacy_path,
+        ])
+        .status
+        .success()
+    );
+    let explicit = run(&[
+        "--jsonld-options",
+        &expanded,
+        "convert",
+        "--from",
+        "nquads",
+        "--to",
+        "jsonld",
+        &input,
+        &expanded_path,
+    ]);
+    assert!(explicit.status.success(), "expanded: {}", stderr(&explicit));
+    assert_eq!(
+        std::fs::read(&legacy_path).expect("legacy output"),
+        std::fs::read(&expanded_path).expect("explicit output"),
+        "explicit expanded mode must preserve the compatibility bytes"
+    );
+
+    let compacted_path = path(dir, "compacted.jsonld");
+    let compacted = run(&[
+        "--jsonld-options",
+        &prefixes,
+        "convert",
+        "--from",
+        "nquads",
+        "--to",
+        "jsonld",
+        &input,
+        &compacted_path,
+    ]);
+    assert!(
+        compacted.status.success(),
+        "context: {}",
+        stderr(&compacted)
+    );
+    let compacted_text = std::fs::read_to_string(&compacted_path).expect("compacted output");
+    assert!(compacted_text.contains("schema:name"));
+    assert!(compacted_text.contains("ex:alice"));
+
+    let yaml_path = path(dir, "compacted.yamlld");
+    let yaml = run(&[
+        "--jsonld-options",
+        &prefixes,
+        "convert",
+        "--from",
+        "nquads",
+        "--to",
+        "yamlld",
+        &input,
+        &yaml_path,
+    ]);
+    assert!(yaml.status.success(), "YAML context: {}", stderr(&yaml));
+    assert!(
+        std::fs::read_to_string(&yaml_path)
+            .expect("YAML output")
+            .starts_with(
+                "# yaml-language-server: $schema=https://example.org/purrdf.schema.json\n"
+            )
+    );
+    assert_eq!(
+        canonical(dir, "jsonld", &compacted_path),
+        canonical(dir, "yamlld", &yaml_path),
+        "configured JSON-LD and YAML-LD must be semantically identical"
+    );
+
+    let registry_path = path(dir, "registry.jsonld");
+    let registry_result = run(&[
+        "--jsonld-options",
+        &registry,
+        "convert",
+        "--from",
+        "nquads",
+        "--to",
+        "jsonld",
+        &input,
+        &registry_path,
+    ]);
+    assert!(
+        registry_result.status.success(),
+        "registry: {}",
+        stderr(&registry_result)
+    );
+    assert!(
+        std::fs::read_to_string(registry_path)
+            .expect("registry output")
+            .contains(r#""@context": "https://example.org/context""#)
+    );
+
+    let mut repeated = String::new();
+    for index in 0..32 {
+        writeln!(
+            repeated,
+            "<https://example.org/resource/s{index}> <https://example.org/vocab/p{index}> <https://example.org/resource/o{index}> ."
+        )
+        .expect("fixture row");
+    }
+    let repeated_input = write_file(dir, "derived.nq", &repeated);
+    let derived_path = path(dir, "derived.jsonld");
+    let derived_result = run(&[
+        "--jsonld-options",
+        &derived,
+        "convert",
+        "--from",
+        "nquads",
+        "--to",
+        "jsonld",
+        &repeated_input,
+        &derived_path,
+    ]);
+    assert!(
+        derived_result.status.success(),
+        "derived: {}",
+        stderr(&derived_result)
+    );
+    let derived_text = std::fs::read_to_string(&derived_path).expect("derived output");
+    assert!(derived_text.contains("ns0:"));
+    assert!(!derived_text.contains("@vocab"));
+
+    let malformed = write_file(
+        dir,
+        "malformed-options.json",
+        r#"{"version":1,"mode":"expanded","unknown":true}"#,
+    );
+    let malformed_result = run(&[
+        "--jsonld-options",
+        &malformed,
+        "convert",
+        "--from",
+        "nquads",
+        "--to",
+        "jsonld",
+        &input,
+        &path(dir, "malformed.jsonld"),
+    ]);
+    assert_eq!(malformed_result.status.code(), Some(1));
+    assert!(stderr(&malformed_result).contains("unknown JSON-LD options member"));
+
+    let unused = run(&[
+        "--jsonld-options",
+        &expanded,
+        "convert",
+        "--from",
+        "nquads",
+        "--to",
+        "nquads",
+        &input,
+        &path(dir, "unused.nq"),
+    ]);
+    assert_eq!(unused.status.code(), Some(2));
+    assert!(stderr(&unused).contains("requires a JSON-LD or YAML-LD RDF output"));
+}
+
 /// SEED C to a `carries_star = false` target (RDF/XML, TriX, HexTuples) PROJECTS the
 /// statement layer: exit 0, base quad present, star layer gone, and the ledger records
 /// the dropped statement rows. (This is the real behavior; none of these fail-close in

--- a/crates/cli/tests/convert_cli.rs
+++ b/crates/cli/tests/convert_cli.rs
@@ -298,6 +298,49 @@ fn seed_c_statement_layer_roundtrips_star_capable_targets() {
     }
 }
 
+/// Freeze the CLI's no-options expanded JSON-LD/YAML-LD bytes before configurable
+/// context support is introduced.
+#[test]
+fn expanded_jsonld_and_yamlld_cli_bytes_are_frozen() {
+    const INPUT: &str = "<https://example.org/alice> <https://schema.org/name> \"Alice\" .\n";
+    const JSONLD: &str = r#"{
+  "@context": {},
+  "@graph": [
+    {
+      "@id": "https://example.org/alice",
+      "https://schema.org/name": {
+        "@value": "Alice"
+      }
+    }
+  ]
+}"#;
+    const YAMLLD: &str = concat!(
+        "# yaml-language-server: $schema=purrdf.schema.json\n",
+        "# The default reference is the bundled purrdf.schema.json; pass an explicit\n",
+        "# schema_url to point editors at a hosted copy.\n",
+        "'@context': {}\n",
+        "'@graph':\n",
+        "- '@id': https://example.org/alice\n",
+        "  https://schema.org/name:\n",
+        "    '@value': Alice\n",
+    );
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input = write_file(dir.path(), "baseline.nq", INPUT);
+    for (format, expected) in [("jsonld", JSONLD), ("yamlld", YAMLLD)] {
+        let output = path(dir.path(), &format!("baseline.{format}"));
+        let result = run(&[
+            "convert", "--from", "nquads", "--to", format, &input, &output,
+        ]);
+        assert!(result.status.success(), "{format}: {}", stderr(&result));
+        assert_eq!(
+            std::fs::read_to_string(output).expect("read baseline output"),
+            expected,
+            "expanded {format} bytes changed"
+        );
+    }
+}
+
 /// SEED C to a `carries_star = false` target (RDF/XML, TriX, HexTuples) PROJECTS the
 /// statement layer: exit 0, base quad present, star layer gone, and the ledger records
 /// the dropped statement rows. (This is the real behavior; none of these fail-close in

--- a/crates/cli/tests/convert_cli.rs
+++ b/crates/cli/tests/convert_cli.rs
@@ -51,6 +51,8 @@ use std::io::Write as _;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
 
+use purrdf_rdf::JsonLdContextLimits;
+
 /// The nine native RDF syntaxes, by their `--from`/`--to` token. Every format appears
 /// as BOTH a source and a destination in the matrix.
 const FORMATS: [&str; 9] = [
@@ -557,6 +559,33 @@ fn configured_jsonld_cli_modes_registry_yaml_and_errors_share_one_schema() {
     ]);
     assert_eq!(unused.status.code(), Some(2));
     assert!(stderr(&unused).contains("requires a JSON-LD or YAML-LD RDF output"));
+}
+
+#[test]
+fn jsonld_options_file_is_rejected_at_the_shared_byte_ceiling() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input = write_file(dir.path(), "input.nq", SEED_A);
+    let options = path(dir.path(), "oversized-options.json");
+    let limit = JsonLdContextLimits::default().max_options_bytes();
+    std::fs::write(&options, vec![b' '; limit + 1]).expect("write oversized options");
+
+    let result = run(&[
+        "--jsonld-options",
+        &options,
+        "convert",
+        "--from",
+        "nquads",
+        "--to",
+        "jsonld",
+        &input,
+        &path(dir.path(), "output.jsonld"),
+    ]);
+    assert_eq!(result.status.code(), Some(1));
+    assert!(
+        stderr(&result).contains(&format!("exceeds the {limit}-byte limit")),
+        "{}",
+        stderr(&result)
+    );
 }
 
 /// SEED C to a `carries_star = false` target (RDF/XML, TriX, HexTuples) PROJECTS the

--- a/crates/cli/tests/projection_cli.rs
+++ b/crates/cli/tests/projection_cli.rs
@@ -215,6 +215,68 @@ fn stdin_stdout_paths_keep_binary_and_rdf_streams_clean() {
 }
 
 #[test]
+fn configured_jsonld_options_reach_lift_and_are_rejected_by_project() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = write(&dir.path().join("config.json"), lpg_config());
+    let options = write(
+        &dir.path().join("jsonld-options.json"),
+        br#"{"version":1,"mode":"context","prefixes":{"ex":"https://example.org/"}}"#,
+    );
+    let archive = dir.path().join("graph.tar");
+    let archive_path = archive.to_str().expect("archive path");
+    let input = write(&dir.path().join("input.ttl"), TURTLE);
+    let projected = run(&[
+        "project",
+        "--profile",
+        "lpg-csv",
+        "--config",
+        &config,
+        &input,
+        archive_path,
+    ]);
+    assert!(projected.status.success());
+
+    let lifted = run(&[
+        "--jsonld-options",
+        &options,
+        "lift",
+        "--profile",
+        "lpg-csv",
+        "--config",
+        &config,
+        "--to",
+        "jsonld",
+        archive_path,
+        "-",
+    ]);
+    assert!(
+        lifted.status.success(),
+        "lift: {}",
+        String::from_utf8_lossy(&lifted.stderr)
+    );
+    let json = String::from_utf8(lifted.stdout).expect("JSON-LD");
+    assert!(json.contains("ex:s"));
+    assert!(json.contains("ex:p"));
+
+    let rejected = run(&[
+        "--jsonld-options",
+        &options,
+        "project",
+        "--profile",
+        "lpg-csv",
+        "--config",
+        &config,
+        &input,
+        archive_path,
+    ]);
+    assert_eq!(rejected.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&rejected.stderr)
+            .contains("cannot be used with projection carrier output")
+    );
+}
+
+#[test]
 fn malformed_config_archive_and_double_stdin_fail_closed() {
     let dir = tempfile::tempdir().expect("tempdir");
     let input = write(&dir.path().join("input.ttl"), TURTLE);

--- a/crates/cli/tests/query_cli.rs
+++ b/crates/cli/tests/query_cli.rs
@@ -519,3 +519,41 @@ fn select_writes_results_to_a_captured_stdout_pipe() {
         stdout(&out)
     );
 }
+
+#[test]
+fn configured_jsonld_options_reach_graph_results_and_reject_select_results() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let ttl = write_file(dir, "data.ttl", DATA_TTL);
+    let options = write_file(
+        dir,
+        "jsonld-options.json",
+        r#"{"version":1,"mode":"context","prefixes":{"ex":"http://example.org/"}}"#,
+    );
+    let graph = run(&[
+        "--jsonld-options",
+        &options,
+        "query",
+        "--data",
+        &ttl,
+        "--results-format",
+        "jsonld",
+        "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }",
+    ]);
+    assert!(graph.status.success(), "graph: {}", stderr(&graph));
+    assert!(stdout(&graph).contains("ex:alice"));
+    assert!(stdout(&graph).contains("ex:knows"));
+
+    let select = run(&[
+        "--jsonld-options",
+        &options,
+        "query",
+        "--data",
+        &ttl,
+        "--results-format",
+        "json",
+        "SELECT ?s WHERE { ?s ?p ?o }",
+    ]);
+    assert_eq!(select.status.code(), Some(2));
+    assert!(stderr(&select).contains("requires an RDF graph result"));
+}

--- a/crates/cli/tests/reason_cli.rs
+++ b/crates/cli/tests/reason_cli.rs
@@ -512,3 +512,37 @@ fn pack_output_is_a_valid_pack_carrying_the_inference() {
         "the closure pack must carry the inferred `ex:rex a ex:Animal`; got: {text}"
     );
 }
+
+#[test]
+fn configured_jsonld_options_reach_reason_output() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = dir.path();
+    let seed = write_file(
+        dir,
+        "configured.nt",
+        "<http://example.org/a> <http://example.org/knows> <http://example.org/b> .\n",
+    );
+    let options = write_file(
+        dir,
+        "jsonld-options.json",
+        r#"{"version":1,"mode":"context","prefixes":{"ex":"http://example.org/"}}"#,
+    );
+    let output = path(dir, "closure.jsonld");
+    let result = run(&[
+        "--jsonld-options",
+        &options,
+        "reason",
+        "--regime",
+        "simple",
+        "--from",
+        "ntriples",
+        "--to",
+        "jsonld",
+        &seed,
+        &output,
+    ]);
+    assert!(result.status.success(), "reason: {}", stderr(&result));
+    let text = std::fs::read_to_string(output).expect("configured output");
+    assert!(text.contains("ex:a"));
+    assert!(text.contains("ex:knows"));
+}

--- a/crates/purrdf/src/lib.rs
+++ b/crates/purrdf/src/lib.rs
@@ -349,4 +349,20 @@ mod tests {
         assert_eq!(ns.compact_iri("https://example.org/vocab/Cat"), "vocab:Cat");
         assert!(smv.statement_metadata.ends_with("StatementMetadata"));
     }
+
+    #[test]
+    fn facade_exposes_configured_jsonld_serialization() {
+        let dataset = RdfDatasetBuilder::new().freeze().expect("empty dataset");
+        let options = JsonLdSerializeOptions::expanded();
+        let direct = serialize_dataset_to_jsonld_with_options(&dataset, &options)
+            .expect("configured JSON-LD through umbrella facade");
+        let generic = serialize_dataset_to_format_with_jsonld_options(
+            &dataset,
+            NativeRdfFormat::JsonLd,
+            None,
+            &options,
+        )
+        .expect("generic configured JSON-LD through umbrella facade");
+        assert_eq!(direct.as_bytes(), generic.bytes);
+    }
 }

--- a/crates/rdf-capi/README.md
+++ b/crates/rdf-capi/README.md
@@ -31,6 +31,19 @@ make capi-header                # regenerate the committed include/purrdf.h afte
 The committed header `include/purrdf.h` **is the ABI contract**; CI fails if it
 drifts from the crate (`make capi-check`).
 
+## Configured JSON-LD and YAML-LD
+
+`purrdf_jsonld_context_compile` decodes the shared versioned options document
+and returns an immutable, thread-safe `PurrdfJsonLdContext`. Reuse that handle
+with `purrdf_serialize_jsonld_configured`, then free it with
+`purrdf_jsonld_context_free`. The serializer accepts exactly one options byte
+slice or compiled handle and preserves an optional caller YAML schema URL.
+
+The three modes are explicit: byte-frozen `expanded`, caller-owned `context`,
+and deterministic dataset-IRI `derived`. Context IRI and `@import` resolution is
+restricted to the immutable registry in the options document; libpurrdf never
+performs network context loading.
+
 ## Graph, tabular, and research-object projection carriers
 
 `purrdf_project` and `purrdf_lift` expose the same canonical archive engine as
@@ -122,6 +135,7 @@ executes that example against the generated shared library and committed header.
 | Handle | Safety |
 |--------|--------|
 | `PurrdfDataset` | `Send + Sync` — frozen; may be read concurrently from many threads |
+| `PurrdfJsonLdContext` | `Send + Sync` — immutable compiled context; may be reused concurrently |
 | `PurrdfGraph` | single-threaded mutable (COW delta); external locking required to share |
 | `PurrdfCursor` / `PurrdfRowCursor` | single-threaded |
 | `PurrdfBuffer` / `PurrdfError` | immutable once returned; read from any thread, free once |

--- a/crates/rdf-capi/include/purrdf.h
+++ b/crates/rdf-capi/include/purrdf.h
@@ -243,6 +243,12 @@ typedef struct PurrdfError PurrdfError;
 typedef struct PurrdfGraph PurrdfGraph;
 
 /**
+ * An immutable compiled JSON-LD context. Release with
+ * `purrdf_jsonld_context_free`; the handle is safe for concurrent reads.
+ */
+typedef struct PurrdfJsonLdContext PurrdfJsonLdContext;
+
+/**
  * A SPARQL SELECT result cursor. Owns its variable names and solution rows
  * (dataset-independent `TermValue`s).
  *
@@ -757,6 +763,47 @@ int32_t purrdf_rowcursor_term(const PurrdfRowCursor *rc,
  * `rc` must be null or a live row cursor not already freed.
  */
 void purrdf_rowcursor_free(PurrdfRowCursor *rc);
+
+/**
+ * Compile a reusable context from a versioned JSON-LD options document.
+ *
+ * # Safety
+ * `options_json` must point to `options_len` readable bytes; the output pointers
+ * must be writable. On success, free `*out_context` with
+ * `purrdf_jsonld_context_free`.
+ */
+int32_t purrdf_jsonld_context_compile(const uint8_t *options_json,
+                                      size_t options_len,
+                                      PurrdfJsonLdContext **out_context,
+                                      PurrdfError **out_error);
+
+/**
+ * Release a compiled JSON-LD context handle. No-op on null.
+ *
+ * # Safety
+ * `context` must be null or a live handle not already freed.
+ */
+void purrdf_jsonld_context_free(PurrdfJsonLdContext *context);
+
+/**
+ * Serialize JSON-LD or YAML-LD with exactly one versioned options document or
+ * reusable compiled context. `yaml_schema_url` may be null and overrides the
+ * options document for YAML-LD when supplied.
+ *
+ * # Safety
+ * `dataset` and `media_type` must be live/non-null. If `options_json` is not
+ * null it points to `options_len` readable bytes and `context` must be null; if
+ * `options_json` is null, `options_len` must be zero and `context` must be live.
+ * Output pointers must be writable.
+ */
+int32_t purrdf_serialize_jsonld_configured(const PurrdfDataset *dataset,
+                                           const char *media_type,
+                                           const uint8_t *options_json,
+                                           size_t options_len,
+                                           const PurrdfJsonLdContext *context,
+                                           const char *yaml_schema_url,
+                                           PurrdfBuffer **out_buffer,
+                                           PurrdfError **out_error);
 
 /**
  * Serialize the frozen dataset to `media_type` (e.g. `"text/turtle"`,

--- a/crates/rdf-capi/src/serialize.rs
+++ b/crates/rdf-capi/src/serialize.rs
@@ -5,14 +5,154 @@
 //! the RDF-1.2 statement-layer loss count surfaced (MAXIMAL INFORMATION FLOW).
 
 use std::os::raw::c_char;
+use std::sync::Arc;
 
-use purrdf_rs::{classify, serialize_dataset_to_format};
+use purrdf_rs::{
+    CompiledJsonLdContext, JsonLdSerializeMode, JsonLdSerializeOptions, classify,
+    serialize_dataset_to_format, serialize_dataset_to_format_with_jsonld_options,
+};
 
 use crate::buffer::PurrdfBuffer;
 use crate::error::PurrdfError;
 use crate::handles::PurrdfDataset;
 use crate::status::PurrdfStatus;
 use crate::{cstr_to_str, opt_cstr_to_str};
+
+/// An immutable compiled JSON-LD context. Release with
+/// `purrdf_jsonld_context_free`; the handle is safe for concurrent reads.
+#[derive(Debug)]
+pub struct PurrdfJsonLdContext(Arc<CompiledJsonLdContext>);
+
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<PurrdfJsonLdContext>();
+};
+
+/// Compile a reusable context from a versioned JSON-LD options document.
+///
+/// # Safety
+/// `options_json` must point to `options_len` readable bytes; the output pointers
+/// must be writable. On success, free `*out_context` with
+/// `purrdf_jsonld_context_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn purrdf_jsonld_context_compile(
+    options_json: *const u8,
+    options_len: usize,
+    out_context: *mut *mut PurrdfJsonLdContext,
+    out_error: *mut *mut PurrdfError,
+) -> i32 {
+    unsafe {
+        ffi_try!(out_error, {
+            if options_json.is_null() || out_context.is_null() {
+                return Err(PurrdfError::new(
+                    PurrdfStatus::NullPointer,
+                    "null pointer argument to purrdf_jsonld_context_compile",
+                ));
+            }
+            let json = std::slice::from_raw_parts(options_json, options_len);
+            let options = decode_options(json)?;
+            let JsonLdSerializeMode::Context(context) = options.mode() else {
+                return Err(PurrdfError::new(
+                    PurrdfStatus::SerializeError,
+                    "compiled JSON-LD context requires options mode `context`",
+                ));
+            };
+            *out_context = Box::into_raw(Box::new(PurrdfJsonLdContext(Arc::clone(context))));
+            Ok(PurrdfStatus::Ok)
+        })
+    }
+}
+
+/// Release a compiled JSON-LD context handle. No-op on null.
+///
+/// # Safety
+/// `context` must be null or a live handle not already freed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn purrdf_jsonld_context_free(context: *mut PurrdfJsonLdContext) {
+    unsafe {
+        ffi_guard!((), {
+            if !context.is_null() {
+                drop(Box::from_raw(context));
+            }
+        });
+    }
+}
+
+/// Serialize JSON-LD or YAML-LD with exactly one versioned options document or
+/// reusable compiled context. `yaml_schema_url` may be null and overrides the
+/// options document for YAML-LD when supplied.
+///
+/// # Safety
+/// `dataset` and `media_type` must be live/non-null. If `options_json` is not
+/// null it points to `options_len` readable bytes and `context` must be null; if
+/// `options_json` is null, `options_len` must be zero and `context` must be live.
+/// Output pointers must be writable.
+#[unsafe(no_mangle)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the C ABI names each pointer, length, configuration, and output explicitly"
+)]
+pub unsafe extern "C" fn purrdf_serialize_jsonld_configured(
+    dataset: *const PurrdfDataset,
+    media_type: *const c_char,
+    options_json: *const u8,
+    options_len: usize,
+    context: *const PurrdfJsonLdContext,
+    yaml_schema_url: *const c_char,
+    out_buffer: *mut *mut PurrdfBuffer,
+    out_error: *mut *mut PurrdfError,
+) -> i32 {
+    unsafe {
+        ffi_try!(out_error, {
+            if dataset.is_null() || media_type.is_null() || out_buffer.is_null() {
+                return Err(PurrdfError::new(
+                    PurrdfStatus::NullPointer,
+                    "null required pointer argument to purrdf_serialize_jsonld_configured",
+                ));
+            }
+            let mut options = match (options_json.is_null(), context.is_null()) {
+                (false, true) => {
+                    decode_options(std::slice::from_raw_parts(options_json, options_len))?
+                }
+                (true, false) if options_len == 0 => {
+                    JsonLdSerializeOptions::compiled(Arc::clone(&(*context).0))
+                }
+                _ => {
+                    return Err(PurrdfError::new(
+                        PurrdfStatus::SerializeError,
+                        "provide exactly one of options_json or context",
+                    ));
+                }
+            };
+            if let Some(url) = opt_cstr_to_str(yaml_schema_url)? {
+                options = options.with_yaml_schema_url(url).map_err(|diagnostic| {
+                    PurrdfError::from_diagnostic(PurrdfStatus::SerializeError, &diagnostic)
+                })?;
+            }
+            let media = cstr_to_str(media_type)?;
+            let format = classify(media).map_err(|diagnostic| {
+                PurrdfError::from_diagnostic(PurrdfStatus::UnsupportedFormat, &diagnostic)
+            })?;
+            let outcome = serialize_dataset_to_format_with_jsonld_options(
+                PurrdfDataset::dataset(dataset),
+                format,
+                None,
+                &options,
+            )
+            .map_err(|diagnostic| {
+                PurrdfError::from_diagnostic(PurrdfStatus::SerializeError, &diagnostic)
+            })?;
+            *out_buffer = PurrdfBuffer::into_raw(outcome.bytes);
+            Ok(PurrdfStatus::Ok)
+        })
+    }
+}
+
+fn decode_options(json: &[u8]) -> Result<JsonLdSerializeOptions, PurrdfError> {
+    JsonLdSerializeOptions::from_json(json).map_err(|diagnostic| {
+        PurrdfError::from_diagnostic(PurrdfStatus::SerializeError, &diagnostic)
+    })
+}
 
 /// Serialize the frozen dataset to `media_type` (e.g. `"text/turtle"`,
 /// `"application/n-quads"`). `base_iri` may be null. The output bytes go to

--- a/crates/rdf-capi/tests/abi.rs
+++ b/crates/rdf-capi/tests/abi.rs
@@ -443,6 +443,59 @@ fn serialize_round_trips_through_ntriples() {
 }
 
 #[test]
+fn expanded_jsonld_and_yamlld_abi_bytes_are_frozen() {
+    const INPUT: &str = "<https://example.org/alice> <https://schema.org/name> \"Alice\" .";
+    const JSONLD: &str = r#"{
+  "@context": {},
+  "@graph": [
+    {
+      "@id": "https://example.org/alice",
+      "https://schema.org/name": {
+        "@value": "Alice"
+      }
+    }
+  ]
+}"#;
+    const YAMLLD: &str = concat!(
+        "# yaml-language-server: $schema=purrdf.schema.json\n",
+        "# The default reference is the bundled purrdf.schema.json; pass an explicit\n",
+        "# schema_url to point editors at a hosted copy.\n",
+        "'@context': {}\n",
+        "'@graph':\n",
+        "- '@id': https://example.org/alice\n",
+        "  https://schema.org/name:\n",
+        "    '@value': Alice\n",
+    );
+
+    unsafe {
+        let dataset = parse("text/turtle", INPUT);
+        for (media_type, expected) in [
+            ("application/ld+json", JSONLD),
+            ("application/ld+yaml", YAMLLD),
+        ] {
+            let media = CString::new(media_type).unwrap();
+            let mut buffer: *mut PurrdfBuffer = std::ptr::null_mut();
+            let mut dropped = usize::MAX;
+            let mut error: *mut PurrdfError = std::ptr::null_mut();
+            let status = purrdf_serialize(
+                dataset,
+                media.as_ptr(),
+                std::ptr::null(),
+                &raw mut buffer,
+                &raw mut dropped,
+                &raw mut error,
+            );
+            assert_eq!(status, PurrdfStatus::Ok as i32);
+            assert!(error.is_null());
+            assert_eq!(dropped, 0);
+            assert_eq!(buffer_bytes(buffer), expected.as_bytes());
+            purrdf_buffer_free(buffer);
+        }
+        purrdf_dataset_free(dataset);
+    }
+}
+
+#[test]
 fn parse_rejects_malformed_turtle_without_aborting() {
     unsafe {
         let media = CString::new("text/turtle").unwrap();

--- a/crates/rdf-capi/tests/abi.rs
+++ b/crates/rdf-capi/tests/abi.rs
@@ -28,7 +28,10 @@ use purrdf::rowcursor::{
     PurrdfRowCursor, purrdf_rowcursor_free, purrdf_rowcursor_next, purrdf_rowcursor_term,
     purrdf_rowcursor_variable_count, purrdf_rowcursor_variable_name,
 };
-use purrdf::serialize::purrdf_serialize;
+use purrdf::serialize::{
+    PurrdfJsonLdContext, purrdf_jsonld_context_compile, purrdf_jsonld_context_free,
+    purrdf_serialize, purrdf_serialize_jsonld_configured,
+};
 use purrdf::status::{PurrdfAbiVersion, PurrdfCapabilities, PurrdfStatus};
 use purrdf::term::{
     PurrdfGraphMatch, PurrdfGraphMatchKind, PurrdfStr, PurrdfTermKind, PurrdfTermView,
@@ -491,6 +494,90 @@ fn expanded_jsonld_and_yamlld_abi_bytes_are_frozen() {
             assert_eq!(buffer_bytes(buffer), expected.as_bytes());
             purrdf_buffer_free(buffer);
         }
+        purrdf_dataset_free(dataset);
+    }
+}
+
+#[test]
+fn configured_jsonld_context_handle_reuses_bytes_and_preserves_yaml_schema() {
+    const INPUT: &str = "<https://example.org/alice> <https://schema.org/name> \"Alice\" .";
+    const OPTIONS: &str = r#"{"version":1,"mode":"context","prefixes":{"ex":"https://example.org/","schema":"https://schema.org/"}}"#;
+    unsafe {
+        let dataset = parse("text/turtle", INPUT);
+        let mut context: *mut PurrdfJsonLdContext = std::ptr::null_mut();
+        let mut error: *mut PurrdfError = std::ptr::null_mut();
+        assert_eq!(
+            purrdf_jsonld_context_compile(
+                OPTIONS.as_ptr(),
+                OPTIONS.len(),
+                &raw mut context,
+                &raw mut error,
+            ),
+            PurrdfStatus::Ok as i32
+        );
+        assert!(!context.is_null());
+        assert!(error.is_null());
+
+        for (media_type, schema) in [
+            ("application/ld+json", None),
+            (
+                "application/ld+yaml",
+                Some("https://example.org/purrdf.schema.json"),
+            ),
+        ] {
+            let media = CString::new(media_type).unwrap();
+            let schema = schema.map(|value| CString::new(value).unwrap());
+            let mut buffer: *mut PurrdfBuffer = std::ptr::null_mut();
+            assert_eq!(
+                purrdf_serialize_jsonld_configured(
+                    dataset,
+                    media.as_ptr(),
+                    std::ptr::null(),
+                    0,
+                    context,
+                    schema
+                        .as_ref()
+                        .map_or(std::ptr::null(), |value| value.as_ptr()),
+                    &raw mut buffer,
+                    &raw mut error,
+                ),
+                PurrdfStatus::Ok as i32
+            );
+            let text = String::from_utf8(buffer_bytes(buffer)).unwrap();
+            assert!(text.contains("ex:alice"));
+            assert!(text.contains("schema:name"));
+            if let Some(schema) = schema {
+                assert!(text.starts_with(&format!(
+                    "# yaml-language-server: $schema={}\n",
+                    schema.to_str().unwrap()
+                )));
+            }
+            purrdf_buffer_free(buffer);
+        }
+
+        let media = CString::new("application/ld+json").unwrap();
+        let mut buffer: *mut PurrdfBuffer = std::ptr::null_mut();
+        assert_eq!(
+            purrdf_serialize_jsonld_configured(
+                dataset,
+                media.as_ptr(),
+                OPTIONS.as_ptr(),
+                OPTIONS.len(),
+                context,
+                std::ptr::null(),
+                &raw mut buffer,
+                &raw mut error,
+            ),
+            PurrdfStatus::SerializeError as i32
+        );
+        assert!(buffer.is_null());
+        assert!(!error.is_null());
+        let message = std::ffi::CStr::from_ptr(purrdf_error_message(error));
+        assert!(message.to_bytes().starts_with(b"provide exactly one"));
+        purrdf_error_free(error);
+
+        purrdf_jsonld_context_free(context);
+        purrdf_jsonld_context_free(std::ptr::null_mut());
         purrdf_dataset_free(dataset);
     }
 }

--- a/crates/rdf-wasm/js/README.md
+++ b/crates/rdf-wasm/js/README.md
@@ -76,6 +76,24 @@ const names = engine.select(
 console.log(names.rows.take(0)?.message.value);
 ```
 
+Configured JSON-LD/YAML-LD calls the same Rust context engine as native PurRDF:
+
+```js
+import { CompiledJsonLdContext } from "@blackcatinformatics/purrdf";
+
+const options = JSON.stringify({
+  version: 1,
+  mode: "context",
+  prefixes: { ex: "https://ex/" },
+});
+const context = new CompiledJsonLdContext(options);
+const jsonld = reparsed.serializeWithContext("jsonld", context);
+```
+
+`serializeConfigured` handles one-shot expanded, context, registry-backed, or
+derived requests. Matching `QueryEngine.queryRawConfigured` and
+`queryRawWithContext` methods serialize CONSTRUCT/DESCRIBE graph results.
+
 ## Graph, tabular, and research-object projection archives
 
 Projection and lift run entirely in memory through the native Rust engine. The
@@ -128,6 +146,7 @@ once. A runnable Node example is
   `directionalLiteral`, `variable`, `defaultGraph`, `quad`, `quotedTriple`,
   `fromTerm`, `fromQuad`.
 - `Dataset` — `Dataset.parse(input, format, base?)`, `serialize(format)`,
+  `serializeConfigured(format, optionsJson)`, `serializeWithContext(format, context)`,
   `add` / `delete` / `has` / `match` / `quads` / `size`, iteration.
   Formats: `turtle`, `ntriples`, `nquads`, `trig`, `rdfxml` (`serialize` also `jsonld`).
 - `Dataset.canonicalize()` / `Dataset.isomorphic(other)` — RDFC-1.0 canonical N-Quads

--- a/crates/rdf-wasm/js/bench/parse.bench.mjs
+++ b/crates/rdf-wasm/js/bench/parse.bench.mjs
@@ -22,7 +22,7 @@
 //   BENCH_ITERS    timed iterations after warm-up     (default 7)
 //   BENCH_WARMUP   warm-up iterations (discarded)     (default 2)
 
-import { ready, Dataset } from "../index.mjs";
+import { ready, CompiledJsonLdContext, Dataset } from "../index.mjs";
 
 await ready();
 
@@ -102,4 +102,47 @@ console.log(
   `BENCH parse ntriples: triples=${TRIPLES} bytes=${bytes} ` +
     `iters=${ITERS} median_ms=${fmt(med)} min_ms=${fmt(min)} ` +
     `triples_per_s=${fmt(triplesPerSec, 0)} MB_per_s=${fmt(mbPerSec)}`,
+);
+
+const contextOptions = JSON.stringify({
+  version: 1,
+  mode: "context",
+  prefixes: {
+    s: "https://example.org/s/",
+    p: "https://example.org/p/",
+    o: "https://example.org/o/",
+  },
+});
+const compileSamples = [];
+for (let i = 0; i < ITERS; i++) {
+  const t0 = process.hrtime.bigint();
+  const context = new CompiledJsonLdContext(contextOptions);
+  const t1 = process.hrtime.bigint();
+  compileSamples.push(Number(t1 - t0) / 1e6);
+  context.free();
+}
+const dataset = Dataset.parse(corpus, "ntriples");
+const context = new CompiledJsonLdContext(contextOptions);
+const serializeSamples = [];
+let compacted = "";
+for (let i = 0; i < ITERS; i++) {
+  const t0 = process.hrtime.bigint();
+  compacted = dataset.serializeWithContext("jsonld", context);
+  const t1 = process.hrtime.bigint();
+  serializeSamples.push(Number(t1 - t0) / 1e6);
+}
+const parseSamples = [];
+for (let i = 0; i < ITERS; i++) {
+  const t0 = process.hrtime.bigint();
+  const reparsed = Dataset.parse(compacted, "jsonld");
+  const t1 = process.hrtime.bigint();
+  if (reparsed.size !== TRIPLES) throw new Error("configured JSON-LD size mismatch");
+  parseSamples.push(Number(t1 - t0) / 1e6);
+  reparsed.free();
+}
+console.log(
+  `BENCH jsonld configured: triples=${TRIPLES} output_bytes=${Buffer.byteLength(compacted)} ` +
+    `compile_median_ms=${fmt(median(compileSamples), 4)} ` +
+    `serialize_median_ms=${fmt(median(serializeSamples))} ` +
+    `parse_median_ms=${fmt(median(parseSamples))}`,
 );

--- a/crates/rdf-wasm/js/index.d.ts
+++ b/crates/rdf-wasm/js/index.d.ts
@@ -61,6 +61,20 @@ export interface QueryRawOptions extends QueryOptions {
   readonly format?: QueryRawFormat | string | null;
 }
 
+/** Closed, versioned options document consumed by the shared Rust JSON-LD engine. */
+export type JsonLdSerializeOptions =
+  | { readonly version: 1; readonly mode: "expanded"; readonly yaml_schema_url?: string }
+  | { readonly version: 1; readonly mode: "derived"; readonly yaml_schema_url?: string }
+  | {
+      readonly version: 1;
+      readonly mode: "context";
+      readonly prefixes?: Readonly<Record<string, string>>;
+      readonly context?: unknown;
+      readonly document_iri?: string;
+      readonly registry?: Readonly<Record<string, unknown>>;
+      readonly yaml_schema_url?: string;
+    };
+
 export type QueryBindingRow = Record<string, RdfTerm | undefined>;
 
 export interface QueryBindingRows extends IterableIterator<QueryBindingRow> {
@@ -383,11 +397,23 @@ export class Dataset implements Iterable<Quad> {
   visualExport(options?: VisualizationOptions | null): VisualExport;
   visualSvg(options?: VisualizationOptions | null): VisualSvgDocument;
   serialize(format: string): string;
+  serializeConfigured(format: "jsonld" | "yamlld" | string, optionsJson: string): string;
+  serializeWithContext(
+    format: "jsonld" | "yamlld" | string,
+    context: CompiledJsonLdContext,
+    yamlSchemaUrl?: string | null,
+  ): string;
   query(sparql: string, base?: string | null): string;
   canonicalize(): string;
   isomorphic(other: Dataset): boolean;
   toStream(): AsyncIterableIterator<Quad>;
   [Symbol.iterator](): IterableIterator<Quad>;
+  free(): void;
+}
+
+export class CompiledJsonLdContext {
+  constructor(optionsJson: string);
+  canonicalContextJson(): string;
   free(): void;
 }
 
@@ -443,6 +469,21 @@ export class QueryEngine {
   describe(dataset: Dataset, sparql: string, options?: QueryOptions | null): Dataset;
   update(dataset: Dataset, sparql: string, options?: QueryOptions | null): Dataset;
   queryRaw(dataset: Dataset, sparql: string, options?: QueryRawOptions | null): string;
+  queryRawConfigured(
+    dataset: Dataset,
+    sparql: string,
+    base: string | null | undefined,
+    format: "jsonld" | "yamlld" | string,
+    optionsJson: string,
+  ): string;
+  queryRawWithContext(
+    dataset: Dataset,
+    sparql: string,
+    base: string | null | undefined,
+    format: "jsonld" | "yamlld" | string,
+    context: CompiledJsonLdContext,
+    yamlSchemaUrl?: string | null,
+  ): string;
   free(): void;
 }
 

--- a/crates/rdf-wasm/js/index.mjs
+++ b/crates/rdf-wasm/js/index.mjs
@@ -19,6 +19,7 @@
 //     over the synchronous `Dataset.quads()` / `Sink` engine surface.
 
 import init, {
+  CompiledJsonLdContext,
   DataFactory,
   Dataset,
   liftProjection,
@@ -331,6 +332,7 @@ export async function streamToDataset(quadStream) {
 }
 
 export {
+  CompiledJsonLdContext,
   DataFactory,
   Dataset,
   liftProjection,

--- a/crates/rdf-wasm/js/tests/jsonld-configured.test.mjs
+++ b/crates/rdf-wasm/js/tests/jsonld-configured.test.mjs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  CompiledJsonLdContext,
+  Dataset,
+  QueryEngine,
+  ready,
+} from "../index.mjs";
+
+await ready();
+
+const OPTIONS = JSON.stringify({
+  version: 1,
+  mode: "context",
+  prefixes: {
+    ex: "https://example.org/",
+    schema: "https://schema.org/",
+  },
+});
+const SOURCE = '<https://example.org/alice> <https://schema.org/name> "Alice" .\n';
+
+test("configured Dataset serialization reuses compiled contexts", () => {
+  const dataset = Dataset.parse(SOURCE, "nquads");
+  const direct = dataset.serializeConfigured("jsonld", OPTIONS);
+  const context = new CompiledJsonLdContext(OPTIONS);
+  const reused = dataset.serializeWithContext("jsonld", context);
+  assert.equal(direct, reused);
+  assert.equal(JSON.parse(direct)["@graph"][0]["@id"], "ex:alice");
+  assert.equal(JSON.parse(direct)["@graph"][0]["schema:name"]["@value"], "Alice");
+});
+
+test("configured graph results and YAML schema headers use the same engine", () => {
+  const dataset = Dataset.parse(SOURCE, "nquads");
+  const engine = new QueryEngine();
+  const query = "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }";
+  const jsonld = engine.queryRawConfigured(dataset, query, undefined, "jsonld", OPTIONS);
+  assert.equal(JSON.parse(jsonld)["@graph"][0]["@id"], "ex:alice");
+
+  const context = new CompiledJsonLdContext(OPTIONS);
+  const yaml = engine.queryRawWithContext(
+    dataset,
+    query,
+    undefined,
+    "yamlld",
+    context,
+    "https://example.org/purrdf.schema.json",
+  );
+  assert.match(yaml, /^# yaml-language-server: \$schema=https:\/\/example\.org\/purrdf\.schema\.json/m);
+});
+
+test("closed options fail before output", () => {
+  const dataset = Dataset.parse(SOURCE, "nquads");
+  assert.throws(
+    () => dataset.serializeConfigured("jsonld", '{"version":1,"mode":"expanded","extra":true}'),
+    /unknown/,
+  );
+});

--- a/crates/rdf-wasm/js/tests/pack-smoke.mjs
+++ b/crates/rdf-wasm/js/tests/pack-smoke.mjs
@@ -20,10 +20,13 @@ const PACKAGE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)));
 // profiles. Both ceilings track the optimized wasm artifact (see the Makefile
 // WASM_SIZE_BUDGET_BYTES note); each is the measured size plus about 3%
 // headroom. The five strict bidirectional research-object codecs are the
-// capability responsible for this reviewed increase. Measured: gzipped tarball
-// 2_116_853 bytes; unpacked 6_185_306 bytes.
-const MAX_TARBALL_BYTES = 2_181_000;
-const MAX_UNPACKED_BYTES = 6_371_000;
+// capability responsible for the earlier reviewed increase. The configured
+// JSON-LD context engine is now also public in wasm (strict options/registry
+// decoding plus reusable compiled contexts), which is the capability responsible
+// for this reviewed increase. Measured: gzipped tarball 2_265_551 bytes;
+// unpacked 6_575_869 bytes. Both ceilings retain about 3% headroom.
+const MAX_TARBALL_BYTES = 2_335_000;
+const MAX_UNPACKED_BYTES = 6_780_000;
 const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 const NPM_INSTALL_TIMEOUT_MS = 180_000;
 const SMOKE_TIMEOUT_MS = 60_000;

--- a/crates/rdf-wasm/js/tests/roundtrip.test.mjs
+++ b/crates/rdf-wasm/js/tests/roundtrip.test.mjs
@@ -61,6 +61,37 @@ test("parse → serialize → reparse round-trips N-Triples", () => {
   assert.equal(reparsed.size, 1);
 });
 
+test("expanded JSON-LD and YAML-LD wasm bytes are frozen", () => {
+  const input = '<https://example.org/alice> <https://schema.org/name> "Alice" .\n';
+  const ds = Dataset.parse(input, "nquads");
+  assert.equal(
+    ds.serialize("jsonld"),
+    `{
+  "@context": {},
+  "@graph": [
+    {
+      "@id": "https://example.org/alice",
+      "https://schema.org/name": {
+        "@value": "Alice"
+      }
+    }
+  ]
+}`,
+  );
+  assert.equal(
+    ds.serialize("yamlld"),
+    `# yaml-language-server: $schema=purrdf.schema.json
+# The default reference is the bundled purrdf.schema.json; pass an explicit
+# schema_url to point editors at a hosted copy.
+'@context': {}
+'@graph':
+- '@id': https://example.org/alice
+  https://schema.org/name:
+    '@value': Alice
+`,
+  );
+});
+
 test("DatasetCore add/has/delete/match/iterate", () => {
   const f = new DataFactory();
   const q1 = f.quad(

--- a/crates/rdf-wasm/js/tests/types/package-root.types.ts
+++ b/crates/rdf-wasm/js/tests/types/package-root.types.ts
@@ -3,6 +3,7 @@
 
 import {
   ready,
+  CompiledJsonLdContext,
   DataFactory,
   Dataset,
   liftProjection,
@@ -53,6 +54,18 @@ for (const item of matched) {
 
 const stream: AsyncIterableIterator<Quad> = matched.toStream();
 const serialized: string = matched.serialize("nquads");
+const configured: string = matched.serializeConfigured(
+  "jsonld",
+  JSON.stringify({ version: 1, mode: "derived" }),
+);
+const compiledContext = new CompiledJsonLdContext(
+  JSON.stringify({
+    version: 1,
+    mode: "context",
+    prefixes: { ex: "https://example.org/" },
+  }),
+);
+const compacted: string = matched.serializeWithContext("jsonld", compiledContext);
 const canonical: string = matched.canonicalize();
 const same: boolean = matched.isomorphic(Dataset.parse(serialized, "nquads"));
 const projection: ProjectionPackage = matched.project("lpg-csv", JSON.stringify({

--- a/crates/rdf-wasm/src/dataset.rs
+++ b/crates/rdf-wasm/src/dataset.rs
@@ -13,8 +13,9 @@
 use purrdf::dataset_view::{DatasetMut, GraphMatchValue};
 use purrdf::ir::MutableDataset;
 use purrdf::{
-    RdfDatasetBuilder, RdfDiagnostic, SerializeGraph, TermValue, canonical_flat_nquads,
-    datasets_isomorphic, parse_dataset, serialize_dataset,
+    JsonLdSerializeOptions, RdfDatasetBuilder, RdfDiagnostic, SerializeGraph, TermValue,
+    canonical_flat_nquads, datasets_isomorphic, parse_dataset, serialize_dataset,
+    serialize_dataset_with_jsonld_options,
 };
 use serde::Deserialize;
 use wasm_bindgen::prelude::*;
@@ -27,6 +28,7 @@ use purrdf::viz::{
 
 use crate::codec::resolve_media_type;
 use crate::convert::{quad_to_quad_values, quad_values_to_quad, rdf_term_to_term_value};
+use crate::jsonld::{CompiledJsonLdContext, context_options, decode_options};
 use crate::term::{Quad, Term, TermInner};
 
 /// Lower an optional pattern [`Term`] to an optional [`TermValue`] (None = wildcard).
@@ -235,6 +237,33 @@ impl Dataset {
             .map_err(|e| JsError::new(&format!("serialization produced non-UTF-8 bytes: {e}")))
     }
 
+    /// Serialize JSON-LD/YAML-LD using the shared versioned options decoder.
+    #[wasm_bindgen(js_name = serializeConfigured)]
+    pub fn serialize_configured(
+        &self,
+        format: &str,
+        options_json: &str,
+    ) -> Result<String, JsError> {
+        self.serialize_with_options(format, &decode_options(options_json)?)
+    }
+
+    /// Serialize JSON-LD/YAML-LD using a reusable compiled context.
+    #[wasm_bindgen(js_name = serializeWithContext)]
+    pub fn serialize_with_context(
+        &self,
+        format: &str,
+        context: &CompiledJsonLdContext,
+        yaml_schema_url: Option<String>,
+    ) -> Result<String, JsError> {
+        let mut options = context_options(context);
+        if let Some(url) = yaml_schema_url {
+            options = options
+                .with_yaml_schema_url(&url)
+                .map_err(|error| JsError::new(&error.to_string()))?;
+        }
+        self.serialize_with_options(format, &options)
+    }
+
     /// `canonicalize()` → the dataset as canonical, flat N-Quads under RDFC-1.0
     /// (SHA-256).
     ///
@@ -373,6 +402,27 @@ impl Dataset {
             out.insert(qv.clone());
         }
         Ok(Self { inner: out })
+    }
+}
+
+impl Dataset {
+    pub(crate) fn serialize_with_options(
+        &self,
+        format: &str,
+        options: &JsonLdSerializeOptions,
+    ) -> Result<String, JsError> {
+        let frozen = self.inner.freeze().map_err(|error| diag_to_err(&error))?;
+        let media_type = resolve_media_type(format).map_err(|error| JsError::new(&error))?;
+        let bytes = serialize_dataset_with_jsonld_options(
+            &frozen,
+            media_type,
+            SerializeGraph::Dataset,
+            options,
+        )
+        .map_err(|error| diag_to_err(&error))?;
+        String::from_utf8(bytes).map_err(|error| {
+            JsError::new(&format!("serialization produced non-UTF-8 bytes: {error}"))
+        })
     }
 }
 

--- a/crates/rdf-wasm/src/jsonld.rs
+++ b/crates/rdf-wasm/src/jsonld.rs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Reusable configured JSON-LD contexts for the WebAssembly surface.
+
+use std::sync::Arc;
+
+use purrdf::{CompiledJsonLdContext as EngineContext, JsonLdSerializeMode, JsonLdSerializeOptions};
+use wasm_bindgen::prelude::*;
+
+/// An immutable JSON-LD 1.1 context compiled once and reusable across datasets.
+#[wasm_bindgen]
+#[derive(Debug, Clone)]
+pub struct CompiledJsonLdContext {
+    pub(crate) inner: Arc<EngineContext>,
+}
+
+#[wasm_bindgen]
+impl CompiledJsonLdContext {
+    /// Compile the context branch of a versioned JSON-LD options document.
+    #[wasm_bindgen(constructor)]
+    pub fn new(options_json: &str) -> Result<Self, JsError> {
+        let options = decode_options(options_json)?;
+        let JsonLdSerializeMode::Context(context) = options.mode() else {
+            return Err(JsError::new(
+                "CompiledJsonLdContext requires JSON-LD options with mode `context`",
+            ));
+        };
+        Ok(Self {
+            inner: Arc::clone(context),
+        })
+    }
+
+    /// Return the recursively canonical context document as JSON.
+    #[wasm_bindgen(js_name = canonicalContextJson)]
+    pub fn canonical_context_json(&self) -> Result<String, JsError> {
+        serde_json::to_string(self.inner.canonical_context())
+            .map_err(|error| JsError::new(&error.to_string()))
+    }
+}
+
+pub(crate) fn decode_options(json: &str) -> Result<JsonLdSerializeOptions, JsError> {
+    JsonLdSerializeOptions::from_json(json.as_bytes())
+        .map_err(|error| JsError::new(&error.to_string()))
+}
+
+pub(crate) fn context_options(context: &CompiledJsonLdContext) -> JsonLdSerializeOptions {
+    JsonLdSerializeOptions::compiled(Arc::clone(&context.inner))
+}

--- a/crates/rdf-wasm/src/lib.rs
+++ b/crates/rdf-wasm/src/lib.rs
@@ -67,6 +67,7 @@ mod codec;
 mod convert;
 mod dataset;
 mod factory;
+mod jsonld;
 mod projection;
 mod query;
 pub mod shacl;
@@ -75,6 +76,7 @@ mod term;
 
 pub use dataset::Dataset;
 pub use factory::DataFactory;
+pub use jsonld::CompiledJsonLdContext;
 pub use projection::{ProjectionLift, ProjectionPackage, lift_projection};
 pub use query::{QueryEngine, QueryResult, SelectResult, SelectRow};
 pub use stream::Sink;

--- a/crates/rdf-wasm/src/query.rs
+++ b/crates/rdf-wasm/src/query.rs
@@ -27,7 +27,7 @@
 use std::rc::Rc;
 
 use purrdf::ir::MutableDataset;
-use purrdf::{SerializeGraph, serialize_dataset};
+use purrdf::{JsonLdSerializeOptions, SerializeGraph, serialize_dataset};
 use purrdf_core::{SparqlEngine, SparqlRequest, SparqlResult};
 use purrdf_sparql_eval::NativeSparqlEngine;
 use purrdf_sparql_results::{
@@ -38,6 +38,7 @@ use wasm_bindgen::prelude::*;
 use crate::codec::resolve_media_type;
 use crate::convert::term_value_into_rdf_term;
 use crate::dataset::{Dataset, diag_to_err};
+use crate::jsonld::{CompiledJsonLdContext, context_options, decode_options};
 use crate::term::Term;
 
 /// The typed result kind exposed to the package-root JavaScript wrapper.
@@ -326,6 +327,42 @@ impl QueryEngine {
         let result = self.run_query(dataset, sparql, base.as_deref())?;
         serialize_query_result(&result, format.as_deref())
     }
+
+    /// Serialize a CONSTRUCT/DESCRIBE result with configured JSON-LD/YAML-LD.
+    #[wasm_bindgen(js_name = queryRawConfigured)]
+    #[allow(clippy::needless_pass_by_value)] // binding ABI receives owned values
+    pub fn query_raw_configured(
+        &self,
+        dataset: &Dataset,
+        sparql: &str,
+        base: Option<String>,
+        format: &str,
+        options_json: &str,
+    ) -> Result<String, JsError> {
+        let options = decode_options(options_json)?;
+        self.query_raw_with_options(dataset, sparql, base.as_deref(), format, &options)
+    }
+
+    /// Serialize a CONSTRUCT/DESCRIBE result with a reusable compiled context.
+    #[wasm_bindgen(js_name = queryRawWithContext)]
+    #[allow(clippy::needless_pass_by_value)] // binding ABI receives owned values
+    pub fn query_raw_with_context(
+        &self,
+        dataset: &Dataset,
+        sparql: &str,
+        base: Option<String>,
+        format: &str,
+        context: &CompiledJsonLdContext,
+        yaml_schema_url: Option<String>,
+    ) -> Result<String, JsError> {
+        let mut options = context_options(context);
+        if let Some(url) = yaml_schema_url {
+            options = options
+                .with_yaml_schema_url(&url)
+                .map_err(|error| JsError::new(&error.to_string()))?;
+        }
+        self.query_raw_with_options(dataset, sparql, base.as_deref(), format, &options)
+    }
 }
 
 impl Default for QueryEngine {
@@ -345,6 +382,26 @@ impl QueryEngine {
         self.inner
             .query(&frozen, sparql_request(sparql, base))
             .map_err(|e| diag_to_err(&e))
+    }
+
+    fn query_raw_with_options(
+        &self,
+        dataset: &Dataset,
+        sparql: &str,
+        base: Option<&str>,
+        format: &str,
+        options: &JsonLdSerializeOptions,
+    ) -> Result<String, JsError> {
+        match self.run_query(dataset, sparql, base)? {
+            SparqlResult::Graph(graph) => Dataset {
+                inner: MutableDataset::new(graph),
+            }
+            .serialize_with_options(format, options),
+            other => Err(kind_mismatch(
+                "CONSTRUCT/DESCRIBE graph for configured JSON-LD serialization",
+                &other,
+            )),
+        }
     }
 }
 

--- a/crates/rdf/Cargo.toml
+++ b/crates/rdf/Cargo.toml
@@ -131,6 +131,8 @@ name = "gen_streamable_vectors"
 path = "src/bin/gen_streamable_vectors.rs"
 
 [dev-dependencies]
+# Trusted draft-2020-12 oracle for the public JSON-LD options schema.
+boon = { workspace = true }
 # Rich colored line-diffs on assert_eq! failure. Drop-in: a shadowing
 # `use pretty_assertions::assert_eq;` per test file; identical on pass.
 pretty_assertions = { workspace = true }

--- a/crates/rdf/Cargo.toml
+++ b/crates/rdf/Cargo.toml
@@ -149,6 +149,12 @@ name = "native_codecs"
 harness = false
 
 [[bench]]
+# One-shot allocation/count/retained/peak-byte baseline for expanded JSON-LD parse and
+# serialization. Separate from Criterion so allocator atomics do not perturb timing.
+name = "jsonld_alloc"
+harness = false
+
+[[bench]]
 # Renderer-neutral RDF 1.2 projection, scene, and deterministic layered layout.
 # Report-only; excluded from check.
 name = "viz_layout"

--- a/crates/rdf/benches/jsonld_alloc.rs
+++ b/crates/rdf/benches/jsonld_alloc.rs
@@ -7,8 +7,6 @@
 //! latency measurements. It reports allocation count, requested bytes, retained bytes,
 //! peak working bytes, and output bytes for the exact fixtures used by the timed bench.
 
-#![allow(missing_docs)]
-
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::hint::black_box;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};

--- a/crates/rdf/benches/jsonld_alloc.rs
+++ b/crates/rdf/benches/jsonld_alloc.rs
@@ -13,7 +13,10 @@ use std::alloc::{GlobalAlloc, Layout, System};
 use std::hint::black_box;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 
-use purrdf_rdf::native_codecs::jsonld::{parse_jsonld, serialize_dataset_to_jsonld};
+use purrdf_rdf::native_codecs::jsonld::{
+    CompiledJsonLdContext, JsonLdSerializeOptions, parse_jsonld, serialize_dataset_to_jsonld,
+    serialize_dataset_to_jsonld_with_options,
+};
 
 #[path = "support/jsonld.rs"]
 mod fixture;
@@ -148,6 +151,42 @@ fn probe(rows: usize) {
     );
     black_box(parsed);
     black_box(json);
+
+    let caller = JsonLdSerializeOptions::compiled(std::sync::Arc::new(
+        CompiledJsonLdContext::from_prefixes([
+            ("ex", "https://example.org/"),
+            ("p", "https://example.org/p/"),
+            ("o", "https://example.org/o/"),
+        ])
+        .expect("compile context"),
+    ));
+    for (mode, options) in [
+        ("caller", caller),
+        ("derived", JsonLdSerializeOptions::derived()),
+    ] {
+        let before = reset_peak();
+        let json = serialize_dataset_to_jsonld_with_options(&dataset, &options)
+            .expect("configured JSON-LD serialization");
+        let after = snapshot();
+        report(
+            &format!("serialize_{mode}_rows_{rows}"),
+            before,
+            after,
+            json.len(),
+        );
+
+        let before = reset_peak();
+        let parsed = parse_jsonld(json.as_bytes()).expect("configured JSON-LD parse");
+        let after = snapshot();
+        report(
+            &format!("parse_{mode}_rows_{rows}"),
+            before,
+            after,
+            json.len(),
+        );
+        black_box(parsed);
+        black_box(json);
+    }
 }
 
 fn main() {

--- a/crates/rdf/benches/jsonld_alloc.rs
+++ b/crates/rdf/benches/jsonld_alloc.rs
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! One-shot allocation probes for the pre-change expanded JSON-LD codec.
+//!
+//! This process is separate from Criterion because allocator atomics would contaminate
+//! latency measurements. It reports allocation count, requested bytes, retained bytes,
+//! peak working bytes, and output bytes for the exact fixtures used by the timed bench.
+
+#![allow(missing_docs)]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+
+use purrdf_rdf::native_codecs::jsonld::{parse_jsonld, serialize_dataset_to_jsonld};
+
+#[path = "support/jsonld.rs"]
+mod fixture;
+
+use fixture::{LARGE_ROWS, SMALL_ROWS, build_dataset};
+
+static ALLOCATION_COUNT: AtomicU64 = AtomicU64::new(0);
+static ALLOCATION_BYTES: AtomicU64 = AtomicU64::new(0);
+static LIVE_BYTES: AtomicI64 = AtomicI64::new(0);
+static PEAK_BYTES: AtomicI64 = AtomicI64::new(0);
+
+struct CountingAllocator;
+
+fn usize_to_u64(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+fn usize_to_i64(value: usize) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
+fn record_allocation(size: usize) {
+    ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+    ALLOCATION_BYTES.fetch_add(usize_to_u64(size), Ordering::Relaxed);
+    let size = usize_to_i64(size);
+    let live = LIVE_BYTES
+        .fetch_add(size, Ordering::Relaxed)
+        .saturating_add(size);
+    let mut peak = PEAK_BYTES.load(Ordering::Relaxed);
+    while live > peak {
+        match PEAK_BYTES.compare_exchange_weak(peak, live, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(observed) => peak = observed,
+        }
+    }
+}
+
+fn record_deallocation(size: usize) {
+    LIVE_BYTES.fetch_sub(usize_to_i64(size), Ordering::Relaxed);
+}
+
+// SAFETY: every operation delegates to `System` with the exact incoming
+// pointer/layout. Atomic accounting does not affect allocator ownership.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: delegated with the exact layout supplied by the caller.
+        let pointer = unsafe { System.alloc(layout) };
+        if !pointer.is_null() {
+            record_allocation(layout.size());
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        record_deallocation(layout.size());
+        // SAFETY: delegated with the exact pointer/layout supplied by the caller.
+        unsafe { System.dealloc(pointer, layout) }
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: delegated with the exact pointer/layout and requested size.
+        let resized = unsafe { System.realloc(pointer, layout, new_size) };
+        if !resized.is_null() {
+            record_deallocation(layout.size());
+            record_allocation(new_size);
+        }
+        resized
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+#[derive(Clone, Copy)]
+struct Snapshot {
+    count: u64,
+    requested: u64,
+    live: i64,
+    peak: i64,
+}
+
+fn reset_peak() -> Snapshot {
+    let live = LIVE_BYTES.load(Ordering::Relaxed);
+    PEAK_BYTES.store(live, Ordering::Relaxed);
+    Snapshot {
+        count: ALLOCATION_COUNT.load(Ordering::Relaxed),
+        requested: ALLOCATION_BYTES.load(Ordering::Relaxed),
+        live,
+        peak: live,
+    }
+}
+
+fn snapshot() -> Snapshot {
+    Snapshot {
+        count: ALLOCATION_COUNT.load(Ordering::Relaxed),
+        requested: ALLOCATION_BYTES.load(Ordering::Relaxed),
+        live: LIVE_BYTES.load(Ordering::Relaxed),
+        peak: PEAK_BYTES.load(Ordering::Relaxed),
+    }
+}
+
+fn report(label: &str, before: Snapshot, after: Snapshot, artifact_bytes: usize) {
+    println!(
+        "[jsonld_alloc] {label}: allocations={} requested_bytes={} retained_bytes={} peak_working_bytes={} artifact_bytes={artifact_bytes}",
+        after.count.saturating_sub(before.count),
+        after.requested.saturating_sub(before.requested),
+        after.live.saturating_sub(before.live),
+        after.peak.saturating_sub(before.peak),
+    );
+}
+
+fn probe(rows: usize) {
+    let dataset = build_dataset(rows);
+    let before = reset_peak();
+    let json = serialize_dataset_to_jsonld(&dataset).expect("expanded JSON-LD serialization");
+    let after = snapshot();
+    report(
+        &format!("serialize_expanded_rows_{rows}"),
+        before,
+        after,
+        json.len(),
+    );
+
+    let before = reset_peak();
+    let parsed = parse_jsonld(json.as_bytes()).expect("expanded JSON-LD parse");
+    let after = snapshot();
+    report(
+        &format!("parse_expanded_rows_{rows}"),
+        before,
+        after,
+        json.len(),
+    );
+    black_box(parsed);
+    black_box(json);
+}
+
+fn main() {
+    probe(SMALL_ROWS);
+    probe(LARGE_ROWS);
+}

--- a/crates/rdf/benches/native_codecs.rs
+++ b/crates/rdf/benches/native_codecs.rs
@@ -316,6 +316,38 @@ fn bench_jsonld_derived_many_namespaces(c: &mut Criterion) {
     group.finish();
 }
 
+/// Named-graph usage accounting and multivalue ordering are independent carrier
+/// hot paths, so keep adversarial shapes for both in the report-only benchmark.
+fn bench_jsonld_carrier_stress(c: &mut Criterion) {
+    let context = std::sync::Arc::new(
+        CompiledJsonLdContext::from_prefixes([("bench", "https://bench.example/")])
+            .expect("compile benchmark context"),
+    );
+    let options = JsonLdSerializeOptions::compiled(context);
+    let mut group = c.benchmark_group("jsonld_carrier_stress");
+    group.sample_size(10);
+    for (name, dataset) in [
+        (
+            "named_graphs_512",
+            jsonld_fixture::build_many_named_graph_dataset(512),
+        ),
+        (
+            "multivalue_4096",
+            jsonld_fixture::build_multivalue_dataset(4_096),
+        ),
+    ] {
+        group.bench_with_input(name, &dataset, |bencher, dataset| {
+            bencher.iter(|| {
+                black_box(
+                    serialize_dataset_to_jsonld_with_options(black_box(dataset), &options)
+                        .expect("serialize carrier stress fixture"),
+                );
+            });
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_parse_nquads,
@@ -324,6 +356,7 @@ criterion_group!(
     bench_serialize_nquads,
     bench_jsonld_expanded,
     bench_jsonld_configured,
-    bench_jsonld_derived_many_namespaces
+    bench_jsonld_derived_many_namespaces,
+    bench_jsonld_carrier_stress
 );
 criterion_main!(benches);

--- a/crates/rdf/benches/native_codecs.rs
+++ b/crates/rdf/benches/native_codecs.rs
@@ -13,8 +13,8 @@
 
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use purrdf_rdf::native_codecs::jsonld::{
-    CompiledJsonLdContext, JsonLdSerializeOptions, parse_jsonld, serialize_dataset_to_jsonld,
-    serialize_dataset_to_jsonld_with_options,
+    CompiledJsonLdContext, JsonLdSerializeOptions, derive_jsonld_context, parse_jsonld,
+    serialize_dataset_to_jsonld, serialize_dataset_to_jsonld_with_options,
 };
 use purrdf_rdf::{
     ParseOptions, SerializeGraph, parse_dataset, parse_dataset_with, serialize_dataset,
@@ -299,6 +299,23 @@ fn bench_jsonld_configured(c: &mut Criterion) {
     group.finish();
 }
 
+/// Context derivation has an explicit work ceiling; this adversarial shape keeps
+/// many profitable namespaces and distinct IRIs below it while exposing scaling.
+fn bench_jsonld_derived_many_namespaces(c: &mut Criterion) {
+    const NAMESPACES: usize = 64;
+    const IRIS_PER_NAMESPACE: usize = 32;
+
+    let dataset = jsonld_fixture::build_many_namespace_dataset(NAMESPACES, IRIS_PER_NAMESPACE);
+    let mut group = c.benchmark_group("jsonld_derived_context");
+    group.sample_size(10);
+    group.bench_function("64_namespaces_32_iris", |bencher| {
+        bencher.iter(|| {
+            black_box(derive_jsonld_context(black_box(&dataset)).expect("derive bounded context"));
+        });
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_parse_nquads,
@@ -306,6 +323,7 @@ criterion_group!(
     bench_parse_nquads_span_tracking,
     bench_serialize_nquads,
     bench_jsonld_expanded,
-    bench_jsonld_configured
+    bench_jsonld_configured,
+    bench_jsonld_derived_many_namespaces
 );
 criterion_main!(benches);

--- a/crates/rdf/benches/native_codecs.rs
+++ b/crates/rdf/benches/native_codecs.rs
@@ -12,7 +12,10 @@
 //! serializer exercise dataset-capable paths.
 
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
-use purrdf_rdf::native_codecs::jsonld::{parse_jsonld, serialize_dataset_to_jsonld};
+use purrdf_rdf::native_codecs::jsonld::{
+    CompiledJsonLdContext, JsonLdSerializeOptions, parse_jsonld, serialize_dataset_to_jsonld,
+    serialize_dataset_to_jsonld_with_options,
+};
 use purrdf_rdf::{
     ParseOptions, SerializeGraph, parse_dataset, parse_dataset_with, serialize_dataset,
 };
@@ -225,12 +228,84 @@ fn bench_jsonld_expanded(c: &mut Criterion) {
     group.finish();
 }
 
+/// Configured context compilation and caller/derived serialization are measured
+/// separately so context reuse is visible rather than hidden in codec throughput.
+fn bench_jsonld_configured(c: &mut Criterion) {
+    use std::sync::Arc;
+
+    {
+        let mut compile = c.benchmark_group("jsonld_context_compile");
+        compile.bench_function("prefixes", |bencher| {
+            bencher.iter(|| {
+                let context = CompiledJsonLdContext::from_prefixes(black_box([
+                    ("ex", "https://example.org/"),
+                    ("p", "https://example.org/p/"),
+                    ("o", "https://example.org/o/"),
+                ]))
+                .expect("compile context");
+                black_box(context);
+            });
+        });
+        compile.finish();
+    }
+
+    let context = Arc::new(
+        CompiledJsonLdContext::from_prefixes([
+            ("ex", "https://example.org/"),
+            ("p", "https://example.org/p/"),
+            ("o", "https://example.org/o/"),
+        ])
+        .expect("compile context"),
+    );
+    let caller = JsonLdSerializeOptions::compiled(context);
+    let derived = JsonLdSerializeOptions::derived();
+    let mut group = c.benchmark_group("jsonld_configured");
+    for rows in [JSONLD_SMALL_ROWS, JSONLD_LARGE_ROWS] {
+        let dataset = jsonld_fixture::build_dataset(rows);
+        for (mode, options) in [("caller", &caller), ("derived", &derived)] {
+            let prepared = serialize_dataset_to_jsonld_with_options(&dataset, options)
+                .expect("prepare configured JSON-LD");
+            group.bench_with_input(
+                BenchmarkId::new(format!("serialize_{mode}"), rows),
+                &dataset,
+                |bencher, value| {
+                    bencher.iter(|| {
+                        black_box(
+                            serialize_dataset_to_jsonld_with_options(black_box(value), options)
+                                .expect("configured JSON-LD serialization"),
+                        );
+                    });
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new(format!("parse_{mode}"), rows),
+                &prepared,
+                |bencher, text| {
+                    bencher.iter(|| {
+                        black_box(
+                            parse_jsonld(black_box(text.as_bytes()))
+                                .expect("configured JSON-LD parse"),
+                        );
+                    });
+                },
+            );
+            eprintln!(
+                "[jsonld_configured] mode={mode} rows={rows} quads={} output_bytes={}",
+                dataset.quad_count(),
+                prepared.len()
+            );
+        }
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_parse_nquads,
     bench_parse_nquads_parallel_vs_sequential,
     bench_parse_nquads_span_tracking,
     bench_serialize_nquads,
-    bench_jsonld_expanded
+    bench_jsonld_expanded,
+    bench_jsonld_configured
 );
 criterion_main!(benches);

--- a/crates/rdf/benches/native_codecs.rs
+++ b/crates/rdf/benches/native_codecs.rs
@@ -11,10 +11,16 @@
 //! deterministic N-Quads with default and named graph rows so both parser and
 //! serializer exercise dataset-capable paths.
 
-use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use purrdf_rdf::native_codecs::jsonld::{parse_jsonld, serialize_dataset_to_jsonld};
 use purrdf_rdf::{
     ParseOptions, SerializeGraph, parse_dataset, parse_dataset_with, serialize_dataset,
 };
+
+#[path = "support/jsonld.rs"]
+mod jsonld_fixture;
+
+use jsonld_fixture::{LARGE_ROWS as JSONLD_LARGE_ROWS, SMALL_ROWS as JSONLD_SMALL_ROWS};
 
 const ROWS: usize = 2_000;
 
@@ -181,11 +187,50 @@ fn bench_serialize_nquads(c: &mut Criterion) {
     group.finish();
 }
 
+/// Pre-change expanded JSON-LD parse/serialize timing over one deterministic RDF 1.2
+/// fixture at two scales. Allocation and peak-memory metrics live in the separate
+/// `jsonld_alloc` process so allocator atomics cannot perturb Criterion timings.
+fn bench_jsonld_expanded(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jsonld_expanded_baseline");
+    for rows in [JSONLD_SMALL_ROWS, JSONLD_LARGE_ROWS] {
+        let dataset = jsonld_fixture::build_dataset(rows);
+        let json = serialize_dataset_to_jsonld(&dataset).expect("prepare expanded JSON-LD");
+        group.throughput(Throughput::Elements(
+            u64::try_from(dataset.quad_count()).expect("quad count fits in u64"),
+        ));
+        group.bench_with_input(
+            BenchmarkId::new("serialize", rows),
+            &dataset,
+            |bencher, ds| {
+                bencher.iter(|| {
+                    let output = serialize_dataset_to_jsonld(black_box(ds))
+                        .expect("expanded JSON-LD serialization");
+                    black_box(output);
+                });
+            },
+        );
+        group.bench_with_input(BenchmarkId::new("parse", rows), &json, |bencher, text| {
+            bencher.iter(|| {
+                let dataset =
+                    parse_jsonld(black_box(text.as_bytes())).expect("expanded JSON-LD parse");
+                black_box(dataset);
+            });
+        });
+        eprintln!(
+            "[jsonld_baseline] rows={rows} quads={} output_bytes={}",
+            dataset.quad_count(),
+            json.len()
+        );
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_parse_nquads,
     bench_parse_nquads_parallel_vs_sequential,
     bench_parse_nquads_span_tracking,
-    bench_serialize_nquads
+    bench_serialize_nquads,
+    bench_jsonld_expanded
 );
 criterion_main!(benches);

--- a/crates/rdf/benches/support/jsonld.rs
+++ b/crates/rdf/benches/support/jsonld.rs
@@ -45,3 +45,24 @@ pub(crate) fn build_dataset(rows: usize) -> Arc<RdfDataset> {
 
     builder.freeze().expect("deterministic JSON-LD fixture")
 }
+
+#[allow(
+    dead_code,
+    reason = "native_codecs uses this shared fixture; jsonld_alloc does not"
+)]
+pub(crate) fn build_many_namespace_dataset(
+    namespace_count: usize,
+    iris_per_namespace: usize,
+) -> Arc<RdfDataset> {
+    let mut builder = RdfDatasetBuilder::new();
+    let subject = builder.intern_iri("urn:subject");
+    let object = builder.intern_iri("urn:object");
+    for namespace in 0..namespace_count {
+        for local in 0..iris_per_namespace {
+            let predicate =
+                builder.intern_iri(&format!("https://bench.example/ns/{namespace}/term{local}"));
+            builder.push_quad(subject, predicate, object, None);
+        }
+    }
+    builder.freeze().expect("many-namespace JSON-LD fixture")
+}

--- a/crates/rdf/benches/support/jsonld.rs
+++ b/crates/rdf/benches/support/jsonld.rs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Deterministic RDF 1.2 fixtures shared by JSON-LD timing and allocation probes.
+
+use std::sync::Arc;
+
+use purrdf_rdf::{RdfDataset, RdfDatasetBuilder, RdfLiteral};
+
+pub(crate) const SMALL_ROWS: usize = 128;
+pub(crate) const LARGE_ROWS: usize = 2_000;
+pub(crate) const STAR_STRIDE: usize = 8;
+
+pub(crate) fn build_dataset(rows: usize) -> Arc<RdfDataset> {
+    let mut builder = RdfDatasetBuilder::new();
+    let predicate = builder.intern_iri("https://example.org/predicate");
+    let name = builder.intern_iri("https://example.org/name");
+    let asserts = builder.intern_iri("https://example.org/asserts");
+    let confidence = builder.intern_iri("https://example.org/confidence");
+    let graph = builder.intern_iri("https://example.org/graph");
+
+    for index in 0..rows {
+        let subject = builder.intern_iri(&format!("https://example.org/subject/{index}"));
+        let object = builder.intern_iri(&format!("https://example.org/object/{index}"));
+        let literal = builder.intern_literal(RdfLiteral::language_tagged(
+            format!("deterministic value {index}"),
+            if index % 2 == 0 { "en" } else { "fr" },
+        ));
+        let graph_name = (index % 4 == 0).then_some(graph);
+        builder.push_quad(subject, predicate, object, graph_name);
+        builder.push_quad(subject, name, literal, graph_name);
+
+        if index % STAR_STRIDE == 0 {
+            let proposition = builder.intern_triple(subject, predicate, object);
+            let reifier = builder.intern_iri(&format!("https://example.org/reifier/{index}"));
+            let score = builder.intern_literal(RdfLiteral::typed(
+                format!("{}.5", index % 10),
+                "http://www.w3.org/2001/XMLSchema#decimal",
+            ));
+            builder.push_reifier_in_graph(reifier, proposition, graph_name);
+            builder.push_annotation_in_graph(reifier, confidence, score, graph_name);
+            builder.push_quad(subject, asserts, proposition, graph_name);
+        }
+    }
+
+    builder.freeze().expect("deterministic JSON-LD fixture")
+}

--- a/crates/rdf/benches/support/jsonld.rs
+++ b/crates/rdf/benches/support/jsonld.rs
@@ -66,3 +66,34 @@ pub(crate) fn build_many_namespace_dataset(
     }
     builder.freeze().expect("many-namespace JSON-LD fixture")
 }
+
+#[allow(
+    dead_code,
+    reason = "native_codecs uses these shared fixtures; jsonld_alloc does not"
+)]
+pub(crate) fn build_many_named_graph_dataset(graph_count: usize) -> Arc<RdfDataset> {
+    let mut builder = RdfDatasetBuilder::new();
+    let predicate = builder.intern_iri("https://bench.example/predicate");
+    for index in 0..graph_count {
+        let subject = builder.intern_iri(&format!("https://bench.example/subject/{index}"));
+        let object = builder.intern_iri(&format!("https://bench.example/object/{index}"));
+        let graph = builder.intern_iri(&format!("https://bench.example/graph/{index}"));
+        builder.push_quad(subject, predicate, object, Some(graph));
+    }
+    builder.freeze().expect("many-graph JSON-LD fixture")
+}
+
+#[allow(
+    dead_code,
+    reason = "native_codecs uses these shared fixtures; jsonld_alloc does not"
+)]
+pub(crate) fn build_multivalue_dataset(value_count: usize) -> Arc<RdfDataset> {
+    let mut builder = RdfDatasetBuilder::new();
+    let subject = builder.intern_iri("https://bench.example/subject");
+    let predicate = builder.intern_iri("https://bench.example/value");
+    for index in 0..value_count {
+        let object = builder.intern_iri(&format!("https://bench.example/object/{index:05}"));
+        builder.push_quad(subject, predicate, object, None);
+    }
+    builder.freeze().expect("multivalue JSON-LD fixture")
+}

--- a/crates/rdf/src/lib.rs
+++ b/crates/rdf/src/lib.rs
@@ -96,6 +96,15 @@ pub mod viz;
 pub use dataset_io::dataset_from_bytes;
 pub use gts_import_graph::import_gts_graph;
 pub use gts_import_sink::import_gts_events;
+pub use native_codecs::jsonld::{
+    CompiledJsonLdContext, JSON_LD_SERIALIZE_OPTIONS_VERSION, JsonLdContainer, JsonLdContextLimits,
+    JsonLdContextRegistry, JsonLdDirection, JsonLdNullable, JsonLdSerializeMode,
+    JsonLdSerializeOptions, JsonLdTermDefinition, JsonLdTermSelection, JsonLdTermSelectionKind,
+    JsonLdTypeMapping, derive_jsonld_context, serialize_dataset_to_jsonld,
+    serialize_dataset_to_jsonld_with_context, serialize_dataset_to_jsonld_with_options,
+    serialize_dataset_to_yamlld, serialize_dataset_to_yamlld_with_context,
+    serialize_dataset_to_yamlld_with_options,
+};
 pub use native_codecs::okf::{
     OkfBundle, OkfConfig, OkfError, OkfReadOutcome, OkfWriteOutcome, OkfWriter, lift_okf_bundle,
     write_okf_bundle,
@@ -103,7 +112,8 @@ pub use native_codecs::okf::{
 pub use native_codecs::{
     GtsCodecBackend, NativeRdfFormat, ParseOptions, SerializeOutcome, SpanTable, classify,
     parse_dataset, parse_dataset_with, serialize_dataset, serialize_dataset_base_only,
-    serialize_dataset_to_format,
+    serialize_dataset_to_format, serialize_dataset_to_format_with_jsonld_options,
+    serialize_dataset_with_jsonld_options,
 };
 pub use native_quads::{
     canonical_flat_nquads, canonical_flat_nquads_with, dataset_from_quad_sources,

--- a/crates/rdf/src/native_codecs/jsonld.rs
+++ b/crates/rdf/src/native_codecs/jsonld.rs
@@ -17,6 +17,7 @@ mod carrier;
 /// Compiled JSON-LD 1.1 contexts, immutable offline registries, and configured
 /// serialization options shared by every JSON-LD/YAML-LD surface.
 pub mod context;
+mod derived;
 mod expand;
 
 pub use context::{
@@ -230,6 +231,21 @@ pub fn serialize_dataset_to_jsonld_with_options(
     serialize_ser_graph_with_options(&graph, options)
 }
 
+/// Derive a deterministic, vocabulary-neutral JSON-LD context from dataset IRI slots.
+///
+/// Only reversible `#`, `/`, and URN-style `:` namespace boundaries that reduce total
+/// encoded bytes are retained. Aliases are assigned as `ns0`, `ns1`, … from sorted
+/// namespace IRIs; no `@vocab` mapping or caller vocabulary is invented.
+pub fn derive_jsonld_context(dataset: &RdfDataset) -> Result<CompiledJsonLdContext, RdfDiagnostic> {
+    let graph = build_ser_graph(
+        dataset,
+        NativeRdfFormat::NQuads,
+        SerializeGraph::Dataset,
+        true,
+    )?;
+    derived::derive_context(&build_carrier(&graph, true)?)
+}
+
 /// Serialize an already-materialized [`SerGraph`] to a deterministic JSON-LD-star
 /// document.
 fn serialize_ser_graph(graph: &SerGraph) -> Result<String, RdfDiagnostic> {
@@ -245,10 +261,10 @@ fn serialize_ser_graph_with_options(
     match options.mode() {
         JsonLdSerializeMode::Expanded => serialize_carrier_expanded(&carrier),
         JsonLdSerializeMode::Context(context) => serialize_carrier_compacted(&carrier, context),
-        JsonLdSerializeMode::Derived => Err(RdfDiagnostic::error(
-            "jsonld-derived-unavailable",
-            "derived JSON-LD context selection requires dataset derivation",
-        )),
+        JsonLdSerializeMode::Derived => {
+            let context = derived::derive_context(&carrier)?;
+            serialize_carrier_compacted(&carrier, &context)
+        }
     }
 }
 

--- a/crates/rdf/src/native_codecs/jsonld.rs
+++ b/crates/rdf/src/native_codecs/jsonld.rs
@@ -27,8 +27,9 @@ pub use context::{
     JsonLdTypeMapping,
 };
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt::Write as _;
+use std::hash::BuildHasherDefault;
 use std::io::Write as IoWrite;
 use std::sync::Arc;
 
@@ -114,6 +115,8 @@ struct Indexes<'a> {
 type QuadGroups = BTreeMap<Option<usize>, BTreeMap<usize, Vec<(usize, usize)>>>;
 /// Reifier id to every `(subject, predicate, object, graph)` binding it owns.
 type BindingsByReifier = BTreeMap<usize, Vec<(usize, usize, usize, Option<usize>)>>;
+type FixedHashMap<K, V> = std::collections::HashMap<K, V, BuildHasherDefault<ahash::AHasher>>;
+type FixedHashSet<T> = HashSet<T, BuildHasherDefault<ahash::AHasher>>;
 
 // ── serialize-side helpers over the first-party SerGraph ────────────────────────────
 
@@ -902,28 +905,38 @@ fn fold_document_rdf_lists(document: &mut CarrierDocument) {
     for (index, graph) in document.named_graphs.iter().enumerate() {
         graph_usage[index + 1].insert(graph.id.clone());
     }
+    let mut usage_counts: FixedHashMap<String, usize> = FixedHashMap::default();
+    for usage in &graph_usage {
+        for id in usage {
+            *usage_counts.entry(id.clone()).or_default() += 1;
+        }
+    }
 
-    let external_for = |index: usize| -> BTreeSet<String> {
-        graph_usage
-            .iter()
-            .enumerate()
-            .filter(|(other, _)| *other != index)
-            .flat_map(|(_, usage)| usage.iter().cloned())
-            .collect()
-    };
-    fold_rdf_lists(&mut document.default_nodes, &external_for(0));
+    fold_rdf_lists(&mut document.default_nodes, |id| {
+        used_in_another_graph(id, &graph_usage[0], &usage_counts)
+    });
     for (index, graph) in document.named_graphs.iter_mut().enumerate() {
-        let mut externally_used = external_for(index + 1);
+        let current_usage = &graph_usage[index + 1];
         // A graph name and a node/list identifier inhabit the same RDF blank-node
         // identity space.  Keep that identity explicit even when the only other use
         // of the identifier is as the name of the graph currently being folded.
-        externally_used.insert(graph.id.clone());
-        fold_rdf_lists(&mut graph.nodes, &externally_used);
+        let graph_id = graph.id.as_str();
+        fold_rdf_lists(&mut graph.nodes, |id| {
+            id == graph_id || used_in_another_graph(id, current_usage, &usage_counts)
+        });
     }
 }
 
-fn carrier_node_usage(nodes: &[CarrierNode]) -> BTreeSet<String> {
-    let mut usage = BTreeSet::new();
+fn used_in_another_graph(
+    id: &str,
+    current_usage: &FixedHashSet<String>,
+    usage_counts: &FixedHashMap<String, usize>,
+) -> bool {
+    usage_counts.get(id).copied().unwrap_or_default() > usize::from(current_usage.contains(id))
+}
+
+fn carrier_node_usage(nodes: &[CarrierNode]) -> FixedHashSet<String> {
+    let mut usage = FixedHashSet::default();
     for node in nodes {
         usage.insert(node.id.clone());
         for values in node.properties.values() {
@@ -937,7 +950,7 @@ fn carrier_node_usage(nodes: &[CarrierNode]) -> BTreeSet<String> {
 
 fn collect_carrier_value_ids(
     value: &CarrierValue,
-    output: &mut BTreeSet<String>,
+    output: &mut FixedHashSet<String>,
     annotation_subjects: bool,
 ) {
     collect_carrier_term_ids(&value.term, output);
@@ -953,7 +966,7 @@ fn collect_carrier_value_ids(
     }
 }
 
-fn collect_carrier_term_ids(term: &CarrierTerm, output: &mut BTreeSet<String>) {
+fn collect_carrier_term_ids(term: &CarrierTerm, output: &mut FixedHashSet<String>) {
     match term {
         CarrierTerm::Id(id) => {
             output.insert(id.clone());
@@ -971,21 +984,21 @@ fn collect_carrier_term_ids(term: &CarrierTerm, output: &mut BTreeSet<String>) {
     }
 }
 
-fn fold_rdf_lists(nodes: &mut Vec<CarrierNode>, externally_used: &BTreeSet<String>) {
+fn fold_rdf_lists(nodes: &mut Vec<CarrierNode>, externally_used: impl Fn(&str) -> bool) {
     let mut annotation_subjects = BTreeSet::new();
     for node in nodes.iter() {
         collect_annotation_subjects(node, &mut annotation_subjects);
     }
-    let node_by_id: BTreeMap<String, usize> = nodes
+    let node_by_id: FixedHashMap<&str, usize> = nodes
         .iter()
         .enumerate()
-        .map(|(index, node)| (node.id.clone(), index))
+        .map(|(index, node)| (node.id.as_str(), index))
         .collect();
     let candidates: BTreeSet<String> = nodes
         .iter()
         .filter(|node| {
             node.id.starts_with("_:")
-                && !externally_used.contains(&node.id)
+                && !externally_used(&node.id)
                 && !annotation_subjects.contains(&node.id)
                 && node.types.is_empty()
                 && node.properties.len() == 2
@@ -1031,7 +1044,10 @@ fn fold_rdf_lists(nodes: &mut Vec<CarrierNode>, externally_used: &BTreeSet<Strin
             if !seen.insert(current.clone()) || incoming.get(&current) != Some(&1) {
                 break false;
             }
-            let Some(node) = node_by_id.get(&current).and_then(|index| nodes.get(*index)) else {
+            let Some(node) = node_by_id
+                .get(current.as_str())
+                .and_then(|index| nodes.get(*index))
+            else {
                 break false;
             };
             let Some(first) = node.properties.get(RDF_FIRST).and_then(|rows| rows.first()) else {
@@ -1302,7 +1318,7 @@ fn term_to_value(graph: &SerGraph, term: &SerTerm) -> Result<CarrierTerm, RdfDia
             {
                 None
             } else {
-                Some(absolute_iri(&datatype))
+                Some(datatype)
             };
             Ok(CarrierTerm::Literal(CarrierLiteral {
                 lexical: term.value.clone().unwrap_or_default(),
@@ -1426,37 +1442,6 @@ fn term_sort_key(graph: &SerGraph, term: &SerTerm) -> String {
 /// Preserve a source IRI verbatim at the vocabulary-free serialization boundary.
 fn absolute_iri(iri: &str) -> String {
     iri.to_string()
-}
-
-/// Deterministic comparison of JSON-LD value objects.
-fn cmp_value(a: &Value, b: &Value) -> std::cmp::Ordering {
-    let key = |v: &Value| -> String {
-        if let Some(s) = v.as_str() {
-            return format!("0:{s}");
-        }
-        if let Some(obj) = v.as_object() {
-            let mut parts: Vec<String> = Vec::new();
-            if let Some(id) = obj.get("@id").and_then(Value::as_str) {
-                parts.push(format!("id={id}"));
-            }
-            if let Some(val) = obj.get("@value").and_then(Value::as_str) {
-                parts.push(format!("value={val}"));
-            }
-            if let Some(lang) = obj.get("@language").and_then(Value::as_str) {
-                parts.push(format!("lang={lang}"));
-            }
-            if let Some(dir) = obj.get("@direction").and_then(Value::as_str) {
-                parts.push(format!("dir={dir}"));
-            }
-            if let Some(dt) = obj.get("@type").and_then(Value::as_str) {
-                parts.push(format!("dt={dt}"));
-            }
-            parts.sort();
-            return format!("1:{}", parts.join("|"));
-        }
-        format!("2:{v}")
-    };
-    key(a).cmp(&key(b))
 }
 
 // ── parse side: JSON-LD-star → native carrier ───────────────────────────────────────

--- a/crates/rdf/src/native_codecs/jsonld.rs
+++ b/crates/rdf/src/native_codecs/jsonld.rs
@@ -13,6 +13,17 @@
 //! The JSON output is byte-deterministic: every map is a [`BTreeMap`] and every array is
 //! explicitly sorted, so the document does not depend on input append order.
 
+/// Compiled JSON-LD 1.1 contexts, immutable offline registries, and configured
+/// serialization options shared by every JSON-LD/YAML-LD surface.
+pub mod context;
+
+pub use context::{
+    CompiledJsonLdContext, JSON_LD_SERIALIZE_OPTIONS_VERSION, JsonLdContainer, JsonLdContextLimits,
+    JsonLdContextRegistry, JsonLdDirection, JsonLdNullable, JsonLdSerializeMode,
+    JsonLdSerializeOptions, JsonLdTermDefinition, JsonLdTermSelection, JsonLdTermSelectionKind,
+    JsonLdTypeMapping,
+};
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 use std::sync::Arc;

--- a/crates/rdf/src/native_codecs/jsonld.rs
+++ b/crates/rdf/src/native_codecs/jsonld.rs
@@ -434,11 +434,11 @@ fn jsonld_to_yaml(json: &str, schema_url: Option<&str>) -> Result<String, RdfDia
     Ok(header + &body)
 }
 
-/// Build the deliberately empty JSON-LD `@context`.
+/// Build the deliberately empty JSON-LD `@context` for the byte-frozen legacy route.
 ///
-/// PurRDF owns no vocabulary or prefix policy. Every emitted predicate, datatype,
-/// triple-term predicate, and reifier predicate is therefore an absolute source IRI;
-/// callers may compact the document under their own context after serialization.
+/// Configured serializers compact through the caller's context or an explicitly
+/// selected deterministic derived context. No-options entry points retain this exact
+/// expanded representation for compatibility.
 fn build_context() -> Value {
     to_json_object(BTreeMap::new())
 }

--- a/crates/rdf/src/native_codecs/jsonld.rs
+++ b/crates/rdf/src/native_codecs/jsonld.rs
@@ -44,7 +44,7 @@ use super::codec::RdfCodec;
 use super::ser_model::{SerGraph, SerTerm, SerTermKind};
 use super::serialize::build_ser_graph;
 use super::text_parse::LineParseMode;
-use crate::{RdfDataset, RdfDiagnostic, RdfQuad, RdfTerm, SerializeGraph};
+use crate::{DatasetView, RdfDataset, RdfDiagnostic, RdfQuad, RdfTerm, SerializeGraph};
 
 // Literal datatype sentinels (read off the carrier's first-class literal fields).
 const RDF_DIR_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString";
@@ -200,7 +200,7 @@ impl RdfCodec for YamlLdCodec {
 }
 
 /// Serialize the carrier dataset to a deterministic JSON-LD-star document.
-pub fn serialize_dataset_to_jsonld(dataset: &RdfDataset) -> Result<String, RdfDiagnostic> {
+pub fn serialize_dataset_to_jsonld<D: DatasetView>(dataset: &D) -> Result<String, RdfDiagnostic> {
     // Build the same first-party graph shape the RDF text serializers walk. A
     // dataset-capable format (N-Quads) keeps named graphs; the full RDF 1.2 statement
     // layer participates.
@@ -218,8 +218,8 @@ pub fn serialize_dataset_to_jsonld(dataset: &RdfDataset) -> Result<String, RdfDi
 /// Expanded mode is byte-identical to [`serialize_dataset_to_jsonld`]. A compiled
 /// caller context is applied through the typed RDF 1.2 carrier; derived mode is
 /// implemented by the deterministic dataset analysis layer.
-pub fn serialize_dataset_to_jsonld_with_options(
-    dataset: &RdfDataset,
+pub fn serialize_dataset_to_jsonld_with_options<D: DatasetView>(
+    dataset: &D,
     options: &JsonLdSerializeOptions,
 ) -> Result<String, RdfDiagnostic> {
     let graph = build_ser_graph(
@@ -231,12 +231,33 @@ pub fn serialize_dataset_to_jsonld_with_options(
     serialize_ser_graph_with_options(&graph, options)
 }
 
+/// Serialize a dataset through an already compiled, reusable caller context.
+///
+/// This is the allocation-light overload for callers that retain one context across
+/// many datasets. It is equivalent to context-mode [`JsonLdSerializeOptions`] without
+/// cloning the compiled context.
+pub fn serialize_dataset_to_jsonld_with_context<D: DatasetView>(
+    dataset: &D,
+    context: &CompiledJsonLdContext,
+) -> Result<String, RdfDiagnostic> {
+    let graph = build_ser_graph(
+        dataset,
+        NativeRdfFormat::NQuads,
+        SerializeGraph::Dataset,
+        true,
+    )?;
+    let carrier = build_carrier(&graph, true)?;
+    serialize_carrier_compacted(&carrier, context)
+}
+
 /// Derive a deterministic, vocabulary-neutral JSON-LD context from dataset IRI slots.
 ///
 /// Only reversible `#`, `/`, and URN-style `:` namespace boundaries that reduce total
 /// encoded bytes are retained. Aliases are assigned as `ns0`, `ns1`, … from sorted
 /// namespace IRIs; no `@vocab` mapping or caller vocabulary is invented.
-pub fn derive_jsonld_context(dataset: &RdfDataset) -> Result<CompiledJsonLdContext, RdfDiagnostic> {
+pub fn derive_jsonld_context<D: DatasetView>(
+    dataset: &D,
+) -> Result<CompiledJsonLdContext, RdfDiagnostic> {
     let graph = build_ser_graph(
         dataset,
         NativeRdfFormat::NQuads,
@@ -252,7 +273,7 @@ fn serialize_ser_graph(graph: &SerGraph) -> Result<String, RdfDiagnostic> {
     serialize_carrier_expanded(&build_carrier(graph, false)?)
 }
 
-fn serialize_ser_graph_with_options(
+pub(crate) fn serialize_ser_graph_with_options(
     graph: &SerGraph,
     options: &JsonLdSerializeOptions,
 ) -> Result<String, RdfDiagnostic> {
@@ -333,8 +354,8 @@ impl IoWrite for BoundedJsonOutput {
 /// The JSON-LD-star document is re-serialized to YAML with sorted keys, block style, no
 /// anchors/aliases, and an explicit `@context`. The header carries a YAML
 /// language-server schema reference.
-pub fn serialize_dataset_to_yamlld(
-    dataset: &RdfDataset,
+pub fn serialize_dataset_to_yamlld<D: DatasetView>(
+    dataset: &D,
     schema_url: Option<&str>,
 ) -> Result<String, RdfDiagnostic> {
     let graph = build_ser_graph(
@@ -346,6 +367,41 @@ pub fn serialize_dataset_to_yamlld(
     serialize_ser_graph_to_yamlld(&graph, schema_url)
 }
 
+/// Serialize a dataset to deterministic YAML-LD under an explicitly selected mode.
+///
+/// The optional schema reference is carried by [`JsonLdSerializeOptions`] so direct,
+/// generic, CLI, and foreign-language routes all produce the same header bytes.
+pub fn serialize_dataset_to_yamlld_with_options<D: DatasetView>(
+    dataset: &D,
+    options: &JsonLdSerializeOptions,
+) -> Result<String, RdfDiagnostic> {
+    let graph = build_ser_graph(
+        dataset,
+        NativeRdfFormat::NQuads,
+        SerializeGraph::Dataset,
+        true,
+    )?;
+    serialize_ser_graph_to_yamlld_with_options(&graph, options)
+}
+
+/// Serialize a dataset to deterministic YAML-LD through an already compiled,
+/// reusable caller context.
+pub fn serialize_dataset_to_yamlld_with_context<D: DatasetView>(
+    dataset: &D,
+    context: &CompiledJsonLdContext,
+    schema_url: Option<&str>,
+) -> Result<String, RdfDiagnostic> {
+    let graph = build_ser_graph(
+        dataset,
+        NativeRdfFormat::NQuads,
+        SerializeGraph::Dataset,
+        true,
+    )?;
+    let carrier = build_carrier(&graph, true)?;
+    let json = serialize_carrier_compacted(&carrier, context)?;
+    jsonld_to_yaml(&json, schema_url)
+}
+
 /// Serialize an already-materialized [`SerGraph`] to deterministic YAML-LD-star bytes —
 /// the graph-level core shared by [`serialize_dataset_to_yamlld`] and [`YamlLdCodec`].
 fn serialize_ser_graph_to_yamlld(
@@ -353,8 +409,20 @@ fn serialize_ser_graph_to_yamlld(
     schema_url: Option<&str>,
 ) -> Result<String, RdfDiagnostic> {
     let json = serialize_ser_graph(graph)?;
+    jsonld_to_yaml(&json, schema_url)
+}
+
+pub(crate) fn serialize_ser_graph_to_yamlld_with_options(
+    graph: &SerGraph,
+    options: &JsonLdSerializeOptions,
+) -> Result<String, RdfDiagnostic> {
+    let json = serialize_ser_graph_with_options(graph, options)?;
+    jsonld_to_yaml(&json, options.yaml_schema_url())
+}
+
+fn jsonld_to_yaml(json: &str, schema_url: Option<&str>) -> Result<String, RdfDiagnostic> {
     let value: Value =
-        serde_json::from_str(&json).map_err(|e| decode(format!("parse JSON-LD for YAML: {e}")))?;
+        serde_json::from_str(json).map_err(|e| decode(format!("parse JSON-LD for YAML: {e}")))?;
     let body =
         serde_yaml::to_string(&value).map_err(|e| decode(format!("YAML-LD serialization: {e}")))?;
     let url = schema_url.unwrap_or(BUNDLED_SCHEMA_REF);

--- a/crates/rdf/src/native_codecs/jsonld.rs
+++ b/crates/rdf/src/native_codecs/jsonld.rs
@@ -13,9 +13,11 @@
 //! The JSON output is byte-deterministic: every map is a [`BTreeMap`] and every array is
 //! explicitly sorted, so the document does not depend on input append order.
 
+mod carrier;
 /// Compiled JSON-LD 1.1 contexts, immutable offline registries, and configured
 /// serialization options shared by every JSON-LD/YAML-LD surface.
 pub mod context;
+mod expand;
 
 pub use context::{
     CompiledJsonLdContext, JSON_LD_SERIALIZE_OPTIONS_VERSION, JsonLdContainer, JsonLdContextLimits,
@@ -26,23 +28,30 @@ pub use context::{
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
+use std::io::Write as IoWrite;
 use std::sync::Arc;
 
 use serde_json::Value;
+
+use self::carrier::{
+    Document as CarrierDocument, Literal as CarrierLiteral, NamedGraph as CarrierNamedGraph,
+    Node as CarrierNode, Term as CarrierTerm, Triple as CarrierTriple, Value as CarrierValue,
+};
 
 use super::NativeRdfFormat;
 use super::codec::RdfCodec;
 use super::ser_model::{SerGraph, SerTerm, SerTermKind};
 use super::serialize::build_ser_graph;
 use super::text_parse::LineParseMode;
-use crate::{
-    RdfDataset, RdfDiagnostic, RdfLiteral, RdfQuad, RdfTerm, RdfTextDirection, RdfTriple,
-    SerializeGraph,
-};
+use crate::{RdfDataset, RdfDiagnostic, RdfQuad, RdfTerm, SerializeGraph};
 
 // Literal datatype sentinels (read off the carrier's first-class literal fields).
 const RDF_DIR_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString";
+const RDF_FIRST: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#first";
+const RDF_JSON: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON";
 const RDF_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
+const RDF_NIL: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil";
+const RDF_REST: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest";
 const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
 
 const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
@@ -51,6 +60,11 @@ const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
 /// `schemas-archive/purrdf.schema.json`, so a bare member name resolves inside the
 /// bundle.
 const BUNDLED_SCHEMA_REF: &str = "purrdf.schema.json";
+const MAX_JSON_LD_OUTPUT_BYTES: usize = 256 * 1024 * 1024;
+const MAX_JSON_LD_CARRIER_ROWS: usize = 4_194_304;
+const MAX_JSON_LD_CARRIER_TEXT_BYTES: usize = 256 * 1024 * 1024;
+const ESTIMATED_CARRIER_ROW_BYTES: usize = 256;
+const COMPACTED_CARRIER_WORKING_COPIES: usize = 3;
 
 /// RDF 1.2 reifier predicate.
 pub const RDF_REIFIES: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies";
@@ -80,8 +94,6 @@ pub struct StatementMetadataVocab<'a> {
     pub q_object_literal: &'a str,
 }
 
-/// Default-graph and named-graph node maps returned by [`build_graphs`].
-type GraphNodes = (BTreeMap<String, Value>, BTreeMap<String, Value>);
 /// Reifier lookup: base triple (s,p,o) in a given graph (`None` = default graph) ->
 /// reifier ids that annotate it. Graph-scoped: the SAME base triple reified by
 /// DIFFERENT reifiers in DIFFERENT named graphs must not cross-contaminate.
@@ -99,6 +111,8 @@ struct Indexes<'a> {
 }
 /// Quads grouped by graph name and then by subject.
 type QuadGroups = BTreeMap<Option<usize>, BTreeMap<usize, Vec<(usize, usize)>>>;
+/// Reifier id to every `(subject, predicate, object, graph)` binding it owns.
+type BindingsByReifier = BTreeMap<usize, Vec<(usize, usize, usize, Option<usize>)>>;
 
 // ── serialize-side helpers over the first-party SerGraph ────────────────────────────
 
@@ -198,27 +212,104 @@ pub fn serialize_dataset_to_jsonld(dataset: &RdfDataset) -> Result<String, RdfDi
     serialize_ser_graph(&graph)
 }
 
+/// Serialize a carrier dataset under an explicitly selected JSON-LD mode.
+///
+/// Expanded mode is byte-identical to [`serialize_dataset_to_jsonld`]. A compiled
+/// caller context is applied through the typed RDF 1.2 carrier; derived mode is
+/// implemented by the deterministic dataset analysis layer.
+pub fn serialize_dataset_to_jsonld_with_options(
+    dataset: &RdfDataset,
+    options: &JsonLdSerializeOptions,
+) -> Result<String, RdfDiagnostic> {
+    let graph = build_ser_graph(
+        dataset,
+        NativeRdfFormat::NQuads,
+        SerializeGraph::Dataset,
+        true,
+    )?;
+    serialize_ser_graph_with_options(&graph, options)
+}
+
 /// Serialize an already-materialized [`SerGraph`] to a deterministic JSON-LD-star
 /// document.
 fn serialize_ser_graph(graph: &SerGraph) -> Result<String, RdfDiagnostic> {
-    let mut doc = BTreeMap::new();
-    doc.insert("@context".to_string(), build_context());
+    serialize_carrier_expanded(&build_carrier(graph, false)?)
+}
 
-    let (default_nodes, named_graphs) = build_graphs(graph)?;
-
-    let mut top_graph: Vec<Value> = default_nodes.into_values().collect();
-    for (_, graph_obj) in named_graphs {
-        top_graph.push(graph_obj);
+fn serialize_ser_graph_with_options(
+    graph: &SerGraph,
+    options: &JsonLdSerializeOptions,
+) -> Result<String, RdfDiagnostic> {
+    let fold_lists = !matches!(options.mode(), JsonLdSerializeMode::Expanded);
+    let carrier = build_carrier(graph, fold_lists)?;
+    match options.mode() {
+        JsonLdSerializeMode::Expanded => serialize_carrier_expanded(&carrier),
+        JsonLdSerializeMode::Context(context) => serialize_carrier_compacted(&carrier, context),
+        JsonLdSerializeMode::Derived => Err(RdfDiagnostic::error(
+            "jsonld-derived-unavailable",
+            "derived JSON-LD context selection requires dataset derivation",
+        )),
     }
-    // Deterministic order: default-graph nodes by @id, then named graphs by @id.
-    top_graph.sort_by_key(json_key);
+}
 
-    if !top_graph.is_empty() {
-        doc.insert("@graph".to_string(), Value::Array(top_graph));
+fn serialize_carrier_expanded(carrier: &CarrierDocument) -> Result<String, RdfDiagnostic> {
+    let mut output = BoundedJsonOutput::new(MAX_JSON_LD_OUTPUT_BYTES);
+    carrier.write_expanded_json(&mut output, &build_context())?;
+    finish_json_output(output)
+}
+
+fn serialize_carrier_compacted(
+    carrier: &CarrierDocument,
+    context: &CompiledJsonLdContext,
+) -> Result<String, RdfDiagnostic> {
+    let mut output = BoundedJsonOutput::new(MAX_JSON_LD_OUTPUT_BYTES);
+    carrier.write_compacted_json(&mut output, context)?;
+    finish_json_output(output)
+}
+
+fn finish_json_output(output: BoundedJsonOutput) -> Result<String, RdfDiagnostic> {
+    String::from_utf8(output.into_bytes())
+        .map_err(|source| decode(format!("JSON-LD output is not UTF-8: {source}")))
+}
+
+struct BoundedJsonOutput {
+    bytes: Vec<u8>,
+    limit: usize,
+}
+
+impl BoundedJsonOutput {
+    fn new(limit: usize) -> Self {
+        Self {
+            bytes: Vec::new(),
+            limit,
+        }
     }
 
-    let value = to_json_object(doc);
-    serde_json::to_string_pretty(&value).map_err(|e| decode(format!("JSON-LD serialization: {e}")))
+    fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+impl IoWrite for BoundedJsonOutput {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        let next = self
+            .bytes
+            .len()
+            .checked_add(bytes.len())
+            .ok_or_else(|| std::io::Error::other("JSON-LD output length overflow"))?;
+        if next > self.limit {
+            return Err(std::io::Error::other(format!(
+                "JSON-LD output exceeds {} bytes",
+                self.limit
+            )));
+        }
+        self.bytes.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 /// Serialize the carrier dataset to deterministic YAML-LD-star bytes.
@@ -268,8 +359,9 @@ fn build_context() -> Value {
     to_json_object(BTreeMap::new())
 }
 
-/// Build default-graph nodes and named-graph objects.
-fn build_graphs(graph: &SerGraph) -> Result<GraphNodes, RdfDiagnostic> {
+/// Build the typed expanded carrier from the first-party serialization graph.
+fn build_carrier(graph: &SerGraph, fold_lists: bool) -> Result<CarrierDocument, RdfDiagnostic> {
+    validate_source_carrier_budget(graph)?;
     // Reifier index: base triple (s,p,o) in graph g -> reifier ids that annotate it.
     let mut reifier_of: ReifierIndex = BTreeMap::new();
     for &(rid, (s, p, o), g) in &graph.reifiers {
@@ -309,10 +401,22 @@ fn build_graphs(graph: &SerGraph) -> Result<GraphNodes, RdfDiagnostic> {
         });
     }
 
+    validate_materialized_carrier_budget(graph, &annotations_of)?;
+
     let indexes = Indexes {
         reifier_of: &reifier_of,
         annotations_of: &annotations_of,
     };
+
+    let mut bindings_by_reifier = BindingsByReifier::new();
+    for &(rid, (s, p, o), g) in &graph.reifiers {
+        if graph.terms[rid].kind != SerTermKind::Triple {
+            bindings_by_reifier
+                .entry(rid)
+                .or_default()
+                .push((s, p, o, g));
+        }
+    }
 
     // Group quads by graph name (None = default graph) and then by subject.
     let mut by_graph: QuadGroups = BTreeMap::new();
@@ -338,7 +442,7 @@ fn build_graphs(graph: &SerGraph) -> Result<GraphNodes, RdfDiagnostic> {
         .iter()
         .map(|&(s, p, o, g)| (s, p, o, g))
         .collect();
-    let mut orphan_by_graph: BTreeMap<Option<usize>, Vec<Value>> = BTreeMap::new();
+    let mut orphan_by_graph: BTreeMap<Option<usize>, Vec<CarrierNode>> = BTreeMap::new();
     for &(rid, (s, p, o), g) in &graph.reifiers {
         // A triple term is self-reifying: its `reifier` row's "reifier" is the triple
         // term itself (kind `Triple`), carrying the term's components — NOT a real
@@ -352,9 +456,30 @@ fn build_graphs(graph: &SerGraph) -> Result<GraphNodes, RdfDiagnostic> {
             orphan_by_graph.entry(g).or_default().push(node);
         }
     }
+    // An annotation row has its own graph and need not share that graph with the
+    // reifier declaration. When another graph owns the declaration, emit an
+    // annotation-only node in this graph; the explicit/implicit reifier binding in its
+    // original graph still identifies the subject as a reifier during the two-pass
+    // fold. Without this fragment a graph-scoped annotation is silently omitted.
+    for &(rid, annotation_graph) in annotations_of.keys() {
+        let represented_in_graph = bindings_by_reifier
+            .get(&rid)
+            .is_some_and(|bindings| bindings.iter().any(|binding| binding.3 == annotation_graph));
+        if !represented_in_graph {
+            orphan_by_graph
+                .entry(annotation_graph)
+                .or_default()
+                .push(build_annotation_node(
+                    graph,
+                    rid,
+                    annotation_graph,
+                    &indexes,
+                )?);
+        }
+    }
 
-    let mut default_nodes: BTreeMap<String, Value> = BTreeMap::new();
-    let mut named_graphs: BTreeMap<String, Value> = BTreeMap::new();
+    let mut default_nodes: BTreeMap<String, CarrierNode> = BTreeMap::new();
+    let mut named_graphs: BTreeMap<String, CarrierNamedGraph> = BTreeMap::new();
 
     // Iterate the union of graph names carrying asserted quads OR orphan reifiers (a graph
     // may carry only orphan reifiers, so `by_graph` alone would miss it).
@@ -364,7 +489,7 @@ fn build_graphs(graph: &SerGraph) -> Result<GraphNodes, RdfDiagnostic> {
         .chain(orphan_by_graph.keys().copied())
         .collect();
     for g in graph_keys {
-        let mut nodes: Vec<Value> = Vec::new();
+        let mut nodes: Vec<CarrierNode> = Vec::new();
         if let Some(subjects) = by_graph.remove(&g) {
             for (s, pos) in subjects {
                 let node = build_node(graph, s, pos, g, &indexes)?;
@@ -374,33 +499,597 @@ fn build_graphs(graph: &SerGraph) -> Result<GraphNodes, RdfDiagnostic> {
         if let Some(orphans) = orphan_by_graph.remove(&g) {
             nodes.extend(orphans);
         }
-        // Sort nodes by their @id (or lexical key for bnodes).
-        nodes.sort_by_key(node_id_key);
+        let mut by_id: BTreeMap<String, CarrierNode> = BTreeMap::new();
+        for mut node in nodes {
+            let target = by_id
+                .entry(node.id.clone())
+                .or_insert_with(|| CarrierNode::new(node.id.clone()));
+            target.types.append(&mut node.types);
+            target.types.sort();
+            target.types.dedup();
+            for (property, mut values) in node.properties {
+                target
+                    .properties
+                    .entry(property)
+                    .or_default()
+                    .append(&mut values);
+            }
+            target.sort_values();
+        }
+        let nodes: Vec<CarrierNode> = by_id.into_values().collect();
 
         match g {
             None => {
                 for node in nodes {
-                    if let Some(Value::String(id)) = node.get("@id") {
-                        default_nodes.insert(id.clone(), node);
-                    } else {
-                        // Bnode subject without @id should not happen because we always
-                        // emit _:label; keep a stable fallback key.
-                        default_nodes.insert(format!("__bnode:{node:?}"), node);
-                    }
+                    default_nodes.insert(node.id.clone(), node);
                 }
             }
             Some(gid) => {
                 let graph_term = &graph.terms[gid];
                 let graph_id = term_id(graph_term)?;
-                let mut graph_obj = BTreeMap::new();
-                graph_obj.insert("@id".to_string(), Value::String(graph_id.clone()));
-                graph_obj.insert("@graph".to_string(), Value::Array(nodes));
-                named_graphs.insert(graph_id, to_json_object(graph_obj));
+                named_graphs.insert(
+                    graph_id.clone(),
+                    CarrierNamedGraph {
+                        id: graph_id,
+                        nodes,
+                    },
+                );
             }
         }
     }
 
-    Ok((default_nodes, named_graphs))
+    let mut document = CarrierDocument {
+        default_nodes: default_nodes.into_values().collect(),
+        named_graphs: named_graphs.into_values().collect(),
+    };
+    if fold_lists {
+        fold_document_rdf_lists(&mut document);
+    }
+    Ok(document)
+}
+
+fn validate_source_carrier_budget(graph: &SerGraph) -> Result<(), RdfDiagnostic> {
+    let rows = graph
+        .terms
+        .len()
+        .checked_add(graph.quads.len())
+        .and_then(|count| count.checked_add(graph.reifiers.len()))
+        .and_then(|count| count.checked_add(graph.annotations.len()))
+        .ok_or_else(|| decode("JSON-LD carrier row count overflow"))?;
+    if rows > MAX_JSON_LD_CARRIER_ROWS {
+        return Err(decode(format!(
+            "JSON-LD carrier requires {rows} rows; limit is {MAX_JSON_LD_CARRIER_ROWS}"
+        )));
+    }
+    let retained_text = graph.terms.iter().try_fold(0usize, |total, term| {
+        [
+            term.value.as_deref(),
+            term.lang.as_deref(),
+            term.direction.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .try_fold(total, |total, value| total.checked_add(value.len()))
+    });
+    let retained_text =
+        retained_text.ok_or_else(|| decode("JSON-LD carrier retained-text byte count overflow"))?;
+    if retained_text > MAX_JSON_LD_CARRIER_TEXT_BYTES {
+        return Err(decode(format!(
+            "JSON-LD carrier retains {retained_text} text bytes; limit is \
+             {MAX_JSON_LD_CARRIER_TEXT_BYTES}"
+        )));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct CarrierFootprint {
+    rows: usize,
+    text_bytes: usize,
+}
+
+impl CarrierFootprint {
+    fn add(&mut self, other: Self) -> Result<(), RdfDiagnostic> {
+        self.rows = self
+            .rows
+            .checked_add(other.rows)
+            .ok_or_else(|| decode("JSON-LD materialized carrier row count overflow"))?;
+        self.text_bytes = self
+            .text_bytes
+            .checked_add(other.text_bytes)
+            .ok_or_else(|| decode("JSON-LD materialized carrier text count overflow"))?;
+        Ok(())
+    }
+
+    fn add_term(
+        &mut self,
+        graph: &SerGraph,
+        term: usize,
+        memo: &mut BTreeMap<usize, Self>,
+        visiting: &mut BTreeSet<usize>,
+    ) -> Result<(), RdfDiagnostic> {
+        self.add(carrier_term_footprint(graph, term, memo, visiting)?)
+    }
+}
+
+/// Reject source graphs whose typed-carrier expansion would amplify shared terms or
+/// annotations beyond the fixed working-memory envelope.
+///
+/// The source interner stores text once, while the immutable carrier intentionally owns
+/// strings at each semantic occurrence.  Count those occurrences before construction,
+/// including every copy of an annotation node attached to a proposition.  The final
+/// estimate also reserves space for B-tree/vector/string bookkeeping, the prepared
+/// compaction copy, and the largest transient compacted subtree.
+fn validate_materialized_carrier_budget(
+    graph: &SerGraph,
+    annotations_of: &AnnotationIndex,
+) -> Result<(), RdfDiagnostic> {
+    validate_materialized_carrier_budget_with_limits(
+        graph,
+        annotations_of,
+        MAX_JSON_LD_CARRIER_ROWS,
+        MAX_JSON_LD_CARRIER_TEXT_BYTES,
+    )
+}
+
+fn validate_materialized_carrier_budget_with_limits(
+    graph: &SerGraph,
+    annotations_of: &AnnotationIndex,
+    max_rows: usize,
+    max_working_bytes: usize,
+) -> Result<(), RdfDiagnostic> {
+    let mut footprint = CarrierFootprint::default();
+    let mut memo = BTreeMap::new();
+    let mut visiting = BTreeSet::new();
+
+    for &(subject, predicate, object, graph_name) in &graph.quads {
+        footprint.rows = footprint
+            .rows
+            .checked_add(1)
+            .ok_or_else(|| decode("JSON-LD materialized carrier row count overflow"))?;
+        for term in [Some(subject), Some(predicate), Some(object), graph_name]
+            .into_iter()
+            .flatten()
+        {
+            footprint.add_term(graph, term, &mut memo, &mut visiting)?;
+        }
+    }
+
+    let asserted: BTreeSet<(usize, usize, usize, Option<usize>)> = graph
+        .quads
+        .iter()
+        .map(|&(subject, predicate, object, graph_name)| (subject, predicate, object, graph_name))
+        .collect();
+    let mut represented_annotations = BTreeSet::new();
+    for &(reifier, (subject, predicate, object), graph_name) in &graph.reifiers {
+        if graph.terms[reifier].kind == SerTermKind::Triple {
+            continue;
+        }
+        represented_annotations.insert((reifier, graph_name));
+        footprint.rows = footprint
+            .rows
+            .checked_add(1)
+            .ok_or_else(|| decode("JSON-LD materialized carrier row count overflow"))?;
+        for term in [
+            Some(reifier),
+            Some(subject),
+            Some(predicate),
+            Some(object),
+            graph_name,
+        ]
+        .into_iter()
+        .flatten()
+        {
+            footprint.add_term(graph, term, &mut memo, &mut visiting)?;
+        }
+        add_annotation_footprint(
+            graph,
+            annotations_of.get(&(reifier, graph_name)),
+            &mut footprint,
+            &mut memo,
+            &mut visiting,
+        )?;
+        // An asserted binding owns the annotation node on its value object; an orphan
+        // additionally owns the explicit rdf:reifies triple represented above.
+        if !asserted.contains(&(subject, predicate, object, graph_name)) {
+            footprint.rows = footprint
+                .rows
+                .checked_add(1)
+                .ok_or_else(|| decode("JSON-LD materialized carrier row count overflow"))?;
+        }
+    }
+    for (&(reifier, graph_name), annotations) in annotations_of {
+        if represented_annotations.contains(&(reifier, graph_name)) {
+            continue;
+        }
+        footprint.rows = footprint
+            .rows
+            .checked_add(1)
+            .ok_or_else(|| decode("JSON-LD materialized carrier row count overflow"))?;
+        footprint.add_term(graph, reifier, &mut memo, &mut visiting)?;
+        if let Some(graph_name) = graph_name {
+            footprint.add_term(graph, graph_name, &mut memo, &mut visiting)?;
+        }
+        add_annotation_footprint(
+            graph,
+            Some(annotations),
+            &mut footprint,
+            &mut memo,
+            &mut visiting,
+        )?;
+    }
+
+    let structural_bytes = footprint
+        .rows
+        .checked_mul(ESTIMATED_CARRIER_ROW_BYTES)
+        .and_then(|bytes| bytes.checked_add(footprint.text_bytes))
+        .and_then(|bytes| bytes.checked_mul(COMPACTED_CARRIER_WORKING_COPIES))
+        .ok_or_else(|| decode("JSON-LD carrier working-byte estimate overflow"))?;
+    if footprint.rows > max_rows || structural_bytes > max_working_bytes {
+        return Err(decode(format!(
+            "JSON-LD materialized carrier requires {} rows and {structural_bytes} working bytes; \
+             limits are {max_rows} rows and {max_working_bytes} bytes",
+            footprint.rows
+        )));
+    }
+    Ok(())
+}
+
+fn add_annotation_footprint(
+    graph: &SerGraph,
+    annotations: Option<&Vec<(usize, usize)>>,
+    footprint: &mut CarrierFootprint,
+    memo: &mut BTreeMap<usize, CarrierFootprint>,
+    visiting: &mut BTreeSet<usize>,
+) -> Result<(), RdfDiagnostic> {
+    let Some(annotations) = annotations else {
+        return Ok(());
+    };
+    for &(predicate, value) in annotations {
+        footprint.rows = footprint
+            .rows
+            .checked_add(1)
+            .ok_or_else(|| decode("JSON-LD materialized carrier row count overflow"))?;
+        footprint.add_term(graph, predicate, memo, visiting)?;
+        footprint.add_term(graph, value, memo, visiting)?;
+    }
+    Ok(())
+}
+
+fn carrier_term_footprint(
+    graph: &SerGraph,
+    term_id: usize,
+    memo: &mut BTreeMap<usize, CarrierFootprint>,
+    visiting: &mut BTreeSet<usize>,
+) -> Result<CarrierFootprint, RdfDiagnostic> {
+    if let Some(footprint) = memo.get(&term_id) {
+        return Ok(*footprint);
+    }
+    if !visiting.insert(term_id) {
+        return Err(decode(
+            "cyclic RDF triple term cannot be materialized as JSON-LD",
+        ));
+    }
+    let term = graph.terms.get(term_id).ok_or_else(|| {
+        decode(format!(
+            "JSON-LD carrier term index {term_id} is out of range"
+        ))
+    })?;
+    let mut footprint = CarrierFootprint {
+        rows: 1,
+        text_bytes: term
+            .value
+            .as_deref()
+            .map_or(0, str::len)
+            .checked_add(term.lang.as_deref().map_or(0, str::len))
+            .and_then(|bytes| bytes.checked_add(term.direction.as_deref().map_or(0, str::len)))
+            .ok_or_else(|| decode("JSON-LD materialized carrier text count overflow"))?,
+    };
+    if term.kind == SerTermKind::Bnode {
+        footprint.text_bytes = footprint
+            .text_bytes
+            .checked_add(2)
+            .ok_or_else(|| decode("JSON-LD materialized carrier text count overflow"))?;
+    }
+    if let Some(datatype) = term.datatype {
+        footprint.add_term(graph, datatype, memo, visiting)?;
+    }
+    if term.kind == SerTermKind::Triple {
+        let (subject, predicate, object) = triple_components(graph, term)
+            .ok_or_else(|| decode("RDF triple term has no component binding"))?;
+        for component in <[usize; 3]>::from((subject, predicate, object)) {
+            footprint.add_term(graph, component, memo, visiting)?;
+        }
+    }
+    visiting.remove(&term_id);
+    memo.insert(term_id, footprint);
+    Ok(footprint)
+}
+
+fn fold_document_rdf_lists(document: &mut CarrierDocument) {
+    let mut graph_usage = Vec::with_capacity(document.named_graphs.len() + 1);
+    graph_usage.push(carrier_node_usage(&document.default_nodes));
+    graph_usage.extend(
+        document
+            .named_graphs
+            .iter()
+            .map(|graph| carrier_node_usage(&graph.nodes)),
+    );
+    for (index, graph) in document.named_graphs.iter().enumerate() {
+        graph_usage[index + 1].insert(graph.id.clone());
+    }
+
+    let external_for = |index: usize| -> BTreeSet<String> {
+        graph_usage
+            .iter()
+            .enumerate()
+            .filter(|(other, _)| *other != index)
+            .flat_map(|(_, usage)| usage.iter().cloned())
+            .collect()
+    };
+    fold_rdf_lists(&mut document.default_nodes, &external_for(0));
+    for (index, graph) in document.named_graphs.iter_mut().enumerate() {
+        let mut externally_used = external_for(index + 1);
+        // A graph name and a node/list identifier inhabit the same RDF blank-node
+        // identity space.  Keep that identity explicit even when the only other use
+        // of the identifier is as the name of the graph currently being folded.
+        externally_used.insert(graph.id.clone());
+        fold_rdf_lists(&mut graph.nodes, &externally_used);
+    }
+}
+
+fn carrier_node_usage(nodes: &[CarrierNode]) -> BTreeSet<String> {
+    let mut usage = BTreeSet::new();
+    for node in nodes {
+        usage.insert(node.id.clone());
+        for values in node.properties.values() {
+            for value in values {
+                collect_carrier_value_ids(value, &mut usage, true);
+            }
+        }
+    }
+    usage
+}
+
+fn collect_carrier_value_ids(
+    value: &CarrierValue,
+    output: &mut BTreeSet<String>,
+    annotation_subjects: bool,
+) {
+    collect_carrier_term_ids(&value.term, output);
+    for annotation in &value.annotations {
+        if annotation_subjects {
+            output.insert(annotation.id.clone());
+        }
+        for values in annotation.properties.values() {
+            for value in values {
+                collect_carrier_value_ids(value, output, annotation_subjects);
+            }
+        }
+    }
+}
+
+fn collect_carrier_term_ids(term: &CarrierTerm, output: &mut BTreeSet<String>) {
+    match term {
+        CarrierTerm::Id(id) => {
+            output.insert(id.clone());
+        }
+        CarrierTerm::Triple(triple) => {
+            collect_carrier_term_ids(&triple.subject, output);
+            collect_carrier_term_ids(&triple.object, output);
+        }
+        CarrierTerm::List(values) => {
+            for value in values {
+                collect_carrier_value_ids(value, output, true);
+            }
+        }
+        CarrierTerm::Literal(_) => {}
+    }
+}
+
+fn fold_rdf_lists(nodes: &mut Vec<CarrierNode>, externally_used: &BTreeSet<String>) {
+    let mut annotation_subjects = BTreeSet::new();
+    for node in nodes.iter() {
+        collect_annotation_subjects(node, &mut annotation_subjects);
+    }
+    let node_by_id: BTreeMap<String, usize> = nodes
+        .iter()
+        .enumerate()
+        .map(|(index, node)| (node.id.clone(), index))
+        .collect();
+    let candidates: BTreeSet<String> = nodes
+        .iter()
+        .filter(|node| {
+            node.id.starts_with("_:")
+                && !externally_used.contains(&node.id)
+                && !annotation_subjects.contains(&node.id)
+                && node.types.is_empty()
+                && node.properties.len() == 2
+                && node
+                    .properties
+                    .get(RDF_FIRST)
+                    .is_some_and(|values| values.len() == 1 && values[0].annotations.is_empty())
+                && node
+                    .properties
+                    .get(RDF_REST)
+                    .is_some_and(|values| values.len() == 1 && values[0].annotations.is_empty())
+        })
+        .map(|node| node.id.clone())
+        .collect();
+
+    let mut incoming: BTreeMap<String, usize> = BTreeMap::new();
+    let mut external_heads = BTreeSet::new();
+    for node in nodes.iter() {
+        for (property, values) in &node.properties {
+            for value in values {
+                count_list_references(
+                    value,
+                    &candidates,
+                    &mut incoming,
+                    &mut external_heads,
+                    property == RDF_REST && candidates.contains(&node.id),
+                );
+            }
+        }
+    }
+
+    let mut lists = BTreeMap::new();
+    let mut consumed = BTreeSet::new();
+    for head in external_heads {
+        if incoming.get(&head) != Some(&1) {
+            continue;
+        }
+        let mut current = head.clone();
+        let mut seen = BTreeSet::new();
+        let mut values = Vec::new();
+        let mut chain = Vec::new();
+        let valid = loop {
+            if !seen.insert(current.clone()) || incoming.get(&current) != Some(&1) {
+                break false;
+            }
+            let Some(node) = node_by_id.get(&current).and_then(|index| nodes.get(*index)) else {
+                break false;
+            };
+            let Some(first) = node.properties.get(RDF_FIRST).and_then(|rows| rows.first()) else {
+                break false;
+            };
+            let Some(rest) = node.properties.get(RDF_REST).and_then(|rows| rows.first()) else {
+                break false;
+            };
+            values.push(first.clone());
+            chain.push(current.clone());
+            let CarrierTerm::Id(rest_id) = &rest.term else {
+                break false;
+            };
+            if rest_id == RDF_NIL {
+                break true;
+            }
+            if !candidates.contains(rest_id) {
+                break false;
+            }
+            current.clone_from(rest_id);
+        };
+        if valid && chain.iter().all(|id| !consumed.contains(id)) {
+            consumed.extend(chain);
+            lists.insert(head, values);
+        }
+    }
+
+    if lists.is_empty() {
+        return;
+    }
+    for node in nodes.iter_mut() {
+        for values in node.properties.values_mut() {
+            for value in values {
+                rewrite_folded_lists(value, &lists);
+            }
+        }
+        node.sort_values();
+    }
+    nodes.retain(|node| !consumed.contains(&node.id));
+}
+
+fn collect_annotation_subjects(node: &CarrierNode, output: &mut BTreeSet<String>) {
+    for values in node.properties.values() {
+        for value in values {
+            for annotation in &value.annotations {
+                output.insert(annotation.id.clone());
+                collect_annotation_subjects(annotation, output);
+            }
+        }
+    }
+}
+
+fn count_list_references(
+    value: &CarrierValue,
+    candidates: &BTreeSet<String>,
+    incoming: &mut BTreeMap<String, usize>,
+    external_heads: &mut BTreeSet<String>,
+    direct_rest: bool,
+) {
+    count_list_term_references(
+        &value.term,
+        candidates,
+        incoming,
+        external_heads,
+        direct_rest,
+    );
+    for annotation in &value.annotations {
+        for values in annotation.properties.values() {
+            for value in values {
+                count_list_references(value, candidates, incoming, external_heads, false);
+            }
+        }
+    }
+}
+
+fn count_list_term_references(
+    term: &CarrierTerm,
+    candidates: &BTreeSet<String>,
+    incoming: &mut BTreeMap<String, usize>,
+    external_heads: &mut BTreeSet<String>,
+    direct_rest: bool,
+) {
+    match term {
+        CarrierTerm::Id(id) if candidates.contains(id) => {
+            *incoming.entry(id.clone()).or_default() += 1;
+            if !direct_rest {
+                external_heads.insert(id.clone());
+            }
+        }
+        CarrierTerm::Triple(triple) => {
+            count_list_term_references(
+                &triple.subject,
+                candidates,
+                incoming,
+                external_heads,
+                false,
+            );
+            count_list_term_references(&triple.object, candidates, incoming, external_heads, false);
+        }
+        CarrierTerm::List(values) => {
+            for value in values {
+                count_list_references(value, candidates, incoming, external_heads, false);
+            }
+        }
+        CarrierTerm::Id(_) | CarrierTerm::Literal(_) => {}
+    }
+}
+
+fn rewrite_folded_lists(value: &mut CarrierValue, lists: &BTreeMap<String, Vec<CarrierValue>>) {
+    rewrite_folded_term(&mut value.term, lists);
+    for annotation in &mut value.annotations {
+        for values in annotation.properties.values_mut() {
+            for value in values {
+                rewrite_folded_lists(value, lists);
+            }
+        }
+        annotation.sort_values();
+    }
+}
+
+fn rewrite_folded_term(term: &mut CarrierTerm, lists: &BTreeMap<String, Vec<CarrierValue>>) {
+    match term {
+        CarrierTerm::Id(id) => {
+            if let Some(values) = lists.get(id) {
+                let mut values = values.clone();
+                for value in &mut values {
+                    rewrite_folded_lists(value, lists);
+                }
+                *term = CarrierTerm::List(values);
+            }
+        }
+        CarrierTerm::Triple(triple) => {
+            rewrite_folded_term(&mut triple.subject, lists);
+            rewrite_folded_term(&mut triple.object, lists);
+        }
+        CarrierTerm::List(values) => {
+            for value in values {
+                rewrite_folded_lists(value, lists);
+            }
+        }
+        CarrierTerm::Literal(_) => {}
+    }
 }
 
 /// Build one node object for a subject from its predicate/object rows.
@@ -410,15 +1099,11 @@ fn build_node(
     pos: Vec<(usize, usize)>,
     g: Option<usize>,
     indexes: &Indexes<'_>,
-) -> Result<Value, RdfDiagnostic> {
+) -> Result<CarrierNode, RdfDiagnostic> {
     let subject_term = &graph.terms[subject];
-    let mut node = BTreeMap::new();
-    node.insert("@id".to_string(), Value::String(term_id(subject_term)?));
+    let mut node = CarrierNode::new(term_id(subject_term)?);
 
     // Group predicate -> objects, preserving rdf:type separately.
-    let mut types: Vec<Value> = Vec::new();
-    let mut props: BTreeMap<String, Vec<Value>> = BTreeMap::new();
-
     for (p, o) in pos {
         let predicate_term = &graph.terms[p];
         let predicate_iri = predicate_term
@@ -428,30 +1113,15 @@ fn build_node(
         let object_term = &graph.terms[o];
 
         if predicate_iri == RDF_TYPE {
-            types.push(term_ref_value(object_term)?);
+            node.types.push(term_id(object_term)?);
         } else {
             let key = absolute_iri(predicate_iri);
             let value = build_value_object(graph, subject, p, o, g, object_term, indexes)?;
-            props.entry(key).or_default().push(value);
+            node.properties.entry(key).or_default().push(value);
         }
     }
-
-    if !types.is_empty() {
-        types.sort_by(cmp_value);
-        node.insert("@type".to_string(), Value::Array(types));
-    }
-
-    for (key, mut values) in props {
-        values.sort_by(cmp_value);
-        let value = if values.len() == 1 {
-            values.into_iter().next().unwrap()
-        } else {
-            Value::Array(values)
-        };
-        node.insert(key, value);
-    }
-
-    Ok(to_json_object(node))
+    node.sort_values();
+    Ok(node)
 }
 
 /// Build a value object for a quad object, attaching `@annotation` when the
@@ -464,35 +1134,19 @@ fn build_value_object(
     g: Option<usize>,
     object_term: &SerTerm,
     indexes: &Indexes<'_>,
-) -> Result<Value, RdfDiagnostic> {
-    let mut value = if object_term.kind == SerTermKind::Triple {
+) -> Result<CarrierValue, RdfDiagnostic> {
+    let term = if object_term.kind == SerTermKind::Triple {
         build_triple_term_value(graph, object_term)?
     } else {
         term_to_value(graph, object_term)?
     };
-
+    let mut value = CarrierValue::plain(term);
     if let Some(reifiers) = indexes.reifier_of.get(&(subject, predicate, object, g)) {
-        let annotations: Result<Vec<Value>, _> = reifiers
+        let annotations: Result<Vec<CarrierNode>, _> = reifiers
             .iter()
             .map(|&rid| build_annotation_node(graph, rid, g, indexes))
             .collect();
-        let annotations = annotations?;
-        let ann_value = if annotations.len() == 1 {
-            annotations.into_iter().next().unwrap()
-        } else {
-            Value::Array(annotations)
-        };
-        // Attach @annotation to the value object.
-        if let Value::Object(ref mut map) = value {
-            map.insert("@annotation".to_string(), ann_value);
-        } else {
-            // Wrap a non-object value (should not happen for annotated triples)
-            // into a value object with @annotation.
-            let mut wrapper = BTreeMap::new();
-            wrapper.insert("@value".to_string(), value);
-            wrapper.insert("@annotation".to_string(), ann_value);
-            value = to_json_object(wrapper);
-        }
+        value.annotations = annotations?;
     }
 
     Ok(value)
@@ -500,7 +1154,7 @@ fn build_value_object(
 
 /// Render a triple term as its distinguishable JSON-LD-star `@triple` object, resolving
 /// its `(s,p,o)` components through the term's own self-reifier binding.
-fn build_triple_term_value(graph: &SerGraph, term: &SerTerm) -> Result<Value, RdfDiagnostic> {
+fn build_triple_term_value(graph: &SerGraph, term: &SerTerm) -> Result<CarrierTerm, RdfDiagnostic> {
     let (s, p, o) = triple_components(graph, term)
         .ok_or_else(|| parse("triple term with no components".to_string()))?;
     build_nested_triple_node(graph, s, p, o)
@@ -518,7 +1172,7 @@ fn build_nested_triple_node(
     s: usize,
     p: usize,
     o: usize,
-) -> Result<Value, RdfDiagnostic> {
+) -> Result<CarrierTerm, RdfDiagnostic> {
     let subject = encode_triple_component(graph, s)?;
     let object = encode_triple_component(graph, o)?;
     let p_term = &graph.terms[p];
@@ -527,19 +1181,16 @@ fn build_nested_triple_node(
         .as_deref()
         .ok_or_else(|| parse("triple-term predicate missing IRI".to_string()))?;
 
-    let mut triple = BTreeMap::new();
-    triple.insert("@subject".to_string(), subject);
-    triple.insert("@predicate".to_string(), Value::String(absolute_iri(p_iri)));
-    triple.insert("@object".to_string(), object);
-
-    let mut map = BTreeMap::new();
-    map.insert("@triple".to_string(), to_json_object(triple));
-    Ok(to_json_object(map))
+    Ok(CarrierTerm::Triple(Box::new(CarrierTriple {
+        subject: Box::new(subject),
+        predicate: absolute_iri(p_iri),
+        object: Box::new(object),
+    })))
 }
 
 /// Encode one component (subject or object) of a triple term, recursing on nested triple
 /// terms so `<<( <<( … )>> p o )>>` round-trips.
-fn encode_triple_component(graph: &SerGraph, idx: usize) -> Result<Value, RdfDiagnostic> {
+fn encode_triple_component(graph: &SerGraph, idx: usize) -> Result<CarrierTerm, RdfDiagnostic> {
     let term = &graph.terms[idx];
     if term.kind == SerTermKind::Triple {
         build_triple_term_value(graph, term)
@@ -549,39 +1200,32 @@ fn encode_triple_component(graph: &SerGraph, idx: usize) -> Result<Value, RdfDia
 }
 
 /// Convert a single RDF term to its JSON-LD value-object form.
-fn term_to_value(graph: &SerGraph, term: &SerTerm) -> Result<Value, RdfDiagnostic> {
+fn term_to_value(graph: &SerGraph, term: &SerTerm) -> Result<CarrierTerm, RdfDiagnostic> {
     match term.kind {
-        SerTermKind::Iri | SerTermKind::Bnode => {
-            let mut map = BTreeMap::new();
-            map.insert("@id".to_string(), Value::String(term_id(term)?));
-            Ok(to_json_object(map))
-        }
+        SerTermKind::Iri | SerTermKind::Bnode => Ok(CarrierTerm::Id(term_id(term)?)),
         SerTermKind::Literal => {
-            let mut map = BTreeMap::new();
-            map.insert(
-                "@value".to_string(),
-                Value::String(term.value.clone().unwrap_or_default()),
-            );
             let datatype = datatype_iri(graph, term);
             // Key @language / @direction off the carrier's FIRST-CLASS language /
             // direction fields, not solely the datatype IRI: the native model carries a
             // directional-language string as `rdf:langString` + a separate `direction`,
             // so a datatype-only test would drop @direction.
-            if datatype == RDF_DIR_LANG_STRING || term.direction.is_some() {
-                if let Some(lang) = &term.lang {
-                    map.insert("@language".to_string(), Value::String(lang.clone()));
-                }
-                if let Some(dir) = &term.direction {
-                    map.insert("@direction".to_string(), Value::String(dir.clone()));
-                }
-            } else if datatype == RDF_LANG_STRING || term.lang.is_some() {
-                if let Some(lang) = &term.lang {
-                    map.insert("@language".to_string(), Value::String(lang.clone()));
-                }
-            } else if datatype != XSD_STRING {
-                map.insert("@type".to_string(), Value::String(absolute_iri(&datatype)));
-            }
-            Ok(to_json_object(map))
+            let language = term.lang.clone();
+            let direction = term.direction.clone();
+            let datatype = if datatype == RDF_DIR_LANG_STRING
+                || datatype == RDF_LANG_STRING
+                || datatype == XSD_STRING
+                || language.is_some()
+            {
+                None
+            } else {
+                Some(absolute_iri(&datatype))
+            };
+            Ok(CarrierTerm::Literal(CarrierLiteral {
+                lexical: term.value.clone().unwrap_or_default(),
+                datatype,
+                language,
+                direction,
+            }))
         }
         SerTermKind::Triple => Err(parse(
             "term_to_value does not handle triple terms; caller should use build_value_object"
@@ -596,13 +1240,11 @@ fn build_annotation_node(
     reifier_id: usize,
     g: Option<usize>,
     indexes: &Indexes<'_>,
-) -> Result<Value, RdfDiagnostic> {
+) -> Result<CarrierNode, RdfDiagnostic> {
     let reifier_term = &graph.terms[reifier_id];
-    let mut node = BTreeMap::new();
-    node.insert("@id".to_string(), Value::String(term_id(reifier_term)?));
+    let mut node = CarrierNode::new(term_id(reifier_term)?);
 
     if let Some(anns) = indexes.annotations_of.get(&(reifier_id, g)) {
-        let mut props: BTreeMap<String, Vec<Value>> = BTreeMap::new();
         for &(p, v) in anns {
             let p_term = &graph.terms[p];
             let p_iri = p_term
@@ -610,21 +1252,15 @@ fn build_annotation_node(
                 .as_deref()
                 .ok_or_else(|| parse("annotation predicate missing IRI".to_string()))?;
             let v_term = &graph.terms[v];
-            let value = simple_term_value(graph, v_term)?;
-            props.entry(absolute_iri(p_iri)).or_default().push(value);
-        }
-        for (key, mut values) in props {
-            values.sort_by(cmp_value);
-            let value = if values.len() == 1 {
-                values.into_iter().next().unwrap()
-            } else {
-                Value::Array(values)
-            };
-            node.insert(key, value);
+            let value = CarrierValue::plain(simple_term_value(graph, v_term)?);
+            node.properties
+                .entry(absolute_iri(p_iri))
+                .or_default()
+                .push(value);
         }
     }
-
-    Ok(to_json_object(node))
+    node.sort_values();
+    Ok(node)
 }
 
 /// Build a standalone node for a reifier whose base triple is not asserted:
@@ -639,62 +1275,25 @@ fn build_orphan_reifier_node(
     o: usize,
     g: Option<usize>,
     indexes: &Indexes<'_>,
-) -> Result<Value, RdfDiagnostic> {
-    let Value::Object(entries) = build_annotation_node(graph, reifier_id, g, indexes)? else {
-        unreachable!("build_annotation_node always returns a JSON object");
-    };
-    let mut node: BTreeMap<String, Value> = entries.into_iter().collect();
-    node.insert(
-        absolute_iri(RDF_REIFIES),
-        build_nested_triple_node(graph, s, p, o)?,
-    );
-    Ok(to_json_object(node))
+) -> Result<CarrierNode, RdfDiagnostic> {
+    let mut node = build_annotation_node(graph, reifier_id, g, indexes)?;
+    node.properties
+        .entry(absolute_iri(RDF_REIFIES))
+        .or_default()
+        .push(CarrierValue::plain(build_nested_triple_node(
+            graph, s, p, o,
+        )?));
+    node.sort_values();
+    Ok(node)
 }
 
 /// Convert a term to a value object without recursive triple-term handling.
-fn simple_term_value(graph: &SerGraph, term: &SerTerm) -> Result<Value, RdfDiagnostic> {
-    match term.kind {
-        SerTermKind::Iri | SerTermKind::Bnode => {
-            let mut map = BTreeMap::new();
-            map.insert("@id".to_string(), Value::String(term_id(term)?));
-            Ok(to_json_object(map))
-        }
-        SerTermKind::Literal => {
-            let mut map = BTreeMap::new();
-            map.insert(
-                "@value".to_string(),
-                Value::String(term.value.clone().unwrap_or_default()),
-            );
-            let datatype = datatype_iri(graph, term);
-            // Same first-class language/direction handling as `term_to_value`.
-            if datatype == RDF_DIR_LANG_STRING || term.direction.is_some() {
-                if let Some(lang) = &term.lang {
-                    map.insert("@language".to_string(), Value::String(lang.clone()));
-                }
-                if let Some(dir) = &term.direction {
-                    map.insert("@direction".to_string(), Value::String(dir.clone()));
-                }
-            } else if datatype == RDF_LANG_STRING || term.lang.is_some() {
-                if let Some(lang) = &term.lang {
-                    map.insert("@language".to_string(), Value::String(lang.clone()));
-                }
-            } else if datatype != XSD_STRING {
-                map.insert("@type".to_string(), Value::String(absolute_iri(&datatype)));
-            }
-            Ok(to_json_object(map))
-        }
-        // Triple-valued annotation objects (an annotation whose value is itself a quoted
-        // triple term) serialize to the same distinguishable `@triple` object as
-        // object-position triple terms, so they round-trip losslessly.
-        SerTermKind::Triple => build_triple_term_value(graph, term),
+fn simple_term_value(graph: &SerGraph, term: &SerTerm) -> Result<CarrierTerm, RdfDiagnostic> {
+    if term.kind == SerTermKind::Triple {
+        build_triple_term_value(graph, term)
+    } else {
+        term_to_value(graph, term)
     }
-}
-
-/// A value object for `rdf:type` targets (always IRI/bnode references).
-fn term_ref_value(term: &SerTerm) -> Result<Value, RdfDiagnostic> {
-    let mut map = BTreeMap::new();
-    map.insert("@id".to_string(), Value::String(term_id(term)?));
-    Ok(to_json_object(map))
 }
 
 /// Return a stable `@id` string for an IRI or blank node term.
@@ -745,23 +1344,6 @@ fn absolute_iri(iri: &str) -> String {
     iri.to_string()
 }
 
-/// Sort key for a top-level @graph entry (named graph object or default node).
-fn json_key(value: &Value) -> String {
-    match value {
-        Value::Object(map) => map
-            .get("@id")
-            .and_then(Value::as_str)
-            .unwrap_or("")
-            .to_string(),
-        _ => String::new(),
-    }
-}
-
-/// Sort key for a node object used while ordering the default-graph nodes.
-fn node_id_key(value: &Value) -> String {
-    json_key(value)
-}
-
 /// Deterministic comparison of JSON-LD value objects.
 fn cmp_value(a: &Value, b: &Value) -> std::cmp::Ordering {
     let key = |v: &Value| -> String {
@@ -799,396 +1381,35 @@ fn cmp_value(a: &Value, b: &Value) -> std::cmp::Ordering {
 ///
 /// This is the inverse of [`serialize_dataset_to_jsonld`]: it interprets the
 /// `@annotation` idiom produced by the PurRDF JSON-LD-star emitter and reconstructs RDF
-/// 1.2 reifier quads (`rdf:reifies` with quoted triple objects) plus annotation triples
-/// in the default graph. Those reifier/annotation rows are FOLDED into the dataset's RDF
-/// 1.2 statement layer at freeze time (`dataset_from_quads`). Named graphs and
-/// directional language strings are preserved. Unsupported JSON-LD features hard-fail.
+/// 1.2 reifier quads (`rdf:reifies` with quoted triple objects) plus graph-scoped
+/// annotation triples. Those rows are folded into the dataset's RDF 1.2 statement layer
+/// at freeze time. Named graphs and directional language strings are preserved; a shape
+/// that cannot be represented by the RDF dataset fails before data is discarded.
 pub fn parse_jsonld(json_bytes: &[u8]) -> Result<Arc<RdfDataset>, RdfDiagnostic> {
-    let json = std::str::from_utf8(json_bytes)
-        .map_err(|e| decode(format!("JSON-LD-star bytes are not UTF-8: {e}")))?;
-    let value: Value =
-        serde_json::from_str(json).map_err(|e| decode(format!("parse JSON-LD-star: {e}")))?;
-    let mut prefixes: BTreeMap<String, String> = BTreeMap::new();
-    let mut vocab = String::new();
-    if let Some(Value::Object(ctx)) = value.get("@context") {
-        for (k, v) in ctx {
-            if k == "@vocab" {
-                if let Some(ns) = v.as_str() {
-                    vocab = ns.to_string();
-                }
-            } else if let Some(ns) = v.as_str() {
-                prefixes.insert(k.clone(), ns.to_string());
-            }
-        }
-    }
-
-    let expand = |curie_or_iri: &str| -> String {
-        if curie_or_iri.starts_with("http://") || curie_or_iri.starts_with("https://") {
-            return curie_or_iri.to_string();
-        }
-        if let Some((p, local)) = curie_or_iri.split_once(':')
-            && let Some(ns) = prefixes.get(p)
-        {
-            return format!("{ns}{local}");
-        }
-        if !vocab.is_empty() && !curie_or_iri.contains(':') {
-            return format!("{vocab}{curie_or_iri}");
-        }
-        curie_or_iri.to_string()
-    };
-
-    // Accumulate native quads (including un-folded `rdf:reifies` rows); the fold to the
-    // RDF 1.2 statement layer happens at `dataset_from_quads` freeze time.
-    let quads: std::cell::RefCell<Vec<RdfQuad>> = std::cell::RefCell::new(Vec::new());
-
-    let emit_node = |node: &Value, graph_iri: Option<&str>| -> Result<(), RdfDiagnostic> {
-        let id = node
-            .get("@id")
-            .and_then(Value::as_str)
-            .ok_or_else(|| decode("node without @id".to_string()))?;
-        let subject: RdfTerm = node_id_term(id, &expand)?;
-        // Validate the named-graph IRI (mirrors the old `NamedNode::new` Result path).
-        let graph_name: Option<RdfTerm> = graph_iri
-            .map(|g| validated_iri_term(&expand(g)))
-            .transpose()?;
-
-        if let Some(types) = node.get("@type") {
-            // `@type` is a single value or an array; each entry is a string CURIE/IRI
-            // (standard JSON-LD) or a `{"@id": …}` node reference (the PurRDF emitter
-            // form). Both expand to an rdf:type object IRI.
-            let entries: Vec<&Value> = match types {
-                Value::Array(arr) => arr.iter().collect(),
-                other => vec![other],
-            };
-            for t in entries {
-                let t_id = t
-                    .as_str()
-                    .or_else(|| t.get("@id").and_then(Value::as_str))
-                    .ok_or_else(|| decode("@type value is neither a string nor an @id node"))?;
-                let obj = validated_iri_term(&expand(t_id))?;
-                push_quad(&quads, subject.clone(), RDF_TYPE, obj, graph_name.clone());
-            }
-        }
-
-        // The `@id` extraction above (`node.get("@id")…ok_or_else`) returns Err for any
-        // non-object node, so reaching here guarantees `node` is a JSON object.
-        let node_obj = node
-            .as_object()
-            .expect("emit_node already proved `node` is an object via its @id lookup");
-        for (key, val) in node_obj {
-            if matches!(key.as_str(), "@id" | "@type" | "@context" | "@graph") {
-                continue;
-            }
-            let predicate = expand(key);
-            // Validate the predicate IRI (mirrors the old `NamedNode::new` Result path).
-            validated_iri_term(&predicate)?;
-            let values = if let Value::Array(arr) = val {
-                arr.clone()
-            } else {
-                vec![val.clone()]
-            };
-            for v in values {
-                emit_value_quad(
-                    &quads,
-                    &subject,
-                    &predicate,
-                    graph_name.as_ref(),
-                    &v,
-                    &expand,
-                )?;
-            }
-        }
-        Ok(())
-    };
-
-    match &value {
-        Value::Array(entries) => {
-            for entry in entries {
-                emit_graph_entry(entry, &emit_node)?;
-            }
-        }
-        Value::Object(obj) if obj.contains_key("@graph") => {
-            let graphs = obj
-                .get("@graph")
-                .and_then(Value::as_array)
-                .ok_or_else(|| decode("@graph must be an array".to_string()))?;
-            for entry in graphs {
-                emit_graph_entry(entry, &emit_node)?;
-            }
-        }
-        Value::Object(_) => {
-            emit_node(&value, None)?;
-        }
-        _ => {
-            return Err(decode(
-                "JSON-LD document must be an object or array of objects".to_string(),
-            ));
-        }
-    }
-
-    // Freeze + fold the RDF 1.2 statement layer (a `rdf:reifies` triple-term object
-    // becomes a reifier binding; a reifier subject's other triples become annotations).
-    crate::dataset_from_quads(&quads.into_inner())
-        .map_err(|e| parse(format!("freeze JSON-LD-star quads: {e}")))
+    let context = CompiledJsonLdContext::compile(&to_json_object(BTreeMap::new()), None)?;
+    parse_jsonld_with_context(json_bytes, &context)
 }
 
-/// Build an [`RdfTerm`] for a node `@id` (`_:label` blank node or expanded IRI),
-/// validating the IRI through the SPARQL-algebra parser (mirrors the old
-/// `oxigraph::model::NamedNode::new` Result discrimination).
-fn node_id_term(id: &str, expand: &dyn Fn(&str) -> String) -> Result<RdfTerm, RdfDiagnostic> {
-    if let Some(label) = id.strip_prefix("_:") {
-        Ok(RdfTerm::blank_node(label.to_string()))
-    } else {
-        validated_iri_term(&expand(id))
-    }
-}
-
-/// Validate `iri` as an absolute IRI (preserving the old `NamedNode::new` Ok/Err
-/// discrimination) and return it as an [`RdfTerm`].
-fn validated_iri_term(iri: &str) -> Result<RdfTerm, RdfDiagnostic> {
-    purrdf_sparql_algebra::NamedNode::new(iri.to_string()).map_err(|e| decode(e.to_string()))?;
-    Ok(RdfTerm::iri(iri.to_string()))
-}
-
-/// Push a base quad (optionally in a named graph) into the native accumulator.
-fn push_quad(
-    quads: &std::cell::RefCell<Vec<RdfQuad>>,
-    subject: RdfTerm,
-    predicate: &str,
-    object: RdfTerm,
-    graph_name: Option<RdfTerm>,
-) {
-    let mut quad = RdfQuad::new(subject, predicate, object);
-    if let Some(g) = graph_name {
-        quad = quad.in_graph(g);
-    }
-    quads.borrow_mut().push(quad);
-}
-
-type EmitNodeFn<'a> = dyn Fn(&Value, Option<&str>) -> Result<(), RdfDiagnostic> + 'a;
-
-fn emit_graph_entry(entry: &Value, emit_node: &EmitNodeFn<'_>) -> Result<(), RdfDiagnostic> {
-    if entry.get("@graph").is_some() {
-        let graph_id = entry
-            .get("@id")
-            .and_then(Value::as_str)
-            .ok_or_else(|| decode("named graph object must have @id".to_string()))?;
-        for node in entry
-            .get("@graph")
-            .and_then(Value::as_array)
-            .ok_or_else(|| decode("@graph must be an array".to_string()))?
-        {
-            emit_node(node, Some(graph_id))?;
-        }
-    } else {
-        emit_node(entry, None)?;
-    }
-    Ok(())
-}
-
-fn emit_value_quad(
-    quads: &std::cell::RefCell<Vec<RdfQuad>>,
-    subject: &RdfTerm,
-    predicate: &str,
-    graph_name: Option<&RdfTerm>,
-    value: &Value,
-    expand: &dyn Fn(&str) -> String,
-) -> Result<(), RdfDiagnostic> {
-    let (object, annotation) = parse_value_object(value, expand)?;
-    push_quad(
-        quads,
-        subject.clone(),
-        predicate,
-        object.clone(),
-        graph_name.cloned(),
-    );
-
-    if let Some(ann) = annotation {
-        // The emitter may attach one annotation object or an array when several
-        // distinct reifiers annotate the same base triple.
-        let annotations: Vec<&Value> = match &ann {
-            Value::Array(arr) => arr.iter().collect(),
-            other => vec![other],
-        };
-        for ann_node in annotations {
-            let reifier_subject = ann_node
-                .get("@id")
-                .and_then(Value::as_str)
-                .ok_or_else(|| decode("annotation without @id".to_string()))?;
-            let reifier: RdfTerm = node_id_term(reifier_subject, expand)?;
-            // The `rdf:reifies` quoted-triple row is pushed un-folded; the
-            // `dataset_from_quads` freeze folds it into the reifier table.
-            let quoted =
-                RdfTerm::triple(RdfTriple::new(subject.clone(), predicate, object.clone()));
-            // The reifier binding + its annotations land in the SAME graph as the base
-            // triple they annotate (the enclosing @graph), so a reifier on a named-graph
-            // triple round-trips into that named graph rather than the default graph.
-            push_quad(
-                quads,
-                reifier.clone(),
-                RDF_REIFIES,
-                quoted,
-                graph_name.cloned(),
-            );
-
-            // The `@id` extraction above (`ann_node.get("@id")…ok_or_else`) returns Err for
-            // any non-object node, so reaching here guarantees `ann_node` is a JSON object.
-            let ann_obj = ann_node
-                .as_object()
-                .expect("the @id lookup above already proved `ann_node` is an object");
-            for (key, val) in ann_obj {
-                if key == "@id" {
-                    continue;
-                }
-                let ann_predicate = expand(key);
-                validated_iri_term(&ann_predicate)?;
-                let vals = if let Value::Array(arr) = val {
-                    arr.clone()
-                } else {
-                    vec![val.clone()]
-                };
-                for v in vals {
-                    let (ann_object, _) = parse_value_object(&v, expand)?;
-                    push_quad(
-                        quads,
-                        reifier.clone(),
-                        &ann_predicate,
-                        ann_object,
-                        graph_name.cloned(),
-                    );
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn parse_value_object(
-    value: &Value,
-    expand: &dyn Fn(&str) -> String,
-) -> Result<(RdfTerm, Option<Value>), RdfDiagnostic> {
-    if let Some(s) = value.as_str() {
-        return Ok((validated_iri_term(&expand(s))?, None));
-    }
-    let obj = value
-        .as_object()
-        .ok_or_else(|| decode(format!("expected value object, got {value}")))?;
-    let annotation = obj.get("@annotation").cloned();
-
-    // A distinguishable `@triple` object reconstructs an RDF-1.2 triple term (recursing
-    // through `@subject`/`@object`), the inverse of `build_nested_triple_node`.
-    if let Some(triple) = obj.get("@triple") {
-        return Ok((parse_triple_term(triple, expand)?, annotation));
-    }
-
-    if let Some(id) = obj.get("@id").and_then(Value::as_str) {
-        return Ok((node_id_term(id, expand)?, annotation));
-    }
-
-    let lex = obj
-        .get("@value")
-        .and_then(Value::as_str)
-        .ok_or_else(|| decode("literal without @value".to_string()))?
-        .to_string();
-    let lang = obj.get("@language").and_then(Value::as_str);
-    let direction = obj.get("@direction").and_then(Value::as_str);
-    let datatype = obj.get("@type").and_then(Value::as_str);
-
-    // The native model preserves the project's long private-use language subtags
-    // (`x-purrdf-norwegiannynorsk`, >8 chars) verbatim — there is no strict tag
-    // validation to reject them, matching the end-to-end preservation and the
-    // lenient codecs that produced this JSON-LD-star input.
-    let literal = match (lang, direction, datatype) {
-        (Some(lang), Some(dir), _) => {
-            let dir = match dir {
-                "ltr" => RdfTextDirection::Ltr,
-                "rtl" => RdfTextDirection::Rtl,
-                _ => return Err(decode(format!("invalid direction {dir}"))),
-            };
-            RdfLiteral {
-                lexical_form: lex,
-                datatype: None,
-                language: Some(lang.to_string()),
-                direction: Some(dir),
-            }
-        }
-        (Some(lang), None, _) => RdfLiteral::language_tagged(lex, lang),
-        (None, _, Some(dt)) => {
-            let dt = expand(dt);
-            validated_iri_term(&dt)?;
-            RdfLiteral::typed(lex, dt)
-        }
-        _ => RdfLiteral::simple(lex),
-    };
-
-    Ok((RdfTerm::literal(literal), annotation))
-}
-
-/// Reconstruct an RDF-1.2 triple term from a `@triple` object — the inverse of
-/// [`build_nested_triple_node`]. `@subject`/`@object` recurse through
-/// [`parse_value_object`] (so nested triple term COMPONENTS round-trip: a triple term
-/// whose subject or object is itself a triple term); `@predicate` is an IRI string
-/// expanded through the document `@context` when caller-authored input uses one.
+/// Parse JSON-LD-star bytes through a reusable compiled active context.
 ///
-/// A triple *term* carries no annotation of its own in the RDF 1.2 abstract syntax — it
-/// is a bare `(s, p, o)` value. Reification/annotation is always a SEPARATE statement
-/// about a reifier (`?r rdf:reifies <<( s p o )>>` plus annotation triples on `?r`); the
-/// native encoder never emits `@annotation` nested inside a `@triple` component (inner
-/// annotations ride separate reifier quads instead — see
-/// `object_position_triple_term_round_trips_jsonld`/`reifier_and_annotation_round_trip`
-/// in `native_codecs::tests`). So an `@annotation` found on a `@subject`/`@object`
-/// component here is not a well-formed RDF-1.2 term shape; per the no-swallowed-errors
-/// policy this is a hard failure rather than a silent drop or an ad hoc thread-through.
-fn parse_triple_term(
-    value: &Value,
-    expand: &dyn Fn(&str) -> String,
-) -> Result<RdfTerm, RdfDiagnostic> {
-    let obj = value
-        .as_object()
-        .ok_or_else(|| decode(format!("@triple must be an object, got {value}")))?;
-    if obj.contains_key("@annotation") {
-        return Err(decode(
-            "@annotation is not permitted inside a @triple object: a triple term \
-             carries no annotation in RDF 1.2; annotate via a separate reifier"
-                .to_string(),
-        ));
-    }
-    let subject = obj
-        .get("@subject")
-        .ok_or_else(|| decode("@triple missing @subject".to_string()))?;
-    let predicate = obj
-        .get("@predicate")
-        .and_then(Value::as_str)
-        .ok_or_else(|| decode("@triple @predicate must be a string".to_string()))?;
-    let object = obj
-        .get("@object")
-        .ok_or_else(|| decode("@triple missing @object".to_string()))?;
+/// The compiled context supplies both the initial active context and the immutable
+/// offline registry used by any context IRI or `@import` found in the document. This is
+/// the inverse surface for registry-backed configured serialization; no network lookup
+/// is attempted.
+pub fn parse_jsonld_with_context(
+    json_bytes: &[u8],
+    context: &CompiledJsonLdContext,
+) -> Result<Arc<RdfDataset>, RdfDiagnostic> {
+    let value = context::parse_document(json_bytes)?;
+    let carrier = expand::expand_document(&value, context)?;
+    expand::carrier_to_dataset(&carrier)
+}
 
-    let (subject_term, subject_ann) = parse_value_object(subject, expand)?;
-    if subject_ann.is_some() {
-        return Err(decode(
-            "@annotation is not permitted inside a @triple component: a triple term \
-             carries no annotation in RDF 1.2; annotate via a separate reifier"
-                .to_string(),
-        ));
-    }
-    let predicate_iri = expand(predicate);
-    validated_iri_term(&predicate_iri)?;
-    let (object_term, object_ann) = parse_value_object(object, expand)?;
-    if object_ann.is_some() {
-        return Err(decode(
-            "@annotation is not permitted inside a @triple component: a triple term \
-             carries no annotation in RDF 1.2; annotate via a separate reifier"
-                .to_string(),
-        ));
-    }
-
-    Ok(RdfTerm::triple(RdfTriple::new(
-        subject_term,
-        &predicate_iri,
-        object_term,
-    )))
+/// Validate `iri` as an absolute IRI and return the native term.
+fn validated_iri_term(iri: &str) -> Result<RdfTerm, RdfDiagnostic> {
+    purrdf_sparql_algebra::NamedNode::new(iri.to_owned())
+        .map_err(|source| decode(source.to_string()))?;
+    Ok(RdfTerm::iri(iri))
 }
 
 // ── statement-metadata downcast ─────────────────────────────────────────────────────
@@ -1413,4 +1634,117 @@ fn decode(message: impl Into<String>) -> RdfDiagnostic {
 /// A JSON-LD/YAML-LD parse diagnostic (well-formed surface that does not map to RDF).
 fn parse(message: impl Into<String>) -> RdfDiagnostic {
     RdfDiagnostic::error("native-jsonld-parse", message)
+}
+
+#[cfg(test)]
+mod carrier_law_tests {
+    use proptest::prelude::*;
+    use serde_json::json;
+
+    use super::*;
+
+    fn assert_exact_carrier_lens(dataset: &RdfDataset, context_value: &Value) {
+        let graph = build_ser_graph(
+            dataset,
+            NativeRdfFormat::NQuads,
+            SerializeGraph::Dataset,
+            true,
+        )
+        .expect("serialization graph");
+        let expanded = build_carrier(&graph, true).expect("typed expanded carrier");
+        let context = CompiledJsonLdContext::compile(context_value, None).expect("context");
+        let compacted = serialize_carrier_compacted(&expanded, &context).expect("compaction");
+        let document = context::parse_document(compacted.as_bytes()).expect("strict JSON");
+        let initial = CompiledJsonLdContext::compile(&json!({}), None).expect("empty context");
+        let reexpanded = expand::expand_document(&document, &initial).expect("re-expansion");
+        assert_eq!(expanded, reexpanded, "compacted document:\n{compacted}");
+    }
+
+    #[test]
+    fn rich_rdf_1_2_carrier_is_an_exact_context_lens() {
+        let source = concat!(
+            "<https://example.org/s> <https://example.org/items> _:head .\n",
+            "_:head <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> \"one\"@en .\n",
+            "_:head <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .\n",
+            "<https://example.org/s> <https://example.org/p> <https://example.org/o> <https://example.org/g> .\n",
+            "<https://example.org/meta> <https://example.org/quotes> <<( <https://example.org/s> <https://example.org/p> <https://example.org/o> )>> .\n",
+            "_:r <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( <https://example.org/s> <https://example.org/p> <https://example.org/o> )>> .\n",
+            "_:r <https://example.org/source> <https://example.org/doc> .\n",
+        );
+        let dataset = crate::parse_dataset(source.as_bytes(), "application/n-quads", None)
+            .expect("rich RDF 1.2 fixture");
+        assert_exact_carrier_lens(
+            &dataset,
+            &json!({
+                "ex": {"@id": "https://example.org/", "@prefix": true},
+                "items": {"@id": "ex:items", "@container": "@list", "@language": "en"}
+            }),
+        );
+    }
+
+    #[test]
+    fn materialized_budget_counts_reused_term_payload_per_occurrence() {
+        let literal = "x".repeat(1_024);
+        let one = format!("<https://example.org/s0> <https://example.org/p> \"{literal}\" .\n");
+        let mut many = String::new();
+        for index in 0..4 {
+            writeln!(
+                many,
+                "<https://example.org/s{index}> <https://example.org/p> \"{literal}\" ."
+            )
+            .expect("write budget fixture");
+        }
+        let build = |source: &str| {
+            let dataset = crate::parse_dataset(source.as_bytes(), "application/n-quads", None)
+                .expect("budget fixture");
+            build_ser_graph(
+                &dataset,
+                NativeRdfFormat::NQuads,
+                SerializeGraph::Dataset,
+                true,
+            )
+            .expect("serialization graph")
+        };
+        let annotations = AnnotationIndex::new();
+        assert!(
+            validate_materialized_carrier_budget_with_limits(
+                &build(&one),
+                &annotations,
+                MAX_JSON_LD_CARRIER_ROWS,
+                10_000,
+            )
+            .is_ok()
+        );
+        let error = validate_materialized_carrier_budget_with_limits(
+            &build(&many),
+            &annotations,
+            MAX_JSON_LD_CARRIER_ROWS,
+            10_000,
+        )
+        .expect_err("reused literal clones exceed materialized budget");
+        assert_eq!(error.code, "native-jsonld-decode");
+        assert!(error.message.contains("working bytes"));
+    }
+
+    proptest! {
+        #[test]
+        fn generated_carriers_obey_exact_compact_expand_equality(
+            rows in prop::collection::btree_set(("[a-z]{1,8}", "[a-z]{1,8}"), 1..32)
+        ) {
+            let mut source = String::new();
+            for (predicate, object) in rows {
+                writeln!(
+                    source,
+                    "<https://example.org/s> <https://example.org/{predicate}> <https://example.org/{object}> ."
+                )
+                .expect("write fixture");
+            }
+            let dataset = crate::parse_dataset(source.as_bytes(), "application/n-quads", None)
+                .expect("generated fixture");
+            assert_exact_carrier_lens(
+                &dataset,
+                &json!({"ex": {"@id": "https://example.org/", "@prefix": true}}),
+            );
+        }
+    }
 }

--- a/crates/rdf/src/native_codecs/jsonld/carrier.rs
+++ b/crates/rdf/src/native_codecs/jsonld/carrier.rs
@@ -206,15 +206,17 @@ impl Serialize for CompactedGraph<'_> {
             graph.serialize_element(&compacted)?;
         }
         for named in &self.document.named_graphs {
-            if !embedded_graphs.borrow().contains(&named.id) {
-                graph.serialize_element(&CompactedNamedGraph {
-                    graph: named,
-                    document: self.document,
-                    context: self.context,
-                    graph_index_plans: self.graph_index_plans,
-                    embedded_graphs: &embedded_graphs,
-                })?;
+            if embedded_graphs.borrow().contains(&named.id) {
+                continue;
             }
+            embedded_graphs.borrow_mut().insert(named.id.clone());
+            graph.serialize_element(&CompactedNamedGraph {
+                graph: named,
+                document: self.document,
+                context: self.context,
+                graph_index_plans: self.graph_index_plans,
+                embedded_graphs: &embedded_graphs,
+            })?;
         }
         graph.end()
     }

--- a/crates/rdf/src/native_codecs/jsonld/carrier.rs
+++ b/crates/rdf/src/native_codecs/jsonld/carrier.rs
@@ -1,0 +1,1588 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Typed expanded carrier shared by JSON-LD-star serialization and expansion.
+//!
+//! RDF positions and JSON-LD keywords are represented by Rust fields and enums until
+//! final emission. Caller terms therefore cannot collide with `@id`, `@value`, or the
+//! PurRDF RDF 1.2 extension controls, and context compaction never rewrites an
+//! arbitrary JSON tree.
+
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::Write;
+
+use serde::ser::{Error as _, SerializeMap, SerializeSeq};
+use serde::{Serialize, Serializer};
+use serde_json::Value as JsonValue;
+
+use super::{
+    CompiledJsonLdContext, JsonLdContainer, JsonLdDirection, JsonLdNullable, JsonLdTermDefinition,
+    JsonLdTermSelection, JsonLdTermSelectionKind, JsonLdTypeMapping, RdfDiagnostic, cmp_value,
+    decode, to_json_object,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Document {
+    pub(super) default_nodes: Vec<Node>,
+    pub(super) named_graphs: Vec<NamedGraph>,
+}
+
+impl Document {
+    pub(super) fn write_expanded_json<W: Write>(
+        &self,
+        writer: W,
+        context: &JsonValue,
+    ) -> Result<(), RdfDiagnostic> {
+        serde_json::to_writer_pretty(
+            writer,
+            &ExpandedDocument {
+                document: self,
+                context,
+            },
+        )
+        .map_err(|source| decode(format!("JSON-LD serialization: {source}")))
+    }
+
+    pub(super) fn write_compacted_json<W: Write>(
+        &self,
+        writer: W,
+        context: &CompiledJsonLdContext,
+    ) -> Result<(), RdfDiagnostic> {
+        let mut prepared = self.clone();
+        let graph_index_plans = plan_graph_index_containers(&prepared, context)?;
+        consume_graph_index_metadata(&mut prepared.default_nodes, None, &graph_index_plans);
+        for graph in &mut prepared.named_graphs {
+            consume_graph_index_metadata(
+                &mut graph.nodes,
+                Some(graph.id.as_str()),
+                &graph_index_plans,
+            );
+        }
+        relocate_reverse_properties(&mut prepared.default_nodes, context)?;
+        for graph in &mut prepared.named_graphs {
+            relocate_reverse_properties(&mut graph.nodes, context)?;
+        }
+        serde_json::to_writer_pretty(
+            writer,
+            &CompactedDocument {
+                document: &prepared,
+                context,
+                graph_index_plans: &graph_index_plans,
+            },
+        )
+        .map_err(|source| decode(format!("JSON-LD serialization: {source}")))
+    }
+}
+
+struct ExpandedDocument<'a> {
+    document: &'a Document,
+    context: &'a JsonValue,
+}
+
+impl Serialize for ExpandedDocument<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let has_graph =
+            !self.document.default_nodes.is_empty() || !self.document.named_graphs.is_empty();
+        let mut document = serializer.serialize_map(Some(if has_graph { 2 } else { 1 }))?;
+        document.serialize_entry("@context", self.context)?;
+        if has_graph {
+            document.serialize_entry("@graph", &ExpandedGraph(self.document))?;
+        }
+        document.end()
+    }
+}
+
+struct ExpandedGraph<'a>(&'a Document);
+
+impl Serialize for ExpandedGraph<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut graph = serializer
+            .serialize_seq(Some(self.0.default_nodes.len() + self.0.named_graphs.len()))?;
+        let mut nodes = self.0.default_nodes.iter().peekable();
+        let mut named = self.0.named_graphs.iter().peekable();
+        while nodes.peek().is_some() || named.peek().is_some() {
+            if named
+                .peek()
+                .is_some_and(|graph| nodes.peek().is_none_or(|node| graph.id < node.id))
+            {
+                graph.serialize_element(&ExpandedNamedGraph(
+                    named.next().expect("peeked named graph"),
+                ))?;
+            } else {
+                graph.serialize_element(
+                    &nodes
+                        .next()
+                        .expect("one expanded entry remains")
+                        .expanded_json(),
+                )?;
+            }
+        }
+        graph.end()
+    }
+}
+
+struct ExpandedNamedGraph<'a>(&'a NamedGraph);
+
+impl Serialize for ExpandedNamedGraph<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut graph = serializer.serialize_map(Some(2))?;
+        graph.serialize_entry("@graph", &ExpandedNodes(&self.0.nodes))?;
+        graph.serialize_entry("@id", &self.0.id)?;
+        graph.end()
+    }
+}
+
+struct ExpandedNodes<'a>(&'a [Node]);
+
+impl Serialize for ExpandedNodes<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut nodes = serializer.serialize_seq(Some(self.0.len()))?;
+        for node in self.0 {
+            nodes.serialize_element(&node.expanded_json())?;
+        }
+        nodes.end()
+    }
+}
+
+struct CompactedDocument<'a> {
+    document: &'a Document,
+    context: &'a CompiledJsonLdContext,
+    graph_index_plans: &'a GraphIndexPlans,
+}
+
+impl Serialize for CompactedDocument<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let has_graph =
+            !self.document.default_nodes.is_empty() || !self.document.named_graphs.is_empty();
+        let mut document = serializer.serialize_map(Some(if has_graph { 2 } else { 1 }))?;
+        document.serialize_entry("@context", self.context.canonical_context())?;
+        if has_graph {
+            let graph_key = compact_keyword(self.context, "@graph").map_err(S::Error::custom)?;
+            document.serialize_entry(
+                &graph_key,
+                &CompactedGraph {
+                    document: self.document,
+                    context: self.context,
+                    graph_index_plans: self.graph_index_plans,
+                },
+            )?;
+        }
+        document.end()
+    }
+}
+
+struct CompactedGraph<'a> {
+    document: &'a Document,
+    context: &'a CompiledJsonLdContext,
+    graph_index_plans: &'a GraphIndexPlans,
+}
+
+impl Serialize for CompactedGraph<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let named_by_id: BTreeMap<&str, &NamedGraph> = self
+            .document
+            .named_graphs
+            .iter()
+            .map(|named| (named.id.as_str(), named))
+            .collect();
+        let embedded_graphs = RefCell::new(BTreeSet::new());
+        let mut graph = serializer.serialize_seq(None)?;
+        for node in &self.document.default_nodes {
+            let mut compacted = node
+                .compacted_json(self.context)
+                .map_err(S::Error::custom)?;
+            apply_graph_containers(
+                node,
+                None,
+                &mut compacted,
+                self.context,
+                self.document,
+                &named_by_id,
+                &mut embedded_graphs.borrow_mut(),
+                self.graph_index_plans,
+            )
+            .map_err(S::Error::custom)?;
+            graph.serialize_element(&compacted)?;
+        }
+        for named in &self.document.named_graphs {
+            if !embedded_graphs.borrow().contains(&named.id) {
+                graph.serialize_element(&CompactedNamedGraph {
+                    graph: named,
+                    document: self.document,
+                    context: self.context,
+                    graph_index_plans: self.graph_index_plans,
+                    embedded_graphs: &embedded_graphs,
+                })?;
+            }
+        }
+        graph.end()
+    }
+}
+
+struct CompactedNamedGraph<'a> {
+    graph: &'a NamedGraph,
+    document: &'a Document,
+    context: &'a CompiledJsonLdContext,
+    graph_index_plans: &'a GraphIndexPlans,
+    embedded_graphs: &'a RefCell<BTreeSet<String>>,
+}
+
+impl Serialize for CompactedNamedGraph<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut graph = serializer.serialize_map(Some(2))?;
+        let id_key = compact_keyword(self.context, "@id").map_err(S::Error::custom)?;
+        let graph_key = compact_keyword(self.context, "@graph").map_err(S::Error::custom)?;
+        let id = compact_id(self.context, &self.graph.id, false).map_err(S::Error::custom)?;
+        let nodes = CompactedNodes {
+            nodes: &self.graph.nodes,
+            scope: Some(self.graph.id.as_str()),
+            document: self.document,
+            context: self.context,
+            graph_index_plans: self.graph_index_plans,
+            embedded_graphs: self.embedded_graphs,
+        };
+        if graph_key < id_key {
+            graph.serialize_entry(&graph_key, &nodes)?;
+            graph.serialize_entry(&id_key, &id)?;
+        } else {
+            graph.serialize_entry(&id_key, &id)?;
+            graph.serialize_entry(&graph_key, &nodes)?;
+        }
+        graph.end()
+    }
+}
+
+struct CompactedNodes<'a> {
+    nodes: &'a [Node],
+    scope: Option<&'a str>,
+    document: &'a Document,
+    context: &'a CompiledJsonLdContext,
+    graph_index_plans: &'a GraphIndexPlans,
+    embedded_graphs: &'a RefCell<BTreeSet<String>>,
+}
+
+impl Serialize for CompactedNodes<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let named_by_id: BTreeMap<&str, &NamedGraph> = self
+            .document
+            .named_graphs
+            .iter()
+            .map(|named| (named.id.as_str(), named))
+            .collect();
+        let mut nodes = serializer.serialize_seq(Some(self.nodes.len()))?;
+        for node in self.nodes {
+            let mut compacted = node
+                .compacted_json(self.context)
+                .map_err(S::Error::custom)?;
+            apply_graph_containers(
+                node,
+                self.scope,
+                &mut compacted,
+                self.context,
+                self.document,
+                &named_by_id,
+                &mut self.embedded_graphs.borrow_mut(),
+                self.graph_index_plans,
+            )
+            .map_err(S::Error::custom)?;
+            nodes.serialize_element(&compacted)?;
+        }
+        nodes.end()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct NamedGraph {
+    pub(super) id: String,
+    pub(super) nodes: Vec<Node>,
+}
+
+impl NamedGraph {
+    fn compacted_contents(
+        &self,
+        context: &CompiledJsonLdContext,
+        document: &Document,
+        named_by_id: &BTreeMap<&str, &Self>,
+        embedded_graphs: &mut BTreeSet<String>,
+        graph_index_plans: &GraphIndexPlans,
+        force_array: bool,
+    ) -> Result<JsonValue, RdfDiagnostic> {
+        let nodes = self
+            .nodes
+            .iter()
+            .map(|node| {
+                let mut compacted = node.compacted_json(context)?;
+                apply_graph_containers(
+                    node,
+                    Some(self.id.as_str()),
+                    &mut compacted,
+                    context,
+                    document,
+                    named_by_id,
+                    embedded_graphs,
+                    graph_index_plans,
+                )?;
+                Ok(compacted)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(if !force_array && let [only] = nodes.as_slice() {
+            only.clone()
+        } else {
+            JsonValue::Array(nodes)
+        })
+    }
+}
+
+type GraphIndexPlans = BTreeMap<(Option<String>, String, String), GraphIndexPlan>;
+
+#[derive(Debug, Clone)]
+struct GraphIndexPlan {
+    index_mapping: String,
+    keys_by_graph: BTreeMap<String, String>,
+}
+
+fn plan_graph_index_containers(
+    document: &Document,
+    context: &CompiledJsonLdContext,
+) -> Result<GraphIndexPlans, RdfDiagnostic> {
+    let named_by_id: BTreeMap<&str, &NamedGraph> = document
+        .named_graphs
+        .iter()
+        .map(|graph| (graph.id.as_str(), graph))
+        .collect();
+    let references = document_id_reference_counts(document);
+    let selection = JsonLdTermSelection::new(
+        [
+            vec![
+                JsonLdContainer::Graph,
+                JsonLdContainer::Index,
+                JsonLdContainer::Set,
+            ],
+            vec![JsonLdContainer::Graph, JsonLdContainer::Index],
+        ],
+        JsonLdTermSelectionKind::Type,
+        ["@none", "@any"],
+    );
+    let mut plans = BTreeMap::new();
+    plan_graph_index_scope(
+        None,
+        &document.default_nodes,
+        &named_by_id,
+        &references,
+        context,
+        &selection,
+        &mut plans,
+    )?;
+    for graph in &document.named_graphs {
+        plan_graph_index_scope(
+            Some(graph.id.as_str()),
+            &graph.nodes,
+            &named_by_id,
+            &references,
+            context,
+            &selection,
+            &mut plans,
+        )?;
+    }
+    Ok(plans)
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "graph-index planning keeps scope, carrier, context, and destination explicit"
+)]
+fn plan_graph_index_scope(
+    scope: Option<&str>,
+    nodes: &[Node],
+    named_by_id: &BTreeMap<&str, &NamedGraph>,
+    references: &BTreeMap<String, usize>,
+    context: &CompiledJsonLdContext,
+    selection: &JsonLdTermSelection,
+    plans: &mut GraphIndexPlans,
+) -> Result<(), RdfDiagnostic> {
+    let metadata_by_id: BTreeMap<&str, &Node> =
+        nodes.iter().map(|node| (node.id.as_str(), node)).collect();
+    for node in nodes {
+        for (property, values) in &node.properties {
+            if values.is_empty() || values.iter().any(|value| {
+                !value.annotations.is_empty()
+                    || !matches!(&value.term, Term::Id(id) if named_by_id.contains_key(id.as_str()))
+            }) {
+                continue;
+            }
+            let term = context.compact_iri_with_selection(property, true, Some(selection))?;
+            let Some(definition) = context.term(&term).filter(|definition| {
+                definition.containers().contains(&JsonLdContainer::Graph)
+                    && definition.containers().contains(&JsonLdContainer::Index)
+            }) else {
+                continue;
+            };
+            let Some(index_mapping) = definition.index_mapping() else {
+                continue;
+            };
+            let mut keys_by_graph = BTreeMap::new();
+            let mut lossless = true;
+            for value in values {
+                let Term::Id(graph_id) = &value.term else {
+                    unreachable!("graph-container eligibility checked node references")
+                };
+                if !graph_id.starts_with("_:") || references.get(graph_id) != Some(&1) {
+                    lossless = false;
+                    break;
+                }
+                let key = match metadata_by_id.get(graph_id.as_str()) {
+                    None => "@none".to_owned(),
+                    Some(metadata)
+                        if metadata.types.is_empty()
+                            && metadata.reverse_properties.is_empty()
+                            && metadata.properties.len() == 1 =>
+                    {
+                        let Some(index_values) = metadata.properties.get(index_mapping) else {
+                            lossless = false;
+                            break;
+                        };
+                        let [index_value] = index_values.as_slice() else {
+                            lossless = false;
+                            break;
+                        };
+                        let Term::Literal(index) = &index_value.term else {
+                            lossless = false;
+                            break;
+                        };
+                        if !index_value.annotations.is_empty()
+                            || index.datatype.is_some()
+                            || index.language.is_some()
+                            || index.direction.is_some()
+                        {
+                            lossless = false;
+                            break;
+                        }
+                        index.lexical.clone()
+                    }
+                    Some(_) => {
+                        lossless = false;
+                        break;
+                    }
+                };
+                keys_by_graph.insert(graph_id.clone(), key);
+            }
+            if lossless {
+                plans.insert(
+                    (scope.map(str::to_owned), node.id.clone(), property.clone()),
+                    GraphIndexPlan {
+                        index_mapping: index_mapping.to_owned(),
+                        keys_by_graph,
+                    },
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn consume_graph_index_metadata(
+    nodes: &mut Vec<Node>,
+    scope: Option<&str>,
+    plans: &GraphIndexPlans,
+) {
+    let consumed: BTreeSet<&str> = plans
+        .iter()
+        .filter(|((plan_scope, _, _), _)| plan_scope.as_deref() == scope)
+        .flat_map(|(_, plan)| {
+            plan.keys_by_graph
+                .iter()
+                .filter_map(|(graph, key)| (key != "@none").then_some(graph.as_str()))
+        })
+        .collect();
+    nodes.retain(|node| !consumed.contains(node.id.as_str()));
+}
+
+fn document_id_reference_counts(document: &Document) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    for node in document.default_nodes.iter().chain(
+        document
+            .named_graphs
+            .iter()
+            .flat_map(|graph| graph.nodes.iter()),
+    ) {
+        count_node_term_ids(node, &mut counts);
+    }
+    counts
+}
+
+fn count_node_term_ids(node: &Node, counts: &mut BTreeMap<String, usize>) {
+    for values in node
+        .properties
+        .values()
+        .chain(node.reverse_properties.values())
+    {
+        for value in values {
+            count_value_term_ids(value, counts);
+        }
+    }
+}
+
+fn count_value_term_ids(value: &Value, counts: &mut BTreeMap<String, usize>) {
+    count_term_ids(&value.term, counts);
+    for annotation in &value.annotations {
+        *counts.entry(annotation.id.clone()).or_default() += 1;
+        count_node_term_ids(annotation, counts);
+    }
+}
+
+fn count_term_ids(term: &Term, counts: &mut BTreeMap<String, usize>) {
+    match term {
+        Term::Id(id) => *counts.entry(id.clone()).or_default() += 1,
+        Term::Triple(triple) => {
+            count_term_ids(&triple.subject, counts);
+            count_term_ids(&triple.object, counts);
+        }
+        Term::List(values) => {
+            for value in values {
+                count_value_term_ids(value, counts);
+            }
+        }
+        Term::Literal(_) => {}
+    }
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "graph-container emission keeps scope, carrier, context, and state explicit"
+)]
+fn apply_graph_containers(
+    node: &Node,
+    scope: Option<&str>,
+    compacted: &mut JsonValue,
+    context: &CompiledJsonLdContext,
+    document: &Document,
+    named_by_id: &BTreeMap<&str, &NamedGraph>,
+    embedded_graphs: &mut BTreeSet<String>,
+    graph_index_plans: &GraphIndexPlans,
+) -> Result<(), RdfDiagnostic> {
+    for (iri, values) in &node.properties {
+        if values.is_empty()
+            || values.iter().any(|value| {
+                !value.annotations.is_empty()
+                    || !matches!(&value.term, Term::Id(id) if named_by_id.contains_key(id.as_str()))
+            })
+        {
+            continue;
+        }
+        let graph_selection = JsonLdTermSelection::new(
+            [
+                vec![
+                    JsonLdContainer::Graph,
+                    JsonLdContainer::Index,
+                    JsonLdContainer::Set,
+                ],
+                vec![JsonLdContainer::Graph, JsonLdContainer::Index],
+                vec![
+                    JsonLdContainer::Graph,
+                    JsonLdContainer::Id,
+                    JsonLdContainer::Set,
+                ],
+                vec![JsonLdContainer::Graph, JsonLdContainer::Id],
+                vec![JsonLdContainer::Graph, JsonLdContainer::Set],
+                vec![JsonLdContainer::Graph],
+            ],
+            JsonLdTermSelectionKind::Type,
+            ["@none", "@any"],
+        );
+        let term = context.compact_iri_with_selection(iri, true, Some(&graph_selection))?;
+        let Some(definition) = context
+            .term(&term)
+            .filter(|definition| definition.containers().contains(&JsonLdContainer::Graph))
+        else {
+            continue;
+        };
+        let has_id_map = definition.containers().contains(&JsonLdContainer::Id);
+        let has_index_map = definition.containers().contains(&JsonLdContainer::Index);
+        let index_plan =
+            graph_index_plans.get(&(scope.map(str::to_owned), node.id.clone(), iri.clone()));
+        if has_index_map && index_plan.is_none() {
+            continue;
+        }
+        if !has_id_map
+            && values
+                .iter()
+                .any(|value| matches!(&value.term, Term::Id(id) if !id.starts_with("_:")))
+        {
+            continue;
+        }
+        if values
+            .iter()
+            .any(|value| matches!(&value.term, Term::Id(id) if embedded_graphs.contains(id)))
+        {
+            // A graph already embedded on the current deterministic walk remains a
+            // regular node reference here.  This both preserves repeated references
+            // and prevents recursive graph-container cycles.
+            continue;
+        }
+        for value in values {
+            let Term::Id(id) = &value.term else {
+                unreachable!("graph-container eligibility checked node references")
+            };
+            embedded_graphs.insert(id.clone());
+        }
+        let scoped = context.scoped_context(&term)?;
+        let value_context = scoped.as_ref().unwrap_or(context);
+        let force_array = definition.containers().contains(&JsonLdContainer::Set);
+        let graph_value = if let Some(index_plan) = index_plan {
+            debug_assert_eq!(
+                definition.index_mapping(),
+                Some(index_plan.index_mapping.as_str())
+            );
+            let mut map: BTreeMap<String, Vec<JsonValue>> = BTreeMap::new();
+            for value in values {
+                let Term::Id(id) = &value.term else {
+                    unreachable!("graph-container eligibility checked node references")
+                };
+                let named = named_by_id
+                    .get(id.as_str())
+                    .expect("graph-container eligibility checked named graph");
+                map.entry(
+                    index_plan
+                        .keys_by_graph
+                        .get(id)
+                        .expect("graph-index plan covers every referenced graph")
+                        .clone(),
+                )
+                .or_default()
+                .push(named.compacted_contents(
+                    value_context,
+                    document,
+                    named_by_id,
+                    embedded_graphs,
+                    graph_index_plans,
+                    force_array,
+                )?);
+            }
+            to_json_object(
+                map.into_iter()
+                    .map(|(index, values)| {
+                        let value = if !force_array && let [only] = values.as_slice() {
+                            only.clone()
+                        } else {
+                            JsonValue::Array(values)
+                        };
+                        (index, value)
+                    })
+                    .collect(),
+            )
+        } else if has_id_map {
+            let mut map = BTreeMap::new();
+            for value in values {
+                let Term::Id(id) = &value.term else {
+                    unreachable!("graph-container eligibility checked node references")
+                };
+                let named = named_by_id
+                    .get(id.as_str())
+                    .expect("graph-container eligibility checked named graph");
+                insert_unique(
+                    &mut map,
+                    &compact_id(value_context, id, false)?,
+                    named.compacted_contents(
+                        value_context,
+                        document,
+                        named_by_id,
+                        embedded_graphs,
+                        graph_index_plans,
+                        force_array,
+                    )?,
+                )?;
+            }
+            to_json_object(map)
+        } else {
+            let mut bodies = Vec::new();
+            for value in values {
+                let Term::Id(id) = &value.term else {
+                    unreachable!("graph-container eligibility checked node references")
+                };
+                let named = named_by_id
+                    .get(id.as_str())
+                    .expect("graph-container eligibility checked named graph");
+                bodies.push(named.compacted_contents(
+                    value_context,
+                    document,
+                    named_by_id,
+                    embedded_graphs,
+                    graph_index_plans,
+                    force_array,
+                )?);
+            }
+            if !force_array && let [only] = bodies.as_slice() {
+                only.clone()
+            } else {
+                JsonValue::Array(bodies)
+            }
+        };
+
+        remove_regular_property(node, compacted, context, iri, values)?;
+        insert_compacted_property(compacted, context, &term, definition, graph_value)?;
+    }
+    Ok(())
+}
+
+fn remove_regular_property(
+    _node: &Node,
+    compacted: &mut JsonValue,
+    context: &CompiledJsonLdContext,
+    iri: &str,
+    values: &[Value],
+) -> Result<(), RdfDiagnostic> {
+    let object = compacted
+        .as_object_mut()
+        .expect("a compacted carrier node is an object");
+    let mut terms = BTreeSet::new();
+    for value in values {
+        terms.insert(context.compact_iri_with_selection(iri, true, Some(&value.selection()))?);
+    }
+    for term in terms {
+        if let Some(nest) = context.term(&term).and_then(JsonLdTermDefinition::nest) {
+            let nest = if nest == "@nest" {
+                compact_keyword(context, "@nest")?
+            } else {
+                nest.to_owned()
+            };
+            if let Some(nested) = object.get_mut(&nest).and_then(JsonValue::as_object_mut) {
+                nested.remove(&term);
+                if nested.is_empty() {
+                    object.remove(&nest);
+                }
+            }
+        } else {
+            object.remove(&term);
+        }
+    }
+    Ok(())
+}
+
+fn insert_compacted_property(
+    compacted: &mut JsonValue,
+    context: &CompiledJsonLdContext,
+    term: &str,
+    definition: &JsonLdTermDefinition,
+    value: JsonValue,
+) -> Result<(), RdfDiagnostic> {
+    let object = compacted
+        .as_object_mut()
+        .expect("a compacted carrier node is an object");
+    if let Some(nest) = definition.nest() {
+        let nest = if nest == "@nest" {
+            compact_keyword(context, "@nest")?
+        } else {
+            nest.to_owned()
+        };
+        let nested = object
+            .entry(nest)
+            .or_insert_with(|| JsonValue::Object(serde_json::Map::new()))
+            .as_object_mut()
+            .ok_or_else(|| decode("JSON-LD @nest target is not an object"))?;
+        if nested.insert(term.to_owned(), value).is_some() {
+            return Err(decode(format!(
+                "JSON-LD compaction produced duplicate member `{term}`"
+            )));
+        }
+    } else if object.insert(term.to_owned(), value).is_some() {
+        return Err(decode(format!(
+            "JSON-LD compaction produced duplicate member `{term}`"
+        )));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Node {
+    pub(super) id: String,
+    pub(super) types: Vec<String>,
+    pub(super) properties: BTreeMap<String, Vec<Value>>,
+    pub(super) reverse_properties: BTreeMap<String, Vec<Value>>,
+}
+
+impl Node {
+    pub(super) fn new(id: String) -> Self {
+        Self {
+            id,
+            types: Vec::new(),
+            properties: BTreeMap::new(),
+            reverse_properties: BTreeMap::new(),
+        }
+    }
+
+    pub(super) fn sort_values(&mut self) {
+        self.types.sort();
+        for values in self.properties.values_mut() {
+            values.sort_by(|left, right| cmp_value(&left.expanded_json(), &right.expanded_json()));
+        }
+        for values in self.reverse_properties.values_mut() {
+            values.sort_by(|left, right| cmp_value(&left.expanded_json(), &right.expanded_json()));
+        }
+    }
+
+    pub(super) fn expanded_json(&self) -> JsonValue {
+        let mut node = BTreeMap::new();
+        node.insert("@id".to_owned(), JsonValue::String(self.id.clone()));
+        if !self.types.is_empty() {
+            node.insert(
+                "@type".to_owned(),
+                JsonValue::Array(
+                    self.types
+                        .iter()
+                        .map(|iri| {
+                            to_json_object(BTreeMap::from([(
+                                "@id".to_owned(),
+                                JsonValue::String(iri.clone()),
+                            )]))
+                        })
+                        .collect(),
+                ),
+            );
+        }
+        for (property, values) in &self.properties {
+            let values: Vec<JsonValue> = values.iter().map(Value::expanded_json).collect();
+            let value = if let [only] = values.as_slice() {
+                only.clone()
+            } else {
+                JsonValue::Array(values)
+            };
+            node.insert(property.clone(), value);
+        }
+        if !self.reverse_properties.is_empty() {
+            let mut reverse = BTreeMap::new();
+            for (property, values) in &self.reverse_properties {
+                let values: Vec<JsonValue> = values.iter().map(Value::expanded_json).collect();
+                reverse.insert(
+                    property.clone(),
+                    if let [only] = values.as_slice() {
+                        only.clone()
+                    } else {
+                        JsonValue::Array(values)
+                    },
+                );
+            }
+            node.insert("@reverse".to_owned(), to_json_object(reverse));
+        }
+        to_json_object(node)
+    }
+
+    fn compacted_json(&self, context: &CompiledJsonLdContext) -> Result<JsonValue, RdfDiagnostic> {
+        let mut node = BTreeMap::new();
+        insert_unique(
+            &mut node,
+            &compact_keyword(context, "@id")?,
+            JsonValue::String(compact_id(context, &self.id, false)?),
+        )?;
+        if !self.types.is_empty() {
+            let type_key = compact_keyword(context, "@type")?;
+            let types = self
+                .types
+                .iter()
+                .map(|iri| context.compact_iri(iri, true).map(JsonValue::String))
+                .collect::<Result<Vec<_>, _>>()?;
+            insert_unique(
+                &mut node,
+                &type_key,
+                if let [only] = types.as_slice() {
+                    only.clone()
+                } else {
+                    JsonValue::Array(types)
+                },
+            )?;
+        }
+
+        let mut nested: BTreeMap<String, BTreeMap<String, JsonValue>> = BTreeMap::new();
+        for (iri, values) in &self.properties {
+            let mut by_term: BTreeMap<String, Vec<&Value>> = BTreeMap::new();
+            for value in values {
+                let selection = value.selection();
+                let term = context.compact_iri_with_selection(iri, true, Some(&selection))?;
+                by_term.entry(term).or_default().push(value);
+            }
+            for (term, values) in by_term {
+                let definition = context.term(&term);
+                if definition.is_some_and(JsonLdTermDefinition::is_reverse_property) {
+                    return Err(decode(format!(
+                        "forward property `{iri}` cannot be emitted through reverse term `{term}`"
+                    )));
+                }
+                let scoped = context.scoped_context(&term)?;
+                let value_context = scoped.as_ref().unwrap_or(context);
+                let compacted = compact_property_values(value_context, &term, definition, &values)?;
+                if let Some(nest) = definition.and_then(JsonLdTermDefinition::nest) {
+                    let nest_key = if nest == "@nest" {
+                        compact_keyword(context, "@nest")?
+                    } else {
+                        nest.to_owned()
+                    };
+                    insert_unique(nested.entry(nest_key).or_default(), &term, compacted)?;
+                } else {
+                    insert_unique(&mut node, &term, compacted)?;
+                }
+            }
+        }
+        for (iri, values) in &self.reverse_properties {
+            let selection = reverse_selection();
+            let term = context.compact_iri_with_selection(iri, true, Some(&selection))?;
+            let definition = context.term(&term).filter(|definition| {
+                definition.is_reverse_property() && definition.iri_mapping() == Some(iri)
+            });
+            let Some(definition) = definition else {
+                return Err(decode(format!(
+                    "reverse property `{iri}` has no lossless reverse term"
+                )));
+            };
+            let values = values.iter().collect::<Vec<_>>();
+            insert_unique(
+                &mut node,
+                &term,
+                compact_property_values(context, &term, Some(definition), &values)?,
+            )?;
+        }
+        for (nest, values) in nested {
+            insert_unique(&mut node, &nest, to_json_object(values))?;
+        }
+        Ok(to_json_object(node))
+    }
+}
+
+fn reverse_selection() -> JsonLdTermSelection {
+    JsonLdTermSelection::new(
+        [vec![JsonLdContainer::Set], Vec::new()],
+        JsonLdTermSelectionKind::Type,
+        ["@reverse", "@none", "@any"],
+    )
+}
+
+fn relocate_reverse_properties(
+    nodes: &mut Vec<Node>,
+    context: &CompiledJsonLdContext,
+) -> Result<(), RdfDiagnostic> {
+    #[derive(Debug)]
+    struct Move {
+        source: String,
+        property: String,
+        original: Value,
+        target: String,
+        reversed: Value,
+    }
+
+    let selection = reverse_selection();
+    let mut moves = Vec::new();
+    for node in nodes.iter() {
+        for (property, values) in &node.properties {
+            let term = context.compact_iri_with_selection(property, true, Some(&selection))?;
+            let has_reverse_term = context.term(&term).is_some_and(|definition| {
+                definition.is_reverse_property() && definition.iri_mapping() == Some(property)
+            });
+            if !has_reverse_term {
+                continue;
+            }
+            for value in values {
+                let Term::Id(target) = &value.term else {
+                    continue;
+                };
+                let mut reversed = value.clone();
+                reversed.term = Term::Id(node.id.clone());
+                moves.push(Move {
+                    source: node.id.clone(),
+                    property: property.clone(),
+                    original: value.clone(),
+                    target: target.clone(),
+                    reversed,
+                });
+            }
+        }
+    }
+
+    if moves.is_empty() {
+        return Ok(());
+    }
+    let mut by_id: BTreeMap<String, Node> = nodes
+        .drain(..)
+        .map(|node| (node.id.clone(), node))
+        .collect();
+    for movement in moves {
+        if let Some(source) = by_id.get_mut(&movement.source)
+            && let Some(values) = source.properties.get_mut(&movement.property)
+            && let Some(index) = values.iter().position(|value| value == &movement.original)
+        {
+            values.remove(index);
+            if values.is_empty() {
+                source.properties.remove(&movement.property);
+            }
+        }
+        by_id
+            .entry(movement.target.clone())
+            .or_insert_with(|| Node::new(movement.target))
+            .reverse_properties
+            .entry(movement.property)
+            .or_default()
+            .push(movement.reversed);
+    }
+    for node in by_id.values_mut() {
+        node.sort_values();
+    }
+    *nodes = by_id.into_values().collect();
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Value {
+    pub(super) term: Term,
+    pub(super) annotations: Vec<Node>,
+}
+
+impl Value {
+    pub(super) fn plain(term: Term) -> Self {
+        Self {
+            term,
+            annotations: Vec::new(),
+        }
+    }
+
+    pub(super) fn expanded_json(&self) -> JsonValue {
+        let mut value = self.term.expanded_json();
+        if !self.annotations.is_empty() {
+            let annotations: Vec<JsonValue> =
+                self.annotations.iter().map(Node::expanded_json).collect();
+            let annotation = if let [only] = annotations.as_slice() {
+                only.clone()
+            } else {
+                JsonValue::Array(annotations)
+            };
+            value
+                .as_object_mut()
+                .expect("every typed carrier term emits a JSON object")
+                .insert("@annotation".to_owned(), annotation);
+        }
+        value
+    }
+
+    fn selection(&self) -> JsonLdTermSelection {
+        let containers = match &self.term {
+            Term::List(_) => vec![
+                vec![JsonLdContainer::List, JsonLdContainer::Set],
+                vec![JsonLdContainer::List],
+                vec![JsonLdContainer::Set],
+                Vec::new(),
+            ],
+            Term::Id(_) if self.annotations.is_empty() => vec![
+                vec![JsonLdContainer::Id, JsonLdContainer::Set],
+                vec![JsonLdContainer::Id],
+                vec![JsonLdContainer::Set],
+                Vec::new(),
+            ],
+            Term::Literal(literal) if literal.datatype.is_none() && self.annotations.is_empty() => {
+                vec![
+                    vec![JsonLdContainer::Language, JsonLdContainer::Set],
+                    vec![JsonLdContainer::Language],
+                    vec![JsonLdContainer::Set],
+                    Vec::new(),
+                ]
+            }
+            _ => vec![vec![JsonLdContainer::Set], Vec::new()],
+        };
+        let (kind, preferred) = match &self.term {
+            Term::List(values) => common_list_preferences(values),
+            _ => self.shape_preferences(),
+        };
+        JsonLdTermSelection::new(containers, kind, preferred)
+    }
+
+    fn shape_preferences(&self) -> (JsonLdTermSelectionKind, Vec<String>) {
+        if !self.annotations.is_empty() {
+            return (
+                JsonLdTermSelectionKind::Type,
+                vec!["@none".to_owned(), "@any".to_owned()],
+            );
+        }
+        match &self.term {
+            Term::Id(_) | Term::Triple(_) => (
+                JsonLdTermSelectionKind::Type,
+                ["@id", "@vocab", "@none", "@any"]
+                    .into_iter()
+                    .map(str::to_owned)
+                    .collect(),
+            ),
+            Term::List(_) => (
+                JsonLdTermSelectionKind::Type,
+                vec!["@none".to_owned(), "@any".to_owned()],
+            ),
+            Term::Literal(literal) => literal_preferences(literal),
+        }
+    }
+}
+
+fn common_list_preferences(values: &[Value]) -> (JsonLdTermSelectionKind, Vec<String>) {
+    let Some(first) = values.first() else {
+        return (
+            JsonLdTermSelectionKind::Type,
+            ["@id", "@none", "@any"]
+                .into_iter()
+                .map(str::to_owned)
+                .collect(),
+        );
+    };
+    let candidate = first.shape_preferences();
+    let common = candidate.1.first();
+    if common.is_some()
+        && values.iter().skip(1).all(|value| {
+            let other = value.shape_preferences();
+            other.0 == candidate.0 && other.1.first() == common
+        })
+    {
+        candidate
+    } else {
+        (
+            JsonLdTermSelectionKind::Type,
+            vec!["@none".to_owned(), "@any".to_owned()],
+        )
+    }
+}
+
+fn literal_preferences(literal: &Literal) -> (JsonLdTermSelectionKind, Vec<String>) {
+    if let Some(datatype) = &literal.datatype {
+        let preferred =
+            if datatype == super::RDF_JSON && canonical_json_value(&literal.lexical).is_some() {
+                vec![
+                    "@json".to_owned(),
+                    datatype.clone(),
+                    "@none".to_owned(),
+                    "@any".to_owned(),
+                ]
+            } else {
+                vec![datatype.clone(), "@none".to_owned(), "@any".to_owned()]
+            };
+        return (JsonLdTermSelectionKind::Type, preferred);
+    }
+    let mut preferred = Vec::new();
+    match (&literal.language, &literal.direction) {
+        (Some(language), Some(direction)) => {
+            preferred.push(format!("{}_{}", language.to_ascii_lowercase(), direction));
+            preferred.push(language.to_ascii_lowercase());
+            preferred.push(format!("_{direction}"));
+        }
+        (Some(language), None) => preferred.push(language.to_ascii_lowercase()),
+        (None, Some(direction)) => preferred.push(format!("_{direction}")),
+        (None, None) => preferred.push("@null".to_owned()),
+    }
+    preferred.push("@none".to_owned());
+    preferred.push("@any".to_owned());
+    (JsonLdTermSelectionKind::Language, preferred)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Term {
+    Id(String),
+    Literal(Literal),
+    Triple(Box<Triple>),
+    List(Vec<Value>),
+}
+
+impl Term {
+    fn expanded_json(&self) -> JsonValue {
+        match self {
+            Self::Id(id) => to_json_object(BTreeMap::from([(
+                "@id".to_owned(),
+                JsonValue::String(id.clone()),
+            )])),
+            Self::Literal(literal) => literal.expanded_json(),
+            Self::Triple(triple) => to_json_object(BTreeMap::from([(
+                "@triple".to_owned(),
+                triple.expanded_json(),
+            )])),
+            Self::List(values) => to_json_object(BTreeMap::from([(
+                "@list".to_owned(),
+                JsonValue::Array(values.iter().map(Value::expanded_json).collect()),
+            )])),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Literal {
+    pub(super) lexical: String,
+    pub(super) datatype: Option<String>,
+    pub(super) language: Option<String>,
+    pub(super) direction: Option<String>,
+}
+
+impl Literal {
+    fn expanded_json(&self) -> JsonValue {
+        let mut literal = BTreeMap::new();
+        literal.insert("@value".to_owned(), JsonValue::String(self.lexical.clone()));
+        if let Some(language) = &self.language {
+            literal.insert("@language".to_owned(), JsonValue::String(language.clone()));
+        }
+        if let Some(direction) = &self.direction {
+            literal.insert(
+                "@direction".to_owned(),
+                JsonValue::String(direction.clone()),
+            );
+        }
+        if let Some(datatype) = &self.datatype {
+            literal.insert("@type".to_owned(), JsonValue::String(datatype.clone()));
+        }
+        to_json_object(literal)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Triple {
+    pub(super) subject: Box<Term>,
+    pub(super) predicate: String,
+    pub(super) object: Box<Term>,
+}
+
+impl Triple {
+    fn expanded_json(&self) -> JsonValue {
+        to_json_object(BTreeMap::from([
+            ("@object".to_owned(), self.object.expanded_json()),
+            (
+                "@predicate".to_owned(),
+                JsonValue::String(self.predicate.clone()),
+            ),
+            ("@subject".to_owned(), self.subject.expanded_json()),
+        ]))
+    }
+}
+
+fn compact_property_values(
+    context: &CompiledJsonLdContext,
+    term: &str,
+    definition: Option<&JsonLdTermDefinition>,
+    values: &[&Value],
+) -> Result<JsonValue, RdfDiagnostic> {
+    if definition.is_some_and(|definition| definition.containers().contains(&JsonLdContainer::Id)) {
+        return compact_id_map(context, term, definition, values);
+    }
+    if definition
+        .is_some_and(|definition| definition.containers().contains(&JsonLdContainer::Language))
+    {
+        return compact_language_map(context, term, definition, values);
+    }
+    let compacted = values
+        .iter()
+        .map(|value| value.compacted_json(context, definition))
+        .collect::<Result<Vec<_>, _>>()?;
+    let force_array = definition
+        .is_some_and(|definition| definition.containers().contains(&JsonLdContainer::Set));
+    Ok(if !force_array && let [only] = compacted.as_slice() {
+        only.clone()
+    } else {
+        JsonValue::Array(compacted)
+    })
+}
+
+fn compact_id_map(
+    context: &CompiledJsonLdContext,
+    term: &str,
+    definition: Option<&JsonLdTermDefinition>,
+    values: &[&Value],
+) -> Result<JsonValue, RdfDiagnostic> {
+    let definition = definition.expect("@id container requires a term definition");
+    let mut id_map: BTreeMap<String, Vec<JsonValue>> = BTreeMap::new();
+    for value in values {
+        let Term::Id(id) = &value.term else {
+            return Err(decode(format!(
+                "term `{term}` has an @id container but selected a non-node value"
+            )));
+        };
+        if !value.annotations.is_empty() {
+            return Err(decode(format!(
+                "term `{term}` @id container would lose statement annotations"
+            )));
+        }
+        id_map
+            .entry(compact_id(context, id, false)?)
+            .or_default()
+            .push(to_json_object(BTreeMap::new()));
+    }
+    let force_array = definition.containers().contains(&JsonLdContainer::Set);
+    Ok(to_json_object(
+        id_map
+            .into_iter()
+            .map(|(id, values)| {
+                let value = if !force_array && let [only] = values.as_slice() {
+                    only.clone()
+                } else {
+                    JsonValue::Array(values)
+                };
+                (id, value)
+            })
+            .collect(),
+    ))
+}
+
+fn compact_language_map(
+    context: &CompiledJsonLdContext,
+    term: &str,
+    definition: Option<&JsonLdTermDefinition>,
+    values: &[&Value],
+) -> Result<JsonValue, RdfDiagnostic> {
+    let definition = definition.expect("language container requires a term definition");
+    let mut language_map: BTreeMap<String, Vec<JsonValue>> = BTreeMap::new();
+    for value in values {
+        let Term::Literal(literal) = &value.term else {
+            return Err(decode(format!(
+                "term `{term}` has a language container but selected a non-literal value"
+            )));
+        };
+        if !value.annotations.is_empty()
+            || literal.datatype.is_some()
+            || literal.direction.as_deref()
+                != match definition.direction_mapping() {
+                    Some(JsonLdNullable::Null) => None,
+                    Some(JsonLdNullable::Value(JsonLdDirection::LeftToRight)) => Some("ltr"),
+                    Some(JsonLdNullable::Value(JsonLdDirection::RightToLeft)) => Some("rtl"),
+                    None => context.default_direction().map(JsonLdDirection::as_str),
+                }
+        {
+            return Err(decode(format!(
+                "term `{term}` language container would lose literal metadata"
+            )));
+        }
+        let language = literal.language.as_deref().unwrap_or("@none").to_owned();
+        language_map
+            .entry(language)
+            .or_default()
+            .push(JsonValue::String(literal.lexical.clone()));
+    }
+    let force_array = definition.containers().contains(&JsonLdContainer::Set);
+    Ok(to_json_object(
+        language_map
+            .into_iter()
+            .map(|(language, values)| {
+                let value = if !force_array && let [only] = values.as_slice() {
+                    only.clone()
+                } else {
+                    JsonValue::Array(values)
+                };
+                (language, value)
+            })
+            .collect(),
+    ))
+}
+
+impl Value {
+    fn compacted_json(
+        &self,
+        context: &CompiledJsonLdContext,
+        definition: Option<&JsonLdTermDefinition>,
+    ) -> Result<JsonValue, RdfDiagnostic> {
+        let mut compacted = match &self.term {
+            Term::Id(id) => {
+                let coercion = definition.and_then(JsonLdTermDefinition::type_mapping);
+                if self.annotations.is_empty()
+                    && matches!(
+                        coercion,
+                        Some(JsonLdTypeMapping::Id | JsonLdTypeMapping::Vocab)
+                    )
+                {
+                    let vocab = matches!(coercion, Some(JsonLdTypeMapping::Vocab));
+                    JsonValue::String(compact_id(context, id, vocab)?)
+                } else {
+                    to_json_object(BTreeMap::from([(
+                        compact_keyword(context, "@id")?,
+                        JsonValue::String(compact_id(context, id, false)?),
+                    )]))
+                }
+            }
+            Term::Literal(literal) => {
+                compact_literal(context, definition, literal, self.annotations.is_empty())?
+            }
+            Term::Triple(triple) => to_json_object(BTreeMap::from([(
+                "@triple".to_owned(),
+                triple.compacted_json(context)?,
+            )])),
+            Term::List(values) => {
+                let values = values
+                    .iter()
+                    .map(|value| {
+                        // List-item compaction inherits the parent term's
+                        // type/language/direction coercion. A nested list must not
+                        // inherit the outer @list container itself or it would lose
+                        // one structural level.
+                        let item_definition = if matches!(value.term, Term::List(_)) {
+                            None
+                        } else {
+                            definition
+                        };
+                        value.compacted_json(context, item_definition)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                if definition.is_some_and(|definition| {
+                    definition.containers().contains(&JsonLdContainer::List)
+                }) {
+                    JsonValue::Array(values)
+                } else {
+                    to_json_object(BTreeMap::from([(
+                        compact_keyword(context, "@list")?,
+                        JsonValue::Array(values),
+                    )]))
+                }
+            }
+        };
+        if !self.annotations.is_empty() {
+            let annotations = self
+                .annotations
+                .iter()
+                .map(|node| node.compacted_json(context))
+                .collect::<Result<Vec<_>, _>>()?;
+            let annotation = if let [only] = annotations.as_slice() {
+                only.clone()
+            } else {
+                JsonValue::Array(annotations)
+            };
+            compacted
+                .as_object_mut()
+                .ok_or_else(|| decode("annotated JSON-LD value cannot compact to a scalar"))?
+                .insert("@annotation".to_owned(), annotation);
+        }
+        Ok(compacted)
+    }
+}
+
+impl Triple {
+    fn compacted_json(&self, context: &CompiledJsonLdContext) -> Result<JsonValue, RdfDiagnostic> {
+        Ok(to_json_object(BTreeMap::from([
+            (
+                "@object".to_owned(),
+                compact_component(context, &self.object)?,
+            ),
+            (
+                "@predicate".to_owned(),
+                JsonValue::String(context.compact_iri(&self.predicate, true)?),
+            ),
+            (
+                "@subject".to_owned(),
+                compact_component(context, &self.subject)?,
+            ),
+        ])))
+    }
+}
+
+fn compact_component(
+    context: &CompiledJsonLdContext,
+    term: &Term,
+) -> Result<JsonValue, RdfDiagnostic> {
+    Value::plain(term.clone()).compacted_json(context, None)
+}
+
+fn compact_literal(
+    context: &CompiledJsonLdContext,
+    definition: Option<&JsonLdTermDefinition>,
+    literal: &Literal,
+    may_collapse: bool,
+) -> Result<JsonValue, RdfDiagnostic> {
+    if may_collapse
+        && definition
+            .is_some_and(|definition| literal_matches_mapping(context, definition, literal))
+    {
+        if definition
+            .is_some_and(|definition| definition.type_mapping() == Some(&JsonLdTypeMapping::Json))
+            && let Some(parsed) = canonical_json_value(&literal.lexical)
+        {
+            return Ok(parsed);
+        }
+        if definition
+            .is_none_or(|definition| definition.type_mapping() != Some(&JsonLdTypeMapping::Json))
+        {
+            return Ok(JsonValue::String(literal.lexical.clone()));
+        }
+    }
+    let mut value = BTreeMap::new();
+    insert_unique(
+        &mut value,
+        &compact_keyword(context, "@value")?,
+        JsonValue::String(literal.lexical.clone()),
+    )?;
+    if let Some(language) = &literal.language {
+        insert_unique(
+            &mut value,
+            &compact_keyword(context, "@language")?,
+            JsonValue::String(language.clone()),
+        )?;
+    }
+    if let Some(direction) = &literal.direction {
+        insert_unique(
+            &mut value,
+            &compact_keyword(context, "@direction")?,
+            JsonValue::String(direction.clone()),
+        )?;
+    }
+    if let Some(datatype) = &literal.datatype {
+        insert_unique(
+            &mut value,
+            &compact_keyword(context, "@type")?,
+            JsonValue::String(context.compact_iri(datatype, true)?),
+        )?;
+    }
+    Ok(to_json_object(value))
+}
+
+fn canonical_json_value(lexical: &str) -> Option<JsonValue> {
+    let parsed: JsonValue = serde_json::from_str(lexical).ok()?;
+    (serde_json::to_string(&parsed).ok()?.as_str() == lexical).then_some(parsed)
+}
+
+fn literal_matches_mapping(
+    context: &CompiledJsonLdContext,
+    definition: &JsonLdTermDefinition,
+    literal: &Literal,
+) -> bool {
+    match (&literal.datatype, definition.type_mapping()) {
+        (Some(datatype), Some(JsonLdTypeMapping::Datatype(mapping))) => datatype == mapping,
+        (Some(datatype), Some(JsonLdTypeMapping::Json)) => datatype == super::RDF_JSON,
+        (Some(_), _) => false,
+        (None, Some(_)) => false,
+        (None, None) => {
+            let language = match definition.language_mapping() {
+                Some(JsonLdNullable::Null) => None,
+                Some(JsonLdNullable::Value(language)) => Some(language),
+                None => context.default_language(),
+            };
+            let direction = match definition.direction_mapping() {
+                Some(JsonLdNullable::Null) => None,
+                Some(JsonLdNullable::Value(JsonLdDirection::LeftToRight)) => Some("ltr"),
+                Some(JsonLdNullable::Value(JsonLdDirection::RightToLeft)) => Some("rtl"),
+                None => context.default_direction().map(JsonLdDirection::as_str),
+            };
+            literal.language.as_deref() == language && literal.direction.as_deref() == direction
+        }
+    }
+}
+
+fn compact_keyword(
+    context: &CompiledJsonLdContext,
+    keyword: &str,
+) -> Result<String, RdfDiagnostic> {
+    context.compact_iri(keyword, true)
+}
+
+fn compact_id(
+    context: &CompiledJsonLdContext,
+    id: &str,
+    vocab: bool,
+) -> Result<String, RdfDiagnostic> {
+    if id.starts_with("_:") {
+        Ok(id.to_owned())
+    } else {
+        context.compact_iri(id, vocab)
+    }
+}
+
+fn insert_unique(
+    object: &mut BTreeMap<String, JsonValue>,
+    key: &str,
+    value: JsonValue,
+) -> Result<(), RdfDiagnostic> {
+    if object.insert(key.to_owned(), value).is_some() {
+        return Err(decode(format!(
+            "JSON-LD compaction produced duplicate member `{key}`"
+        )));
+    }
+    Ok(())
+}

--- a/crates/rdf/src/native_codecs/jsonld/carrier.rs
+++ b/crates/rdf/src/native_codecs/jsonld/carrier.rs
@@ -18,8 +18,8 @@ use serde_json::Value as JsonValue;
 
 use super::{
     CompiledJsonLdContext, JsonLdContainer, JsonLdDirection, JsonLdNullable, JsonLdTermDefinition,
-    JsonLdTermSelection, JsonLdTermSelectionKind, JsonLdTypeMapping, RdfDiagnostic, cmp_value,
-    decode, to_json_object,
+    JsonLdTermSelection, JsonLdTermSelectionKind, JsonLdTypeMapping, RdfDiagnostic, decode,
+    to_json_object,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -816,10 +816,10 @@ impl Node {
     pub(super) fn sort_values(&mut self) {
         self.types.sort();
         for values in self.properties.values_mut() {
-            values.sort_by(|left, right| cmp_value(&left.expanded_json(), &right.expanded_json()));
+            values.sort_by(compare_values);
         }
         for values in self.reverse_properties.values_mut() {
-            values.sort_by(|left, right| cmp_value(&left.expanded_json(), &right.expanded_json()));
+            values.sort_by(compare_values);
         }
     }
 
@@ -1034,6 +1034,72 @@ fn relocate_reverse_properties(
 pub(super) struct Value {
     pub(super) term: Term,
     pub(super) annotations: Vec<Node>,
+}
+
+#[derive(Clone, Copy)]
+struct ValueSortPart<'a> {
+    label: &'static str,
+    value: &'a str,
+}
+
+const EMPTY_VALUE_SORT_PART: ValueSortPart<'static> = ValueSortPart {
+    label: "",
+    value: "",
+};
+
+struct ValueSortKey<'a> {
+    parts: [ValueSortPart<'a>; 4],
+    len: usize,
+}
+
+impl<'a> ValueSortKey<'a> {
+    fn new(value: &'a Value) -> Self {
+        let mut key = Self {
+            parts: [EMPTY_VALUE_SORT_PART; 4],
+            len: 0,
+        };
+        match &value.term {
+            Term::Id(id) => key.push("id=", id),
+            Term::Literal(literal) => {
+                if let Some(direction) = &literal.direction {
+                    key.push("dir=", direction);
+                }
+                if let Some(datatype) = &literal.datatype {
+                    key.push("dt=", datatype);
+                }
+                if let Some(language) = &literal.language {
+                    key.push("lang=", language);
+                }
+                key.push("value=", &literal.lexical);
+            }
+            Term::Triple(_) | Term::List(_) => {}
+        }
+        key
+    }
+
+    fn push(&mut self, label: &'static str, value: &'a str) {
+        self.parts[self.len] = ValueSortPart { label, value };
+        self.len += 1;
+    }
+
+    fn bytes(&self) -> impl Iterator<Item = u8> + '_ {
+        self.parts[..self.len]
+            .iter()
+            .enumerate()
+            .flat_map(|(index, part)| {
+                (index > 0)
+                    .then_some(b'|')
+                    .into_iter()
+                    .chain(part.label.bytes())
+                    .chain(part.value.bytes())
+            })
+    }
+}
+
+fn compare_values(left: &Value, right: &Value) -> std::cmp::Ordering {
+    ValueSortKey::new(left)
+        .bytes()
+        .cmp(ValueSortKey::new(right).bytes())
 }
 
 impl Value {
@@ -1587,4 +1653,69 @@ fn insert_unique(
         )));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn materialized_sort_key(value: &Value) -> String {
+        let object = value.expanded_json();
+        let object = object.as_object().expect("carrier value object");
+        let mut parts = Vec::new();
+        for (keyword, label) in [
+            ("@id", "id"),
+            ("@value", "value"),
+            ("@language", "lang"),
+            ("@direction", "dir"),
+            ("@type", "dt"),
+        ] {
+            if let Some(value) = object.get(keyword).and_then(JsonValue::as_str) {
+                parts.push(format!("{label}={value}"));
+            }
+        }
+        parts.sort();
+        format!("1:{}", parts.join("|"))
+    }
+
+    fn literal(
+        lexical: &str,
+        datatype: Option<&str>,
+        language: Option<&str>,
+        direction: Option<&str>,
+    ) -> Value {
+        Value::plain(Term::Literal(Literal {
+            lexical: lexical.to_owned(),
+            datatype: datatype.map(str::to_owned),
+            language: language.map(str::to_owned),
+            direction: direction.map(str::to_owned),
+        }))
+    }
+
+    #[test]
+    fn allocation_free_value_order_matches_the_materialized_json_key() {
+        let values = [
+            Value::plain(Term::List(Vec::new())),
+            Value::plain(Term::Triple(Box::new(Triple {
+                subject: Box::new(Term::Id("urn:s".to_owned())),
+                predicate: "urn:p".to_owned(),
+                object: Box::new(Term::Id("urn:o".to_owned())),
+            }))),
+            Value::plain(Term::Id("https://example.org/a".to_owned())),
+            Value::plain(Term::Id("https://example.org/aZ".to_owned())),
+            literal("a", None, None, None),
+            literal("aZ", None, Some("en"), None),
+            literal("z", Some("urn:datatype"), None, Some("a")),
+            literal("z", Some("urn:datatype"), None, Some("aZ")),
+            literal("é", None, Some("fr"), Some("ltr")),
+        ];
+        for left in &values {
+            for right in &values {
+                assert_eq!(
+                    compare_values(left, right),
+                    materialized_sort_key(left).cmp(&materialized_sort_key(right))
+                );
+            }
+        }
+    }
 }

--- a/crates/rdf/src/native_codecs/jsonld/context/compiler.rs
+++ b/crates/rdf/src/native_codecs/jsonld/context/compiler.rs
@@ -1,0 +1,1875 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! JSON-LD 1.1 active-context and inverse-context algorithms.
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use serde_json::{Map, Value};
+
+use super::{
+    ActiveContext, CompiledJsonLdContext, InverseContext, JsonLdContainer, JsonLdContextLimits,
+    JsonLdContextRegistry, JsonLdDirection, JsonLdNullable, JsonLdTermDefinition,
+    JsonLdTermSelection, JsonLdTermSelectionKind, JsonLdTypeMapping, canonicalize, context_error,
+    context_limit, validate_absolute_iri,
+};
+use crate::RdfDiagnostic;
+
+const KEYWORDS: &[&str] = &[
+    "@base",
+    "@container",
+    "@context",
+    "@direction",
+    "@graph",
+    "@id",
+    "@import",
+    "@included",
+    "@index",
+    "@json",
+    "@language",
+    "@list",
+    "@nest",
+    "@none",
+    "@prefix",
+    "@propagate",
+    "@protected",
+    "@reverse",
+    "@set",
+    "@type",
+    "@value",
+    "@version",
+    "@vocab",
+];
+
+const CONTEXT_KEYWORDS: &[&str] = &[
+    "@base",
+    "@direction",
+    "@import",
+    "@language",
+    "@propagate",
+    "@protected",
+    "@type",
+    "@version",
+    "@vocab",
+];
+
+const EXTENSION_CONTROLS: &[&str] = &[
+    "@annotation",
+    "@object",
+    "@predicate",
+    "@subject",
+    "@triple",
+];
+
+const TERM_DEFINITION_KEYS: &[&str] = &[
+    "@container",
+    "@context",
+    "@direction",
+    "@id",
+    "@index",
+    "@language",
+    "@nest",
+    "@prefix",
+    "@protected",
+    "@reverse",
+    "@type",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DefinitionState {
+    Defining,
+    Defined,
+}
+
+#[derive(Debug, Default)]
+struct Budget {
+    terms: usize,
+    work: usize,
+    complexity: usize,
+    loaded_bytes: usize,
+}
+
+struct Compiler<'a> {
+    registry: &'a JsonLdContextRegistry,
+    limits: JsonLdContextLimits,
+    initial_base: Option<String>,
+    budget: Budget,
+    remote_stack: Vec<String>,
+    remote_cache: BTreeMap<String, Arc<Value>>,
+    override_protected: bool,
+}
+
+pub(super) fn compile(
+    supplied: &Value,
+    document_iri: Option<&str>,
+    registry: &JsonLdContextRegistry,
+    limits: JsonLdContextLimits,
+) -> Result<CompiledJsonLdContext, RdfDiagnostic> {
+    let document_iri = document_iri.map(str::to_owned);
+    if let Some(iri) = &document_iri {
+        validate_absolute_iri(iri, "JSON-LD document IRI")?;
+    }
+    let context = extract_context(supplied)?;
+    let mut compiler = Compiler {
+        registry,
+        limits,
+        initial_base: document_iri.clone(),
+        budget: Budget::default(),
+        remote_stack: Vec::new(),
+        remote_cache: BTreeMap::new(),
+        override_protected: false,
+    };
+    compiler.charge_value(context, 0)?;
+    let canonical_context = canonicalize(context);
+    let context_bytes = serde_json::to_vec(&canonical_context)
+        .map_err(|source| context_error(format!("encode canonical JSON-LD context: {source}")))?;
+    if context_bytes.len() > limits.max_context_bytes() {
+        return Err(context_limit(format!(
+            "canonical JSON-LD context is {} bytes; limit is {}",
+            context_bytes.len(),
+            limits.max_context_bytes()
+        )));
+    }
+    let mut active = ActiveContext::new(document_iri.clone());
+    compiler.process_context(&mut active, context, document_iri.as_deref(), false, 0)?;
+    let inverse = build_inverse_context(&active);
+    Ok(CompiledJsonLdContext {
+        canonical_context,
+        active,
+        inverse,
+        registry: registry.clone(),
+    })
+}
+
+fn extract_context(value: &Value) -> Result<&Value, RdfDiagnostic> {
+    match value {
+        Value::Object(object) if object.contains_key("@context") => object
+            .get("@context")
+            .ok_or_else(|| context_error("JSON-LD context wrapper is missing @context")),
+        _ => Ok(value),
+    }
+}
+
+impl Compiler<'_> {
+    fn charge_work(&mut self, description: &str) -> Result<(), RdfDiagnostic> {
+        self.budget.work = self
+            .budget
+            .work
+            .checked_add(1)
+            .ok_or_else(|| context_limit("JSON-LD context work counter overflow"))?;
+        if self.budget.work > self.limits.max_expansion_work() {
+            return Err(context_limit(format!(
+                "JSON-LD context expansion work exceeds {} operations while {description}",
+                self.limits.max_expansion_work()
+            )));
+        }
+        Ok(())
+    }
+
+    fn charge_complexity(&mut self, amount: usize, description: &str) -> Result<(), RdfDiagnostic> {
+        self.budget.complexity = self
+            .budget
+            .complexity
+            .checked_add(amount)
+            .ok_or_else(|| context_limit("JSON-LD definition-complexity counter overflow"))?;
+        if self.budget.complexity > self.limits.max_definition_complexity() {
+            return Err(context_limit(format!(
+                "JSON-LD definition complexity exceeds {} while {description}",
+                self.limits.max_definition_complexity()
+            )));
+        }
+        Ok(())
+    }
+
+    fn charge_value(&mut self, value: &Value, depth: usize) -> Result<(), RdfDiagnostic> {
+        if depth > self.limits.max_nesting() {
+            return Err(context_limit(format!(
+                "JSON-LD context nesting exceeds depth {}",
+                self.limits.max_nesting()
+            )));
+        }
+        self.charge_work("walking the supplied context")?;
+        match value {
+            Value::String(text) => self.charge_complexity(text.len(), "reading a string"),
+            Value::Array(values) => {
+                self.charge_complexity(values.len(), "reading an array")?;
+                for value in values {
+                    self.charge_value(value, depth + 1)?;
+                }
+                Ok(())
+            }
+            Value::Object(values) => {
+                self.charge_complexity(values.len(), "reading an object")?;
+                for (key, value) in values {
+                    self.charge_complexity(key.len(), "reading an object key")?;
+                    self.charge_value(value, depth + 1)?;
+                }
+                Ok(())
+            }
+            Value::Null | Value::Bool(_) | Value::Number(_) => Ok(()),
+        }
+    }
+
+    fn process_context(
+        &mut self,
+        active: &mut ActiveContext,
+        local: &Value,
+        base_url: Option<&str>,
+        remote: bool,
+        depth: usize,
+    ) -> Result<(), RdfDiagnostic> {
+        self.process_context_inner(active, local, base_url, remote, depth, true)
+    }
+
+    fn process_context_inner(
+        &mut self,
+        active: &mut ActiveContext,
+        local: &Value,
+        base_url: Option<&str>,
+        remote: bool,
+        depth: usize,
+        select_propagation: bool,
+    ) -> Result<(), RdfDiagnostic> {
+        if depth > self.limits.max_nesting() {
+            return Err(context_limit(format!(
+                "JSON-LD context processing exceeds depth {}",
+                self.limits.max_nesting()
+            )));
+        }
+        self.charge_work("processing a local context")?;
+        if select_propagation {
+            let propagate = match local {
+                Value::Object(object) => match object.get("@propagate") {
+                    None => true,
+                    Some(Value::Bool(value)) => *value,
+                    Some(_) => {
+                        return Err(context_error("JSON-LD @propagate must be boolean"));
+                    }
+                },
+                _ => true,
+            };
+            if !propagate && active.previous_context.is_none() {
+                active.previous_context = Some(Arc::new(active.clone()));
+            }
+            active.propagate = propagate;
+        }
+        match local {
+            Value::Null => self.reset_context(active),
+            Value::Array(entries) => {
+                for entry in entries {
+                    self.process_context_inner(active, entry, base_url, remote, depth + 1, false)?;
+                }
+                Ok(())
+            }
+            Value::String(reference) => {
+                let iri = resolve_reference(reference, base_url, "context IRI")?;
+                self.process_remote_context(active, &iri, depth + 1)
+            }
+            Value::Object(object) => {
+                self.process_context_object(active, object, base_url, remote, depth + 1)
+            }
+            Value::Bool(_) | Value::Number(_) => Err(context_error(
+                "JSON-LD local context must be null, an object, an array, or an IRI",
+            )),
+        }
+    }
+
+    fn reset_context(&self, active: &mut ActiveContext) -> Result<(), RdfDiagnostic> {
+        if !self.override_protected
+            && let Some((term, _)) = active
+                .terms
+                .iter()
+                .find(|(_, definition)| definition.protected)
+        {
+            return Err(context_error(format!(
+                "null context would erase protected term `{term}`"
+            )));
+        }
+        let previous_context = (!active.propagate)
+            .then(|| active.previous_context.clone())
+            .flatten();
+        let propagate = active.propagate;
+        *active = ActiveContext::new(self.initial_base.clone());
+        if !propagate {
+            active.propagate = false;
+            active.previous_context = previous_context;
+        }
+        Ok(())
+    }
+
+    fn process_remote_context(
+        &mut self,
+        active: &mut ActiveContext,
+        iri: &str,
+        depth: usize,
+    ) -> Result<(), RdfDiagnostic> {
+        if self.remote_stack.iter().any(|entry| entry == iri) {
+            return Err(context_error(format!(
+                "offline context cycle: {} -> {iri}",
+                self.remote_stack.join(" -> ")
+            )));
+        }
+        let document = self.load_registry_document(iri, depth, "context")?;
+        let context = document
+            .as_object()
+            .and_then(|object| object.get("@context"))
+            .ok_or_else(|| {
+                context_error(format!(
+                    "offline context document `{iri}` must contain @context"
+                ))
+            })?
+            .clone();
+        self.remote_stack.push(iri.to_owned());
+        let result = self.process_context(active, &context, Some(iri), true, depth + 1);
+        self.remote_stack.pop();
+        result
+    }
+
+    fn process_context_object(
+        &mut self,
+        active: &mut ActiveContext,
+        object: &Map<String, Value>,
+        base_url: Option<&str>,
+        remote: bool,
+        depth: usize,
+    ) -> Result<(), RdfDiagnostic> {
+        let mut local = if let Some(import) = object.get("@import") {
+            let reference = import
+                .as_str()
+                .ok_or_else(|| context_error("JSON-LD @import must be an IRI string"))?;
+            let iri = resolve_reference(reference, base_url, "@import IRI")?;
+            self.load_import_object(&iri, depth + 1)?
+        } else {
+            Map::new()
+        };
+        for (key, value) in object {
+            if key != "@import" {
+                local.insert(key.clone(), value.clone());
+            }
+        }
+        self.validate_context_object_keywords(&local)?;
+        if let Some(version) = local.get("@version") {
+            let valid = version.as_f64().is_some_and(|number| number == 1.1);
+            if !valid {
+                return Err(context_error("JSON-LD @version must be the number 1.1"));
+            }
+        }
+        self.process_context_settings(active, &local, remote)?;
+        self.define_local_terms(active, &local, base_url, depth + 1)
+    }
+
+    fn load_import_object(
+        &mut self,
+        iri: &str,
+        depth: usize,
+    ) -> Result<Map<String, Value>, RdfDiagnostic> {
+        if self.remote_stack.iter().any(|entry| entry == iri) {
+            return Err(context_error(format!(
+                "offline @import cycle: {} -> {iri}",
+                self.remote_stack.join(" -> ")
+            )));
+        }
+        let document = self.load_registry_document(iri, depth, "@import")?;
+        let imported = document
+            .as_object()
+            .and_then(|wrapper| wrapper.get("@context"))
+            .and_then(Value::as_object)
+            .ok_or_else(|| {
+                context_error(format!(
+                    "offline @import document `{iri}` must contain an object @context"
+                ))
+            })?
+            .clone();
+        if imported.contains_key("@import") {
+            return Err(context_error(format!(
+                "imported context `{iri}` must not contain another @import"
+            )));
+        }
+        Ok(imported)
+    }
+
+    fn load_registry_document(
+        &mut self,
+        iri: &str,
+        depth: usize,
+        purpose: &str,
+    ) -> Result<Arc<Value>, RdfDiagnostic> {
+        if let Some(document) = self.remote_cache.get(iri) {
+            return Ok(Arc::clone(document));
+        }
+        let bytes = self.registry.get(iri).ok_or_else(|| {
+            context_error(format!(
+                "offline context registry has no document for `{iri}` ({purpose})"
+            ))
+        })?;
+        self.budget.loaded_bytes = self
+            .budget
+            .loaded_bytes
+            .checked_add(bytes.len())
+            .ok_or_else(|| context_limit("loaded context byte counter overflow"))?;
+        if self.budget.loaded_bytes > self.limits.max_registry_bytes() {
+            return Err(context_limit(format!(
+                "loaded offline context bytes exceed {}",
+                self.limits.max_registry_bytes()
+            )));
+        }
+        let document = super::parse_strict_json(
+            bytes,
+            self.limits.strict_json(),
+            &format!("offline {purpose} document `{iri}`"),
+        )?;
+        self.charge_value(&document, depth)?;
+        let document = Arc::new(document);
+        self.remote_cache
+            .insert(iri.to_owned(), Arc::clone(&document));
+        Ok(document)
+    }
+
+    fn validate_context_object_keywords(
+        &self,
+        object: &Map<String, Value>,
+    ) -> Result<(), RdfDiagnostic> {
+        for key in object.keys().filter(|key| key.starts_with('@')) {
+            if is_extension_control(key) {
+                return Err(context_error(format!(
+                    "caller contexts cannot redefine PurRDF control `{key}`"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn process_context_settings(
+        &self,
+        active: &mut ActiveContext,
+        object: &Map<String, Value>,
+        remote: bool,
+    ) -> Result<(), RdfDiagnostic> {
+        if let Some(value) = object.get("@propagate") {
+            value
+                .as_bool()
+                .ok_or_else(|| context_error("JSON-LD @propagate must be boolean"))?;
+        }
+        if !remote && let Some(value) = object.get("@base") {
+            active.base_iri = match value {
+                Value::Null => None,
+                Value::String(reference) => Some(resolve_reference(
+                    reference,
+                    active.base_iri.as_deref(),
+                    "@base",
+                )?),
+                _ => return Err(context_error("JSON-LD @base must be a string or null")),
+            };
+        }
+        if let Some(value) = object.get("@vocab") {
+            active.vocab_mapping = match value {
+                Value::Null => None,
+                Value::String(reference) => {
+                    if is_keyword_form(reference) {
+                        return Err(context_error(format!(
+                            "JSON-LD @vocab cannot use reserved keyword-form value `{reference}`"
+                        )));
+                    }
+                    let expanded = if is_blank_node_identifier(reference) {
+                        reference.clone()
+                    } else {
+                        resolve_reference(reference, active.base_iri.as_deref(), "@vocab")?
+                    };
+                    validate_iri_or_blank_node(&expanded, "@vocab mapping")?;
+                    Some(expanded)
+                }
+                _ => return Err(context_error("JSON-LD @vocab must be a string or null")),
+            };
+        }
+        if let Some(value) = object.get("@language") {
+            active.default_language = match value {
+                Value::Null => None,
+                Value::String(language) => Some(language.to_ascii_lowercase()),
+                _ => {
+                    return Err(context_error("JSON-LD @language must be a string or null"));
+                }
+            };
+        }
+        if let Some(value) = object.get("@direction") {
+            active.default_direction = match value {
+                Value::Null => None,
+                Value::String(direction) => {
+                    Some(JsonLdDirection::parse(direction).ok_or_else(|| {
+                        context_error("JSON-LD @direction must be `ltr`, `rtl`, or null")
+                    })?)
+                }
+                _ => {
+                    return Err(context_error(
+                        "JSON-LD @direction must be `ltr`, `rtl`, or null",
+                    ));
+                }
+            };
+        }
+        Ok(())
+    }
+
+    fn define_local_terms(
+        &mut self,
+        active: &mut ActiveContext,
+        object: &Map<String, Value>,
+        base_url: Option<&str>,
+        depth: usize,
+    ) -> Result<(), RdfDiagnostic> {
+        let default_protected = match object.get("@protected") {
+            None => false,
+            Some(Value::Bool(value)) => *value,
+            Some(_) => return Err(context_error("JSON-LD @protected must be boolean")),
+        };
+        let terms: Vec<String> = object
+            .keys()
+            .filter(|key| key.as_str() == "@type" || !CONTEXT_KEYWORDS.contains(&key.as_str()))
+            .cloned()
+            .collect();
+        let mut states = BTreeMap::new();
+        for term in &terms {
+            self.define_term(
+                active,
+                object,
+                term,
+                default_protected,
+                base_url,
+                &mut states,
+                depth,
+            )?;
+        }
+
+        // Validate each term-scoped context against the fully defined active context.
+        // The canonical local value remains attached to the term and is reused by the
+        // typed carrier; this validation deliberately does not materialize an expanded
+        // JSON tree.
+        let scoped: Vec<(String, Value)> = terms
+            .iter()
+            .filter_map(|term| {
+                active
+                    .terms
+                    .get(term)
+                    .and_then(|definition| definition.scoped_context.clone())
+                    .map(|context| (term.clone(), context))
+            })
+            .collect();
+        for (term, context) in scoped {
+            let mut scoped_active = active.clone();
+            // Avoid recursively validating the same scope merely because the parent
+            // active context contains its definition. Nested scoped definitions that
+            // occur textually inside `context` are still parsed and validated.
+            if let Some(definition) = scoped_active.terms.get_mut(&term) {
+                definition.scoped_context = None;
+            }
+            let previous_override = self.override_protected;
+            self.override_protected = true;
+            let result =
+                self.process_context(&mut scoped_active, &context, base_url, false, depth + 1);
+            self.override_protected = previous_override;
+            result?;
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn define_term(
+        &mut self,
+        active: &mut ActiveContext,
+        local: &Map<String, Value>,
+        term: &str,
+        default_protected: bool,
+        base_url: Option<&str>,
+        states: &mut BTreeMap<String, DefinitionState>,
+        depth: usize,
+    ) -> Result<(), RdfDiagnostic> {
+        match states.get(term) {
+            Some(DefinitionState::Defined) => return Ok(()),
+            Some(DefinitionState::Defining) => {
+                return Err(context_error(format!(
+                    "cyclic JSON-LD term definition involving `{term}`"
+                )));
+            }
+            None => {}
+        }
+        if is_keyword_form(term) && !is_keyword(term) {
+            states.insert(term.to_owned(), DefinitionState::Defined);
+            return Ok(());
+        }
+        if depth > self.limits.max_nesting() {
+            return Err(context_limit(format!(
+                "JSON-LD term-definition recursion exceeds depth {}",
+                self.limits.max_nesting()
+            )));
+        }
+        validate_term_name(term)?;
+        self.charge_work(&format!("defining term `{term}`"))?;
+        if self.budget.terms == self.limits.max_terms() {
+            return Err(context_limit(format!(
+                "JSON-LD context exceeds {} term definitions",
+                self.limits.max_terms()
+            )));
+        }
+        self.budget.terms += 1;
+        states.insert(term.to_owned(), DefinitionState::Defining);
+
+        let value = local
+            .get(term)
+            .ok_or_else(|| context_error(format!("missing local definition for `{term}`")))?
+            .clone();
+        let old = active.terms.remove(term);
+        let compiled = self.compile_term_definition(
+            active,
+            local,
+            term,
+            value,
+            default_protected,
+            base_url,
+            states,
+            depth + 1,
+        );
+        let mut definition = match compiled {
+            Ok(definition) => definition,
+            Err(error) => {
+                if let Some(old) = old {
+                    active.terms.insert(term.to_owned(), old);
+                }
+                states.remove(term);
+                return Err(error);
+            }
+        };
+
+        if let Some(old) = old
+            && old.protected
+            && !self.override_protected
+        {
+            if !definitions_equal_ignoring_protected(&old, &definition) {
+                active.terms.insert(term.to_owned(), old);
+                states.remove(term);
+                return Err(context_error(format!(
+                    "protected JSON-LD term `{term}` cannot be redefined"
+                )));
+            }
+            definition = old;
+        }
+        active.terms.insert(term.to_owned(), definition);
+        states.insert(term.to_owned(), DefinitionState::Defined);
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn compile_term_definition(
+        &mut self,
+        active: &mut ActiveContext,
+        local: &Map<String, Value>,
+        term: &str,
+        value: Value,
+        default_protected: bool,
+        base_url: Option<&str>,
+        states: &mut BTreeMap<String, DefinitionState>,
+        depth: usize,
+    ) -> Result<JsonLdTermDefinition, RdfDiagnostic> {
+        let simple_term = value.is_string();
+        let object: Map<String, Value> = match value {
+            Value::Null => BTreeMap::from([("@id".to_owned(), Value::Null)])
+                .into_iter()
+                .collect(),
+            Value::String(id) => BTreeMap::from([("@id".to_owned(), Value::String(id))])
+                .into_iter()
+                .collect(),
+            Value::Object(object) => object,
+            _ => {
+                return Err(context_error(format!(
+                    "term `{term}` definition must be null, a string, or an object"
+                )));
+            }
+        };
+        if term == "@type" {
+            return compile_type_keyword_definition(&object, default_protected);
+        }
+        for key in object.keys() {
+            if !TERM_DEFINITION_KEYS.contains(&key.as_str()) {
+                return Err(context_error(format!(
+                    "term `{term}` has unsupported definition member `{key}`"
+                )));
+            }
+        }
+
+        let protected = match object.get("@protected") {
+            None => default_protected,
+            Some(Value::Bool(value)) => *value,
+            Some(_) => {
+                return Err(context_error(format!(
+                    "term `{term}` @protected must be boolean"
+                )));
+            }
+        };
+
+        let type_mapping = object
+            .get("@type")
+            .map(|value| {
+                self.compile_type_mapping(
+                    active,
+                    local,
+                    term,
+                    value,
+                    base_url,
+                    default_protected,
+                    states,
+                    depth,
+                )
+            })
+            .transpose()?;
+
+        let reverse_property = object.contains_key("@reverse");
+        if reverse_property {
+            if object.contains_key("@id") || object.contains_key("@nest") {
+                return Err(context_error(format!(
+                    "reverse term `{term}` cannot define @id or @nest"
+                )));
+            }
+            let reverse = object
+                .get("@reverse")
+                .expect("reverse member was checked as present");
+            let reverse = reverse
+                .as_str()
+                .ok_or_else(|| context_error(format!("term `{term}` @reverse must be a string")))?;
+            if is_keyword_form(reverse) && !is_keyword(reverse) {
+                return Ok(empty_definition(protected));
+            }
+            let expanded = self.expand_local_iri(
+                active,
+                local,
+                reverse,
+                true,
+                false,
+                base_url,
+                default_protected,
+                states,
+                depth,
+            )?;
+            validate_property_mapping(term, &expanded)?;
+            let containers = object
+                .get("@container")
+                .map(|value| compile_reverse_containers(term, value))
+                .transpose()?
+                .unwrap_or_default();
+            return Ok(JsonLdTermDefinition {
+                iri_mapping: Some(expanded),
+                reverse_property: true,
+                prefix: false,
+                protected,
+                type_mapping,
+                language_mapping: None,
+                direction_mapping: None,
+                containers,
+                index_mapping: None,
+                nest: None,
+                scoped_context: None,
+                scoped_context_base: None,
+            });
+        }
+
+        let iri_mapping = if let Some(id) = object.get("@id") {
+            match id {
+                Value::Null => None,
+                Value::String(id) if is_keyword_form(id) && !is_keyword(id) => None,
+                Value::String(id) if id == term => Some(self.derive_term_mapping(
+                    active,
+                    local,
+                    term,
+                    base_url,
+                    default_protected,
+                    states,
+                    depth,
+                )?),
+                Value::String(id) => {
+                    let expanded = self.expand_local_iri(
+                        active,
+                        local,
+                        id,
+                        true,
+                        false,
+                        base_url,
+                        default_protected,
+                        states,
+                        depth,
+                    )?;
+                    validate_term_mapping(term, &expanded)?;
+                    if term_has_mapping_syntax(term) {
+                        let term_mapping = self.derive_term_mapping(
+                            active,
+                            local,
+                            term,
+                            base_url,
+                            default_protected,
+                            states,
+                            depth,
+                        )?;
+                        if term_mapping != expanded {
+                            return Err(context_error(format!(
+                                "term `{term}` @id expands to `{expanded}`, but the term itself expands to `{term_mapping}`"
+                            )));
+                        }
+                    }
+                    Some(expanded)
+                }
+                _ => {
+                    return Err(context_error(format!(
+                        "term `{term}` @id must be a string or null"
+                    )));
+                }
+            }
+        } else {
+            Some(self.derive_term_mapping(
+                active,
+                local,
+                term,
+                base_url,
+                default_protected,
+                states,
+                depth,
+            )?)
+        };
+
+        let prefix = match object.get("@prefix") {
+            None => simple_term && is_implicit_prefix(term, iri_mapping.as_deref()),
+            Some(Value::Bool(value)) => *value,
+            Some(_) => {
+                return Err(context_error(format!(
+                    "term `{term}` @prefix must be boolean"
+                )));
+            }
+        };
+        if object.contains_key("@prefix") && term.contains([':', '/']) {
+            return Err(context_error(format!(
+                "term `{term}` with @prefix must not contain `:` or `/`"
+            )));
+        }
+        if prefix {
+            let mapping = iri_mapping
+                .as_deref()
+                .ok_or_else(|| context_error(format!("prefix term `{term}` has a null mapping")))?;
+            if is_keyword(mapping) || is_extension_control(mapping) {
+                return Err(context_error(format!(
+                    "prefix term `{term}` cannot map to `{mapping}`"
+                )));
+            }
+            validate_iri_or_blank_node(mapping, &format!("prefix mapping for `{term}`"))?;
+        }
+
+        let containers = object
+            .get("@container")
+            .map(|value| compile_containers(term, value))
+            .transpose()?
+            .unwrap_or_default();
+        validate_container_combination(term, &containers, false)?;
+        let type_mapping = if containers.contains(&JsonLdContainer::Type) {
+            match type_mapping {
+                None => Some(JsonLdTypeMapping::Id),
+                Some(JsonLdTypeMapping::Id | JsonLdTypeMapping::Vocab) => type_mapping,
+                Some(_) => {
+                    return Err(context_error(format!(
+                        "term `{term}` with an @type container requires @type coercion @id or @vocab"
+                    )));
+                }
+            }
+        } else {
+            type_mapping
+        };
+
+        let language_mapping = if type_mapping.is_none() {
+            object
+                .get("@language")
+                .map(|value| compile_language_mapping(term, value))
+                .transpose()?
+        } else {
+            None
+        };
+        let direction_mapping = if type_mapping.is_none() {
+            object
+                .get("@direction")
+                .map(|value| compile_direction_mapping(term, value))
+                .transpose()?
+        } else {
+            None
+        };
+
+        let index_mapping = object
+            .get("@index")
+            .map(|value| {
+                if !containers.contains(&JsonLdContainer::Index) {
+                    return Err(context_error(format!(
+                        "term `{term}` @index requires an @index container"
+                    )));
+                }
+                let index = value.as_str().ok_or_else(|| {
+                    context_error(format!("term `{term}` @index must be a string"))
+                })?;
+                let expanded = self.expand_local_iri(
+                    active,
+                    local,
+                    index,
+                    true,
+                    false,
+                    base_url,
+                    default_protected,
+                    states,
+                    depth,
+                )?;
+                validate_absolute_iri(&expanded, &format!("index mapping for term `{term}`"))?;
+                Ok(expanded)
+            })
+            .transpose()?;
+
+        let nest = object
+            .get("@nest")
+            .map(|value| {
+                let nest = value.as_str().ok_or_else(|| {
+                    context_error(format!("term `{term}` @nest must be a string"))
+                })?;
+                if is_keyword(nest) && nest != "@nest" {
+                    return Err(context_error(format!(
+                        "term `{term}` @nest cannot use keyword `{nest}`"
+                    )));
+                }
+                Ok(nest.to_owned())
+            })
+            .transpose()?;
+
+        let scoped_context = object.get("@context").map(canonicalize);
+        let scoped_context_base = scoped_context
+            .as_ref()
+            .and_then(|_| base_url.map(str::to_owned));
+
+        Ok(JsonLdTermDefinition {
+            iri_mapping,
+            reverse_property,
+            prefix,
+            protected,
+            type_mapping,
+            language_mapping,
+            direction_mapping,
+            containers,
+            index_mapping,
+            nest,
+            scoped_context,
+            scoped_context_base,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn derive_term_mapping(
+        &mut self,
+        active: &mut ActiveContext,
+        local: &Map<String, Value>,
+        term: &str,
+        base_url: Option<&str>,
+        default_protected: bool,
+        states: &mut BTreeMap<String, DefinitionState>,
+        depth: usize,
+    ) -> Result<String, RdfDiagnostic> {
+        if is_blank_node_identifier(term) {
+            return Ok(term.to_owned());
+        }
+        if let Some((prefix, suffix)) = term.split_once(':')
+            && !prefix.is_empty()
+        {
+            if local.contains_key(prefix) {
+                self.define_term(
+                    active,
+                    local,
+                    prefix,
+                    default_protected,
+                    base_url,
+                    states,
+                    depth + 1,
+                )?;
+            }
+            if let Some(mapping) = active
+                .terms
+                .get(prefix)
+                .and_then(|definition| definition.iri_mapping.as_deref())
+            {
+                let expanded = format!("{mapping}{suffix}");
+                validate_iri_or_blank_node(&expanded, &format!("mapping for term `{term}`"))?;
+                return Ok(expanded);
+            }
+            if let Ok(parsed) = purrdf_iri::parse(term)
+                && parsed.has_scheme()
+            {
+                return Ok(term.to_owned());
+            }
+            return Err(context_error(format!(
+                "term `{term}` uses an undefined compact-IRI prefix `{prefix}`"
+            )));
+        }
+        if term.contains('/') {
+            let expanded = resolve_reference(
+                term,
+                active.base_iri.as_deref(),
+                &format!("mapping for term `{term}`"),
+            )?;
+            validate_absolute_iri(&expanded, &format!("mapping for term `{term}`"))?;
+            return Ok(expanded);
+        }
+        if let Some(vocab) = &active.vocab_mapping {
+            let expanded = format!("{vocab}{term}");
+            validate_iri_or_blank_node(&expanded, &format!("mapping for term `{term}`"))?;
+            return Ok(expanded);
+        }
+        Err(context_error(format!(
+            "term `{term}` needs @id, a compact-IRI prefix, or an active @vocab"
+        )))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn expand_local_iri(
+        &mut self,
+        active: &mut ActiveContext,
+        local: &Map<String, Value>,
+        value: &str,
+        vocab: bool,
+        document_relative: bool,
+        base_url: Option<&str>,
+        default_protected: bool,
+        states: &mut BTreeMap<String, DefinitionState>,
+        depth: usize,
+    ) -> Result<String, RdfDiagnostic> {
+        self.charge_work(&format!("expanding `{value}`"))?;
+        if is_keyword(value) {
+            return Ok(value.to_owned());
+        }
+        if is_extension_control(value) {
+            return Err(context_error(format!(
+                "caller contexts cannot alias PurRDF control `{value}`"
+            )));
+        }
+        if is_keyword_form(value) {
+            return Err(context_error(format!(
+                "reserved keyword-form value `{value}` does not expand to an IRI"
+            )));
+        }
+        if vocab && local.contains_key(value) {
+            self.define_term(
+                active,
+                local,
+                value,
+                default_protected,
+                base_url,
+                states,
+                depth + 1,
+            )?;
+        }
+        if vocab && let Some(definition) = active.terms.get(value) {
+            return definition
+                .iri_mapping
+                .clone()
+                .ok_or_else(|| context_error(format!("term `{value}` has a null IRI mapping")));
+        }
+        if let Some(definition) = active.terms.get(value)
+            && definition.iri_mapping.as_deref().is_some_and(is_keyword)
+        {
+            return definition
+                .iri_mapping
+                .clone()
+                .ok_or_else(|| context_error(format!("term `{value}` has a null IRI mapping")));
+        }
+        if let Some((prefix, suffix)) = value.split_once(':')
+            && !prefix.is_empty()
+        {
+            if prefix == "_" || suffix.starts_with("//") {
+                return Ok(value.to_owned());
+            }
+            if local.contains_key(prefix) {
+                self.define_term(
+                    active,
+                    local,
+                    prefix,
+                    default_protected,
+                    base_url,
+                    states,
+                    depth + 1,
+                )?;
+            }
+            if let Some(mapping) = active
+                .terms
+                .get(prefix)
+                .filter(|definition| definition.prefix)
+                .and_then(|definition| definition.iri_mapping.as_deref())
+            {
+                let expanded = format!("{mapping}{suffix}");
+                validate_iri_or_blank_node(&expanded, "expanded compact IRI")?;
+                return Ok(expanded);
+            }
+            if let Ok(parsed) = purrdf_iri::parse(value)
+                && parsed.has_scheme()
+            {
+                return Ok(value.to_owned());
+            }
+            return Err(context_error(format!(
+                "compact IRI `{value}` uses undefined prefix `{prefix}`"
+            )));
+        }
+        if vocab && let Some(vocab_mapping) = &active.vocab_mapping {
+            return Ok(format!("{vocab_mapping}{value}"));
+        }
+        if document_relative {
+            return resolve_reference(value, active.base_iri.as_deref(), "IRI");
+        }
+        Err(context_error(format!(
+            "relative IRI `{value}` has no applicable @vocab or @base"
+        )))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn compile_type_mapping(
+        &mut self,
+        active: &mut ActiveContext,
+        local: &Map<String, Value>,
+        term: &str,
+        value: &Value,
+        base_url: Option<&str>,
+        default_protected: bool,
+        states: &mut BTreeMap<String, DefinitionState>,
+        depth: usize,
+    ) -> Result<JsonLdTypeMapping, RdfDiagnostic> {
+        let value = value
+            .as_str()
+            .ok_or_else(|| context_error(format!("term `{term}` @type must be a string")))?;
+        match value {
+            "@id" => Ok(JsonLdTypeMapping::Id),
+            "@vocab" => Ok(JsonLdTypeMapping::Vocab),
+            "@json" => Ok(JsonLdTypeMapping::Json),
+            "@none" => Ok(JsonLdTypeMapping::None),
+            _ => {
+                let expanded = self.expand_local_iri(
+                    active,
+                    local,
+                    value,
+                    true,
+                    false,
+                    base_url,
+                    default_protected,
+                    states,
+                    depth,
+                )?;
+                if is_keyword(&expanded) || is_extension_control(&expanded) {
+                    return Err(context_error(format!(
+                        "term `{term}` has invalid @type mapping `{expanded}`"
+                    )));
+                }
+                validate_absolute_iri(&expanded, &format!("@type mapping for `{term}`"))?;
+                Ok(JsonLdTypeMapping::Datatype(expanded))
+            }
+        }
+    }
+}
+
+fn empty_definition(protected: bool) -> JsonLdTermDefinition {
+    JsonLdTermDefinition {
+        iri_mapping: None,
+        reverse_property: false,
+        prefix: false,
+        protected,
+        type_mapping: None,
+        language_mapping: None,
+        direction_mapping: None,
+        containers: BTreeSet::new(),
+        index_mapping: None,
+        nest: None,
+        scoped_context: None,
+        scoped_context_base: None,
+    }
+}
+
+fn compile_type_keyword_definition(
+    object: &Map<String, Value>,
+    default_protected: bool,
+) -> Result<JsonLdTermDefinition, RdfDiagnostic> {
+    for key in object.keys() {
+        if !matches!(key.as_str(), "@container" | "@protected") {
+            return Err(context_error(format!(
+                "JSON-LD @type definition cannot contain `{key}`"
+            )));
+        }
+    }
+    let protected = match object.get("@protected") {
+        None => default_protected,
+        Some(Value::Bool(value)) => *value,
+        Some(_) => {
+            return Err(context_error(
+                "JSON-LD @type definition @protected must be boolean",
+            ));
+        }
+    };
+    let containers = match object.get("@container") {
+        None => BTreeSet::new(),
+        Some(Value::String(value)) if value == "@set" => BTreeSet::from([JsonLdContainer::Set]),
+        Some(_) => {
+            return Err(context_error(
+                "JSON-LD @type definition @container must be @set",
+            ));
+        }
+    };
+    let mut definition = empty_definition(protected);
+    definition.iri_mapping = Some("@type".to_owned());
+    definition.containers = containers;
+    Ok(definition)
+}
+
+fn compile_reverse_containers(
+    term: &str,
+    value: &Value,
+) -> Result<BTreeSet<JsonLdContainer>, RdfDiagnostic> {
+    match value {
+        Value::Null => Ok(BTreeSet::new()),
+        Value::String(value) if value == "@set" => Ok(BTreeSet::from([JsonLdContainer::Set])),
+        Value::String(value) if value == "@index" => Ok(BTreeSet::from([JsonLdContainer::Index])),
+        _ => Err(context_error(format!(
+            "reverse term `{term}` @container must be @set, @index, or null"
+        ))),
+    }
+}
+
+fn definitions_equal_ignoring_protected(
+    left: &JsonLdTermDefinition,
+    right: &JsonLdTermDefinition,
+) -> bool {
+    let mut left = left.clone();
+    let mut right = right.clone();
+    left.protected = false;
+    right.protected = false;
+    left == right
+}
+
+fn term_has_mapping_syntax(term: &str) -> bool {
+    let colon = term
+        .find(':')
+        .is_some_and(|position| position > 0 && position + 1 < term.len());
+    colon || term.contains('/')
+}
+
+fn is_keyword_form(value: &str) -> bool {
+    value.strip_prefix('@').is_some_and(|suffix| {
+        !suffix.is_empty() && suffix.bytes().all(|byte| byte.is_ascii_alphabetic())
+    })
+}
+
+fn is_blank_node_identifier(value: &str) -> bool {
+    value
+        .strip_prefix("_:")
+        .is_some_and(|label| !label.is_empty() && !label.chars().any(char::is_whitespace))
+}
+
+fn validate_iri_or_blank_node(value: &str, description: &str) -> Result<(), RdfDiagnostic> {
+    if is_blank_node_identifier(value) {
+        Ok(())
+    } else {
+        validate_absolute_iri(value, description)
+    }
+}
+
+fn validate_term_name(term: &str) -> Result<(), RdfDiagnostic> {
+    if term.is_empty() {
+        return Err(context_error("JSON-LD term must not be empty"));
+    }
+    if is_keyword(term) && term != "@type" {
+        return Err(context_error(format!(
+            "JSON-LD keyword `{term}` cannot be redefined"
+        )));
+    }
+    if is_extension_control(term) {
+        return Err(context_error(format!("invalid JSON-LD term `{term}`")));
+    }
+    Ok(())
+}
+
+fn validate_term_mapping(term: &str, mapping: &str) -> Result<(), RdfDiagnostic> {
+    if mapping == "@context" || is_extension_control(mapping) {
+        return Err(context_error(format!(
+            "term `{term}` cannot alias reserved control `{mapping}`"
+        )));
+    }
+    if is_keyword(mapping) {
+        return Ok(());
+    }
+    validate_iri_or_blank_node(mapping, &format!("IRI mapping for term `{term}`"))
+}
+
+fn validate_property_mapping(term: &str, mapping: &str) -> Result<(), RdfDiagnostic> {
+    if is_keyword(mapping) || is_extension_control(mapping) {
+        return Err(context_error(format!(
+            "property term `{term}` cannot map to keyword `{mapping}`"
+        )));
+    }
+    validate_iri_or_blank_node(mapping, &format!("property mapping for term `{term}`"))
+}
+
+fn is_implicit_prefix(term: &str, mapping: Option<&str>) -> bool {
+    if term.contains([':', '/']) {
+        return false;
+    }
+    mapping.is_some_and(|iri| {
+        is_blank_node_identifier(iri)
+            || iri.ends_with('/')
+            || iri.ends_with('#')
+            || iri.ends_with(':')
+            || iri.ends_with('?')
+            || iri.ends_with('[')
+            || iri.ends_with(']')
+            || iri.ends_with('@')
+    })
+}
+
+fn compile_language_mapping(
+    term: &str,
+    value: &Value,
+) -> Result<JsonLdNullable<String>, RdfDiagnostic> {
+    match value {
+        Value::Null => Ok(JsonLdNullable::Null),
+        Value::String(language) => Ok(JsonLdNullable::Value(language.to_ascii_lowercase())),
+        _ => Err(context_error(format!(
+            "term `{term}` @language must be a string or null"
+        ))),
+    }
+}
+
+fn compile_direction_mapping(
+    term: &str,
+    value: &Value,
+) -> Result<JsonLdNullable<JsonLdDirection>, RdfDiagnostic> {
+    match value {
+        Value::Null => Ok(JsonLdNullable::Null),
+        Value::String(direction) => JsonLdDirection::parse(direction)
+            .map(JsonLdNullable::Value)
+            .ok_or_else(|| {
+                context_error(format!(
+                    "term `{term}` @direction must be `ltr`, `rtl`, or null"
+                ))
+            }),
+        _ => Err(context_error(format!(
+            "term `{term}` @direction must be `ltr`, `rtl`, or null"
+        ))),
+    }
+}
+
+fn compile_containers(
+    term: &str,
+    value: &Value,
+) -> Result<BTreeSet<JsonLdContainer>, RdfDiagnostic> {
+    let entries: Vec<&str> = match value {
+        Value::String(entry) => vec![entry],
+        Value::Array(entries) if !entries.is_empty() => entries
+            .iter()
+            .map(|entry| {
+                entry.as_str().ok_or_else(|| {
+                    context_error(format!(
+                        "term `{term}` @container array members must be strings"
+                    ))
+                })
+            })
+            .collect::<Result<_, _>>()?,
+        Value::Array(_) => {
+            return Err(context_error(format!(
+                "term `{term}` @container array must not be empty"
+            )));
+        }
+        _ => {
+            return Err(context_error(format!(
+                "term `{term}` @container must be a string or non-empty array"
+            )));
+        }
+    };
+    let mut containers = BTreeSet::new();
+    for entry in entries {
+        let container = JsonLdContainer::parse(entry).ok_or_else(|| {
+            context_error(format!(
+                "term `{term}` has unsupported @container value `{entry}`"
+            ))
+        })?;
+        if !containers.insert(container) {
+            return Err(context_error(format!(
+                "term `{term}` repeats @container value `{entry}`"
+            )));
+        }
+    }
+    Ok(containers)
+}
+
+fn validate_container_combination(
+    term: &str,
+    containers: &BTreeSet<JsonLdContainer>,
+    reverse: bool,
+) -> Result<(), RdfDiagnostic> {
+    use JsonLdContainer::{Graph, Id, Index, Language, List, Set, Type};
+    if reverse && containers.iter().any(|entry| !matches!(entry, Set | Index)) {
+        return Err(context_error(format!(
+            "reverse term `{term}` may only use @set or @index containers"
+        )));
+    }
+    let valid = match containers.len() {
+        0 | 1 => true,
+        2 => {
+            containers == &BTreeSet::from([Set, Index])
+                || containers == &BTreeSet::from([Set, Id])
+                || containers == &BTreeSet::from([Set, Type])
+                || containers == &BTreeSet::from([Set, Language])
+                || containers == &BTreeSet::from([Set, Graph])
+                || containers == &BTreeSet::from([Graph, Id])
+                || containers == &BTreeSet::from([Graph, Index])
+        }
+        3 => {
+            containers == &BTreeSet::from([Set, Graph, Id])
+                || containers == &BTreeSet::from([Set, Graph, Index])
+        }
+        _ => false,
+    };
+    if !valid || (containers.contains(&List) && containers.len() != 1) {
+        return Err(context_error(format!(
+            "term `{term}` has an illegal @container combination"
+        )));
+    }
+    Ok(())
+}
+
+fn is_keyword(value: &str) -> bool {
+    KEYWORDS.contains(&value)
+}
+
+fn is_extension_control(value: &str) -> bool {
+    EXTENSION_CONTROLS.contains(&value)
+}
+
+fn resolve_reference(
+    reference: &str,
+    base: Option<&str>,
+    description: &str,
+) -> Result<String, RdfDiagnostic> {
+    if let Ok(parsed) = purrdf_iri::parse(reference)
+        && parsed.has_scheme()
+    {
+        return Ok(reference.to_owned());
+    }
+    let base = base.ok_or_else(|| {
+        context_error(format!(
+            "relative {description} `{reference}` requires an absolute base IRI"
+        ))
+    })?;
+    let base = purrdf_iri::parse(base)
+        .map_err(|source| context_error(format!("invalid base IRI `{base}`: {source}")))?;
+    base.resolve(reference)
+        .map(|resolved| resolved.as_str().to_owned())
+        .map_err(|source| {
+            context_error(format!(
+                "cannot resolve {description} `{reference}` against `{base}`: {source}"
+            ))
+        })
+}
+
+fn build_inverse_context(active: &ActiveContext) -> InverseContext {
+    let mut inverse = InverseContext::new();
+    let mut terms: Vec<(&String, &JsonLdTermDefinition)> = active.terms.iter().collect();
+    terms.sort_by(|(left, _), (right, _)| {
+        left.chars()
+            .count()
+            .cmp(&right.chars().count())
+            .then_with(|| left.cmp(right))
+    });
+    for (term, definition) in terms {
+        let Some(iri) = definition.iri_mapping.as_ref() else {
+            continue;
+        };
+        let container = container_key(&definition.containers);
+        let selection = inverse
+            .entry(iri.clone())
+            .or_default()
+            .entry(container)
+            .or_default();
+        selection
+            .fallback
+            .entry("@none".to_owned())
+            .or_insert_with(|| term.clone());
+
+        if definition.reverse_property {
+            selection
+                .types
+                .entry("@reverse".to_owned())
+                .or_insert_with(|| term.clone());
+            continue;
+        }
+        if definition.type_mapping == Some(JsonLdTypeMapping::None) {
+            selection
+                .languages
+                .entry("@any".to_owned())
+                .or_insert_with(|| term.clone());
+            selection
+                .types
+                .entry("@any".to_owned())
+                .or_insert_with(|| term.clone());
+            continue;
+        }
+        if let Some(mapping) = &definition.type_mapping {
+            selection
+                .types
+                .entry(mapping.inverse_key().to_owned())
+                .or_insert_with(|| term.clone());
+            continue;
+        }
+
+        match (
+            definition.language_mapping.as_ref(),
+            definition.direction_mapping.as_ref(),
+        ) {
+            (Some(language), Some(direction)) => {
+                let key = explicit_language_direction_key(language, direction);
+                selection
+                    .languages
+                    .entry(key)
+                    .or_insert_with(|| term.clone());
+            }
+            (Some(language), None) => {
+                let key = match language {
+                    JsonLdNullable::Null => "@null".to_owned(),
+                    JsonLdNullable::Value(language) => language.to_ascii_lowercase(),
+                };
+                selection
+                    .languages
+                    .entry(key)
+                    .or_insert_with(|| term.clone());
+            }
+            (None, Some(direction)) => {
+                let key = match direction {
+                    JsonLdNullable::Null => "@none".to_owned(),
+                    JsonLdNullable::Value(direction) => format!("_{}", direction.as_str()),
+                };
+                selection
+                    .languages
+                    .entry(key)
+                    .or_insert_with(|| term.clone());
+            }
+            (None, None) => {
+                let default_language = active.default_language.as_deref().unwrap_or("@none");
+                if let Some(direction) = active.default_direction {
+                    selection
+                        .languages
+                        .entry(format!("{default_language}_{}", direction.as_str()))
+                        .or_insert_with(|| term.clone());
+                } else {
+                    selection
+                        .languages
+                        .entry(default_language.to_ascii_lowercase())
+                        .or_insert_with(|| term.clone());
+                }
+                selection
+                    .languages
+                    .entry("@none".to_owned())
+                    .or_insert_with(|| term.clone());
+                selection
+                    .types
+                    .entry("@none".to_owned())
+                    .or_insert_with(|| term.clone());
+            }
+        }
+    }
+    inverse
+}
+
+fn container_key(containers: &BTreeSet<JsonLdContainer>) -> String {
+    if containers.is_empty() {
+        return "@none".to_owned();
+    }
+    let mut values: Vec<&str> = containers.iter().map(|entry| entry.as_str()).collect();
+    values.sort_unstable();
+    values.concat()
+}
+
+fn explicit_language_direction_key(
+    language: &JsonLdNullable<String>,
+    direction: &JsonLdNullable<JsonLdDirection>,
+) -> String {
+    match (language, direction) {
+        (JsonLdNullable::Value(language), JsonLdNullable::Value(direction)) => {
+            format!("{}_{}", language.to_ascii_lowercase(), direction.as_str())
+        }
+        (JsonLdNullable::Value(language), JsonLdNullable::Null) => language.to_ascii_lowercase(),
+        (JsonLdNullable::Null, JsonLdNullable::Value(direction)) => {
+            format!("_{}", direction.as_str())
+        }
+        (JsonLdNullable::Null, JsonLdNullable::Null) => "@null".to_owned(),
+    }
+}
+
+pub(super) fn expand_iri(
+    active: &ActiveContext,
+    value: &str,
+    vocab: bool,
+    document_relative: bool,
+) -> Result<Option<String>, RdfDiagnostic> {
+    if is_keyword(value) || is_extension_control(value) {
+        return Ok(Some(value.to_owned()));
+    }
+    if is_keyword_form(value) {
+        return Ok(None);
+    }
+    if let Some(definition) = active.terms.get(value)
+        && definition.iri_mapping.as_deref().is_some_and(is_keyword)
+    {
+        return Ok(definition.iri_mapping.clone());
+    }
+    if vocab && let Some(definition) = active.terms.get(value) {
+        return Ok(definition.iri_mapping.clone());
+    }
+    if let Some((prefix, suffix)) = value.split_once(':')
+        && !prefix.is_empty()
+    {
+        if prefix == "_" || suffix.starts_with("//") {
+            return Ok(Some(value.to_owned()));
+        }
+        if let Some(mapping) = active
+            .terms
+            .get(prefix)
+            .filter(|definition| definition.prefix)
+            .and_then(|definition| definition.iri_mapping.as_deref())
+        {
+            let expanded = format!("{mapping}{suffix}");
+            validate_iri_or_blank_node(&expanded, "expanded compact IRI")?;
+            return Ok(Some(expanded));
+        }
+        if let Ok(parsed) = purrdf_iri::parse(value)
+            && parsed.has_scheme()
+        {
+            return Ok(Some(value.to_owned()));
+        }
+        return Err(context_error(format!(
+            "compact IRI `{value}` uses an undefined prefix `{prefix}`"
+        )));
+    }
+    if vocab && let Some(mapping) = &active.vocab_mapping {
+        return Ok(Some(format!("{mapping}{value}")));
+    }
+    if document_relative {
+        return resolve_reference(value, active.base_iri.as_deref(), "IRI").map(Some);
+    }
+    Err(context_error(format!(
+        "relative IRI `{value}` has no applicable @vocab or @base"
+    )))
+}
+
+pub(super) fn compact_iri(
+    active: &ActiveContext,
+    inverse: &InverseContext,
+    iri: &str,
+    vocab: bool,
+    selection: Option<&JsonLdTermSelection>,
+) -> Result<String, RdfDiagnostic> {
+    if is_extension_control(iri) {
+        return Ok(iri.to_owned());
+    }
+    if is_blank_node_identifier(iri) {
+        return Ok(iri.to_owned());
+    }
+    if !is_keyword(iri) {
+        validate_absolute_iri(iri, "IRI to compact")?;
+    }
+    if vocab {
+        if let Some(term) = select_inverse_term(inverse, iri, selection) {
+            return Ok(term.to_owned());
+        }
+        if let Some(vocab_mapping) = &active.vocab_mapping
+            && let Some(suffix) = iri.strip_prefix(vocab_mapping)
+            && !suffix.is_empty()
+            && !suffix.contains(':')
+            && !active.terms.contains_key(suffix)
+        {
+            return Ok(suffix.to_owned());
+        }
+    }
+    if let Some(candidate) = compact_with_prefix(active, iri, selection.is_none()) {
+        return Ok(candidate);
+    }
+    reject_iri_confused_with_prefix(active, iri)?;
+    if vocab {
+        return Ok(iri.to_owned());
+    }
+    Ok(active
+        .base_iri
+        .as_deref()
+        .and_then(|base| remove_base(base, iri))
+        .unwrap_or_else(|| iri.to_owned()))
+}
+
+fn select_inverse_term<'a>(
+    inverse: &'a InverseContext,
+    iri: &str,
+    selection: Option<&JsonLdTermSelection>,
+) -> Option<&'a str> {
+    let containers = selection.map_or_else(
+        || vec!["@none".to_owned()],
+        |selection| selection.containers.clone(),
+    );
+    let kind = selection.map_or(JsonLdTermSelectionKind::Any, |selection| selection.kind);
+    let preferred = selection.map_or_else(
+        || vec!["@none".to_owned()],
+        |selection| selection.preferred_values.clone(),
+    );
+    let by_container = inverse.get(iri)?;
+    for container in containers {
+        let Some(candidate) = by_container.get(&container) else {
+            continue;
+        };
+        let table = match kind {
+            JsonLdTermSelectionKind::Type => &candidate.types,
+            JsonLdTermSelectionKind::Language => &candidate.languages,
+            JsonLdTermSelectionKind::Any => &candidate.fallback,
+        };
+        for value in &preferred {
+            if let Some(term) = table.get(value) {
+                return Some(term);
+            }
+        }
+    }
+    None
+}
+
+fn compact_with_prefix(active: &ActiveContext, iri: &str, value_is_null: bool) -> Option<String> {
+    let mut candidates = Vec::new();
+    for (term, definition) in &active.terms {
+        if !definition.prefix {
+            continue;
+        }
+        let Some(mapping) = definition.iri_mapping.as_deref() else {
+            continue;
+        };
+        let Some(suffix) = iri.strip_prefix(mapping) else {
+            continue;
+        };
+        if suffix.is_empty() || suffix.starts_with("//") || suffix.chars().any(char::is_whitespace)
+        {
+            continue;
+        }
+        let candidate = format!("{term}:{suffix}");
+        if let Some(definition) = active.terms.get(&candidate)
+            && (!value_is_null || definition.iri_mapping.as_deref() != Some(iri))
+        {
+            continue;
+        }
+        candidates.push(candidate);
+    }
+    candidates.sort_by(|left, right| {
+        left.chars()
+            .count()
+            .cmp(&right.chars().count())
+            .then_with(|| left.cmp(right))
+    });
+    candidates.into_iter().next()
+}
+
+fn reject_iri_confused_with_prefix(active: &ActiveContext, iri: &str) -> Result<(), RdfDiagnostic> {
+    let parsed = purrdf_iri::parse(iri).map_err(|source| {
+        context_error(format!("parse IRI `{iri}` during compaction: {source}"))
+    })?;
+    let Some(scheme) = parsed.scheme() else {
+        return Ok(());
+    };
+    if parsed.authority().is_none()
+        && active
+            .terms
+            .get(scheme)
+            .is_some_and(|definition| definition.prefix)
+    {
+        return Err(context_error(format!(
+            "IRI `{iri}` is confused with active JSON-LD prefix `{scheme}`"
+        )));
+    }
+    Ok(())
+}
+
+fn remove_base(base: &str, iri: &str) -> Option<String> {
+    let base_iri = purrdf_iri::parse(base).ok()?;
+    let target = purrdf_iri::parse(iri).ok()?;
+    if base_iri.scheme() != target.scheme() || base_iri.authority() != target.authority() {
+        return None;
+    }
+
+    let mut candidates = Vec::new();
+    if base == iri {
+        candidates.push(String::new());
+    }
+    if base_iri.path() == target.path()
+        && base_iri.query() == target.query()
+        && let Some(fragment) = target.fragment()
+    {
+        candidates.push(format!("#{fragment}"));
+    }
+    if base_iri.path() == target.path()
+        && let Some(query) = target.query()
+    {
+        let mut candidate = format!("?{query}");
+        if let Some(fragment) = target.fragment() {
+            candidate.push('#');
+            candidate.push_str(fragment);
+        }
+        candidates.push(candidate);
+    }
+
+    let mut absolute_path = target.path().to_owned();
+    if let Some(query) = target.query() {
+        absolute_path.push('?');
+        absolute_path.push_str(query);
+    }
+    if let Some(fragment) = target.fragment() {
+        absolute_path.push('#');
+        absolute_path.push_str(fragment);
+    }
+    candidates.push(absolute_path);
+
+    let base_directory = base_iri
+        .path()
+        .rsplit_once('/')
+        .map_or("", |(directory, _)| directory);
+    let base_segments: Vec<&str> = base_directory
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    let target_segments: Vec<&str> = target
+        .path()
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    let shared = base_segments
+        .iter()
+        .zip(&target_segments)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let mut relative = "../".repeat(base_segments.len().saturating_sub(shared));
+    relative.push_str(&target_segments[shared..].join("/"));
+    if relative.is_empty() {
+        relative.push_str("./");
+    }
+    if let Some(query) = target.query() {
+        relative.push('?');
+        relative.push_str(query);
+    }
+    if let Some(fragment) = target.fragment() {
+        relative.push('#');
+        relative.push_str(fragment);
+    }
+    candidates.push(relative);
+
+    candidates.retain(|candidate| {
+        base_iri
+            .resolve(candidate)
+            .is_ok_and(|resolved| resolved.as_str() == iri)
+    });
+    candidates.sort_by(|left, right| {
+        left.len()
+            .cmp(&right.len())
+            .then_with(|| lexical_relative_preference(left, right))
+    });
+    candidates.into_iter().next()
+}
+
+fn lexical_relative_preference(left: &str, right: &str) -> Ordering {
+    left.cmp(right)
+}

--- a/crates/rdf/src/native_codecs/jsonld/context/compiler.rs
+++ b/crates/rdf/src/native_codecs/jsonld/context/compiler.rs
@@ -169,7 +169,7 @@ pub(super) fn apply_context(
     let mut compiler = Compiler {
         registry: &parent.registry,
         limits,
-        initial_base: parent.active.base_iri.clone(),
+        initial_base: parent.active.original_base_iri.clone(),
         budget: Budget::default(),
         remote_stack: Vec::new(),
         remote_cache: BTreeMap::new(),
@@ -1787,10 +1787,16 @@ fn select_inverse_term<'a>(
         let Some(candidate) = by_container.get(&container) else {
             continue;
         };
+        if kind == JsonLdTermSelectionKind::Any {
+            if let Some(term) = candidate.fallback.get("@none") {
+                return Some(term);
+            }
+            continue;
+        }
         let table = match kind {
             JsonLdTermSelectionKind::Type => &candidate.types,
             JsonLdTermSelectionKind::Language => &candidate.languages,
-            JsonLdTermSelectionKind::Any => &candidate.fallback,
+            JsonLdTermSelectionKind::Any => unreachable!("handled above"),
         };
         for value in &preferred {
             if let Some(term) = table.get(value) {

--- a/crates/rdf/src/native_codecs/jsonld/context/compiler.rs
+++ b/crates/rdf/src/native_codecs/jsonld/context/compiler.rs
@@ -641,7 +641,10 @@ impl Compiler<'_> {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "the JSON-LD term-definition algorithm keeps its recursive state explicit"
+    )]
     fn define_term(
         &mut self,
         active: &mut ActiveContext,
@@ -726,7 +729,10 @@ impl Compiler<'_> {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "the JSON-LD term-definition algorithm keeps its inputs explicit"
+    )]
     fn compile_term_definition(
         &mut self,
         active: &mut ActiveContext,
@@ -1027,7 +1033,10 @@ impl Compiler<'_> {
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "derived term mapping shares the compiler's bounded recursive state"
+    )]
     fn derive_term_mapping(
         &mut self,
         active: &mut ActiveContext,
@@ -1092,7 +1101,10 @@ impl Compiler<'_> {
         )))
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "IRI expansion keeps every JSON-LD algorithm flag and recursion input explicit"
+    )]
     fn expand_local_iri(
         &mut self,
         active: &mut ActiveContext,
@@ -1191,7 +1203,10 @@ impl Compiler<'_> {
         )))
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "type mapping compilation shares the compiler's bounded recursive state"
+    )]
     fn compile_type_mapping(
         &mut self,
         active: &mut ActiveContext,

--- a/crates/rdf/src/native_codecs/jsonld/context/compiler.rs
+++ b/crates/rdf/src/native_codecs/jsonld/context/compiler.rs
@@ -143,6 +143,75 @@ pub(super) fn compile(
     })
 }
 
+pub(super) fn compile_scoped(
+    parent: &CompiledJsonLdContext,
+    definition: &JsonLdTermDefinition,
+) -> Result<Option<CompiledJsonLdContext>, RdfDiagnostic> {
+    let Some(context) = definition.scoped_context.as_ref() else {
+        return Ok(None);
+    };
+    apply_context(
+        parent,
+        context,
+        definition.scoped_context_base.as_deref(),
+        true,
+    )
+    .map(Some)
+}
+
+pub(super) fn apply_context(
+    parent: &CompiledJsonLdContext,
+    context: &Value,
+    base_url: Option<&str>,
+    override_protected: bool,
+) -> Result<CompiledJsonLdContext, RdfDiagnostic> {
+    let limits = JsonLdContextLimits::default();
+    let mut compiler = Compiler {
+        registry: &parent.registry,
+        limits,
+        initial_base: parent.active.base_iri.clone(),
+        budget: Budget::default(),
+        remote_stack: Vec::new(),
+        remote_cache: BTreeMap::new(),
+        override_protected,
+    };
+    compiler.charge_value(context, 0)?;
+    let mut active = parent.active.clone();
+    compiler.process_context(
+        &mut active,
+        context,
+        base_url.or(parent.active.base_iri.as_deref()),
+        false,
+        0,
+    )?;
+    let inverse = build_inverse_context(&active);
+    Ok(CompiledJsonLdContext {
+        canonical_context: canonicalize(context),
+        active,
+        inverse,
+        registry: parent.registry.clone(),
+    })
+}
+
+pub(super) fn child_context(parent: &CompiledJsonLdContext) -> CompiledJsonLdContext {
+    let active = if parent.active.propagate {
+        parent.active.clone()
+    } else {
+        parent
+            .active
+            .previous_context
+            .as_deref()
+            .cloned()
+            .unwrap_or_else(|| parent.active.clone())
+    };
+    CompiledJsonLdContext {
+        canonical_context: parent.canonical_context.clone(),
+        inverse: build_inverse_context(&active),
+        active,
+        registry: parent.registry.clone(),
+    }
+}
+
 fn extract_context(value: &Value) -> Result<&Value, RdfDiagnostic> {
     match value {
         Value::Object(object) if object.contains_key("@context") => object

--- a/crates/rdf/src/native_codecs/jsonld/context/mod.rs
+++ b/crates/rdf/src/native_codecs/jsonld/context/mod.rs
@@ -70,6 +70,16 @@ impl JsonLdContextLimits {
         self.registry_bytes
     }
 
+    /// Maximum UTF-8 bytes accepted by the shared serialization-options document.
+    ///
+    /// The envelope may contain one local context, the full aggregate offline
+    /// registry, and bounded registry keys/JSON structure.
+    pub const fn max_options_bytes(self) -> usize {
+        self.context_bytes
+            .saturating_add(self.registry_bytes)
+            .saturating_add(self.context_bytes)
+    }
+
     /// Maximum compiled term definitions across one compilation.
     pub const fn max_terms(self) -> usize {
         self.terms
@@ -93,6 +103,14 @@ impl JsonLdContextLimits {
     fn strict_json(self) -> StrictJsonLimits {
         StrictJsonLimits {
             bytes: self.context_bytes,
+            depth: self.nesting,
+            values: self.expansion_work,
+        }
+    }
+
+    fn strict_options_json(self) -> StrictJsonLimits {
+        StrictJsonLimits {
+            bytes: self.max_options_bytes(),
             depth: self.nesting,
             values: self.expansion_work,
         }
@@ -324,6 +342,7 @@ impl JsonLdTermDefinition {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ActiveContext {
+    original_base_iri: Option<String>,
     base_iri: Option<String>,
     vocab_mapping: Option<String>,
     default_language: Option<String>,
@@ -336,6 +355,7 @@ struct ActiveContext {
 impl ActiveContext {
     fn new(base_iri: Option<String>) -> Self {
         Self {
+            original_base_iri: base_iri.clone(),
             base_iri,
             vocab_mapping: None,
             default_language: None,
@@ -391,7 +411,7 @@ impl JsonLdContextRegistry {
         let mut total_bytes = 0usize;
         for (iri, bytes) in documents {
             if retained.len() == limits.max_registry_documents() {
-                return Err(context_error(format!(
+                return Err(context_limit(format!(
                     "offline context registry exceeds {} documents",
                     limits.max_registry_documents()
                 )));
@@ -400,7 +420,7 @@ impl JsonLdContextRegistry {
             validate_absolute_iri(&iri, "offline context document IRI")?;
             let bytes = bytes.into();
             if bytes.len() > limits.max_context_bytes() {
-                return Err(context_error(format!(
+                return Err(context_limit(format!(
                     "offline context document `{iri}` is {} bytes; limit is {}",
                     bytes.len(),
                     limits.max_context_bytes()

--- a/crates/rdf/src/native_codecs/jsonld/context/mod.rs
+++ b/crates/rdf/src/native_codecs/jsonld/context/mod.rs
@@ -1,0 +1,733 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Deterministic JSON-LD 1.1 context compilation and offline resolution.
+//!
+//! The types in this module form the semantic seam shared by JSON-LD and YAML-LD.
+//! Context documents are caller-owned, decoded without duplicate members, resolved only
+//! through an immutable local registry, and compiled into one active/inverse context.
+//! No code in this module performs network I/O or supplies a vocabulary default.
+
+mod compiler;
+mod options;
+mod strict;
+#[cfg(test)]
+mod tests;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use crate::RdfDiagnostic;
+
+pub use options::{JsonLdSerializeMode, JsonLdSerializeOptions};
+
+use self::strict::{StrictJsonLimits, parse_strict_json};
+
+/// Version of the closed JSON-LD serialization-options document.
+pub const JSON_LD_SERIALIZE_OPTIONS_VERSION: u32 = 1;
+
+const DEFAULT_MAX_CONTEXT_BYTES: usize = 1_048_576;
+const DEFAULT_MAX_REGISTRY_DOCUMENTS: usize = 128;
+const DEFAULT_MAX_REGISTRY_BYTES: usize = 8_388_608;
+const DEFAULT_MAX_TERMS: usize = 4_096;
+const DEFAULT_MAX_NESTING: usize = 64;
+const DEFAULT_MAX_EXPANSION_WORK: usize = 262_144;
+const DEFAULT_MAX_DEFINITION_COMPLEXITY: usize = 131_072;
+
+/// Fixed resource ceilings for context decoding and compilation.
+///
+/// Public compilation always uses [`Default`]. The fields are intentionally private:
+/// every PurRDF consumer receives the same denial-of-service and portability envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JsonLdContextLimits {
+    context_bytes: usize,
+    registry_documents: usize,
+    registry_bytes: usize,
+    terms: usize,
+    nesting: usize,
+    expansion_work: usize,
+    definition_complexity: usize,
+}
+
+impl JsonLdContextLimits {
+    /// Maximum UTF-8 bytes in one supplied context or registry document.
+    pub const fn max_context_bytes(self) -> usize {
+        self.context_bytes
+    }
+
+    /// Maximum number of documents in an offline registry.
+    pub const fn max_registry_documents(self) -> usize {
+        self.registry_documents
+    }
+
+    /// Maximum aggregate bytes retained by an offline registry.
+    pub const fn max_registry_bytes(self) -> usize {
+        self.registry_bytes
+    }
+
+    /// Maximum compiled term definitions across one compilation.
+    pub const fn max_terms(self) -> usize {
+        self.terms
+    }
+
+    /// Maximum JSON/context recursion depth.
+    pub const fn max_nesting(self) -> usize {
+        self.nesting
+    }
+
+    /// Maximum bounded context-processing operations.
+    pub const fn max_expansion_work(self) -> usize {
+        self.expansion_work
+    }
+
+    /// Maximum aggregate definition keys and scalar bytes processed.
+    pub const fn max_definition_complexity(self) -> usize {
+        self.definition_complexity
+    }
+
+    fn strict_json(self) -> StrictJsonLimits {
+        StrictJsonLimits {
+            bytes: self.context_bytes,
+            depth: self.nesting,
+            values: self.expansion_work,
+        }
+    }
+}
+
+impl Default for JsonLdContextLimits {
+    fn default() -> Self {
+        Self {
+            context_bytes: DEFAULT_MAX_CONTEXT_BYTES,
+            registry_documents: DEFAULT_MAX_REGISTRY_DOCUMENTS,
+            registry_bytes: DEFAULT_MAX_REGISTRY_BYTES,
+            terms: DEFAULT_MAX_TERMS,
+            nesting: DEFAULT_MAX_NESTING,
+            expansion_work: DEFAULT_MAX_EXPANSION_WORK,
+            definition_complexity: DEFAULT_MAX_DEFINITION_COMPLEXITY,
+        }
+    }
+}
+
+/// Base direction carried by a JSON-LD 1.1 context or term definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum JsonLdDirection {
+    /// Left-to-right text.
+    LeftToRight,
+    /// Right-to-left text.
+    RightToLeft,
+}
+
+impl JsonLdDirection {
+    /// JSON-LD spelling of this direction.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LeftToRight => "ltr",
+            Self::RightToLeft => "rtl",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "ltr" => Some(Self::LeftToRight),
+            "rtl" => Some(Self::RightToLeft),
+            _ => None,
+        }
+    }
+}
+
+/// Explicit nullable mapping in a JSON-LD term definition.
+///
+/// The surrounding `Option` used by term getters distinguishes an absent mapping from
+/// either of these explicit states.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum JsonLdNullable<T> {
+    /// The context explicitly resets the inherited value with JSON `null`.
+    Null,
+    /// The context supplies a concrete value.
+    Value(T),
+}
+
+impl<T> JsonLdNullable<T> {
+    /// Borrow the concrete value while preserving the explicit-null state.
+    pub const fn as_ref(&self) -> JsonLdNullable<&T> {
+        match self {
+            Self::Null => JsonLdNullable::Null,
+            Self::Value(value) => JsonLdNullable::Value(value),
+        }
+    }
+}
+
+/// One JSON-LD 1.1 container mapping component.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum JsonLdContainer {
+    /// Preserve a set even when it contains one value.
+    Set,
+    /// Compact an RDF collection through a list object.
+    List,
+    /// Index values by language.
+    Language,
+    /// Index values by `@index` or a mapped index property.
+    Index,
+    /// Index node objects by `@id`.
+    Id,
+    /// Index node objects by `@type`.
+    Type,
+    /// Compact named graph objects.
+    Graph,
+}
+
+impl JsonLdContainer {
+    /// JSON-LD keyword spelling of this container component.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Set => "@set",
+            Self::List => "@list",
+            Self::Language => "@language",
+            Self::Index => "@index",
+            Self::Id => "@id",
+            Self::Type => "@type",
+            Self::Graph => "@graph",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "@set" => Some(Self::Set),
+            "@list" => Some(Self::List),
+            "@language" => Some(Self::Language),
+            "@index" => Some(Self::Index),
+            "@id" => Some(Self::Id),
+            "@type" => Some(Self::Type),
+            "@graph" => Some(Self::Graph),
+            _ => None,
+        }
+    }
+}
+
+/// Type coercion attached to a compiled JSON-LD term.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum JsonLdTypeMapping {
+    /// Coerce strings to node identifiers resolved document-relatively.
+    Id,
+    /// Coerce strings to node identifiers resolved against `@vocab`.
+    Vocab,
+    /// Carry an `rdf:JSON` literal as native JSON.
+    Json,
+    /// Explicitly select no type mapping.
+    None,
+    /// Coerce values to the supplied absolute datatype IRI.
+    Datatype(String),
+}
+
+impl JsonLdTypeMapping {
+    fn inverse_key(&self) -> &str {
+        match self {
+            Self::Id => "@id",
+            Self::Vocab => "@vocab",
+            Self::Json => "@json",
+            Self::None => "@none",
+            Self::Datatype(iri) => iri,
+        }
+    }
+}
+
+/// Compiled definition for one term or keyword alias.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsonLdTermDefinition {
+    iri_mapping: Option<String>,
+    reverse_property: bool,
+    prefix: bool,
+    protected: bool,
+    type_mapping: Option<JsonLdTypeMapping>,
+    language_mapping: Option<JsonLdNullable<String>>,
+    direction_mapping: Option<JsonLdNullable<JsonLdDirection>>,
+    containers: BTreeSet<JsonLdContainer>,
+    index_mapping: Option<String>,
+    nest: Option<String>,
+    scoped_context: Option<Value>,
+    scoped_context_base: Option<String>,
+}
+
+impl JsonLdTermDefinition {
+    /// Expanded IRI or keyword selected by this term; `None` is a null mapping.
+    pub fn iri_mapping(&self) -> Option<&str> {
+        self.iri_mapping.as_deref()
+    }
+
+    /// Whether the term is a reverse property.
+    pub const fn is_reverse_property(&self) -> bool {
+        self.reverse_property
+    }
+
+    /// Whether the term may be used as a compact-IRI prefix.
+    pub const fn is_prefix(&self) -> bool {
+        self.prefix
+    }
+
+    /// Whether later contexts are forbidden from changing this definition.
+    pub const fn is_protected(&self) -> bool {
+        self.protected
+    }
+
+    /// Optional type coercion.
+    pub const fn type_mapping(&self) -> Option<&JsonLdTypeMapping> {
+        self.type_mapping.as_ref()
+    }
+
+    /// Explicit language mapping; outer `None` means the member was absent.
+    pub fn language_mapping(&self) -> Option<JsonLdNullable<&str>> {
+        self.language_mapping.as_ref().map(|value| match value {
+            JsonLdNullable::Null => JsonLdNullable::Null,
+            JsonLdNullable::Value(language) => JsonLdNullable::Value(language.as_str()),
+        })
+    }
+
+    /// Explicit direction mapping; outer `None` means the member was absent.
+    pub const fn direction_mapping(&self) -> Option<JsonLdNullable<JsonLdDirection>> {
+        match &self.direction_mapping {
+            None => None,
+            Some(JsonLdNullable::Null) => Some(JsonLdNullable::Null),
+            Some(JsonLdNullable::Value(direction)) => Some(JsonLdNullable::Value(*direction)),
+        }
+    }
+
+    /// Deterministically ordered container mapping.
+    pub const fn containers(&self) -> &BTreeSet<JsonLdContainer> {
+        &self.containers
+    }
+
+    /// Expanded custom index-property mapping, when configured.
+    pub fn index_mapping(&self) -> Option<&str> {
+        self.index_mapping.as_deref()
+    }
+
+    /// `@nest` keyword or alias used by the term.
+    pub fn nest(&self) -> Option<&str> {
+        self.nest.as_deref()
+    }
+
+    /// Canonical term-scoped local context, when present.
+    pub const fn scoped_context(&self) -> Option<&Value> {
+        self.scoped_context.as_ref()
+    }
+
+    /// Base URL retained for normative processing of the term-scoped context.
+    pub fn scoped_context_base_iri(&self) -> Option<&str> {
+        self.scoped_context_base.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ActiveContext {
+    base_iri: Option<String>,
+    vocab_mapping: Option<String>,
+    default_language: Option<String>,
+    default_direction: Option<JsonLdDirection>,
+    propagate: bool,
+    previous_context: Option<Arc<Self>>,
+    terms: BTreeMap<String, JsonLdTermDefinition>,
+}
+
+impl ActiveContext {
+    fn new(base_iri: Option<String>) -> Self {
+        Self {
+            base_iri,
+            vocab_mapping: None,
+            default_language: None,
+            default_direction: None,
+            propagate: true,
+            previous_context: None,
+            terms: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct InverseSelection {
+    types: BTreeMap<String, String>,
+    languages: BTreeMap<String, String>,
+    fallback: BTreeMap<String, String>,
+}
+
+type InverseContext = BTreeMap<String, BTreeMap<String, InverseSelection>>;
+
+/// Immutable collection of caller-supplied context documents keyed by absolute IRI.
+///
+/// Construction validates identifiers and fixed resource ceilings. Compilation can
+/// resolve context IRIs and `@import` only through this collection; no network loader
+/// exists.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct JsonLdContextRegistry {
+    documents: Arc<BTreeMap<String, Arc<[u8]>>>,
+    total_bytes: usize,
+}
+
+impl JsonLdContextRegistry {
+    /// Construct a duplicate-free immutable registry from JSON document bytes.
+    pub fn new<I, K, B>(documents: I) -> Result<Self, RdfDiagnostic>
+    where
+        I: IntoIterator<Item = (K, B)>,
+        K: Into<String>,
+        B: Into<Vec<u8>>,
+    {
+        Self::new_with_limits(documents, JsonLdContextLimits::default())
+    }
+
+    fn new_with_limits<I, K, B>(
+        documents: I,
+        limits: JsonLdContextLimits,
+    ) -> Result<Self, RdfDiagnostic>
+    where
+        I: IntoIterator<Item = (K, B)>,
+        K: Into<String>,
+        B: Into<Vec<u8>>,
+    {
+        let mut retained = BTreeMap::new();
+        let mut total_bytes = 0usize;
+        for (iri, bytes) in documents {
+            if retained.len() == limits.max_registry_documents() {
+                return Err(context_error(format!(
+                    "offline context registry exceeds {} documents",
+                    limits.max_registry_documents()
+                )));
+            }
+            let iri = iri.into();
+            validate_absolute_iri(&iri, "offline context document IRI")?;
+            let bytes = bytes.into();
+            if bytes.len() > limits.max_context_bytes() {
+                return Err(context_error(format!(
+                    "offline context document `{iri}` is {} bytes; limit is {}",
+                    bytes.len(),
+                    limits.max_context_bytes()
+                )));
+            }
+            total_bytes = total_bytes
+                .checked_add(bytes.len())
+                .ok_or_else(|| context_limit("offline context registry byte count overflow"))?;
+            if total_bytes > limits.max_registry_bytes() {
+                return Err(context_limit(format!(
+                    "offline context registry exceeds {} aggregate bytes",
+                    limits.max_registry_bytes()
+                )));
+            }
+            if retained.insert(iri.clone(), Arc::from(bytes)).is_some() {
+                return Err(context_error(format!(
+                    "duplicate offline context document IRI `{iri}`"
+                )));
+            }
+        }
+        Ok(Self {
+            documents: Arc::new(retained),
+            total_bytes,
+        })
+    }
+
+    /// Number of registered context documents.
+    pub fn len(&self) -> usize {
+        self.documents.len()
+    }
+
+    /// Whether no context documents are registered.
+    pub fn is_empty(&self) -> bool {
+        self.documents.is_empty()
+    }
+
+    /// Aggregate number of retained JSON bytes.
+    pub const fn total_bytes(&self) -> usize {
+        self.total_bytes
+    }
+
+    fn get(&self, iri: &str) -> Option<&[u8]> {
+        self.documents.get(iri).map(AsRef::as_ref)
+    }
+}
+
+/// Immutable compiled JSON-LD 1.1 active and inverse context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompiledJsonLdContext {
+    canonical_context: Value,
+    active: ActiveContext,
+    inverse: InverseContext,
+    registry: JsonLdContextRegistry,
+}
+
+impl CompiledJsonLdContext {
+    /// Compile a caller-owned context JSON value without a registry.
+    pub fn compile(context: &Value, document_iri: Option<&str>) -> Result<Self, RdfDiagnostic> {
+        Self::compile_with_registry(context, document_iri, &JsonLdContextRegistry::default())
+    }
+
+    /// Strictly decode and compile caller-owned JSON bytes without a registry.
+    pub fn compile_json(bytes: &[u8], document_iri: Option<&str>) -> Result<Self, RdfDiagnostic> {
+        Self::compile_json_with_registry(bytes, document_iri, &JsonLdContextRegistry::default())
+    }
+
+    /// Compile a context value with immutable offline context-IRI and `@import` lookup.
+    pub fn compile_with_registry(
+        context: &Value,
+        document_iri: Option<&str>,
+        registry: &JsonLdContextRegistry,
+    ) -> Result<Self, RdfDiagnostic> {
+        compiler::compile(
+            context,
+            document_iri,
+            registry,
+            JsonLdContextLimits::default(),
+        )
+    }
+
+    /// Strictly decode and compile context JSON with immutable offline lookup.
+    pub fn compile_json_with_registry(
+        bytes: &[u8],
+        document_iri: Option<&str>,
+        registry: &JsonLdContextRegistry,
+    ) -> Result<Self, RdfDiagnostic> {
+        let limits = JsonLdContextLimits::default();
+        let context = parse_strict_json(bytes, limits.strict_json(), "JSON-LD context")?;
+        compiler::compile(&context, document_iri, registry, limits)
+    }
+
+    /// Compile a context IRI resolved solely through an immutable offline registry.
+    pub fn compile_registry_context(
+        context_iri: &str,
+        registry: &JsonLdContextRegistry,
+    ) -> Result<Self, RdfDiagnostic> {
+        Self::compile_with_registry(&Value::String(context_iri.to_owned()), None, registry)
+    }
+
+    /// Compile deterministic `@prefix: true` definitions from a caller prefix map.
+    pub fn from_prefixes<I, K, V>(prefixes: I) -> Result<Self, RdfDiagnostic>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        let mut context = BTreeMap::new();
+        let limits = JsonLdContextLimits::default();
+        for (prefix, namespace) in prefixes {
+            if context.len() == limits.max_terms() {
+                return Err(context_limit(format!(
+                    "JSON-LD prefix map exceeds {} entries",
+                    limits.max_terms()
+                )));
+            }
+            let prefix = prefix.into();
+            let namespace = namespace.into();
+            if context.contains_key(&prefix) {
+                return Err(context_error(format!(
+                    "duplicate JSON-LD prefix `{prefix}`"
+                )));
+            }
+            let definition = Value::Object(
+                BTreeMap::from([
+                    ("@id".to_owned(), Value::String(namespace)),
+                    ("@prefix".to_owned(), Value::Bool(true)),
+                ])
+                .into_iter()
+                .collect(),
+            );
+            context.insert(prefix, definition);
+        }
+        Self::compile(&Value::Object(context.into_iter().collect()), None)
+    }
+
+    /// Canonical caller context retained for deterministic emission.
+    pub const fn canonical_context(&self) -> &Value {
+        &self.canonical_context
+    }
+
+    /// Immutable offline registry retained for term-scoped context reuse.
+    pub const fn registry(&self) -> &JsonLdContextRegistry {
+        &self.registry
+    }
+
+    /// Canonical compact JSON bytes for the retained context.
+    pub fn canonical_json(&self) -> String {
+        serde_json::to_string(&self.canonical_context)
+            .expect("serde_json::Value serialization is infallible")
+    }
+
+    /// Active base IRI, when configured.
+    pub fn base_iri(&self) -> Option<&str> {
+        self.active.base_iri.as_deref()
+    }
+
+    /// Active vocabulary mapping, when configured.
+    pub fn vocab_mapping(&self) -> Option<&str> {
+        self.active.vocab_mapping.as_deref()
+    }
+
+    /// Active default language, normalized to lowercase.
+    pub fn default_language(&self) -> Option<&str> {
+        self.active.default_language.as_deref()
+    }
+
+    /// Active default base direction.
+    pub const fn default_direction(&self) -> Option<JsonLdDirection> {
+        self.active.default_direction
+    }
+
+    /// Whether this context propagates to nested node objects.
+    pub const fn propagates(&self) -> bool {
+        self.active.propagate
+    }
+
+    /// Whether `@propagate: false` retained a previous active context.
+    pub const fn has_previous_context(&self) -> bool {
+        self.active.previous_context.is_some()
+    }
+
+    /// Deterministically ordered compiled term definitions.
+    pub const fn terms(&self) -> &BTreeMap<String, JsonLdTermDefinition> {
+        &self.active.terms
+    }
+
+    /// Definition for a term or keyword alias.
+    pub fn term(&self, term: &str) -> Option<&JsonLdTermDefinition> {
+        self.active.terms.get(term)
+    }
+
+    /// Expand an IRI, compact IRI, term, or keyword under this active context.
+    ///
+    /// `vocab` selects vocabulary-relative term expansion; `document_relative`
+    /// selects resolution against the active `@base`. A null term mapping returns
+    /// `Ok(None)`.
+    pub fn expand_iri(
+        &self,
+        value: &str,
+        vocab: bool,
+        document_relative: bool,
+    ) -> Result<Option<String>, RdfDiagnostic> {
+        compiler::expand_iri(&self.active, value, vocab, document_relative)
+    }
+
+    /// Compact one absolute IRI without an associated value.
+    ///
+    /// This follows JSON-LD's `value = null` compaction branches. Vocabulary
+    /// positions consult the inverse context and prefix definitions; document
+    /// positions compact against `@base` where the round-trip is exact.
+    pub fn compact_iri(&self, iri: &str, vocab: bool) -> Result<String, RdfDiagnostic> {
+        compiler::compact_iri(&self.active, &self.inverse, iri, vocab, None)
+    }
+
+    /// Compact an absolute vocabulary IRI using explicit inverse-context value-shape
+    /// preferences.
+    ///
+    /// A present selection represents an associated non-null value. `None` has the
+    /// same `value = null` semantics as [`Self::compact_iri`].
+    pub fn compact_iri_with_selection(
+        &self,
+        iri: &str,
+        vocab: bool,
+        selection: Option<&JsonLdTermSelection>,
+    ) -> Result<String, RdfDiagnostic> {
+        compiler::compact_iri(&self.active, &self.inverse, iri, vocab, selection)
+    }
+}
+
+/// Inverse-context branch used while selecting a compact term.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JsonLdTermSelectionKind {
+    /// Select by type coercion (`@id`, `@vocab`, datatype, or `@none`).
+    Type,
+    /// Select by language/base-direction preference.
+    Language,
+    /// Select the shortest/lexically first term independent of value coercion.
+    Any,
+}
+
+/// Ordered inverse-context preferences for one IRI-compaction decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsonLdTermSelection {
+    containers: Vec<String>,
+    kind: JsonLdTermSelectionKind,
+    preferred_values: Vec<String>,
+}
+
+impl JsonLdTermSelection {
+    /// Construct an ordered selection from container sets and preferred inverse keys.
+    ///
+    /// An empty container set is represented as JSON-LD's `@none` container. Container
+    /// sets and preference values retain caller order; members inside each set are
+    /// canonicalized lexically.
+    pub fn new<I, C, P, S>(
+        containers: I,
+        kind: JsonLdTermSelectionKind,
+        preferred_values: P,
+    ) -> Self
+    where
+        I: IntoIterator<Item = C>,
+        C: IntoIterator<Item = JsonLdContainer>,
+        P: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let containers = containers
+            .into_iter()
+            .map(|container| {
+                let mut values: Vec<&str> =
+                    container.into_iter().map(JsonLdContainer::as_str).collect();
+                if values.is_empty() {
+                    "@none".to_owned()
+                } else {
+                    values.sort_unstable();
+                    values.concat()
+                }
+            })
+            .collect();
+        Self {
+            containers,
+            kind,
+            preferred_values: preferred_values.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    /// Ordered canonical container keys consulted by inverse selection.
+    pub fn container_keys(&self) -> &[String] {
+        &self.containers
+    }
+
+    /// Selected inverse-context branch.
+    pub const fn kind(&self) -> JsonLdTermSelectionKind {
+        self.kind
+    }
+
+    /// Ordered type or language/direction preference keys.
+    pub fn preferred_values(&self) -> &[String] {
+        &self.preferred_values
+    }
+}
+
+fn canonicalize(value: &Value) -> Value {
+    match value {
+        Value::Array(values) => Value::Array(values.iter().map(canonicalize).collect()),
+        Value::Object(values) => {
+            let sorted: BTreeMap<String, Value> = values
+                .iter()
+                .map(|(key, value)| (key.clone(), canonicalize(value)))
+                .collect();
+            Value::Object(sorted.into_iter().collect())
+        }
+        scalar => scalar.clone(),
+    }
+}
+
+fn validate_absolute_iri(iri: &str, description: &str) -> Result<(), RdfDiagnostic> {
+    let parsed = purrdf_iri::parse(iri)
+        .map_err(|source| context_error(format!("invalid {description} `{iri}`: {source}")))?;
+    if !parsed.has_scheme() {
+        return Err(context_error(format!(
+            "{description} must be absolute: `{iri}`"
+        )));
+    }
+    Ok(())
+}
+
+fn context_error(message: impl Into<String>) -> RdfDiagnostic {
+    RdfDiagnostic::error("jsonld-context-invalid", message)
+}
+
+fn context_limit(message: impl Into<String>) -> RdfDiagnostic {
+    RdfDiagnostic::error("jsonld-context-limit", message)
+}

--- a/crates/rdf/src/native_codecs/jsonld/context/mod.rs
+++ b/crates/rdf/src/native_codecs/jsonld/context/mod.rs
@@ -35,6 +35,9 @@ const DEFAULT_MAX_TERMS: usize = 4_096;
 const DEFAULT_MAX_NESTING: usize = 64;
 const DEFAULT_MAX_EXPANSION_WORK: usize = 262_144;
 const DEFAULT_MAX_DEFINITION_COMPLEXITY: usize = 131_072;
+const MAX_JSON_LD_DOCUMENT_BYTES: usize = 256 * 1024 * 1024;
+const MAX_JSON_LD_DOCUMENT_DEPTH: usize = 128;
+const MAX_JSON_LD_DOCUMENT_VALUES: usize = 4_194_304;
 
 /// Fixed resource ceilings for context decoding and compilation.
 ///
@@ -589,6 +592,29 @@ impl CompiledJsonLdContext {
         self.active.terms.get(term)
     }
 
+    /// Compile the term-scoped context attached to `term` over this active context.
+    ///
+    /// Returns `None` when the term has no scoped context. Offline registry and base-URL
+    /// state are retained; protected definitions may be overridden as required by the
+    /// JSON-LD 1.1 scoped-context algorithm.
+    pub fn scoped_context(&self, term: &str) -> Result<Option<Self>, RdfDiagnostic> {
+        let Some(definition) = self.term(term) else {
+            return Ok(None);
+        };
+        compiler::compile_scoped(self, definition)
+    }
+
+    /// Apply a node-local context over this compiled active context.
+    pub fn apply_local_context(&self, context: &Value) -> Result<Self, RdfDiagnostic> {
+        compiler::apply_context(self, context, self.base_iri(), false)
+    }
+
+    /// Active context inherited by a nested node object under `@propagate` rules.
+    #[must_use]
+    pub fn child_context(&self) -> Self {
+        compiler::child_context(self)
+    }
+
     /// Expand an IRI, compact IRI, term, or keyword under this active context.
     ///
     /// `vocab` selects vocabulary-relative term expansion; `document_relative`
@@ -711,6 +737,18 @@ fn canonicalize(value: &Value) -> Value {
         }
         scalar => scalar.clone(),
     }
+}
+
+pub(super) fn parse_document(bytes: &[u8]) -> Result<Value, RdfDiagnostic> {
+    parse_strict_json(
+        bytes,
+        StrictJsonLimits {
+            bytes: MAX_JSON_LD_DOCUMENT_BYTES,
+            depth: MAX_JSON_LD_DOCUMENT_DEPTH,
+            values: MAX_JSON_LD_DOCUMENT_VALUES,
+        },
+        "JSON-LD document",
+    )
 }
 
 fn validate_absolute_iri(iri: &str, description: &str) -> Result<(), RdfDiagnostic> {

--- a/crates/rdf/src/native_codecs/jsonld/context/options.rs
+++ b/crates/rdf/src/native_codecs/jsonld/context/options.rs
@@ -1,0 +1,325 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Closed, versioned serialization options shared by Rust and foreign bindings.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use super::{
+    CompiledJsonLdContext, JSON_LD_SERIALIZE_OPTIONS_VERSION, JsonLdContextLimits,
+    JsonLdContextRegistry, canonicalize, context_error, parse_strict_json,
+};
+use crate::RdfDiagnostic;
+
+const OPTION_KEYS: &[&str] = &[
+    "context",
+    "document_iri",
+    "mode",
+    "prefixes",
+    "registry",
+    "version",
+    "yaml_schema_url",
+];
+
+/// Explicit output mode for configured JSON-LD/YAML-LD serialization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JsonLdSerializeMode {
+    /// Emit the frozen expanded compatibility representation with an empty context.
+    Expanded,
+    /// Compact through a reusable caller-supplied compiled context.
+    Context(Arc<CompiledJsonLdContext>),
+    /// Derive deterministic neutral aliases solely from IRIs present in the dataset.
+    Derived,
+}
+
+/// Closed version-1 JSON-LD/YAML-LD serialization request.
+///
+/// Existing no-options codec functions remain expanded compatibility shims. Configured
+/// entry points accept this type, whose constructors require an explicit mode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsonLdSerializeOptions {
+    version: u32,
+    mode: JsonLdSerializeMode,
+    yaml_schema_url: Option<String>,
+}
+
+impl JsonLdSerializeOptions {
+    /// Explicit expanded compatibility mode.
+    pub const fn expanded() -> Self {
+        Self {
+            version: JSON_LD_SERIALIZE_OPTIONS_VERSION,
+            mode: JsonLdSerializeMode::Expanded,
+            yaml_schema_url: None,
+        }
+    }
+
+    /// Explicit deterministic dataset-derived mode.
+    pub const fn derived() -> Self {
+        Self {
+            version: JSON_LD_SERIALIZE_OPTIONS_VERSION,
+            mode: JsonLdSerializeMode::Derived,
+            yaml_schema_url: None,
+        }
+    }
+
+    /// Explicit caller-context mode using an already compiled reusable context.
+    pub fn compiled(context: Arc<CompiledJsonLdContext>) -> Self {
+        Self {
+            version: JSON_LD_SERIALIZE_OPTIONS_VERSION,
+            mode: JsonLdSerializeMode::Context(context),
+            yaml_schema_url: None,
+        }
+    }
+
+    /// Compile a caller-owned local context into explicit caller-context mode.
+    pub fn context(context: &Value, document_iri: Option<&str>) -> Result<Self, RdfDiagnostic> {
+        let compiled = CompiledJsonLdContext::compile(context, document_iri)?;
+        Ok(Self::compiled(Arc::new(compiled)))
+    }
+
+    /// Compile a caller-owned context with immutable offline registry lookup.
+    pub fn context_with_registry(
+        context: &Value,
+        document_iri: Option<&str>,
+        registry: &JsonLdContextRegistry,
+    ) -> Result<Self, RdfDiagnostic> {
+        let compiled =
+            CompiledJsonLdContext::compile_with_registry(context, document_iri, registry)?;
+        Ok(Self::compiled(Arc::new(compiled)))
+    }
+
+    /// Compile deterministic caller prefix definitions into explicit context mode.
+    pub fn prefixes<I, K, V>(prefixes: I) -> Result<Self, RdfDiagnostic>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        let compiled = CompiledJsonLdContext::from_prefixes(prefixes)?;
+        Ok(Self::compiled(Arc::new(compiled)))
+    }
+
+    /// Strictly decode the shared versioned JSON options document.
+    ///
+    /// Duplicate members, unknown fields, incompatible mode fields, malformed
+    /// contexts, and resource-limit excesses are hard failures with stable diagnostic
+    /// codes.
+    pub fn from_json(bytes: &[u8]) -> Result<Self, RdfDiagnostic> {
+        let limits = JsonLdContextLimits::default();
+        let value = parse_strict_json(bytes, limits.strict_json(), "JSON-LD options")?;
+        decode_options(&value, limits)
+    }
+
+    /// Version of this options document.
+    pub const fn version(&self) -> u32 {
+        self.version
+    }
+
+    /// Explicit selected serialization mode.
+    pub const fn mode(&self) -> &JsonLdSerializeMode {
+        &self.mode
+    }
+
+    /// Optional caller-selected YAML language-server schema reference.
+    pub fn yaml_schema_url(&self) -> Option<&str> {
+        self.yaml_schema_url.as_deref()
+    }
+
+    /// Attach a non-empty YAML language-server schema IRI reference.
+    pub fn with_yaml_schema_url(
+        mut self,
+        schema_url: impl Into<String>,
+    ) -> Result<Self, RdfDiagnostic> {
+        let schema_url = schema_url.into();
+        if schema_url.is_empty()
+            || schema_url.chars().any(char::is_whitespace)
+            || purrdf_iri::parse(&schema_url).is_err()
+        {
+            return Err(context_error(format!(
+                "invalid YAML-LD schema IRI reference `{schema_url}`"
+            )));
+        }
+        self.yaml_schema_url = Some(schema_url);
+        Ok(self)
+    }
+
+    /// JSON Schema for the shared version-1 options document.
+    pub fn json_schema() -> Value {
+        serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false,
+            "properties": {
+                "context": {},
+                "document_iri": {"type": "string"},
+                "mode": {"enum": ["expanded", "context", "derived"]},
+                "prefixes": {
+                    "additionalProperties": {"type": "string"},
+                    "type": "object"
+                },
+                "registry": {
+                    "additionalProperties": {
+                        "properties": {"@context": {}},
+                        "required": ["@context"],
+                        "type": "object"
+                    },
+                    "type": "object"
+                },
+                "version": {"const": JSON_LD_SERIALIZE_OPTIONS_VERSION},
+                "yaml_schema_url": {"type": "string"}
+            },
+            "required": ["version", "mode"],
+            "type": "object"
+        })
+    }
+}
+
+fn decode_options(
+    value: &Value,
+    limits: JsonLdContextLimits,
+) -> Result<JsonLdSerializeOptions, RdfDiagnostic> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| context_error("JSON-LD options must be an object"))?;
+    for key in object.keys() {
+        if !OPTION_KEYS.contains(&key.as_str()) {
+            return Err(context_error(format!(
+                "unknown JSON-LD options member `{key}`"
+            )));
+        }
+    }
+    let version = object
+        .get("version")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| context_error("JSON-LD options require integer version 1"))?;
+    if version != u64::from(JSON_LD_SERIALIZE_OPTIONS_VERSION) {
+        return Err(context_error(format!(
+            "unsupported JSON-LD options version `{version}`; expected {JSON_LD_SERIALIZE_OPTIONS_VERSION}"
+        )));
+    }
+    let mode = object
+        .get("mode")
+        .and_then(Value::as_str)
+        .ok_or_else(|| context_error("JSON-LD options require string mode"))?;
+
+    let context_fields: BTreeSet<&str> = ["context", "document_iri", "prefixes", "registry"]
+        .into_iter()
+        .filter(|key| object.contains_key(*key))
+        .collect();
+    let mut options = match mode {
+        "expanded" => {
+            reject_fields(mode, &context_fields)?;
+            JsonLdSerializeOptions::expanded()
+        }
+        "derived" => {
+            reject_fields(mode, &context_fields)?;
+            JsonLdSerializeOptions::derived()
+        }
+        "context" => decode_context_mode(object, limits)?,
+        other => {
+            return Err(context_error(format!(
+                "unknown JSON-LD serialization mode `{other}`"
+            )));
+        }
+    };
+    if let Some(schema_url) = object.get("yaml_schema_url") {
+        let schema_url = schema_url
+            .as_str()
+            .ok_or_else(|| context_error("yaml_schema_url must be a string"))?;
+        options = options.with_yaml_schema_url(schema_url)?;
+    }
+    Ok(options)
+}
+
+fn reject_fields(mode: &str, fields: &BTreeSet<&str>) -> Result<(), RdfDiagnostic> {
+    if fields.is_empty() {
+        return Ok(());
+    }
+    Err(context_error(format!(
+        "JSON-LD mode `{mode}` does not accept {}",
+        fields.iter().copied().collect::<Vec<_>>().join(", ")
+    )))
+}
+
+fn decode_context_mode(
+    object: &serde_json::Map<String, Value>,
+    limits: JsonLdContextLimits,
+) -> Result<JsonLdSerializeOptions, RdfDiagnostic> {
+    let has_context = object.contains_key("context");
+    let has_prefixes = object.contains_key("prefixes");
+    if has_context == has_prefixes {
+        return Err(context_error(
+            "JSON-LD context mode requires exactly one of context or prefixes",
+        ));
+    }
+    if has_prefixes && (object.contains_key("document_iri") || object.contains_key("registry")) {
+        return Err(context_error(
+            "prefix-map context mode does not accept document_iri or registry",
+        ));
+    }
+    if let Some(prefixes) = object.get("prefixes") {
+        let prefixes = prefixes
+            .as_object()
+            .ok_or_else(|| context_error("JSON-LD prefixes must be an object"))?;
+        let mappings: Result<Vec<(String, String)>, RdfDiagnostic> = prefixes
+            .iter()
+            .map(|(prefix, namespace)| {
+                let namespace = namespace.as_str().ok_or_else(|| {
+                    context_error(format!("prefix `{prefix}` namespace must be a string"))
+                })?;
+                Ok((prefix.clone(), namespace.to_owned()))
+            })
+            .collect();
+        return JsonLdSerializeOptions::prefixes(mappings?);
+    }
+
+    let registry = decode_registry(object.get("registry"), limits)?;
+    let document_iri = object.get("document_iri").map(|value| {
+        value
+            .as_str()
+            .ok_or_else(|| context_error("document_iri must be a string"))
+    });
+    let document_iri = document_iri.transpose()?;
+    JsonLdSerializeOptions::context_with_registry(
+        object
+            .get("context")
+            .expect("context mode proved context is present"),
+        document_iri,
+        &registry,
+    )
+}
+
+fn decode_registry(
+    value: Option<&Value>,
+    limits: JsonLdContextLimits,
+) -> Result<JsonLdContextRegistry, RdfDiagnostic> {
+    let Some(value) = value else {
+        return Ok(JsonLdContextRegistry::default());
+    };
+    let object = value
+        .as_object()
+        .ok_or_else(|| context_error("JSON-LD registry must be an object"))?;
+    let mut documents = BTreeMap::new();
+    for (iri, document) in object {
+        if documents.len() == limits.max_registry_documents() {
+            return Err(super::context_limit(format!(
+                "JSON-LD options registry exceeds {} documents",
+                limits.max_registry_documents()
+            )));
+        }
+        if !document
+            .as_object()
+            .is_some_and(|wrapper| wrapper.contains_key("@context"))
+        {
+            return Err(context_error(format!(
+                "registry document `{iri}` must be an object containing @context"
+            )));
+        }
+        let bytes = serde_json::to_vec(&canonicalize(document))
+            .map_err(|source| context_error(format!("encode registry document: {source}")))?;
+        documents.insert(iri.clone(), bytes);
+    }
+    JsonLdContextRegistry::new_with_limits(documents, limits)
+}

--- a/crates/rdf/src/native_codecs/jsonld/context/options.rs
+++ b/crates/rdf/src/native_codecs/jsonld/context/options.rs
@@ -109,7 +109,7 @@ impl JsonLdSerializeOptions {
     /// codes.
     pub fn from_json(bytes: &[u8]) -> Result<Self, RdfDiagnostic> {
         let limits = JsonLdContextLimits::default();
-        let value = parse_strict_json(bytes, limits.strict_json(), "JSON-LD options")?;
+        let value = parse_strict_json(bytes, limits.strict_options_json(), "JSON-LD options")?;
         decode_options(&value, limits)
     }
 
@@ -170,6 +170,48 @@ impl JsonLdSerializeOptions {
                 "version": {"const": JSON_LD_SERIALIZE_OPTIONS_VERSION},
                 "yaml_schema_url": {"type": "string"}
             },
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {"mode": {"enum": ["expanded", "derived"]}},
+                        "required": ["mode"]
+                    },
+                    "then": {
+                        "not": {
+                            "anyOf": [
+                                {"required": ["context"]},
+                                {"required": ["document_iri"]},
+                                {"required": ["prefixes"]},
+                                {"required": ["registry"]}
+                            ]
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {"mode": {"const": "context"}},
+                        "required": ["mode"]
+                    },
+                    "then": {
+                        "oneOf": [
+                            {
+                                "required": ["context"],
+                                "not": {"required": ["prefixes"]}
+                            },
+                            {
+                                "required": ["prefixes"],
+                                "not": {
+                                    "anyOf": [
+                                        {"required": ["context"]},
+                                        {"required": ["document_iri"]},
+                                        {"required": ["registry"]}
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
             "required": ["version", "mode"],
             "type": "object"
         })

--- a/crates/rdf/src/native_codecs/jsonld/context/strict.rs
+++ b/crates/rdf/src/native_codecs/jsonld/context/strict.rs
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Duplicate-free, bounded JSON decoding shared by JSON-LD contexts and options.
+
+use std::cell::Cell;
+
+use serde::de::{DeserializeSeed, Error as _, MapAccess, SeqAccess, Visitor};
+use serde_json::{Map, Number, Value};
+
+use crate::RdfDiagnostic;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct StrictJsonLimits {
+    pub(super) bytes: usize,
+    pub(super) depth: usize,
+    pub(super) values: usize,
+}
+
+pub(super) fn parse_strict_json(
+    bytes: &[u8],
+    limits: StrictJsonLimits,
+    description: &str,
+) -> Result<Value, RdfDiagnostic> {
+    if bytes.len() > limits.bytes {
+        return Err(error(format!(
+            "{description} is {} bytes; limit is {}",
+            bytes.len(),
+            limits.bytes
+        )));
+    }
+    let remaining = Cell::new(limits.values);
+    let mut deserializer = serde_json::Deserializer::from_slice(bytes);
+    let value = StrictJsonSeed {
+        remaining: &remaining,
+        depth: 0,
+        max_depth: limits.depth,
+    }
+    .deserialize(&mut deserializer)
+    .map_err(|source| error(format!("parse {description}: {source}")))?;
+    deserializer
+        .end()
+        .map_err(|source| error(format!("parse {description}: {source}")))?;
+    Ok(value)
+}
+
+#[derive(Clone, Copy)]
+struct StrictJsonSeed<'a> {
+    remaining: &'a Cell<usize>,
+    depth: usize,
+    max_depth: usize,
+}
+
+impl<'de> DeserializeSeed<'de> for StrictJsonSeed<'_> {
+    type Value = Value;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        if self.depth > self.max_depth {
+            return Err(D::Error::custom(format!(
+                "JSON nesting exceeds depth limit {}",
+                self.max_depth
+            )));
+        }
+        let remaining = self.remaining.get();
+        if remaining == 0 {
+            return Err(D::Error::custom(
+                "JSON value count exceeds configured limit",
+            ));
+        }
+        self.remaining.set(remaining - 1);
+        deserializer.deserialize_any(StrictJsonVisitor(self))
+    }
+}
+
+struct StrictJsonVisitor<'a>(StrictJsonSeed<'a>);
+
+impl<'de> Visitor<'de> for StrictJsonVisitor<'_> {
+    type Value = Value;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a duplicate-free JSON value")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(Value::Bool(value))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(Value::Number(Number::from(value)))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(Value::Number(Number::from(value)))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Number::from_f64(value)
+            .map(Value::Number)
+            .ok_or_else(|| E::custom("non-finite JSON number"))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(Value::String(value.to_owned()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(Value::String(value))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        self.0.deserialize(deserializer)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let child = StrictJsonSeed {
+            depth: self.0.depth + 1,
+            ..self.0
+        };
+        let mut values = Vec::with_capacity(sequence.size_hint().unwrap_or(0).min(1_024));
+        while let Some(value) = sequence.next_element_seed(child)? {
+            values.push(value);
+        }
+        Ok(Value::Array(values))
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let child = StrictJsonSeed {
+            depth: self.0.depth + 1,
+            ..self.0
+        };
+        let mut values = Map::new();
+        while let Some(key) = map.next_key::<String>()? {
+            if values.contains_key(&key) {
+                return Err(A::Error::custom(format!(
+                    "duplicate JSON object member `{key}`"
+                )));
+            }
+            values.insert(key, map.next_value_seed(child)?);
+        }
+        Ok(Value::Object(values))
+    }
+}
+
+fn error(message: impl Into<String>) -> RdfDiagnostic {
+    RdfDiagnostic::error("jsonld-json-input", message)
+}

--- a/crates/rdf/src/native_codecs/jsonld/context/tests.rs
+++ b/crates/rdf/src/native_codecs/jsonld/context/tests.rs
@@ -4,7 +4,7 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use serde_json::json;
+use serde_json::{Value, json};
 
 use super::*;
 
@@ -468,6 +468,123 @@ fn options_decoder_is_versioned_closed_and_mode_explicit() {
 }
 
 #[test]
+fn options_schema_and_decoder_have_identical_mode_field_constraints() {
+    fn schema_accepts(instance: &Value) -> bool {
+        let location = "mem:///jsonld-options.schema.json";
+        let mut schemas = boon::Schemas::new();
+        let mut compiler = boon::Compiler::new();
+        compiler
+            .add_resource(location, JsonLdSerializeOptions::json_schema())
+            .expect("register options schema");
+        let compiled = compiler
+            .compile(location, &mut schemas)
+            .expect("compile options schema");
+        schemas.validate(instance, compiled).is_ok()
+    }
+
+    let cases = [
+        (json!({"mode": "expanded", "version": 1}), true),
+        (json!({"mode": "derived", "version": 1}), true),
+        (
+            json!({"context": {}, "mode": "context", "version": 1}),
+            true,
+        ),
+        (
+            json!({
+                "context": {},
+                "document_iri": "https://example.org/document",
+                "mode": "context",
+                "registry": {
+                    "https://example.org/context": {"@context": {}}
+                },
+                "version": 1
+            }),
+            true,
+        ),
+        (
+            json!({
+                "mode": "context",
+                "prefixes": {"ex": "https://example.org/"},
+                "version": 1
+            }),
+            true,
+        ),
+        (
+            json!({"context": {}, "mode": "expanded", "version": 1}),
+            false,
+        ),
+        (
+            json!({
+                "document_iri": "https://example.org/",
+                "mode": "derived",
+                "version": 1
+            }),
+            false,
+        ),
+        (json!({"mode": "context", "version": 1}), false),
+        (
+            json!({
+                "context": {},
+                "mode": "context",
+                "prefixes": {"ex": "https://example.org/"},
+                "version": 1
+            }),
+            false,
+        ),
+        (
+            json!({
+                "document_iri": "https://example.org/",
+                "mode": "context",
+                "prefixes": {"ex": "https://example.org/"},
+                "version": 1
+            }),
+            false,
+        ),
+        (
+            json!({
+                "mode": "context",
+                "prefixes": {"ex": "https://example.org/"},
+                "registry": {},
+                "version": 1
+            }),
+            false,
+        ),
+    ];
+    for (instance, expected) in cases {
+        let bytes = serde_json::to_vec(&instance).expect("encode options case");
+        assert_eq!(
+            JsonLdSerializeOptions::from_json(&bytes).is_ok(),
+            expected,
+            "decoder parity for {instance}"
+        );
+        assert_eq!(
+            schema_accepts(&instance),
+            expected,
+            "schema parity for {instance}"
+        );
+    }
+}
+
+#[test]
+fn options_input_can_carry_more_than_one_context_ceiling_of_registry_data() {
+    let padding = "x".repeat(600_000);
+    let options = json!({
+        "context": {},
+        "mode": "context",
+        "registry": {
+            "https://example.org/first": {"@context": null, "padding": padding},
+            "https://example.org/second": {"@context": null, "padding": padding}
+        },
+        "version": 1
+    });
+    let bytes = serde_json::to_vec(&options).expect("encode registry-bearing options");
+    let limits = JsonLdContextLimits::default();
+    assert!(bytes.len() > limits.max_context_bytes());
+    assert!(bytes.len() < limits.max_options_bytes());
+    JsonLdSerializeOptions::from_json(&bytes).expect("decode aggregate registry options");
+}
+
+#[test]
 fn fixed_limits_accept_exact_boundaries_and_reject_one_over() {
     let exact_registry_limits = JsonLdContextLimits {
         context_bytes: 4,
@@ -481,13 +598,21 @@ fn fixed_limits_accept_exact_boundaries_and_reject_one_over() {
     )
     .expect("exact registry byte/count limits");
     assert_eq!(registry.total_bytes(), 4);
-    assert!(
-        JsonLdContextRegistry::new_with_limits(
-            [("https://example.org/context", b"null ".to_vec())],
-            exact_registry_limits,
-        )
-        .is_err()
-    );
+    let byte_error = JsonLdContextRegistry::new_with_limits(
+        [("https://example.org/context", b"null ".to_vec())],
+        exact_registry_limits,
+    )
+    .expect_err("one byte over per-document limit");
+    assert_eq!(byte_error.code, "jsonld-context-limit");
+    let count_error = JsonLdContextRegistry::new_with_limits(
+        [
+            ("https://example.org/first", b"null".to_vec()),
+            ("https://example.org/second", b"null".to_vec()),
+        ],
+        exact_registry_limits,
+    )
+    .expect_err("one document over registry limit");
+    assert_eq!(count_error.code, "jsonld-context-limit");
     assert!(
         JsonLdContextRegistry::new_with_limits(
             [
@@ -749,6 +874,53 @@ fn inverse_context_uses_exact_language_direction_and_any_keys() {
             expected
         );
     }
+}
+
+#[test]
+fn any_inverse_selection_ignores_coercion_preferences() {
+    let iri = "https://example.org/p";
+    let compiled = CompiledJsonLdContext::compile(
+        &json!({
+            "plain": iri,
+            "typed": {"@id": iri, "@type": "@id"}
+        }),
+        None,
+    )
+    .expect("inverse context");
+    let selection = JsonLdTermSelection::new(
+        [Vec::<JsonLdContainer>::new()],
+        JsonLdTermSelectionKind::Any,
+        ["@id"],
+    );
+    assert_eq!(
+        compiled
+            .compact_iri_with_selection(iri, true, Some(&selection))
+            .expect("fallback selection"),
+        "plain"
+    );
+}
+
+#[test]
+fn null_local_context_resets_to_original_document_base() {
+    let compiled = CompiledJsonLdContext::compile(
+        &json!({"@base": "nested/"}),
+        Some("https://example.org/root/document"),
+    )
+    .expect("mutated active base");
+    assert_eq!(
+        compiled.base_iri(),
+        Some("https://example.org/root/nested/")
+    );
+
+    let reset = compiled
+        .apply_local_context(&Value::Null)
+        .expect("reset local context");
+    assert_eq!(
+        reset
+            .expand_iri("item", false, true)
+            .expect("expand against reset base"),
+        Some("https://example.org/root/item".to_owned())
+    );
 }
 
 #[test]

--- a/crates/rdf/src/native_codecs/jsonld/context/tests.rs
+++ b/crates/rdf/src/native_codecs/jsonld/context/tests.rs
@@ -1,0 +1,865 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use serde_json::json;
+
+use super::*;
+
+fn limits() -> JsonLdContextLimits {
+    JsonLdContextLimits {
+        context_bytes: 1_024,
+        registry_documents: 8,
+        registry_bytes: 4_096,
+        terms: 64,
+        nesting: 16,
+        expansion_work: 1_024,
+        definition_complexity: 1_024,
+    }
+}
+
+#[test]
+fn prefix_context_expands_compacts_and_canonicalizes_idempotently() {
+    let compiled = CompiledJsonLdContext::from_prefixes([
+        ("z", "https://z.example/"),
+        ("ex", "https://example.org/ns#"),
+    ])
+    .expect("prefix context");
+
+    assert_eq!(
+        compiled.canonical_json(),
+        r#"{"ex":{"@id":"https://example.org/ns#","@prefix":true},"z":{"@id":"https://z.example/","@prefix":true}}"#
+    );
+    assert_eq!(
+        compiled
+            .expand_iri("ex:Thing", true, false)
+            .expect("expand"),
+        Some("https://example.org/ns#Thing".to_owned())
+    );
+    assert_eq!(
+        compiled
+            .compact_iri("https://example.org/ns#Thing", true)
+            .expect("compact"),
+        "ex:Thing"
+    );
+
+    let recompiled = CompiledJsonLdContext::compile(compiled.canonical_context(), None)
+        .expect("recompile canonical context");
+    assert_eq!(recompiled, compiled);
+}
+
+#[test]
+fn full_context_compiles_type_language_container_reverse_nest_and_scope() {
+    let context = json!({
+        "@base": "https://example.org/doc/",
+        "@direction": "ltr",
+        "@language": "EN",
+        "@protected": true,
+        "@version": 1.1,
+        "@vocab": "https://example.org/vocab/",
+        "schema": {"@id": "https://schema.org/", "@prefix": true},
+        "id": "@id",
+        "nest": "@nest",
+        "name": {
+            "@container": "@set",
+            "@direction": "rtl",
+            "@id": "schema:name",
+            "@language": null
+        },
+        "link": {"@id": "schema:url", "@type": "@id"},
+        "typed": {"@container": ["@set", "@type"], "@id": "schema:item"},
+        "reverse": {"@container": "@set", "@reverse": "schema:parent"},
+        "nested": {"@id": "schema:nested", "@nest": "nest"},
+        "indexed": {
+            "@container": "@index",
+            "@id": "schema:indexed",
+            "@index": "schema:position"
+        },
+        "scoped": {
+            "@context": {"inner": "schema:inner"},
+            "@id": "schema:scoped"
+        },
+        "payload": {"@id": "schema:payload", "@type": "@json"}
+    });
+    let compiled = CompiledJsonLdContext::compile(&context, None).expect("compile");
+
+    assert_eq!(compiled.base_iri(), Some("https://example.org/doc/"));
+    assert_eq!(compiled.vocab_mapping(), Some("https://example.org/vocab/"));
+    assert_eq!(compiled.default_language(), Some("en"));
+    assert_eq!(
+        compiled.default_direction(),
+        Some(JsonLdDirection::LeftToRight)
+    );
+    assert!(compiled.term("schema").expect("schema").is_prefix());
+    assert_eq!(compiled.term("id").expect("id").iri_mapping(), Some("@id"));
+    assert_eq!(
+        compiled
+            .expand_iri("id", false, false)
+            .expect("keyword alias"),
+        Some("@id".to_owned())
+    );
+    assert_eq!(
+        compiled.compact_iri("_:b0", false).expect("blank node"),
+        "_:b0"
+    );
+
+    let name = compiled.term("name").expect("name");
+    assert_eq!(name.containers(), &BTreeSet::from([JsonLdContainer::Set]));
+    assert_eq!(name.language_mapping(), Some(JsonLdNullable::Null));
+    assert_eq!(
+        name.direction_mapping(),
+        Some(JsonLdNullable::Value(JsonLdDirection::RightToLeft))
+    );
+    assert!(name.is_protected());
+    assert_eq!(
+        compiled.term("link").expect("link").type_mapping(),
+        Some(&JsonLdTypeMapping::Id)
+    );
+    assert!(
+        compiled
+            .term("reverse")
+            .expect("reverse")
+            .is_reverse_property()
+    );
+    assert_eq!(
+        compiled.term("nested").expect("nested").nest(),
+        Some("nest")
+    );
+    assert_eq!(
+        compiled.term("indexed").expect("indexed").index_mapping(),
+        Some("https://schema.org/position")
+    );
+    assert!(
+        compiled
+            .term("scoped")
+            .expect("scoped")
+            .scoped_context()
+            .is_some()
+    );
+    assert_eq!(
+        compiled.term("payload").expect("payload").type_mapping(),
+        Some(&JsonLdTypeMapping::Json)
+    );
+}
+
+#[test]
+fn context_arrays_reset_and_protected_redefinition_is_rejected() {
+    let context = json!([
+        {"@vocab": "https://old.example/", "old": "https://old.example/value"},
+        null,
+        {"@vocab": "https://new.example/", "new": "value"}
+    ]);
+    let compiled = CompiledJsonLdContext::compile(&context, None).expect("reset context");
+    assert!(compiled.term("old").is_none());
+    assert_eq!(
+        compiled.term("new").expect("new").iri_mapping(),
+        Some("https://new.example/value")
+    );
+
+    let error = CompiledJsonLdContext::compile(
+        &json!([
+            {"@protected": true, "x": "https://example.org/x"},
+            {"x": "https://example.org/changed"}
+        ]),
+        None,
+    )
+    .expect_err("protected redefinition");
+    assert_eq!(error.code, "jsonld-context-invalid");
+    assert!(error.message.contains("protected JSON-LD term `x`"));
+
+    let error = CompiledJsonLdContext::compile(
+        &json!([{"@protected": true, "x": "https://example.org/x"}, null]),
+        None,
+    )
+    .expect_err("protected null reset");
+    assert!(error.message.contains("erase protected term `x`"));
+}
+
+#[test]
+fn offline_registry_resolves_context_iris_and_imports_without_network() {
+    let registry = JsonLdContextRegistry::new([
+        (
+            "https://example.org/base",
+            br#"{"@context":{"base":{"@id":"https://example.org/ns/","@prefix":true}}}"#.to_vec(),
+        ),
+        (
+            "https://example.org/child",
+            br#"{"@context":{"@import":"https://example.org/base","local":"base:local"}}"#.to_vec(),
+        ),
+    ])
+    .expect("registry");
+    let compiled =
+        CompiledJsonLdContext::compile_registry_context("https://example.org/child", &registry)
+            .expect("registry context");
+    assert_eq!(registry.len(), 2);
+    assert_eq!(
+        compiled.term("local").expect("local").iri_mapping(),
+        Some("https://example.org/ns/local")
+    );
+    assert_eq!(
+        compiled.canonical_context(),
+        &Value::String("https://example.org/child".to_owned())
+    );
+}
+
+#[test]
+fn registry_missing_documents_cycles_and_duplicate_members_fail_stably() {
+    let missing = CompiledJsonLdContext::compile_registry_context(
+        "https://example.org/missing",
+        &JsonLdContextRegistry::default(),
+    )
+    .expect_err("missing document");
+    assert_eq!(missing.code, "jsonld-context-invalid");
+    assert!(missing.message.contains("no document"));
+
+    let registry = JsonLdContextRegistry::new([
+        (
+            "https://example.org/a",
+            br#"{"@context":"https://example.org/b"}"#.to_vec(),
+        ),
+        (
+            "https://example.org/b",
+            br#"{"@context":"https://example.org/a"}"#.to_vec(),
+        ),
+    ])
+    .expect("cycle registry");
+    let cycle = CompiledJsonLdContext::compile_registry_context("https://example.org/a", &registry)
+        .expect_err("cycle");
+    assert!(cycle.message.contains("offline context cycle"));
+
+    let duplicate = CompiledJsonLdContext::compile_json(
+        br#"{"x":"https://example.org/one","x":"https://example.org/two"}"#,
+        None,
+    )
+    .expect_err("duplicate member");
+    assert_eq!(duplicate.code, "jsonld-json-input");
+    assert!(
+        duplicate
+            .message
+            .contains("duplicate JSON object member `x`")
+    );
+}
+
+#[test]
+fn inverse_term_selection_obeys_shape_before_shortest_lexical_ties() {
+    let context = json!({
+        "a": {"@id": "https://example.org/p", "@type": "@id"},
+        "b": "https://example.org/p",
+        "languageName": {"@id": "https://example.org/p", "@language": "en"}
+    });
+    let compiled = CompiledJsonLdContext::compile(&context, None).expect("context");
+
+    let id = JsonLdTermSelection::new(
+        [Vec::<JsonLdContainer>::new()],
+        JsonLdTermSelectionKind::Type,
+        ["@id", "@none"],
+    );
+    assert_eq!(
+        compiled
+            .compact_iri_with_selection("https://example.org/p", true, Some(&id))
+            .expect("id term"),
+        "a"
+    );
+
+    let language = JsonLdTermSelection::new(
+        [Vec::<JsonLdContainer>::new()],
+        JsonLdTermSelectionKind::Language,
+        ["en", "@none"],
+    );
+    assert_eq!(
+        compiled
+            .compact_iri_with_selection("https://example.org/p", true, Some(&language))
+            .expect("language term"),
+        "languageName"
+    );
+
+    let none = JsonLdTermSelection::new(
+        [Vec::<JsonLdContainer>::new()],
+        JsonLdTermSelectionKind::Language,
+        ["@none"],
+    );
+    assert_eq!(
+        compiled
+            .compact_iri_with_selection("https://example.org/p", true, Some(&none))
+            .expect("untyped term"),
+        "b"
+    );
+}
+
+#[test]
+fn base_and_vocab_resolution_round_trip_exactly() {
+    let compiled = CompiledJsonLdContext::compile(
+        &json!({
+            "@base": "https://example.org/a/b/",
+            "@vocab": "../v/",
+            "term": "item"
+        }),
+        None,
+    )
+    .expect("relative settings");
+    assert_eq!(compiled.vocab_mapping(), Some("https://example.org/a/v/"));
+    assert_eq!(
+        compiled.term("term").expect("term").iri_mapping(),
+        Some("https://example.org/a/v/item")
+    );
+    assert_eq!(
+        compiled.expand_iri("c", false, true).expect("expand base"),
+        Some("https://example.org/a/b/c".to_owned())
+    );
+    assert_eq!(
+        compiled
+            .compact_iri("https://example.org/a/b/c", false)
+            .expect("remove base"),
+        "c"
+    );
+}
+
+#[test]
+fn null_base_is_not_resurrected_from_the_document_url() {
+    for relative_setting in [json!({"@base": "later"}), json!({"@vocab": "later/"})] {
+        let error = CompiledJsonLdContext::compile(
+            &json!([{"@base": null}, relative_setting]),
+            Some("https://example.org/document"),
+        )
+        .expect_err("relative setting after null @base");
+        assert!(error.message.contains("requires an absolute base IRI"));
+    }
+
+    let error = CompiledJsonLdContext::compile(
+        &json!([{"@base": null}, {"path/item": {}}]),
+        Some("https://example.org/document"),
+    )
+    .expect_err("relative term after null @base");
+    assert!(error.message.contains("requires an absolute base IRI"));
+}
+
+#[test]
+fn prefix_presence_and_mapped_index_rules_are_enforced() {
+    for context in [
+        json!({
+            "ex": {"@id": "https://example.org/", "@prefix": true},
+            "ex:item": {"@id": "https://example.org/item", "@prefix": false}
+        }),
+        json!({
+            "path/item": {
+                "@id": "https://example.org/path/item",
+                "@prefix": false
+            }
+        }),
+    ] {
+        let error = CompiledJsonLdContext::compile(&context, Some("https://example.org/"))
+            .expect_err("@prefix member on colon or slash term");
+        assert!(error.message.contains("with @prefix must not contain"));
+    }
+
+    let error = CompiledJsonLdContext::compile(
+        &json!({
+            "indexed": {
+                "@container": "@index",
+                "@id": "https://example.org/indexed",
+                "@index": "_:blank"
+            }
+        }),
+        None,
+    )
+    .expect_err("blank-node mapped index");
+    assert!(error.message.contains("index mapping"));
+}
+
+#[test]
+fn iri_compaction_rejects_prefix_confusion_and_shape_unsafe_fallbacks() {
+    let confused = CompiledJsonLdContext::compile(
+        &json!({"urn": {"@id": "https://example.org/", "@prefix": true}}),
+        None,
+    )
+    .expect("prefix context");
+    for vocab in [false, true] {
+        let error = confused
+            .compact_iri("urn:item", vocab)
+            .expect_err("IRI confused with prefix");
+        assert!(
+            error
+                .message
+                .contains("confused with active JSON-LD prefix `urn`")
+        );
+    }
+    assert_eq!(
+        confused
+            .compact_iri("urn://authority/path", true)
+            .expect("authority disambiguates IRI"),
+        "urn://authority/path"
+    );
+
+    let shaped = CompiledJsonLdContext::compile(
+        &json!({
+            "ex": {"@id": "https://example.org/", "@prefix": true},
+            "ex:item": {"@id": "https://example.org/item", "@type": "@id"}
+        }),
+        None,
+    )
+    .expect("shaped compact-IRI term");
+    let language = JsonLdTermSelection::new(
+        [Vec::<JsonLdContainer>::new()],
+        JsonLdTermSelectionKind::Language,
+        ["fr"],
+    );
+    assert_eq!(
+        shaped
+            .compact_iri_with_selection("https://example.org/item", true, Some(&language),)
+            .expect("shape-safe compaction"),
+        "https://example.org/item"
+    );
+    assert_eq!(
+        shaped
+            .compact_iri("https://example.org/item", false)
+            .expect("null-value prefix fallback"),
+        "ex:item"
+    );
+
+    let vocab = CompiledJsonLdContext::compile(
+        &json!({
+            "@vocab": "https://example.org/",
+            "item": {"@id": "https://example.org/item", "@type": "@id"}
+        }),
+        None,
+    )
+    .expect("vocabulary context");
+    assert_eq!(
+        vocab
+            .compact_iri_with_selection("https://example.org/item", true, Some(&language),)
+            .expect("existing term blocks vocabulary suffix"),
+        "https://example.org/item"
+    );
+}
+
+#[test]
+fn options_decoder_is_versioned_closed_and_mode_explicit() {
+    let expanded = JsonLdSerializeOptions::from_json(br#"{"mode":"expanded","version":1}"#)
+        .expect("expanded options");
+    assert!(matches!(expanded.mode(), JsonLdSerializeMode::Expanded));
+
+    let context = JsonLdSerializeOptions::from_json(
+        br#"{"mode":"context","prefixes":{"ex":"https://example.org/"},"version":1,"yaml_schema_url":"schema.json"}"#,
+    )
+    .expect("prefix options");
+    let JsonLdSerializeMode::Context(compiled) = context.mode() else {
+        panic!("context mode");
+    };
+    assert_eq!(
+        compiled.expand_iri("ex:item", true, false).expect("expand"),
+        Some("https://example.org/item".to_owned())
+    );
+    assert_eq!(context.yaml_schema_url(), Some("schema.json"));
+
+    for invalid in [
+        br#"{"mode":"expanded","mode":"derived","version":1}"#.as_slice(),
+        br#"{"mode":"expanded","prefixes":{},"version":1}"#.as_slice(),
+        br#"{"mode":"expanded","unknown":true,"version":1}"#.as_slice(),
+        br#"{"mode":"expanded","version":2}"#.as_slice(),
+    ] {
+        assert!(JsonLdSerializeOptions::from_json(invalid).is_err());
+    }
+    assert_eq!(
+        JsonLdSerializeOptions::json_schema()["properties"]["version"]["const"],
+        JSON_LD_SERIALIZE_OPTIONS_VERSION
+    );
+}
+
+#[test]
+fn fixed_limits_accept_exact_boundaries_and_reject_one_over() {
+    let exact_registry_limits = JsonLdContextLimits {
+        context_bytes: 4,
+        registry_documents: 1,
+        registry_bytes: 4,
+        ..limits()
+    };
+    let registry = JsonLdContextRegistry::new_with_limits(
+        [("https://example.org/context", b"null".to_vec())],
+        exact_registry_limits,
+    )
+    .expect("exact registry byte/count limits");
+    assert_eq!(registry.total_bytes(), 4);
+    assert!(
+        JsonLdContextRegistry::new_with_limits(
+            [("https://example.org/context", b"null ".to_vec())],
+            exact_registry_limits,
+        )
+        .is_err()
+    );
+    assert!(
+        JsonLdContextRegistry::new_with_limits(
+            [
+                ("https://example.org/one", b"null".to_vec()),
+                ("https://example.org/two", b"null".to_vec()),
+            ],
+            exact_registry_limits,
+        )
+        .is_err()
+    );
+
+    let exact_terms = JsonLdContextLimits {
+        terms: 2,
+        ..limits()
+    };
+    assert!(
+        compiler::compile(
+            &json!({"a": "https://example.org/a", "b": "https://example.org/b"}),
+            None,
+            &JsonLdContextRegistry::default(),
+            exact_terms,
+        )
+        .is_ok()
+    );
+    let one_over = compiler::compile(
+        &json!({
+            "a": "https://example.org/a",
+            "b": "https://example.org/b",
+            "c": "https://example.org/c"
+        }),
+        None,
+        &JsonLdContextRegistry::default(),
+        exact_terms,
+    )
+    .expect_err("term one-over");
+    assert_eq!(one_over.code, "jsonld-context-limit");
+
+    let exact_work = JsonLdContextLimits {
+        expansion_work: 2,
+        definition_complexity: 0,
+        ..limits()
+    };
+    assert!(
+        compiler::compile(
+            &Value::Null,
+            None,
+            &JsonLdContextRegistry::default(),
+            exact_work,
+        )
+        .is_ok()
+    );
+    let one_over_work = compiler::compile(
+        &Value::Null,
+        None,
+        &JsonLdContextRegistry::default(),
+        JsonLdContextLimits {
+            expansion_work: 1,
+            ..exact_work
+        },
+    )
+    .expect_err("work one-over");
+    assert_eq!(one_over_work.code, "jsonld-context-limit");
+
+    let strict = StrictJsonLimits {
+        bytes: 4,
+        depth: 1,
+        values: 1,
+    };
+    assert_eq!(
+        parse_strict_json(b"null", strict, "boundary").expect("exact strict limits"),
+        Value::Null
+    );
+    assert!(parse_strict_json(b"null ", strict, "boundary").is_err());
+}
+
+#[test]
+fn protected_terms_retain_identical_definitions_and_scopes_may_override() {
+    let compiled = CompiledJsonLdContext::compile(
+        &json!([
+            {"@protected": true, "x": "https://example.org/x"},
+            {"x": {"@id": "https://example.org/x", "@protected": false}}
+        ]),
+        None,
+    )
+    .expect("identical protected redefinition");
+    assert!(compiled.term("x").expect("x").is_protected());
+
+    let scoped = CompiledJsonLdContext::compile(
+        &json!({
+            "@protected": true,
+            "x": "https://example.org/x",
+            "scope": {
+                "@id": "https://example.org/scope",
+                "@context": {"x": "https://example.org/scoped-x"}
+            }
+        }),
+        Some("https://example.org/context/document"),
+    )
+    .expect("scoped context validates with protected override");
+    assert_eq!(
+        scoped.term("x").expect("outer x").iri_mapping(),
+        Some("https://example.org/x")
+    );
+    assert_eq!(
+        scoped
+            .term("scope")
+            .expect("scope")
+            .scoped_context_base_iri(),
+        Some("https://example.org/context/document")
+    );
+}
+
+#[test]
+fn type_keyword_and_type_containers_follow_json_ld_11_rules() {
+    let compiled = CompiledJsonLdContext::compile(
+        &json!({
+            "@type": {"@container": "@set", "@protected": true},
+            "typed": {"@container": "@type", "@id": "https://example.org/typed"},
+            "vocabTyped": {
+                "@container": ["@set", "@type"],
+                "@id": "https://example.org/vocab-typed",
+                "@type": "@vocab"
+            }
+        }),
+        None,
+    )
+    .expect("type definitions");
+    let keyword = compiled.term("@type").expect("@type definition");
+    assert_eq!(keyword.iri_mapping(), Some("@type"));
+    assert!(keyword.is_protected());
+    assert_eq!(
+        keyword.containers(),
+        &BTreeSet::from([JsonLdContainer::Set])
+    );
+    assert_eq!(
+        compiled.term("typed").expect("typed").type_mapping(),
+        Some(&JsonLdTypeMapping::Id)
+    );
+    assert_eq!(
+        compiled
+            .term("vocabTyped")
+            .expect("vocab typed")
+            .type_mapping(),
+        Some(&JsonLdTypeMapping::Vocab)
+    );
+
+    for invalid in [
+        json!({"@type": "https://example.org/type"}),
+        json!({"@type": {"@container": "@index"}}),
+        json!({
+            "bad": {
+                "@container": "@type",
+                "@id": "https://example.org/bad",
+                "@type": "https://example.org/datatype"
+            }
+        }),
+    ] {
+        assert!(CompiledJsonLdContext::compile(&invalid, None).is_err());
+    }
+}
+
+#[test]
+fn explicit_self_mappings_compact_iri_consistency_and_relative_terms_are_checked() {
+    let self_mapped = CompiledJsonLdContext::compile(
+        &json!({"@vocab": "https://example.org/vocab/", "x": {"@id": "x"}}),
+        None,
+    )
+    .expect("self mapping");
+    assert_eq!(
+        self_mapped.term("x").expect("x").iri_mapping(),
+        Some("https://example.org/vocab/x")
+    );
+
+    let relative = CompiledJsonLdContext::compile(
+        &json!({"path/item": {}}),
+        Some("https://example.org/base/document"),
+    )
+    .expect("relative IRI term");
+    assert_eq!(
+        relative
+            .term("path/item")
+            .expect("relative term")
+            .iri_mapping(),
+        Some("https://example.org/base/path/item")
+    );
+
+    let mismatch = CompiledJsonLdContext::compile(
+        &json!({
+            "ex": {"@id": "https://example.org/", "@prefix": true},
+            "ex:item": {"@id": "https://other.example/item"}
+        }),
+        None,
+    )
+    .expect_err("compact IRI term must agree with explicit mapping");
+    assert!(mismatch.message.contains("term itself expands"));
+}
+
+#[test]
+fn reverse_definitions_accept_null_containers_and_stop_after_reverse() {
+    let compiled = CompiledJsonLdContext::compile(
+        &json!({
+            "reverse": {
+                "@container": null,
+                "@direction": "rtl",
+                "@language": "en",
+                "@reverse": "https://example.org/reverse",
+                "@type": "@id"
+            }
+        }),
+        None,
+    )
+    .expect("reverse definition");
+    let reverse = compiled.term("reverse").expect("reverse");
+    assert!(reverse.is_reverse_property());
+    assert!(reverse.containers().is_empty());
+    assert_eq!(reverse.type_mapping(), Some(&JsonLdTypeMapping::Id));
+    assert_eq!(reverse.language_mapping(), None);
+    assert_eq!(reverse.direction_mapping(), None);
+
+    assert!(
+        CompiledJsonLdContext::compile(
+            &json!({"bad": {"@reverse": "https://example.org/p", "@nest": "nest"}}),
+            None,
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn inverse_context_uses_exact_language_direction_and_any_keys() {
+    let iri = "https://example.org/p";
+    let compiled = CompiledJsonLdContext::compile(
+        &json!({
+            "bothNull": {"@direction": null, "@id": iri, "@language": null},
+            "direction": {"@direction": "rtl", "@id": iri},
+            "directionNull": {"@direction": null, "@id": iri},
+            "language": {"@id": iri, "@language": "EN"},
+            "untyped": {"@id": iri, "@type": "@none"}
+        }),
+        None,
+    )
+    .expect("inverse context");
+
+    let cases = [
+        (JsonLdTermSelectionKind::Language, "@null", "bothNull"),
+        (JsonLdTermSelectionKind::Language, "_rtl", "direction"),
+        (JsonLdTermSelectionKind::Language, "@none", "directionNull"),
+        (JsonLdTermSelectionKind::Language, "en", "language"),
+        (JsonLdTermSelectionKind::Language, "@any", "untyped"),
+        (JsonLdTermSelectionKind::Type, "@any", "untyped"),
+    ];
+    for (kind, preferred, expected) in cases {
+        let selection =
+            JsonLdTermSelection::new([Vec::<JsonLdContainer>::new()], kind, [preferred]);
+        assert_eq!(
+            compiled
+                .compact_iri_with_selection(iri, true, Some(&selection))
+                .expect("inverse selection"),
+            expected
+        );
+    }
+}
+
+#[test]
+fn propagation_import_merge_cache_and_keyword_form_behavior_are_bounded() {
+    let propagated = CompiledJsonLdContext::compile(
+        &json!({
+            "@propagate": false,
+            "x": "https://example.org/x",
+            "y": "https://example.org/y"
+        }),
+        None,
+    )
+    .expect("non-propagating context");
+    assert!(!propagated.propagates());
+    assert!(propagated.has_previous_context());
+    let array = CompiledJsonLdContext::compile(
+        &json!([{"@propagate": false, "x": "https://example.org/x"}]),
+        None,
+    )
+    .expect("array item validates @propagate without changing the call default");
+    assert!(array.propagates());
+    assert!(!array.has_previous_context());
+
+    let imported = br#"{"@context":{"path/item":{"@id":"https://example.org/dir/path/item"}}}"#;
+    let repeated = br#"{"@context":{"cached":"https://example.org/cached"}}"#;
+    let registry = JsonLdContextRegistry::new([
+        ("https://example.org/imported", imported.to_vec()),
+        ("https://example.org/repeated", repeated.to_vec()),
+    ])
+    .expect("registry");
+    let merged = CompiledJsonLdContext::compile_with_registry(
+        &json!({"@import": "https://example.org/imported"}),
+        Some("https://example.org/dir/document"),
+        &registry,
+    )
+    .expect("reverse-merged import");
+    assert_eq!(
+        merged
+            .term("path/item")
+            .expect("imported term")
+            .iri_mapping(),
+        Some("https://example.org/dir/path/item")
+    );
+
+    let cache_limits = JsonLdContextLimits {
+        context_bytes: 256,
+        registry_bytes: repeated.len(),
+        ..limits()
+    };
+    compiler::compile(
+        &json!([
+            "https://example.org/repeated",
+            "https://example.org/repeated"
+        ]),
+        None,
+        &registry,
+        cache_limits,
+    )
+    .expect("cached remote context is charged once");
+
+    let ignored = CompiledJsonLdContext::compile(
+        &json!({"@Unknown": "ignored", "x": "https://example.org/x"}),
+        None,
+    )
+    .expect("unknown keyword form is ignored");
+    assert!(ignored.term("@Unknown").is_none());
+    assert!(
+        CompiledJsonLdContext::compile(&json!({"@triple": "https://example.org/forbidden"}), None,)
+            .is_err()
+    );
+}
+
+#[test]
+fn canonical_context_byte_limit_accepts_exactly_and_rejects_one_over() {
+    let context = json!({"x": "https://example.org/x"});
+    let canonical_bytes = serde_json::to_vec(&canonicalize(&context)).expect("canonical bytes");
+    let exact = JsonLdContextLimits {
+        context_bytes: canonical_bytes.len(),
+        ..limits()
+    };
+    compiler::compile(&context, None, &JsonLdContextRegistry::default(), exact)
+        .expect("exact context byte limit");
+    let error = compiler::compile(
+        &context,
+        None,
+        &JsonLdContextRegistry::default(),
+        JsonLdContextLimits {
+            context_bytes: canonical_bytes.len() - 1,
+            ..exact
+        },
+    )
+    .expect_err("one byte over context limit");
+    assert_eq!(error.code, "jsonld-context-limit");
+}
+
+#[test]
+fn compiled_context_is_safe_to_reuse_across_threads_and_options() {
+    let compiled = Arc::new(
+        CompiledJsonLdContext::from_prefixes([("ex", "https://example.org/")]).expect("context"),
+    );
+    let options = JsonLdSerializeOptions::compiled(Arc::clone(&compiled));
+    let handle = std::thread::spawn(move || {
+        let JsonLdSerializeMode::Context(context) = options.mode() else {
+            panic!("context mode");
+        };
+        context
+            .expand_iri("ex:item", true, false)
+            .expect("thread expansion")
+    });
+    assert_eq!(
+        handle.join().expect("thread"),
+        Some("https://example.org/item".to_owned())
+    );
+}

--- a/crates/rdf/src/native_codecs/jsonld/derived.rs
+++ b/crates/rdf/src/native_codecs/jsonld/derived.rs
@@ -3,7 +3,8 @@
 
 //! Deterministic, vocabulary-neutral context derivation from typed carrier IRI slots.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, HashSet};
+use std::hash::BuildHasherDefault;
 
 use super::carrier::{Document, Node, Term, Value};
 use super::{CompiledJsonLdContext, RdfDiagnostic};
@@ -13,7 +14,8 @@ const MAX_NAMESPACE_CANDIDATES: usize = 4_096;
 const MAX_DERIVED_TERMS: usize = 4_096;
 const MAX_DERIVED_CONTEXT_BYTES: usize = 1_048_576;
 const MAX_DERIVATION_WORK: usize = 262_144;
-const CONSERVATIVE_ALIAS: &str = "ns4095";
+
+type FixedHashSet<T> = HashSet<T, BuildHasherDefault<ahash::AHasher>>;
 
 #[derive(Debug, Clone, Copy)]
 struct DerivationLimits {
@@ -60,13 +62,13 @@ impl CandidateStats {
         Ok(())
     }
 
-    fn is_profitable(self, namespace: &str) -> Result<bool, RdfDiagnostic> {
+    fn is_profitable(self, alias: &str, namespace: &str) -> Result<bool, RdfDiagnostic> {
         let compacted_bytes = self
             .occurrences
-            .checked_mul(CONSERVATIVE_ALIAS.len() + 1)
+            .checked_mul(alias.len() + 1)
             .and_then(|bytes| bytes.checked_add(self.suffix_bytes))
             .ok_or_else(|| derived_limit("derived namespace compacted-byte count overflow"))?;
-        let context_cost = prefix_definition_cost(CONSERVATIVE_ALIAS, namespace)?;
+        let context_cost = prefix_definition_cost(alias, namespace)?;
         Ok(self
             .expanded_bytes
             .checked_sub(compacted_bytes)
@@ -76,7 +78,8 @@ impl CandidateStats {
 
 struct Collector {
     limits: DerivationLimits,
-    distinct: BTreeSet<String>,
+    distinct: FixedHashSet<String>,
+    reserved_schemes: FixedHashSet<String>,
     candidates: BTreeMap<String, CandidateStats>,
     work: usize,
 }
@@ -85,7 +88,8 @@ impl Collector {
     fn new(limits: DerivationLimits) -> Self {
         Self {
             limits,
-            distinct: BTreeSet::new(),
+            distinct: FixedHashSet::default(),
+            reserved_schemes: FixedHashSet::default(),
             candidates: BTreeMap::new(),
             work: 0,
         }
@@ -121,6 +125,12 @@ impl Collector {
                 )));
             }
             self.distinct.insert(iri.to_owned());
+            self.reserved_schemes.insert(
+                parsed
+                    .scheme()
+                    .expect("absolute IRI has a scheme")
+                    .to_ascii_lowercase(),
+            );
         }
         let Some(namespace) = namespace_boundary(iri) else {
             return Ok(());
@@ -142,24 +152,41 @@ impl Collector {
     }
 
     fn finish(self) -> Result<CompiledJsonLdContext, RdfDiagnostic> {
-        let mut selected = Vec::new();
+        let mut prefixes = Vec::new();
+        let mut alias_index = 0usize;
         for (namespace, stats) in self.candidates {
-            if stats.is_profitable(&namespace)? {
-                selected.push(namespace);
+            while self.reserved_schemes.contains(&format!("ns{alias_index}")) {
+                alias_index = alias_index
+                    .checked_add(1)
+                    .ok_or_else(|| derived_limit("derived alias index overflow"))?;
+            }
+            let alias = format!("ns{alias_index}");
+            if stats.is_profitable(&alias, &namespace)? {
+                prefixes.push((alias, namespace));
+                alias_index = alias_index
+                    .checked_add(1)
+                    .ok_or_else(|| derived_limit("derived alias index overflow"))?;
             }
         }
-        if selected.len() > self.limits.terms {
+        if prefixes.len() > self.limits.terms {
             return Err(derived_limit(format!(
                 "derived context requires {} terms; limit is {}",
-                selected.len(),
+                prefixes.len(),
                 self.limits.terms
             )));
         }
-        let prefixes = selected
-            .into_iter()
-            .enumerate()
-            .map(|(index, namespace)| (format!("ns{index}"), namespace))
-            .collect::<Vec<_>>();
+        let validation_work = self
+            .distinct
+            .len()
+            .checked_mul(prefixes.len())
+            .and_then(|work| work.checked_add(self.work))
+            .ok_or_else(|| derived_limit("derived-context validation work count overflow"))?;
+        if validation_work > self.limits.work {
+            return Err(derived_limit(format!(
+                "derived-context analysis and validation require {validation_work} operations; limit is {}",
+                self.limits.work
+            )));
+        }
         let context = CompiledJsonLdContext::from_prefixes(prefixes)?;
         let bytes = context.canonical_json().len();
         if bytes > self.limits.context_bytes {
@@ -168,7 +195,9 @@ impl Collector {
                 self.limits.context_bytes
             )));
         }
-        for iri in &self.distinct {
+        let mut distinct = self.distinct.iter().collect::<Vec<_>>();
+        distinct.sort_unstable();
+        for iri in distinct {
             let compacted = context.compact_iri(iri, true)?;
             let expanded = context
                 .expand_iri(&compacted, true, false)?
@@ -414,5 +443,46 @@ mod tests {
             let error = derive_from(iris.iter().copied(), limits).expect_err("one over limit");
             assert_eq!(error.code, "jsonld-derived-limit");
         }
+    }
+
+    #[test]
+    fn aliases_skip_schemes_present_in_the_dataset() {
+        let mut iris = repeated("https://example.org/vocab/", 32);
+        iris.push("ns0:external".to_owned());
+        let context = derive_from(iris.iter().map(String::as_str), DerivationLimits::default())
+            .expect("derive collision-free context");
+        assert!(context.canonical_context().get("ns0").is_none());
+        assert_eq!(
+            context.canonical_context()["ns1"]["@id"],
+            "https://example.org/vocab/"
+        );
+        assert_eq!(
+            context
+                .expand_iri(
+                    &context
+                        .compact_iri("ns0:external", true)
+                        .expect("compact absolute IRI"),
+                    true,
+                    false,
+                )
+                .expect("expand compact IRI"),
+            Some("ns0:external".to_owned())
+        );
+    }
+
+    #[test]
+    fn validation_work_limit_charges_every_iri_prefix_pair() {
+        let iris = repeated("https://example.org/vocab/", 32);
+        let exact = DerivationLimits {
+            work: 64,
+            ..DerivationLimits::default()
+        };
+        derive_from(iris.iter().map(String::as_str), exact).expect("exact work boundary");
+        let error = derive_from(
+            iris.iter().map(String::as_str),
+            DerivationLimits { work: 63, ..exact },
+        )
+        .expect_err("validation work exceeds limit by one");
+        assert_eq!(error.code, "jsonld-derived-limit");
     }
 }

--- a/crates/rdf/src/native_codecs/jsonld/derived.rs
+++ b/crates/rdf/src/native_codecs/jsonld/derived.rs
@@ -1,0 +1,418 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Deterministic, vocabulary-neutral context derivation from typed carrier IRI slots.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::carrier::{Document, Node, Term, Value};
+use super::{CompiledJsonLdContext, RdfDiagnostic};
+
+const MAX_DISTINCT_IRIS: usize = 65_536;
+const MAX_NAMESPACE_CANDIDATES: usize = 4_096;
+const MAX_DERIVED_TERMS: usize = 4_096;
+const MAX_DERIVED_CONTEXT_BYTES: usize = 1_048_576;
+const MAX_DERIVATION_WORK: usize = 262_144;
+const CONSERVATIVE_ALIAS: &str = "ns4095";
+
+#[derive(Debug, Clone, Copy)]
+struct DerivationLimits {
+    distinct_iris: usize,
+    namespace_candidates: usize,
+    terms: usize,
+    context_bytes: usize,
+    work: usize,
+}
+
+impl Default for DerivationLimits {
+    fn default() -> Self {
+        Self {
+            distinct_iris: MAX_DISTINCT_IRIS,
+            namespace_candidates: MAX_NAMESPACE_CANDIDATES,
+            terms: MAX_DERIVED_TERMS,
+            context_bytes: MAX_DERIVED_CONTEXT_BYTES,
+            work: MAX_DERIVATION_WORK,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct CandidateStats {
+    expanded_bytes: usize,
+    suffix_bytes: usize,
+    occurrences: usize,
+}
+
+impl CandidateStats {
+    fn record(&mut self, iri: &str, namespace: &str) -> Result<(), RdfDiagnostic> {
+        self.expanded_bytes = self
+            .expanded_bytes
+            .checked_add(iri.len())
+            .ok_or_else(|| derived_limit("derived namespace expanded-byte count overflow"))?;
+        self.suffix_bytes = self
+            .suffix_bytes
+            .checked_add(iri.len() - namespace.len())
+            .ok_or_else(|| derived_limit("derived namespace suffix-byte count overflow"))?;
+        self.occurrences = self
+            .occurrences
+            .checked_add(1)
+            .ok_or_else(|| derived_limit("derived namespace occurrence count overflow"))?;
+        Ok(())
+    }
+
+    fn is_profitable(self, namespace: &str) -> Result<bool, RdfDiagnostic> {
+        let compacted_bytes = self
+            .occurrences
+            .checked_mul(CONSERVATIVE_ALIAS.len() + 1)
+            .and_then(|bytes| bytes.checked_add(self.suffix_bytes))
+            .ok_or_else(|| derived_limit("derived namespace compacted-byte count overflow"))?;
+        let context_cost = prefix_definition_cost(CONSERVATIVE_ALIAS, namespace)?;
+        Ok(self
+            .expanded_bytes
+            .checked_sub(compacted_bytes)
+            .is_some_and(|saving| saving > context_cost))
+    }
+}
+
+struct Collector {
+    limits: DerivationLimits,
+    distinct: BTreeSet<String>,
+    candidates: BTreeMap<String, CandidateStats>,
+    work: usize,
+}
+
+impl Collector {
+    fn new(limits: DerivationLimits) -> Self {
+        Self {
+            limits,
+            distinct: BTreeSet::new(),
+            candidates: BTreeMap::new(),
+            work: 0,
+        }
+    }
+
+    fn record(&mut self, iri: &str) -> Result<(), RdfDiagnostic> {
+        self.work = self
+            .work
+            .checked_add(1)
+            .ok_or_else(|| derived_limit("derived-context work count overflow"))?;
+        if self.work > self.limits.work {
+            return Err(derived_limit(format!(
+                "derived-context analysis exceeds {} IRI-slot operations",
+                self.limits.work
+            )));
+        }
+        if iri.starts_with("_:") {
+            return Ok(());
+        }
+        let parsed = purrdf_iri::parse(iri).map_err(|source| {
+            derived_invalid(format!("cannot derive from invalid IRI `{iri}`: {source}"))
+        })?;
+        if !parsed.has_scheme() {
+            return Err(derived_invalid(format!(
+                "cannot derive from relative IRI `{iri}`"
+            )));
+        }
+        if !self.distinct.contains(iri) {
+            if self.distinct.len() == self.limits.distinct_iris {
+                return Err(derived_limit(format!(
+                    "derived-context analysis exceeds {} distinct IRIs",
+                    self.limits.distinct_iris
+                )));
+            }
+            self.distinct.insert(iri.to_owned());
+        }
+        let Some(namespace) = namespace_boundary(iri) else {
+            return Ok(());
+        };
+        if !self.candidates.contains_key(namespace) {
+            if self.candidates.len() == self.limits.namespace_candidates {
+                return Err(derived_limit(format!(
+                    "derived-context analysis exceeds {} namespace candidates",
+                    self.limits.namespace_candidates
+                )));
+            }
+            self.candidates
+                .insert(namespace.to_owned(), CandidateStats::default());
+        }
+        self.candidates
+            .get_mut(namespace)
+            .expect("candidate was inserted or already present")
+            .record(iri, namespace)
+    }
+
+    fn finish(self) -> Result<CompiledJsonLdContext, RdfDiagnostic> {
+        let mut selected = Vec::new();
+        for (namespace, stats) in self.candidates {
+            if stats.is_profitable(&namespace)? {
+                selected.push(namespace);
+            }
+        }
+        if selected.len() > self.limits.terms {
+            return Err(derived_limit(format!(
+                "derived context requires {} terms; limit is {}",
+                selected.len(),
+                self.limits.terms
+            )));
+        }
+        let prefixes = selected
+            .into_iter()
+            .enumerate()
+            .map(|(index, namespace)| (format!("ns{index}"), namespace))
+            .collect::<Vec<_>>();
+        let context = CompiledJsonLdContext::from_prefixes(prefixes)?;
+        let bytes = context.canonical_json().len();
+        if bytes > self.limits.context_bytes {
+            return Err(derived_limit(format!(
+                "derived context is {bytes} bytes; limit is {}",
+                self.limits.context_bytes
+            )));
+        }
+        for iri in &self.distinct {
+            let compacted = context.compact_iri(iri, true)?;
+            let expanded = context
+                .expand_iri(&compacted, true, false)?
+                .ok_or_else(|| derived_invalid("derived compact IRI has a null mapping"))?;
+            if expanded != *iri {
+                return Err(derived_invalid(format!(
+                    "derived compact IRI `{compacted}` does not round-trip `{iri}`"
+                )));
+            }
+        }
+        Ok(context)
+    }
+}
+
+pub(super) fn derive_context(document: &Document) -> Result<CompiledJsonLdContext, RdfDiagnostic> {
+    let mut collector = Collector::new(DerivationLimits::default());
+    collect_document(document, &mut collector)?;
+    collector.finish()
+}
+
+fn collect_document(document: &Document, collector: &mut Collector) -> Result<(), RdfDiagnostic> {
+    for node in &document.default_nodes {
+        collect_node(node, collector)?;
+    }
+    for graph in &document.named_graphs {
+        collector.record(&graph.id)?;
+        for node in &graph.nodes {
+            collect_node(node, collector)?;
+        }
+    }
+    Ok(())
+}
+
+fn collect_node(node: &Node, collector: &mut Collector) -> Result<(), RdfDiagnostic> {
+    collector.record(&node.id)?;
+    for rdf_type in &node.types {
+        collector.record(rdf_type)?;
+    }
+    for (predicate, values) in node.properties.iter().chain(node.reverse_properties.iter()) {
+        collector.record(predicate)?;
+        for value in values {
+            collect_value(value, collector)?;
+        }
+    }
+    Ok(())
+}
+
+fn collect_value(value: &Value, collector: &mut Collector) -> Result<(), RdfDiagnostic> {
+    collect_term(&value.term, collector)?;
+    for annotation in &value.annotations {
+        collect_node(annotation, collector)?;
+    }
+    Ok(())
+}
+
+fn collect_term(term: &Term, collector: &mut Collector) -> Result<(), RdfDiagnostic> {
+    match term {
+        Term::Id(iri) => collector.record(iri),
+        Term::Literal(literal) => {
+            if let Some(datatype) = &literal.datatype {
+                collector.record(datatype)?;
+            }
+            Ok(())
+        }
+        Term::Triple(triple) => {
+            collect_term(&triple.subject, collector)?;
+            collector.record(&triple.predicate)?;
+            collect_term(&triple.object, collector)
+        }
+        Term::List(values) => {
+            for value in values {
+                collect_value(value, collector)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn namespace_boundary(iri: &str) -> Option<&str> {
+    let parsed = purrdf_iri::parse(iri).ok()?;
+    if !parsed.has_scheme() || parsed.query().is_some() {
+        return None;
+    }
+    let scheme_end = parsed.scheme()?.len() + 1;
+    let boundary = iri
+        .rfind('#')
+        .filter(|index| *index >= scheme_end)
+        .or_else(|| iri.rfind('/').filter(|index| *index >= scheme_end))
+        .or_else(|| iri.rfind(':').filter(|index| *index >= scheme_end))?;
+    let split = boundary.checked_add(1)?;
+    let suffix = iri.get(split..)?;
+    if suffix.is_empty() || suffix.starts_with("//") || suffix.chars().any(char::is_whitespace) {
+        return None;
+    }
+    let namespace = iri.get(..split)?;
+    purrdf_iri::parse(namespace)
+        .is_ok_and(|parsed| parsed.has_scheme())
+        .then_some(namespace)
+}
+
+fn prefix_definition_cost(alias: &str, namespace: &str) -> Result<usize, RdfDiagnostic> {
+    let value = serde_json::json!({alias: {"@id": namespace, "@prefix": true}});
+    serde_json::to_vec(&value)
+        .map(|bytes| bytes.len())
+        .map_err(|source| derived_invalid(format!("encode derived prefix definition: {source}")))
+}
+
+fn derived_limit(message: impl Into<String>) -> RdfDiagnostic {
+    RdfDiagnostic::error("jsonld-derived-limit", message)
+}
+
+fn derived_invalid(message: impl Into<String>) -> RdfDiagnostic {
+    RdfDiagnostic::error("jsonld-derived-invalid", message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn derive_from<'a>(
+        iris: impl IntoIterator<Item = &'a str>,
+        limits: DerivationLimits,
+    ) -> Result<CompiledJsonLdContext, RdfDiagnostic> {
+        let mut collector = Collector::new(limits);
+        for iri in iris {
+            collector.record(iri)?;
+        }
+        collector.finish()
+    }
+
+    fn repeated(namespace: &str, count: usize) -> Vec<String> {
+        (0..count)
+            .map(|index| format!("{namespace}term{index}"))
+            .collect()
+    }
+
+    #[test]
+    fn safe_boundaries_cover_fragment_path_and_urn_namespaces() {
+        assert_eq!(
+            namespace_boundary("https://example.org/vocab#Term"),
+            Some("https://example.org/vocab#")
+        );
+        assert_eq!(
+            namespace_boundary("https://example.org/vocab/Term"),
+            Some("https://example.org/vocab/")
+        );
+        assert_eq!(namespace_boundary("urn:example:Term"), Some("urn:example:"));
+        assert_eq!(namespace_boundary("https://example.org/"), None);
+        assert_eq!(namespace_boundary("https://example.org/x?q=1"), None);
+    }
+
+    #[test]
+    fn aliases_are_sorted_neutral_profitable_and_vocab_free() {
+        let mut iris = repeated("https://z.example/vocab/", 32);
+        iris.extend(repeated("https://a.example/vocab#", 32));
+        iris.reverse();
+        let borrowed = iris.iter().map(String::as_str).collect::<Vec<_>>();
+        let context = derive_from(borrowed.iter().copied(), DerivationLimits::default())
+            .expect("derive context");
+        assert_eq!(context.vocab_mapping(), None);
+        assert_eq!(
+            context.canonical_context()["ns0"]["@id"],
+            "https://a.example/vocab#"
+        );
+        assert_eq!(
+            context.canonical_context()["ns1"]["@id"],
+            "https://z.example/vocab/"
+        );
+        assert_eq!(context.canonical_context()["ns0"]["@prefix"], true);
+
+        let mut sorted = borrowed.clone();
+        sorted.sort_unstable();
+        let reordered = derive_from(sorted, DerivationLimits::default()).expect("reordered");
+        assert_eq!(context.canonical_json(), reordered.canonical_json());
+    }
+
+    #[test]
+    fn unprofitable_candidates_are_discarded_stably() {
+        let context = derive_from(["https://example.org/only"], DerivationLimits::default())
+            .expect("derive empty context");
+        assert_eq!(context.canonical_context(), &serde_json::json!({}));
+    }
+
+    #[test]
+    fn distinct_candidate_and_work_limits_accept_boundary_and_reject_one_over() {
+        let limits = DerivationLimits {
+            distinct_iris: 2,
+            namespace_candidates: 2,
+            terms: 2,
+            context_bytes: MAX_DERIVED_CONTEXT_BYTES,
+            work: 2,
+        };
+        derive_from(["https://a.example/x", "https://b.example/y"], limits)
+            .expect("exact boundaries");
+        for constrained in [
+            DerivationLimits {
+                distinct_iris: 1,
+                ..limits
+            },
+            DerivationLimits {
+                namespace_candidates: 1,
+                ..limits
+            },
+            DerivationLimits { work: 1, ..limits },
+        ] {
+            let error = derive_from(["https://a.example/x", "https://b.example/y"], constrained)
+                .expect_err("one over limit");
+            assert_eq!(error.code, "jsonld-derived-limit");
+        }
+    }
+
+    #[test]
+    fn term_and_context_byte_limits_are_exact() {
+        let first = repeated("https://a.example/a/", 32);
+        let second = repeated("https://b.example/b/", 32);
+        let iris = first
+            .iter()
+            .chain(&second)
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        let context = derive_from(iris.iter().copied(), DerivationLimits::default())
+            .expect("derive two terms");
+        let exact_bytes = context.canonical_json().len();
+        derive_from(
+            iris.iter().copied(),
+            DerivationLimits {
+                terms: 2,
+                context_bytes: exact_bytes,
+                ..DerivationLimits::default()
+            },
+        )
+        .expect("exact term and byte boundary");
+        for limits in [
+            DerivationLimits {
+                terms: 1,
+                ..DerivationLimits::default()
+            },
+            DerivationLimits {
+                context_bytes: exact_bytes - 1,
+                ..DerivationLimits::default()
+            },
+        ] {
+            let error = derive_from(iris.iter().copied(), limits).expect_err("one over limit");
+            assert_eq!(error.code, "jsonld-derived-limit");
+        }
+    }
+}

--- a/crates/rdf/src/native_codecs/jsonld/expand.rs
+++ b/crates/rdf/src/native_codecs/jsonld/expand.rs
@@ -770,7 +770,10 @@ impl Builder {
         Ok(result)
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "container expansion keeps independent id, type, and index injections explicit"
+    )]
     fn expand_container_node(
         &mut self,
         raw: &JsonValue,

--- a/crates/rdf/src/native_codecs/jsonld/expand.rs
+++ b/crates/rdf/src/native_codecs/jsonld/expand.rs
@@ -1,0 +1,1447 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Context-aware expansion from compact JSON-LD-star into the typed carrier.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use serde_json::{Map, Value as JsonValue};
+
+use super::carrier::{Document, Literal, NamedGraph, Node, Term, Triple, Value};
+use super::{
+    CompiledJsonLdContext, JsonLdContainer, JsonLdDirection, JsonLdNullable, JsonLdTermDefinition,
+    JsonLdTypeMapping, RDF_FIRST, RDF_JSON, RDF_NIL, RDF_REIFIES, RDF_REST, RDF_TYPE, RdfDataset,
+    RdfDiagnostic, RdfQuad, RdfTerm, XSD_STRING, decode, parse, validated_iri_term,
+};
+use crate::{RdfLiteral, RdfTextDirection, RdfTriple};
+
+const XSD_BOOLEAN: &str = "http://www.w3.org/2001/XMLSchema#boolean";
+const XSD_DOUBLE: &str = "http://www.w3.org/2001/XMLSchema#double";
+const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+
+pub(super) fn expand_document(
+    document: &JsonValue,
+    context: &CompiledJsonLdContext,
+) -> Result<Document, RdfDiagnostic> {
+    let mut builder = Builder::new(document);
+    match document {
+        JsonValue::Array(entries) => {
+            for entry in entries {
+                builder.expand_graph_entry(entry, None, context)?;
+            }
+        }
+        JsonValue::Object(_) => builder.expand_graph_entry(document, None, context)?,
+        _ => {
+            return Err(decode(
+                "JSON-LD document must be an object or array of objects",
+            ));
+        }
+    }
+    Ok(builder.finish())
+}
+
+pub(super) fn carrier_to_dataset(document: &Document) -> Result<Arc<RdfDataset>, RdfDiagnostic> {
+    let mut lowerer = Lowerer::new(document);
+    for node in &document.default_nodes {
+        lowerer.lower_node(node, None)?;
+    }
+    for graph in &document.named_graphs {
+        let graph_name = id_term(&graph.id)?;
+        for node in &graph.nodes {
+            lowerer.lower_node(node, Some(&graph_name))?;
+        }
+    }
+    crate::dataset_from_quads(&lowerer.quads)
+        .map_err(|source| parse(format!("freeze JSON-LD-star quads: {source}")))
+}
+
+#[derive(Debug, Clone, Copy)]
+enum NodeDisposition {
+    Merge,
+    Detached,
+}
+
+struct Builder {
+    graphs: BTreeMap<Option<String>, BTreeMap<String, Node>>,
+    reserved_blank_nodes: BTreeSet<String>,
+    next_blank_node: usize,
+}
+
+impl Builder {
+    fn new(document: &JsonValue) -> Self {
+        let mut reserved_blank_nodes = BTreeSet::new();
+        collect_blank_node_ids(document, &mut reserved_blank_nodes);
+        Self {
+            graphs: BTreeMap::new(),
+            reserved_blank_nodes,
+            next_blank_node: 0,
+        }
+    }
+
+    fn finish(mut self) -> Document {
+        for nodes in self.graphs.values_mut() {
+            for node in nodes.values_mut() {
+                node.sort_values();
+            }
+        }
+        let default_nodes = self
+            .graphs
+            .remove(&None)
+            .unwrap_or_default()
+            .into_values()
+            .collect();
+        let named_graphs = self
+            .graphs
+            .into_iter()
+            .filter_map(|(graph, nodes)| {
+                graph.map(|id| NamedGraph {
+                    id,
+                    nodes: nodes.into_values().collect(),
+                })
+            })
+            .collect();
+        Document {
+            default_nodes,
+            named_graphs,
+        }
+    }
+
+    fn fresh_blank_node(&mut self) -> String {
+        loop {
+            let id = format!("_:jsonld{}", self.next_blank_node);
+            self.next_blank_node += 1;
+            if self.reserved_blank_nodes.insert(id.clone()) {
+                return id;
+            }
+        }
+    }
+
+    fn merge_node(&mut self, graph: Option<&str>, mut fragment: Node) {
+        let nodes = self.graphs.entry(graph.map(str::to_owned)).or_default();
+        let target = nodes
+            .entry(fragment.id.clone())
+            .or_insert_with(|| Node::new(fragment.id.clone()));
+        target.types.append(&mut fragment.types);
+        target.types.sort();
+        target.types.dedup();
+        for (property, mut values) in fragment.properties {
+            target
+                .properties
+                .entry(property)
+                .or_default()
+                .append(&mut values);
+        }
+        target.sort_values();
+    }
+
+    fn add_property(
+        &mut self,
+        graph: Option<&str>,
+        subject: String,
+        property: String,
+        value: Value,
+    ) {
+        let mut node = Node::new(subject);
+        node.properties.entry(property).or_default().push(value);
+        self.merge_node(graph, node);
+    }
+
+    fn expand_graph_entry(
+        &mut self,
+        entry: &JsonValue,
+        graph: Option<&str>,
+        context: &CompiledJsonLdContext,
+    ) -> Result<(), RdfDiagnostic> {
+        let object = entry
+            .as_object()
+            .ok_or_else(|| decode("JSON-LD graph entry must be an object"))?;
+        let active = object_context(context, object)?;
+        let members = expanded_members(&active, object)?;
+        if let Some(graph_value) = member(&members, "@graph") {
+            let has_node_members = members.iter().any(|entry| {
+                !matches!(
+                    entry.expanded.as_str(),
+                    "@context" | "@graph" | "@id" | "@included" | "@index"
+                )
+            });
+            let graph_id = if let Some(id) = member(&members, "@id") {
+                Some(expand_id_value(&active, id.value)?)
+            } else if has_node_members {
+                Some(self.fresh_blank_node())
+            } else {
+                graph.map(str::to_owned)
+            };
+            for node in as_values(graph_value.value) {
+                self.expand_graph_entry(node, graph_id.as_deref(), &active.child_context())?;
+            }
+            if let Some(included) = member(&members, "@included") {
+                for included in as_values(included.value) {
+                    self.expand_graph_entry(included, graph, &active.child_context())?;
+                }
+            }
+
+            // A graph object may also be a node object. Its @type, ordinary
+            // properties, @reverse, and @nest members describe the graph name in the
+            // containing graph and must not disappear merely because @graph is
+            // present. A pure @id/@graph wrapper, however, contributes no node
+            // statement of its own.
+            if has_node_members {
+                if member(&members, "@id").is_some() {
+                    self.expand_node(entry, graph, &active, NodeDisposition::Merge)?;
+                } else {
+                    let mut node = object.clone();
+                    insert_expanded_control(
+                        &mut node,
+                        &active,
+                        "@id",
+                        JsonValue::String(
+                            graph_id
+                                .clone()
+                                .expect("mixed graph object minted a graph identifier"),
+                        ),
+                    )?;
+                    self.expand_node(
+                        &JsonValue::Object(node),
+                        graph,
+                        &active,
+                        NodeDisposition::Merge,
+                    )?;
+                }
+            }
+            return Ok(());
+        }
+        self.expand_node(entry, graph, &active, NodeDisposition::Merge)
+            .map(|_| ())
+    }
+
+    fn expand_node(
+        &mut self,
+        value: &JsonValue,
+        graph: Option<&str>,
+        context: &CompiledJsonLdContext,
+        disposition: NodeDisposition,
+    ) -> Result<Node, RdfDiagnostic> {
+        let object = value
+            .as_object()
+            .ok_or_else(|| decode("JSON-LD node must be an object"))?;
+        let active = object_context(context, object)?;
+        let members = expanded_members(&active, object)?;
+        let id = member(&members, "@id")
+            .map(|entry| expand_id_value(&active, entry.value))
+            .transpose()?
+            .unwrap_or_else(|| self.fresh_blank_node());
+        let mut node = Node::new(id);
+
+        if let Some(types) = member(&members, "@type") {
+            for value in as_values(types.value) {
+                let compact = value
+                    .as_str()
+                    .or_else(|| {
+                        value
+                            .as_object()
+                            .and_then(|object| {
+                                expanded_member(&active, object, "@id").ok().flatten()
+                            })
+                            .and_then(JsonValue::as_str)
+                    })
+                    .ok_or_else(|| decode("@type value must be an IRI string"))?;
+                node.types
+                    .push(expand_required(&active, compact, true, false)?);
+            }
+        }
+
+        self.expand_node_members(&mut node, &members, graph, &active)?;
+        node.sort_values();
+        if matches!(disposition, NodeDisposition::Merge) {
+            self.merge_node(graph, node.clone());
+        }
+        Ok(node)
+    }
+
+    fn expand_node_members(
+        &mut self,
+        node: &mut Node,
+        members: &[ExpandedMember<'_>],
+        graph: Option<&str>,
+        context: &CompiledJsonLdContext,
+    ) -> Result<(), RdfDiagnostic> {
+        for entry in members {
+            match entry.expanded.as_str() {
+                "@context" | "@id" | "@type" => {}
+                "@included" => {
+                    for included in as_values(entry.value) {
+                        self.expand_node(
+                            included,
+                            graph,
+                            &context.child_context(),
+                            NodeDisposition::Merge,
+                        )?;
+                    }
+                }
+                "@nest" => {
+                    for nested in as_values(entry.value) {
+                        let object = nested
+                            .as_object()
+                            .ok_or_else(|| decode("@nest value must be an object"))?;
+                        let nested_members = expanded_members(context, object)?;
+                        self.expand_node_members(node, &nested_members, graph, context)?;
+                    }
+                }
+                "@reverse" => {
+                    let reverse = entry
+                        .value
+                        .as_object()
+                        .ok_or_else(|| decode("@reverse value must be an object"))?;
+                    let reverse_members = expanded_members(context, reverse)?;
+                    for reverse_entry in reverse_members {
+                        if reverse_entry.expanded.starts_with('@') {
+                            return Err(decode(format!(
+                                "unsupported keyword `{}` inside @reverse",
+                                reverse_entry.expanded
+                            )));
+                        }
+                        self.expand_property(node, graph, context, &reverse_entry, true)?;
+                    }
+                }
+                // `expand_graph_entry` processes this member before asking the node
+                // path to retain any co-resident node statements.
+                "@graph" | "@index" => {}
+                keyword if keyword.starts_with('@') => {
+                    return Err(decode(format!(
+                        "unsupported JSON-LD node keyword `{keyword}`"
+                    )));
+                }
+                _ => self.expand_property(node, graph, context, entry, false)?,
+            }
+        }
+        Ok(())
+    }
+
+    fn expand_property(
+        &mut self,
+        node: &mut Node,
+        graph: Option<&str>,
+        context: &CompiledJsonLdContext,
+        entry: &ExpandedMember<'_>,
+        reverse_block: bool,
+    ) -> Result<(), RdfDiagnostic> {
+        let definition = context.term(entry.original);
+        let scoped = context.scoped_context(entry.original)?;
+        let value_context = scoped.as_ref().unwrap_or(context);
+        let values = self.expand_property_values(entry.value, graph, value_context, definition)?;
+        let reverse =
+            reverse_block ^ definition.is_some_and(JsonLdTermDefinition::is_reverse_property);
+        if reverse {
+            for mut value in values {
+                let Term::Id(target) = value.term else {
+                    return Err(decode(format!(
+                        "reverse property `{}` requires node-reference values",
+                        entry.original
+                    )));
+                };
+                value.term = Term::Id(node.id.clone());
+                self.add_property(graph, target, entry.expanded.clone(), value);
+            }
+        } else {
+            node.properties
+                .entry(entry.expanded.clone())
+                .or_default()
+                .extend(values);
+        }
+        Ok(())
+    }
+
+    fn expand_property_values(
+        &mut self,
+        raw: &JsonValue,
+        graph: Option<&str>,
+        context: &CompiledJsonLdContext,
+        definition: Option<&JsonLdTermDefinition>,
+    ) -> Result<Vec<Value>, RdfDiagnostic> {
+        if definition.is_some_and(|definition| {
+            definition.type_mapping() == Some(&JsonLdTypeMapping::Json)
+                && !definition.containers().contains(&JsonLdContainer::Set)
+        }) {
+            return Ok(vec![expand_scalar(raw, context, definition)?]);
+        }
+        if definition
+            .is_some_and(|definition| definition.containers().contains(&JsonLdContainer::Graph))
+        {
+            return self.expand_graph_container(raw, graph, context, definition);
+        }
+        if definition
+            .is_some_and(|definition| definition.containers().contains(&JsonLdContainer::Language))
+        {
+            return expand_language_map(raw, context, definition);
+        }
+        if definition
+            .is_some_and(|definition| definition.containers().contains(&JsonLdContainer::Id))
+        {
+            return self.expand_id_map(raw, graph, context, definition);
+        }
+        if definition
+            .is_some_and(|definition| definition.containers().contains(&JsonLdContainer::Type))
+        {
+            return self.expand_type_map(raw, graph, context, definition);
+        }
+        if definition
+            .is_some_and(|definition| definition.containers().contains(&JsonLdContainer::Index))
+            && raw.is_object()
+        {
+            return self.expand_index_map(raw, graph, context, definition);
+        }
+        if definition
+            .is_some_and(|definition| definition.containers().contains(&JsonLdContainer::List))
+        {
+            let mut items = Vec::new();
+            for raw in as_values(raw) {
+                if let Some(value) = self.expand_value(raw, graph, context, definition)? {
+                    items.push(value);
+                }
+            }
+            return Ok(vec![Value::plain(Term::List(items))]);
+        }
+        if let Some(object) = raw.as_object() {
+            let active = object_context(context, object)?;
+            let members = expanded_members(&active, object)?;
+            if let Some(set) = member(&members, "@set") {
+                reject_unexpected_members(&members, "@set object", &["@context", "@set"])?;
+                return self.expand_property_values(set.value, graph, &active, definition);
+            }
+        }
+        let mut values = Vec::new();
+        for raw in as_values(raw) {
+            if let Some(value) = self.expand_value(raw, graph, context, definition)? {
+                values.push(value);
+            }
+        }
+        Ok(values)
+    }
+
+    fn expand_value(
+        &mut self,
+        raw: &JsonValue,
+        graph: Option<&str>,
+        context: &CompiledJsonLdContext,
+        definition: Option<&JsonLdTermDefinition>,
+    ) -> Result<Option<Value>, RdfDiagnostic> {
+        if raw.is_null() {
+            return Ok(None);
+        }
+        if !raw.is_object() {
+            return expand_scalar(raw, context, definition).map(Some);
+        }
+        let object = raw
+            .as_object()
+            .expect("non-object values returned before this point");
+        let active = object_context(context, object)?;
+        let members = expanded_members(&active, object)?;
+        if let Some(set) = member(&members, "@set") {
+            reject_unexpected_members(&members, "@set object", &["@context", "@set"])?;
+            let values = self.expand_property_values(set.value, graph, &active, definition)?;
+            if let [only] = values.as_slice() {
+                return Ok(Some(only.clone()));
+            }
+            return Err(decode("nested @set value must contain exactly one value"));
+        }
+        let mut value = if let Some(list) = member(&members, "@list") {
+            reject_unexpected_members(
+                &members,
+                "@list object",
+                &["@annotation", "@context", "@list"],
+            )?;
+            let mut items = Vec::new();
+            for item in as_values(list.value) {
+                if let Some(value) = self.expand_value(item, graph, &active, None)? {
+                    items.push(value);
+                }
+            }
+            Value::plain(Term::List(items))
+        } else if let Some(graph_value) = member(&members, "@graph") {
+            reject_unexpected_members(
+                &members,
+                "@graph object",
+                &["@annotation", "@context", "@graph", "@id", "@index"],
+            )?;
+            let graph_id = member(&members, "@id")
+                .map(|entry| expand_id_value(&active, entry.value))
+                .transpose()?
+                .unwrap_or_else(|| self.fresh_blank_node());
+            if member(&members, "@index").is_some() {
+                return Err(decode(
+                    "data-bearing @index metadata has no RDF dataset representation",
+                ));
+            }
+            self.expand_graph_contents(graph_value.value, &graph_id, &active)?;
+            Value::plain(Term::Id(graph_id))
+        } else if let Some(triple) = member(&members, "@triple") {
+            Value::plain(Term::Triple(Box::new(self.expand_triple(
+                triple.value,
+                graph,
+                &active,
+            )?)))
+        } else if member(&members, "@value").is_some_and(|member| member.value.is_null()) {
+            reject_unexpected_members(
+                &members,
+                "@value object",
+                &[
+                    "@annotation",
+                    "@context",
+                    "@direction",
+                    "@language",
+                    "@type",
+                    "@value",
+                ],
+            )?;
+            if member(&members, "@annotation").is_some() {
+                return Err(decode("null @value object cannot carry @annotation"));
+            }
+            return Ok(None);
+        } else if member(&members, "@value").is_some() {
+            reject_unexpected_members(
+                &members,
+                "@value object",
+                &[
+                    "@annotation",
+                    "@context",
+                    "@direction",
+                    "@language",
+                    "@type",
+                    "@value",
+                ],
+            )?;
+            Value::plain(Term::Literal(expand_value_object(&members, &active)?))
+        } else if let Some(id) = member(&members, "@id") {
+            let id = expand_id_value(&active, id.value)?;
+            let has_node_content = members.iter().any(|member| {
+                !matches!(member.expanded.as_str(), "@context" | "@id" | "@annotation")
+            });
+            if has_node_content {
+                let mut node_object = object.clone();
+                node_object.remove("@annotation");
+                self.expand_node(
+                    &JsonValue::Object(node_object),
+                    graph,
+                    &active,
+                    NodeDisposition::Merge,
+                )?;
+            }
+            Value::plain(Term::Id(id))
+        } else {
+            let node = self.expand_node(raw, graph, &active, NodeDisposition::Merge)?;
+            Value::plain(Term::Id(node.id))
+        };
+
+        if let Some(annotation) = member(&members, "@annotation") {
+            for annotation in as_values(annotation.value) {
+                value.annotations.push(self.expand_node(
+                    annotation,
+                    graph,
+                    &active,
+                    NodeDisposition::Detached,
+                )?);
+            }
+        }
+        Ok(Some(value))
+    }
+
+    fn expand_graph_container(
+        &mut self,
+        raw: &JsonValue,
+        graph: Option<&str>,
+        context: &CompiledJsonLdContext,
+        definition: Option<&JsonLdTermDefinition>,
+    ) -> Result<Vec<Value>, RdfDiagnostic> {
+        let definition = definition.expect("@graph container requires a term definition");
+        let containers = definition.containers();
+        if containers.contains(&JsonLdContainer::Id) || containers.contains(&JsonLdContainer::Index)
+        {
+            let map = raw
+                .as_object()
+                .ok_or_else(|| decode("@graph map container value must be an object"))?;
+            let mut values = Vec::new();
+            for (key, entries) in map {
+                for entry in as_values(entries) {
+                    let graph_id = if containers.contains(&JsonLdContainer::Id) && key != "@none" {
+                        expand_required(context, key, false, true)?
+                    } else {
+                        self.fresh_blank_node()
+                    };
+                    self.expand_graph_contents(entry, &graph_id, context)?;
+                    if containers.contains(&JsonLdContainer::Index) && key != "@none" {
+                        let index_mapping = definition.index_mapping().ok_or_else(|| {
+                            decode("data-bearing @index metadata has no RDF dataset representation")
+                        })?;
+                        self.add_property(
+                            graph,
+                            graph_id.clone(),
+                            index_mapping.to_owned(),
+                            Value::plain(Term::Literal(Literal {
+                                lexical: key.clone(),
+                                datatype: None,
+                                language: None,
+                                direction: None,
+                            })),
+                        );
+                    }
+                    values.push(Value::plain(Term::Id(graph_id)));
+                }
+            }
+            return Ok(values);
+        }
+
+        let mut values = Vec::new();
+        for entry in as_values(raw) {
+            let graph_id = self.fresh_blank_node();
+            self.expand_graph_contents(entry, &graph_id, context)?;
+            values.push(Value::plain(Term::Id(graph_id)));
+        }
+        Ok(values)
+    }
+
+    fn expand_graph_contents(
+        &mut self,
+        raw: &JsonValue,
+        graph_id: &str,
+        context: &CompiledJsonLdContext,
+    ) -> Result<(), RdfDiagnostic> {
+        self.graphs.entry(Some(graph_id.to_owned())).or_default();
+        for entry in as_values(raw) {
+            self.expand_graph_entry(entry, Some(graph_id), &context.child_context())?;
+        }
+        Ok(())
+    }
+
+    fn expand_triple(
+        &mut self,
+        raw: &JsonValue,
+        graph: Option<&str>,
+        context: &CompiledJsonLdContext,
+    ) -> Result<Triple, RdfDiagnostic> {
+        let object = raw
+            .as_object()
+            .ok_or_else(|| decode("@triple must be an object"))?;
+        let members = expanded_members(context, object)?;
+        reject_unexpected_members(
+            &members,
+            "@triple object",
+            &[
+                "@annotation",
+                "@context",
+                "@object",
+                "@predicate",
+                "@subject",
+            ],
+        )?;
+        if member(&members, "@annotation").is_some() {
+            return Err(decode(
+                "@annotation is not permitted inside a @triple object in RDF 1.2",
+            ));
+        }
+        let subject =
+            member(&members, "@subject").ok_or_else(|| decode("@triple missing @subject"))?;
+        let predicate =
+            member(&members, "@predicate").ok_or_else(|| decode("@triple missing @predicate"))?;
+        let object =
+            member(&members, "@object").ok_or_else(|| decode("@triple missing @object"))?;
+        let subject = self
+            .expand_value(subject.value, graph, context, None)?
+            .ok_or_else(|| decode("@triple @subject cannot be null"))?;
+        let object = self
+            .expand_value(object.value, graph, context, None)?
+            .ok_or_else(|| decode("@triple @object cannot be null"))?;
+        if !subject.annotations.is_empty() || !object.annotations.is_empty() {
+            return Err(decode(
+                "@annotation is not permitted inside a @triple component in RDF 1.2",
+            ));
+        }
+        if matches!(subject.term, Term::Literal(_) | Term::List(_)) {
+            return Err(decode("@triple @subject must be a node or triple term"));
+        }
+        let predicate = predicate
+            .value
+            .as_str()
+            .ok_or_else(|| decode("@triple @predicate must be a string"))?;
+        Ok(Triple {
+            subject: Box::new(subject.term),
+            predicate: expand_required(context, predicate, true, false)?,
+            object: Box::new(object.term),
+        })
+    }
+
+    fn expand_id_map(
+        &mut self,
+        raw: &JsonValue,
+        graph: Option<&str>,
+        context: &CompiledJsonLdContext,
+        definition: Option<&JsonLdTermDefinition>,
+    ) -> Result<Vec<Value>, RdfDiagnostic> {
+        let object = raw
+            .as_object()
+            .ok_or_else(|| decode("@id container value must be an object"))?;
+        let mut result = Vec::new();
+        for (key, entries) in object {
+            for entry in as_values(entries) {
+                let id = if key == "@none" {
+                    None
+                } else {
+                    Some(expand_required(context, key, false, true)?)
+                };
+                result.push(self.expand_container_node(
+                    entry,
+                    graph,
+                    context,
+                    definition,
+                    id.as_deref(),
+                    None,
+                    None,
+                )?);
+            }
+        }
+        Ok(result)
+    }
+
+    fn expand_type_map(
+        &mut self,
+        raw: &JsonValue,
+        graph: Option<&str>,
+        context: &CompiledJsonLdContext,
+        definition: Option<&JsonLdTermDefinition>,
+    ) -> Result<Vec<Value>, RdfDiagnostic> {
+        let object = raw
+            .as_object()
+            .ok_or_else(|| decode("@type container value must be an object"))?;
+        let mut result = Vec::new();
+        for (key, entries) in object {
+            let rdf_type = (key != "@none")
+                .then(|| expand_required(context, key, true, false))
+                .transpose()?;
+            for entry in as_values(entries) {
+                result.push(self.expand_container_node(
+                    entry,
+                    graph,
+                    context,
+                    definition,
+                    None,
+                    rdf_type.as_deref(),
+                    None,
+                )?);
+            }
+        }
+        Ok(result)
+    }
+
+    fn expand_index_map(
+        &mut self,
+        raw: &JsonValue,
+        graph: Option<&str>,
+        context: &CompiledJsonLdContext,
+        definition: Option<&JsonLdTermDefinition>,
+    ) -> Result<Vec<Value>, RdfDiagnostic> {
+        let object = raw
+            .as_object()
+            .ok_or_else(|| decode("@index container value must be an object"))?;
+        let index_mapping = definition.and_then(JsonLdTermDefinition::index_mapping);
+        let mut result = Vec::new();
+        for (key, entries) in object {
+            if key != "@none" && index_mapping.is_none() {
+                return Err(decode(
+                    "data-bearing @index metadata has no RDF dataset representation",
+                ));
+            }
+            for entry in as_values(entries) {
+                result.push(
+                    self.expand_container_node(
+                        entry,
+                        graph,
+                        context,
+                        definition,
+                        None,
+                        None,
+                        (key != "@none").then_some((
+                            index_mapping.expect("checked mapped index"),
+                            key.as_str(),
+                        )),
+                    )?,
+                );
+            }
+        }
+        Ok(result)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn expand_container_node(
+        &mut self,
+        raw: &JsonValue,
+        graph: Option<&str>,
+        context: &CompiledJsonLdContext,
+        definition: Option<&JsonLdTermDefinition>,
+        id: Option<&str>,
+        rdf_type: Option<&str>,
+        index: Option<(&str, &str)>,
+    ) -> Result<Value, RdfDiagnostic> {
+        let mut object = match raw {
+            JsonValue::Object(object) => object.clone(),
+            JsonValue::Null => Map::new(),
+            _ => {
+                return self
+                    .expand_value(raw, graph, context, definition)?
+                    .ok_or_else(|| decode("container value cannot be null"));
+            }
+        };
+        if let Some(id) = id {
+            insert_expanded_control(
+                &mut object,
+                context,
+                "@id",
+                JsonValue::String(id.to_owned()),
+            )?;
+        }
+        if let Some(rdf_type) = rdf_type {
+            insert_expanded_control(
+                &mut object,
+                context,
+                "@type",
+                JsonValue::String(rdf_type.to_owned()),
+            )?;
+        }
+        let node = self.expand_node(
+            &JsonValue::Object(object),
+            graph,
+            context,
+            NodeDisposition::Merge,
+        )?;
+        if let Some((property, value)) = index {
+            self.add_property(
+                graph,
+                node.id.clone(),
+                property.to_owned(),
+                Value::plain(Term::Literal(Literal {
+                    lexical: value.to_owned(),
+                    datatype: None,
+                    language: None,
+                    direction: None,
+                })),
+            );
+        }
+        Ok(Value::plain(Term::Id(node.id)))
+    }
+}
+
+fn expand_language_map(
+    raw: &JsonValue,
+    context: &CompiledJsonLdContext,
+    definition: Option<&JsonLdTermDefinition>,
+) -> Result<Vec<Value>, RdfDiagnostic> {
+    let object = raw
+        .as_object()
+        .ok_or_else(|| decode("@language container value must be an object"))?;
+    let direction = effective_direction(context, definition);
+    let mut values = Vec::new();
+    for (language, entries) in object {
+        for entry in as_values(entries) {
+            let lexical = entry
+                .as_str()
+                .ok_or_else(|| decode("language-map values must be strings"))?;
+            values.push(Value::plain(Term::Literal(Literal {
+                lexical: lexical.to_owned(),
+                datatype: None,
+                language: (language != "@none").then(|| language.to_ascii_lowercase()),
+                direction: direction.map(str::to_owned),
+            })));
+        }
+    }
+    Ok(values)
+}
+
+fn expand_scalar(
+    raw: &JsonValue,
+    context: &CompiledJsonLdContext,
+    definition: Option<&JsonLdTermDefinition>,
+) -> Result<Value, RdfDiagnostic> {
+    if let Some(mapping) = definition.and_then(JsonLdTermDefinition::type_mapping) {
+        match mapping {
+            JsonLdTypeMapping::Id | JsonLdTypeMapping::Vocab => {
+                let value = raw
+                    .as_str()
+                    .ok_or_else(|| decode("@id/@vocab coercion requires a string"))?;
+                return Ok(Value::plain(Term::Id(expand_required(
+                    context,
+                    value,
+                    matches!(mapping, JsonLdTypeMapping::Vocab),
+                    matches!(mapping, JsonLdTypeMapping::Id),
+                )?)));
+            }
+            JsonLdTypeMapping::Json => {
+                return Ok(Value::plain(Term::Literal(Literal {
+                    lexical: serde_json::to_string(raw)
+                        .map_err(|source| decode(format!("encode rdf:JSON value: {source}")))?,
+                    datatype: Some(RDF_JSON.to_owned()),
+                    language: None,
+                    direction: None,
+                })));
+            }
+            JsonLdTypeMapping::Datatype(datatype) => {
+                return Ok(Value::plain(Term::Literal(Literal {
+                    lexical: scalar_lexical_for_datatype(raw, Some(datatype))?,
+                    datatype: Some(datatype.clone()),
+                    language: None,
+                    direction: None,
+                })));
+            }
+            JsonLdTypeMapping::None => {}
+        }
+    }
+    let (lexical, datatype) = match raw {
+        JsonValue::String(value) => (value.clone(), None),
+        JsonValue::Bool(value) => (value.to_string(), Some(XSD_BOOLEAN.to_owned())),
+        JsonValue::Number(value) if value.as_i64().is_some() || value.as_u64().is_some() => {
+            (value.to_string(), Some(XSD_INTEGER.to_owned()))
+        }
+        JsonValue::Number(value) => (canonical_json_double(value)?, Some(XSD_DOUBLE.to_owned())),
+        _ => {
+            return Err(decode(
+                "JSON-LD scalar must be a string, number, or boolean",
+            ));
+        }
+    };
+    Ok(Value::plain(Term::Literal(Literal {
+        lexical,
+        datatype,
+        language: if raw.is_string() {
+            effective_language(context, definition).map(str::to_owned)
+        } else {
+            None
+        },
+        direction: if raw.is_string() {
+            effective_direction(context, definition).map(str::to_owned)
+        } else {
+            None
+        },
+    })))
+}
+
+fn expand_value_object(
+    members: &[ExpandedMember<'_>],
+    context: &CompiledJsonLdContext,
+) -> Result<Literal, RdfDiagnostic> {
+    let value = member(members, "@value")
+        .expect("caller checked @value member")
+        .value;
+    let expanded_type = member(members, "@type")
+        .map(|entry| {
+            entry
+                .value
+                .as_str()
+                .ok_or_else(|| decode("@type in a value object must be a string"))
+                .and_then(|value| expand_required(context, value, true, false))
+        })
+        .transpose()?;
+    let json_keyword = expanded_type.as_deref() == Some("@json");
+    let datatype = expanded_type.map(|datatype| {
+        if datatype == "@json" {
+            RDF_JSON.to_owned()
+        } else {
+            datatype
+        }
+    });
+    let language = member(members, "@language")
+        .map(|entry| {
+            entry
+                .value
+                .as_str()
+                .map(str::to_ascii_lowercase)
+                .ok_or_else(|| decode("@language must be a string"))
+        })
+        .transpose()?;
+    let direction = member(members, "@direction")
+        .map(|entry| {
+            let direction = entry
+                .value
+                .as_str()
+                .ok_or_else(|| decode("@direction must be a string"))?;
+            if !matches!(direction, "ltr" | "rtl") {
+                return Err(decode("@direction must be `ltr` or `rtl`"));
+            }
+            Ok(direction.to_owned())
+        })
+        .transpose()?;
+    if datatype.is_some() && (language.is_some() || direction.is_some()) {
+        return Err(decode(
+            "JSON-LD value object cannot combine @type with @language/@direction",
+        ));
+    }
+    if json_keyword {
+        return Ok(Literal {
+            lexical: serde_json::to_string(value)
+                .map_err(|source| decode(format!("encode rdf:JSON value: {source}")))?,
+            datatype,
+            language: None,
+            direction: None,
+        });
+    }
+    let inferred_datatype = if datatype.is_none() {
+        match value {
+            JsonValue::Bool(_) => Some(XSD_BOOLEAN.to_owned()),
+            JsonValue::Number(number) if number.as_i64().is_some() || number.as_u64().is_some() => {
+                Some(XSD_INTEGER.to_owned())
+            }
+            JsonValue::Number(_) => Some(XSD_DOUBLE.to_owned()),
+            _ => None,
+        }
+    } else {
+        None
+    };
+    let datatype = datatype
+        .filter(|datatype| datatype != XSD_STRING)
+        .or(inferred_datatype);
+    let lexical = scalar_lexical_for_datatype(value, datatype.as_deref())?;
+    Ok(Literal {
+        lexical,
+        datatype,
+        language,
+        direction,
+    })
+}
+
+fn scalar_lexical_for_datatype(
+    value: &JsonValue,
+    datatype: Option<&str>,
+) -> Result<String, RdfDiagnostic> {
+    match value {
+        JsonValue::String(value) => Ok(value.clone()),
+        JsonValue::Bool(value) => Ok(value.to_string()),
+        JsonValue::Number(value) if datatype == Some(XSD_DOUBLE) => canonical_json_double(value),
+        JsonValue::Number(value) if value.as_i64().is_some() || value.as_u64().is_some() => {
+            Ok(value.to_string())
+        }
+        // JSON-LD's RDF conversion uses the canonical xsd:double lexical for
+        // every non-integral JSON number even when a context coerces the final
+        // datatype to another IRI.
+        JsonValue::Number(value) => canonical_json_double(value),
+        _ => Err(decode(
+            "literal @value must be a scalar unless @type is @json",
+        )),
+    }
+}
+
+fn canonical_json_double(value: &serde_json::Number) -> Result<String, RdfDiagnostic> {
+    value
+        .as_f64()
+        .map(purrdf_xsd::numeric::canonical_double)
+        .ok_or_else(|| {
+            decode(format!(
+                "JSON number `{value}` is outside the xsd:double value space"
+            ))
+        })
+}
+
+fn effective_language<'a>(
+    context: &'a CompiledJsonLdContext,
+    definition: Option<&'a JsonLdTermDefinition>,
+) -> Option<&'a str> {
+    match definition.and_then(JsonLdTermDefinition::language_mapping) {
+        Some(JsonLdNullable::Null) => None,
+        Some(JsonLdNullable::Value(language)) => Some(language),
+        None => context.default_language(),
+    }
+}
+
+fn effective_direction(
+    context: &CompiledJsonLdContext,
+    definition: Option<&JsonLdTermDefinition>,
+) -> Option<&'static str> {
+    match definition.and_then(JsonLdTermDefinition::direction_mapping) {
+        Some(JsonLdNullable::Null) => None,
+        Some(JsonLdNullable::Value(JsonLdDirection::LeftToRight)) => Some("ltr"),
+        Some(JsonLdNullable::Value(JsonLdDirection::RightToLeft)) => Some("rtl"),
+        None => context.default_direction().map(JsonLdDirection::as_str),
+    }
+}
+
+fn object_context(
+    parent: &CompiledJsonLdContext,
+    object: &Map<String, JsonValue>,
+) -> Result<CompiledJsonLdContext, RdfDiagnostic> {
+    object.get("@context").map_or_else(
+        || Ok(parent.clone()),
+        |local| parent.apply_local_context(local),
+    )
+}
+
+struct ExpandedMember<'a> {
+    original: &'a str,
+    expanded: String,
+    value: &'a JsonValue,
+}
+
+fn expanded_members<'a>(
+    context: &CompiledJsonLdContext,
+    object: &'a Map<String, JsonValue>,
+) -> Result<Vec<ExpandedMember<'a>>, RdfDiagnostic> {
+    let mut seen = BTreeSet::new();
+    let mut members = Vec::with_capacity(object.len());
+    for (key, value) in object {
+        let Some(expanded) = context.expand_iri(key, true, false)? else {
+            continue;
+        };
+        if expanded.starts_with('@') && !seen.insert(expanded.clone()) {
+            return Err(decode(format!(
+                "JSON-LD object has multiple members expanding to `{expanded}`"
+            )));
+        }
+        members.push(ExpandedMember {
+            original: key,
+            expanded,
+            value,
+        });
+    }
+    Ok(members)
+}
+
+fn member<'a, 'b>(
+    members: &'b [ExpandedMember<'a>],
+    keyword: &str,
+) -> Option<&'b ExpandedMember<'a>> {
+    members.iter().find(|entry| entry.expanded == keyword)
+}
+
+fn expanded_member<'a>(
+    context: &CompiledJsonLdContext,
+    object: &'a Map<String, JsonValue>,
+    keyword: &str,
+) -> Result<Option<&'a JsonValue>, RdfDiagnostic> {
+    let members = expanded_members(context, object)?;
+    Ok(member(&members, keyword).map(|member| member.value))
+}
+
+fn reject_unexpected_members(
+    members: &[ExpandedMember<'_>],
+    shape: &str,
+    allowed: &[&str],
+) -> Result<(), RdfDiagnostic> {
+    if let Some(member) = members
+        .iter()
+        .find(|member| !allowed.contains(&member.expanded.as_str()))
+    {
+        return Err(decode(format!(
+            "{shape} contains unexpected member `{}`",
+            member.original
+        )));
+    }
+    Ok(())
+}
+
+fn expand_required(
+    context: &CompiledJsonLdContext,
+    value: &str,
+    vocab: bool,
+    document_relative: bool,
+) -> Result<String, RdfDiagnostic> {
+    context
+        .expand_iri(value, vocab, document_relative)?
+        .ok_or_else(|| decode(format!("`{value}` has a null JSON-LD IRI mapping")))
+}
+
+fn expand_id_value(
+    context: &CompiledJsonLdContext,
+    value: &JsonValue,
+) -> Result<String, RdfDiagnostic> {
+    let value = value
+        .as_str()
+        .ok_or_else(|| decode("@id must be a string"))?;
+    if value.starts_with("_:") {
+        Ok(value.to_owned())
+    } else {
+        expand_required(context, value, false, true)
+    }
+}
+
+fn as_values(value: &JsonValue) -> Vec<&JsonValue> {
+    match value {
+        JsonValue::Array(values) => values.iter().collect(),
+        value => vec![value],
+    }
+}
+
+fn insert_expanded_control(
+    object: &mut Map<String, JsonValue>,
+    context: &CompiledJsonLdContext,
+    keyword: &str,
+    value: JsonValue,
+) -> Result<(), RdfDiagnostic> {
+    if expanded_member(context, object, keyword)?.is_some() {
+        return Err(decode(format!(
+            "container map value already defines `{keyword}`"
+        )));
+    }
+    object.insert(keyword.to_owned(), value);
+    Ok(())
+}
+
+fn collect_blank_node_ids(value: &JsonValue, output: &mut BTreeSet<String>) {
+    match value {
+        JsonValue::String(value) if value.starts_with("_:") => {
+            output.insert(value.clone());
+        }
+        JsonValue::Array(values) => {
+            for value in values {
+                collect_blank_node_ids(value, output);
+            }
+        }
+        JsonValue::Object(object) => {
+            for value in object.values() {
+                collect_blank_node_ids(value, output);
+            }
+        }
+        _ => {}
+    }
+}
+
+struct Lowerer {
+    quads: Vec<RdfQuad>,
+    reserved_blank_nodes: BTreeSet<String>,
+    next_list: usize,
+}
+
+impl Lowerer {
+    fn new(document: &Document) -> Self {
+        let mut reserved_blank_nodes = BTreeSet::new();
+        for graph in &document.named_graphs {
+            reserve_blank_id(&graph.id, &mut reserved_blank_nodes);
+        }
+        for node in document.default_nodes.iter().chain(
+            document
+                .named_graphs
+                .iter()
+                .flat_map(|graph| graph.nodes.iter()),
+        ) {
+            reserve_node_blank_ids(node, &mut reserved_blank_nodes);
+        }
+        Self {
+            quads: Vec::new(),
+            reserved_blank_nodes,
+            next_list: 0,
+        }
+    }
+
+    fn fresh_list_node(&mut self) -> RdfTerm {
+        loop {
+            let label = format!("jsonld_list_{}", self.next_list);
+            self.next_list += 1;
+            if self.reserved_blank_nodes.insert(label.clone()) {
+                return RdfTerm::blank_node(label);
+            }
+        }
+    }
+
+    fn lower_node(&mut self, node: &Node, graph: Option<&RdfTerm>) -> Result<(), RdfDiagnostic> {
+        let subject = id_term(&node.id)?;
+        for rdf_type in &node.types {
+            self.push(
+                subject.clone(),
+                RDF_TYPE,
+                validated_iri_term(rdf_type)?,
+                graph,
+            );
+        }
+        for (predicate, values) in &node.properties {
+            validated_iri_term(predicate)?;
+            for value in values {
+                let object = self.lower_term(&value.term, graph)?;
+                self.push(subject.clone(), predicate, object.clone(), graph);
+                self.lower_annotations(&subject, predicate, &object, &value.annotations, graph)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn lower_annotations(
+        &mut self,
+        subject: &RdfTerm,
+        predicate: &str,
+        object: &RdfTerm,
+        annotations: &[Node],
+        graph: Option<&RdfTerm>,
+    ) -> Result<(), RdfDiagnostic> {
+        for annotation in annotations {
+            let reifier = id_term(&annotation.id)?;
+            let triple =
+                RdfTerm::triple(RdfTriple::new(subject.clone(), predicate, object.clone()));
+            self.push(reifier.clone(), RDF_REIFIES, triple, graph);
+            for rdf_type in &annotation.types {
+                self.push(
+                    reifier.clone(),
+                    RDF_TYPE,
+                    validated_iri_term(rdf_type)?,
+                    graph,
+                );
+            }
+            for (ann_predicate, values) in &annotation.properties {
+                validated_iri_term(ann_predicate)?;
+                for value in values {
+                    let ann_object = self.lower_term(&value.term, graph)?;
+                    self.push(reifier.clone(), ann_predicate, ann_object.clone(), graph);
+                    self.lower_annotations(
+                        &reifier,
+                        ann_predicate,
+                        &ann_object,
+                        &value.annotations,
+                        graph,
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn lower_term(
+        &mut self,
+        term: &Term,
+        graph: Option<&RdfTerm>,
+    ) -> Result<RdfTerm, RdfDiagnostic> {
+        match term {
+            Term::Id(id) => id_term(id),
+            Term::Literal(literal) => lower_literal(literal),
+            Term::Triple(triple) => {
+                let subject = self.lower_term(&triple.subject, graph)?;
+                if matches!(subject, RdfTerm::Literal(_)) {
+                    return Err(decode("RDF triple-term subject cannot be a literal"));
+                }
+                validated_iri_term(&triple.predicate)?;
+                let object = self.lower_term(&triple.object, graph)?;
+                Ok(RdfTerm::triple(RdfTriple::new(
+                    subject,
+                    &triple.predicate,
+                    object,
+                )))
+            }
+            Term::List(values) => self.lower_list(values, graph),
+        }
+    }
+
+    fn lower_list(
+        &mut self,
+        values: &[Value],
+        graph: Option<&RdfTerm>,
+    ) -> Result<RdfTerm, RdfDiagnostic> {
+        if values.is_empty() {
+            return validated_iri_term(RDF_NIL);
+        }
+        let head = self.fresh_list_node();
+        let mut current = head.clone();
+        for (index, value) in values.iter().enumerate() {
+            let item = self.lower_term(&value.term, graph)?;
+            self.push(current.clone(), RDF_FIRST, item.clone(), graph);
+            self.lower_annotations(&current, RDF_FIRST, &item, &value.annotations, graph)?;
+            let rest = if index + 1 == values.len() {
+                validated_iri_term(RDF_NIL)?
+            } else {
+                self.fresh_list_node()
+            };
+            self.push(current, RDF_REST, rest.clone(), graph);
+            current = rest;
+        }
+        Ok(head)
+    }
+
+    fn push(
+        &mut self,
+        subject: RdfTerm,
+        predicate: &str,
+        object: RdfTerm,
+        graph: Option<&RdfTerm>,
+    ) {
+        let mut quad = RdfQuad::new(subject, predicate, object);
+        if let Some(graph) = graph {
+            quad = quad.in_graph(graph.clone());
+        }
+        self.quads.push(quad);
+    }
+}
+
+fn reserve_node_blank_ids(node: &Node, output: &mut BTreeSet<String>) {
+    reserve_blank_id(&node.id, output);
+    for values in node
+        .properties
+        .values()
+        .chain(node.reverse_properties.values())
+    {
+        for value in values {
+            reserve_value_blank_ids(value, output);
+        }
+    }
+}
+
+fn reserve_value_blank_ids(value: &Value, output: &mut BTreeSet<String>) {
+    reserve_term_blank_ids(&value.term, output);
+    for annotation in &value.annotations {
+        reserve_node_blank_ids(annotation, output);
+    }
+}
+
+fn reserve_term_blank_ids(term: &Term, output: &mut BTreeSet<String>) {
+    match term {
+        Term::Id(id) => reserve_blank_id(id, output),
+        Term::Triple(triple) => {
+            reserve_term_blank_ids(&triple.subject, output);
+            reserve_term_blank_ids(&triple.object, output);
+        }
+        Term::List(values) => {
+            for value in values {
+                reserve_value_blank_ids(value, output);
+            }
+        }
+        Term::Literal(_) => {}
+    }
+}
+
+fn reserve_blank_id(id: &str, output: &mut BTreeSet<String>) {
+    if let Some(label) = id.strip_prefix("_:") {
+        output.insert(label.to_owned());
+    }
+}
+
+fn id_term(id: &str) -> Result<RdfTerm, RdfDiagnostic> {
+    if let Some(label) = id.strip_prefix("_:") {
+        if label.is_empty() {
+            return Err(decode("blank-node identifier cannot be empty"));
+        }
+        Ok(RdfTerm::blank_node(label.to_owned()))
+    } else {
+        validated_iri_term(id)
+    }
+}
+
+fn lower_literal(literal: &Literal) -> Result<RdfTerm, RdfDiagnostic> {
+    let value = match (
+        literal.language.as_deref(),
+        literal.direction.as_deref(),
+        literal.datatype.as_deref(),
+    ) {
+        (Some(language), Some(direction), _) => {
+            let direction = match direction {
+                "ltr" => RdfTextDirection::Ltr,
+                "rtl" => RdfTextDirection::Rtl,
+                _ => return Err(decode(format!("invalid direction `{direction}`"))),
+            };
+            RdfLiteral {
+                lexical_form: literal.lexical.clone(),
+                datatype: None,
+                language: Some(language.to_owned()),
+                direction: Some(direction),
+            }
+        }
+        (Some(language), None, _) => RdfLiteral::language_tagged(literal.lexical.clone(), language),
+        (None, None, Some(datatype)) => {
+            validated_iri_term(datatype)?;
+            RdfLiteral::typed(literal.lexical.clone(), datatype)
+        }
+        (None, Some(_), _) => {
+            return Err(decode("directional literal requires a language tag"));
+        }
+        (None, None, None) => RdfLiteral::simple(literal.lexical.clone()),
+    };
+    Ok(RdfTerm::literal(value))
+}

--- a/crates/rdf/src/native_codecs/jsonld/expand.rs
+++ b/crates/rdf/src/native_codecs/jsonld/expand.rs
@@ -453,7 +453,7 @@ impl Builder {
             )?;
             let mut items = Vec::new();
             for item in as_values(list.value) {
-                if let Some(value) = self.expand_value(item, graph, &active, None)? {
+                if let Some(value) = self.expand_value(item, graph, &active, definition)? {
                     items.push(value);
                 }
             }
@@ -534,7 +534,7 @@ impl Builder {
         };
 
         if let Some(annotation) = member(&members, "@annotation") {
-            for annotation in as_values(annotation.value) {
+            for annotation in non_null_values(annotation.value) {
                 value.annotations.push(self.expand_node(
                     annotation,
                     graph,
@@ -562,7 +562,7 @@ impl Builder {
                 .ok_or_else(|| decode("@graph map container value must be an object"))?;
             let mut values = Vec::new();
             for (key, entries) in map {
-                for entry in as_values(entries) {
+                for entry in non_null_values(entries) {
                     let graph_id = if containers.contains(&JsonLdContainer::Id) && key != "@none" {
                         expand_required(context, key, false, true)?
                     } else {
@@ -592,7 +592,7 @@ impl Builder {
         }
 
         let mut values = Vec::new();
-        for entry in as_values(raw) {
+        for entry in non_null_values(raw) {
             let graph_id = self.fresh_blank_node();
             self.expand_graph_contents(entry, &graph_id, context)?;
             values.push(Value::plain(Term::Id(graph_id)));
@@ -607,7 +607,7 @@ impl Builder {
         context: &CompiledJsonLdContext,
     ) -> Result<(), RdfDiagnostic> {
         self.graphs.entry(Some(graph_id.to_owned())).or_default();
-        for entry in as_values(raw) {
+        for entry in non_null_values(raw) {
             self.expand_graph_entry(entry, Some(graph_id), &context.child_context())?;
         }
         Ok(())
@@ -682,7 +682,7 @@ impl Builder {
             .ok_or_else(|| decode("@id container value must be an object"))?;
         let mut result = Vec::new();
         for (key, entries) in object {
-            for entry in as_values(entries) {
+            for entry in non_null_values(entries) {
                 let id = if key == "@none" {
                     None
                 } else {
@@ -717,7 +717,7 @@ impl Builder {
             let rdf_type = (key != "@none")
                 .then(|| expand_required(context, key, true, false))
                 .transpose()?;
-            for entry in as_values(entries) {
+            for entry in non_null_values(entries) {
                 result.push(self.expand_container_node(
                     entry,
                     graph,
@@ -750,7 +750,7 @@ impl Builder {
                     "data-bearing @index metadata has no RDF dataset representation",
                 ));
             }
-            for entry in as_values(entries) {
+            for entry in non_null_values(entries) {
                 result.push(
                     self.expand_container_node(
                         entry,
@@ -783,7 +783,6 @@ impl Builder {
     ) -> Result<Value, RdfDiagnostic> {
         let mut object = match raw {
             JsonValue::Object(object) => object.clone(),
-            JsonValue::Null => Map::new(),
             _ => {
                 return self
                     .expand_value(raw, graph, context, definition)?
@@ -840,7 +839,7 @@ fn expand_language_map(
     let direction = effective_direction(context, definition);
     let mut values = Vec::new();
     for (language, entries) in object {
-        for entry in as_values(entries) {
+        for entry in non_null_values(entries) {
             let lexical = entry
                 .as_str()
                 .ok_or_else(|| decode("language-map values must be strings"))?;
@@ -1158,11 +1157,15 @@ fn expand_id_value(
     }
 }
 
-fn as_values(value: &JsonValue) -> Vec<&JsonValue> {
+fn as_values(value: &JsonValue) -> &[JsonValue] {
     match value {
-        JsonValue::Array(values) => values.iter().collect(),
-        value => vec![value],
+        JsonValue::Array(values) => values,
+        value => std::slice::from_ref(value),
     }
+}
+
+fn non_null_values(value: &JsonValue) -> impl Iterator<Item = &JsonValue> {
+    as_values(value).iter().filter(|value| !value.is_null())
 }
 
 fn insert_expanded_control(

--- a/crates/rdf/src/native_codecs/mod.rs
+++ b/crates/rdf/src/native_codecs/mod.rs
@@ -71,6 +71,7 @@ pub use span::{ParseOptions, SpanTable};
 pub use parse::parse_dataset_forced_sequential;
 pub use serialize::{
     SerializeOutcome, serialize_dataset, serialize_dataset_base_only, serialize_dataset_to_format,
+    serialize_dataset_to_format_with_jsonld_options, serialize_dataset_with_jsonld_options,
 };
 
 use std::io::Write;

--- a/crates/rdf/src/native_codecs/serialize.rs
+++ b/crates/rdf/src/native_codecs/serialize.rs
@@ -20,6 +20,7 @@
 use std::collections::HashMap;
 use std::io::Write;
 
+use super::jsonld::JsonLdSerializeOptions;
 use super::media_type::{NativeRdfFormat, classify};
 use super::ser_model::{SerAnnotationRow, SerGraph, SerReifierRow, SerTerm, SerTermKind};
 use crate::ir::TermRef;
@@ -43,6 +44,35 @@ pub fn serialize_dataset<D: DatasetView>(
     selection: SerializeGraph<'_>,
 ) -> Result<Vec<u8>, RdfDiagnostic> {
     serialize_dataset_inner(dataset, media_type, selection, true)
+}
+
+/// Serialize JSON-LD or YAML-LD through the generic media-type surface under an
+/// explicit configured mode.
+///
+/// Supplying JSON-LD options for another syntax is a hard error instead of silently
+/// ignoring caller policy. Existing [`serialize_dataset`] calls retain their frozen
+/// expanded compatibility behavior.
+pub fn serialize_dataset_with_jsonld_options<D: DatasetView>(
+    dataset: &D,
+    media_type: &str,
+    selection: SerializeGraph<'_>,
+    options: &JsonLdSerializeOptions,
+) -> Result<Vec<u8>, RdfDiagnostic> {
+    let format = classify(media_type)?;
+    if !matches!(format, NativeRdfFormat::JsonLd | NativeRdfFormat::YamlLd) {
+        return Err(jsonld_options_unused(format));
+    }
+    let graph = build_ser_graph(dataset, format, selection, true)?;
+    let text = match format {
+        NativeRdfFormat::JsonLd => {
+            super::jsonld::serialize_ser_graph_with_options(&graph, options)?
+        }
+        NativeRdfFormat::YamlLd => {
+            super::jsonld::serialize_ser_graph_to_yamlld_with_options(&graph, options)?
+        }
+        _ => unreachable!("format was restricted to JSON-LD/YAML-LD"),
+    };
+    Ok(text.into_bytes())
 }
 
 /// Serialize a frozen [`RdfDataset`](crate::RdfDataset) to RDF text of `media_type`, emitting ONLY the
@@ -155,6 +185,43 @@ pub fn serialize_dataset_to_format<D: DatasetView>(
             directional_literals_dropped,
         })
     }
+}
+
+/// Serialize through the generic format surface with explicit JSON-LD/YAML-LD
+/// configuration.
+///
+/// The function accepts only the two JSON-LD family formats and reports zero loss for
+/// their RDF 1.2-capable carrier. Passing another format is a stable hard failure.
+pub fn serialize_dataset_to_format_with_jsonld_options<D: DatasetView>(
+    dataset: &D,
+    format: NativeRdfFormat,
+    _base_iri: Option<&str>,
+    options: &JsonLdSerializeOptions,
+) -> Result<SerializeOutcome, RdfDiagnostic> {
+    if !matches!(format, NativeRdfFormat::JsonLd | NativeRdfFormat::YamlLd) {
+        return Err(jsonld_options_unused(format));
+    }
+    let bytes = serialize_dataset_with_jsonld_options(
+        dataset,
+        format.media_type(),
+        SerializeGraph::Dataset,
+        options,
+    )?;
+    Ok(SerializeOutcome {
+        bytes,
+        statement_rows_dropped: 0,
+        directional_literals_dropped: 0,
+    })
+}
+
+fn jsonld_options_unused(format: NativeRdfFormat) -> RdfDiagnostic {
+    RdfDiagnostic::error(
+        "jsonld-options-unused",
+        format!(
+            "JSON-LD serialization options cannot be used with `{}`",
+            format.media_type()
+        ),
+    )
 }
 
 /// Count the base-quad OBJECT literals whose resolved term carries an RDF-1.2 base

--- a/crates/rdf/src/projections/csvw/config.rs
+++ b/crates/rdf/src/projections/csvw/config.rs
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::native_codecs::jsonld::CompiledJsonLdContext;
 
 use super::super::{ProjectionError, ProjectionLimits, validate_absolute_iri};
 
@@ -129,6 +132,8 @@ impl<'de> Deserialize<'de> for CsvwVocabulary {
 pub struct CsvwContext {
     iri: String,
     prefixes: BTreeMap<String, String>,
+    #[serde(skip)]
+    compiled: Arc<CompiledJsonLdContext>,
 }
 
 impl CsvwContext {
@@ -148,7 +153,19 @@ impl CsvwContext {
             validate_prefix(prefix)?;
             validate_namespace(namespace.clone(), "CSVW context prefix")?;
         }
-        Ok(Self { iri, prefixes })
+        let compiled = CompiledJsonLdContext::from_prefixes(
+            prefixes
+                .iter()
+                .map(|(prefix, namespace)| (prefix.clone(), namespace.clone())),
+        )
+        .map_err(|error| {
+            ProjectionError::configuration(format!("compile CSVW JSON-LD context: {error}"))
+        })?;
+        Ok(Self {
+            iri,
+            prefixes,
+            compiled: Arc::new(compiled),
+        })
     }
 
     /// Context identity serialized into generated metadata.
@@ -167,29 +184,34 @@ impl CsvwContext {
     ///
     /// Returns an input failure for an unknown prefix or malformed expanded IRI.
     pub fn expand_iri(&self, value: &str) -> Result<String, ProjectionError> {
-        if let Some((prefix, suffix)) = value.split_once(':')
-            && let Some(namespace) = self.prefixes.get(prefix)
+        if let Some((prefix, _)) = value.split_once(':')
+            && self.prefixes.contains_key(prefix)
         {
-            let expanded = format!("{namespace}{suffix}");
+            let expanded = self
+                .compiled
+                .expand_iri(value, true, false)
+                .map_err(|error| {
+                    ProjectionError::syntax(format!("expand CSVW compact IRI `{value}`: {error}"))
+                })?
+                .ok_or_else(|| {
+                    ProjectionError::syntax(format!(
+                        "CSVW compact IRI `{value}` has a null mapping"
+                    ))
+                })?;
             validate_absolute_iri(&expanded, "expanded CSVW IRI")?;
             return Ok(expanded);
         }
         if validate_absolute_iri(value, "CSVW IRI").is_ok() {
             return Ok(value.to_owned());
         }
-        let (prefix, suffix) = value.split_once(':').ok_or_else(|| {
+        let (prefix, _) = value.split_once(':').ok_or_else(|| {
             ProjectionError::syntax(format!(
                 "CSVW compact IRI `{value}` has no caller-supplied prefix"
             ))
         })?;
-        let namespace = self.prefixes.get(prefix).ok_or_else(|| {
-            ProjectionError::syntax(format!(
-                "CSVW compact IRI `{value}` uses unknown prefix `{prefix}`"
-            ))
-        })?;
-        let expanded = format!("{namespace}{suffix}");
-        validate_absolute_iri(&expanded, "expanded CSVW IRI")?;
-        Ok(expanded)
+        Err(ProjectionError::syntax(format!(
+            "CSVW compact IRI `{value}` uses unknown prefix `{prefix}`"
+        )))
     }
 }
 

--- a/crates/rdf/src/projections/csvw/rdf.rs
+++ b/crates/rdf/src/projections/csvw/rdf.rs
@@ -454,6 +454,8 @@ fn percent_encode(value: &str) -> String {
 }
 
 fn expand_jsonld_iri(value: &str, config: &CsvwConfig) -> Result<String, ProjectionError> {
+    // CSVW's fixed class names and metadata-base fallback are profile rules layered
+    // above the caller-supplied context; compact-IRI processing stays in CsvwContext.
     if matches!(
         value,
         "TableGroup" | "Table" | "Schema" | "Column" | "Dialect" | "Template"

--- a/crates/rdf/src/projections/research_object/dcat.rs
+++ b/crates/rdf/src/projections/research_object/dcat.rs
@@ -11,8 +11,6 @@ use purrdf_core::{DatasetView, LossLedger, research_object_to_rdf_loss_ledger};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
 
-use crate::native_codecs::jsonld::parse_jsonld;
-
 use super::super::{ProjectionError, ProjectionPackage, stable_identifier, validate_absolute_iri};
 use super::json::{
     ResearchObjectPackageProjection, ResearchObjectReadOutcome, canonical_json, ensure_sound,
@@ -730,85 +728,25 @@ fn graph_id(value: &Value) -> &str {
 }
 
 fn validate_semantic_jsonld(value: &Value, config: &DcatConfig) -> Result<(), ProjectionError> {
-    let expanded = expand_jsonld(value, config.context())?;
+    let mut expanded = value.clone();
+    expanded
+        .as_object_mut()
+        .expect("DCAT writer constructs an object document")
+        .remove("@context");
     let bytes = canonical_json(
         &expanded,
         config.common().limits(),
         "expanded DCAT semantic JSON-LD",
     )?;
-    parse_jsonld(&bytes).map_err(|error| {
+    crate::native_codecs::jsonld::parse_jsonld_with_context(
+        &bytes,
+        config.context().compiled_context(),
+    )
+    .map_err(|error| {
         ProjectionError::integrity(format!("validate DCAT JSON-LD semantics: {error}"))
             .at_path(DCAT_ARTIFACT)
     })?;
     Ok(())
-}
-
-fn expand_jsonld(value: &Value, context: &OfflineJsonLdContext) -> Result<Value, ProjectionError> {
-    match value {
-        Value::Array(values) => values
-            .iter()
-            .map(|value| expand_jsonld(value, context))
-            .collect::<Result<Vec<_>, _>>()
-            .map(Value::Array),
-        Value::Object(object) => {
-            let mut expanded = Map::new();
-            for (key, value) in object {
-                if key == "@context" {
-                    expanded.insert(key.clone(), Value::Object(Map::new()));
-                    continue;
-                }
-                let expanded_key = if key.starts_with('@') {
-                    key.clone()
-                } else if let Some(iri) = context.expand(key) {
-                    iri.to_owned()
-                } else if validate_absolute_iri(key, "DCAT JSON-LD property").is_ok() {
-                    key.clone()
-                } else {
-                    return Err(ProjectionError::integrity(format!(
-                        "DCAT compact term `{key}` has no offline expansion"
-                    ))
-                    .at_path(DCAT_ARTIFACT));
-                };
-                let expanded_value = if key == "@type" {
-                    expand_type_value(value, context)?
-                } else {
-                    expand_jsonld(value, context)?
-                };
-                expanded.insert(expanded_key, expanded_value);
-            }
-            Ok(Value::Object(expanded))
-        }
-        _ => Ok(value.clone()),
-    }
-}
-
-fn expand_type_value(
-    value: &Value,
-    context: &OfflineJsonLdContext,
-) -> Result<Value, ProjectionError> {
-    match value {
-        Value::String(value) => {
-            if let Some(iri) = context.expand(value) {
-                Ok(Value::String(iri.to_owned()))
-            } else if validate_absolute_iri(value, "DCAT JSON-LD type").is_ok() {
-                Ok(Value::String(value.clone()))
-            } else {
-                Err(ProjectionError::integrity(format!(
-                    "DCAT type `{value}` has no offline expansion"
-                ))
-                .at_path(DCAT_ARTIFACT))
-            }
-        }
-        Value::Array(values) => values
-            .iter()
-            .map(|value| expand_type_value(value, context))
-            .collect::<Result<Vec<_>, _>>()
-            .map(Value::Array),
-        _ => Err(
-            ProjectionError::integrity("DCAT @type must be a string or string array")
-                .at_path(DCAT_ARTIFACT),
-        ),
-    }
 }
 
 struct RawNode {

--- a/crates/rdf/src/projections/research_object/dcat.rs
+++ b/crates/rdf/src/projections/research_object/dcat.rs
@@ -728,16 +728,7 @@ fn graph_id(value: &Value) -> &str {
 }
 
 fn validate_semantic_jsonld(value: &Value, config: &DcatConfig) -> Result<(), ProjectionError> {
-    let mut expanded = value.clone();
-    expanded
-        .as_object_mut()
-        .expect("DCAT writer constructs an object document")
-        .remove("@context");
-    let bytes = canonical_json(
-        &expanded,
-        config.common().limits(),
-        "expanded DCAT semantic JSON-LD",
-    )?;
+    let bytes = canonical_json(value, config.common().limits(), "DCAT semantic JSON-LD")?;
     crate::native_codecs::jsonld::parse_jsonld_with_context(
         &bytes,
         config.context().compiled_context(),

--- a/crates/rdf/src/projections/research_object/json.rs
+++ b/crates/rdf/src/projections/research_object/json.rs
@@ -12,7 +12,9 @@ use serde::de::{DeserializeSeed, Error as _, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Number, Value};
 
-use crate::native_codecs::jsonld::{parse_jsonld, serialize_dataset_to_jsonld};
+use crate::native_codecs::jsonld::{
+    CompiledJsonLdContext, parse_jsonld, serialize_dataset_to_jsonld,
+};
 
 use super::super::{ProjectionError, ProjectionLimits, ProjectionPackage, validate_absolute_iri};
 use super::{ResearchObjectConfig, ResearchObjectModel};
@@ -26,6 +28,8 @@ use super::{ResearchObjectConfig, ResearchObjectModel};
 pub struct OfflineJsonLdContext {
     value: Value,
     definitions: BTreeMap<String, String>,
+    #[serde(skip)]
+    compiled: Arc<CompiledJsonLdContext>,
 }
 
 impl OfflineJsonLdContext {
@@ -64,7 +68,26 @@ impl OfflineJsonLdContext {
                 )));
             }
         }
-        Ok(Self { value, definitions })
+        let compiled_value = Value::Object(
+            definitions
+                .iter()
+                // Profile lookup tables historically permit colon-bearing role keys
+                // whose expansion is not CURIE concatenation. Those remain explicit
+                // profile rules; plain JSON-LD terms use the shared context engine.
+                .filter(|(term, _)| !term.contains(':'))
+                .map(|(term, iri)| (term.clone(), Value::String(iri.clone())))
+                .collect(),
+        );
+        let compiled = CompiledJsonLdContext::compile(&compiled_value, None).map_err(|error| {
+            ProjectionError::configuration(format!(
+                "compile offline JSON-LD term definitions: {error}"
+            ))
+        })?;
+        Ok(Self {
+            value,
+            definitions,
+            compiled: Arc::new(compiled),
+        })
     }
 
     /// Exact JSON value emitted as `@context`.
@@ -77,9 +100,25 @@ impl OfflineJsonLdContext {
         &self.definitions
     }
 
+    /// Reusable compiled active context backing this compatibility adapter.
+    pub fn compiled_context(&self) -> &CompiledJsonLdContext {
+        &self.compiled
+    }
+
     /// Resolve a configured compact term to its absolute vocabulary IRI.
     pub fn expand(&self, term: &str) -> Option<&str> {
-        self.definitions.get(term).map(String::as_str)
+        let expanded = self.definitions.get(term).map(String::as_str);
+        if !term.contains(':') {
+            debug_assert_eq!(
+                self.compiled
+                    .expand_iri(term, true, false)
+                    .ok()
+                    .flatten()
+                    .as_deref(),
+                expanded
+            );
+        }
+        expanded
     }
 }
 
@@ -462,6 +501,14 @@ mod tests {
         )
         .expect("context");
         assert_eq!(valid.expand("name"), Some("https://example.org/name"));
+        assert_eq!(
+            valid
+                .compiled_context()
+                .expand_iri("name", true, false)
+                .expect("expand configured term")
+                .as_deref(),
+            Some("https://example.org/name")
+        );
 
         assert!(
             OfflineJsonLdContext::new(

--- a/crates/rdf/tests/fixtures/jsonld-w3c-rec/LICENSE.md
+++ b/crates/rdf/tests/fixtures/jsonld-w3c-rec/LICENSE.md
@@ -1,0 +1,2 @@
+The JSON-LD Test Suite is covered by the dual-licensing approach described in
+[LICENSES FOR W3C TEST SUITES](https://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html).

--- a/crates/rdf/tests/fixtures/jsonld-w3c-rec/REUSE.toml
+++ b/crates/rdf/tests/fixtures/jsonld-w3c-rec/REUSE.toml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+version = 1
+
+[[annotations]]
+path = ["LICENSE.md", "compaction_vectors.json", "vectors.json"]
+SPDX-FileCopyrightText = "W3C JSON-LD Working Group contributors"
+SPDX-License-Identifier = "W3C-20150513"

--- a/crates/rdf/tests/fixtures/jsonld-w3c-rec/UPSTREAM.md
+++ b/crates/rdf/tests/fixtures/jsonld-w3c-rec/UPSTREAM.md
@@ -11,7 +11,8 @@ SHA-256 checksums in `vectors.json` or `compaction_vectors.json`.
 - Upstream: <https://github.com/w3c/json-ld-api>
 - Tag: `REC-2020-07-16`
 - Revision: `3e7fa5377b2b3c5176eacf8bde8e01fdb7c4a062`
-- Upstream paths: `tests/toRdf-manifest.jsonld` and `tests/toRdf/`
+- Upstream paths: `tests/toRdf-manifest.jsonld`, `tests/toRdf/`,
+  `tests/compact-manifest.jsonld`, and `tests/compact/`
 - Imported: 2026-07-17
 - Upstream terms: W3C Test Suite License, referenced in `LICENSE.md`
 

--- a/crates/rdf/tests/fixtures/jsonld-w3c-rec/UPSTREAM.md
+++ b/crates/rdf/tests/fixtures/jsonld-w3c-rec/UPSTREAM.md
@@ -1,0 +1,34 @@
+<!-- SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca> -->
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# Pinned W3C JSON-LD 1.1 conformance vectors
+
+This directory vendors 73 positive, offline, star-free `toRdf` cases and 13
+exact compaction cases from the W3C JSON-LD 1.1 Recommendation test suite. Each
+case retains the upstream input, oracle output, name, purpose, and byte-level
+SHA-256 checksums in `vectors.json` or `compaction_vectors.json`.
+
+- Upstream: <https://github.com/w3c/json-ld-api>
+- Tag: `REC-2020-07-16`
+- Revision: `3e7fa5377b2b3c5176eacf8bde8e01fdb7c4a062`
+- Upstream paths: `tests/toRdf-manifest.jsonld` and `tests/toRdf/`
+- Imported: 2026-07-17
+- Upstream terms: W3C Test Suite License, referenced in `LICENSE.md`
+
+The selection includes every positive, local, default-option core `toRdf` case
+in the upstream 0001-0036 and 0113-0132 ranges that does not require an implicit
+document URL, generalized RDF, or the standalone RFC 3986 stress matrix. It also
+covers full and compact IRIs, blank nodes, language and typed
+literals, type coercion, lists, reverse properties, scoped contexts, language,
+graph, ID, and type maps, JSON literals, transparent nesting, mapped indexes,
+protected terms, and order independence. Cases needing network retrieval,
+document-location injection, HTML processing, generalized RDF, or non-default
+API options are not applicable to PurRDF's offline dataset codec. The exact
+selection is executable and reviewable in `scripts/vendor-jsonld-rec.py`.
+
+The harness compares PurRDF expansion with the pinned N-Quads using RDF dataset
+isomorphism and compares compaction with the exact pinned W3C JSON after removing
+only PurRDF's documented single-node carrier wrapper. Both expected result sets
+are independent W3C oracles; no implementation output was used to generate them.
+The harness has no xfail path and asserts exact 73-case expansion/to-RDF and
+13-case compaction pass counts, revision, tag, unique IDs, and every checksum.

--- a/crates/rdf/tests/fixtures/jsonld-w3c-rec/compaction_vectors.json
+++ b/crates/rdf/tests/fixtures/jsonld-w3c-rec/compaction_vectors.json
@@ -1,0 +1,151 @@
+{
+  "schema_version": 1,
+  "upstream_revision": "3e7fa5377b2b3c5176eacf8bde8e01fdb7c4a062",
+  "upstream_tag": "REC-2020-07-16",
+  "expected_vector_count": 13,
+  "vectors": [
+    {
+      "id": "0005",
+      "name": "@type and prefix compaction",
+      "purpose": "Compact uses prefixes in @type",
+      "input_sha256": "497309c857317ae717e0410f4cb7cee29ee976cc5c36bd0002532faf667fa204",
+      "context_sha256": "f0f1ffe14ded2ebc2775f1422d6366114cc34e8f175cdef7000d83495ba81108",
+      "expected_sha256": "3729427a738c5beb5e54728bbbb6da55e5063b2e6254dd6b3026e65b0e75380c",
+      "input": "{\n  \"@id\": \"http://example.org/id1\",\n  \"@type\": [\"http://example.org/Type1\", \"http://example.org/Type2\"],\n  \"http://example.org/term1\": {\"@value\": \"v1\", \"@type\": \"http://example.org/datatype\"},\n  \"http://example.org/term2\": {\"@id\": \"http://example.org/id2\"}\n}",
+      "context": "{\n  \"@context\": {\n    \"ex\": \"http://example.org/\",\n    \"term1\": {\"@id\": \"ex:term1\", \"@type\": \"ex:datatype\"},\n    \"term2\": {\"@id\": \"ex:term2\", \"@type\": \"@id\"}\n  }\n}",
+      "expected": "{\n  \"@context\": {\n    \"ex\": \"http://example.org/\",\n    \"term1\": {\"@id\": \"ex:term1\", \"@type\": \"ex:datatype\"},\n    \"term2\": {\"@id\": \"ex:term2\", \"@type\": \"@id\"}\n  },\n  \"@id\": \"ex:id1\",\n  \"@type\": [\"ex:Type1\", \"ex:Type2\"],\n  \"term1\": \"v1\",\n  \"term2\": \"ex:id2\"\n}"
+    },
+    {
+      "id": "0006",
+      "name": "keep expanded object format if @type doesn't match",
+      "purpose": "Values not matching a coerced @type remain in expanded form",
+      "input_sha256": "b4a91a5867295896a252133a685f56733c0524a11fb7f30b10db6c7f6d2ade28",
+      "context_sha256": "79a9baea8fb32dc58f8dff55436cb6a8e540f536b08ec96ec6a97e9a3803a24a",
+      "expected_sha256": "481392e9b87095ed80eb2102750e4b30fe5f090423ad66b5232ddd43340a7b3b",
+      "input": "{\n  \"@id\": \"http://example.org/id1\",\n  \"@type\": [\"http://example.org/Type1\", \"http://example.org/Type2\"],\n  \"http://example.org/term1\": {\"@value\": \"v1\", \"@type\": \"http://example.org/different-datatype\"},\n  \"http://example.org/term2\": {\"@id\": \"http://example.org/id2\"}\n}\n",
+      "context": "{\n  \"@context\": {\n    \"ex\": \"http://example.org/\",\n    \"term1\": { \"@id\": \"ex:term1\", \"@type\": \"ex:datatype\" },\n    \"term2\": \"ex:term2\"\n  }\n}\n",
+      "expected": "{\n  \"@context\": {\n    \"ex\": \"http://example.org/\",\n    \"term1\": {\n      \"@id\": \"ex:term1\",\n      \"@type\": \"ex:datatype\"\n    },\n    \"term2\": \"ex:term2\"\n  },\n  \"@id\": \"ex:id1\",\n  \"@type\": [\"ex:Type1\", \"ex:Type2\"],\n  \"ex:term1\": {\"@value\": \"v1\", \"@type\": \"ex:different-datatype\"},\n  \"term2\": {\"@id\": \"ex:id2\"}\n}\n"
+    },
+    {
+      "id": "0013",
+      "name": "@value with @language",
+      "purpose": "Values with @language remain in expanded form by default",
+      "input_sha256": "ea95811783b355edb700b563964bf197b8901e34681bcb7b1f29f5529854afeb",
+      "context_sha256": "a539309efbe7be8122e34ffc7ed7e4d9f841e5b251babfb44e2d9d9d5ab2ec90",
+      "expected_sha256": "16bda288bf40d0b7d76af41dcc64b3dd0aa385bd8eb772edc7878be76f765c7f",
+      "input": "{\n  \"@id\": \"http://example.org/test\",\n  \"http://example.org/vocab#test\": {\"@value\": \"test\", \"@language\": \"en\"}\n}",
+      "context": "{\n  \"@context\": {\n    \"ex\": \"http://example.org/vocab#\"\n  }\n}",
+      "expected": "{\n  \"@context\": {\n    \"ex\": \"http://example.org/vocab#\"\n  },\n  \"@id\": \"http://example.org/test\",\n  \"ex:test\": {\"@value\": \"test\", \"@language\": \"en\"}\n}"
+    },
+    {
+      "id": "0022",
+      "name": "@list compaction of nested properties",
+      "purpose": "Compact nested properties using @list containers",
+      "input_sha256": "52a69ffa428f98807721ebe1727c98bd7a400472159c01d90a857b6249cecedd",
+      "context_sha256": "3b3e20a02005b7ae5682b949eececc60fde5dc30b52187938fd32cf5b84aab24",
+      "expected_sha256": "f806db006c4ea28e68702d84625d41bee8e9f796536548d0fe31c402b95e88ce",
+      "input": "[\n  {\n    \"@id\": \"https://example.org/ns#Game\",\n    \"@type\": [\n      \"http://www.w3.org/2002/07/owl#Class\"\n    ],\n    \"https://example.org/ns#properties\": [\n      {\n        \"@list\": [\n          {\n            \"@id\": \"https://example.org/ns#title\"\n          },\n          {\n            \"@id\": \"https://example.org/ns#slug\"\n          }\n        ]\n      }\n    ]\n  },\n  {\n    \"@id\": \"https://example.org/ns#properties\",\n    \"@type\": [\n      \"http://www.w3.org/1999/02/22-rdf-syntax-ns#Property\"\n    ]\n  },\n  {\n    \"@id\": \"https://example.org/ns#slug\",\n    \"@type\": [\n      \"http://www.w3.org/2002/07/owl#DataProperty\",\n      \"http://www.w3.org/2002/07/owl#FunctionalProperty\"\n    ]\n  },\n  {\n    \"@id\": \"https://example.org/ns#title\",\n    \"@type\": [\n      \"http://www.w3.org/2002/07/owl#DataProperty\"\n    ]\n  }\n]\n",
+      "context": "{\n  \"@context\": {\n    \"owl\": \"http://www.w3.org/2002/07/owl#\",\n    \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n    \"ex\": \"https://example.org/ns#\",\n    \"id\": \"@id\",\n    \"type\": \"@type\",\n    \"ex:properties\": { \"@container\": \"@list\" }\n  }\n}\n",
+      "expected": "{\n  \"@context\": {\n    \"owl\": \"http://www.w3.org/2002/07/owl#\",\n    \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n    \"ex\": \"https://example.org/ns#\",\n    \"id\": \"@id\",\n    \"type\": \"@type\",\n    \"ex:properties\": {\n        \"@container\": \"@list\"\n    }\n  },\n  \"@graph\": [\n    {\n      \"id\": \"ex:Game\",\n      \"type\": \"owl:Class\",\n      \"ex:properties\": [\n        { \"id\": \"ex:title\" },\n        { \"id\": \"ex:slug\" }\n      ]\n    },\n    {\n      \"id\": \"ex:properties\",\n      \"type\": \"rdf:Property\"\n    },\n    {\n      \"id\": \"ex:slug\",\n      \"type\": [ \"owl:DataProperty\", \"owl:FunctionalProperty\" ]\n    },\n    {\n      \"id\": \"ex:title\",\n      \"type\": \"owl:DataProperty\"\n    }\n  ]\n}\n"
+    },
+    {
+      "id": "0024",
+      "name": "most specific term matching in @list.",
+      "purpose": "The most specific term that matches all of the elements in the list, taking into account the default language, must be selected.",
+      "input_sha256": "fc2006192770aff4e78da7f7e4b556e20c4103cd46402ae458e51b9e188c8358",
+      "context_sha256": "6f77e97d1faa20c88d4e1a3e9fab9f38b08bf7bf992a257871e45e2aa950e6ed",
+      "expected_sha256": "b82b401104623efe0baebd0b0deba35429b72f37419cd4d908f379e5c74aed70",
+      "input": "{\n\n  \"@context\": {\n    \"type1\": \"http://example.com/t1\",\n    \"type2\": \"http://example.com/t2\"\n  },\n  \"@id\": \"http://example.com/id1\",\n  \"http://example.com/termLanguage\": [\n    {\n      \"@list\": [\n        { \"@value\": \"termLL0.1\", \"@language\": \"de\" },\n        { \"@value\": \"termLL0.2\", \"@language\": \"de\" }\n      ]\n    },\n    {\n      \"@list\": [\n        { \"@value\": \"termLL1.1\", \"@language\": \"en\" },\n        { \"@value\": \"termLL1.2\", \"@language\": \"en\" }\n      ]\n    },\n    {\n      \"@list\": [\n        \"termLL2.1\",\n        \"termLL2.2\"\n      ]\n    }\n  ],\n  \"http://example.com/termType\": [\n    {\n      \"@list\": [\n        { \"@value\": \"termTL0.1\", \"@type\": \"type1\" },\n        { \"@value\": \"termTL0.2\", \"@type\": \"type2\" }\n      ]\n    },\n    {\n      \"@list\": [\n        { \"@value\": \"termTL1.1\", \"@type\": \"type1\" },\n        { \"@value\": \"termTL1.2\", \"@type\": \"type1\" }\n      ]\n    },\n    {\n      \"@list\": [\n        { \"@value\": \"termTL2.1\", \"@type\": \"type2\" },\n        { \"@value\": \"termTL2.2\", \"@type\": \"type2\" }\n      ]\n    }\n  ]\n}\n",
+      "context": "{\n  \"@context\": {\n    \"type1\": \"http://example.com/t1\",\n    \"type2\": \"http://example.com/t2\",\n    \"@language\": \"de\",\n    \"termL\": { \"@id\": \"http://example.com/termLanguage\" },\n    \"termLL0\": { \"@id\": \"http://example.com/termLanguage\", \"@container\": \"@list\" },\n    \"termLL1\": { \"@id\": \"http://example.com/termLanguage\", \"@container\": \"@list\", \"@language\": \"en\" },\n    \"termLL2\": { \"@id\": \"http://example.com/termLanguage\", \"@container\": \"@list\", \"@language\": null },\n    \"termT\": { \"@id\": \"http://example.com/termType\" },\n    \"termTL0\": { \"@id\": \"http://example.com/termType\", \"@container\": \"@list\" },\n    \"termTL1\": { \"@id\": \"http://example.com/termType\", \"@container\": \"@list\", \"@type\": \"type1\" },\n    \"termTL2\": { \"@id\": \"http://example.com/termType\", \"@container\": \"@list\", \"@type\": \"type2\" }\n  }\n}\n",
+      "expected": "{\n  \"@context\": {\n    \"type1\": \"http://example.com/t1\",\n    \"type2\": \"http://example.com/t2\",\n    \"@language\": \"de\",\n    \"termL\": { \"@id\": \"http://example.com/termLanguage\" },\n    \"termLL0\": { \"@id\": \"http://example.com/termLanguage\", \"@container\": \"@list\" },\n    \"termLL1\": { \"@id\": \"http://example.com/termLanguage\", \"@container\": \"@list\", \"@language\": \"en\" },\n    \"termLL2\": { \"@id\": \"http://example.com/termLanguage\", \"@container\": \"@list\", \"@language\": null },\n    \"termT\": { \"@id\": \"http://example.com/termType\" },\n    \"termTL0\": { \"@id\": \"http://example.com/termType\", \"@container\": \"@list\" },\n    \"termTL1\": { \"@id\": \"http://example.com/termType\", \"@container\": \"@list\", \"@type\": \"type1\" },\n    \"termTL2\": { \"@id\": \"http://example.com/termType\", \"@container\": \"@list\", \"@type\": \"type2\" }\n  },\n  \"@id\": \"http://example.com/id1\",\n  \"termLL0\": [\n    \"termLL0.1\",\n    \"termLL0.2\"\n  ],\n  \"termLL1\": [\n    \"termLL1.1\",\n    \"termLL1.2\"\n  ],\n  \"termLL2\": [\n    \"termLL2.1\",\n    \"termLL2.2\"\n  ],\n  \"termTL0\": [\n    {\n      \"@type\": \"type1\",\n      \"@value\": \"termTL0.1\"\n    },\n    {\n      \"@type\": \"type2\",\n      \"@value\": \"termTL0.2\"\n    }\n  ],\n  \"termTL1\": [\n    \"termTL1.1\",\n    \"termTL1.2\"\n  ],\n  \"termTL2\": [\n    \"termTL2.1\",\n    \"termTL2.2\"\n  ]\n}\n"
+    },
+    {
+      "id": "0025",
+      "name": "Language maps",
+      "purpose": "Multiple values with different languages use language maps if property has @container: @language",
+      "input_sha256": "841bcec59394d005a7e6a42ddd7cecc6b77cd1d4ca1ee75a085ec769c9d5f719",
+      "context_sha256": "63b3ade733742cd478dff98597ed0dfbf653f9dbfc4ccd71c8aa5256ca3ada9a",
+      "expected_sha256": "d31dac5dda5a8293ad36c13d2de9b3824d64887c5857990eca2fdf05e189e288",
+      "input": "[\n  {\n    \"@id\": \"http://example.com/queen\",\n    \"http://example.com/vocab/label\":\n    [\n      {\n        \"@value\": \"The Queen\",\n        \"@language\": \"en\"\n      }, {\n        \"@value\": \"Die Königin\",\n        \"@language\": \"de\"\n      }, {\n        \"@value\": \"Ihre Majestät\",\n        \"@language\": \"de\"\n      }\n    ]\n  }\n]\n",
+      "context": "{\n  \"@context\": {\n    \"vocab\": \"http://example.com/vocab/\",\n    \"label\": {\n      \"@id\": \"vocab:label\",\n      \"@container\": \"@language\"\n    }\n  }\n}\n",
+      "expected": "{\n  \"@context\": {\n    \"vocab\": \"http://example.com/vocab/\",\n    \"label\": {\n      \"@id\": \"vocab:label\",\n      \"@container\": \"@language\"\n    }\n  },\n  \"@id\": \"http://example.com/queen\",\n  \"label\": {\n    \"en\": \"The Queen\",\n    \"de\": [ \"Die Königin\", \"Ihre Majestät\" ]\n  }\n}\n"
+    },
+    {
+      "id": "0073",
+      "name": "Mapped @id and @type",
+      "purpose": "Ensure that compaction works with mapped @id and @type",
+      "input_sha256": "4b829088afcb6de4391e9efd1724c15ea4a424758cac53f6f4f7e58b99b98d96",
+      "context_sha256": "dcabe972a3728a80aedb9455748a4d40267175abe055d487212acc0b8d901acd",
+      "expected_sha256": "49f7d3411a0d37221a7b8c2b0ff34ad3d2306a8332ad6b0ea43d48d2e7f8760c",
+      "input": "{\n  \"@context\": {\n    \"id\":      {\"@type\": \"@id\", \"@id\": \"@id\"},\n    \"type\":    {\"@type\": \"@id\", \"@id\": \"@type\"}\n  },\n  \"id\": \"http://example.org/anno9\",\n  \"type\": \"http://example.org/Annotation\"\n}\n",
+      "context": "{\n  \"@context\": {\n    \"id\":      {\"@type\": \"@id\", \"@id\": \"@id\"},\n    \"type\":    {\"@type\": \"@id\", \"@id\": \"@type\"}\n  }\n}\n",
+      "expected": "{\n  \"@context\": {\n    \"id\": {\n      \"@type\": \"@id\",\n      \"@id\": \"@id\"\n    },\n    \"type\": {\n      \"@type\": \"@id\",\n      \"@id\": \"@type\"\n    }\n  },\n  \"id\": \"http://example.org/anno9\",\n  \"type\": \"http://example.org/Annotation\"\n}\n"
+    },
+    {
+      "id": "di04",
+      "name": "simple language map with term direction",
+      "purpose": "Term selection with language maps and @direction.",
+      "input_sha256": "5c8378d4a717a2c20b10e8e1894ba2e9e2ba61f167b30bed11d03297504e438b",
+      "context_sha256": "a92c3ae2ae82fafa6e0a4d8aa5167b31927ce321e07aed4b2e043250b91008a7",
+      "expected_sha256": "d2638766e9cf71f3cde5d06c1e10ed4f29feca849208e5c9afffd46314533159",
+      "input": "[\n  {\n    \"@id\": \"http://example.com/queen\",\n    \"http://example.com/vocab/label\": [\n      {\"@value\": \"Die Königin\", \"@language\": \"de\", \"@direction\": \"ltr\"},\n      {\"@value\": \"Ihre Majestät\", \"@language\": \"de\", \"@direction\": \"ltr\"},\n      {\"@value\": \"The Queen\", \"@language\": \"en\", \"@direction\": \"ltr\"}\n    ]\n  }\n]",
+      "context": "{\n  \"@context\": {\n    \"@version\": 1.1,\n    \"vocab\": \"http://example.com/vocab/\",\n    \"label\": {\n      \"@id\": \"vocab:label\",\n      \"@direction\": \"ltr\",\n      \"@container\": \"@language\"\n    }\n  }\n}",
+      "expected": "{\n  \"@context\": {\n    \"@version\": 1.1,\n    \"vocab\": \"http://example.com/vocab/\",\n    \"label\": {\n      \"@id\": \"vocab:label\",\n      \"@direction\": \"ltr\",\n      \"@container\": \"@language\"\n    }\n  },\n  \"@id\": \"http://example.com/queen\",\n  \"label\": {\n    \"en\": \"The Queen\",\n    \"de\": [ \"Die Königin\", \"Ihre Majestät\" ]\n  }\n}"
+    },
+    {
+      "id": "di05",
+      "name": "simple language map with overriding term direction",
+      "purpose": "Term selection with language maps and @direction.",
+      "input_sha256": "5c8378d4a717a2c20b10e8e1894ba2e9e2ba61f167b30bed11d03297504e438b",
+      "context_sha256": "e9c40959cb941535f701c608039766b99db9e42970441a250a5d150569b12de9",
+      "expected_sha256": "0d9ea87f68973258f52ae367d67add94ea638da73e1c29f86220a8d9842ab5f2",
+      "input": "[\n  {\n    \"@id\": \"http://example.com/queen\",\n    \"http://example.com/vocab/label\": [\n      {\"@value\": \"Die Königin\", \"@language\": \"de\", \"@direction\": \"ltr\"},\n      {\"@value\": \"Ihre Majestät\", \"@language\": \"de\", \"@direction\": \"ltr\"},\n      {\"@value\": \"The Queen\", \"@language\": \"en\", \"@direction\": \"ltr\"}\n    ]\n  }\n]",
+      "context": "{\n  \"@context\": {\n    \"@version\": 1.1,\n    \"@direction\": \"rtl\",\n    \"vocab\": \"http://example.com/vocab/\",\n    \"label\": {\n      \"@id\": \"vocab:label\",\n      \"@direction\": \"ltr\",\n      \"@container\": \"@language\"\n    }\n  }\n}",
+      "expected": "{\n  \"@context\": {\n    \"@version\": 1.1,\n    \"@direction\": \"rtl\",\n    \"vocab\": \"http://example.com/vocab/\",\n    \"label\": {\n      \"@id\": \"vocab:label\",\n      \"@direction\": \"ltr\",\n      \"@container\": \"@language\"\n    }\n  },\n  \"@id\": \"http://example.com/queen\",\n  \"label\": {\n    \"en\": \"The Queen\",\n    \"de\": [ \"Die Königin\", \"Ihre Majestät\" ]\n  }\n}"
+    },
+    {
+      "id": "di06",
+      "name": "simple language map with overriding null direction",
+      "purpose": "Term selection with language maps and @direction.",
+      "input_sha256": "4da3deae1c839d823128b5554be1f1d20cf77c4e88b7b2b148caf82c065a48ef",
+      "context_sha256": "de683bbdd9b9ff7599e399bbb43fed6308b11492131657a66e4a36b3cbcc687b",
+      "expected_sha256": "265d0e38e649c2daf3dcc6231e4732bdf1e8638f9e26ee9fd68d8a408caeda7b",
+      "input": "[\n  {\n    \"@id\": \"http://example.com/queen\",\n    \"http://example.com/vocab/label\": [\n      {\"@value\": \"Die Königin\", \"@language\": \"de\"},\n      {\"@value\": \"Ihre Majestät\", \"@language\": \"de\"},\n      {\"@value\": \"The Queen\", \"@language\": \"en\"}\n    ]\n  }\n]",
+      "context": "{\n  \"@context\": {\n    \"@version\": 1.1,\n    \"@direction\": \"rtl\",\n    \"vocab\": \"http://example.com/vocab/\",\n    \"label\": {\n      \"@id\": \"vocab:label\",\n      \"@direction\": null,\n      \"@container\": \"@language\"\n    }\n  }\n}",
+      "expected": "{\n  \"@context\": {\n    \"@version\": 1.1,\n    \"@direction\": \"rtl\",\n    \"vocab\": \"http://example.com/vocab/\",\n    \"label\": {\n      \"@id\": \"vocab:label\",\n      \"@direction\": null,\n      \"@container\": \"@language\"\n    }\n  },\n  \"@id\": \"http://example.com/queen\",\n  \"label\": {\n    \"en\": \"The Queen\",\n    \"de\": [ \"Die Königin\", \"Ihre Majestät\" ]\n  }\n}"
+    },
+    {
+      "id": "la01",
+      "name": "most specific term matching in @list.",
+      "purpose": "The most specific term that matches all of the elements in the list, taking into account the default language, must be selected, without considering case of language.",
+      "input_sha256": "fc2006192770aff4e78da7f7e4b556e20c4103cd46402ae458e51b9e188c8358",
+      "context_sha256": "a705addd8789b35b8c198ae9e0612557838a97b833bb1dc0a52a16908aa3a5a9",
+      "expected_sha256": "2a791a7cb7fdd19a79fae679836769f30bddb76317dabb1f5bdd431b25ba17b7",
+      "input": "{\n\n  \"@context\": {\n    \"type1\": \"http://example.com/t1\",\n    \"type2\": \"http://example.com/t2\"\n  },\n  \"@id\": \"http://example.com/id1\",\n  \"http://example.com/termLanguage\": [\n    {\n      \"@list\": [\n        { \"@value\": \"termLL0.1\", \"@language\": \"de\" },\n        { \"@value\": \"termLL0.2\", \"@language\": \"de\" }\n      ]\n    },\n    {\n      \"@list\": [\n        { \"@value\": \"termLL1.1\", \"@language\": \"en\" },\n        { \"@value\": \"termLL1.2\", \"@language\": \"en\" }\n      ]\n    },\n    {\n      \"@list\": [\n        \"termLL2.1\",\n        \"termLL2.2\"\n      ]\n    }\n  ],\n  \"http://example.com/termType\": [\n    {\n      \"@list\": [\n        { \"@value\": \"termTL0.1\", \"@type\": \"type1\" },\n        { \"@value\": \"termTL0.2\", \"@type\": \"type2\" }\n      ]\n    },\n    {\n      \"@list\": [\n        { \"@value\": \"termTL1.1\", \"@type\": \"type1\" },\n        { \"@value\": \"termTL1.2\", \"@type\": \"type1\" }\n      ]\n    },\n    {\n      \"@list\": [\n        { \"@value\": \"termTL2.1\", \"@type\": \"type2\" },\n        { \"@value\": \"termTL2.2\", \"@type\": \"type2\" }\n      ]\n    }\n  ]\n}\n",
+      "context": "{\n  \"@context\": {\n    \"type1\": \"http://example.com/t1\",\n    \"type2\": \"http://example.com/t2\",\n    \"@language\": \"de\",\n    \"termL\": { \"@id\": \"http://example.com/termLanguage\" },\n    \"termLL0\": { \"@id\": \"http://example.com/termLanguage\", \"@container\": \"@list\" },\n    \"termLL1\": { \"@id\": \"http://example.com/termLanguage\", \"@container\": \"@list\", \"@language\": \"eN\" },\n    \"termLL2\": { \"@id\": \"http://example.com/termLanguage\", \"@container\": \"@list\", \"@language\": null },\n    \"termT\": { \"@id\": \"http://example.com/termType\" },\n    \"termTL0\": { \"@id\": \"http://example.com/termType\", \"@container\": \"@list\" },\n    \"termTL1\": { \"@id\": \"http://example.com/termType\", \"@container\": \"@list\", \"@type\": \"type1\" },\n    \"termTL2\": { \"@id\": \"http://example.com/termType\", \"@container\": \"@list\", \"@type\": \"type2\" }\n  }\n}\n",
+      "expected": "{\n  \"@context\": {\n    \"type1\": \"http://example.com/t1\",\n    \"type2\": \"http://example.com/t2\",\n    \"@language\": \"de\",\n    \"termL\": { \"@id\": \"http://example.com/termLanguage\" },\n    \"termLL0\": { \"@id\": \"http://example.com/termLanguage\", \"@container\": \"@list\" },\n    \"termLL1\": { \"@id\": \"http://example.com/termLanguage\", \"@container\": \"@list\", \"@language\": \"eN\" },\n    \"termLL2\": { \"@id\": \"http://example.com/termLanguage\", \"@container\": \"@list\", \"@language\": null },\n    \"termT\": { \"@id\": \"http://example.com/termType\" },\n    \"termTL0\": { \"@id\": \"http://example.com/termType\", \"@container\": \"@list\" },\n    \"termTL1\": { \"@id\": \"http://example.com/termType\", \"@container\": \"@list\", \"@type\": \"type1\" },\n    \"termTL2\": { \"@id\": \"http://example.com/termType\", \"@container\": \"@list\", \"@type\": \"type2\" }\n  },\n  \"@id\": \"http://example.com/id1\",\n  \"termLL0\": [\n    \"termLL0.1\",\n    \"termLL0.2\"\n  ],\n  \"termLL1\": [\n    \"termLL1.1\",\n    \"termLL1.2\"\n  ],\n  \"termLL2\": [\n    \"termLL2.1\",\n    \"termLL2.2\"\n  ],\n  \"termTL0\": [\n    {\n      \"@type\": \"type1\",\n      \"@value\": \"termTL0.1\"\n    },\n    {\n      \"@type\": \"type2\",\n      \"@value\": \"termTL0.2\"\n    }\n  ],\n  \"termTL1\": [\n    \"termTL1.1\",\n    \"termTL1.2\"\n  ],\n  \"termTL2\": [\n    \"termTL2.1\",\n    \"termTL2.2\"\n  ]\n}\n"
+    },
+    {
+      "id": "m011",
+      "name": "@language map with no @language",
+      "purpose": "index on @language",
+      "input_sha256": "812cba7d912f6af0c7458be451e3cf15b151e0f62603221cc2a53153c5f3859d",
+      "context_sha256": "0df4570d447cc6a1c489a3a99b8d6fe4b75b41577bbb601084eb48d5c3ee0562",
+      "expected_sha256": "b3f38362dc4eb28880facb3e66a531f2dfda3bb31748d6558b5219df9488f80a",
+      "input": "[\n  {\n    \"@id\": \"http://example.com/queen\",\n    \"http://example.com/vocab/label\": [\n      {\"@value\": \"The Queen\", \"@language\": \"en\"},\n      {\"@value\": \"Die Königin\", \"@language\": \"de\"},\n      {\"@value\": \"Ihre Majestät\"}\n    ]\n  }\n]",
+      "context": "{\n  \"@context\": {\n    \"vocab\": \"http://example.com/vocab/\",\n    \"label\": {\"@id\": \"vocab:label\", \"@container\": \"@language\"}\n  }\n}",
+      "expected": "{\n  \"@context\": {\n    \"vocab\": \"http://example.com/vocab/\",\n    \"label\": {\"@id\": \"vocab:label\", \"@container\": \"@language\"}\n  },\n  \"@id\": \"http://example.com/queen\",\n  \"label\": {\n    \"en\": \"The Queen\",\n    \"de\": \"Die Königin\",\n    \"@none\": \"Ihre Majestät\"\n  }\n}"
+    },
+    {
+      "id": "p002",
+      "name": "Compact IRI does not use expanded term definition in 1.1",
+      "purpose": "Terms with an expanded term definition are not used for creating compact IRIs",
+      "input_sha256": "e0966e4ffdbf909c71191034e21a759866916a43b323108d31e9e9feeef2139c",
+      "context_sha256": "eb7f94a7c3c22009158cd2dd33d1a861d3b4b6b07748dbb5219e0d984474c7d1",
+      "expected_sha256": "77def0f896876936357941594a506b67c3e2095273078406d9e1099f2cba78df",
+      "input": "{\n  \"@id\": \"http://example.org/id1\",\n  \"@type\": [\"http://example.org/Type1\", \"http://example.org/Type2\"],\n  \"http://example.org/term\": {\"@id\": \"http://example.org/id2\"}\n}\n",
+      "context": "{\n  \"@context\": {\n    \"ex\": {\"@id\": \"http://example.org/\"}\n  }\n}\n",
+      "expected": "{\n  \"@context\": {\n    \"ex\": {\"@id\": \"http://example.org/\"}\n  },\n  \"@id\": \"http://example.org/id1\",\n  \"@type\": [\"http://example.org/Type1\", \"http://example.org/Type2\"],\n  \"http://example.org/term\": {\"@id\": \"http://example.org/id2\"}\n}"
+    }
+  ]
+}

--- a/crates/rdf/tests/fixtures/jsonld-w3c-rec/vectors.json
+++ b/crates/rdf/tests/fixtures/jsonld-w3c-rec/vectors.json
@@ -1,0 +1,665 @@
+{
+  "schema_version": 1,
+  "upstream_revision": "3e7fa5377b2b3c5176eacf8bde8e01fdb7c4a062",
+  "upstream_tag": "REC-2020-07-16",
+  "expected_vector_count": 73,
+  "vectors": [
+    {
+      "id": "0001",
+      "name": "Plain literal with URIs",
+      "purpose": "Tests generation of a triple using full URIs and a plain literal.",
+      "input_sha256": "93c5c11512f2e711c6e2a5b4690a4c1279f0e498b98d0a01231292f78a21f676",
+      "expected_sha256": "f8e7ec19fc3a3a0e4d82dbd02c2175fcaf278ac0c643ae3b1223c5939f82d105",
+      "input": "{\n  \"@id\": \"http://greggkellogg.net/foaf#me\",\n  \"http://xmlns.com/foaf/0.1/name\": \"Gregg Kellogg\"\n}",
+      "expected_nquads": "<http://greggkellogg.net/foaf#me> <http://xmlns.com/foaf/0.1/name> \"Gregg Kellogg\" .\n"
+    },
+    {
+      "id": "0002",
+      "name": "Plain literal with CURIE from default context",
+      "purpose": "Tests generation of a triple using a CURIE defined in the default context.",
+      "input_sha256": "46f10214ab1f9e974dbff56b05f84fa522d7364bc0da88e5ae4b3a5810706c4d",
+      "expected_sha256": "f8e7ec19fc3a3a0e4d82dbd02c2175fcaf278ac0c643ae3b1223c5939f82d105",
+      "input": "{\n  \"@context\": {\"foaf\": \"http://xmlns.com/foaf/0.1/\"},\n  \"@id\": \"http://greggkellogg.net/foaf#me\",\n  \"foaf:name\": \"Gregg Kellogg\"\n}",
+      "expected_nquads": "<http://greggkellogg.net/foaf#me> <http://xmlns.com/foaf/0.1/name> \"Gregg Kellogg\" .\n"
+    },
+    {
+      "id": "0003",
+      "name": "Default subject is BNode",
+      "purpose": "Tests that a BNode is created if no explicit subject is set.",
+      "input_sha256": "d045268199b7afb6be50ea6cd720bb5806f68a8998e73d4572efb25490fc5caa",
+      "expected_sha256": "b53d014a5125e0b025e3512666746f7cf5b5ce3e245b76a7089f9f05134cfdec",
+      "input": "{\n  \"@context\": {\"foaf\": \"http://xmlns.com/foaf/0.1/\"},\n  \"@type\": \"foaf:Person\"\n}",
+      "expected_nquads": "_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .\n"
+    },
+    {
+      "id": "0004",
+      "name": "Literal with language tag",
+      "purpose": "Tests that a plain literal is created with a language tag.",
+      "input_sha256": "7851d3ed2ae40a4beb443ed24a26ce573f323336d4e487338ad8cc43e3471a69",
+      "expected_sha256": "e34f31d45901ae5c0d03660fd1357c057da476bedb900488d09818de4b8aacea",
+      "input": "{\n  \"http://www.w3.org/2000/01/rdf-schema#label\": {\n    \"@value\": \"A plain literal with a lang tag.\",\n    \"@language\": \"en-us\"\n  }\n}",
+      "expected_nquads": "_:b0 <http://www.w3.org/2000/01/rdf-schema#label> \"A plain literal with a lang tag.\"@en-us .\n"
+    },
+    {
+      "id": "0005",
+      "name": "Extended character set literal",
+      "purpose": "Tests that a literal may be created using extended characters.",
+      "input_sha256": "ff52947453c21e2fd115fd98258d1cd4e32ed536abb0e21d75dabcdbbab38e9f",
+      "expected_sha256": "63b0c11fddc102b52c567f822b2c3b9e4e611678ff45a2001fe23b4c8a195f6c",
+      "input": "{\n  \"@id\": \"http://greggkellogg.net/foaf#me\",\n  \"http://xmlns.com/foaf/0.1/knows\": {\n    \"http://xmlns.com/foaf/0.1/name\": {\"@value\": \"Herman Iván\", \"@language\": \"hu\"}\n  }\n}\n",
+      "expected_nquads": "<http://greggkellogg.net/foaf#me> <http://xmlns.com/foaf/0.1/knows> _:b0 .\n_:b0 <http://xmlns.com/foaf/0.1/name> \"Herman Iván\"@hu .\n"
+    },
+    {
+      "id": "0006",
+      "name": "Typed literal",
+      "purpose": "Tests creation of a literal with a datatype.",
+      "input_sha256": "0e76879ffb969c7e44f3a5a51d8774aa3dec7ff82ec3f7a1dc90d035ba66302e",
+      "expected_sha256": "0c9e9df81c4fa0bec6b0bbc55c08d5f0497823bd349e69d68cd4f1086fe5c8bb",
+      "input": "{\n  \"@id\":  \"http://greggkellogg.net/foaf#me\",\n  \"http://purl.org/dc/terms/created\":  {\n    \"@value\": \"1957-02-27\",\n    \"@type\": \"http://www.w3.org/2001/XMLSchema#date\"\n  }\n}\n",
+      "expected_nquads": "<http://greggkellogg.net/foaf#me> <http://purl.org/dc/terms/created> \"1957-02-27\"^^<http://www.w3.org/2001/XMLSchema#date> .\n"
+    },
+    {
+      "id": "0007",
+      "name": "Tests 'a' generates rdf:type and object is implicit IRI",
+      "purpose": "Verify that 'a' is an alias for rdf:type, and the object is created as an IRI.",
+      "input_sha256": "07e5a2f9c0890055774800246c4c04b0b07af403278152bf7f5c9d5e59dda8a6",
+      "expected_sha256": "ace843033fc185afad1e08f993e65bd61c63360c9739949fe9dbbab92a2ed390",
+      "input": "{\n  \"@id\": \"http://greggkellogg.net/foaf#me\",\n  \"@type\": \"http://xmlns.com/foaf/0.1/Person\"\n}",
+      "expected_nquads": "<http://greggkellogg.net/foaf#me> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .\n"
+    },
+    {
+      "id": "0008",
+      "name": "Test prefix defined in @context",
+      "purpose": "Generate an IRI using a prefix defined within an @context.",
+      "input_sha256": "747966f3c89ec9db8c0aed8477fb54beddcfaf1360c5770b2a0ae0ba55bd64b5",
+      "expected_sha256": "e0a9b2166565157ae013504509c8ecf54bd4ac68157ef6437b3eb4aea02c310e",
+      "input": "{\n  \"@context\": {\"d\": \"http://example.com/default#\"},\n  \"d:foo\": \"bar\"\n}\n",
+      "expected_nquads": "_:b0 <http://example.com/default#foo> \"bar\" .\n"
+    },
+    {
+      "id": "0009",
+      "name": "Test using an empty suffix",
+      "purpose": "An empty suffix may be used.",
+      "input_sha256": "c2c3c248f77d4927bc4e8f1e7847bae80f24ed559ec08d479be945aca22adb01",
+      "expected_sha256": "dac36a49c297327f39b63d5cc3119a06f0e30a1f79b132a20fd822cdd90fafd9",
+      "input": "{\n  \"@context\": {\"foo\": \"http://example.com/default#\"},\n  \"foo:\": \"bar\"\n}\n",
+      "expected_nquads": "_:b0 <http://example.com/default#> \"bar\" .\n"
+    },
+    {
+      "id": "0010",
+      "name": "Test object processing defines object",
+      "purpose": "A property referencing an associative array gets object from subject of array.",
+      "input_sha256": "8fc65dcdd95694c5e5e24fbcc69fddc55520b0eb56e2f17e7a071d40383f79be",
+      "expected_sha256": "312cb29a4348d5118cab2b3f46c3eece4c21668a6cd9b4670908bc4e69bee459",
+      "input": "{\n  \"@context\": {\"foaf\": \"http://xmlns.com/foaf/0.1/\"},\n  \"@id\": \"http://greggkellogg.net/foaf#me\",\n  \"foaf:knows\": {\n    \"@id\": \"http://manu.sporny.org/#me\",\n    \"foaf:name\": \"Manu Sporny\"\n  }\n}\n",
+      "expected_nquads": "<http://greggkellogg.net/foaf#me> <http://xmlns.com/foaf/0.1/knows> <http://manu.sporny.org/#me> .\n<http://manu.sporny.org/#me> <http://xmlns.com/foaf/0.1/name> \"Manu Sporny\" .\n"
+    },
+    {
+      "id": "0011",
+      "name": "Test object processing defines object with implicit BNode",
+      "purpose": "If no @ is specified, a BNode is created, and will be used as the object of an enclosing property.",
+      "input_sha256": "c8b5656b4447685c719542b3672759ca59cac5d9b523720e6a18d905c204eef7",
+      "expected_sha256": "218eb4b0477629b7ab848d022e107708c043a99389a764f12e257fc82b9563cb",
+      "input": "{\n  \"@context\": {\n    \"foaf\": \"http://xmlns.com/foaf/0.1/\"\n  },\n  \"@id\": \"http://greggkellogg.net/foaf#me\",\n  \"foaf:knows\": {\n    \"foaf:name\": \"Dave Longley\"\n  }\n}\n",
+      "expected_nquads": "<http://greggkellogg.net/foaf#me> <http://xmlns.com/foaf/0.1/knows> _:b0 .\n_:b0 <http://xmlns.com/foaf/0.1/name> \"Dave Longley\" .\n"
+    },
+    {
+      "id": "0012",
+      "name": "Multiple Objects for a Single Property",
+      "purpose": "Tests that Multiple Objects are for a Single Property using array syntax.",
+      "input_sha256": "9dd6ac87e3d8bd7f9599bfc7b2b6d03f9bc27ccea48657491525b6260a2e709e",
+      "expected_sha256": "ef8bcba32299d64959640502482efe33dee559b6e007ae8771d4ba3f9de30328",
+      "input": "{\n  \"@context\": {\n    \"foaf\": \"http://xmlns.com/foaf/0.1/\"\n  },\n  \"@id\": \"http://greggkellogg.net/foaf#me\",\n  \"foaf:knows\": [\"Manu Sporny\", \"Dave Longley\"]\n}",
+      "expected_nquads": "<http://greggkellogg.net/foaf#me> <http://xmlns.com/foaf/0.1/knows> \"Dave Longley\" .\n<http://greggkellogg.net/foaf#me> <http://xmlns.com/foaf/0.1/knows> \"Manu Sporny\" .\n"
+    },
+    {
+      "id": "0013",
+      "name": "Creation of an empty list",
+      "purpose": "Tests that @list: [] generates an empty list.",
+      "input_sha256": "1281d583f894b9a66aed7883623e75e6811f04ab0dcb3dbbf2851555c57f78e3",
+      "expected_sha256": "4097f1a25593a6bf7b08a062cb51ab018b19a4a75abb698e181aec79ced16f04",
+      "input": "{\n  \"@context\": {\n    \"foaf\": \"http://xmlns.com/foaf/0.1/\"\n  },\n  \"@id\": \"http://greggkellogg.net/foaf#me\",\n  \"foaf:knows\": {\"@list\": []}\n}\n",
+      "expected_nquads": "<http://greggkellogg.net/foaf#me> <http://xmlns.com/foaf/0.1/knows> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .\n"
+    },
+    {
+      "id": "0014",
+      "name": "Creation of a list with single element",
+      "purpose": "Tests that @list generates a list.",
+      "input_sha256": "3771f90524dad33b4c68c706ca6cf8cc17c429fef4872b4f2b214b8216755704",
+      "expected_sha256": "c4f4e8a9b1238ba6c93e0a9434e560a72e1fd41ba4399df2a86e1b37660f2f12",
+      "input": "{\n  \"@context\": {\n    \"foaf\": \"http://xmlns.com/foaf/0.1/\"\n  },\n  \"@id\": \"http://greggkellogg.net/foaf#me\",\n  \"foaf:knows\": {\"@list\": [\"Manu Sporny\"]}\n}\n",
+      "expected_nquads": "<http://greggkellogg.net/foaf#me> <http://xmlns.com/foaf/0.1/knows> _:b0 .\n_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> \"Manu Sporny\" .\n_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .\n"
+    },
+    {
+      "id": "0015",
+      "name": "Creation of a list with multiple elements",
+      "purpose": "Tests that list with multiple elements.",
+      "input_sha256": "b2935191a0e0d8d2ca94bbcad0972a03b18b05162ebd81c64df4776f19e56df2",
+      "expected_sha256": "ba620b0183eb5d5e1055d954f3e29794e901ba0defb3723c67eebe0c8bedb024",
+      "input": "{\n  \"@context\": {\n    \"foaf\": \"http://xmlns.com/foaf/0.1/\"\n  },\n  \"@id\": \"http://greggkellogg.net/foaf#me\",\n  \"foaf:knows\": {\"@list\": [\"Manu Sporny\", \"Dave Longley\"]}\n}\n",
+      "expected_nquads": "<http://greggkellogg.net/foaf#me> <http://xmlns.com/foaf/0.1/knows> _:b0 .\n_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> \"Manu Sporny\" .\n_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b1 .\n_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> \"Dave Longley\" .\n_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .\n"
+    },
+    {
+      "id": "0019",
+      "name": "Test type coercion to anyURI",
+      "purpose": "Tests coercion of object to anyURI when specified.",
+      "input_sha256": "f3797143a6d61178963f6748b5ac06e5f5fa7aee52d8a0a8382eaa8c2d03f8de",
+      "expected_sha256": "fa3051c4e7a84467e96c7b3b33613240de8b64aedcaf0116b3b19bee64795381",
+      "input": "{\n  \"@context\": {\n    \"foaf\": \"http://xmlns.com/foaf/0.1/\",\n    \"knows\": {\"@id\": \"http://xmlns.com/foaf/0.1/knows\", \"@type\": \"@id\"}\n  },\n  \"@id\":    \"http://greggkellogg.net/foaf#me\",\n  \"knows\":  \"http://manu.sporny.org/#me\"\n}\n",
+      "expected_nquads": "<http://greggkellogg.net/foaf#me> <http://xmlns.com/foaf/0.1/knows> <http://manu.sporny.org/#me> .\n"
+    },
+    {
+      "id": "0020",
+      "name": "Test type coercion to typed literal",
+      "purpose": "Tests coercion of object to a typed literal when specified.",
+      "input_sha256": "1336270a081c0f085f397c746b515fbc4cf93aeee872ff7e5f998ad908de47c0",
+      "expected_sha256": "0c9e9df81c4fa0bec6b0bbc55c08d5f0497823bd349e69d68cd4f1086fe5c8bb",
+      "input": "{\n  \"@context\": {\n    \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n    \"created\": {\"@id\": \"http://purl.org/dc/terms/created\", \"@type\": \"xsd:date\"}\n  },\n  \"@id\":  \"http://greggkellogg.net/foaf#me\",\n  \"created\":  \"1957-02-27\"\n}\n",
+      "expected_nquads": "<http://greggkellogg.net/foaf#me> <http://purl.org/dc/terms/created> \"1957-02-27\"^^<http://www.w3.org/2001/XMLSchema#date> .\n"
+    },
+    {
+      "id": "0022",
+      "name": "Test coercion of double value",
+      "purpose": "Tests that a decimal value generates a xsd:double typed literal;.",
+      "input_sha256": "a0b92e2f339e61db9772920a7c5da68aaf74a574a4b9a4830c1e6118b2d649da",
+      "expected_sha256": "56d0eef997db3874546c66194314eb9096159a97a6975d6d9343cf5f7f112d2d",
+      "input": "{\n  \"@context\": { \"measure\": \"http://example/measure#\"},\n  \"measure:cups\": 5.3\n}\n",
+      "expected_nquads": "_:b0 <http://example/measure#cups> \"5.3E0\"^^<http://www.w3.org/2001/XMLSchema#double> .\n"
+    },
+    {
+      "id": "0023",
+      "name": "Test coercion of integer value",
+      "purpose": "Tests that a decimal value generates a xsd:integer typed literal.",
+      "input_sha256": "a4cd9a52716840a800f4b9f3d0a57a73ffec67aab86c6899ba9f3607d73f1f9e",
+      "expected_sha256": "4b8476be40e2e7d149ee3a0ed942f2094dae39eaf6c0e7335b20eac5c53f90ee",
+      "input": "{\n  \"@context\": { \"chem\": \"http://example/chem#\"},\n  \"chem:protons\": 12\n}",
+      "expected_nquads": "_:b0 <http://example/chem#protons> \"12\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n"
+    },
+    {
+      "id": "0024",
+      "name": "Test coercion of boolean value",
+      "purpose": "Tests that a decimal value generates a xsd:boolean typed literal.",
+      "input_sha256": "71a52ea280119e4df5423020c62072756817860c845aa3d1403fdaed0b64f3f4",
+      "expected_sha256": "6388fda7da6769c71922c2c75e9a37daa9fa57923c72bdb73800bedc667e5eff",
+      "input": "{\n  \"@context\": { \"sensor\": \"http://example/sensor#\"},\n  \"sensor:active\": true\n}",
+      "expected_nquads": "_:b0 <http://example/sensor#active> \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n"
+    },
+    {
+      "id": "0025",
+      "name": "Test list coercion with single element",
+      "purpose": "Tests that an array with a single element on a property with @list coercion creates an RDF Collection.",
+      "input_sha256": "617fdee5df2080f424ca02b4bf2fd0f5470930927e86238d0be6e8c872e61aca",
+      "expected_sha256": "c4f4e8a9b1238ba6c93e0a9434e560a72e1fd41ba4399df2a86e1b37660f2f12",
+      "input": "{\n  \"@context\": {\n    \"knows\": {\"@id\": \"http://xmlns.com/foaf/0.1/knows\", \"@container\": \"@list\"}\n  },\n  \"@id\": \"http://greggkellogg.net/foaf#me\",\n  \"knows\": [\"Manu Sporny\"]\n}\n",
+      "expected_nquads": "<http://greggkellogg.net/foaf#me> <http://xmlns.com/foaf/0.1/knows> _:b0 .\n_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> \"Manu Sporny\" .\n_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .\n"
+    },
+    {
+      "id": "0026",
+      "name": "Test creation of multiple types",
+      "purpose": "Tests that @type with an array of types creates multiple types.",
+      "input_sha256": "2ccfb90310efec7d1676fdbeed362105700bed71f0a91e427b947dc9769761dd",
+      "expected_sha256": "c8b95c1588cb0cde34073231a02d67879612ed032a1e9c67ed9447d7dce91dfa",
+      "input": "{\n  \"@context\": {\"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\"},\n  \"@type\": [\"rdfs:Resource\", \"rdfs:Class\"]\n}\n",
+      "expected_nquads": "_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Class> .\n_:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2000/01/rdf-schema#Resource> .\n"
+    },
+    {
+      "id": "0027",
+      "name": "Simple named graph (Wikidata)",
+      "purpose": "Using @graph with other keys places triples in a named graph.",
+      "input_sha256": "e5b967ee36604b4b02d499eb64609de7b7353a7a03eecaa5478a2fb04b12529c",
+      "expected_sha256": "707c56204bc4ca2f75fab260ac0267624b3aeb52f5c0c9723b375a3fdd2a3654",
+      "input": "{\n  \"@context\": {\n    \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n    \"ex\": \"http://example.org/\",\n    \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n    \"ex:locatedIn\": {\"@type\": \"@id\"},\n    \"ex:hasPopulaton\": {\"@type\": \"xsd:integer\"},\n    \"ex:hasReference\": {\"@type\": \"@id\"}\n  },\n  \"@graph\": [\n    {\n      \"@id\": \"http://example.org/ParisFact1\",\n      \"@type\": \"rdf:Graph\",\n      \"@graph\": {\n        \"@id\": \"http://example.org/location/Paris#this\",\n        \"ex:locatedIn\": \"http://example.org/location/France#this\"\n      },\n      \"ex:hasReference\": [\"http://www.britannica.com/\", \"http://www.wikipedia.org/\", \"http://www.brockhaus.de/\"]\n    },\n    {\n      \"@id\": \"http://example.org/ParisFact2\",\n      \"@type\": \"rdf:Graph\",\n      \"@graph\": {\n        \"@id\": \"http://example.org/location/Paris#this\",\n        \"ex:hasPopulation\": 7000000\n      },\n      \"ex:hasReference\": \"http://www.wikipedia.org/\"\n    }\n  ]\n}\n",
+      "expected_nquads": "<http://example.org/ParisFact1> <http://example.org/hasReference> <http://www.britannica.com/> .\n<http://example.org/ParisFact1> <http://example.org/hasReference> <http://www.brockhaus.de/> .\n<http://example.org/ParisFact1> <http://example.org/hasReference> <http://www.wikipedia.org/> .\n<http://example.org/ParisFact1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Graph> .\n<http://example.org/ParisFact2> <http://example.org/hasReference> <http://www.wikipedia.org/> .\n<http://example.org/ParisFact2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Graph> .\n<http://example.org/location/Paris#this> <http://example.org/hasPopulation> \"7000000\"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/ParisFact2> .\n<http://example.org/location/Paris#this> <http://example.org/locatedIn> <http://example.org/location/France#this> <http://example.org/ParisFact1> .\n"
+    },
+    {
+      "id": "0028",
+      "name": "Simple named graph",
+      "purpose": "Signing a graph.",
+      "input_sha256": "08ec1e259a93b64f41fdf43239a6ab4754f17cc07e825cb4f4401fe4f0b747b4",
+      "expected_sha256": "ddcc710898f9b30a56a3369afcde16757f8343011c009915523050abb1b82870",
+      "input": "{\n  \"@context\": {\n    \"sec\": \"http://purl.org/security#\",\n    \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n    \"rdf\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n    \"dcterms\": \"http://purl.org/dc/terms/\",\n    \"sec:signer\": {\"@type\": \"@id\"},\n    \"dcterms:created\": {\"@type\": \"xsd:dateTime\"}\n  },\n  \"@id\": \"http://example.org/sig1\",\n  \"@type\": [\"rdf:Graph\", \"sec:SignedGraph\"],\n  \"dcterms:created\": \"2011-09-23T20:21:34Z\",\n  \"sec:signer\": \"http://payswarm.example.com/i/john/keys/5\",\n  \"sec:signatureValue\": \"OGQzNGVkMzVm4NTIyZTkZDYMmMzQzNmExMgoYzI43Q3ODIyOWM32NjI=\",\n  \"@graph\": {\n    \"@id\": \"http://example.org/fact1\",\n    \"dcterms:title\": \"Hello World!\"\n  }\n}",
+      "expected_nquads": "<http://example.org/fact1> <http://purl.org/dc/terms/title> \"Hello World!\" <http://example.org/sig1> .\n<http://example.org/sig1> <http://purl.org/dc/terms/created> \"2011-09-23T20:21:34Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n<http://example.org/sig1> <http://purl.org/security#signatureValue> \"OGQzNGVkMzVm4NTIyZTkZDYMmMzQzNmExMgoYzI43Q3ODIyOWM32NjI=\" .\n<http://example.org/sig1> <http://purl.org/security#signer> <http://payswarm.example.com/i/john/keys/5> .\n<http://example.org/sig1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/security#SignedGraph> .\n<http://example.org/sig1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/1999/02/22-rdf-syntax-ns#Graph> .\n"
+    },
+    {
+      "id": "0029",
+      "name": "named graph with embedded named graph",
+      "purpose": "Tests that named graphs containing named graphs flatten to single level of graph naming.",
+      "input_sha256": "47eda412ffc3bda303bb761080d80f8801cb1d2c2e5034a5ce905abeb0de81e9",
+      "expected_sha256": "81076f94edba3ed1fdf9d83d99b3f49bee0ca5da3fccd7c38c660d840a9b5c82",
+      "input": "{\n  \"@context\": {\n    \"wd\": \"http://data.wikipedia.org/vocab#\",\n    \"ws\": \"http://data.wikipedia.org/snaks/\",\n    \"wp\": \"http://en.wikipedia.org/wiki/\"\n  },\n  \"@id\": \"ws:Assertions\",\n  \"@type\": \"wd:SnakSet\",\n  \"@graph\": {\n    \"@id\": \"ws:BerlinFact\",\n    \"@type\": \"wd:Snak\",\n    \"@graph\": {\n      \"@id\": \"wp:Berlin\",\n      \"wd:population\": 3499879\n    },\n    \"wd:assertedBy\": \"http://www.statistik-berlin-brandenburg.de/\"\n  }\n}\n",
+      "expected_nquads": "<http://data.wikipedia.org/snaks/Assertions> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://data.wikipedia.org/vocab#SnakSet> .\n<http://data.wikipedia.org/snaks/BerlinFact> <http://data.wikipedia.org/vocab#assertedBy> \"http://www.statistik-berlin-brandenburg.de/\" <http://data.wikipedia.org/snaks/Assertions> .\n<http://data.wikipedia.org/snaks/BerlinFact> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://data.wikipedia.org/vocab#Snak> <http://data.wikipedia.org/snaks/Assertions> .\n<http://en.wikipedia.org/wiki/Berlin> <http://data.wikipedia.org/vocab#population> \"3499879\"^^<http://www.w3.org/2001/XMLSchema#integer> <http://data.wikipedia.org/snaks/BerlinFact> .\n"
+    },
+    {
+      "id": "0030",
+      "name": "top-level graph with string subject reference",
+      "purpose": "Tests graphs containing subject references as strings.",
+      "input_sha256": "399f5433a79f5fb7792fa724b1ba9bd76ede76640b203fd151d850d8291ff908",
+      "expected_sha256": "316b442616500a0c57112958f5dceef66dda921a39bb79842e8b88217129a893",
+      "input": "{\n  \"@context\": {\n    \"xsd\": \"http://www.w3.org/2001/XMLSchema#\",\n    \"knows\": \"http://xmlns.com/foaf/0.1/knows\",\n    \"name\": \"http://xmlns.com/foaf/0.1/name\",\n    \"asOf\": \"http://example.org/asOf\"\n  },\n  \"@id\": \"http://example.org/linked-data-graph\",\n  \"asOf\": {\"@value\": \"2012-04-09\", \"@type\": \"xsd:date\"},\n  \"@graph\":\n  [\n    {\n      \"@id\": \"http://manu.sporny.org/i/public\",\n      \"@type\": \"foaf:Person\",\n      \"name\": \"Manu Sporny\",\n      \"knows\": \"http://greggkellogg.net/foaf#me\"\n    },\n    {\n      \"@id\": \"http://greggkellogg.net/foaf#me\",\n      \"@type\": \"foaf:Person\",\n      \"name\": \"Gregg Kellogg\",\n      \"knows\": \"http://manu.sporny.org/i/public\"\n    },\n    {\n      \"@id\": \"http://www.markus-lanthaler.com/\"\n    }\n  ]\n}\n",
+      "expected_nquads": "<http://example.org/linked-data-graph> <http://example.org/asOf> \"2012-04-09\"^^<http://www.w3.org/2001/XMLSchema#date> .\n<http://greggkellogg.net/foaf#me> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <foaf:Person> <http://example.org/linked-data-graph> .\n<http://greggkellogg.net/foaf#me> <http://xmlns.com/foaf/0.1/knows> \"http://manu.sporny.org/i/public\" <http://example.org/linked-data-graph> .\n<http://greggkellogg.net/foaf#me> <http://xmlns.com/foaf/0.1/name> \"Gregg Kellogg\" <http://example.org/linked-data-graph> .\n<http://manu.sporny.org/i/public> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <foaf:Person> <http://example.org/linked-data-graph> .\n<http://manu.sporny.org/i/public> <http://xmlns.com/foaf/0.1/knows> \"http://greggkellogg.net/foaf#me\" <http://example.org/linked-data-graph> .\n<http://manu.sporny.org/i/public> <http://xmlns.com/foaf/0.1/name> \"Manu Sporny\" <http://example.org/linked-data-graph> .\n"
+    },
+    {
+      "id": "0031",
+      "name": "Reverse property",
+      "purpose": "Tests conversion of reverse properties.",
+      "input_sha256": "9f57eb26433a36ba57a677fd780b22c6da5535b51adac89858397dbb28202356",
+      "expected_sha256": "cee78d890d92f3b4aa79235e34e45955cf9183c3635dd9372852b4a861a10a4b",
+      "input": "{\n  \"@context\": {\n    \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\",\n    \"defines\": { \"@reverse\": \"rdfs:definedBy\" },\n    \"label\": \"rdfs:label\"\n  },\n  \"@id\": \"http://example.com/vocab\",\n  \"label\": \"My vocabulary\",\n  \"defines\": [\n    {\n      \"@id\": \"http://example.com/vocab#property\",\n      \"label\": \"A property\"\n    }\n  ]\n}\n",
+      "expected_nquads": "<http://example.com/vocab#property> <http://www.w3.org/2000/01/rdf-schema#definedBy> <http://example.com/vocab> .\n<http://example.com/vocab#property> <http://www.w3.org/2000/01/rdf-schema#label> \"A property\" .\n<http://example.com/vocab> <http://www.w3.org/2000/01/rdf-schema#label> \"My vocabulary\" .\n"
+    },
+    {
+      "id": "0032",
+      "name": "@context reordering",
+      "purpose": "Tests that generated triples do not depend on order of @context.",
+      "input_sha256": "4c5cb08798db3f4506d2e996bc7623a4b867ef0937cf753a33b39c7c2aa22331",
+      "expected_sha256": "917e13944778fab53300a53d54e1e27ddd82bb6d12c3a1fbbebba1eba2665b50",
+      "input": "{\n  \"@id\": \"ex:node1\",\n  \"owl:sameAs\": {\n    \"@id\": \"ex:node2\",\n    \"rdfs:label\": \"Node 2\",\n    \"link\": \"ex:node3\",\n    \"@context\": {\n      \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\"\n    }\n  },\n  \"@context\": {\n    \"ex\": \"http://example.org/\",\n    \"owl\": \"http://www.w3.org/2002/07/owl#\",\n    \"link\": { \"@id\": \"ex:link\", \"@type\": \"@id\" }\n  }\n}\n",
+      "expected_nquads": "<http://example.org/node1> <http://www.w3.org/2002/07/owl#sameAs> <http://example.org/node2> .\n<http://example.org/node2> <http://example.org/link> <http://example.org/node3> .\n<http://example.org/node2> <http://www.w3.org/2000/01/rdf-schema#label> \"Node 2\" .\n"
+    },
+    {
+      "id": "0033",
+      "name": "@id reordering",
+      "purpose": "Tests that generated triples do not depend on order of @id.",
+      "input_sha256": "7df95c233422bf9bf8c2aa0e0180426fac82669759e3f688acccc438ab2d136c",
+      "expected_sha256": "917e13944778fab53300a53d54e1e27ddd82bb6d12c3a1fbbebba1eba2665b50",
+      "input": "{\n  \"@context\": {\n    \"ex\": \"http://example.org/\",\n    \"owl\": \"http://www.w3.org/2002/07/owl#\",\n    \"link\": {\n      \"@id\": \"ex:link\",\n      \"@type\": \"@id\"\n    }\n  },\n  \"owl:sameAs\": {\n    \"@context\": {\n      \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\"\n    },\n    \"rdfs:label\": \"Node 2\",\n    \"link\": \"ex:node3\",\n    \"@id\": \"ex:node2\"\n  },\n  \"@id\": \"ex:node1\"\n}\n",
+      "expected_nquads": "<http://example.org/node1> <http://www.w3.org/2002/07/owl#sameAs> <http://example.org/node2> .\n<http://example.org/node2> <http://example.org/link> <http://example.org/node3> .\n<http://example.org/node2> <http://www.w3.org/2000/01/rdf-schema#label> \"Node 2\" .\n"
+    },
+    {
+      "id": "0034",
+      "name": "context properties reordering",
+      "purpose": "Tests that generated triples do not depend on order of properties inside @context.",
+      "input_sha256": "224b0222191366db43eb2ac8cee18df5a7de08228f2fe10b4f25190e04e1fbd6",
+      "expected_sha256": "917e13944778fab53300a53d54e1e27ddd82bb6d12c3a1fbbebba1eba2665b50",
+      "input": "{\n  \"@context\": {\n    \"link\": { \"@id\": \"ex:link\", \"@type\": \"@id\" },\n    \"ex\": \"http://example.org/\",\n    \"owl\": \"http://www.w3.org/2002/07/owl#\"\n  },\n  \"@id\": \"ex:node1\",\n  \"owl:sameAs\": {\n    \"@context\": {\n      \"rdfs\": \"http://www.w3.org/2000/01/rdf-schema#\"\n    },\n    \"@id\": \"ex:node2\",\n    \"rdfs:label\": \"Node 2\",\n    \"link\": \"ex:node3\"\n  }\n}\n",
+      "expected_nquads": "<http://example.org/node1> <http://www.w3.org/2002/07/owl#sameAs> <http://example.org/node2> .\n<http://example.org/node2> <http://example.org/link> <http://example.org/node3> .\n<http://example.org/node2> <http://www.w3.org/2000/01/rdf-schema#label> \"Node 2\" .\n"
+    },
+    {
+      "id": "0035",
+      "name": "non-fractional numbers converted to xsd:double",
+      "purpose": "xsd:double's canonical lexical is used when converting numbers without fraction that are coerced to xsd:double",
+      "input_sha256": "4c76faa16f22754969f5a2f1480dcee5da9c68e1d460ee446a3bf968ca8ac1b7",
+      "expected_sha256": "226d130927f198d87aa8962a46aae953a4a75b83d17a9b420b9a882cd0e7f733",
+      "input": "{\n  \"@context\": {\n    \"double\": {\n      \"@id\": \"http://example.com/double\",\n      \"@type\": \"http://www.w3.org/2001/XMLSchema#double\"\n    },\n    \"integer\": {\n      \"@id\": \"http://example.com/integer\",\n      \"@type\": \"http://www.w3.org/2001/XMLSchema#integer\"\n    }\n  },\n  \"double\": [1, 2.2 ],\n  \"integer\": [8, 9.9 ]\n}\n",
+      "expected_nquads": "_:b0 <http://example.com/double> \"1.0E0\"^^<http://www.w3.org/2001/XMLSchema#double> .\n_:b0 <http://example.com/double> \"2.2E0\"^^<http://www.w3.org/2001/XMLSchema#double> .\n_:b0 <http://example.com/integer> \"8\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n_:b0 <http://example.com/integer> \"9.9E0\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n"
+    },
+    {
+      "id": "0036",
+      "name": "Use nodeMapGeneration bnode labels",
+      "purpose": "The toRDF algorithm does not relabel blank nodes; it reuses the counter from the nodeMapGeneration to generate new ones",
+      "input_sha256": "2f8300e0bdce0840fc073d27c47216ba811e31d0520a44416bb98c1d56c18c10",
+      "expected_sha256": "d28605c8490cded4bc7ba31f64462b1097e07a86e76e1183d9b7aa7608118424",
+      "input": "{\n  \"@id\": \"http://example.com/\",\n  \"ex:prop1\": {\n    \"@list\": [ { \"@id\": \"_:x1\" }, { \"@id\": \"_:x2\" } ]\n  },\n  \"ex:prop2\": { \"@id\": \"_:x3\" }\n}\n",
+      "expected_nquads": "<http://example.com/> <ex:prop1> _:b3 .\n<http://example.com/> <ex:prop2> _:b2 .\n_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .\n_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b4 .\n_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .\n_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .\n"
+    },
+    {
+      "id": "0113",
+      "name": "Dataset with a IRI named graph",
+      "purpose": "Basic use of creating a named graph using an IRI name",
+      "input_sha256": "71c0f0205599e66d448b25cef2e851193e9f23b31bc31567aa635ec21dd0375c",
+      "expected_sha256": "ca5fbc6e086a1e95201ae3b9319eb1a7451323eab1b8a1887d957b9c07d511ca",
+      "input": "{\n  \"@id\": \"http://example/g\",\n  \"@graph\": {\n    \"@id\": \"http://example/s\",\n    \"http://example/p\": {\"@id\": \"http://example/o\"}\n  }\n}",
+      "expected_nquads": "<http://example/s> <http://example/p> <http://example/o> <http://example/g> .\n"
+    },
+    {
+      "id": "0114",
+      "name": "Dataset with a IRI named graph",
+      "purpose": "Basic use of creating a named graph using a BNode name",
+      "input_sha256": "2cd57c8b7525c7fec0e39ca75af3619734a4cc3cd64842bf1f3bcb24b1e2b6a9",
+      "expected_sha256": "31b79d184bf9b04d3934f690fa821d3b53cfb2dcd14fb7a48be66988ae9a48f3",
+      "input": "{\n  \"@id\": \"_:g\",\n  \"@graph\": {\n    \"@id\": \"http://example/s\",\n    \"http://example/p\": {\"@id\": \"http://example/o\"}\n  }\n}",
+      "expected_nquads": "<http://example/s> <http://example/p> <http://example/o> _:b0 .\n"
+    },
+    {
+      "id": "0115",
+      "name": "Dataset with a default and two named graphs",
+      "purpose": "Dataset with a default and two named graphs (IRI and BNode)",
+      "input_sha256": "acbd626f3b0a39c6a0f48aa626a4a4eac5292b189bd1c525897e2e8c015fe64a",
+      "expected_sha256": "036e7ff8e756a6e2b124c3943f9b80e087b8d61da71ba5e311ec7039111b4b4a",
+      "input": "{\n  \"@graph\": [{\n    \"@id\": \"http://example/s0\",\n    \"http://example/p0\": {\"@id\": \"http://example/o0\"}\n  },\n  {\n    \"@id\": \"http://example/g\",\n    \"@graph\": {\n      \"@id\": \"http://example/s1\",\n      \"http://example/p1\": {\"@id\": \"http://example/o1\"}\n    }\n  },\n  {\n    \"@id\": \"_:g\",\n    \"@graph\": {\n      \"@id\": \"http://example/s2\",\n      \"http://example/p2\": {\"@id\": \"http://example/o2\"}\n    }\n  }]\n}",
+      "expected_nquads": "<http://example/s0> <http://example/p0> <http://example/o0> .\n<http://example/s1> <http://example/p1> <http://example/o1> <http://example/g> .\n<http://example/s2> <http://example/p2> <http://example/o2> _:b0 .\n"
+    },
+    {
+      "id": "0116",
+      "name": "Dataset from node with embedded named graph",
+      "purpose": "Embedding @graph in a node creates a named graph",
+      "input_sha256": "bca60facf901288b8e0c60aeb7f3c6d8e9c458ce1724255920a21351644b87cb",
+      "expected_sha256": "06995aa41cadad268f44735e7fe93f1ac927420e654ea8e768edf778756adf21",
+      "input": "{\n  \"@id\": \"http://example/s0\",\n  \"http://example/p0\": {\"@id\": \"http://example/o0\"},\n  \"@graph\": {\n    \"@id\": \"http://example/s1\",\n    \"http://example/p1\": {\"@id\": \"http://example/o1\"}\n  }\n}",
+      "expected_nquads": "<http://example/s0> <http://example/p0> <http://example/o0> .\n<http://example/s1> <http://example/p1> <http://example/o1> <http://example/s0> .\n"
+    },
+    {
+      "id": "0117",
+      "name": "Dataset from node with embedded named graph (bnode)",
+      "purpose": "Embedding @graph in a node creates a named graph. Graph name is created if there is no subject",
+      "input_sha256": "4d8342ec69007040c6dcdaded310f0303e307e9189cae3677241db7a891b12a1",
+      "expected_sha256": "803c61be54a4065275d1e21aafc2d71cc5e8a99ad37f59a336c55d8189fa69de",
+      "input": "{\n  \"http://example/p0\": {\"@id\": \"http://example/o0\"},\n  \"@graph\": {\n    \"@id\": \"http://example/s1\",\n    \"http://example/p1\": {\"@id\": \"http://example/o1\"}\n  }\n}\n",
+      "expected_nquads": "<http://example/s1> <http://example/p1> <http://example/o1> _:b0 .\n_:b0 <http://example/p0> <http://example/o0> .\n"
+    },
+    {
+      "id": "0119",
+      "name": "Blank nodes with reverse properties",
+      "purpose": "Proper (re-)labeling of blank nodes if used with reverse properties.",
+      "input_sha256": "c69c7a93f8d793afe66f1ad824195e1487818204352396a1b559c44c0db410b0",
+      "expected_sha256": "c92af09ae4d25be0709b463c2d787e4660fdc03bcca79720047702b9a9d1f1a9",
+      "input": "{\n  \"@context\": {\n    \"foo\": \"http://example.org/foo\",\n    \"bar\": { \"@reverse\": \"http://example.org/bar\", \"@type\": \"@id\" }\n  },\n  \"foo\": \"Foo\",\n  \"bar\": [ \"http://example.org/origin\", \"_:b0\" ]\n}\n",
+      "expected_nquads": "<http://example.org/origin> <http://example.org/bar> _:b0 .\n_:b0 <http://example.org/foo> \"Foo\" .\n_:b1 <http://example.org/bar> _:b0 .\n"
+    },
+    {
+      "id": "0120",
+      "name": "IRI Resolution (0)",
+      "purpose": "IRI resolution according to RFC3986.",
+      "input_sha256": "c587c6fc81c61df6add3f05d085c491bb34abdaf4b25dfa7d3c4dabd1aa0a92b",
+      "expected_sha256": "61d2931577323b0499e92e3bd8529393823a0cd5e4d45dac800c54f8a6daaf8c",
+      "input": "{\n  \"@context\": {\"@base\": \"http://a/bb/ccc/d;p?q\", \"urn:ex:p\": {\"@type\": \"@id\"}},\n  \"@graph\": [\n    {\"@id\": \"urn:ex:s001\", \"urn:ex:p\": \"g:h\"},\n    {\"@id\": \"urn:ex:s002\", \"urn:ex:p\": \"g\"},\n    {\"@id\": \"urn:ex:s003\", \"urn:ex:p\": \"./g\"},\n    {\"@id\": \"urn:ex:s004\", \"urn:ex:p\": \"g/\"},\n    {\"@id\": \"urn:ex:s005\", \"urn:ex:p\": \"/g\"},\n    {\"@id\": \"urn:ex:s006\", \"urn:ex:p\": \"//g\"},\n    {\"@id\": \"urn:ex:s007\", \"urn:ex:p\": \"?y\"},\n    {\"@id\": \"urn:ex:s008\", \"urn:ex:p\": \"g?y\"},\n    {\"@id\": \"urn:ex:s009\", \"urn:ex:p\": \"#s\"},\n    {\"@id\": \"urn:ex:s010\", \"urn:ex:p\": \"g#s\"},\n    {\"@id\": \"urn:ex:s011\", \"urn:ex:p\": \"g?y#s\"},\n    {\"@id\": \"urn:ex:s012\", \"urn:ex:p\": \";x\"},\n    {\"@id\": \"urn:ex:s013\", \"urn:ex:p\": \"g;x\"},\n    {\"@id\": \"urn:ex:s014\", \"urn:ex:p\": \"g;x?y#s\"},\n    {\"@id\": \"urn:ex:s015\", \"urn:ex:p\": \"\"},\n    {\"@id\": \"urn:ex:s016\", \"urn:ex:p\": \".\"},\n    {\"@id\": \"urn:ex:s017\", \"urn:ex:p\": \"./\"},\n    {\"@id\": \"urn:ex:s018\", \"urn:ex:p\": \"..\"},\n    {\"@id\": \"urn:ex:s019\", \"urn:ex:p\": \"../\"},\n    {\"@id\": \"urn:ex:s020\", \"urn:ex:p\": \"../g\"},\n    {\"@id\": \"urn:ex:s021\", \"urn:ex:p\": \"../..\"},\n    {\"@id\": \"urn:ex:s022\", \"urn:ex:p\": \"../../\"},\n    {\"@id\": \"urn:ex:s023\", \"urn:ex:p\": \"../../g\"},\n    {\"@id\": \"urn:ex:s024\", \"urn:ex:p\": \"../../../g\"},\n    {\"@id\": \"urn:ex:s025\", \"urn:ex:p\": \"../../../../g\"},\n    {\"@id\": \"urn:ex:s026\", \"urn:ex:p\": \"/./g\"},\n    {\"@id\": \"urn:ex:s027\", \"urn:ex:p\": \"/../g\"},\n    {\"@id\": \"urn:ex:s028\", \"urn:ex:p\": \"g.\"},\n    {\"@id\": \"urn:ex:s029\", \"urn:ex:p\": \".g\"},\n    {\"@id\": \"urn:ex:s030\", \"urn:ex:p\": \"g..\"},\n    {\"@id\": \"urn:ex:s031\", \"urn:ex:p\": \"..g\"},\n    {\"@id\": \"urn:ex:s032\", \"urn:ex:p\": \"./../g\"},\n    {\"@id\": \"urn:ex:s033\", \"urn:ex:p\": \"./g/.\"},\n    {\"@id\": \"urn:ex:s034\", \"urn:ex:p\": \"g/./h\"},\n    {\"@id\": \"urn:ex:s035\", \"urn:ex:p\": \"g/../h\"},\n    {\"@id\": \"urn:ex:s036\", \"urn:ex:p\": \"g;x=1/./y\"},\n    {\"@id\": \"urn:ex:s037\", \"urn:ex:p\": \"g;x=1/../y\"},\n    {\"@id\": \"urn:ex:s038\", \"urn:ex:p\": \"g?y/./x\"},\n    {\"@id\": \"urn:ex:s039\", \"urn:ex:p\": \"g?y/../x\"},\n    {\"@id\": \"urn:ex:s040\", \"urn:ex:p\": \"g#s/./x\"},\n    {\"@id\": \"urn:ex:s041\", \"urn:ex:p\": \"g#s/../x\"},\n    {\"@id\": \"urn:ex:s042\", \"urn:ex:p\": \"http:g\"}\n  ]\n}",
+      "expected_nquads": "<urn:ex:s001> <urn:ex:p> <g:h> .\n<urn:ex:s002> <urn:ex:p> <http://a/bb/ccc/g> .\n<urn:ex:s003> <urn:ex:p> <http://a/bb/ccc/g> .\n<urn:ex:s004> <urn:ex:p> <http://a/bb/ccc/g/> .\n<urn:ex:s005> <urn:ex:p> <http://a/g> .\n<urn:ex:s006> <urn:ex:p> <http://g> .\n<urn:ex:s007> <urn:ex:p> <http://a/bb/ccc/d;p?y> .\n<urn:ex:s008> <urn:ex:p> <http://a/bb/ccc/g?y> .\n<urn:ex:s009> <urn:ex:p> <http://a/bb/ccc/d;p?q#s> .\n<urn:ex:s010> <urn:ex:p> <http://a/bb/ccc/g#s> .\n<urn:ex:s011> <urn:ex:p> <http://a/bb/ccc/g?y#s> .\n<urn:ex:s012> <urn:ex:p> <http://a/bb/ccc/;x> .\n<urn:ex:s013> <urn:ex:p> <http://a/bb/ccc/g;x> .\n<urn:ex:s014> <urn:ex:p> <http://a/bb/ccc/g;x?y#s> .\n<urn:ex:s015> <urn:ex:p> <http://a/bb/ccc/d;p?q> .\n<urn:ex:s016> <urn:ex:p> <http://a/bb/ccc/> .\n<urn:ex:s017> <urn:ex:p> <http://a/bb/ccc/> .\n<urn:ex:s018> <urn:ex:p> <http://a/bb/> .\n<urn:ex:s019> <urn:ex:p> <http://a/bb/> .\n<urn:ex:s020> <urn:ex:p> <http://a/bb/g> .\n<urn:ex:s021> <urn:ex:p> <http://a/> .\n<urn:ex:s022> <urn:ex:p> <http://a/> .\n<urn:ex:s023> <urn:ex:p> <http://a/g> .\n<urn:ex:s024> <urn:ex:p> <http://a/g> .\n<urn:ex:s025> <urn:ex:p> <http://a/g> .\n<urn:ex:s026> <urn:ex:p> <http://a/g> .\n<urn:ex:s027> <urn:ex:p> <http://a/g> .\n<urn:ex:s028> <urn:ex:p> <http://a/bb/ccc/g.> .\n<urn:ex:s029> <urn:ex:p> <http://a/bb/ccc/.g> .\n<urn:ex:s030> <urn:ex:p> <http://a/bb/ccc/g..> .\n<urn:ex:s031> <urn:ex:p> <http://a/bb/ccc/..g> .\n<urn:ex:s032> <urn:ex:p> <http://a/bb/g> .\n<urn:ex:s033> <urn:ex:p> <http://a/bb/ccc/g/> .\n<urn:ex:s034> <urn:ex:p> <http://a/bb/ccc/g/h> .\n<urn:ex:s035> <urn:ex:p> <http://a/bb/ccc/h> .\n<urn:ex:s036> <urn:ex:p> <http://a/bb/ccc/g;x=1/y> .\n<urn:ex:s037> <urn:ex:p> <http://a/bb/ccc/y> .\n<urn:ex:s038> <urn:ex:p> <http://a/bb/ccc/g?y/./x> .\n<urn:ex:s039> <urn:ex:p> <http://a/bb/ccc/g?y/../x> .\n<urn:ex:s040> <urn:ex:p> <http://a/bb/ccc/g#s/./x> .\n<urn:ex:s041> <urn:ex:p> <http://a/bb/ccc/g#s/../x> .\n<urn:ex:s042> <urn:ex:p> <http:g> .\n"
+    },
+    {
+      "id": "0121",
+      "name": "IRI Resolution (1)",
+      "purpose": "IRI resolution according to RFC3986.",
+      "input_sha256": "c310c597e2e23cd2e75fcbeb96a9f67a264b23dac5a1bdfc325fcd1eb12c4774",
+      "expected_sha256": "b14a2d667a916f29f296a14064a1a1da8a06df1c56097c904a4d3fdaab68f307",
+      "input": "{\n  \"@context\": {\"@base\": \"http://a/bb/ccc/d/\", \"urn:ex:p\": {\"@type\": \"@id\"}},\n  \"@graph\": [\n    {\"@id\": \"urn:ex:s043\", \"urn:ex:p\": \"g:h\"},\n    {\"@id\": \"urn:ex:s044\", \"urn:ex:p\": \"g\"},\n    {\"@id\": \"urn:ex:s045\", \"urn:ex:p\": \"./g\"},\n    {\"@id\": \"urn:ex:s046\", \"urn:ex:p\": \"g/\"},\n    {\"@id\": \"urn:ex:s047\", \"urn:ex:p\": \"/g\"},\n    {\"@id\": \"urn:ex:s048\", \"urn:ex:p\": \"//g\"},\n    {\"@id\": \"urn:ex:s049\", \"urn:ex:p\": \"?y\"},\n    {\"@id\": \"urn:ex:s050\", \"urn:ex:p\": \"g?y\"},\n    {\"@id\": \"urn:ex:s051\", \"urn:ex:p\": \"#s\"},\n    {\"@id\": \"urn:ex:s052\", \"urn:ex:p\": \"g#s\"},\n    {\"@id\": \"urn:ex:s053\", \"urn:ex:p\": \"g?y#s\"},\n    {\"@id\": \"urn:ex:s054\", \"urn:ex:p\": \";x\"},\n    {\"@id\": \"urn:ex:s055\", \"urn:ex:p\": \"g;x\"},\n    {\"@id\": \"urn:ex:s056\", \"urn:ex:p\": \"g;x?y#s\"},\n    {\"@id\": \"urn:ex:s057\", \"urn:ex:p\": \"\"},\n    {\"@id\": \"urn:ex:s058\", \"urn:ex:p\": \".\"},\n    {\"@id\": \"urn:ex:s059\", \"urn:ex:p\": \"./\"},\n    {\"@id\": \"urn:ex:s060\", \"urn:ex:p\": \"..\"},\n    {\"@id\": \"urn:ex:s061\", \"urn:ex:p\": \"../\"},\n    {\"@id\": \"urn:ex:s062\", \"urn:ex:p\": \"../g\"},\n    {\"@id\": \"urn:ex:s063\", \"urn:ex:p\": \"../..\"},\n    {\"@id\": \"urn:ex:s064\", \"urn:ex:p\": \"../../\"},\n    {\"@id\": \"urn:ex:s065\", \"urn:ex:p\": \"../../g\"},\n    {\"@id\": \"urn:ex:s066\", \"urn:ex:p\": \"../../../g\"},\n    {\"@id\": \"urn:ex:s067\", \"urn:ex:p\": \"../../../../g\"},\n    {\"@id\": \"urn:ex:s068\", \"urn:ex:p\": \"/./g\"},\n    {\"@id\": \"urn:ex:s069\", \"urn:ex:p\": \"/../g\"},\n    {\"@id\": \"urn:ex:s070\", \"urn:ex:p\": \"g.\"},\n    {\"@id\": \"urn:ex:s071\", \"urn:ex:p\": \".g\"},\n    {\"@id\": \"urn:ex:s072\", \"urn:ex:p\": \"g..\"},\n    {\"@id\": \"urn:ex:s073\", \"urn:ex:p\": \"..g\"},\n    {\"@id\": \"urn:ex:s074\", \"urn:ex:p\": \"./../g\"},\n    {\"@id\": \"urn:ex:s075\", \"urn:ex:p\": \"./g/.\"},\n    {\"@id\": \"urn:ex:s076\", \"urn:ex:p\": \"g/./h\"},\n    {\"@id\": \"urn:ex:s077\", \"urn:ex:p\": \"g/../h\"},\n    {\"@id\": \"urn:ex:s078\", \"urn:ex:p\": \"g;x=1/./y\"},\n    {\"@id\": \"urn:ex:s079\", \"urn:ex:p\": \"g;x=1/../y\"},\n    {\"@id\": \"urn:ex:s080\", \"urn:ex:p\": \"g?y/./x\"},\n    {\"@id\": \"urn:ex:s081\", \"urn:ex:p\": \"g?y/../x\"},\n    {\"@id\": \"urn:ex:s082\", \"urn:ex:p\": \"g#s/./x\"},\n    {\"@id\": \"urn:ex:s083\", \"urn:ex:p\": \"g#s/../x\"},\n    {\"@id\": \"urn:ex:s084\", \"urn:ex:p\": \"http:g\"}\n  ]\n}",
+      "expected_nquads": "<urn:ex:s043> <urn:ex:p> <g:h> .\n<urn:ex:s044> <urn:ex:p> <http://a/bb/ccc/d/g> .\n<urn:ex:s045> <urn:ex:p> <http://a/bb/ccc/d/g> .\n<urn:ex:s046> <urn:ex:p> <http://a/bb/ccc/d/g/> .\n<urn:ex:s047> <urn:ex:p> <http://a/g> .\n<urn:ex:s048> <urn:ex:p> <http://g> .\n<urn:ex:s049> <urn:ex:p> <http://a/bb/ccc/d/?y> .\n<urn:ex:s050> <urn:ex:p> <http://a/bb/ccc/d/g?y> .\n<urn:ex:s051> <urn:ex:p> <http://a/bb/ccc/d/#s> .\n<urn:ex:s052> <urn:ex:p> <http://a/bb/ccc/d/g#s> .\n<urn:ex:s053> <urn:ex:p> <http://a/bb/ccc/d/g?y#s> .\n<urn:ex:s054> <urn:ex:p> <http://a/bb/ccc/d/;x> .\n<urn:ex:s055> <urn:ex:p> <http://a/bb/ccc/d/g;x> .\n<urn:ex:s056> <urn:ex:p> <http://a/bb/ccc/d/g;x?y#s> .\n<urn:ex:s057> <urn:ex:p> <http://a/bb/ccc/d/> .\n<urn:ex:s058> <urn:ex:p> <http://a/bb/ccc/d/> .\n<urn:ex:s059> <urn:ex:p> <http://a/bb/ccc/d/> .\n<urn:ex:s060> <urn:ex:p> <http://a/bb/ccc/> .\n<urn:ex:s061> <urn:ex:p> <http://a/bb/ccc/> .\n<urn:ex:s062> <urn:ex:p> <http://a/bb/ccc/g> .\n<urn:ex:s063> <urn:ex:p> <http://a/bb/> .\n<urn:ex:s064> <urn:ex:p> <http://a/bb/> .\n<urn:ex:s065> <urn:ex:p> <http://a/bb/g> .\n<urn:ex:s066> <urn:ex:p> <http://a/g> .\n<urn:ex:s067> <urn:ex:p> <http://a/g> .\n<urn:ex:s068> <urn:ex:p> <http://a/g> .\n<urn:ex:s069> <urn:ex:p> <http://a/g> .\n<urn:ex:s070> <urn:ex:p> <http://a/bb/ccc/d/g.> .\n<urn:ex:s071> <urn:ex:p> <http://a/bb/ccc/d/.g> .\n<urn:ex:s072> <urn:ex:p> <http://a/bb/ccc/d/g..> .\n<urn:ex:s073> <urn:ex:p> <http://a/bb/ccc/d/..g> .\n<urn:ex:s074> <urn:ex:p> <http://a/bb/ccc/g> .\n<urn:ex:s075> <urn:ex:p> <http://a/bb/ccc/d/g/> .\n<urn:ex:s076> <urn:ex:p> <http://a/bb/ccc/d/g/h> .\n<urn:ex:s077> <urn:ex:p> <http://a/bb/ccc/d/h> .\n<urn:ex:s078> <urn:ex:p> <http://a/bb/ccc/d/g;x=1/y> .\n<urn:ex:s079> <urn:ex:p> <http://a/bb/ccc/d/y> .\n<urn:ex:s080> <urn:ex:p> <http://a/bb/ccc/d/g?y/./x> .\n<urn:ex:s081> <urn:ex:p> <http://a/bb/ccc/d/g?y/../x> .\n<urn:ex:s082> <urn:ex:p> <http://a/bb/ccc/d/g#s/./x> .\n<urn:ex:s083> <urn:ex:p> <http://a/bb/ccc/d/g#s/../x> .\n<urn:ex:s084> <urn:ex:p> <http:g> .\n"
+    },
+    {
+      "id": "0122",
+      "name": "IRI Resolution (2)",
+      "purpose": "IRI resolution according to RFC3986.",
+      "input_sha256": "44c44f3b9308e7cd6e1a5f238eb2e7012c958a587f32757334a92fb1348424cc",
+      "expected_sha256": "0f5633737d01594a0967e162ff1513acadc89f6e7fccde643b489cd0781c1140",
+      "input": "{\n  \"@context\": {\"@base\": \"http://a/bb/ccc/./d;p?q\", \"urn:ex:p\": {\"@type\": \"@id\"}},\n  \"@graph\": [\n    {\"@id\": \"urn:ex:s085\", \"urn:ex:p\": \"g:h\"},\n    {\"@id\": \"urn:ex:s086\", \"urn:ex:p\": \"g\"},\n    {\"@id\": \"urn:ex:s087\", \"urn:ex:p\": \"./g\"},\n    {\"@id\": \"urn:ex:s088\", \"urn:ex:p\": \"g/\"},\n    {\"@id\": \"urn:ex:s089\", \"urn:ex:p\": \"/g\"},\n    {\"@id\": \"urn:ex:s090\", \"urn:ex:p\": \"//g\"},\n    {\"@id\": \"urn:ex:s091\", \"urn:ex:p\": \"?y\"},\n    {\"@id\": \"urn:ex:s092\", \"urn:ex:p\": \"g?y\"},\n    {\"@id\": \"urn:ex:s093\", \"urn:ex:p\": \"#s\"},\n    {\"@id\": \"urn:ex:s094\", \"urn:ex:p\": \"g#s\"},\n    {\"@id\": \"urn:ex:s095\", \"urn:ex:p\": \"g?y#s\"},\n    {\"@id\": \"urn:ex:s096\", \"urn:ex:p\": \";x\"},\n    {\"@id\": \"urn:ex:s097\", \"urn:ex:p\": \"g;x\"},\n    {\"@id\": \"urn:ex:s098\", \"urn:ex:p\": \"g;x?y#s\"},\n    {\"@id\": \"urn:ex:s099\", \"urn:ex:p\": \"\"},\n    {\"@id\": \"urn:ex:s100\", \"urn:ex:p\": \".\"},\n    {\"@id\": \"urn:ex:s101\", \"urn:ex:p\": \"./\"},\n    {\"@id\": \"urn:ex:s102\", \"urn:ex:p\": \"..\"},\n    {\"@id\": \"urn:ex:s103\", \"urn:ex:p\": \"../\"},\n    {\"@id\": \"urn:ex:s104\", \"urn:ex:p\": \"../g\"},\n    {\"@id\": \"urn:ex:s105\", \"urn:ex:p\": \"../..\"},\n    {\"@id\": \"urn:ex:s106\", \"urn:ex:p\": \"../../\"},\n    {\"@id\": \"urn:ex:s107\", \"urn:ex:p\": \"../../g\"},\n    {\"@id\": \"urn:ex:s108\", \"urn:ex:p\": \"../../../g\"},\n    {\"@id\": \"urn:ex:s109\", \"urn:ex:p\": \"../../../../g\"},\n    {\"@id\": \"urn:ex:s110\", \"urn:ex:p\": \"/./g\"},\n    {\"@id\": \"urn:ex:s111\", \"urn:ex:p\": \"/../g\"},\n    {\"@id\": \"urn:ex:s112\", \"urn:ex:p\": \"g.\"},\n    {\"@id\": \"urn:ex:s113\", \"urn:ex:p\": \".g\"},\n    {\"@id\": \"urn:ex:s114\", \"urn:ex:p\": \"g..\"},\n    {\"@id\": \"urn:ex:s115\", \"urn:ex:p\": \"..g\"},\n    {\"@id\": \"urn:ex:s116\", \"urn:ex:p\": \"./../g\"},\n    {\"@id\": \"urn:ex:s117\", \"urn:ex:p\": \"./g/.\"},\n    {\"@id\": \"urn:ex:s118\", \"urn:ex:p\": \"g/./h\"},\n    {\"@id\": \"urn:ex:s119\", \"urn:ex:p\": \"g/../h\"},\n    {\"@id\": \"urn:ex:s120\", \"urn:ex:p\": \"g;x=1/./y\"},\n    {\"@id\": \"urn:ex:s121\", \"urn:ex:p\": \"g;x=1/../y\"},\n    {\"@id\": \"urn:ex:s122\", \"urn:ex:p\": \"g?y/./x\"},\n    {\"@id\": \"urn:ex:s123\", \"urn:ex:p\": \"g?y/../x\"},\n    {\"@id\": \"urn:ex:s124\", \"urn:ex:p\": \"g#s/./x\"},\n    {\"@id\": \"urn:ex:s125\", \"urn:ex:p\": \"g#s/../x\"},\n    {\"@id\": \"urn:ex:s126\", \"urn:ex:p\": \"http:g\"}\n  ]\n}",
+      "expected_nquads": "<urn:ex:s085> <urn:ex:p> <g:h> .\n<urn:ex:s086> <urn:ex:p> <http://a/bb/ccc/g> .\n<urn:ex:s087> <urn:ex:p> <http://a/bb/ccc/g> .\n<urn:ex:s088> <urn:ex:p> <http://a/bb/ccc/g/> .\n<urn:ex:s089> <urn:ex:p> <http://a/g> .\n<urn:ex:s090> <urn:ex:p> <http://g> .\n<urn:ex:s091> <urn:ex:p> <http://a/bb/ccc/./d;p?y> .\n<urn:ex:s092> <urn:ex:p> <http://a/bb/ccc/g?y> .\n<urn:ex:s093> <urn:ex:p> <http://a/bb/ccc/./d;p?q#s> .\n<urn:ex:s094> <urn:ex:p> <http://a/bb/ccc/g#s> .\n<urn:ex:s095> <urn:ex:p> <http://a/bb/ccc/g?y#s> .\n<urn:ex:s096> <urn:ex:p> <http://a/bb/ccc/;x> .\n<urn:ex:s097> <urn:ex:p> <http://a/bb/ccc/g;x> .\n<urn:ex:s098> <urn:ex:p> <http://a/bb/ccc/g;x?y#s> .\n<urn:ex:s099> <urn:ex:p> <http://a/bb/ccc/./d;p?q> .\n<urn:ex:s100> <urn:ex:p> <http://a/bb/ccc/> .\n<urn:ex:s101> <urn:ex:p> <http://a/bb/ccc/> .\n<urn:ex:s102> <urn:ex:p> <http://a/bb/> .\n<urn:ex:s103> <urn:ex:p> <http://a/bb/> .\n<urn:ex:s104> <urn:ex:p> <http://a/bb/g> .\n<urn:ex:s105> <urn:ex:p> <http://a/> .\n<urn:ex:s106> <urn:ex:p> <http://a/> .\n<urn:ex:s107> <urn:ex:p> <http://a/g> .\n<urn:ex:s108> <urn:ex:p> <http://a/g> .\n<urn:ex:s109> <urn:ex:p> <http://a/g> .\n<urn:ex:s110> <urn:ex:p> <http://a/g> .\n<urn:ex:s111> <urn:ex:p> <http://a/g> .\n<urn:ex:s112> <urn:ex:p> <http://a/bb/ccc/g.> .\n<urn:ex:s113> <urn:ex:p> <http://a/bb/ccc/.g> .\n<urn:ex:s114> <urn:ex:p> <http://a/bb/ccc/g..> .\n<urn:ex:s115> <urn:ex:p> <http://a/bb/ccc/..g> .\n<urn:ex:s116> <urn:ex:p> <http://a/bb/g> .\n<urn:ex:s117> <urn:ex:p> <http://a/bb/ccc/g/> .\n<urn:ex:s118> <urn:ex:p> <http://a/bb/ccc/g/h> .\n<urn:ex:s119> <urn:ex:p> <http://a/bb/ccc/h> .\n<urn:ex:s120> <urn:ex:p> <http://a/bb/ccc/g;x=1/y> .\n<urn:ex:s121> <urn:ex:p> <http://a/bb/ccc/y> .\n<urn:ex:s122> <urn:ex:p> <http://a/bb/ccc/g?y/./x> .\n<urn:ex:s123> <urn:ex:p> <http://a/bb/ccc/g?y/../x> .\n<urn:ex:s124> <urn:ex:p> <http://a/bb/ccc/g#s/./x> .\n<urn:ex:s125> <urn:ex:p> <http://a/bb/ccc/g#s/../x> .\n<urn:ex:s126> <urn:ex:p> <http:g> .\n"
+    },
+    {
+      "id": "0123",
+      "name": "IRI Resolution (3)",
+      "purpose": "IRI resolution according to RFC3986.",
+      "input_sha256": "8bb0b609056bf4636548ae3e4a84696d11541f041de13f841bff17c3cea221f3",
+      "expected_sha256": "4fda9bcf043398470a6af8a36e6a5a5e093e398bc634baa156199bc94b489645",
+      "input": "{\n  \"@context\": {\"@base\": \"http://a/bb/ccc/../d;p?q\", \"urn:ex:p\": {\"@type\": \"@id\"}},\n  \"@graph\": [\n    {\"@id\": \"urn:ex:s127\", \"urn:ex:p\": \"g:h\"},\n    {\"@id\": \"urn:ex:s128\", \"urn:ex:p\": \"g\"},\n    {\"@id\": \"urn:ex:s129\", \"urn:ex:p\": \"./g\"},\n    {\"@id\": \"urn:ex:s130\", \"urn:ex:p\": \"g/\"},\n    {\"@id\": \"urn:ex:s131\", \"urn:ex:p\": \"/g\"},\n    {\"@id\": \"urn:ex:s132\", \"urn:ex:p\": \"//g\"},\n    {\"@id\": \"urn:ex:s133\", \"urn:ex:p\": \"?y\"},\n    {\"@id\": \"urn:ex:s134\", \"urn:ex:p\": \"g?y\"},\n    {\"@id\": \"urn:ex:s135\", \"urn:ex:p\": \"#s\"},\n    {\"@id\": \"urn:ex:s136\", \"urn:ex:p\": \"g#s\"},\n    {\"@id\": \"urn:ex:s137\", \"urn:ex:p\": \"g?y#s\"},\n    {\"@id\": \"urn:ex:s138\", \"urn:ex:p\": \";x\"},\n    {\"@id\": \"urn:ex:s139\", \"urn:ex:p\": \"g;x\"},\n    {\"@id\": \"urn:ex:s140\", \"urn:ex:p\": \"g;x?y#s\"},\n    {\"@id\": \"urn:ex:s141\", \"urn:ex:p\": \"\"},\n    {\"@id\": \"urn:ex:s142\", \"urn:ex:p\": \".\"},\n    {\"@id\": \"urn:ex:s143\", \"urn:ex:p\": \"./\"},\n    {\"@id\": \"urn:ex:s144\", \"urn:ex:p\": \"..\"},\n    {\"@id\": \"urn:ex:s145\", \"urn:ex:p\": \"../\"},\n    {\"@id\": \"urn:ex:s146\", \"urn:ex:p\": \"../g\"},\n    {\"@id\": \"urn:ex:s147\", \"urn:ex:p\": \"../..\"},\n    {\"@id\": \"urn:ex:s148\", \"urn:ex:p\": \"../../\"},\n    {\"@id\": \"urn:ex:s149\", \"urn:ex:p\": \"../../g\"},\n    {\"@id\": \"urn:ex:s150\", \"urn:ex:p\": \"../../../g\"},\n    {\"@id\": \"urn:ex:s151\", \"urn:ex:p\": \"../../../../g\"},\n    {\"@id\": \"urn:ex:s152\", \"urn:ex:p\": \"/./g\"},\n    {\"@id\": \"urn:ex:s153\", \"urn:ex:p\": \"/../g\"},\n    {\"@id\": \"urn:ex:s154\", \"urn:ex:p\": \"g.\"},\n    {\"@id\": \"urn:ex:s155\", \"urn:ex:p\": \".g\"},\n    {\"@id\": \"urn:ex:s156\", \"urn:ex:p\": \"g..\"},\n    {\"@id\": \"urn:ex:s157\", \"urn:ex:p\": \"..g\"},\n    {\"@id\": \"urn:ex:s158\", \"urn:ex:p\": \"./../g\"},\n    {\"@id\": \"urn:ex:s159\", \"urn:ex:p\": \"./g/.\"},\n    {\"@id\": \"urn:ex:s160\", \"urn:ex:p\": \"g/./h\"},\n    {\"@id\": \"urn:ex:s161\", \"urn:ex:p\": \"g/../h\"},\n    {\"@id\": \"urn:ex:s162\", \"urn:ex:p\": \"g;x=1/./y\"},\n    {\"@id\": \"urn:ex:s163\", \"urn:ex:p\": \"g;x=1/../y\"},\n    {\"@id\": \"urn:ex:s164\", \"urn:ex:p\": \"g?y/./x\"},\n    {\"@id\": \"urn:ex:s165\", \"urn:ex:p\": \"g?y/../x\"},\n    {\"@id\": \"urn:ex:s166\", \"urn:ex:p\": \"g#s/./x\"},\n    {\"@id\": \"urn:ex:s167\", \"urn:ex:p\": \"g#s/../x\"},\n    {\"@id\": \"urn:ex:s168\", \"urn:ex:p\": \"http:g\"}\n  ]\n}",
+      "expected_nquads": "<urn:ex:s127> <urn:ex:p> <g:h> .\n<urn:ex:s128> <urn:ex:p> <http://a/bb/g> .\n<urn:ex:s129> <urn:ex:p> <http://a/bb/g> .\n<urn:ex:s130> <urn:ex:p> <http://a/bb/g/> .\n<urn:ex:s131> <urn:ex:p> <http://a/g> .\n<urn:ex:s132> <urn:ex:p> <http://g> .\n<urn:ex:s133> <urn:ex:p> <http://a/bb/ccc/../d;p?y> .\n<urn:ex:s134> <urn:ex:p> <http://a/bb/g?y> .\n<urn:ex:s135> <urn:ex:p> <http://a/bb/ccc/../d;p?q#s> .\n<urn:ex:s136> <urn:ex:p> <http://a/bb/g#s> .\n<urn:ex:s137> <urn:ex:p> <http://a/bb/g?y#s> .\n<urn:ex:s138> <urn:ex:p> <http://a/bb/;x> .\n<urn:ex:s139> <urn:ex:p> <http://a/bb/g;x> .\n<urn:ex:s140> <urn:ex:p> <http://a/bb/g;x?y#s> .\n<urn:ex:s141> <urn:ex:p> <http://a/bb/ccc/../d;p?q> .\n<urn:ex:s142> <urn:ex:p> <http://a/bb/> .\n<urn:ex:s143> <urn:ex:p> <http://a/bb/> .\n<urn:ex:s144> <urn:ex:p> <http://a/> .\n<urn:ex:s145> <urn:ex:p> <http://a/> .\n<urn:ex:s146> <urn:ex:p> <http://a/g> .\n<urn:ex:s147> <urn:ex:p> <http://a/> .\n<urn:ex:s148> <urn:ex:p> <http://a/> .\n<urn:ex:s149> <urn:ex:p> <http://a/g> .\n<urn:ex:s150> <urn:ex:p> <http://a/g> .\n<urn:ex:s151> <urn:ex:p> <http://a/g> .\n<urn:ex:s152> <urn:ex:p> <http://a/g> .\n<urn:ex:s153> <urn:ex:p> <http://a/g> .\n<urn:ex:s154> <urn:ex:p> <http://a/bb/g.> .\n<urn:ex:s155> <urn:ex:p> <http://a/bb/.g> .\n<urn:ex:s156> <urn:ex:p> <http://a/bb/g..> .\n<urn:ex:s157> <urn:ex:p> <http://a/bb/..g> .\n<urn:ex:s158> <urn:ex:p> <http://a/g> .\n<urn:ex:s159> <urn:ex:p> <http://a/bb/g/> .\n<urn:ex:s160> <urn:ex:p> <http://a/bb/g/h> .\n<urn:ex:s161> <urn:ex:p> <http://a/bb/h> .\n<urn:ex:s162> <urn:ex:p> <http://a/bb/g;x=1/y> .\n<urn:ex:s163> <urn:ex:p> <http://a/bb/y> .\n<urn:ex:s164> <urn:ex:p> <http://a/bb/g?y/./x> .\n<urn:ex:s165> <urn:ex:p> <http://a/bb/g?y/../x> .\n<urn:ex:s166> <urn:ex:p> <http://a/bb/g#s/./x> .\n<urn:ex:s167> <urn:ex:p> <http://a/bb/g#s/../x> .\n<urn:ex:s168> <urn:ex:p> <http:g> .\n"
+    },
+    {
+      "id": "0126",
+      "name": "IRI Resolution (6)",
+      "purpose": "IRI resolution according to RFC3986.",
+      "input_sha256": "fac64097bf1fcf12ee4086e530431d64d88906d0378d64b7a156290d0294ac77",
+      "expected_sha256": "18be386124ef657ac3408f14ec4ae73b14f454cb9ee39043531dc8faadeb401d",
+      "input": "{\n  \"@context\": {\"@base\": \"file:///a/bb/ccc/d;p?q\", \"urn:ex:p\": {\"@type\": \"@id\"}},\n  \"@graph\": [\n    {\"@id\": \"urn:ex:s253\", \"urn:ex:p\": \"g:h\"},\n    {\"@id\": \"urn:ex:s254\", \"urn:ex:p\": \"g\"},\n    {\"@id\": \"urn:ex:s255\", \"urn:ex:p\": \"./g\"},\n    {\"@id\": \"urn:ex:s256\", \"urn:ex:p\": \"g/\"},\n    {\"@id\": \"urn:ex:s257\", \"urn:ex:p\": \"/g\"},\n    {\"@id\": \"urn:ex:s258\", \"urn:ex:p\": \"//g\"},\n    {\"@id\": \"urn:ex:s259\", \"urn:ex:p\": \"?y\"},\n    {\"@id\": \"urn:ex:s260\", \"urn:ex:p\": \"g?y\"},\n    {\"@id\": \"urn:ex:s261\", \"urn:ex:p\": \"#s\"},\n    {\"@id\": \"urn:ex:s262\", \"urn:ex:p\": \"g#s\"},\n    {\"@id\": \"urn:ex:s263\", \"urn:ex:p\": \"g?y#s\"},\n    {\"@id\": \"urn:ex:s264\", \"urn:ex:p\": \";x\"},\n    {\"@id\": \"urn:ex:s265\", \"urn:ex:p\": \"g;x\"},\n    {\"@id\": \"urn:ex:s266\", \"urn:ex:p\": \"g;x?y#s\"},\n    {\"@id\": \"urn:ex:s267\", \"urn:ex:p\": \"\"},\n    {\"@id\": \"urn:ex:s268\", \"urn:ex:p\": \".\"},\n    {\"@id\": \"urn:ex:s269\", \"urn:ex:p\": \"./\"},\n    {\"@id\": \"urn:ex:s270\", \"urn:ex:p\": \"..\"},\n    {\"@id\": \"urn:ex:s271\", \"urn:ex:p\": \"../\"},\n    {\"@id\": \"urn:ex:s272\", \"urn:ex:p\": \"../g\"},\n    {\"@id\": \"urn:ex:s273\", \"urn:ex:p\": \"../..\"},\n    {\"@id\": \"urn:ex:s274\", \"urn:ex:p\": \"../../\"},\n    {\"@id\": \"urn:ex:s275\", \"urn:ex:p\": \"../../g\"},\n    {\"@id\": \"urn:ex:s276\", \"urn:ex:p\": \"../../../g\"},\n    {\"@id\": \"urn:ex:s277\", \"urn:ex:p\": \"../../../../g\"},\n    {\"@id\": \"urn:ex:s278\", \"urn:ex:p\": \"/./g\"},\n    {\"@id\": \"urn:ex:s279\", \"urn:ex:p\": \"/../g\"},\n    {\"@id\": \"urn:ex:s280\", \"urn:ex:p\": \"g.\"},\n    {\"@id\": \"urn:ex:s281\", \"urn:ex:p\": \".g\"},\n    {\"@id\": \"urn:ex:s282\", \"urn:ex:p\": \"g..\"},\n    {\"@id\": \"urn:ex:s283\", \"urn:ex:p\": \"..g\"},\n    {\"@id\": \"urn:ex:s284\", \"urn:ex:p\": \"./../g\"},\n    {\"@id\": \"urn:ex:s285\", \"urn:ex:p\": \"./g/.\"},\n    {\"@id\": \"urn:ex:s286\", \"urn:ex:p\": \"g/./h\"},\n    {\"@id\": \"urn:ex:s287\", \"urn:ex:p\": \"g/../h\"},\n    {\"@id\": \"urn:ex:s288\", \"urn:ex:p\": \"g;x=1/./y\"},\n    {\"@id\": \"urn:ex:s289\", \"urn:ex:p\": \"g;x=1/../y\"},\n    {\"@id\": \"urn:ex:s290\", \"urn:ex:p\": \"g?y/./x\"},\n    {\"@id\": \"urn:ex:s291\", \"urn:ex:p\": \"g?y/../x\"},\n    {\"@id\": \"urn:ex:s292\", \"urn:ex:p\": \"g#s/./x\"},\n    {\"@id\": \"urn:ex:s293\", \"urn:ex:p\": \"g#s/../x\"},\n    {\"@id\": \"urn:ex:s294\", \"urn:ex:p\": \"http:g\"}\n  ]\n}\n",
+      "expected_nquads": "<urn:ex:s253> <urn:ex:p> <g:h> .\n<urn:ex:s254> <urn:ex:p> <file:///a/bb/ccc/g> .\n<urn:ex:s255> <urn:ex:p> <file:///a/bb/ccc/g> .\n<urn:ex:s256> <urn:ex:p> <file:///a/bb/ccc/g/> .\n<urn:ex:s257> <urn:ex:p> <file:///g> .\n<urn:ex:s258> <urn:ex:p> <file://g> .\n<urn:ex:s259> <urn:ex:p> <file:///a/bb/ccc/d;p?y> .\n<urn:ex:s260> <urn:ex:p> <file:///a/bb/ccc/g?y> .\n<urn:ex:s261> <urn:ex:p> <file:///a/bb/ccc/d;p?q#s> .\n<urn:ex:s262> <urn:ex:p> <file:///a/bb/ccc/g#s> .\n<urn:ex:s263> <urn:ex:p> <file:///a/bb/ccc/g?y#s> .\n<urn:ex:s264> <urn:ex:p> <file:///a/bb/ccc/;x> .\n<urn:ex:s265> <urn:ex:p> <file:///a/bb/ccc/g;x> .\n<urn:ex:s266> <urn:ex:p> <file:///a/bb/ccc/g;x?y#s> .\n<urn:ex:s267> <urn:ex:p> <file:///a/bb/ccc/d;p?q> .\n<urn:ex:s268> <urn:ex:p> <file:///a/bb/ccc/> .\n<urn:ex:s269> <urn:ex:p> <file:///a/bb/ccc/> .\n<urn:ex:s270> <urn:ex:p> <file:///a/bb/> .\n<urn:ex:s271> <urn:ex:p> <file:///a/bb/> .\n<urn:ex:s272> <urn:ex:p> <file:///a/bb/g> .\n<urn:ex:s273> <urn:ex:p> <file:///a/> .\n<urn:ex:s274> <urn:ex:p> <file:///a/> .\n<urn:ex:s275> <urn:ex:p> <file:///a/g> .\n<urn:ex:s276> <urn:ex:p> <file:///g> .\n<urn:ex:s277> <urn:ex:p> <file:///g> .\n<urn:ex:s278> <urn:ex:p> <file:///g> .\n<urn:ex:s279> <urn:ex:p> <file:///g> .\n<urn:ex:s280> <urn:ex:p> <file:///a/bb/ccc/g.> .\n<urn:ex:s281> <urn:ex:p> <file:///a/bb/ccc/.g> .\n<urn:ex:s282> <urn:ex:p> <file:///a/bb/ccc/g..> .\n<urn:ex:s283> <urn:ex:p> <file:///a/bb/ccc/..g> .\n<urn:ex:s284> <urn:ex:p> <file:///a/bb/g> .\n<urn:ex:s285> <urn:ex:p> <file:///a/bb/ccc/g/> .\n<urn:ex:s286> <urn:ex:p> <file:///a/bb/ccc/g/h> .\n<urn:ex:s287> <urn:ex:p> <file:///a/bb/ccc/h> .\n<urn:ex:s288> <urn:ex:p> <file:///a/bb/ccc/g;x=1/y> .\n<urn:ex:s289> <urn:ex:p> <file:///a/bb/ccc/y> .\n<urn:ex:s290> <urn:ex:p> <file:///a/bb/ccc/g?y/./x> .\n<urn:ex:s291> <urn:ex:p> <file:///a/bb/ccc/g?y/../x> .\n<urn:ex:s292> <urn:ex:p> <file:///a/bb/ccc/g#s/./x> .\n<urn:ex:s293> <urn:ex:p> <file:///a/bb/ccc/g#s/../x> .\n<urn:ex:s294> <urn:ex:p> <http:g> .\n"
+    },
+    {
+      "id": "0127",
+      "name": "IRI Resolution (7)",
+      "purpose": "IRI resolution according to RFC3986.",
+      "input_sha256": "bb6ace0e176126515e9c1a0131f9fc4e0213f7265c6605c1ab7e275ee1b78568",
+      "expected_sha256": "5b31a2d349839e6bbf97a8c2fc9642f513b77ed80cad3b3a6880e00b40e609c8",
+      "input": "{\n  \"@context\": {\"@base\": \"http://abc/def/ghi\", \"urn:ex:p\": {\"@type\": \"@id\"}},\n  \"@graph\": [\n    {\"@id\": \"urn:ex:s295\", \"urn:ex:p\": \".\"},\n    {\"@id\": \"urn:ex:s296\", \"urn:ex:p\": \".?a=b\"},\n    {\"@id\": \"urn:ex:s297\", \"urn:ex:p\": \".#a=b\"},\n    {\"@id\": \"urn:ex:s298\", \"urn:ex:p\": \"..\"},\n    {\"@id\": \"urn:ex:s299\", \"urn:ex:p\": \"..?a=b\"},\n    {\"@id\": \"urn:ex:s300\", \"urn:ex:p\": \"..#a=b\"}\n  ]\n}\n",
+      "expected_nquads": "<urn:ex:s295> <urn:ex:p> <http://abc/def/> .\n<urn:ex:s296> <urn:ex:p> <http://abc/def/?a=b> .\n<urn:ex:s297> <urn:ex:p> <http://abc/def/#a=b> .\n<urn:ex:s298> <urn:ex:p> <http://abc/> .\n<urn:ex:s299> <urn:ex:p> <http://abc/?a=b> .\n<urn:ex:s300> <urn:ex:p> <http://abc/#a=b> .\n"
+    },
+    {
+      "id": "0128",
+      "name": "IRI Resolution (8)",
+      "purpose": "IRI resolution according to RFC3986.",
+      "input_sha256": "2976b3b1f06603175bab793780c7f63693d24f5c40d89a33ac5226374d3f6b69",
+      "expected_sha256": "dcff8021f5a6fbf5ac01ca7c93a9a3a62b7ba7173f735c00d43b414596cc6af4",
+      "input": "{\n  \"@context\": {\"@base\": \"http://ab//de//ghi\", \"urn:ex:p\": {\"@type\": \"@id\"}},\n  \"@graph\": [\n    {\"@id\": \"urn:ex:s301\", \"urn:ex:p\": \"xyz\"},\n    {\"@id\": \"urn:ex:s302\", \"urn:ex:p\": \"./xyz\"},\n    {\"@id\": \"urn:ex:s303\", \"urn:ex:p\": \"../xyz\"}\n  ]\n}\n",
+      "expected_nquads": "<urn:ex:s301> <urn:ex:p> <http://ab//de//xyz> .\n<urn:ex:s302> <urn:ex:p> <http://ab//de//xyz> .\n<urn:ex:s303> <urn:ex:p> <http://ab//de/xyz> .\n"
+    },
+    {
+      "id": "0129",
+      "name": "IRI Resolution (9)",
+      "purpose": "IRI resolution according to RFC3986.",
+      "input_sha256": "fce1db61dd9ea3f5ee662fde1445c18a2a547658bfdc828133bcf78d0cbdd933",
+      "expected_sha256": "009224fc6a4692515effae6a240110b4eb0e86c71703f0a8d57518cdccf309e5",
+      "input": "{\n  \"@context\": {\"@base\": \"http://abc/d:f/ghi\", \"urn:ex:p\": {\"@type\": \"@id\"}},\n  \"@graph\": [\n    {\"@id\": \"urn:ex:s304\", \"urn:ex:p\": \"xyz\"},\n    {\"@id\": \"urn:ex:s305\", \"urn:ex:p\": \"./xyz\"},\n    {\"@id\": \"urn:ex:s306\", \"urn:ex:p\": \"../xyz\"}\n  ]\n}\n",
+      "expected_nquads": "<urn:ex:s304> <urn:ex:p> <http://abc/d:f/xyz> .\n<urn:ex:s305> <urn:ex:p> <http://abc/d:f/xyz> .\n<urn:ex:s306> <urn:ex:p> <http://abc/xyz> .\n"
+    },
+    {
+      "id": "0130",
+      "name": "IRI Resolution (10)",
+      "purpose": "IRI resolution according to RFC3986.",
+      "input_sha256": "2c50a8070a06a3928fb299fda100a912a4e867cddf1bc2becfef8d180b8ceb9c",
+      "expected_sha256": "98023182ae8624883559e2623b70108a56ba21b98333059aaa1337d2e977b40d",
+      "input": "{\n  \"@context\": {\"@base\": \"tag:example\", \"urn:ex:p\": {\"@type\": \"@id\"}},\n  \"@graph\": [\n    {\"@id\": \"urn:ex:s307\", \"urn:ex:p\": \"a\"}\n  ]\n}\n",
+      "expected_nquads": "<urn:ex:s307> <urn:ex:p> <tag:a> .\n"
+    },
+    {
+      "id": "0131",
+      "name": "IRI Resolution (11)",
+      "purpose": "IRI resolution according to RFC3986.",
+      "input_sha256": "4081a4627519a44f4b5c00a7b9e5e6a56ea4c51cc794419ca834fa267eb79de2",
+      "expected_sha256": "f96db63e0966f2032d737986af4fc11e530304a3d58de07b283075e4f3322662",
+      "input": "{\n  \"@context\": {\"@base\": \"tag:example/foo\", \"urn:ex:p\": {\"@type\": \"@id\"}},\n  \"@graph\": [\n    {\"@id\": \"urn:ex:s308\", \"urn:ex:p\": \"a\"}\n  ]\n}\n",
+      "expected_nquads": "<urn:ex:s308> <urn:ex:p> <tag:example/a> .\n"
+    },
+    {
+      "id": "0132",
+      "name": "IRI Resolution (12)",
+      "purpose": "IRI resolution according to RFC3986.",
+      "input_sha256": "dc41f3d6b3decd5fd2d8f6059561d26a063461060578b242a894d82c7bfc46d7",
+      "expected_sha256": "0da30e14b9c40081b79750d72ca2c7190caff5905e28e8f7c7e2a74282bef311",
+      "input": "{\n  \"@context\": {\"@base\": \"tag:example/foo/\", \"urn:ex:p\": {\"@type\": \"@id\"}},\n  \"@graph\": [\n    {\"@id\": \"urn:ex:s309\", \"urn:ex:p\": \"a\"}\n  ]\n}\n",
+      "expected_nquads": "<urn:ex:s309> <urn:ex:p> <tag:example/foo/a> .\n"
+    },
+    {
+      "id": "c001",
+      "name": "adding new term",
+      "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
+      "input_sha256": "029db7bb402f77645c1ef51dff7a74adbd6d8674a35c2be2319263820ddc5d85",
+      "expected_sha256": "1286591fd05d43f179570b2c41918ca37db67f2e48a2e62b9a6c8099753de793",
+      "input": "{\n  \"@context\": {\n    \"@vocab\": \"http://example/\",\n    \"foo\": {\"@context\": {\"bar\": \"http://example.org/bar\"}}\n  },\n  \"foo\": {\n    \"bar\": \"baz\"\n  }\n}",
+      "expected_nquads": "_:b0 <http://example/foo> _:b1 .\n_:b1 <http://example.org/bar> \"baz\" .\n"
+    },
+    {
+      "id": "c002",
+      "name": "overriding a term",
+      "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
+      "input_sha256": "d516553d197a6f21664ea348cbbfb5ef87bae6c4d5192bd706caa34e8e2d9c4f",
+      "expected_sha256": "56bacde410fee84ab07e92099ae47a009841c5de6fcab5fe95f290a4da5c674e",
+      "input": "{\n  \"@context\": {\n    \"@vocab\": \"http://example/\",\n    \"foo\": {\"@context\": {\"bar\": {\"@type\": \"@id\"}}},\n    \"bar\": {\"@type\": \"http://www.w3.org/2001/XMLSchema#string\"}\n  },\n  \"foo\": {\n    \"bar\": \"http://example/baz\"\n  }\n}",
+      "expected_nquads": "_:b0 <http://example/foo> _:b1 .\n_:b1 <http://example/bar> <http://example/baz> .\n"
+    },
+    {
+      "id": "c004",
+      "name": "deep @context affects nested nodes",
+      "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
+      "input_sha256": "b365166151b98df6a0cb7aaf2c857ce90a22d38c09e97c750a5d18f74fe024fe",
+      "expected_sha256": "e118ca5d403b417ce64944e1cf2dd20349903669c36733e6bdad8e045f2ee53e",
+      "input": "{\n  \"@context\": {\n    \"@vocab\": \"http://example/\",\n    \"foo\": {\"@context\": {\"baz\": {\"@type\": \"@vocab\"}}}\n  },\n  \"foo\": {\n    \"bar\": {\n      \"baz\": \"buzz\"\n    }\n  }\n}",
+      "expected_nquads": "_:b0 <http://example/foo> _:b1 .\n_:b1 <http://example/bar> _:b2 .\n_:b2 <http://example/baz> <http://example/buzz> .\n"
+    },
+    {
+      "id": "c005",
+      "name": "scoped context layers on intemediate contexts",
+      "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
+      "input_sha256": "cec78b957e3d2bb4cfa5205e7104c63651ae3abd9afb8b151962290b285b41e1",
+      "expected_sha256": "98c60736053b0a6de0577a4f9f909b805b0cc067533c4f350ed7f962010b8cda",
+      "input": "{\n  \"@context\": {\n    \"@vocab\": \"http://example/\",\n    \"b\": {\"@context\": {\"c\": \"http://example.org/c\"}}\n  },\n  \"a\": {\n    \"@context\": {\"@vocab\": \"http://example.com/\"},\n    \"b\": {\n      \"a\": \"A in example.com\",\n      \"c\": \"C in example.org\"\n    },\n    \"c\": \"C in example.com\"\n  },\n  \"c\": \"C in example\"\n}",
+      "expected_nquads": "_:b0 <http://example/a> _:b1 .\n_:b0 <http://example/c> \"C in example\" .\n_:b1 <http://example.com/c> \"C in example.com\" .\n_:b1 <http://example/b> _:b2 .\n_:b2 <http://example.com/a> \"A in example.com\" .\n_:b2 <http://example.org/c> \"C in example.org\" .\n"
+    },
+    {
+      "id": "c035",
+      "name": "Term scoping with embedded contexts.",
+      "purpose": "Terms should make use of @vocab relative to the scope in which the term was defined.",
+      "input_sha256": "100bd5626db4cc3a29fc4d5bf675d752b86a0631a21fdd2208d97c79b80075e4",
+      "expected_sha256": "b7cedbcb1e0704c85734e001dbfacd354c8704ddd550a0e38d9d4c4fcc48aeee",
+      "input": "{\n  \"@context\": {\n    \"@vocab\": \"http://vocab.org/\",\n    \"prop1\": {}\n  },\n  \"@id\": \"ex:outer\",\n  \"foo\": {\n    \"@context\": {\n      \"@vocab\": \"http://vocab.override.org/\"\n    },\n    \"@id\": \"ex:inner\",\n    \"prop1\": \"baz1\",\n    \"prop2\": \"baz2\"\n  }\n}\n",
+      "expected_nquads": "<ex:inner> <http://vocab.org/prop1> \"baz1\" .\n<ex:inner> <http://vocab.override.org/prop2> \"baz2\" .\n<ex:outer> <http://vocab.org/foo> <ex:inner> .\n"
+    },
+    {
+      "id": "c036",
+      "name": "Expansion with empty property-scoped context.",
+      "purpose": "Adding a minimal/empty property-scoped context should not affect expansion of terms defined in the outer scope.",
+      "input_sha256": "4a077e19780454b04bd988dc7d7479c53977a306defce2a64c4b4e7c192924f3",
+      "expected_sha256": "8d7e21212b9a6af089b52d328d4ccdee7cf88ea1d00469d81f81c05530501a2d",
+      "input": "{\n  \"@context\": {\n    \"thing\": {\n      \"@id\": \"ex:thing\",\n      \"@context\": {}\n    },\n    \"title\": \"ex:title\"\n  },\n  \"title\": \"top\",\n  \"thing\": {\n    \"title\": \"sub\"\n  }\n}",
+      "expected_nquads": "_:b0 <ex:thing> _:b1 .\n_:b0 <ex:title> \"top\" .\n_:b1 <ex:title> \"sub\" .\n"
+    },
+    {
+      "id": "di07",
+      "name": "simple language map with mismatching term direction",
+      "purpose": "Term selection with language maps and @direction.",
+      "input_sha256": "664f9ea72a851b8149e2c63dc321a59d7cae74a27837b9455088af4ea17be382",
+      "expected_sha256": "ba0c22579ed756d871ec4eae1333f62a465859df4d30b2486bce4438d156020a",
+      "input": "{\n  \"@context\": {\n    \"@version\": 1.1,\n    \"vocab\": \"http://example.com/vocab/\",\n    \"@direction\": \"rtl\",\n    \"label\": {\n      \"@id\": \"vocab:label\",\n      \"@direction\": null,\n      \"@container\": \"@language\"\n    }\n  },\n  \"@id\": \"http://example.com/queen\",\n  \"label\": {\n    \"en\": \"The Queen\",\n    \"de\": [ \"Die Königin\", \"Ihre Majestät\" ]\n  }\n}",
+      "expected_nquads": "<http://example.com/queen> <http://example.com/vocab/label> \"The Queen\"@en .\n<http://example.com/queen> <http://example.com/vocab/label> \"Die Königin\"@de .\n<http://example.com/queen> <http://example.com/vocab/label> \"Ihre Majestät\"@de .\n"
+    },
+    {
+      "id": "e030",
+      "name": "Language maps",
+      "purpose": "RDF version of expand-0030",
+      "input_sha256": "d31dac5dda5a8293ad36c13d2de9b3824d64887c5857990eca2fdf05e189e288",
+      "expected_sha256": "c06c17ceed4205ecba1c1179a6e8d779b3f637885e5b293cbc1e154a68a14593",
+      "input": "{\n  \"@context\": {\n    \"vocab\": \"http://example.com/vocab/\",\n    \"label\": {\n      \"@id\": \"vocab:label\",\n      \"@container\": \"@language\"\n    }\n  },\n  \"@id\": \"http://example.com/queen\",\n  \"label\": {\n    \"en\": \"The Queen\",\n    \"de\": [ \"Die Königin\", \"Ihre Majestät\" ]\n  }\n}\n",
+      "expected_nquads": "<http://example.com/queen> <http://example.com/vocab/label> \"Die Königin\"@de .\n<http://example.com/queen> <http://example.com/vocab/label> \"Ihre Majestät\"@de .\n<http://example.com/queen> <http://example.com/vocab/label> \"The Queen\"@en .\n"
+    },
+    {
+      "id": "e034",
+      "name": "Multiple properties expanding to the same IRI",
+      "purpose": "RDF version of expand-0034",
+      "input_sha256": "23188ae0b7caf1a447b06f419499c4373024123f513b270ea08fe147ae799bc4",
+      "expected_sha256": "b8e8df33261aa40b9835dbbf8e52cf5c49a387a69da4960488701eb792f878e8",
+      "input": "{\n  \"@context\": {\n    \"@vocab\": \"http://example.com/vocab/\",\n    \"colliding\": \"http://example.com/vocab/collidingTerm\"\n  },\n  \"@id\": \"http://example.com/IriCollissions\",\n  \"colliding\": [\n    \"value 1\",\n    2\n  ],\n  \"collidingTerm\": [\n    3,\n    \"four\"\n  ],\n  \"http://example.com/vocab/collidingTerm\": 5\n}\n",
+      "expected_nquads": "<http://example.com/IriCollissions> <http://example.com/vocab/collidingTerm> \"2\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n<http://example.com/IriCollissions> <http://example.com/vocab/collidingTerm> \"3\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n<http://example.com/IriCollissions> <http://example.com/vocab/collidingTerm> \"5\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n<http://example.com/IriCollissions> <http://example.com/vocab/collidingTerm> \"four\" .\n<http://example.com/IriCollissions> <http://example.com/vocab/collidingTerm> \"value 1\" .\n"
+    },
+    {
+      "id": "e037",
+      "name": "Expanding @reverse",
+      "purpose": "RDF version of expand-0037",
+      "input_sha256": "5e3e4c6500c86d90b95c8a414eca1edc37f1aee303db48b6ab4a152aaa1e7aea",
+      "expected_sha256": "9718670dc8c18fe4bd0a6e1bb45762489d4034de510b261bffa470e22fcf26e7",
+      "input": "{\n  \"@context\": {\n    \"name\": \"http://xmlns.com/foaf/0.1/name\"\n  },\n  \"@id\": \"http://example.com/people/markus\",\n  \"name\": \"Markus Lanthaler\",\n  \"@reverse\": {\n    \"http://xmlns.com/foaf/0.1/knows\": {\n      \"@id\": \"http://example.com/people/dave\",\n      \"name\": \"Dave Longley\"\n    }\n  }\n}\n",
+      "expected_nquads": "<http://example.com/people/dave> <http://xmlns.com/foaf/0.1/knows> <http://example.com/people/markus> .\n<http://example.com/people/dave> <http://xmlns.com/foaf/0.1/name> \"Dave Longley\" .\n<http://example.com/people/markus> <http://xmlns.com/foaf/0.1/name> \"Markus Lanthaler\" .\n"
+    },
+    {
+      "id": "e079",
+      "name": "expand @graph container",
+      "purpose": "Use of @graph containers",
+      "input_sha256": "b83c57d12cb9efad8b588b1b2ca228d815c1b57bfce430562eade26c59227f30",
+      "expected_sha256": "e3cf8e056ebdb47fc675f52385e4d5edce62935c84ea093f197da6bf210baaa3",
+      "input": "{\n  \"@context\": {\n    \"@version\": 1.1,\n    \"input\": {\"@id\": \"foo:input\", \"@container\": \"@graph\"},\n    \"value\": \"foo:value\"\n  },\n  \"input\": {\n    \"value\": \"x\"\n  }\n}\n",
+      "expected_nquads": "_:b2 <foo:value> \"x\" _:b1 .\n_:b0 <foo:input> _:b1 .\n"
+    },
+    {
+      "id": "e080",
+      "name": "expand [@graph, @set] container",
+      "purpose": "Use of [@graph, @set] containers",
+      "input_sha256": "3c0e1237f69649a9755ac79e5b4467cc8776bbf964ea22e62232ab33c26a1672",
+      "expected_sha256": "4e173fd8cd7c4a3af0663ae8d0808585f5d0f0c6522c1c608a0445ba07e4c99c",
+      "input": "{\n  \"@context\": {\n    \"@version\": 1.1,\n    \"input\": {\"@id\": \"foo:input\", \"@container\": [\"@graph\", \"@set\"]},\n    \"value\": \"foo:value\"\n  },\n  \"input\": [{\n    \"value\": \"x\"\n  }]\n}\n",
+      "expected_nquads": "_:b0 <foo:input> _:b1 .\n_:b2 <foo:value> \"x\" _:b1 .\n"
+    },
+    {
+      "id": "e085",
+      "name": "expand [@graph, @id] container",
+      "purpose": "Use of @graph containers with @id",
+      "input_sha256": "a0673af1155212dd3b3c8db053ad600068d92c45f4662938e71ff891efe29086",
+      "expected_sha256": "c0b4c74a2a7b79b325f2b17e1bb3709c97c844788ed1266a3845c76654b3bb3f",
+      "input": "{\n  \"@context\": {\n    \"@vocab\": \"http://example.org/\",\n    \"input\": {\"@container\": [\"@graph\", \"@id\"]}\n  },\n  \"input\": {\n    \"http://example.com/g1\": {\"value\": \"x\"}\n  }\n}",
+      "expected_nquads": "_:b0 <http://example.org/value> \"x\" <http://example.com/g1> .\n_:b1 <http://example.org/input> <http://example.com/g1> .\n"
+    },
+    {
+      "id": "e086",
+      "name": "expand [@graph, @id, @set] container",
+      "purpose": "Use of @graph containers with @id and @set",
+      "input_sha256": "f5eda042f7180367a7510792107e7860917bbb195efb2af9a6115ca7a25676fc",
+      "expected_sha256": "c0b4c74a2a7b79b325f2b17e1bb3709c97c844788ed1266a3845c76654b3bb3f",
+      "input": "{\n  \"@context\": {\n    \"@vocab\": \"http://example.org/\",\n    \"input\": {\"@container\": [\"@graph\", \"@id\", \"@set\"]}\n  },\n  \"input\": {\n    \"http://example.com/g1\": {\"value\": \"x\"}\n  }\n}",
+      "expected_nquads": "_:b0 <http://example.org/value> \"x\" <http://example.com/g1> .\n_:b1 <http://example.org/input> <http://example.com/g1> .\n"
+    },
+    {
+      "id": "e099",
+      "name": "expand [@graph, @id] container (multiple objects)",
+      "purpose": "Use of @graph containers with @id",
+      "input_sha256": "66d8c9d882371a23d739eb5f869f60d29a584138b384955eea5c28f498bb8372",
+      "expected_sha256": "7255cf34a9968f2f5161f24e035b87443d11318c44f05d0a79cea4adff26d301",
+      "input": "{\n  \"@context\": {\n    \"@vocab\": \"http://example.org/\",\n    \"input\": {\"@container\": [\"@graph\", \"@id\"]}\n  },\n  \"input\": {\n    \"http://example.com/g1\": {\"value\": \"x\"},\n    \"http://example.com/g2\": {\"value\": \"y\"}\n  }\n}",
+      "expected_nquads": "_:b1 <http://example.org/value> \"x\" <http://example.com/g1> .\n_:b2 <http://example.org/value> \"y\" <http://example.com/g2> .\n_:b0 <http://example.org/input> <http://example.com/g1> .\n_:b0 <http://example.org/input> <http://example.com/g2> .\n"
+    },
+    {
+      "id": "e100",
+      "name": "expand [@graph, @id, @set] container (multiple objects)",
+      "purpose": "Use of @graph containers with @id and @set",
+      "input_sha256": "91871817201c64ea7f1dba8c83cfcfb6ea968f177f9ac5c76ae7450efe6f3eca",
+      "expected_sha256": "7255cf34a9968f2f5161f24e035b87443d11318c44f05d0a79cea4adff26d301",
+      "input": "{\n  \"@context\": {\n    \"@vocab\": \"http://example.org/\",\n    \"input\": {\"@container\": [\"@graph\", \"@id\", \"@set\"]}\n  },\n  \"input\": {\n    \"http://example.com/g1\": {\"value\": \"x\"},\n    \"http://example.com/g2\": {\"value\": \"y\"}\n  }\n}",
+      "expected_nquads": "_:b1 <http://example.org/value> \"x\" <http://example.com/g1> .\n_:b2 <http://example.org/value> \"y\" <http://example.com/g2> .\n_:b0 <http://example.org/input> <http://example.com/g1> .\n_:b0 <http://example.org/input> <http://example.com/g2> .\n"
+    },
+    {
+      "id": "js06",
+      "name": "Transform JSON literal (object)",
+      "purpose": "Tests transforming property with @type @json to a JSON literal (object).",
+      "input_sha256": "362747c2c82488ed18b2fa593098e1b875f347f9f9c7f970f03a980a62546284",
+      "expected_sha256": "d029f52ac30bb672aafabbcc9da73084104ca341ea9c8f61790d3ff157febd58",
+      "input": "{\n  \"@context\": {\n    \"@version\": 1.1,\n    \"e\": {\"@id\": \"http://example.org/vocab#object\", \"@type\": \"@json\"}\n  },\n  \"e\": {\"foo\": \"bar\"}\n}",
+      "expected_nquads": "_:b0 <http://example.org/vocab#object> \"{\\\"foo\\\":\\\"bar\\\"}\"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> ."
+    },
+    {
+      "id": "js07",
+      "name": "Transform JSON literal (array)",
+      "purpose": "Tests transforming property with @type @json to a JSON literal (array).",
+      "input_sha256": "b57985b0590dbaa50c3a763c4f0faf470459f0e6f407bee4aa43453696b169ec",
+      "expected_sha256": "f77ecea70bd6a04aa07a8e5db8b9fac74f3b9ab2041f0da26a52aa863069c1c0",
+      "input": "{\n  \"@context\": {\n    \"@version\": 1.1,\n    \"e\": {\"@id\": \"http://example.org/vocab#array\", \"@type\": \"@json\"}\n  },\n  \"e\": [{\"foo\": \"bar\"}]\n}",
+      "expected_nquads": "_:b0 <http://example.org/vocab#array> \"[{\\\"foo\\\":\\\"bar\\\"}]\"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> ."
+    },
+    {
+      "id": "m001",
+      "name": "Adds @id to object not having an @id",
+      "purpose": "Expansion using @container: @id",
+      "input_sha256": "e2300684747a2200659e5348a848d285c854de71d6697669b67834c3305a9d39",
+      "expected_sha256": "e2b6d37979c1a8befebf2bc2098c5efc5fe458ed4def8d89d46d1b9e5ce16578",
+      "input": "{\n  \"@context\": {\n    \"@vocab\": \"http://example/\",\n    \"idmap\": {\"@container\": \"@id\"}\n  },\n  \"idmap\": {\n    \"http://example.org/foo\": {\"label\": \"Object with @id <foo>\"},\n    \"_:bar\": {\"label\": \"Object with @id _:bar\"}\n  }\n}",
+      "expected_nquads": "<http://example.org/foo> <http://example/label> \"Object with @id <foo>\" .\n_:b1 <http://example/label> \"Object with @id _:bar\" .\n_:b0 <http://example/idmap> <http://example.org/foo> .\n_:b0 <http://example/idmap> _:b1 .\n"
+    },
+    {
+      "id": "m006",
+      "name": "Adds vocabulary expanded @type to object",
+      "purpose": "Expansion using @container: @type",
+      "input_sha256": "4840a8b79728f8615177db02a6f5e74e00157088e5addbb7dd314c00c5df82ee",
+      "expected_sha256": "f51341c79c1a859ef5b38b6a4b4c41c9d9870d5260d4246ebf5624c25c11f9eb",
+      "input": "{\n  \"@context\": {\n    \"@vocab\": \"http://example/\",\n    \"typemap\": {\"@container\": \"@type\"}\n  },\n  \"typemap\": {\n    \"Foo\": {\"label\": \"Object with @type <foo>\"}\n  }\n}",
+      "expected_nquads": "_:b1 <http://example/label> \"Object with @type <foo>\" .\n_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example/Foo> .\n_:b0 <http://example/typemap> _:b1 .\n"
+    },
+    {
+      "id": "m009",
+      "name": "language map with @none",
+      "purpose": "index on @language",
+      "input_sha256": "4eed3256b6bf2f07692de5e42c172e357217d1cae6ca818f61c85e152ac8d9a8",
+      "expected_sha256": "84590dfd8ccc7cbcebbbbce8a28a368e70973a12be19023a874b8f2056656275",
+      "input": "{\n  \"@context\": {\n    \"vocab\": \"http://example.com/vocab/\",\n    \"label\": {\n      \"@id\": \"vocab:label\",\n      \"@container\": \"@language\"\n    }\n  },\n  \"@id\": \"http://example.com/queen\",\n  \"label\": {\n    \"en\": \"The Queen\",\n    \"de\": [ \"Die Königin\", \"Ihre Majestät\" ],\n    \"@none\": \"The Queen\"\n  }\n}",
+      "expected_nquads": "<http://example.com/queen> <http://example.com/vocab/label> \"Ihre Majestät\"@de .\n<http://example.com/queen> <http://example.com/vocab/label> \"Die Königin\"@de .\n<http://example.com/queen> <http://example.com/vocab/label> \"The Queen\"@en .\n<http://example.com/queen> <http://example.com/vocab/label> \"The Queen\" .\n"
+    },
+    {
+      "id": "n001",
+      "name": "Expands input using @nest",
+      "purpose": "Expansion using @nest",
+      "input_sha256": "07d160e95f7191770aac4a63a246756c1ce61171285a38013ab849855260f7ba",
+      "expected_sha256": "f0d3317e58cf1ac90c68353fe6b5fa142427c9210c7db88177341b6869ecd973",
+      "input": "{\n  \"@context\": {\"@vocab\": \"http://example.org/\"},\n  \"p1\": \"v1\",\n  \"@nest\": {\n    \"p2\": \"v2\"\n  }\n}",
+      "expected_nquads": "_:b0 <http://example.org/p2> \"v2\" .\n_:b0 <http://example.org/p1> \"v1\" .\n"
+    },
+    {
+      "id": "pi11",
+      "name": "property-valued index adds property to graph object",
+      "purpose": "Expanding index maps where index is a property.",
+      "input_sha256": "735aba3fb37cd579ae284036482080dd3bba697599c1964a76c11a06a5230abb",
+      "expected_sha256": "44f3fd0426b0639ee617abd99535dbb22606981658383469dd89682886f08f53",
+      "input": "{\n  \"@context\": {\n    \"@version\": 1.1,\n    \"@vocab\": \"http://example.org/\",\n    \"input\": {\"@container\": [\"@graph\", \"@index\"], \"@index\": \"prop\"}\n  },\n  \"input\": {\n    \"g1\": {\"value\": \"x\"}\n  }\n}",
+      "expected_nquads": "_:b1 <http://example.org/prop> \"g1\" .\n_:b0 <http://example.org/input> _:b1 .\n_:b2 <http://example.org/value> \"x\" _:b1 .\n"
+    },
+    {
+      "id": "pr10",
+      "name": "Simple protected and unprotected terms.",
+      "purpose": "Simple protected and unprotected terms.",
+      "input_sha256": "22432cc071e219ca3fc2e5d973172c3428e9041724f894fb3bd346bec87b547b",
+      "expected_sha256": "4d816eb5f8d5841b849bd3b976dd61b862bf117a0e1ed151b04bf7d9e72d1693",
+      "input": "{\n  \"@context\": {\n    \"@version\": 1.1,\n    \"protected\": {\n      \"@id\": \"ex:protected\",\n      \"@protected\": true\n    },\n    \"unprotected\": \"ex:unprotected\"\n  },\n  \"protected\": \"p === ex:protected\",\n  \"unprotected\": {\n    \"protected\": \"p === ex:protected\"\n  }\n}\n",
+      "expected_nquads": "_:b1 <ex:protected> \"p === ex:protected\" .\n_:b0 <ex:protected> \"p === ex:protected\" .\n_:b0 <ex:unprotected> _:b1 .\n"
+    }
+  ]
+}

--- a/crates/rdf/tests/jsonld_context_lens.rs
+++ b/crates/rdf/tests/jsonld_context_lens.rs
@@ -160,6 +160,27 @@ fn safe_rdf_lists_use_list_containers_and_reconstruct_isomorphically() {
 }
 
 #[test]
+fn explicit_list_items_inherit_active_property_id_coercion() {
+    let source = br#"{
+      "@context": {
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "items": {"@id": "ex:items", "@type": "@id"}
+      },
+      "@id": "ex:s",
+      "items": {"@list": ["ex:a", null, "ex:b"]}
+    }"#;
+    let expected = parse_nquads(concat!(
+        "<https://example.org/s> <https://example.org/items> _:head .\n",
+        "_:head <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://example.org/a> .\n",
+        "_:head <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:tail .\n",
+        "_:tail <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://example.org/b> .\n",
+        "_:tail <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .\n",
+    ));
+    let actual = parse_jsonld(source).expect("expand explicit coerced list");
+    assert!(datasets_isomorphic(&expected, &actual));
+}
+
+#[test]
 fn duplicate_members_and_unmapped_index_metadata_fail_closed() {
     let duplicate = br#"{"@context":{},"@graph":[],"@graph":[]}"#;
     let error = parse_jsonld(duplicate).expect_err("duplicate JSON member");
@@ -337,6 +358,41 @@ fn mapped_index_type_and_set_containers_preserve_rdf() {
 }
 
 #[test]
+fn null_entries_in_graph_id_type_and_index_containers_are_ignored() {
+    let source = br#"{
+      "@context": {
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "graphs": {"@id": "ex:graph", "@container": ["@graph", "@id"]},
+        "ids": {"@id": "ex:id", "@container": "@id"},
+        "indexed": {"@id": "ex:indexed", "@container": "@index", "@index": "ex:key"},
+        "name": "ex:name",
+        "types": {"@id": "ex:typed", "@container": "@type"}
+      },
+      "@id": "ex:s",
+      "graphs": {"ex:g": [null, {"@id": "ex:inside", "name": "Inside"}]},
+      "ids": {"ex:ignored": null, "ex:kept": [null, {}]},
+      "indexed": {"ignored": null, "row-1": [null, {"@id": "ex:indexed-node"}]},
+      "types": {"ex:Ignored": null, "ex:Thing": [null, {"@id": "ex:typed-node"}]}
+    }"#;
+    let expected = parse_nquads(concat!(
+        "<https://example.org/s> <https://example.org/graph> <https://example.org/g> .\n",
+        "<https://example.org/inside> <https://example.org/name> \"Inside\" <https://example.org/g> .\n",
+        "<https://example.org/s> <https://example.org/id> <https://example.org/kept> .\n",
+        "<https://example.org/s> <https://example.org/indexed> <https://example.org/indexed-node> .\n",
+        "<https://example.org/indexed-node> <https://example.org/key> \"row-1\" .\n",
+        "<https://example.org/s> <https://example.org/typed> <https://example.org/typed-node> .\n",
+        "<https://example.org/typed-node> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/Thing> .\n",
+    ));
+    let actual = parse_jsonld(source).expect("expand containers with null entries");
+    assert!(
+        datasets_isomorphic(&expected, &actual),
+        "expected:\n{}\nactual:\n{}",
+        canonical_flat_nquads(&expected).expect("canonical expected"),
+        canonical_flat_nquads(&actual).expect("canonical actual")
+    );
+}
+
+#[test]
 fn graph_id_and_mapped_graph_index_containers_preserve_named_graph_scope() {
     let source = br#"{
       "@context": {
@@ -397,6 +453,32 @@ fn named_graph_references_compact_into_graph_id_maps() {
     assert_eq!(value["@graph"].as_array().expect("graph").len(), 1);
 
     let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand graph id map");
+    assert!(datasets_isomorphic(&dataset, &reparsed));
+}
+
+#[test]
+fn a_standalone_named_graph_is_not_embedded_again_by_a_later_graph() {
+    let source = concat!(
+        "<https://example.org/item> <https://example.org/name> \"A\" <https://example.org/a> .\n",
+        "<https://example.org/catalog> <https://example.org/containsGraph> <https://example.org/a> <https://example.org/z> .\n",
+    );
+    let context = json!({
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "graphs": {"@id": "ex:containsGraph", "@container": ["@graph", "@id"]},
+        "name": "ex:name"
+    });
+    let (dataset, compacted) = serialize_with_context(source, &context);
+    let value: Value = serde_json::from_str(&compacted).expect("JSON output");
+    let top_level = value["@graph"].as_array().expect("top-level graph");
+    assert_eq!(top_level.len(), 2);
+    assert_eq!(
+        top_level
+            .iter()
+            .filter(|entry| entry["@id"] == "ex:a" && entry.get("@graph").is_some())
+            .count(),
+        1
+    );
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand named graphs");
     assert!(datasets_isomorphic(&dataset, &reparsed));
 }
 

--- a/crates/rdf/tests/jsonld_context_lens.rs
+++ b/crates/rdf/tests/jsonld_context_lens.rs
@@ -1,0 +1,705 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Law tests for configured JSON-LD compaction and expansion.
+
+mod common;
+
+use std::fmt::Write as _;
+
+use proptest::prelude::*;
+use purrdf_rdf::native_codecs::jsonld::{
+    CompiledJsonLdContext, JsonLdContextRegistry, JsonLdSerializeOptions, parse_jsonld,
+    parse_jsonld_with_context, serialize_dataset_to_jsonld_with_options,
+};
+use purrdf_rdf::{
+    RdfDatasetBuilder, RdfLiteral, canonical_flat_nquads, datasets_isomorphic, parse_dataset,
+};
+use serde_json::{Value, json};
+
+fn parse_nquads(source: &str) -> std::sync::Arc<purrdf_rdf::RdfDataset> {
+    parse_dataset(source.as_bytes(), "application/n-quads", None).expect("N-Quads fixture")
+}
+
+fn serialize_with_context(
+    source: &str,
+    context: &Value,
+) -> (std::sync::Arc<purrdf_rdf::RdfDataset>, String) {
+    let dataset = parse_nquads(source);
+    let compiled = CompiledJsonLdContext::compile(context, None).expect("compile context");
+    let json = serialize_dataset_to_jsonld_with_options(
+        &dataset,
+        &JsonLdSerializeOptions::compiled(std::sync::Arc::new(compiled)),
+    )
+    .expect("configured serialization");
+    (dataset, json)
+}
+
+#[test]
+fn aliases_base_vocab_and_coercions_compact_and_expand_losslessly() {
+    let source = concat!(
+        "<https://example.org/alice> <https://schema.org/name> \"Alice\"@en .\n",
+        "<https://example.org/alice> <https://schema.org/knows> <https://example.org/bob> .\n",
+        "<https://example.org/alice> <https://schema.org/age> \"42\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
+        "<https://example.org/alice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/Person> .\n",
+    );
+    let context = json!({
+        "@base": "https://example.org/",
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "graph": "@graph",
+        "id": "@id",
+        "type": "@type",
+        "schema": {"@id": "https://schema.org/", "@prefix": true},
+        "xsd": {"@id": "http://www.w3.org/2001/XMLSchema#", "@prefix": true},
+        "age": {"@id": "schema:age", "@type": "xsd:integer"},
+        "knows": {"@id": "schema:knows", "@type": "@id"},
+        "name": {"@id": "schema:name", "@language": "en"}
+    });
+    let (dataset, compacted) = serialize_with_context(source, &context);
+    let value: Value = serde_json::from_str(&compacted).expect("JSON output");
+    let node = &value["graph"][0];
+    assert_eq!(node["id"], "ex:alice");
+    assert_eq!(node["type"], "ex:Person");
+    assert_eq!(node["name"], "Alice");
+    assert_eq!(node["knows"], "ex:bob");
+    assert_eq!(node["age"], "42");
+    assert!(node.get("https://schema.org/name").is_none());
+
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand compact JSON-LD");
+    assert!(
+        datasets_isomorphic(&dataset, &reparsed),
+        "source:\n{}\nreparsed:\n{}",
+        canonical_flat_nquads(&dataset).expect("canonical source"),
+        canonical_flat_nquads(&reparsed).expect("canonical reparsed")
+    );
+}
+
+#[test]
+fn heterogeneous_values_partition_across_compatible_aliases() {
+    let source = concat!(
+        "<https://example.org/s> <https://example.org/p> <https://example.org/o> .\n",
+        "<https://example.org/s> <https://example.org/p> \"hello\"@en .\n",
+    );
+    let context = json!({
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "ref": {"@id": "ex:p", "@type": "@id"},
+        "text": {"@id": "ex:p", "@language": "en"}
+    });
+    let (dataset, compacted) = serialize_with_context(source, &context);
+    let value: Value = serde_json::from_str(&compacted).expect("JSON output");
+    let node = &value["@graph"][0];
+    assert_eq!(node["ref"], "ex:o");
+    assert_eq!(node["text"], "hello");
+
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand partitioned aliases");
+    assert!(
+        datasets_isomorphic(&dataset, &reparsed),
+        "source:\n{}\nreparsed:\n{}\njson:\n{compacted}",
+        canonical_flat_nquads(&dataset).expect("canonical source"),
+        canonical_flat_nquads(&reparsed).expect("canonical reparsed")
+    );
+}
+
+#[test]
+fn safe_rdf_lists_use_list_containers_and_reconstruct_isomorphically() {
+    let source = concat!(
+        "<https://example.org/s> <https://example.org/items> _:head .\n",
+        "_:head <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> \"one\" .\n",
+        "_:head <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:tail .\n",
+        "_:tail <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://example.org/two> .\n",
+        "_:tail <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .\n",
+    );
+    let context = json!({
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "items": {"@container": "@list", "@id": "ex:items"}
+    });
+    let (dataset, compacted) = serialize_with_context(source, &context);
+    let value: Value = serde_json::from_str(&compacted).expect("JSON output");
+    assert_eq!(value["@graph"][0]["items"][0], "one");
+    assert_eq!(value["@graph"][0]["items"][1]["@id"], "ex:two");
+    assert!(!compacted.contains("rdf-syntax-ns#first"));
+
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("reconstruct RDF list");
+    assert!(datasets_isomorphic(&dataset, &reparsed));
+}
+
+#[test]
+fn duplicate_members_and_unmapped_index_metadata_fail_closed() {
+    let duplicate = br#"{"@context":{},"@graph":[],"@graph":[]}"#;
+    let error = parse_jsonld(duplicate).expect_err("duplicate JSON member");
+    assert_eq!(error.code, "jsonld-json-input");
+
+    let indexed = br#"{
+      "@context": {"p": {"@id": "https://example.org/p", "@container": "@index"}},
+      "@id": "https://example.org/s",
+      "p": {"source-row": {"@id": "https://example.org/o"}}
+    }"#;
+    let error = parse_jsonld(indexed).expect_err("unmapped @index metadata");
+    assert!(error.message.contains("no RDF dataset representation"));
+}
+
+#[test]
+fn direct_set_objects_expand_and_lossy_value_shapes_fail_closed() {
+    let direct_set = br#"{
+      "@context": {"ex": {"@id": "https://example.org/", "@prefix": true}},
+      "@id": "ex:s",
+      "ex:p": {"@set": [{"@id": "ex:o1"}, {"@id": "ex:o2"}]}
+    }"#;
+    let expected = parse_nquads(concat!(
+        "<https://example.org/s> <https://example.org/p> <https://example.org/o1> .\n",
+        "<https://example.org/s> <https://example.org/p> <https://example.org/o2> .\n",
+    ));
+    let actual = parse_jsonld(direct_set).expect("expand direct @set object");
+    assert!(
+        datasets_isomorphic(&expected, &actual),
+        "expected:\n{}\nactual:\n{}",
+        canonical_flat_nquads(&expected).expect("canonical expected"),
+        canonical_flat_nquads(&actual).expect("canonical actual")
+    );
+
+    for (description, input) in [
+        (
+            "value object property",
+            br#"{"@id":"https://example.org/s","https://example.org/p":{"@value":"v","https://example.org/lost":"x"}}"#.as_slice(),
+        ),
+        (
+            "list object property",
+            br#"{"@id":"https://example.org/s","https://example.org/p":{"@list":[],"https://example.org/lost":"x"}}"#.as_slice(),
+        ),
+        (
+            "set object property",
+            br#"{"@id":"https://example.org/s","https://example.org/p":{"@set":[],"https://example.org/lost":"x"}}"#.as_slice(),
+        ),
+        (
+            "null value annotation",
+            br#"{"@id":"https://example.org/s","https://example.org/p":{"@value":null,"@annotation":{"@id":"https://example.org/r"}}}"#.as_slice(),
+        ),
+    ] {
+        let error = parse_jsonld(input).expect_err(description);
+        assert!(
+            error.message.contains("unexpected member")
+                || error.message.contains("cannot carry @annotation"),
+            "{description}: {error}"
+        );
+    }
+}
+
+#[test]
+fn rdf_json_collapses_only_when_its_lexical_form_is_canonical() {
+    let context = json!({
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "json": {"@id": "ex:json", "@type": "@json"},
+        "rdf": {"@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "@prefix": true}
+    });
+    let canonical = concat!(
+        "<https://example.org/s> <https://example.org/json> ",
+        "\"{\\\"a\\\":1}\"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .\n",
+    );
+    let (dataset, compacted) = serialize_with_context(canonical, &context);
+    let value: Value = serde_json::from_str(&compacted).expect("JSON output");
+    assert_eq!(value["@graph"][0]["json"], json!({"a": 1}));
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand canonical rdf:JSON");
+    assert!(
+        datasets_isomorphic(&dataset, &reparsed),
+        "source:\n{}\nreparsed:\n{}\njson:\n{compacted}",
+        canonical_flat_nquads(&dataset).expect("canonical source"),
+        canonical_flat_nquads(&reparsed).expect("canonical reparsed")
+    );
+
+    let noncanonical = concat!(
+        "<https://example.org/s> <https://example.org/json> ",
+        "\"{ \\\"a\\\": 1 }\"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .\n",
+    );
+    let (dataset, compacted) = serialize_with_context(noncanonical, &context);
+    let value: Value = serde_json::from_str(&compacted).expect("JSON output");
+    assert_eq!(value["@graph"][0]["ex:json"]["@value"], "{ \"a\": 1 }");
+    assert_eq!(value["@graph"][0]["ex:json"]["@type"], "rdf:JSON");
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand lexical rdf:JSON");
+    assert!(
+        datasets_isomorphic(&dataset, &reparsed),
+        "source:\n{}\nreparsed:\n{}\njson:\n{compacted}",
+        canonical_flat_nquads(&dataset).expect("canonical source"),
+        canonical_flat_nquads(&reparsed).expect("canonical reparsed")
+    );
+}
+
+#[test]
+fn language_and_id_maps_compact_and_expand_losslessly() {
+    let source = concat!(
+        "<https://example.org/s> <https://example.org/label> \"hello\"@en .\n",
+        "<https://example.org/s> <https://example.org/label> \"bonjour\"@fr .\n",
+        "<https://example.org/s> <https://example.org/member> <https://example.org/alice> .\n",
+        "<https://example.org/s> <https://example.org/member> <https://example.org/bob> .\n",
+    );
+    let context = json!({
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "label": {"@id": "ex:label", "@container": "@language"},
+        "member": {"@id": "ex:member", "@container": "@id"}
+    });
+    let (dataset, compacted) = serialize_with_context(source, &context);
+    let value: Value = serde_json::from_str(&compacted).expect("JSON output");
+    assert_eq!(value["@graph"][0]["label"]["en"], "hello");
+    assert_eq!(value["@graph"][0]["label"]["fr"], "bonjour");
+    assert_eq!(value["@graph"][0]["member"]["ex:alice"], json!({}));
+    assert_eq!(value["@graph"][0]["member"]["ex:bob"], json!({}));
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand map containers");
+    assert!(datasets_isomorphic(&dataset, &reparsed));
+}
+
+#[test]
+fn authored_reverse_nest_and_scoped_contexts_expand_through_one_lens() {
+    let source = br#"{
+      "@context": {
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "details": "@nest",
+        "friend": {
+          "@id": "ex:friend",
+          "@context": {"label": "ex:label"}
+        },
+        "knownBy": {"@reverse": "ex:knows", "@type": "@id"},
+        "name": {"@id": "ex:name", "@nest": "details"}
+      },
+      "@id": "ex:alice",
+      "knownBy": "ex:bob",
+      "details": {"name": "Alice"},
+      "friend": {"@id": "ex:carol", "label": "Carol"}
+    }"#;
+    let expected = parse_nquads(concat!(
+        "<https://example.org/bob> <https://example.org/knows> <https://example.org/alice> .\n",
+        "<https://example.org/alice> <https://example.org/name> \"Alice\" .\n",
+        "<https://example.org/alice> <https://example.org/friend> <https://example.org/carol> .\n",
+        "<https://example.org/carol> <https://example.org/label> \"Carol\" .\n",
+    ));
+    let actual = parse_jsonld(source).expect("expand reverse/nest/scoped context");
+    assert!(datasets_isomorphic(&expected, &actual));
+}
+
+#[test]
+fn mapped_index_type_and_set_containers_preserve_rdf() {
+    let source = br#"{
+      "@context": {
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "entries": {"@id": "ex:entry", "@container": "@index", "@index": "ex:source"},
+        "members": {"@id": "ex:member", "@container": "@type"},
+        "tags": {"@id": "ex:tag", "@container": "@set"}
+      },
+      "@id": "ex:s",
+      "entries": {"row-1": {"@id": "ex:o"}},
+      "members": {"ex:Person": {"@id": "ex:bob"}},
+      "tags": ["one", "two"]
+    }"#;
+    let expected = parse_nquads(concat!(
+        "<https://example.org/s> <https://example.org/entry> <https://example.org/o> .\n",
+        "<https://example.org/o> <https://example.org/source> \"row-1\" .\n",
+        "<https://example.org/s> <https://example.org/member> <https://example.org/bob> .\n",
+        "<https://example.org/bob> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/Person> .\n",
+        "<https://example.org/s> <https://example.org/tag> \"one\" .\n",
+        "<https://example.org/s> <https://example.org/tag> \"two\" .\n",
+    ));
+    let actual = parse_jsonld(source).expect("expand index/type/set containers");
+    assert!(datasets_isomorphic(&expected, &actual));
+}
+
+#[test]
+fn graph_id_and_mapped_graph_index_containers_preserve_named_graph_scope() {
+    let source = br#"{
+      "@context": {
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "graphs": {"@id": "ex:containsGraph", "@container": ["@graph", "@id"]},
+        "indexedGraphs": {
+          "@id": "ex:indexedGraph",
+          "@container": ["@graph", "@index"],
+          "@index": "ex:key"
+        },
+        "name": "ex:name"
+      },
+      "@id": "ex:catalog",
+      "graphs": {
+        "ex:g": {"@id": "ex:item", "name": "Item"}
+      },
+      "indexedGraphs": {
+        "row-1": {"@id": "ex:item2", "name": "Two"}
+      }
+    }"#;
+    let expected = parse_nquads(concat!(
+        "<https://example.org/catalog> <https://example.org/containsGraph> <https://example.org/g> .\n",
+        "<https://example.org/item> <https://example.org/name> \"Item\" <https://example.org/g> .\n",
+        "<https://example.org/catalog> <https://example.org/indexedGraph> _:graph .\n",
+        "_:graph <https://example.org/key> \"row-1\" .\n",
+        "<https://example.org/item2> <https://example.org/name> \"Two\" _:graph .\n",
+    ));
+    let actual = parse_jsonld(source).expect("expand @graph map containers");
+    assert!(
+        datasets_isomorphic(&expected, &actual),
+        "expected:\n{}\nactual:\n{}",
+        canonical_flat_nquads(&expected).expect("canonical expected"),
+        canonical_flat_nquads(&actual).expect("canonical actual")
+    );
+}
+
+#[test]
+fn named_graph_references_compact_into_graph_id_maps() {
+    let source = concat!(
+        "<https://example.org/catalog> <https://example.org/containsGraph> <https://example.org/g> .\n",
+        "<https://example.org/item> <https://example.org/name> \"Item\" <https://example.org/g> .\n",
+    );
+    let context = json!({
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "graphs": {"@id": "ex:containsGraph", "@container": ["@graph", "@id"]},
+        "name": "ex:name"
+    });
+    let (dataset, compacted) = serialize_with_context(source, &context);
+    let value: Value = serde_json::from_str(&compacted).expect("JSON output");
+    let catalog = value["@graph"]
+        .as_array()
+        .expect("top-level graph")
+        .iter()
+        .find(|node| node["@id"] == "ex:catalog")
+        .expect("catalog node");
+    assert_eq!(catalog["graphs"]["ex:g"]["@id"], "ex:item");
+    assert_eq!(catalog["graphs"]["ex:g"]["name"], "Item");
+    assert_eq!(value["@graph"].as_array().expect("graph").len(), 1);
+
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand graph id map");
+    assert!(datasets_isomorphic(&dataset, &reparsed));
+}
+
+#[test]
+fn configured_context_preserves_named_graphs_and_rdf_1_2_statement_structures() {
+    let dataset = common::build_fixture();
+    let compiled = CompiledJsonLdContext::compile(
+        &json!({
+            "ex": {"@id": "http://example.org/", "@prefix": true},
+            "rdf": {"@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "@prefix": true},
+            "xsd": {"@id": "http://www.w3.org/2001/XMLSchema#", "@prefix": true}
+        }),
+        None,
+    )
+    .expect("compile context");
+    let compacted = serialize_dataset_to_jsonld_with_options(
+        &dataset,
+        &JsonLdSerializeOptions::compiled(std::sync::Arc::new(compiled)),
+    )
+    .expect("serialize rich RDF 1.2 fixture");
+    assert!(compacted.contains("@triple"));
+    assert!(compacted.contains("@annotation"));
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand rich RDF 1.2 fixture");
+    assert!(
+        datasets_isomorphic(&dataset, &reparsed),
+        "source:\n{}\nreparsed:\n{}\njson:\n{compacted}",
+        canonical_flat_nquads(&dataset).expect("canonical source"),
+        canonical_flat_nquads(&reparsed).expect("canonical reparsed")
+    );
+}
+
+#[test]
+fn configured_context_preserves_many_to_many_reifier_bindings() {
+    let mut builder = RdfDatasetBuilder::new();
+    let subject = builder.intern_iri("https://example.org/s");
+    let predicate = builder.intern_iri("https://example.org/p");
+    let first_object = builder.intern_iri("https://example.org/o1");
+    let second_object = builder.intern_iri("https://example.org/o2");
+    let first = builder.intern_triple(subject, predicate, first_object);
+    let second = builder.intern_triple(subject, predicate, second_object);
+    let shared = builder.intern_iri("https://example.org/shared");
+    let alternate = builder.intern_iri("https://example.org/alternate");
+    let confidence = builder.intern_iri("https://example.org/confidence");
+    let high = builder.intern_literal(RdfLiteral::simple("high"));
+    builder.push_quad(subject, predicate, first_object, None);
+    builder.push_quad(subject, predicate, second_object, None);
+    builder.push_reifier(shared, first);
+    builder.push_reifier(shared, second);
+    builder.push_reifier(alternate, first);
+    builder.push_annotation(shared, confidence, high);
+    let dataset = builder.freeze().expect("freeze many-to-many reifiers");
+
+    let compiled = CompiledJsonLdContext::compile(
+        &json!({"ex": {"@id": "https://example.org/", "@prefix": true}}),
+        None,
+    )
+    .expect("compile context");
+    let compacted = serialize_dataset_to_jsonld_with_options(
+        &dataset,
+        &JsonLdSerializeOptions::compiled(std::sync::Arc::new(compiled)),
+    )
+    .expect("serialize many-to-many reifiers");
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand many-to-many reifiers");
+    assert!(datasets_isomorphic(&dataset, &reparsed));
+}
+
+#[test]
+fn mixed_graph_nodes_numeric_lexicals_and_annotation_types_survive_expansion() {
+    let mixed = br#"{
+      "@context": {
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "measure": {"@id": "https://example.org/measure#", "@prefix": true}
+      },
+      "@graph": [{
+        "@id": "ex:g",
+        "@type": "ex:Graph",
+        "ex:source": {"@id": "ex:reference"},
+        "@graph": {"@id": "ex:s", "measure:cups": 5.3}
+      }]
+    }"#;
+    let expected = parse_nquads(concat!(
+        "<https://example.org/g> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/Graph> .\n",
+        "<https://example.org/g> <https://example.org/source> <https://example.org/reference> .\n",
+        "<https://example.org/s> <https://example.org/measure#cups> \"5.3E0\"^^<http://www.w3.org/2001/XMLSchema#double> <https://example.org/g> .\n",
+    ));
+    let actual = parse_jsonld(mixed).expect("expand mixed graph node");
+    assert!(datasets_isomorphic(&expected, &actual));
+
+    let annotated = br#"{
+      "@id": "https://example.org/s",
+      "https://example.org/p": {
+        "@id": "https://example.org/o",
+        "@annotation": {
+          "@id": "_:r",
+          "@type": "https://example.org/Annotation"
+        }
+      }
+    }"#;
+    let expected = parse_nquads(concat!(
+        "<https://example.org/s> <https://example.org/p> <https://example.org/o> .\n",
+        "_:r <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( <https://example.org/s> <https://example.org/p> <https://example.org/o> )>> .\n",
+        "_:r <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://example.org/Annotation> .\n",
+    ));
+    let actual = parse_jsonld(annotated).expect("expand typed annotation node");
+    assert!(datasets_isomorphic(&expected, &actual));
+}
+
+#[test]
+fn reverse_aliases_and_graph_index_maps_compact_losslessly() {
+    let reverse_source =
+        "<https://example.org/bob> <https://example.org/knows> <https://example.org/alice> .\n";
+    let reverse_context = json!({
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "knownBy": {"@reverse": "ex:knows", "@type": "@id"}
+    });
+    let (dataset, compacted) = serialize_with_context(reverse_source, &reverse_context);
+    let value: Value = serde_json::from_str(&compacted).expect("JSON output");
+    let alice = value["@graph"]
+        .as_array()
+        .expect("top-level graph")
+        .iter()
+        .find(|node| node["@id"] == "ex:alice")
+        .expect("reverse target node");
+    assert_eq!(alice["knownBy"], "ex:bob");
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand reverse alias");
+    assert!(datasets_isomorphic(&dataset, &reparsed));
+
+    let indexed_source = concat!(
+        "<https://example.org/catalog> <https://example.org/indexedGraph> _:graph .\n",
+        "_:graph <https://example.org/key> \"row-1\" .\n",
+        "<https://example.org/item> <https://example.org/name> \"Item\" _:graph .\n",
+    );
+    let indexed_context = json!({
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "indexedGraphs": {
+          "@id": "ex:indexedGraph",
+          "@container": ["@graph", "@index"],
+          "@index": "ex:key"
+        },
+        "name": "ex:name"
+    });
+    let (dataset, compacted) = serialize_with_context(indexed_source, &indexed_context);
+    let value: Value = serde_json::from_str(&compacted).expect("JSON output");
+    assert_eq!(value["@graph"][0]["indexedGraphs"]["row-1"]["name"], "Item");
+    assert_eq!(value["@graph"].as_array().expect("graph").len(), 1);
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand graph index map");
+    assert!(datasets_isomorphic(&dataset, &reparsed));
+}
+
+#[test]
+fn graph_index_containers_apply_inside_named_graphs() {
+    let source = concat!(
+        "<https://example.org/catalog> <https://example.org/indexedGraph> _:target _:outer .\n",
+        "_:target <https://example.org/key> \"row-1\" _:outer .\n",
+        "<https://example.org/item> <https://example.org/name> \"Item\" _:target .\n",
+    );
+    let context = json!({
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "indexedGraphs": {
+          "@id": "ex:indexedGraph",
+          "@container": ["@graph", "@index"],
+          "@index": "ex:key"
+        },
+        "name": "ex:name"
+    });
+    let (dataset, compacted) = serialize_with_context(source, &context);
+    let value: Value = serde_json::from_str(&compacted).expect("JSON output");
+    let outer = value["@graph"]
+        .as_array()
+        .expect("top-level graph")
+        .iter()
+        .find(|node| node["@id"] == "_:outer")
+        .expect("outer named graph");
+    let catalog = outer["@graph"]
+        .as_array()
+        .expect("outer graph contents")
+        .iter()
+        .find(|node| node["@id"] == "ex:catalog")
+        .expect("catalog node");
+    assert_eq!(catalog["indexedGraphs"]["row-1"]["name"], "Item");
+
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand nested graph index map");
+    assert!(datasets_isomorphic(&dataset, &reparsed));
+}
+
+#[test]
+fn list_coercion_and_shared_list_identity_are_preserved() {
+    let language_list = concat!(
+        "<https://example.org/s> <https://example.org/items> _:head .\n",
+        "_:head <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> \"one\"@en .\n",
+        "_:head <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:tail .\n",
+        "_:tail <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> \"two\"@en .\n",
+        "_:tail <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .\n",
+    );
+    let context = json!({
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "items": {"@id": "ex:items", "@container": "@list", "@language": "en"}
+    });
+    let (dataset, compacted) = serialize_with_context(language_list, &context);
+    let value: Value = serde_json::from_str(&compacted).expect("JSON output");
+    assert_eq!(value["@graph"][0]["items"], json!(["one", "two"]));
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand coerced list");
+    assert!(datasets_isomorphic(&dataset, &reparsed));
+
+    let shared = concat!(
+        "<https://example.org/s> <https://example.org/items> _:head .\n",
+        "<https://example.org/x> <https://example.org/quotes> <<( <https://example.org/a> <https://example.org/p> _:head )>> .\n",
+        "_:head <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> \"one\" .\n",
+        "_:head <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .\n",
+    );
+    let (dataset, compacted) = serialize_with_context(shared, &context);
+    assert!(compacted.contains("rdf-syntax-ns#first"));
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand shared list identity");
+    assert!(datasets_isomorphic(&dataset, &reparsed));
+}
+
+#[test]
+fn graph_names_are_not_folded_as_list_heads() {
+    let source = concat!(
+        "<https://example.org/s> <https://example.org/items> _:head _:head .\n",
+        "_:head <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> \"one\" _:head .\n",
+        "_:head <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> _:head .\n",
+    );
+    let context = json!({
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "items": {"@id": "ex:items", "@container": "@list"}
+    });
+    let (dataset, compacted) = serialize_with_context(source, &context);
+    assert!(compacted.contains("rdf-syntax-ns#first"));
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand graph-name list identity");
+    assert!(datasets_isomorphic(&dataset, &reparsed));
+}
+
+#[test]
+fn generated_list_cells_do_not_collide_with_nested_annotation_ids() {
+    let source = br#"{
+      "@id": "https://example.org/s",
+      "https://example.org/p": {
+        "@list": [{"@id": "https://example.org/o"}],
+        "@annotation": {
+          "@id": "_:jsonld_list_0",
+          "https://example.org/confidence": "high"
+        }
+      }
+    }"#;
+    let expected = parse_nquads(concat!(
+        "<https://example.org/s> <https://example.org/p> _:head .\n",
+        "_:head <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://example.org/o> .\n",
+        "_:head <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .\n",
+        "_:jsonld_list_0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( <https://example.org/s> <https://example.org/p> _:head )>> .\n",
+        "_:jsonld_list_0 <https://example.org/confidence> \"high\" .\n",
+    ));
+    let actual = parse_jsonld(source).expect("parse annotated list");
+    assert!(datasets_isomorphic(&expected, &actual));
+}
+
+#[test]
+fn registry_backed_compaction_has_a_matching_parse_lens() {
+    let context_iri = "https://example.org/context.jsonld";
+    let context_document = br#"{
+      "@context": {
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "p": {"@id": "ex:p", "@type": "@id"}
+      }
+    }"#;
+    let registry = JsonLdContextRegistry::new([(context_iri, context_document.as_slice())])
+        .expect("offline registry");
+    let compiled = CompiledJsonLdContext::compile_registry_context(context_iri, &registry)
+        .expect("registry context");
+    let dataset =
+        parse_nquads("<https://example.org/s> <https://example.org/p> <https://example.org/o> .\n");
+    let compacted = serialize_dataset_to_jsonld_with_options(
+        &dataset,
+        &JsonLdSerializeOptions::compiled(std::sync::Arc::new(compiled.clone())),
+    )
+    .expect("registry-backed compaction");
+    let reparsed = parse_jsonld_with_context(compacted.as_bytes(), &compiled)
+        .expect("registry-backed expansion");
+    assert!(datasets_isomorphic(&dataset, &reparsed));
+}
+
+#[test]
+fn compaction_bytes_ignore_input_insertion_order_and_are_idempotent() {
+    let forward = concat!(
+        "<https://example.org/a> <https://example.org/p> <https://example.org/b> .\n",
+        "<https://example.org/a> <https://example.org/q> \"two\" .\n",
+        "<https://example.org/a> <https://example.org/q> \"one\" .\n",
+    );
+    let reverse = concat!(
+        "<https://example.org/a> <https://example.org/q> \"one\" .\n",
+        "<https://example.org/a> <https://example.org/q> \"two\" .\n",
+        "<https://example.org/a> <https://example.org/p> <https://example.org/b> .\n",
+    );
+    let context = json!({
+        "ex": {"@id": "https://example.org/", "@prefix": true},
+        "p": {"@id": "ex:p", "@type": "@id"},
+        "q": "ex:q"
+    });
+    let (_, first) = serialize_with_context(forward, &context);
+    let (_, second) = serialize_with_context(reverse, &context);
+    assert_eq!(first, second);
+
+    let reparsed = parse_jsonld(first.as_bytes()).expect("expand compacted document");
+    let compiled = CompiledJsonLdContext::compile(&context, None).expect("compile context");
+    let reserialized = serialize_dataset_to_jsonld_with_options(
+        &reparsed,
+        &JsonLdSerializeOptions::compiled(std::sync::Arc::new(compiled)),
+    )
+    .expect("compact expanded dataset again");
+    assert_eq!(first, reserialized);
+}
+
+proptest! {
+    #[test]
+    fn compact_expand_is_an_isomorphic_idempotent_lens(
+        rows in prop::collection::btree_set(("[a-z]{1,8}", "[a-z]{1,8}"), 1..24)
+    ) {
+        let source = rows.iter().fold(String::new(), |mut source, (predicate, object)| {
+            writeln!(
+                source,
+                "<https://example.org/s> <https://example.org/{predicate}> <https://example.org/{object}> ."
+            )
+            .expect("writing to String cannot fail");
+            source
+        });
+        let context = json!({
+            "ex": {"@id": "https://example.org/", "@prefix": true},
+            "id": "@id"
+        });
+        let (dataset, compacted) = serialize_with_context(&source, &context);
+        let reparsed = parse_jsonld(compacted.as_bytes()).expect("expand generated compact document");
+        prop_assert!(datasets_isomorphic(&dataset, &reparsed));
+
+        let compiled = CompiledJsonLdContext::compile(&context, None).expect("compile context");
+        let reserialized = serialize_dataset_to_jsonld_with_options(
+            &reparsed,
+            &JsonLdSerializeOptions::compiled(std::sync::Arc::new(compiled)),
+        )
+        .expect("recompact generated dataset");
+        prop_assert_eq!(compacted, reserialized);
+    }
+}

--- a/crates/rdf/tests/jsonld_context_lens.rs
+++ b/crates/rdf/tests/jsonld_context_lens.rs
@@ -9,8 +9,8 @@ use std::fmt::Write as _;
 
 use proptest::prelude::*;
 use purrdf_rdf::native_codecs::jsonld::{
-    CompiledJsonLdContext, JsonLdContextRegistry, JsonLdSerializeOptions, parse_jsonld,
-    parse_jsonld_with_context, serialize_dataset_to_jsonld_with_options,
+    CompiledJsonLdContext, JsonLdContextRegistry, JsonLdSerializeOptions, derive_jsonld_context,
+    parse_jsonld, parse_jsonld_with_context, serialize_dataset_to_jsonld_with_options,
 };
 use purrdf_rdf::{
     RdfDatasetBuilder, RdfLiteral, canonical_flat_nquads, datasets_isomorphic, parse_dataset,
@@ -72,6 +72,42 @@ fn aliases_base_vocab_and_coercions_compact_and_expand_losslessly() {
         canonical_flat_nquads(&dataset).expect("canonical source"),
         canonical_flat_nquads(&reparsed).expect("canonical reparsed")
     );
+}
+
+#[test]
+fn derived_mode_uses_only_sorted_dataset_namespaces_and_round_trips() {
+    let mut source = String::new();
+    for index in 0..32 {
+        writeln!(
+            source,
+            "<https://example.org/resource/s{index}> <https://example.org/vocab/p{index}> <https://example.org/resource/o{index}> ."
+        )
+        .expect("write derived fixture");
+    }
+    writeln!(
+        source,
+        "_:blank <https://example.org/vocab/label> \"blank\" ."
+    )
+    .expect("write blank-node row");
+    let dataset = parse_nquads(&source);
+    let context = derive_jsonld_context(&dataset).expect("derive context");
+    assert_eq!(context.vocab_mapping(), None);
+    assert_eq!(
+        context.canonical_context()["ns0"]["@id"],
+        "https://example.org/resource/"
+    );
+    assert_eq!(
+        context.canonical_context()["ns1"]["@id"],
+        "https://example.org/vocab/"
+    );
+    let compacted =
+        serialize_dataset_to_jsonld_with_options(&dataset, &JsonLdSerializeOptions::derived())
+            .expect("serialize derived context");
+    assert!(compacted.contains("ns0:s0"));
+    assert!(compacted.contains("ns1:p0"));
+    assert!(!compacted.contains("@vocab"));
+    let reparsed = parse_jsonld(compacted.as_bytes()).expect("parse derived output");
+    assert!(datasets_isomorphic(&dataset, &reparsed));
 }
 
 #[test]

--- a/crates/rdf/tests/jsonld_expanded_baseline.rs
+++ b/crates/rdf/tests/jsonld_expanded_baseline.rs
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Byte-compatibility baseline for every Rust route to expanded JSON-LD/YAML-LD.
+
+use purrdf_rdf::native_codecs::jsonld::{serialize_dataset_to_jsonld, serialize_dataset_to_yamlld};
+use purrdf_rdf::{SerializeGraph, parse_dataset, serialize_dataset};
+
+const NQUADS: &str = "<https://example.org/alice> <https://schema.org/name> \"Alice\" .\n";
+
+const JSONLD: &str = r#"{
+  "@context": {},
+  "@graph": [
+    {
+      "@id": "https://example.org/alice",
+      "https://schema.org/name": {
+        "@value": "Alice"
+      }
+    }
+  ]
+}"#;
+
+const YAMLLD: &str = concat!(
+    "# yaml-language-server: $schema=purrdf.schema.json\n",
+    "# The default reference is the bundled purrdf.schema.json; pass an explicit\n",
+    "# schema_url to point editors at a hosted copy.\n",
+    "'@context': {}\n",
+    "'@graph':\n",
+    "- '@id': https://example.org/alice\n",
+    "  https://schema.org/name:\n",
+    "    '@value': Alice\n",
+);
+
+#[test]
+fn direct_and_generic_expanded_bytes_are_frozen() {
+    let dataset = parse_dataset(NQUADS.as_bytes(), "application/n-quads", None)
+        .expect("parse baseline N-Quads");
+
+    assert_eq!(
+        serialize_dataset_to_jsonld(&dataset).expect("direct JSON-LD"),
+        JSONLD
+    );
+    assert_eq!(
+        serialize_dataset(&dataset, "application/ld+json", SerializeGraph::Dataset)
+            .expect("generic JSON-LD"),
+        JSONLD.as_bytes()
+    );
+    assert_eq!(
+        serialize_dataset_to_yamlld(&dataset, None).expect("direct YAML-LD"),
+        YAMLLD
+    );
+    assert_eq!(
+        serialize_dataset(&dataset, "application/ld+yaml", SerializeGraph::Dataset)
+            .expect("generic YAML-LD"),
+        YAMLLD.as_bytes()
+    );
+}

--- a/crates/rdf/tests/jsonld_w3c_conformance.rs
+++ b/crates/rdf/tests/jsonld_w3c_conformance.rs
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Pinned W3C JSON-LD 1.1 to-RDF conformance vectors.
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::sync::Arc;
+
+use purrdf_rdf::native_codecs::jsonld::{
+    CompiledJsonLdContext, JsonLdSerializeOptions, parse_jsonld,
+    serialize_dataset_to_jsonld_with_options,
+};
+use purrdf_rdf::{canonical_flat_nquads, datasets_isomorphic, parse_dataset};
+use serde::Deserialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+const EXPECTED_VECTOR_COUNT: usize = 73;
+const EXPECTED_COMPACTION_VECTOR_COUNT: usize = 13;
+const EXPECTED_REVISION: &str = "3e7fa5377b2b3c5176eacf8bde8e01fdb7c4a062";
+const EXPECTED_TAG: &str = "REC-2020-07-16";
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Corpus {
+    schema_version: u32,
+    upstream_revision: String,
+    upstream_tag: String,
+    expected_vector_count: usize,
+    vectors: Vec<Vector>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Vector {
+    id: String,
+    name: String,
+    purpose: String,
+    input_sha256: String,
+    expected_sha256: String,
+    input: String,
+    expected_nquads: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CompactionCorpus {
+    schema_version: u32,
+    upstream_revision: String,
+    upstream_tag: String,
+    expected_vector_count: usize,
+    vectors: Vec<CompactionVector>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CompactionVector {
+    id: String,
+    name: String,
+    purpose: String,
+    input_sha256: String,
+    context_sha256: String,
+    expected_sha256: String,
+    input: String,
+    context: String,
+    expected: String,
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .fold(String::with_capacity(64), |mut output, byte| {
+            write!(output, "{byte:02x}").expect("writing to String cannot fail");
+            output
+        })
+}
+
+fn flatten_single_carrier_graph(mut value: Value) -> Value {
+    let Some(object) = value.as_object_mut() else {
+        return value;
+    };
+    let Some(Value::Array(mut graph)) = object.remove("@graph") else {
+        return value;
+    };
+    if graph.len() != 1 {
+        object.insert("@graph".to_owned(), Value::Array(graph));
+        return value;
+    }
+    let Value::Object(node) = graph.remove(0) else {
+        object.insert("@graph".to_owned(), Value::Array(graph));
+        return value;
+    };
+    object.extend(node);
+    value
+}
+
+#[test]
+fn pinned_w3c_to_rdf_vectors_match_the_independent_nquads_oracle() {
+    let corpus: Corpus = serde_json::from_str(include_str!("fixtures/jsonld-w3c-rec/vectors.json"))
+        .expect("decode pinned W3C vectors");
+    assert_eq!(corpus.schema_version, 1);
+    assert_eq!(corpus.upstream_revision, EXPECTED_REVISION);
+    assert_eq!(corpus.upstream_tag, EXPECTED_TAG);
+    assert_eq!(corpus.expected_vector_count, EXPECTED_VECTOR_COUNT);
+    assert_eq!(corpus.vectors.len(), EXPECTED_VECTOR_COUNT);
+
+    let mut identifiers = BTreeSet::new();
+    let mut passed = 0;
+    let mut failures = Vec::new();
+    for vector in &corpus.vectors {
+        assert!(
+            identifiers.insert(vector.id.as_str()),
+            "duplicate vector id"
+        );
+        assert!(
+            !vector.name.is_empty(),
+            "{} has no upstream name",
+            vector.id
+        );
+        assert!(
+            !vector.purpose.is_empty(),
+            "{} has no upstream purpose",
+            vector.id
+        );
+        assert_eq!(
+            sha256(vector.input.as_bytes()),
+            vector.input_sha256,
+            "{} input checksum drift",
+            vector.id
+        );
+        assert_eq!(
+            sha256(vector.expected_nquads.as_bytes()),
+            vector.expected_sha256,
+            "{} oracle checksum drift",
+            vector.id
+        );
+
+        let actual = match parse_jsonld(vector.input.as_bytes()) {
+            Ok(dataset) => dataset,
+            Err(error) => {
+                failures.push(format!("{} ({}): {error}", vector.id, vector.name));
+                continue;
+            }
+        };
+        let expected = parse_dataset(
+            vector.expected_nquads.as_bytes(),
+            "application/n-quads",
+            None,
+        )
+        .unwrap_or_else(|error| panic!("{} invalid pinned N-Quads: {error}", vector.id));
+        if datasets_isomorphic(&actual, &expected) {
+            passed += 1;
+        } else {
+            failures.push(format!(
+                "{} ({}):\nexpected:\n{}\nactual:\n{}",
+                vector.id,
+                vector.name,
+                canonical_flat_nquads(&expected).expect("canonical expected dataset"),
+                canonical_flat_nquads(&actual).expect("canonical actual dataset")
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "W3C JSON-LD vector failures:\n{}",
+        failures.join("\n\n")
+    );
+    assert_eq!(passed, EXPECTED_VECTOR_COUNT, "exact W3C pass count");
+}
+
+#[test]
+fn pinned_w3c_compaction_vectors_match_the_independent_json_oracle() {
+    let corpus: CompactionCorpus = serde_json::from_str(include_str!(
+        "fixtures/jsonld-w3c-rec/compaction_vectors.json"
+    ))
+    .expect("decode pinned W3C compaction vectors");
+    assert_eq!(corpus.schema_version, 1);
+    assert_eq!(corpus.upstream_revision, EXPECTED_REVISION);
+    assert_eq!(corpus.upstream_tag, EXPECTED_TAG);
+    assert_eq!(
+        corpus.expected_vector_count,
+        EXPECTED_COMPACTION_VECTOR_COUNT
+    );
+    assert_eq!(corpus.vectors.len(), EXPECTED_COMPACTION_VECTOR_COUNT);
+
+    let mut identifiers = BTreeSet::new();
+    let mut passed = 0;
+    let mut failures = Vec::new();
+    for vector in &corpus.vectors {
+        assert!(
+            identifiers.insert(vector.id.as_str()),
+            "duplicate vector id"
+        );
+        assert!(
+            !vector.name.is_empty(),
+            "{} has no upstream name",
+            vector.id
+        );
+        assert!(
+            !vector.purpose.is_empty(),
+            "{} has no upstream purpose",
+            vector.id
+        );
+        for (description, bytes, expected) in [
+            ("input", vector.input.as_bytes(), &vector.input_sha256),
+            ("context", vector.context.as_bytes(), &vector.context_sha256),
+            (
+                "expected",
+                vector.expected.as_bytes(),
+                &vector.expected_sha256,
+            ),
+        ] {
+            assert_eq!(
+                sha256(bytes),
+                *expected,
+                "{} {description} checksum drift",
+                vector.id
+            );
+        }
+
+        let dataset = match parse_jsonld(vector.input.as_bytes()) {
+            Ok(dataset) => dataset,
+            Err(error) => {
+                failures.push(format!("{} ({}): {error}", vector.id, vector.name));
+                continue;
+            }
+        };
+        let context: Value = serde_json::from_str(&vector.context)
+            .unwrap_or_else(|error| panic!("{} invalid context fixture: {error}", vector.id));
+        let compiled = CompiledJsonLdContext::compile(&context, None)
+            .unwrap_or_else(|error| panic!("{} context did not compile: {error}", vector.id));
+        let output = serialize_dataset_to_jsonld_with_options(
+            &dataset,
+            &JsonLdSerializeOptions::compiled(Arc::new(compiled)),
+        )
+        .unwrap_or_else(|error| panic!("{} compaction failed: {error}", vector.id));
+        let actual: Value = serde_json::from_str(&output).expect("PurRDF emitted JSON");
+        let expected: Value = serde_json::from_str(&vector.expected)
+            .unwrap_or_else(|error| panic!("{} invalid expected JSON: {error}", vector.id));
+        let actual = flatten_single_carrier_graph(actual);
+        if actual == expected {
+            passed += 1;
+        } else {
+            failures.push(format!(
+                "{} ({}):\nexpected:\n{}\nactual:\n{}",
+                vector.id,
+                vector.name,
+                serde_json::to_string_pretty(&expected).expect("expected JSON"),
+                serde_json::to_string_pretty(&actual).expect("actual JSON")
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "W3C JSON-LD compaction vector failures:\n{}",
+        failures.join("\n\n")
+    );
+    assert_eq!(
+        passed, EXPECTED_COMPACTION_VECTOR_COUNT,
+        "exact W3C compaction pass count"
+    );
+}

--- a/crates/rdf/tests/serialize_pack_parity.rs
+++ b/crates/rdf/tests/serialize_pack_parity.rs
@@ -15,7 +15,12 @@
 //! the serializer folds into its deterministic output.
 
 use purrdf_core::{DatasetView, PackBuilder, PackView};
-use purrdf_rdf::{NativeRdfFormat, serialize_dataset_to_format};
+use purrdf_rdf::{
+    CompiledJsonLdContext, JsonLdSerializeOptions, NativeRdfFormat, serialize_dataset_to_format,
+    serialize_dataset_to_format_with_jsonld_options, serialize_dataset_to_jsonld_with_context,
+    serialize_dataset_to_jsonld_with_options, serialize_dataset_to_yamlld_with_options,
+    serialize_dataset_with_jsonld_options,
+};
 
 mod common;
 use common::build_fixture;
@@ -124,4 +129,63 @@ fn pack_view_serializes_identically_to_source_dataset() {
         succeeded >= 7,
         "expected the star-capable + RDF/XML formats to serialize; only {succeeded} did"
     );
+}
+
+#[test]
+fn configured_jsonld_surfaces_accept_any_dataset_view_and_reuse_contexts() {
+    let dataset = build_fixture();
+    let pack = PackBuilder::build_bytes(&dataset).expect("pack build");
+    let view = PackView::from_bytes(&pack).expect("pack opens");
+    let compiled = CompiledJsonLdContext::from_prefixes([
+        ("ex", "http://example.org/"),
+        ("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
+        ("xsd", "http://www.w3.org/2001/XMLSchema#"),
+    ])
+    .expect("compile reusable context");
+    let options = JsonLdSerializeOptions::compiled(std::sync::Arc::new(compiled.clone()))
+        .with_yaml_schema_url("https://example.org/purrdf.schema.json")
+        .expect("schema URL");
+
+    let direct_json = serialize_dataset_to_jsonld_with_options(&view, &options)
+        .expect("configured JSON-LD from PackView");
+    assert_eq!(
+        direct_json,
+        serialize_dataset_to_jsonld_with_context(&view, &compiled)
+            .expect("compiled-context overload")
+    );
+    assert!(direct_json.contains("ex:"), "caller prefix must be used");
+
+    for format in [NativeRdfFormat::JsonLd, NativeRdfFormat::YamlLd] {
+        let source =
+            serialize_dataset_to_format_with_jsonld_options(&*dataset, format, None, &options)
+                .expect("configured source serialization");
+        let packed = serialize_dataset_to_format_with_jsonld_options(&view, format, None, &options)
+            .expect("configured PackView serialization");
+        assert_eq!(source.bytes, packed.bytes, "{format:?} DatasetView parity");
+        let generic = serialize_dataset_with_jsonld_options(
+            &view,
+            format.media_type(),
+            purrdf_rdf::SerializeGraph::Dataset,
+            &options,
+        )
+        .expect("configured generic media-type serialization");
+        assert_eq!(generic, source.bytes, "{format:?} generic parity");
+    }
+
+    let direct_yaml =
+        serialize_dataset_to_yamlld_with_options(&view, &options).expect("configured YAML-LD");
+    assert!(
+        direct_yaml.starts_with(
+            "# yaml-language-server: $schema=https://example.org/purrdf.schema.json\n"
+        )
+    );
+
+    let error = serialize_dataset_to_format_with_jsonld_options(
+        &view,
+        NativeRdfFormat::NQuads,
+        None,
+        &options,
+    )
+    .expect_err("configured options must not be ignored by another format");
+    assert_eq!(error.code, "jsonld-options-unused");
 }

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -52,6 +52,7 @@ hex = { workspace = true }
 regex = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/slice/src/prefix_emit.rs
+++ b/crates/slice/src/prefix_emit.rs
@@ -82,18 +82,43 @@ pub fn emit_core_prefixes(vocab: &SliceVocab) -> String {
 /// builder produced.
 pub fn emit_jsonld_context(vocab: &SliceVocab) -> String {
     let registry = effective_registry(vocab);
+    let mut source = serde_json::Map::new();
+    source.insert(
+        "@vocab".to_owned(),
+        serde_json::Value::String(vocab.ns().to_owned()),
+    );
+    for (prefix, namespace) in &registry {
+        source.insert(prefix.clone(), serde_json::Value::String(namespace.clone()));
+    }
+    let compiled = purrdf::native_codecs::jsonld::CompiledJsonLdContext::compile(
+        &serde_json::Value::Object(source),
+        None,
+    )
+    .expect("validated slice prefix authority must compile as a JSON-LD context");
+    let canonical = compiled
+        .canonical_context()
+        .as_object()
+        .expect("compiled slice context is an object");
     let mut out = String::new();
     out.push_str("{\n");
     out.push_str("  \"@context\": {\n");
-    let _ = writeln!(out, "    \"@vocab\": {},", json_string(vocab.ns()));
+    let canonical_vocab = canonical
+        .get("@vocab")
+        .and_then(serde_json::Value::as_str)
+        .expect("compiled slice context retains @vocab");
+    let _ = writeln!(out, "    \"@vocab\": {},", json_string(canonical_vocab));
     let last = registry.len() - 1;
-    for (i, (prefix, ns)) in registry.iter().enumerate() {
+    for (i, (prefix, _)) in registry.iter().enumerate() {
         let comma = if i == last { "" } else { "," };
+        let namespace = canonical
+            .get(prefix)
+            .and_then(serde_json::Value::as_str)
+            .expect("compiled slice context retains prefix mapping");
         let _ = writeln!(
             out,
             "    {}: {}{comma}",
             json_string(prefix),
-            json_string(ns)
+            json_string(namespace)
         );
     }
     out.push_str("  }\n");

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -37,7 +37,8 @@ They live under `crates/*/benches/`:
   binary64 access, and a one-million-chunk catalog.
 - `crates/rdf-core/benches/purremb_alloc.rs` — one-shot allocation traffic and
   live-byte high-water probes over the same deterministic `.purremb` fixtures.
-- `crates/rdf/benches/native_codecs.rs` — text/XML/JSON-LD codec throughput.
+- `crates/rdf/benches/native_codecs.rs` — text/XML/JSON-LD codec throughput,
+  including separate context compilation and expanded/caller/derived paths.
 - `crates/rdf/benches/projections.rs` — RDF-to-LPG mapping, all four LPG
   carrier writers/readers, exact CSVW write/read, OBO Graphs, SKOS, the shared
   research-object model, and all five research-object carriers, with
@@ -84,7 +85,7 @@ Additional benches are run package-by-package, e.g.
 | `crates/rdf-core/benches/pack_index_compare.rs` | Exact bytes, build latency, and unbound-subject query latency for the shipped FoQ posting indexes vs. a non-shipped bitmap wavelet matrix over the same pack adjacency. |
 | `crates/rdf-core/benches/purremb.rs` | Full validation and resident reopen over a 16,384 x 384 binary32 Matryoshka matrix; target/row/prefix access, exact and coarse-prefix/full-prefix top-10 retrieval, canonical streaming output, a 4,096 x 128 binary64 matrix, and a one-million-chunk hierarchy. |
 | `crates/rdf-core/benches/purremb_alloc.rs` | Allocation calls, requested bytes, retained-byte deltas, and live-byte high-water deltas for PURREMB fixture construction, verification, and streaming. |
-| `crates/rdf/benches/native_codecs.rs` | Throughput of the native Turtle, TriG, N-Triples, N-Quads, RDF/XML, and JSON-LD serializers/parsers. |
+| `crates/rdf/benches/native_codecs.rs` | Throughput of the native Turtle, TriG, N-Triples, N-Quads, RDF/XML, and JSON-LD serializers/parsers; JSON-LD context compilation and expanded/caller/derived modes are reported separately. |
 | `crates/rdf/benches/projections.rs` | Graph, tabular, and research-object mapping/carrier throughput plus allocation counts over deterministic fixtures. |
 | `crates/sparql-algebra/benches/tokenize.rs` | Lexer throughput on long IRI bodies, escaped string literals, and comment tails. |
 | `crates/sparql-eval/benches/query_eval.rs` | End-to-end SPARQL SELECT latency including BGP joins, filters, and aggregates. |

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -73,6 +73,7 @@ number, never a silent skip (see [Ledger discipline](#ledger-discipline) and
 | SHACL (first-party corpus) | `crates/shapes/corpus/` | **69 / 69** frozen expected reports |
 | Schema → SHACL | first-party exact/lossy/corruption/resource suites + locked language oracles | **5 / 5** production directions; exact emitted-schema recompilation or located closed-profile losses; no deferred reader |
 | Syntax codecs | W3C rdf-tests `crates/rdf/tests/corpus/w3c/` | **250 / 250** round-trip (nquads 27, ntriples 29, rdfxml 31, trig 60, turtle 103) · 0 gaps |
+| JSON-LD 1.1 context lens | W3C JSON-LD 1.1 REC + first-party RDF 1.2 vectors | **73 / 73** applicable toRDF · **13 / 13** exact compaction · 0 gaps; frozen provenance and checksums |
 | CSVW | W3C CSVW manifests, `crates/rdf/tests/fixtures/csvw-w3c/` | **270 / 270** RDF cases · **282 / 282** validation cases · 0 xfail; production output also accepted by locked `csvw==4.1.0` |
 | OBO Graphs view | official OBO Graphs 0.3.2 JSON Schema | production advanced-object fixture accepted; deliberate node/chain corruptions rejected |
 | Research-object carriers | five adversarial native fixtures plus shared semantic matrix | **5 / 5** native fixtures import with non-empty located ledgers · **25 / 25** shared-semantic source/target paths stabilize; Frictionless output validates against the vendored Data Package v1 schema |
@@ -108,6 +109,8 @@ number, never a silent skip (see [Ledger discipline](#ledger-discipline) and
   extension-function and standpoint suites.
 - `crates/rdf/tests/corpus/w3c/` — the W3C rdf-tests syntax corpus (Turtle,
   TriG, N-Triples, N-Quads, RDF/XML) driving the native-codec round-trip gate.
+- `crates/rdf/tests/fixtures/jsonld-w3c-rec/` — the revision-pinned W3C JSON-LD 1.1
+  REC vectors and manifest subset used by the shared context-lens harness.
 - `crates/rdf/tests/fixtures/rdfc/` — the W3C rdf-canon (RDFC-1.0) vectors.
 - `crates/rdf/tests/fixtures/csvw-w3c/` — the revision-pinned W3C CSVW RDF
   conversion and metadata-validation manifests. The harness asserts exact case

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -49,7 +49,7 @@ change with `python3 scripts/conformance-matrix.py --write-doc`:
 | ShEx 2.1 validation | shexTest v2.1.0 | 1105 | 0 | 0 | 0 | GREEN |
 | ShEx syntax + ShExC/ShExJ round-trip | shexTest v2.1.0 | 9 | 0 | 0 | 0 | GREEN |
 | rdflib LSP drop-in gate | rdflib 7.6 own tests | 85 | 1 | 1 | 0 | GREEN |
-| purrdf.compat parity | first-party (differential vs rdflib) | 373 | 4 | 4 | 0 | GREEN |
+| purrdf.compat parity | first-party (differential vs rdflib) | 383 | 4 | 4 | 0 | GREEN |
 <!-- END GENERATED: conformance-matrix -->
 
 The `Budget` column is the ledger ratchet's committed ceiling (see

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -21,6 +21,7 @@ SPDX-License-Identifier: CC-BY-4.0
 - [RDF 1.2 Visualization](concepts/visualization.md)
 - [Graph, Tabular & Research-Object Projections](concepts/projections.md)
 - [Codecs & Determinism](concepts/codecs.md)
+- [JSON-LD Contexts & Compaction](concepts/jsonld.md)
 - [Canonicalization & Diff](concepts/canonicalization.md)
 
 # SPARQL

--- a/docs/book/src/concepts/jsonld.md
+++ b/docs/book/src/concepts/jsonld.md
@@ -1,0 +1,123 @@
+<!--
+SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# JSON-LD Contexts & Compaction
+
+PurRDF has three explicit JSON-LD/YAML-LD serialization modes:
+
+- `expanded` preserves the byte-frozen empty-`@context` representation;
+- `context` compiles a caller prefix map or local JSON-LD 1.1 context once and
+  applies normative compaction;
+- `derived` deterministically assigns neutral `ns0`, `ns1`, ... aliases solely
+  from absolute IRIs in the dataset. It never invents a vocabulary or infers
+  `@vocab`.
+
+An RDF dataset does not retain prefix declarations from Turtle, JSON-LD, or
+another source syntax. Supply them explicitly when those declarations are
+application policy. All configured surfaces consume the same closed version-1
+JSON document and reject duplicate members, unknown fields, invalid contexts,
+network-only context references, cycles, and resource-limit excesses before
+emitting output.
+
+```json
+{
+  "version": 1,
+  "mode": "context",
+  "prefixes": {
+    "ex": "https://example.org/",
+    "schema": "https://schema.org/"
+  },
+  "yaml_schema_url": "https://example.org/purrdf.schema.json"
+}
+```
+
+## Rust
+
+```rust,ignore
+use purrdf::{
+    JsonLdSerializeOptions, parse_dataset,
+    serialize_dataset_to_jsonld_with_options,
+};
+
+let dataset = parse_dataset(
+    b"<https://example.org/alice> <https://schema.org/name> \"Alice\" .",
+    "application/n-triples",
+    None,
+)?;
+let options = JsonLdSerializeOptions::prefixes([
+    ("ex", "https://example.org/"),
+    ("schema", "https://schema.org/"),
+])?;
+let jsonld = serialize_dataset_to_jsonld_with_options(&dataset, &options)?;
+# Ok::<(), purrdf::RdfDiagnostic>(())
+```
+
+Keep a `CompiledJsonLdContext` (or `JsonLdSerializeOptions::compiled`) when the
+same application context is used for many datasets. `JsonLdContextRegistry`
+resolves context IRIs and `@import` only from caller-supplied immutable local
+documents; PurRDF never performs network context loading.
+
+## CLI
+
+Write the versioned document to a file, then pass it to any RDF-producing CLI
+path:
+
+```sh
+purrdf --jsonld-options context.json convert --from turtle --to jsonld input.ttl output.jsonld
+```
+
+The option is rejected for non-JSON-LD/YAML-LD output, canonical output,
+non-graph SPARQL results, and carrier projections rather than being ignored.
+
+## Python
+
+```python
+import json
+import purrdf
+
+options = json.dumps({
+    "version": 1,
+    "mode": "context",
+    "prefixes": {"ex": "https://example.org/"},
+})
+context = purrdf.CompiledJsonLdContext(options)
+text = purrdf.serialize_jsonld(
+    nquads,
+    format=purrdf.RdfFormat.N_QUADS,
+    output_format="jsonld",
+    context=context,
+)
+```
+
+`Store.dump`, `MutableDataset.dump`, immutable `RdfDataset`, and the RDFLib
+compatibility `Graph.serialize` surface accept the same configuration. Prefixes
+explicitly bound on a compatibility graph become its caller context.
+
+## JavaScript and WebAssembly
+
+```js
+const options = JSON.stringify({
+  version: 1,
+  mode: "context",
+  prefixes: { ex: "https://example.org/" },
+});
+const context = new CompiledJsonLdContext(options);
+const text = dataset.serializeWithContext("jsonld", context);
+```
+
+Use `serializeConfigured` for one-shot requests. `QueryEngine` exposes matching
+configured methods for CONSTRUCT and DESCRIBE graph results, and the playground
+worker accepts the same options document on its serialization path.
+
+## C
+
+Compile options with `purrdf_jsonld_context_compile`, reuse the returned
+`PurrdfJsonLdContext` with `purrdf_serialize_jsonld_configured`, then release it
+with `purrdf_jsonld_context_free`. The serializer accepts exactly one options
+byte slice or compiled handle. Buffers and errors retain the normal libpurrdf
+ownership rules.
+
+YAML-LD uses the same context lens. Its optional schema URL changes only the
+deterministic YAML language-server header; it does not change RDF semantics.

--- a/docs/playground/app.mjs
+++ b/docs/playground/app.mjs
@@ -333,7 +333,15 @@ async function doParse() {
 // Pane: Round-trip / differential
 // ---------------------------------------------------------------------------
 
-const SER_ORDER = ["turtle", "ntriples", "nquads", "trig", "rdfxml", "jsonld"];
+const SER_ORDER = [
+  "turtle",
+  "ntriples",
+  "nquads",
+  "trig",
+  "rdfxml",
+  "jsonld",
+  "yamlld",
+];
 const MIME = {
   turtle: "text/turtle",
   ntriples: "application/n-triples",
@@ -341,6 +349,7 @@ const MIME = {
   trig: "application/trig",
   rdfxml: "application/rdf+xml",
   jsonld: "application/ld+json",
+  yamlld: "application/ld+yaml",
 };
 const EXT = {
   turtle: "ttl",
@@ -349,6 +358,7 @@ const EXT = {
   trig: "trig",
   rdfxml: "rdf",
   jsonld: "jsonld",
+  yamlld: "yamlld",
 };
 
 async function doSerializeAll() {

--- a/docs/playground/engine.worker.mjs
+++ b/docs/playground/engine.worker.mjs
@@ -130,7 +130,7 @@ const HANDLERS = {
     return { size: current.size, rows: quadsToRows(current) };
   },
 
-  serializeAll() {
+  serializeAll({ jsonldOptions = null } = {}) {
     const ds = requireCurrent();
     const quoted = hasQuotedObject(ds);
     const formats = {};
@@ -141,7 +141,15 @@ const HANDLERS = {
       // error visibly instead of aborting the whole differential.
       let text = null;
       try {
-        text = ds.serialize(f);
+        text =
+          f === "jsonld" && jsonldOptions != null
+            ? ds.serializeConfigured(
+                f,
+                typeof jsonldOptions === "string"
+                  ? jsonldOptions
+                  : JSON.stringify(jsonldOptions),
+              )
+            : ds.serialize(f);
       } catch (e) {
         entry.error = String(e?.message ?? e);
       }

--- a/docs/playground/engine.worker.mjs
+++ b/docs/playground/engine.worker.mjs
@@ -16,9 +16,17 @@ import {
 
 const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
 
-/** The 6 codecs that can PARSE (JSON-LD is a first-class bidirectional codec). */
-const PARSE_FORMATS = ["turtle", "ntriples", "nquads", "trig", "rdfxml", "jsonld"];
-/** The 6 codecs that can SERIALIZE. */
+/** The 7 codecs that can PARSE (JSON-LD and YAML-LD are bidirectional codecs). */
+const PARSE_FORMATS = [
+  "turtle",
+  "ntriples",
+  "nquads",
+  "trig",
+  "rdfxml",
+  "jsonld",
+  "yamlld",
+];
+/** The 7 codecs that can SERIALIZE. */
 const SERIALIZE_FORMATS = [
   "turtle",
   "ntriples",
@@ -26,6 +34,7 @@ const SERIALIZE_FORMATS = [
   "trig",
   "rdfxml",
   "jsonld",
+  "yamlld",
 ];
 
 /** @type {Dataset|null} The single source of truth for the console's graph. */
@@ -142,7 +151,7 @@ const HANDLERS = {
       let text = null;
       try {
         text =
-          f === "jsonld" && jsonldOptions != null
+          (f === "jsonld" || f === "yamlld") && jsonldOptions != null
             ? ds.serializeConfigured(
                 f,
                 typeof jsonldOptions === "string"

--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -55,9 +55,9 @@
     ></div>
 
     <p class="jsonld-note" role="note">
-      Note: JSON-LD is a <strong>first-class bidirectional</strong> codec here — it
-      both parses and serializes, and its JSON-LD-star <code>@triple</code> encoding
-      round-trips object-position quoted triples losslessly.
+      Note: JSON-LD and YAML-LD are <strong>first-class bidirectional</strong> codecs
+      here. Their JSON-LD-star <code>@triple</code> encoding round-trips
+      object-position quoted triples losslessly.
     </p>
 
     <nav class="tabs" aria-label="Console panes">
@@ -85,6 +85,7 @@
             <option value="trig">TriG</option>
             <option value="rdfxml">RDF/XML</option>
             <option value="jsonld">JSON-LD</option>
+            <option value="yamlld">YAML-LD</option>
           </select>
         </div>
         <div class="field">
@@ -101,7 +102,7 @@
       <section id="pane-roundtrip" class="pane" role="tabpanel" aria-labelledby="tab-roundtrip" hidden>
         <h2>Round-trip &amp; differential</h2>
         <p class="muted">
-          Render the current graph in all six serialize formats side-by-side. The
+          Render the current graph in all seven serialize formats side-by-side. The
           canonical RDFC-1.0 N-Quads form is the graph's deterministic identity.
         </p>
         <div class="actions">
@@ -173,6 +174,7 @@
                 <option value="trig">TriG</option>
                 <option value="rdfxml">RDF/XML</option>
                 <option value="jsonld">JSON-LD</option>
+                <option value="yamlld">YAML-LD</option>
               </select>
             </div>
             <div class="field">
@@ -190,6 +192,7 @@
                 <option value="trig">TriG</option>
                 <option value="rdfxml">RDF/XML</option>
                 <option value="jsonld">JSON-LD</option>
+                <option value="yamlld">YAML-LD</option>
               </select>
             </div>
             <div class="field">

--- a/docs/playground/smoke/engine.smoke.test.mjs
+++ b/docs/playground/smoke/engine.smoke.test.mjs
@@ -8,6 +8,8 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import {
   ready,
@@ -62,9 +64,36 @@ const SERIALIZE_FORMATS = [
   "trig",
   "rdfxml",
   "jsonld",
+  "yamlld",
 ];
 
 await ready();
+
+const workerMessages = [];
+let workerMessageHandler = null;
+globalThis.self = {
+  location: { origin: "https://playground.example" },
+  addEventListener(type, handler) {
+    if (type === "message") workerMessageHandler = handler;
+  },
+  postMessage(message) {
+    workerMessages.push(message);
+  },
+};
+const playgroundOut = process.env.PLAYGROUND_OUT;
+assert.ok(playgroundOut, "PLAYGROUND_OUT must point at the assembled console");
+await import(pathToFileURL(join(playgroundOut, "engine.worker.mjs")).href);
+assert.equal(typeof workerMessageHandler, "function");
+
+let workerCallId = 0;
+async function workerCall(op, args = {}) {
+  const id = `smoke-${workerCallId++}`;
+  await workerMessageHandler({ origin: "", data: { id, op, args } });
+  const message = workerMessages.find((candidate) => candidate.id === id);
+  assert.ok(message, `worker did not answer ${op}`);
+  assert.equal(message.ok, true, message.error);
+  return message.result;
+}
 
 test("version() returns a SemVer string", () => {
   const v = version();
@@ -83,39 +112,43 @@ test("parse the preloaded doc (Input pane)", () => {
 });
 
 // A plain graph (no quoted-triple object) — every serializer, incl. JSON-LD,
-// can encode it. This is the graph the "all 6 formats" claim rests on.
+// can encode it. This is the graph the "all 7 formats" claim rests on.
 const PLAIN = `@prefix ex: <http://example.org/> .
 ex:alice ex:knows ex:bob .
 ex:bob ex:name "Bob" .
 `;
 
-test("serialize a plain graph to all 6 formats (Round-trip pane)", () => {
+test("serialize a plain graph to all 7 formats (Round-trip pane)", () => {
   const ds = Dataset.parse(PLAIN, "turtle");
   for (const f of SERIALIZE_FORMATS) {
     const text = ds.serialize(f);
     assert.equal(typeof text, "string");
     assert.ok(text.length > 0, `empty serialization for ${f}`);
   }
-  // JSON-LD is a first-class bidirectional codec: it round-trips as input, too.
-  const jsonld = ds.serialize("jsonld");
-  const back = Dataset.parse(jsonld, "jsonld");
-  assert.ok(ds.isomorphic(back), "JSON-LD round-trip must be isomorphic");
+  // Both linked-data carrier syntaxes are first-class bidirectional codecs.
+  for (const format of ["jsonld", "yamlld"]) {
+    const encoded = ds.serialize(format);
+    const back = Dataset.parse(encoded, format);
+    assert.ok(ds.isomorphic(back), `${format} round-trip must be isomorphic`);
+  }
 });
 
-test("configured JSON-LD follows the playground worker serialization path", () => {
-  const dataset = Dataset.parse(PLAIN, "turtle");
-  const text = dataset.serializeConfigured(
-    "jsonld",
-    JSON.stringify({
+test("configured JSON-LD and YAML-LD follow worker dispatch", async () => {
+  await workerCall("parse", { text: PLAIN, format: "turtle" });
+  const result = await workerCall("serializeAll", {
+    jsonldOptions: {
       version: 1,
       mode: "context",
       prefixes: { ex: "http://example.org/" },
-    }),
-  );
-  assert.equal(JSON.parse(text)["@graph"][0]["@id"], "ex:alice");
+    },
+  });
+  assert.equal(JSON.parse(result.formats.jsonld.text)["@graph"][0]["@id"], "ex:alice");
+  assert.match(result.formats.yamlld.text, /ex:alice/);
+  assert.equal(result.formats.jsonld.roundtrips, true);
+  assert.equal(result.formats.yamlld.roundtrips, true);
 });
 
-test("preloaded (quoted-triple) doc: all 6 formats serialize; JSON-LD round-trips", () => {
+test("preloaded (quoted-triple) doc: all 7 formats serialize; JSON-LD round-trips", () => {
   const ds = Dataset.parse(PRELOADED, "turtle");
   for (const f of SERIALIZE_FORMATS) {
     const text = ds.serialize(f);

--- a/docs/playground/smoke/engine.smoke.test.mjs
+++ b/docs/playground/smoke/engine.smoke.test.mjs
@@ -102,6 +102,19 @@ test("serialize a plain graph to all 6 formats (Round-trip pane)", () => {
   assert.ok(ds.isomorphic(back), "JSON-LD round-trip must be isomorphic");
 });
 
+test("configured JSON-LD follows the playground worker serialization path", () => {
+  const dataset = Dataset.parse(PLAIN, "turtle");
+  const text = dataset.serializeConfigured(
+    "jsonld",
+    JSON.stringify({
+      version: 1,
+      mode: "context",
+      prefixes: { ex: "http://example.org/" },
+    }),
+  );
+  assert.equal(JSON.parse(text)["@graph"][0]["@id"], "ex:alice");
+});
+
 test("preloaded (quoted-triple) doc: all 6 formats serialize; JSON-LD round-trips", () => {
   const ds = Dataset.parse(PRELOADED, "turtle");
   for (const f of SERIALIZE_FORMATS) {

--- a/scripts/vendor-jsonld-rec.py
+++ b/scripts/vendor-jsonld-rec.py
@@ -53,8 +53,13 @@ def read_text(tests: Path, relative: object) -> str:
     return (tests / str(relative)).read_text(encoding="utf-8")
 
 
+def write_json(output: Path, document: object) -> None:
+    with output.open("w", encoding="utf-8", newline="\n") as stream:
+        stream.write(json.dumps(document, indent=2, ensure_ascii=False) + "\n")
+
+
 def vendor_to_rdf(tests: Path, output: Path) -> None:
-    manifest = json.loads((tests / "toRdf-manifest.jsonld").read_text())
+    manifest = json.loads((tests / "toRdf-manifest.jsonld").read_text(encoding="utf-8"))
     cases = cases_by_id(manifest)
     vectors = []
     for identifier in TO_RDF_IDS:
@@ -79,11 +84,11 @@ def vendor_to_rdf(tests: Path, output: Path) -> None:
         "expected_vector_count": len(vectors),
         "vectors": vectors,
     }
-    output.write_text(json.dumps(document, indent=2, ensure_ascii=False) + "\n")
+    write_json(output, document)
 
 
 def vendor_compaction(tests: Path, output: Path) -> None:
-    manifest = json.loads((tests / "compact-manifest.jsonld").read_text())
+    manifest = json.loads((tests / "compact-manifest.jsonld").read_text(encoding="utf-8"))
     cases = cases_by_id(manifest)
     vectors = []
     for identifier in COMPACTION_IDS:
@@ -111,7 +116,7 @@ def vendor_compaction(tests: Path, output: Path) -> None:
         "expected_vector_count": len(vectors),
         "vectors": vectors,
     }
-    output.write_text(json.dumps(document, indent=2, ensure_ascii=False) + "\n")
+    write_json(output, document)
 
 
 def main() -> None:

--- a/scripts/vendor-jsonld-rec.py
+++ b/scripts/vendor-jsonld-rec.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Vendor the reviewed offline RDF-carrier slice of the JSON-LD 1.1 REC suite."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+REVISION = "3e7fa5377b2b3c5176eacf8bde8e01fdb7c4a062"
+TAG = "REC-2020-07-16"
+
+# All positive, local, default-option core to-RDF cases that do not require an
+# implicit document URL (0001-0036 and 0113-0132), followed by the reviewed
+# JSON-LD 1.1 construct cases used by PurRDF's RDF-carrier contract. 0016-0018
+# are document-URL-relative, 0021 is absent upstream, 0118 requests generalized
+# RDF, 0124 is the RFC3986 algorithm stress matrix rather than a carrier case,
+# and 0125 requires a manifest-supplied document base.
+TO_RDF_IDS = (
+    "0001 0002 0003 0004 0005 0006 0007 0008 0009 0010 0011 0012 0013 0014 0015 "
+    "0019 0020 0022 0023 0024 0025 0026 0027 0028 0029 0030 0031 0032 0033 0034 "
+    "0035 0036 0113 0114 0115 0116 0117 0119 0120 0121 0122 0123 0126 0127 0128 "
+    "0129 0130 0131 0132 c001 c002 c004 c005 c035 c036 di07 e030 e034 e037 e079 "
+    "e080 e085 e086 e099 e100 js06 js07 m001 m006 m009 n001 pi11 pr10"
+).split()
+
+# Exact official compaction oracles whose expanded inputs are bijective RDF
+# carrier documents. 0024 and la01 specifically exercise common list
+# language/type selection; RDF 1.2 and graph-index extensions live in the
+# first-party lens suite because the REC predates RDF 1.2 and standard @index
+# metadata is deliberately non-RDF.
+COMPACTION_IDS = (
+    "0005 0006 0013 0022 0024 0025 0073 di04 di05 di06 la01 m011 p002"
+).split()
+
+
+def digest(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def cases_by_id(manifest: dict[str, object]) -> dict[str, dict[str, object]]:
+    cases: dict[str, dict[str, object]] = {}
+    for case in manifest["sequence"]:  # type: ignore[index]
+        identifier = case["@id"].removeprefix("#t")
+        cases.setdefault(identifier, case)
+    return cases
+
+
+def read_text(tests: Path, relative: object) -> str:
+    return (tests / str(relative)).read_text(encoding="utf-8")
+
+
+def vendor_to_rdf(tests: Path, output: Path) -> None:
+    manifest = json.loads((tests / "toRdf-manifest.jsonld").read_text())
+    cases = cases_by_id(manifest)
+    vectors = []
+    for identifier in TO_RDF_IDS:
+        case = cases[identifier]
+        input_text = read_text(tests, case["input"])
+        expected = read_text(tests, case["expect"])
+        vectors.append(
+            {
+                "id": identifier,
+                "name": case["name"],
+                "purpose": case["purpose"],
+                "input_sha256": digest(input_text),
+                "expected_sha256": digest(expected),
+                "input": input_text,
+                "expected_nquads": expected,
+            }
+        )
+    document = {
+        "schema_version": 1,
+        "upstream_revision": REVISION,
+        "upstream_tag": TAG,
+        "expected_vector_count": len(vectors),
+        "vectors": vectors,
+    }
+    output.write_text(json.dumps(document, indent=2, ensure_ascii=False) + "\n")
+
+
+def vendor_compaction(tests: Path, output: Path) -> None:
+    manifest = json.loads((tests / "compact-manifest.jsonld").read_text())
+    cases = cases_by_id(manifest)
+    vectors = []
+    for identifier in COMPACTION_IDS:
+        case = cases[identifier]
+        input_text = read_text(tests, case["input"])
+        context = read_text(tests, case["context"])
+        expected = read_text(tests, case["expect"])
+        vectors.append(
+            {
+                "id": identifier,
+                "name": case["name"],
+                "purpose": case["purpose"],
+                "input_sha256": digest(input_text),
+                "context_sha256": digest(context),
+                "expected_sha256": digest(expected),
+                "input": input_text,
+                "context": context,
+                "expected": expected,
+            }
+        )
+    document = {
+        "schema_version": 1,
+        "upstream_revision": REVISION,
+        "upstream_tag": TAG,
+        "expected_vector_count": len(vectors),
+        "vectors": vectors,
+    }
+    output.write_text(json.dumps(document, indent=2, ensure_ascii=False) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("upstream", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    tests = args.upstream / "tests"
+    args.output.mkdir(parents=True, exist_ok=True)
+    vendor_to_rdf(tests, args.output / "vectors.json")
+    vendor_compaction(tests, args.output / "compaction_vectors.json")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add immutable compiled JSON-LD 1.1 contexts, offline registries, strict versioned serialization options, and deterministic dataset-derived contexts
- compact and expand a typed RDF 1.2 carrier without losing triple terms, reifiers, annotations, named graphs, lists, language/direction, or literal lexical forms
- preserve all no-options expanded JSON-LD/YAML-LD bytes while exposing configured serialization through Rust, every CLI RDF sink, Python/RDFLib compatibility, WebAssembly/TypeScript, C, research-object paths, slices, and the playground
- document and benchmark context compilation plus expanded, caller-context, and derived modes

## Requirement coverage

- Caller prefix maps, full local contexts, `@base`/`@vocab`, aliases, coercions, scoped/protected contexts, reverse/nest mappings, RDF-preserving containers, and immutable registry-backed context IRIs use one compiled lens.
- Derived mode uses only dataset IRIs, deterministic neutral aliases, fixed work/size limits, and never infers `@vocab`.
- Strict decoding rejects duplicates, unknown fields, invalid mappings, registry/import/scoped cycles, resource-limit excesses, and data-bearing metadata that RDF cannot preserve.
- Existing expanded output remains byte-identical and configured APIs require an explicit `expanded`, `context`, or `derived` mode.
- JSON-LD and YAML-LD share the engine; configured YAML schema headers remain caller-controlled.

## Validation

- `cargo fmt --all --check`
- warning-denied Clippy for the affected Rust, Python, wasm, and C crates
- full `purrdf-rdf`, CLI, facade, wasm Rust, and focused C ABI tests
- full Python suite: 382 passed, 1 skipped, 4 ledgered xfail
- TypeScript and Node package tests: 57 passed
- packed npm tarball install/import smoke
- playground smoke: 22 passed
- `make book`, `make book-samples`, and `make metadata`
- W3C JSON-LD harness: 73 applicable toRDF and 13 exact compaction vectors
- all 17 release crates built for `wasm32-unknown-unknown`
- consolidated `make check`

## Compatibility and size evidence

No-options expanded JSON-LD and YAML-LD fixtures remain byte-for-byte unchanged across Rust, CLI, Python, wasm, C, and research-object routes. The optimized wasm artifact is 6,418,213 bytes (gzip -9: 2,236,304) against a reviewed 6,610,000-byte ceiling; the increase links the complete strict options/registry decoder and compiled-context API into the JavaScript surface. The npm tarball is 2,265,551 bytes and unpacked package 6,575,869 bytes.

Native configured benchmark targets compile. A small wasm execution measurement (128 triples, three iterations) reported 0.0371 ms median context compilation, 1.31 ms configured serialization, 2.18 ms configured parsing, and 15,409 output bytes. The longer native report-only benchmark run was not completed before publication; CI timing is not gated on benchmark values.

## Residual risk

JSON-LD 1.1 has a broad semantic surface. The remaining risk is concentrated in unusual combinations of otherwise-supported scoped contexts and containers; strict shape validation, the frozen W3C subset, property/law tests, and expanded-key fallback constrain that risk. Network context loading remains intentionally unsupported for determinism and offline wasm.

Closes #135


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable JSON-LD/YAML-LD serialization (expanded/context/derived) and reusable compiled JSON-LD contexts across Rust, Python, C, and WebAssembly.
  * CLI now supports `--jsonld-options` for convert, query, reason, and lift; projection output rejects incompatible options.
* **Bug Fixes**
  * Improved JSON-LD/YAML-LD option propagation in rdflib compatibility, including prefix parsing and explicit `jsonld_prefixes()` reporting.
* **Documentation**
  * Updated JSON-LD context/compaction guides and refreshed C/wasm/Python API docs; added YAML-LD support to the playground and tightened wasm size CI gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->