### PR TITLE
Optimize realtime and whole-bundle SHACL validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,7 @@ dependencies = [
  "purrdf-sparql-algebra",
  "purrdf-sparql-eval",
  "purrdf-xsd",
+ "rayon",
  "regex",
  "serde",
  "serde_json",

--- a/crates/rdf-core/src/dataset_view.rs
+++ b/crates/rdf-core/src/dataset_view.rs
@@ -627,7 +627,7 @@ impl DatasetView for RdfDataset {
 
     #[inline]
     fn term_id_by_value(&self, value: &TermValue) -> Option<TermId> {
-        // Delegate to the inherent lazy reverse value index (no minting).
+        // Delegate to the retained store-once term index (no minting).
         Self::term_id_by_value(self, value)
     }
 

--- a/crates/rdf-core/src/ir/builder.rs
+++ b/crates/rdf-core/src/ir/builder.rs
@@ -976,6 +976,7 @@ impl RdfDatasetBuilder {
             locations.into_boxed_slice(),
             caps,
             named_graphs.into_boxed_slice(),
+            interner.index,
             interner.content_ids,
             derivation_predicate,
         )

--- a/crates/rdf-core/src/ir/dataset.rs
+++ b/crates/rdf-core/src/ir/dataset.rs
@@ -28,6 +28,8 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, OnceLock};
 
+use hashbrown::HashTable;
+
 use crate::content_id::Blake3ContentId;
 use crate::dataset_view::GraphMatch;
 // Re-exported `pub(crate)` so the sibling `super::dataset::FastHasher` path used by
@@ -45,7 +47,6 @@ use super::term::{BlankScope, InternedTerm, TermId, TermValue, arena_str};
 /// as virtual triples in [`RdfDataset::reifier_quads`].
 const RDF_REIFIES: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies";
 
-type ValueIndex = HashMap<u64, Vec<TermId>, FastHasher>;
 /// Lazy successor→predecessors reverse index for
 /// [`RdfDataset::predecessors`]: each successor `TermId` maps to its
 /// predecessor `TermId`s (decoded from the PREDECESSOR-LINK annotation rows),
@@ -218,13 +219,14 @@ pub struct RdfDataset {
     locations: Box<[(QuadHandle, RdfLocation)]>,
     /// Capability flags, computed ONCE at freeze.
     caps: RdfStoreCapabilities,
-    /// Lazy value→id reverse index for [`RdfDataset::term_id_by_value`].
-    /// Keyed by a canonical **hash** of each term's dataset-independent value (with
-    /// `Vec<TermId>` buckets to resolve the rare collision), NOT by full
-    /// [`TermValue`] copies — so building it duplicates **no** term strings (~10×
-    /// leaner than an owned-key map). Built lazily (the builder's interner index is
-    /// dropped at freeze); `OnceLock` keeps the frozen dataset `Send + Sync`.
-    value_index: OnceLock<ValueIndex>,
+    /// Store-once term hash→id index moved intact from the builder at freeze.
+    ///
+    /// Values are only dense `u32` indices into `terms`; equality resolves through
+    /// the arena, so no term strings are duplicated. Retaining the already-built
+    /// table makes every reverse term lookup immediately available without an
+    /// O(term-count) lazy rebuild on a freshly published immutable snapshot.
+    /// Derived, non-serialized, and never consulted by byte-producing paths.
+    term_index: HashTable<u32>,
     /// Lazy permutation quad indexes for indexed
     /// [`quads_for_pattern`](RdfDataset::quads_for_pattern_indexed) (P4b). SPOG
     /// is free (the `quads` table is already freeze-sorted by `(s, p, o, g)`); the
@@ -267,7 +269,7 @@ pub struct RdfDataset {
     /// [`RdfDataset::predecessors`]/[`RdfDataset::predecessor_chain`]. DERIVED,
     /// NON-SERIALIZED: a pure function of the frozen `annotations` table plus
     /// the configured `derivation_predicate`, identical determinism-safety
-    /// rationale to `value_index`/`indexes` — built lazily (`OnceLock` keeps
+    /// rationale to `term_index`/`indexes` — built lazily (`OnceLock` keeps
     /// the frozen dataset `Send + Sync`), never persisted, and read only by
     /// dataset-local `TermId`s (C0.8: never serialized, never read by a
     /// writer).
@@ -535,6 +537,7 @@ impl RdfDataset {
         locations: Box<[(QuadHandle, RdfLocation)]>,
         caps: RdfStoreCapabilities,
         named_graphs: Box<[TermId]>,
+        term_index: HashTable<u32>,
         content_ids: HashMap<TermId, Blake3ContentId, FastHasher>,
         derivation_predicate: Option<TermId>,
     ) -> Self {
@@ -546,7 +549,7 @@ impl RdfDataset {
             annotations,
             locations,
             caps,
-            value_index: OnceLock::new(),
+            term_index,
             indexes: QuadIndexes::default(),
             named_graphs,
             content_ids,
@@ -1114,123 +1117,20 @@ impl RdfDataset {
             .map(|q| QuadIds::from(*q))
     }
 
-    /// Hash an interned term **with zero allocations**, byte-for-byte identically to
-    /// [`TermValue`]'s manual `Hash` (explicit tags; the literal datatype is hashed
-    /// as its resolved IRI string, triple components recurse). The round-trip tests
-    /// fail if this drifts from `TermValue::hash`.
-    fn hash_term<H: Hasher>(&self, id: TermId, state: &mut H) {
-        match &self.terms[id.index()] {
-            InternedTerm::Iri(iri) => {
-                0u8.hash(state);
-                arena_str(&self.arena, *iri).hash(state);
-            }
-            InternedTerm::Blank { label, scope } => {
-                1u8.hash(state);
-                arena_str(&self.arena, *label).hash(state);
-                scope.hash(state);
-            }
-            InternedTerm::Literal(lit) => {
-                2u8.hash(state);
-                arena_str(&self.arena, lit.lexical_form).hash(state);
-                self.hash_iri_string(lit.datatype, state);
-                lit.language.map(|r| arena_str(&self.arena, r)).hash(state);
-                lit.direction.hash(state);
-            }
-            InternedTerm::Triple { s, p, o } => {
-                3u8.hash(state);
-                self.hash_term(*s, state);
-                self.hash_term(*p, state);
-                self.hash_term(*o, state);
-            }
-        }
-    }
-
-    /// Hash the IRI string of a term known to be an interned IRI (a literal datatype).
-    fn hash_iri_string<H: Hasher>(&self, id: TermId, state: &mut H) {
-        match &self.terms[id.index()] {
-            InternedTerm::Iri(iri) => arena_str(&self.arena, *iri).hash(state),
-            // Unreachable for a validated dataset (a literal datatype is always an
-            // IRI); hash the Debug form rather than panic.
-            other => format!("{other:?}").hash(state),
-        }
-    }
-
-    /// Whether an interned term equals a dataset-independent [`TermValue`], compared
-    /// **with zero allocations** directly against the interned representation
-    /// (resolving each string range through the arena, and the literal datatype id
-    /// to its IRI). Resolves hash collisions in [`RdfDataset::term_id_by_value`].
-    fn term_matches_value(&self, id: TermId, value: &TermValue) -> bool {
-        match (&self.terms[id.index()], value) {
-            (InternedTerm::Iri(iri), TermValue::Iri(v)) => arena_str(&self.arena, *iri) == v,
-            (
-                InternedTerm::Blank { label, scope },
-                TermValue::Blank {
-                    label: vl,
-                    scope: vs,
-                },
-            ) => arena_str(&self.arena, *label) == vl && scope == vs,
-            (
-                InternedTerm::Literal(lit),
-                TermValue::Literal {
-                    lexical_form,
-                    datatype,
-                    language,
-                    direction,
-                },
-            ) => {
-                arena_str(&self.arena, lit.lexical_form) == lexical_form
-                    && lit.direction == *direction
-                    && lit.language.map(|r| arena_str(&self.arena, r)) == language.as_deref()
-                    && self.iri_matches(lit.datatype, datatype)
-            }
-            (
-                InternedTerm::Triple { s, p, o },
-                TermValue::Triple {
-                    s: vs,
-                    p: vp,
-                    o: vo,
-                },
-            ) => {
-                self.term_matches_value(*s, vs)
-                    && self.term_matches_value(*p, vp)
-                    && self.term_matches_value(*o, vo)
-            }
-            _ => false,
-        }
-    }
-
     /// Whether a term known to be an interned IRI equals `expected` (zero-alloc).
     fn iri_matches(&self, id: TermId, expected: &str) -> bool {
         matches!(&self.terms[id.index()], InternedTerm::Iri(iri) if arena_str(&self.arena, *iri) == expected)
     }
 
-    /// Canonical hash of a value, matching [`hash_term`](Self::hash_term).
-    fn hash_of<T: Hash>(value: &T) -> u64 {
-        let mut hasher = ahash::AHasher::default();
-        value.hash(&mut hasher);
-        hasher.finish()
-    }
-
-    fn value_index(&self) -> &ValueIndex {
-        self.value_index.get_or_init(|| {
-            let mut map: ValueIndex =
-                HashMap::with_capacity_and_hasher(self.terms.len(), FastHasher::default());
-            for i in 0..self.terms.len() {
-                let id = TermId::from_index(i as u32);
-                let mut hasher = ahash::AHasher::default();
-                self.hash_term(id, &mut hasher);
-                map.entry(hasher.finish()).or_default().push(id);
-            }
-            map
-        })
-    }
-
-    fn find_hashed(&self, hash: u64, mut matches: impl FnMut(TermId) -> bool) -> Option<TermId> {
-        self.value_index()
-            .get(&hash)?
-            .iter()
+    fn find_term_hashed(
+        &self,
+        hash: u64,
+        mut matches: impl FnMut(TermId) -> bool,
+    ) -> Option<TermId> {
+        self.term_index
+            .find(hash, |&index| matches(TermId::from_index(index)))
             .copied()
-            .find(|&id| matches(id))
+            .map(TermId::from_index)
     }
 
     /// The id of an interned IRI, without allocating an owned [`TermValue`].
@@ -1239,7 +1139,7 @@ impl RdfDataset {
         let mut hasher = ahash::AHasher::default();
         0u8.hash(&mut hasher);
         iri.hash(&mut hasher);
-        self.find_hashed(hasher.finish(), |id| self.iri_matches(id, iri))
+        self.find_term_hashed(hasher.finish(), |id| self.iri_matches(id, iri))
     }
 
     /// The id of an interned blank node, without allocating its label.
@@ -1249,7 +1149,7 @@ impl RdfDataset {
         1u8.hash(&mut hasher);
         label.hash(&mut hasher);
         scope.hash(&mut hasher);
-        self.find_hashed(hasher.finish(), |id| {
+        self.find_term_hashed(hasher.finish(), |id| {
             matches!(
                 &self.terms[id.index()],
                 InternedTerm::Blank { label: stored, scope: stored_scope }
@@ -1267,18 +1167,19 @@ impl RdfDataset {
         language: Option<&str>,
         direction: Option<RdfTextDirection>,
     ) -> Option<TermId> {
+        let datatype_id = self.term_id_by_iri(datatype)?;
         let mut hasher = ahash::AHasher::default();
         2u8.hash(&mut hasher);
         lexical_form.hash(&mut hasher);
-        datatype.hash(&mut hasher);
+        datatype_id.hash(&mut hasher);
         language.hash(&mut hasher);
         direction.hash(&mut hasher);
-        self.find_hashed(hasher.finish(), |id| {
+        self.find_term_hashed(hasher.finish(), |id| {
             let InternedTerm::Literal(lit) = &self.terms[id.index()] else {
                 return false;
             };
             arena_str(&self.arena, lit.lexical_form) == lexical_form
-                && self.iri_matches(lit.datatype, datatype)
+                && lit.datatype == datatype_id
                 && lit.language.map(|r| arena_str(&self.arena, r)) == language
                 && lit.direction == direction
         })
@@ -1298,10 +1199,10 @@ impl RdfDataset {
         }
         let mut hasher = ahash::AHasher::default();
         3u8.hash(&mut hasher);
-        self.hash_term(s, &mut hasher);
-        self.hash_term(p, &mut hasher);
-        self.hash_term(o, &mut hasher);
-        self.find_hashed(hasher.finish(), |id| {
+        s.hash(&mut hasher);
+        p.hash(&mut hasher);
+        o.hash(&mut hasher);
+        self.find_term_hashed(hasher.finish(), |id| {
             matches!(
                 self.terms[id.index()],
                 InternedTerm::Triple { s: stored_s, p: stored_p, o: stored_o }
@@ -1313,18 +1214,28 @@ impl RdfDataset {
     /// The id of an interned term given its **dataset-independent** value, or
     /// `None` if the dataset contains no such term (purrdf P4).
     ///
-    /// The reverse hash→id index is built **lazily on first call** (the builder's
-    /// interner index is dropped at freeze) and cached; `OnceLock::get_or_init`
-    /// guarantees a single build even under concurrent first access. The index is
-    /// keyed by a canonical value hash with `Vec<TermId>` collision buckets and
-    /// stores **no** term strings, so building it is allocation-light. Keying on
-    /// [`TermValue`] (not [`TermRef`]) is the correctness rule: a
+    /// Lookup reuses the builder's store-once hash→id table, retained at freeze.
+    /// Compound dataset-independent values are first resolved recursively into
+    /// this dataset's local ids, then probed through that table. Keying the public
+    /// boundary on [`TermValue`] (not [`TermRef`]) remains the correctness rule: a
     /// `TermRef`'s datatype/triple ids are local to whichever dataset minted them.
     #[must_use]
     pub fn term_id_by_value(&self, value: &TermValue) -> Option<TermId> {
-        self.find_hashed(Self::hash_of(value), |id| {
-            self.term_matches_value(id, value)
-        })
+        match value {
+            TermValue::Iri(iri) => self.term_id_by_iri(iri),
+            TermValue::Blank { label, scope } => self.term_id_by_blank(label, *scope),
+            TermValue::Literal {
+                lexical_form,
+                datatype,
+                language,
+                direction,
+            } => self.term_id_by_literal(lexical_form, datatype, language.as_deref(), *direction),
+            TermValue::Triple { s, p, o } => self.term_id_by_triple(
+                self.term_id_by_value(s)?,
+                self.term_id_by_value(p)?,
+                self.term_id_by_value(o)?,
+            ),
+        }
     }
 
     /// Iterate quads as ID-native [`QuadIds`]. **Zero allocations, infallible, no
@@ -1631,8 +1542,9 @@ impl RdfDataset {
 
     /// Deep-clone a frozen dataset's tables into a fresh owned `RdfDataset`. The
     /// fallback for [`union`](Self::union) when the freshly frozen `Arc` is somehow
-    /// shared (it is not, in practice — `freeze` returns a unique `Arc`). The lazy
-    /// `OnceLock` caches are intentionally NOT cloned; they rebuild on demand.
+    /// shared (it is not, in practice — `freeze` returns a unique `Arc`). The
+    /// store-once term index is structural and cloned with the term table; lazy
+    /// permutation/derivation caches rebuild on demand.
     fn clone_dataset(&self) -> Self {
         Self {
             arena: self.arena.clone(),
@@ -1642,7 +1554,7 @@ impl RdfDataset {
             annotations: self.annotations.clone(),
             locations: self.locations.clone(),
             caps: self.caps,
-            value_index: OnceLock::new(),
+            term_index: self.term_index.clone(),
             indexes: QuadIndexes::default(),
             named_graphs: self.named_graphs.clone(),
             content_ids: self.content_ids.clone(),
@@ -1724,8 +1636,7 @@ impl RdfDataset {
     /// predicate was never interned, or `successor` has no such annotation.
     ///
     /// The SINGLE public predecessor accessor: `O(1)` after the reverse index
-    /// (built once, lazily, on first call via `OnceLock::get_or_init` — mirrors
-    /// [`term_id_by_value`](Self::term_id_by_value)) is warm. The whole
+    /// (built once, lazily, on first call via `OnceLock::get_or_init`) is warm. The whole
     /// annotation table is scanned exactly ONCE to build the index — never
     /// per-call — with each successor's predecessor bucket sorted so the
     /// returned slice's order is deterministic and reproducible regardless of
@@ -1841,9 +1752,8 @@ impl<'a> IntoIterator for &'a RdfDataset {
 // serialization across threads. These guards fail the build if that ever regresses.
 const _: fn() = || {
     fn assert_send_sync<T: Send + Sync>() {}
-    // RdfDataset carries lazy `OnceLock` indexes — the value index and the
-    // permutation quad indexes (P4b). `OnceLock` (not `RefCell`) is what keeps
-    // this guard holding once those interior-mutable caches are added.
+    // RdfDataset carries immutable store-once term indexes plus lazy `OnceLock`
+    // permutation/derivation indexes (P4b). No `RefCell` may enter this surface.
     assert_send_sync::<RdfDataset>();
     assert_send_sync::<TermId>();
     assert_send_sync::<QuadIds>();
@@ -1988,8 +1898,8 @@ mod tests {
     #[test]
     fn term_id_by_value_disambiguates_same_lexical_different_datatype() {
         // Two literals share the lexical form "1" but differ by datatype — the
-        // hash-bucketed index must disambiguate them by value (term_matches_value
-        // resolves the datatype id to its IRI), not collapse them.
+        // retained interner index must resolve the datatype IRI to its local id,
+        // not collapse the two dataset-independent values.
         let mut b = RdfDatasetBuilder::new();
         let as_int = b.intern_literal(RdfLiteral::typed(
             "1",
@@ -2047,14 +1957,14 @@ mod tests {
     }
 
     #[test]
-    fn term_id_by_value_lazy_init_is_thread_safe() {
+    fn term_id_by_value_concurrent_lookup_is_thread_safe() {
         use std::sync::Arc;
         let mut b = RdfDatasetBuilder::new();
         let s = iri(&mut b, "s");
         b.push_quad(s, s, s, None);
         let ds = b.freeze().unwrap(); // Arc<RdfDataset>
         let want = TermValue::Iri("http://example.org/s".to_string());
-        // Many threads race the OnceLock first-init; all must agree.
+        // The retained immutable interner index is directly shareable.
         let handles: Vec<_> = (0..8)
             .map(|_| {
                 let ds = Arc::clone(&ds);
@@ -3081,8 +2991,7 @@ mod tests {
 
         /// Two threads racing to build the lazy predecessor index on first access
         /// observe identical results — `OnceLock::get_or_init` guarantees a single
-        /// build even under concurrent first calls (mirrors `term_id_by_value`'s
-        /// concurrency contract).
+        /// build even under concurrent first calls.
         #[test]
         fn predecessors_concurrent_first_build_is_consistent() {
             let mut b = RdfDatasetBuilder::with_content_addressing(

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -63,6 +63,9 @@ purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.7.0" }
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.
 smallvec = { workspace = true }
+# Deterministic indexed focus-node scheduling. Rayon is always-on and
+# wasm32-clean; on single-threaded wasm it executes the same indexed work inline.
+rayon = { workspace = true }
 
 [dev-dependencies]
 purrdf-gts = { workspace = true }

--- a/crates/shapes/benches/validate.rs
+++ b/crates/shapes/benches/validate.rs
@@ -17,11 +17,16 @@ use std::cell::Cell;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Once};
+use std::time::{Duration, Instant};
 
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use purrdf::loss::LossLedger;
-use purrdf_shapes::engine::validate_graphs;
+use purrdf::{RdfDataset, RdfDatasetBuilder, RdfLiteral};
+use purrdf_shapes::engine::{parse_shapes, validate_graphs, validate_projected_dataset};
 use purrdf_shapes::json_schema::CompiledSchema;
+use purrdf_shapes::shapes::Shapes;
 use purrdf_shapes::{
     LinkmlConfig, LinkmlDocument, Namespaces, SchemaDatatypeMap, SchemaImportConfig, emit_linkml,
     import_json_schema, import_linkml,
@@ -33,6 +38,10 @@ thread_local! {
     static ALLOCATED_BYTES: Cell<u64> = const { Cell::new(0) };
 }
 
+static VALIDATION_COUNTING: AtomicBool = AtomicBool::new(false);
+static VALIDATION_ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+static VALIDATION_ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+
 struct CountingAllocator;
 
 // SAFETY: every operation forwards the original pointer/layout to the system
@@ -41,6 +50,10 @@ unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         ALLOCATIONS.with(|count| count.set(count.get() + 1));
         ALLOCATED_BYTES.with(|bytes| bytes.set(bytes.get() + layout.size() as u64));
+        if VALIDATION_COUNTING.load(Ordering::Relaxed) {
+            VALIDATION_ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            VALIDATION_ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
         unsafe { System.alloc(layout) }
     }
 
@@ -51,6 +64,10 @@ unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
         ALLOCATIONS.with(|count| count.set(count.get() + 1));
         ALLOCATED_BYTES.with(|bytes| bytes.set(bytes.get() + new_size as u64));
+        if VALIDATION_COUNTING.load(Ordering::Relaxed) {
+            VALIDATION_ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            VALIDATION_ALLOCATED_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        }
         unsafe { System.realloc(ptr, layout, new_size) }
     }
 }
@@ -63,6 +80,35 @@ const IMPORT_PROPERTIES_PER_CLASS: usize = 8;
 const LINKML: &str = "https://w3id.org/linkml/";
 const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
 const LINKML_EMIT_SIZES: &[usize] = &[32, 1_024, 60_000];
+const CORE_FOCUS_SIZES: &[usize] = &[3_000, 100_000, 1_000_000];
+const SPARQL_FOCUS_SIZES: &[usize] = &[64, 512, 4_096];
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const RDFS_SUBCLASS_OF: &str = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
+const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+const BENCH_EX: &str = "https://example.org/shacl-bench/";
+
+struct ValidationFixture {
+    dataset: Arc<RdfDataset>,
+    shapes: Shapes,
+    focus_nodes: usize,
+}
+
+struct ValidationCountGuard;
+
+impl ValidationCountGuard {
+    fn start() -> Self {
+        VALIDATION_ALLOCATIONS.store(0, Ordering::Relaxed);
+        VALIDATION_ALLOCATED_BYTES.store(0, Ordering::Relaxed);
+        VALIDATION_COUNTING.store(true, Ordering::Release);
+        Self
+    }
+}
+
+impl Drop for ValidationCountGuard {
+    fn drop(&mut self) {
+        VALIDATION_COUNTING.store(false, Ordering::Release);
+    }
+}
 
 /// Read every `corpus/<case>/{data.nt, shapes.ttl}` pair, sorted by case name.
 fn corpus_cases() -> Vec<(String, String, String)> {
@@ -104,74 +150,185 @@ fn bench_validate(c: &mut Criterion) {
     group.finish();
 }
 
-/// Build a 40-class rdfs:subClassOf chain + 3000 typed focus nodes as N-Triples.
-///
-/// This is the measurement instrument for item 2 (focus-node parallelism).
-/// The engine validates focus nodes SERIALLY: a rayon `par_iter` over this 3000-
-/// node workload was measured here and regressed ~9% (per-focus work is too cheap
-/// — ~5 µs — to amortize thread-pool dispatch and shared-`Store` read contention),
-/// confirming. The frozen `RdfDataset` is `Sync`, so the seam stays ready;
-/// the parallel path re-enters once per-focus cost exceeds ~50–100 µs.
-fn large_hierarchy_inputs() -> (String, String) {
-    // Shape: one NodeShape targeting ex:C0 with sh:pattern + sh:minCount constraints.
-    // Pattern forces per-node regex evaluation (nontrivial per-focus work).
-    let shapes_ttl = r#"
-@prefix sh:   <http://www.w3.org/ns/shacl#> .
-@prefix ex:   <http://example.org/ns#> .
-@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+fn core_focus_fixture(focus_nodes: usize) -> ValidationFixture {
+    const CLASS_DEPTH: usize = 40;
 
-ex:HierarchyShape a sh:NodeShape ;
-    sh:targetClass ex:C0 ;
+    let mut builder = RdfDatasetBuilder::new();
+    let rdf_type = builder.intern_iri(RDF_TYPE);
+    let subclass = builder.intern_iri(RDFS_SUBCLASS_OF);
+    let label_predicate = builder.intern_iri(&format!("{BENCH_EX}label"));
+    let value_predicate = builder.intern_iri(&format!("{BENCH_EX}value"));
+    let member_predicate = builder.intern_iri(&format!("{BENCH_EX}member"));
+
+    let focus_classes: Vec<_> = (0..CLASS_DEPTH)
+        .map(|index| builder.intern_iri(&format!("{BENCH_EX}FocusClass{index}")))
+        .collect();
+    let value_classes: Vec<_> = (0..CLASS_DEPTH)
+        .map(|index| builder.intern_iri(&format!("{BENCH_EX}ValueClass{index}")))
+        .collect();
+    for index in 1..CLASS_DEPTH {
+        builder.push_quad(
+            focus_classes[index],
+            subclass,
+            focus_classes[index - 1],
+            None,
+        );
+        builder.push_quad(
+            value_classes[index],
+            subclass,
+            value_classes[index - 1],
+            None,
+        );
+    }
+
+    let member = builder.intern_iri(&format!("{BENCH_EX}shared-member"));
+    builder.push_quad(member, rdf_type, value_classes[CLASS_DEPTH - 1], None);
+
+    for index in 0..focus_nodes {
+        let focus = builder.intern_iri(&format!("{BENCH_EX}item{index}"));
+        let label = builder.intern_literal(RdfLiteral::simple(format!("item-{index}")));
+        let value = builder.intern_literal(RdfLiteral::typed(index.to_string(), XSD_INTEGER));
+        builder.push_quad(focus, rdf_type, focus_classes[CLASS_DEPTH - 1], None);
+        builder.push_quad(focus, label_predicate, label, None);
+        builder.push_quad(focus, value_predicate, value, None);
+        builder.push_quad(focus, member_predicate, member, None);
+    }
+
+    let dataset = builder.freeze().expect("Core focus fixture must freeze");
+    let shapes = parse_shapes(&format!(
+        r#"
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <{BENCH_EX}> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:WholeBundleShape a sh:NodeShape ;
+    sh:targetClass ex:FocusClass0 ;
     sh:property [
         sh:path ex:label ;
         sh:minCount 1 ;
-        sh:pattern "^item-[0-9]+" ;
+        sh:pattern "^item-[0-9]+$" ;
     ] ;
     sh:property [
         sh:path ex:value ;
         sh:datatype xsd:integer ;
+    ] ;
+    sh:property [
+        sh:path ex:member ;
+        sh:class ex:ValueClass0 ;
     ] .
 "#
-    .to_owned();
-
-    // 40-class chain: C39 subClassOf C38 subClassOf … C1 subClassOf C0
-    let mut nt = String::with_capacity(1_200_000);
-    let ex = "http://example.org/ns#";
-    let rdf_type = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
-    let sub_class_of = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
-
-    use std::fmt::Write as _;
-    for i in 1..40_usize {
-        let _ = writeln!(nt, "<{ex}C{i}> <{sub_class_of}> <{ex}C{}>  .", i - 1);
+    ))
+    .expect("Core focus shapes must parse");
+    ValidationFixture {
+        dataset,
+        shapes,
+        focus_nodes,
     }
-
-    // 3000 typed nodes: spread across leaf class C39 (all reachable via closure)
-    for i in 0..3000_usize {
-        let _ = writeln!(nt, "<{ex}item{i}> <{rdf_type}> <{ex}C39> .");
-        let _ = writeln!(nt, "<{ex}item{i}> <{ex}label> \"item-{i}\" .");
-        let _ = writeln!(
-            nt,
-            "<{ex}item{i}> <{ex}value> \"{i}\"^^<http://www.w3.org/2001/XMLSchema#integer> ."
-        );
-    }
-
-    (nt, shapes_ttl)
 }
 
-fn bench_validate_large(c: &mut Criterion) {
-    let (data_nt, shapes_ttl) = large_hierarchy_inputs();
+fn sparql_focus_fixture(focus_nodes: usize) -> ValidationFixture {
+    let mut builder = RdfDatasetBuilder::new();
+    let rdf_type = builder.intern_iri(RDF_TYPE);
+    let person = builder.intern_iri(&format!("{BENCH_EX}Person"));
+    let amount_predicate = builder.intern_iri(&format!("{BENCH_EX}amount"));
+    for index in 0..focus_nodes {
+        let focus = builder.intern_iri(&format!("{BENCH_EX}sparql-item{index}"));
+        let amount = builder.intern_literal(RdfLiteral::typed("1", XSD_INTEGER));
+        builder.push_quad(focus, rdf_type, person, None);
+        builder.push_quad(focus, amount_predicate, amount, None);
+    }
+    let dataset = builder.freeze().expect("SPARQL focus fixture must freeze");
+    let shapes = parse_shapes(&format!(
+        r#"
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <{BENCH_EX}> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-    let mut group = c.benchmark_group("shacl_validate");
-    group.sample_size(20); // Fewer samples: each iteration is ~10–50ms
-    group.bench_function("large_hierarchy", |b| {
-        b.iter(|| {
-            let report = validate_graphs(&data_nt, &shapes_ttl)
-                .expect("large_hierarchy: validation must not error");
-            std::hint::black_box(report);
-        });
-    });
+ex:tripled a sh:SPARQLFunction ;
+    sh:parameter [ sh:path ex:x ; sh:datatype xsd:integer ] ;
+    sh:returnType xsd:integer ;
+    sh:select "SELECT ((?x * 3) AS ?result) WHERE {{}}" .
+
+ex:WholeBundleSparqlShape a sh:NodeShape ;
+    sh:targetClass ex:Person ;
+    sh:sparql [
+        sh:select "SELECT $this WHERE {{ $this <{BENCH_EX}amount> ?amount . FILTER(<{BENCH_EX}tripled>(?amount) > 100) }}" ;
+    ] .
+"#
+    ))
+    .expect("SPARQL focus shapes must parse");
+    ValidationFixture {
+        dataset,
+        shapes,
+        focus_nodes,
+    }
+}
+
+fn validate_fixture(fixture: &ValidationFixture) {
+    let report = validate_projected_dataset(Arc::clone(&fixture.dataset), &fixture.shapes)
+        .expect("benchmark validation must not error");
+    assert!(report.conforms, "benchmark fixture must conform");
+    black_box(report);
+}
+
+fn print_validation_probe(label: &str, fixture: &ValidationFixture) {
+    validate_fixture(fixture);
+    let guard = ValidationCountGuard::start();
+    let started = Instant::now();
+    validate_fixture(fixture);
+    let elapsed = started.elapsed();
+    drop(guard);
+    println!(
+        "[shacl_focus_validation] case={label} focus_nodes={} quads={} terms={} threads={} elapsed_ns={} allocations={} allocated_bytes={}",
+        fixture.focus_nodes,
+        fixture.dataset.quad_count(),
+        fixture.dataset.term_count(),
+        std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get),
+        elapsed.as_nanos(),
+        VALIDATION_ALLOCATIONS.load(Ordering::Relaxed),
+        VALIDATION_ALLOCATED_BYTES.load(Ordering::Relaxed),
+    );
+}
+
+fn bench_focus_core(c: &mut Criterion) {
+    let mut group = c.benchmark_group("shacl_focus_core");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
+    for &focus_nodes in CORE_FOCUS_SIZES {
+        let fixture = core_focus_fixture(focus_nodes);
+        let probe = Once::new();
+        group.throughput(Throughput::Elements(focus_nodes as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(focus_nodes),
+            &fixture,
+            move |bencher, fixture| {
+                probe.call_once(|| print_validation_probe("core", fixture));
+                bencher.iter(|| validate_fixture(black_box(fixture)));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_focus_sparql(c: &mut Criterion) {
+    let mut group = c.benchmark_group("shacl_focus_sparql");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
+    for &focus_nodes in SPARQL_FOCUS_SIZES {
+        let fixture = sparql_focus_fixture(focus_nodes);
+        let probe = Once::new();
+        group.throughput(Throughput::Elements(focus_nodes as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(focus_nodes),
+            &fixture,
+            move |bencher, fixture| {
+                probe.call_once(|| print_validation_probe("sparql_function", fixture));
+                bencher.iter(|| validate_fixture(black_box(fixture)));
+            },
+        );
+    }
     group.finish();
 }
 
@@ -499,7 +656,8 @@ fn bench_linkml_slot_emission(c: &mut Criterion) {
 criterion_group!(
     benches,
     bench_validate,
-    bench_validate_large,
+    bench_focus_core,
+    bench_focus_sparql,
     bench_schema_import,
     bench_linkml_import,
     bench_linkml_slot_emission

--- a/crates/shapes/benches/validate.rs
+++ b/crates/shapes/benches/validate.rs
@@ -24,7 +24,10 @@ use std::time::{Duration, Instant};
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use purrdf::loss::LossLedger;
 use purrdf::{RdfDataset, RdfDatasetBuilder, RdfLiteral};
-use purrdf_shapes::engine::{parse_shapes, validate_graphs, validate_projected_dataset};
+use purrdf_shapes::engine::{
+    PreparedValidator, parse_shapes, validate_graphs, validate_projected_dataset,
+    validate_projected_dataset_with_focus_filter,
+};
 use purrdf_shapes::json_schema::CompiledSchema;
 use purrdf_shapes::shapes::Shapes;
 use purrdf_shapes::{
@@ -82,6 +85,7 @@ const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
 const LINKML_EMIT_SIZES: &[usize] = &[32, 1_024, 60_000];
 const CORE_FOCUS_SIZES: &[usize] = &[512, 1_024, 2_048, 3_000, 100_000, 1_000_000];
 const SPARQL_FOCUS_SIZES: &[usize] = &[64, 512, 4_096];
+const REALTIME_FOCUS_SIZES: &[usize] = &[1, 8, 64, 512, 4_096];
 const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
 const RDFS_SUBCLASS_OF: &str = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
 const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
@@ -326,6 +330,97 @@ fn bench_focus_sparql(c: &mut Criterion) {
             move |bencher, fixture| {
                 probe.call_once(|| print_validation_probe("sparql_function", fixture));
                 bencher.iter(|| validate_fixture(black_box(fixture)));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn validate_prepared_ids(prepared: &PreparedValidator, focus_ids: &[purrdf::TermId]) {
+    let report = prepared
+        .validate_focus_node_ids(focus_ids)
+        .expect("prepared benchmark validation must not error");
+    assert!(report.conforms, "prepared benchmark fixture must conform");
+    black_box(report);
+}
+
+fn print_realtime_probe(prepared: &PreparedValidator, focus_ids: &[purrdf::TermId]) {
+    validate_prepared_ids(prepared, focus_ids);
+    let guard = ValidationCountGuard::start();
+    let started = Instant::now();
+    validate_prepared_ids(prepared, focus_ids);
+    let elapsed = started.elapsed();
+    drop(guard);
+    println!(
+        "[shacl_focus_realtime] requested_focus_nodes={} elapsed_ns={} allocations={} allocated_bytes={}",
+        focus_ids.len(),
+        elapsed.as_nanos(),
+        VALIDATION_ALLOCATIONS.load(Ordering::Relaxed),
+        VALIDATION_ALLOCATED_BYTES.load(Ordering::Relaxed),
+    );
+}
+
+fn bench_focus_realtime(c: &mut Criterion) {
+    const DATASET_FOCUS_NODES: usize = 1_000_000;
+
+    let fixture = core_focus_fixture(DATASET_FOCUS_NODES);
+    let preparation_guard = ValidationCountGuard::start();
+    let preparation_started = Instant::now();
+    let prepared = PreparedValidator::from_projected_dataset(
+        Arc::clone(&fixture.dataset),
+        Arc::new(fixture.shapes.clone()),
+    )
+    .expect("realtime benchmark preparation must succeed");
+    let preparation_elapsed = preparation_started.elapsed();
+    drop(preparation_guard);
+    println!(
+        "[shacl_focus_prepare] dataset_focus_nodes={DATASET_FOCUS_NODES} elapsed_ns={} allocations={} allocated_bytes={}",
+        preparation_elapsed.as_nanos(),
+        VALIDATION_ALLOCATIONS.load(Ordering::Relaxed),
+        VALIDATION_ALLOCATED_BYTES.load(Ordering::Relaxed),
+    );
+    let all_focus_ids: Vec<_> = (0..*REALTIME_FOCUS_SIZES.last().expect("non-empty sizes"))
+        .map(|index| {
+            fixture
+                .dataset
+                .term_id_by_iri(&format!("{BENCH_EX}item{index}"))
+                .expect("benchmark focus must be interned")
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("shacl_focus_realtime");
+    group.sample_size(20);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+
+    let legacy_focus =
+        purrdf_shapes::term::NamedNode::new_unchecked(format!("{BENCH_EX}item0")).into_term();
+    group.throughput(Throughput::Elements(1));
+    group.bench_function(BenchmarkId::new("compat_filter", 1), |bencher| {
+        bencher.iter(|| {
+            let report = validate_projected_dataset_with_focus_filter(
+                Arc::clone(black_box(&fixture.dataset)),
+                black_box(&fixture.shapes),
+                |_, focus| focus == &legacy_focus,
+            )
+            .expect("compatibility filter benchmark must not error");
+            assert!(report.conforms, "benchmark fixture must conform");
+            black_box(report);
+        });
+    });
+
+    for &focus_nodes in REALTIME_FOCUS_SIZES {
+        let focus_ids = &all_focus_ids[..focus_nodes];
+        let probe = Once::new();
+        let prepared_ref = &prepared;
+        group.throughput(Throughput::Elements(focus_nodes as u64));
+        group.bench_with_input(
+            BenchmarkId::new("prepared_ids", focus_nodes),
+            focus_ids,
+            move |bencher, focus_ids| {
+                probe.call_once(|| print_realtime_probe(prepared_ref, focus_ids));
+                bencher
+                    .iter(|| validate_prepared_ids(black_box(prepared_ref), black_box(focus_ids)));
             },
         );
     }
@@ -658,6 +753,7 @@ criterion_group!(
     bench_validate,
     bench_focus_core,
     bench_focus_sparql,
+    bench_focus_realtime,
     bench_schema_import,
     bench_linkml_import,
     bench_linkml_slot_emission

--- a/crates/shapes/benches/validate.rs
+++ b/crates/shapes/benches/validate.rs
@@ -80,7 +80,7 @@ const IMPORT_PROPERTIES_PER_CLASS: usize = 8;
 const LINKML: &str = "https://w3id.org/linkml/";
 const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
 const LINKML_EMIT_SIZES: &[usize] = &[32, 1_024, 60_000];
-const CORE_FOCUS_SIZES: &[usize] = &[3_000, 100_000, 1_000_000];
+const CORE_FOCUS_SIZES: &[usize] = &[512, 1_024, 2_048, 3_000, 100_000, 1_000_000];
 const SPARQL_FOCUS_SIZES: &[usize] = &[64, 512, 4_096];
 const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
 const RDFS_SUBCLASS_OF: &str = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
@@ -283,7 +283,7 @@ fn print_validation_probe(label: &str, fixture: &ValidationFixture) {
         fixture.focus_nodes,
         fixture.dataset.quad_count(),
         fixture.dataset.term_count(),
-        std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get),
+        rayon::current_num_threads(),
         elapsed.as_nanos(),
         VALIDATION_ALLOCATIONS.load(Ordering::Relaxed),
         VALIDATION_ALLOCATED_BYTES.load(Ordering::Relaxed),

--- a/crates/shapes/src/components.rs
+++ b/crates/shapes/src/components.rs
@@ -651,7 +651,7 @@ fn parse_component(
     let param_names: Vec<String> = parameters.iter().map(|p| p.name.clone()).collect();
 
     let mut node_validator_nodes: Vec<Term> = objects_of(data, component, sh::NODE_VALIDATOR);
-    crate::term::sort_canonical(&mut node_validator_nodes);
+    crate::term::sort_terms_canonical(&mut node_validator_nodes);
     let node_validators = node_validator_nodes
         .into_iter()
         .map(|v| {
@@ -667,7 +667,7 @@ fn parse_component(
         .collect::<Result<Vec<Validator>, _>>()?;
     let mut property_validator_nodes: Vec<Term> =
         objects_of(data, component, sh::PROPERTY_VALIDATOR);
-    crate::term::sort_canonical(&mut property_validator_nodes);
+    crate::term::sort_terms_canonical(&mut property_validator_nodes);
     let property_validators = property_validator_nodes
         .into_iter()
         .map(|v| {
@@ -682,7 +682,7 @@ fn parse_component(
         })
         .collect::<Result<Vec<Validator>, _>>()?;
     let mut validator_nodes: Vec<Term> = objects_of(data, component, sh::VALIDATOR);
-    crate::term::sort_canonical(&mut validator_nodes);
+    crate::term::sort_terms_canonical(&mut validator_nodes);
     let validators = validator_nodes
         .into_iter()
         .map(|v| {

--- a/crates/shapes/src/constraints.rs
+++ b/crates/shapes/src/constraints.rs
@@ -9,8 +9,10 @@
 use std::sync::OnceLock;
 
 use ::purrdf::{FastMap, FastSet, IdSet, RdfDataset, TermId, TermRef};
+use smallvec::SmallVec;
 
 use crate::data::{GraphFilter, ShaclData, native_quads, quads_for_pattern_ids, resolve_id};
+use crate::engine::ValidationPlan;
 use crate::model::{BoxRoleVocab, rdf, sh};
 use crate::path;
 use crate::report::ValidationResult;
@@ -57,6 +59,74 @@ impl ValueNode {
             Self::Foreign(term) => resolve_id(ds, term),
         }
     }
+
+    /// Borrow the lexical surface used by `sh:pattern`/length constraints
+    /// without materializing an interned value node.
+    fn lexical<'a>(&'a self, ds: &'a RdfDataset) -> Option<&'a str> {
+        match self {
+            Self::Interned(id) => match ds.resolve(*id) {
+                TermRef::Iri(iri) => Some(iri),
+                TermRef::Literal { lexical, .. } => Some(lexical),
+                TermRef::Blank { .. } | TermRef::Triple { .. } => None,
+            },
+            Self::Foreign(Term::NamedNode(node)) => Some(node.as_str()),
+            Self::Foreign(Term::Literal(literal)) => Some(literal.value()),
+            Self::Foreign(Term::BlankNode(_) | Term::Triple(_)) => None,
+        }
+    }
+
+    /// Borrow `(lexical, datatype IRI)` for a literal value node.
+    fn literal_parts<'a>(&'a self, ds: &'a RdfDataset) -> Option<(&'a str, &'a str)> {
+        match self {
+            Self::Interned(id) => {
+                let TermRef::Literal {
+                    lexical, datatype, ..
+                } = ds.resolve(*id)
+                else {
+                    return None;
+                };
+                let TermRef::Iri(datatype) = ds.resolve(datatype) else {
+                    return None;
+                };
+                Some((lexical, datatype))
+            }
+            Self::Foreign(Term::Literal(literal)) => {
+                Some((literal.value(), literal.datatype_str()))
+            }
+            Self::Foreign(Term::NamedNode(_) | Term::BlankNode(_) | Term::Triple(_)) => None,
+        }
+    }
+}
+
+/// Borrowed result metadata for one constraint source.
+///
+/// Keeping this separate from [`Shape`] lets property-shape evaluation borrow
+/// the three fields it needs instead of cloning an entire synthetic shape for
+/// every focus node.
+#[derive(Clone, Copy)]
+struct ConstraintSource<'a> {
+    id: &'a Term,
+    severity: &'a crate::report::Severity,
+    message: &'a Option<String>,
+}
+
+impl<'a> From<&'a Shape> for ConstraintSource<'a> {
+    fn from(shape: &'a Shape) -> Self {
+        Self {
+            id: &shape.id,
+            severity: &shape.severity,
+            message: &shape.message,
+        }
+    }
+}
+
+/// Immutable state shared by recursive constraint and property evaluation.
+#[derive(Clone, Copy)]
+struct ValidationContext<'a> {
+    store: &'a ShaclData,
+    box_role_vocab: Option<&'a BoxRoleVocab>,
+    plan: &'a ValidationPlan,
+    depth: u32,
 }
 
 // ── Public surface ─────────────────────────────────────────────────────────────
@@ -100,7 +170,30 @@ pub fn validate_shape_with(
     shape: &Shape,
     box_role_vocab: Option<&BoxRoleVocab>,
 ) -> Result<Vec<ValidationResult>, String> {
-    validate_shape_with_depth(store, focus, shape, box_role_vocab, 0)
+    let plan = ValidationPlan::for_shape(store.core(), shape);
+    validate_shape_with_plan(store, focus, shape, box_role_vocab, &plan)
+}
+
+pub(crate) fn validate_shape_with_plan(
+    store: &ShaclData,
+    focus: &Term,
+    shape: &Shape,
+    box_role_vocab: Option<&BoxRoleVocab>,
+    plan: &ValidationPlan,
+) -> Result<Vec<ValidationResult>, String> {
+    let focus_id = resolve_id(store.core(), focus);
+    validate_shape_with_plan_at(store, focus, focus_id, shape, box_role_vocab, plan)
+}
+
+pub(crate) fn validate_shape_with_plan_at(
+    store: &ShaclData,
+    focus: &Term,
+    focus_id: Option<TermId>,
+    shape: &Shape,
+    box_role_vocab: Option<&BoxRoleVocab>,
+    plan: &ValidationPlan,
+) -> Result<Vec<ValidationResult>, String> {
+    validate_shape_with_depth(store, focus, focus_id, shape, box_role_vocab, plan, 0)
 }
 
 /// [`validate_shape_with`] carrying the ambient `sh:filterShape` / `sh:exists`
@@ -111,8 +204,10 @@ pub fn validate_shape_with(
 fn validate_shape_with_depth(
     store: &ShaclData,
     focus: &Term,
+    focus_id: Option<TermId>,
     shape: &Shape,
     box_role_vocab: Option<&BoxRoleVocab>,
+    plan: &ValidationPlan,
     depth: u32,
 ) -> Result<Vec<ValidationResult>, String> {
     if depth > crate::expression::MAX_RECURSION_DEPTH {
@@ -127,21 +222,27 @@ fn validate_shape_with_depth(
         return Ok(vec![]);
     }
 
+    let context = ValidationContext {
+        store,
+        box_role_vocab,
+        plan,
+        depth,
+    };
     let mut results: Vec<ValidationResult> = Vec::new();
 
     // --- Node-level constraints (value nodes = [focus], no path) ---
-    // The single value node IS the focus term; a node shape has no path traversal
-    // to run in id space, so the focus travels as an owned `Foreign` value node.
-    let node_value_nodes = [ValueNode::Foreign(focus.clone())];
+    // The single value node IS the focus term. Keep an interned focus id-native;
+    // only a genuinely foreign SHACL-AF term needs an owned clone.
+    let node_value_nodes =
+        [focus_id.map_or_else(|| ValueNode::Foreign(focus.clone()), ValueNode::Interned)];
     for constraint in &shape.constraints {
         let mut rs = eval_constraint(
-            store,
+            context,
             focus,
             &node_value_nodes,
             constraint,
             None,
-            shape,
-            depth,
+            ConstraintSource::from(shape),
         )?;
         for r in &mut rs {
             r.apply_box_roles(&shape.box_roles, &[]);
@@ -152,12 +253,12 @@ fn validate_shape_with_depth(
     // --- Property shapes ---
     for ps in &shape.property_shapes {
         results.extend(eval_property_shape(
-            store,
+            context,
             focus,
+            focus_id,
             ps,
-            shape,
-            box_role_vocab,
-            depth,
+            &shape.id,
+            &shape.box_roles,
         )?);
     }
 
@@ -245,7 +346,15 @@ fn eval_closed(
 /// Returns `Err(String)` when a SHACL-SPARQL constraint fails to evaluate
 /// (see [`validate_shape`]).
 pub fn conforms(store: &ShaclData, focus: &Term, shape: &Shape) -> Result<bool, String> {
-    conforms_with_depth(store, focus, shape, 0)
+    let plan = ValidationPlan::for_shape(store.core(), shape);
+    conforms_with_id_depth(
+        store,
+        focus,
+        resolve_id(store.core(), focus),
+        shape,
+        &plan,
+        0,
+    )
 }
 
 /// [`conforms`] carrying the ambient `sh:filterShape` / `sh:exists` re-entry
@@ -267,19 +376,34 @@ pub(crate) fn conforms_with_depth(
     shape: &Shape,
     depth: u32,
 ) -> Result<bool, String> {
-    Ok(validate_shape_with_depth(store, focus, shape, None, depth)?.is_empty())
+    let plan = ValidationPlan::for_shape(store.core(), shape);
+    let focus_id = resolve_id(store.core(), focus);
+    conforms_with_id_depth(store, focus, focus_id, shape, &plan, depth)
+}
+
+#[inline]
+fn conforms_with_id_depth(
+    store: &ShaclData,
+    focus: &Term,
+    focus_id: Option<TermId>,
+    shape: &Shape,
+    plan: &ValidationPlan,
+    depth: u32,
+) -> Result<bool, String> {
+    Ok(validate_shape_with_depth(store, focus, focus_id, shape, None, plan, depth)?.is_empty())
 }
 
 // ── Property shape evaluator ───────────────────────────────────────────────────
 
 fn eval_property_shape(
-    store: &ShaclData,
+    context: ValidationContext<'_>,
     focus: &Term,
+    focus_id: Option<TermId>,
     ps: &PropertyShape,
-    parent_shape: &Shape,
-    box_role_vocab: Option<&BoxRoleVocab>,
-    depth: u32,
+    source_shape: &Term,
+    parent_box_roles: &[NamedNode],
 ) -> Result<Vec<ValidationResult>, String> {
+    let store = context.store;
     // A deactivated property shape validates nothing (SHACL §2.1.3.3).
     if ps.deactivated {
         return Ok(vec![]);
@@ -289,48 +413,37 @@ fn eval_property_shape(
     // owned-`Term` producer. Identity/set constraint arms then compare `TermId`s
     // without materializing, and only the value nodes a violation records — or a
     // content constraint inspects — are resolved to owned terms.
-    let value_nodes: Vec<ValueNode> = match path::eval_ids(store.core(), focus, &ps.path) {
-        Some(ids) => ids.into_iter().map(ValueNode::Interned).collect(),
+    let value_nodes: SmallVec<[ValueNode; 4]> = match focus_id {
+        Some(id) => path::eval_ids_from_id(store.core(), id, &ps.path)
+            .into_iter()
+            .map(ValueNode::Interned)
+            .collect(),
         None => path::eval(store.core(), focus, &ps.path)
             .into_iter()
             .map(ValueNode::Foreign)
             .collect(),
     };
-    let path_term = path::path_to_term(&ps.path);
-    // The complex-path structure stamped onto results whose path comes from
-    // this property shape (None for a plain predicate path).
-    let path_structure: Option<Path> = if matches!(ps.path, Path::Predicate(_)) {
-        None
-    } else {
-        Some(ps.path.clone())
-    };
-    let source_roles = merge_box_roles(&parent_shape.box_roles, &ps.box_roles);
-    let path_roles = path_box_roles(store, &ps.path, box_role_vocab);
-
-    // Build a synthetic shape wrapping the property shape so result
-    // metadata (source_shape, severity, message) can come from the PS.
-    let ps_as_shape = Shape {
-        id: parent_shape.id.clone(),
-        targets: vec![],
-        constraints: ps.constraints.clone(),
-        property_shapes: vec![],
-        severity: ps.severity.clone(),
-        message: ps.message.clone(),
-        deactivated: false,
-        box_roles: source_roles.clone(),
-        rules: vec![],
+    // Report-only path materialization is lazy: conforming focus nodes never
+    // allocate a native path term or clone a complex path structure.
+    let path_term = OnceLock::new();
+    let path_structure = OnceLock::new();
+    let source_roles = merge_box_roles(parent_box_roles, &ps.box_roles);
+    let path_roles = path_box_roles(store, &ps.path, context.box_role_vocab);
+    let constraint_source = ConstraintSource {
+        id: source_shape,
+        severity: &ps.severity,
+        message: &ps.message,
     };
 
     let mut results = Vec::new();
     for constraint in &ps.constraints {
         let mut rs = eval_constraint(
-            store,
+            context,
             focus,
             &value_nodes,
             constraint,
             Some(&ps.path),
-            &ps_as_shape,
-            depth,
+            constraint_source,
         )?;
         // Stamp the property-shape path and focus onto every result, but PRESERVE
         // a path the constraint itself bound — a `sh:sparql` query may project
@@ -338,8 +451,18 @@ fn eval_property_shape(
         // the shape's declared path and must not be clobbered.
         for r in &mut rs {
             if r.result_path.is_none() {
-                r.result_path = Some(path_term.clone());
-                r.path_structure.clone_from(&path_structure);
+                r.result_path = Some(
+                    path_term
+                        .get_or_init(|| path::path_to_term(&ps.path))
+                        .clone(),
+                );
+                r.path_structure.clone_from(path_structure.get_or_init(|| {
+                    if matches!(ps.path, Path::Predicate(_)) {
+                        None
+                    } else {
+                        Some(ps.path.clone())
+                    }
+                }));
             }
             r.focus_node = focus.clone();
             r.apply_box_roles(&source_roles, &path_roles);
@@ -359,12 +482,12 @@ fn eval_property_shape(
             // owned term at the recursion boundary (recursion is not the hot
             // conforming path).
             results.extend(eval_property_shape(
-                store,
+                context,
                 &value.to_term(store.core()),
+                value.as_id(store.core()),
                 nested,
-                &ps_as_shape,
-                box_role_vocab,
-                depth,
+                source_shape,
+                &source_roles,
             )?);
         }
     }
@@ -382,12 +505,13 @@ fn eval_property_shape(
             focus,
             value_nodes: &value_terms,
             ps,
-            ps_as_shape: &ps_as_shape,
+            source_shape,
             source_roles: &source_roles,
             path_roles: &path_roles,
-            path_term: &path_term,
-            box_role_vocab,
-            depth,
+            path_term: path_term.get_or_init(|| path::path_to_term(&ps.path)),
+            box_role_vocab: context.box_role_vocab,
+            plan: context.plan,
+            depth: context.depth,
         })?);
     }
     Ok(results)
@@ -399,11 +523,12 @@ struct ReifierEvalContext<'a> {
     focus: &'a Term,
     value_nodes: &'a [Term],
     ps: &'a PropertyShape,
-    ps_as_shape: &'a Shape,
+    source_shape: &'a Term,
     source_roles: &'a [NamedNode],
     path_roles: &'a [NamedNode],
     path_term: &'a Term,
     box_role_vocab: Option<&'a BoxRoleVocab>,
+    plan: &'a ValidationPlan,
     depth: u32,
 }
 
@@ -413,11 +538,12 @@ fn eval_reifier_shapes(ctx: ReifierEvalContext<'_>) -> Result<Vec<ValidationResu
         focus,
         value_nodes,
         ps,
-        ps_as_shape,
+        source_shape,
         source_roles,
         path_roles,
         path_term,
         box_role_vocab,
+        plan,
         depth,
     } = ctx;
     if ps.reifier_shapes.is_empty() && !ps.reification_required {
@@ -443,7 +569,7 @@ fn eval_reifier_shapes(ctx: ReifierEvalContext<'_>) -> Result<Vec<ValidationResu
                 source_constraint_component: NamedNode::from(
                     sh::REIFIER_SHAPE_CONSTRAINT_COMPONENT,
                 ),
-                source_shape: ps_as_shape.id.clone(),
+                source_shape: source_shape.clone(),
                 severity: ps.severity.clone(),
                 message: ps.message.clone(),
                 source_box_roles: vec![],
@@ -461,8 +587,10 @@ fn eval_reifier_shapes(ctx: ReifierEvalContext<'_>) -> Result<Vec<ValidationResu
                 let inner_results = validate_shape_with_depth(
                     store,
                     reifier,
+                    resolve_id(store.core(), reifier),
                     reifier_shape,
                     box_role_vocab,
+                    plan,
                     depth,
                 )?;
                 if inner_results.is_empty() {
@@ -595,33 +723,33 @@ fn merge_box_roles(left: &[NamedNode], right: &[NamedNode]) -> Vec<NamedNode> {
 ///
 /// `path` is `None` for node-level constraints, `Some` for property shapes.
 fn eval_constraint(
-    store: &ShaclData,
+    context: ValidationContext<'_>,
     focus_node: &Term,
     value_nodes: &[ValueNode],
     constraint: &Constraint,
     path: Option<&Path>,
-    shape: &Shape,
-    depth: u32,
+    source: ConstraintSource<'_>,
 ) -> Result<Vec<ValidationResult>, String> {
+    let store = context.store;
+    let plan = context.plan;
+    let depth = context.depth;
     let ds = store.core();
-    let result_path = path.map(path::path_to_term);
+    let result_path = || path.map(path::path_to_term);
     // The full SHACL path structure travels alongside a COMPLEX result path
     // (its result_path term is a deterministic blank node) so the report
     // serialization can emit the spec-mandated structure.
-    let path_structure: Option<Path> = path.filter(|p| !matches!(p, Path::Predicate(_))).cloned();
-    let severity = shape.severity.clone();
-    let message = shape.message.clone();
-    let source_shape = shape.id.clone();
+    let path_structure = || path.filter(|p| !matches!(p, Path::Predicate(_))).cloned();
+    let severity = source.severity;
+    let message = source.message;
+    let source_shape = source.id;
     let shapes_graph_iri = store.shapes_graph_iri();
 
     macro_rules! result {
         ($component:expr, $value:expr) => {
             ValidationResult {
-                focus_node: value_nodes
-                    .first()
-                    .map_or_else(|| source_shape.clone(), |v| v.to_term(ds)),
-                result_path: result_path.clone(),
-                path_structure: path_structure.clone(),
+                focus_node: focus_node.clone(),
+                result_path: result_path(),
+                path_structure: path_structure(),
                 value: $value,
                 source_constraint_component: NamedNode::from($component),
                 source_shape: source_shape.clone(),
@@ -636,8 +764,8 @@ fn eval_constraint(
         ($component:expr, $focus:expr, $value:expr) => {
             ValidationResult {
                 focus_node: $focus,
-                result_path: result_path.clone(),
-                path_structure: path_structure.clone(),
+                result_path: result_path(),
+                path_structure: path_structure(),
                 value: $value,
                 source_constraint_component: NamedNode::from($component),
                 source_shape: source_shape.clone(),
@@ -674,32 +802,24 @@ fn eval_constraint(
         Constraint::Class(class_iri) => {
             // Hoist the BFS closure computation once, outside the per-value loop.
             // Previously called inside the loop: O(N×M) → now O(M) + O(N).
-            let closure = crate::engine::subclass_closure(store.core(), class_iri);
-            // Resolve `rdf:type`'s interned id once, outside the per-value loop:
-            // it is loop-invariant, so doing it per value node needlessly rebuilt
-            // a `NamedNode`/`String` and hit the interner O(N) times.  `None` means
-            // `rdf:type` is not interned in this dataset, so no `rdf:type` edge can
-            // exist and every non-literal value violates.
-            let rdf_type_id =
-                resolve_id(store.core(), &Term::NamedNode(NamedNode::from(rdf::TYPE)));
+            let closure = plan.class_closure(class_iri);
+            let rdf_type_id = plan.rdf_type_id();
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for vn in value_nodes {
                 // Id-native instance test: an interned value node's class membership
                 // is decided entirely in `TermId` space (literal check + `rdf:type`
                 // edge walk), so a conforming value is never materialized. A
                 // non-interned value node has no `rdf:type` edge and is no instance.
                 let violates = match vn.as_id(ds) {
-                    Some(id) => !is_shacl_instance_id(ds, id, rdf_type_id, &closure),
+                    Some(id) => !is_shacl_instance_id(ds, id, rdf_type_id, closure),
                     None => true,
                 };
                 if violates {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: Some(vn.to_term(ds)),
                         source_constraint_component: NamedNode::from(
                             sh::CLASS_CONSTRAINT_COMPONENT,
@@ -720,22 +840,14 @@ fn eval_constraint(
         // ── Datatype (per value node) ──────────────────────────────────────────
         Constraint::Datatype(dt_iri) => {
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for value in value_nodes {
-                // Content/recursion arm: this constraint needs the value node's term
-                // (its lexical form, datatype, node kind, or a recursion focus), so
-                // resolve it here. `value` borrows the owned term for the rest of the
-                // arm exactly as before.
-                let value_term = value.to_term(ds);
-                let value = &value_term;
-                if !check_datatype(value, dt_iri) {
+                if !check_value_datatype(value, ds, dt_iri) {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
-                        value: Some(value.clone()),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
+                        value: Some(value.to_term(ds)),
                         source_constraint_component: NamedNode::from(
                             sh::DATATYPE_CONSTRAINT_COMPONENT,
                         ),
@@ -755,9 +867,7 @@ fn eval_constraint(
         // ── NodeKind (per value node) ──────────────────────────────────────────
         Constraint::NodeKind(kind) => {
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for value in value_nodes {
                 // Content/recursion arm: this constraint needs the value node's term
                 // (its lexical form, datatype, node kind, or a recursion focus), so
@@ -768,8 +878,8 @@ fn eval_constraint(
                 if !check_node_kind(value, kind) {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: Some(value.clone()),
                         source_constraint_component: NamedNode::from(
                             sh::NODE_KIND_CONSTRAINT_COMPONENT,
@@ -797,9 +907,7 @@ fn eval_constraint(
             let allowed_ids: FastSet<TermId> =
                 allowed.iter().filter_map(|a| resolve_id(ds, a)).collect();
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for vn in value_nodes {
                 let allowed_here = match vn.as_id(ds) {
                     Some(id) => allowed_ids.contains(&id),
@@ -808,8 +916,8 @@ fn eval_constraint(
                 if !allowed_here {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: Some(vn.to_term(ds)),
                         source_constraint_component: NamedNode::from(sh::IN_CONSTRAINT_COMPONENT),
                         source_shape: source_shape.clone(),
@@ -838,20 +946,18 @@ fn eval_constraint(
                     .any(|v| terms_equal(&v.to_term(ds), required)),
             };
             if !found {
-                let focus = value_nodes
-                    .first()
-                    .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+                let focus = focus_node;
                 vec![ValidationResult {
-                    focus_node: focus,
-                    result_path,
-                    path_structure,
+                    focus_node: focus.clone(),
+                    result_path: result_path(),
+                    path_structure: path_structure(),
                     value: None,
                     source_constraint_component: NamedNode::from(
                         sh::HAS_VALUE_CONSTRAINT_COMPONENT,
                     ),
-                    source_shape,
-                    severity,
-                    message,
+                    source_shape: source_shape.clone(),
+                    severity: severity.clone(),
+                    message: message.clone(),
                     source_box_roles: vec![],
                     path_box_roles: vec![],
                     result_box_roles: vec![],
@@ -874,22 +980,9 @@ fn eval_constraint(
             let compiled: &Result<regex::Regex, String> =
                 compiled.get_or_init(|| build_regex(regex, flags.as_deref()));
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for value in value_nodes {
-                // Content/recursion arm: this constraint needs the value node's term
-                // (its lexical form, datatype, node kind, or a recursion focus), so
-                // resolve it here. `value` borrows the owned term for the rest of the
-                // arm exactly as before.
-                let value_term = value.to_term(ds);
-                let value = &value_term;
-                let lexical = match value {
-                    Term::Literal(lit) => Some(lit.value().to_owned()),
-                    Term::NamedNode(nn) => Some(nn.as_str().to_owned()),
-                    _ => None,
-                };
-                let violates = match (compiled, &lexical) {
+                let violates = match (compiled, value.lexical(ds)) {
                     (Err(_), _) => true,   // bad regex → violation on every value node
                     (Ok(_), None) => true, // blank node → violation
                     (Ok(re), Some(lex)) => !re.is_match(lex),
@@ -897,9 +990,9 @@ fn eval_constraint(
                 if violates {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
-                        value: Some(value.clone()),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
+                        value: Some(value.to_term(ds)),
                         source_constraint_component: NamedNode::from(
                             sh::PATTERN_CONSTRAINT_COMPONENT,
                         ),
@@ -919,9 +1012,7 @@ fn eval_constraint(
         // ── MinLength (per value node) ─────────────────────────────────────────
         Constraint::MinLength(n) => {
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for value in value_nodes {
                 // Content/recursion arm: this constraint needs the value node's term
                 // (its lexical form, datatype, node kind, or a recursion focus), so
@@ -937,8 +1028,8 @@ fn eval_constraint(
                 if violates {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: Some(value.clone()),
                         source_constraint_component: NamedNode::from(
                             sh::MIN_LENGTH_CONSTRAINT_COMPONENT,
@@ -959,9 +1050,7 @@ fn eval_constraint(
         // ── MaxLength (per value node) ─────────────────────────────────────────
         Constraint::MaxLength(n) => {
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for value in value_nodes {
                 // Content/recursion arm: this constraint needs the value node's term
                 // (its lexical form, datatype, node kind, or a recursion focus), so
@@ -977,8 +1066,8 @@ fn eval_constraint(
                 if violates {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: Some(value.clone()),
                         source_constraint_component: NamedNode::from(
                             sh::MAX_LENGTH_CONSTRAINT_COMPONENT,
@@ -999,9 +1088,7 @@ fn eval_constraint(
         // ── LanguageIn (per value node) ────────────────────────────────────────
         Constraint::LanguageIn(tags) => {
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for value in value_nodes {
                 // Content/recursion arm: this constraint needs the value node's term
                 // (its lexical form, datatype, node kind, or a recursion focus), so
@@ -1012,8 +1099,8 @@ fn eval_constraint(
                 if !language_matches_any(value, tags) {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: Some(value.clone()),
                         source_constraint_component: NamedNode::from(
                             sh::LANGUAGE_IN_CONSTRAINT_COMPONENT,
@@ -1034,9 +1121,7 @@ fn eval_constraint(
         // ── Not (per value node, recursive) ────────────────────────────────────
         Constraint::Not(inner_shape) => {
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for value in value_nodes {
                 // Content/recursion arm: this constraint needs the value node's term
                 // (its lexical form, datatype, node kind, or a recursion focus), so
@@ -1045,11 +1130,18 @@ fn eval_constraint(
                 let value_term = value.to_term(ds);
                 let value = &value_term;
                 // Violation iff the value node DOES conform to the negated shape.
-                if conforms_with_depth(store, value, inner_shape, depth)? {
+                if conforms_with_id_depth(
+                    store,
+                    value,
+                    resolve_id(ds, value),
+                    inner_shape,
+                    plan,
+                    depth,
+                )? {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: Some(value.clone()),
                         source_constraint_component: NamedNode::from(sh::NOT_CONSTRAINT_COMPONENT),
                         source_shape: source_shape.clone(),
@@ -1088,16 +1180,14 @@ fn eval_constraint(
                     *seen_langs.entry(lang.to_lowercase()).or_insert(0) += 1;
                 }
             }
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             let mut results = Vec::new();
             for (lang, count) in &seen_langs {
                 if *count > 1 {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: None,
                         source_constraint_component: NamedNode::from(
                             sh::UNIQUE_LANG_CONSTRAINT_COMPONENT,
@@ -1121,9 +1211,7 @@ fn eval_constraint(
         // ── MinInclusive / MaxInclusive (per value node) ───────────────────────
         Constraint::MinInclusive(bound) => {
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for value in value_nodes {
                 // Content/recursion arm: this constraint needs the value node's term
                 // (its lexical form, datatype, node kind, or a recursion focus), so
@@ -1138,8 +1226,8 @@ fn eval_constraint(
                 if violates {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: Some(value.clone()),
                         source_constraint_component: NamedNode::from(
                             sh::MIN_INCLUSIVE_CONSTRAINT_COMPONENT,
@@ -1158,9 +1246,7 @@ fn eval_constraint(
         }
         Constraint::MaxInclusive(bound) => {
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for value in value_nodes {
                 // Content/recursion arm: this constraint needs the value node's term
                 // (its lexical form, datatype, node kind, or a recursion focus), so
@@ -1175,8 +1261,8 @@ fn eval_constraint(
                 if violates {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: Some(value.clone()),
                         source_constraint_component: NamedNode::from(
                             sh::MAX_INCLUSIVE_CONSTRAINT_COMPONENT,
@@ -1197,9 +1283,7 @@ fn eval_constraint(
         // ── MinExclusive / MaxExclusive (per value node) ───────────────────────
         Constraint::MinExclusive(bound) => {
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for value in value_nodes {
                 // Content/recursion arm: this constraint needs the value node's term
                 // (its lexical form, datatype, node kind, or a recursion focus), so
@@ -1214,8 +1298,8 @@ fn eval_constraint(
                 if violates {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: Some(value.clone()),
                         source_constraint_component: NamedNode::from(
                             sh::MIN_EXCLUSIVE_CONSTRAINT_COMPONENT,
@@ -1234,9 +1318,7 @@ fn eval_constraint(
         }
         Constraint::MaxExclusive(bound) => {
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for value in value_nodes {
                 // Content/recursion arm: this constraint needs the value node's term
                 // (its lexical form, datatype, node kind, or a recursion focus), so
@@ -1251,8 +1333,8 @@ fn eval_constraint(
                 if violates {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: Some(value.clone()),
                         source_constraint_component: NamedNode::from(
                             sh::MAX_EXCLUSIVE_CONSTRAINT_COMPONENT,
@@ -1273,9 +1355,7 @@ fn eval_constraint(
         // ── And (per value node, recursive) ───────────────────────────────────
         Constraint::And(members) => {
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for value in value_nodes {
                 // Content/recursion arm: this constraint needs the value node's term
                 // (its lexical form, datatype, node kind, or a recursion focus), so
@@ -1285,7 +1365,14 @@ fn eval_constraint(
                 let value = &value_term;
                 let mut all_conform = true;
                 for member in members {
-                    if !conforms_with_depth(store, value, member, depth)? {
+                    if !conforms_with_id_depth(
+                        store,
+                        value,
+                        resolve_id(ds, value),
+                        member,
+                        plan,
+                        depth,
+                    )? {
                         all_conform = false;
                         break;
                     }
@@ -1293,8 +1380,8 @@ fn eval_constraint(
                 if !all_conform {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: Some(value.clone()),
                         source_constraint_component: NamedNode::from(sh::AND_CONSTRAINT_COMPONENT),
                         source_shape: source_shape.clone(),
@@ -1313,9 +1400,7 @@ fn eval_constraint(
         // ── Or (per value node, recursive) ────────────────────────────────────
         Constraint::Or(members) => {
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for value in value_nodes {
                 // Content/recursion arm: this constraint needs the value node's term
                 // (its lexical form, datatype, node kind, or a recursion focus), so
@@ -1325,7 +1410,14 @@ fn eval_constraint(
                 let value = &value_term;
                 let mut any_conforms = false;
                 for member in members {
-                    if conforms_with_depth(store, value, member, depth)? {
+                    if conforms_with_id_depth(
+                        store,
+                        value,
+                        resolve_id(ds, value),
+                        member,
+                        plan,
+                        depth,
+                    )? {
                         any_conforms = true;
                         break;
                     }
@@ -1333,8 +1425,8 @@ fn eval_constraint(
                 if !any_conforms {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: Some(value.clone()),
                         source_constraint_component: NamedNode::from(sh::OR_CONSTRAINT_COMPONENT),
                         source_shape: source_shape.clone(),
@@ -1353,9 +1445,7 @@ fn eval_constraint(
         // ── Xone (per value node, recursive) ──────────────────────────────────
         Constraint::Xone(members) => {
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for value in value_nodes {
                 // Content/recursion arm: this constraint needs the value node's term
                 // (its lexical form, datatype, node kind, or a recursion focus), so
@@ -1365,15 +1455,22 @@ fn eval_constraint(
                 let value = &value_term;
                 let mut count = 0usize;
                 for member in members {
-                    if conforms_with_depth(store, value, member, depth)? {
+                    if conforms_with_id_depth(
+                        store,
+                        value,
+                        resolve_id(ds, value),
+                        member,
+                        plan,
+                        depth,
+                    )? {
                         count += 1;
                     }
                 }
                 if count != 1 {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: Some(value.clone()),
                         source_constraint_component: NamedNode::from(sh::XONE_CONSTRAINT_COMPONENT),
                         source_shape: source_shape.clone(),
@@ -1392,9 +1489,7 @@ fn eval_constraint(
         // ── Node (per value node, recursive) ──────────────────────────────────
         Constraint::Node(inner_shape) => {
             let mut results = Vec::new();
-            let focus = value_nodes
-                .first()
-                .map_or_else(|| source_shape.clone(), |v| v.to_term(ds));
+            let focus = focus_node;
             for value in value_nodes {
                 // Content/recursion arm: this constraint needs the value node's term
                 // (its lexical form, datatype, node kind, or a recursion focus), so
@@ -1402,11 +1497,18 @@ fn eval_constraint(
                 // arm exactly as before.
                 let value_term = value.to_term(ds);
                 let value = &value_term;
-                if !conforms_with_depth(store, value, inner_shape, depth)? {
+                if !conforms_with_id_depth(
+                    store,
+                    value,
+                    resolve_id(ds, value),
+                    inner_shape,
+                    plan,
+                    depth,
+                )? {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
-                        result_path: result_path.clone(),
-                        path_structure: path_structure.clone(),
+                        result_path: result_path(),
+                        path_structure: path_structure(),
                         value: Some(value.clone()),
                         source_constraint_component: NamedNode::from(sh::NODE_CONSTRAINT_COMPONENT),
                         source_shape: source_shape.clone(),
@@ -1543,13 +1645,20 @@ fn eval_constraint(
                 // resolve it to an owned term at the recursion boundary.
                 let v_term = v.to_term(ds);
                 let v = &v_term;
-                if !conforms_with_depth(store, v, qshape, depth)? {
+                if !conforms_with_id_depth(store, v, resolve_id(ds, v), qshape, plan, depth)? {
                     continue;
                 }
                 let mut sibling_conforms = false;
                 if *disjoint {
                     for sibling in siblings {
-                        if conforms_with_depth(store, v, sibling, depth)? {
+                        if conforms_with_id_depth(
+                            store,
+                            v,
+                            resolve_id(ds, v),
+                            sibling,
+                            plan,
+                            depth,
+                        )? {
                             sibling_conforms = true;
                             break;
                         }
@@ -1609,11 +1718,11 @@ fn eval_constraint(
                 focus_node,
                 &query,
                 &NamedNode::from(sh::SPARQL_CONSTRAINT_COMPONENT),
-                &source_shape,
+                source_shape,
                 &sev,
                 msg.as_ref(),
                 shapes_graph_iri,
-                Some(&source_shape),
+                Some(source_shape),
             )
             .map_err(|e| format!("sh:sparql constraint on shape {source_shape}: {e}"))?
         }
@@ -1813,13 +1922,22 @@ fn is_xsd_decimal_lexical(s: &str) -> bool {
 ///   the VALUE space: the native codec keeps `"-2"^^xsd:nonNegativeInteger`
 ///   faithfully typed, but the value is outside the derived range and must
 ///   violate.
+#[cfg(test)]
 fn check_datatype(value: &Term, dt_iri: &NamedNode) -> bool {
     let Term::Literal(lit) = value else {
         return false;
     };
-    let stored_dt = lit.datatype();
-    let lex = lit.value();
-    if stored_dt.as_str() != dt_iri.as_str() {
+    check_datatype_parts(lit.value(), lit.datatype_str(), dt_iri)
+}
+
+fn check_value_datatype(value: &ValueNode, ds: &RdfDataset, dt_iri: &NamedNode) -> bool {
+    value
+        .literal_parts(ds)
+        .is_some_and(|(lexical, datatype)| check_datatype_parts(lexical, datatype, dt_iri))
+}
+
+fn check_datatype_parts(lex: &str, stored_dt: &str, dt_iri: &NamedNode) -> bool {
+    if stored_dt != dt_iri.as_str() {
         return false;
     }
     // Exact datatype-IRI match. For the primitive types validate the lexical

--- a/crates/shapes/src/constraints.rs
+++ b/crates/shapes/src/constraints.rs
@@ -653,7 +653,7 @@ fn reifiers_for(store: &ShaclData, triple_term: &Term) -> Vec<Term> {
     .map(|(subject, _, _)| subject)
     .collect();
     let mut reifiers: Vec<Term> = reifiers_set.into_iter().collect();
-    crate::term::sort_canonical(&mut reifiers);
+    crate::term::sort_terms_canonical(&mut reifiers);
     reifiers
 }
 

--- a/crates/shapes/src/constraints.rs
+++ b/crates/shapes/src/constraints.rs
@@ -1123,21 +1123,13 @@ fn eval_constraint(
             let mut results = Vec::new();
             let focus = focus_node;
             for value in value_nodes {
-                // Content/recursion arm: this constraint needs the value node's term
-                // (its lexical form, datatype, node kind, or a recursion focus), so
-                // resolve it here. `value` borrows the owned term for the rest of the
-                // arm exactly as before.
+                // Preserve interned identity before materializing the recursion
+                // focus; reverse-resolving the owned term would add a hash probe.
+                let value_id = value.as_id(ds);
                 let value_term = value.to_term(ds);
                 let value = &value_term;
                 // Violation iff the value node DOES conform to the negated shape.
-                if conforms_with_id_depth(
-                    store,
-                    value,
-                    resolve_id(ds, value),
-                    inner_shape,
-                    plan,
-                    depth,
-                )? {
+                if conforms_with_id_depth(store, value, value_id, inner_shape, plan, depth)? {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
                         result_path: result_path(),
@@ -1357,22 +1349,13 @@ fn eval_constraint(
             let mut results = Vec::new();
             let focus = focus_node;
             for value in value_nodes {
-                // Content/recursion arm: this constraint needs the value node's term
-                // (its lexical form, datatype, node kind, or a recursion focus), so
-                // resolve it here. `value` borrows the owned term for the rest of the
-                // arm exactly as before.
+                // Resolve identity once even when several member shapes recurse.
+                let value_id = value.as_id(ds);
                 let value_term = value.to_term(ds);
                 let value = &value_term;
                 let mut all_conform = true;
                 for member in members {
-                    if !conforms_with_id_depth(
-                        store,
-                        value,
-                        resolve_id(ds, value),
-                        member,
-                        plan,
-                        depth,
-                    )? {
+                    if !conforms_with_id_depth(store, value, value_id, member, plan, depth)? {
                         all_conform = false;
                         break;
                     }
@@ -1402,22 +1385,13 @@ fn eval_constraint(
             let mut results = Vec::new();
             let focus = focus_node;
             for value in value_nodes {
-                // Content/recursion arm: this constraint needs the value node's term
-                // (its lexical form, datatype, node kind, or a recursion focus), so
-                // resolve it here. `value` borrows the owned term for the rest of the
-                // arm exactly as before.
+                // Resolve identity once even when several member shapes recurse.
+                let value_id = value.as_id(ds);
                 let value_term = value.to_term(ds);
                 let value = &value_term;
                 let mut any_conforms = false;
                 for member in members {
-                    if conforms_with_id_depth(
-                        store,
-                        value,
-                        resolve_id(ds, value),
-                        member,
-                        plan,
-                        depth,
-                    )? {
+                    if conforms_with_id_depth(store, value, value_id, member, plan, depth)? {
                         any_conforms = true;
                         break;
                     }
@@ -1447,22 +1421,13 @@ fn eval_constraint(
             let mut results = Vec::new();
             let focus = focus_node;
             for value in value_nodes {
-                // Content/recursion arm: this constraint needs the value node's term
-                // (its lexical form, datatype, node kind, or a recursion focus), so
-                // resolve it here. `value` borrows the owned term for the rest of the
-                // arm exactly as before.
+                // Resolve identity once even when several member shapes recurse.
+                let value_id = value.as_id(ds);
                 let value_term = value.to_term(ds);
                 let value = &value_term;
                 let mut count = 0usize;
                 for member in members {
-                    if conforms_with_id_depth(
-                        store,
-                        value,
-                        resolve_id(ds, value),
-                        member,
-                        plan,
-                        depth,
-                    )? {
+                    if conforms_with_id_depth(store, value, value_id, member, plan, depth)? {
                         count += 1;
                     }
                 }
@@ -1491,20 +1456,12 @@ fn eval_constraint(
             let mut results = Vec::new();
             let focus = focus_node;
             for value in value_nodes {
-                // Content/recursion arm: this constraint needs the value node's term
-                // (its lexical form, datatype, node kind, or a recursion focus), so
-                // resolve it here. `value` borrows the owned term for the rest of the
-                // arm exactly as before.
+                // Preserve interned identity before materializing the recursion
+                // focus; reverse-resolving the owned term would add a hash probe.
+                let value_id = value.as_id(ds);
                 let value_term = value.to_term(ds);
                 let value = &value_term;
-                if !conforms_with_id_depth(
-                    store,
-                    value,
-                    resolve_id(ds, value),
-                    inner_shape,
-                    plan,
-                    depth,
-                )? {
+                if !conforms_with_id_depth(store, value, value_id, inner_shape, plan, depth)? {
                     results.push(ValidationResult {
                         focus_node: focus.clone(),
                         result_path: result_path(),
@@ -1642,23 +1599,17 @@ fn eval_constraint(
             let mut count = 0u64;
             for v in value_nodes {
                 // Each value node is a recursion focus for the qualified shape;
-                // resolve it to an owned term at the recursion boundary.
+                // retain its interned identity across every recursive check.
+                let v_id = v.as_id(ds);
                 let v_term = v.to_term(ds);
                 let v = &v_term;
-                if !conforms_with_id_depth(store, v, resolve_id(ds, v), qshape, plan, depth)? {
+                if !conforms_with_id_depth(store, v, v_id, qshape, plan, depth)? {
                     continue;
                 }
                 let mut sibling_conforms = false;
                 if *disjoint {
                     for sibling in siblings {
-                        if conforms_with_id_depth(
-                            store,
-                            v,
-                            resolve_id(ds, v),
-                            sibling,
-                            plan,
-                            depth,
-                        )? {
+                        if conforms_with_id_depth(store, v, v_id, sibling, plan, depth)? {
                             sibling_conforms = true;
                             break;
                         }

--- a/crates/shapes/src/constraints.rs
+++ b/crates/shapes/src/constraints.rs
@@ -1845,9 +1845,9 @@ pub(crate) fn substitute_path_placeholder(select: &str, path: Option<&Path>) -> 
 /// closure (SHACL §4.2.5).
 ///
 /// `closure` must contain the class IRI itself plus every transitive subclass
-/// derived from asserted `rdfs:subClassOf` edges (as returned by
-/// [`crate::engine::subclass_closure`]).  The caller hoists the closure
-/// computation once before the per-value-node loop to avoid O(N×M) BFS cost.
+/// derived from asserted `rdfs:subClassOf` edges (as retained by the engine's
+/// dataset-bound validation plan). The caller hoists the closure computation once
+/// before the per-value-node loop to avoid O(N×M) graph-walk cost.
 ///
 /// `rdf_type_id` is `rdf:type`'s pre-resolved interned [`TermId`], hoisted once by
 /// the caller (it is loop-invariant across value nodes).  `None` means `rdf:type`

--- a/crates/shapes/src/engine.rs
+++ b/crates/shapes/src/engine.rs
@@ -1973,11 +1973,89 @@ mod tests {
         );
         let data = load_data_nt(&data_nt);
         let shapes = load_shapes_ttl(&shapes_ttl);
-        let render = |parallel| {
-            let _guard = crate::parallel::force_parallel_for_test(parallel);
-            validate(&data, &shapes).to_ntriples()
+        let render = |threads, parallel, chunk_size| {
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build()
+                .expect("test pool must build")
+                .install(|| {
+                    let _guard = crate::parallel::force_scheduler_for_test(parallel, chunk_size);
+                    validate(&data, &shapes).to_ntriples()
+                })
         };
 
-        assert_eq!(render(false), render(true));
+        let expected = render(1, false, 1);
+        for (threads, chunk_size) in [(2, 1), (4, 3), (4, 16)] {
+            assert_eq!(
+                render(threads, true, chunk_size),
+                expected,
+                "user-function report drifted with {threads} workers and chunk size {chunk_size}"
+            );
+        }
+    }
+
+    #[test]
+    fn complete_corpus_matches_across_scheduler_geometries() {
+        use std::fs;
+        use std::path::PathBuf;
+
+        let corpus = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/corpus"));
+        let mut cases: Vec<_> = fs::read_dir(&corpus)
+            .expect("corpus directory must be readable")
+            .filter_map(|entry| {
+                let path = entry.ok()?.path();
+                path.is_dir().then_some(path)
+            })
+            .collect();
+        cases.sort();
+        assert_eq!(cases.len(), 69, "first-party corpus cardinality drifted");
+
+        let geometries: Vec<_> = [(2, 1), (4, 7), (4, 64)]
+            .into_iter()
+            .map(|(threads, chunk_size)| {
+                let pool = rayon::ThreadPoolBuilder::new()
+                    .num_threads(threads)
+                    .build()
+                    .expect("test pool must build");
+                (threads, chunk_size, pool)
+            })
+            .collect();
+
+        for case in cases {
+            let case_name = case
+                .file_name()
+                .expect("corpus case must have a name")
+                .to_string_lossy();
+            let data = fs::read_to_string(case.join("data.nt"))
+                .unwrap_or_else(|error| panic!("{case_name}: data.nt: {error}"));
+            let shapes = fs::read_to_string(case.join("shapes.ttl"))
+                .unwrap_or_else(|error| panic!("{case_name}: shapes.ttl: {error}"));
+            let render = || {
+                validate_graphs_with_config(
+                    &data,
+                    &shapes,
+                    Some(crate::model::BoxRoleVocab::for_namespace(
+                        "https://example.org/meta/",
+                    )),
+                )
+                .unwrap_or_else(|error| panic!("{case_name}: validation failed: {error}"))
+                .to_ntriples()
+            };
+
+            let expected = {
+                let _guard = crate::parallel::force_scheduler_for_test(false, 1);
+                render()
+            };
+            for (threads, chunk_size, pool) in &geometries {
+                let actual = pool.install(|| {
+                    let _guard = crate::parallel::force_scheduler_for_test(true, *chunk_size);
+                    render()
+                });
+                assert_eq!(
+                    actual, expected,
+                    "{case_name}: report drifted with {threads} workers and chunk size {chunk_size}"
+                );
+            }
+        }
     }
 }

--- a/crates/shapes/src/engine.rs
+++ b/crates/shapes/src/engine.rs
@@ -12,9 +12,10 @@ use std::sync::Arc;
 use ::purrdf::{FastMap, FastSet, IdSet, RdfDataset, RdfDatasetBuilder, RdfTerm, TermId};
 
 use crate::data::{GraphFilter, ShaclData, quads_for_pattern_ids, resolve_id};
+use crate::expression::{FnCall, NodeExpr};
 use crate::model::{rdf, rdfs};
 use crate::report::ValidationReport;
-use crate::shapes::{Shape, Shapes, Target};
+use crate::shapes::{Constraint, PropertyShape, Shape, Shapes, Target};
 use crate::term::{NamedNode, Term, term_id_to_native};
 
 // ── Target resolution helpers ─────────────────────────────────────────────────
@@ -26,8 +27,8 @@ fn resolve_pred(ds: &RdfDataset, pred: &NamedNode) -> Option<TermId> {
 }
 
 /// Collect distinct subjects of `(?, pred, ?)` across all graphs. Dedup is on the
-/// interned [`TermId`] (`Copy`); only distinct subjects are resolved to a term.
-fn subjects_of(ds: &RdfDataset, pred: &NamedNode) -> Vec<Term> {
+/// interned [`TermId`] (`Copy`).
+fn subjects_of(ds: &RdfDataset, pred: &NamedNode) -> Vec<TermId> {
     let Some(pid) = resolve_pred(ds, pred) else {
         return Vec::new();
     };
@@ -35,15 +36,15 @@ fn subjects_of(ds: &RdfDataset, pred: &NamedNode) -> Vec<Term> {
     let mut result = Vec::new();
     for q in quads_for_pattern_ids(ds, None, Some(pid), None, GraphFilter::AnyGraph) {
         if seen.insert(q.s) {
-            result.push(term_id_to_native(ds, q.s));
+            result.push(q.s);
         }
     }
     result
 }
 
 /// Collect distinct objects of `(?, pred, ?)` across all graphs. Dedup is on the
-/// interned [`TermId`] (`Copy`); only distinct objects are resolved to a term.
-fn objects_of(ds: &RdfDataset, pred: &NamedNode) -> Vec<Term> {
+/// interned [`TermId`] (`Copy`).
+fn objects_of(ds: &RdfDataset, pred: &NamedNode) -> Vec<TermId> {
     let Some(pid) = resolve_pred(ds, pred) else {
         return Vec::new();
     };
@@ -51,7 +52,7 @@ fn objects_of(ds: &RdfDataset, pred: &NamedNode) -> Vec<Term> {
     let mut result = Vec::new();
     for q in quads_for_pattern_ids(ds, None, Some(pid), None, GraphFilter::AnyGraph) {
         if seen.insert(q.o) {
-            result.push(term_id_to_native(ds, q.o));
+            result.push(q.o);
         }
     }
     result
@@ -93,26 +94,193 @@ pub(crate) fn subclass_closure(ds: &RdfDataset, class_iri: &NamedNode) -> IdSet 
     closure
 }
 
+/// Dataset-bound invariant state shared by every focus evaluation in one pass.
+///
+/// All class IRIs reachable from the parsed shape tree are discovered once and
+/// their asserted-subclass closures are materialized before focus evaluation.
+/// The resulting map is immutable, so the same plan can be read concurrently
+/// by validation workers without locks or repeated graph walks.
+#[derive(Debug)]
+pub(crate) struct ValidationPlan {
+    rdf_type_id: Option<TermId>,
+    class_closures: FastMap<NamedNode, IdSet>,
+}
+
+impl ValidationPlan {
+    pub(crate) fn for_shapes(ds: &RdfDataset, shapes: &Shapes) -> Self {
+        Self::from_shape_iter(ds, shapes.node_shapes.iter())
+    }
+
+    pub(crate) fn for_shape(ds: &RdfDataset, shape: &Shape) -> Self {
+        Self::from_shape_iter(ds, std::iter::once(shape))
+    }
+
+    fn from_shape_iter<'a>(ds: &RdfDataset, shapes: impl IntoIterator<Item = &'a Shape>) -> Self {
+        let mut classes: FastSet<NamedNode> = FastSet::default();
+        for shape in shapes {
+            collect_shape_classes(shape, &mut classes);
+        }
+        let class_closures = classes
+            .into_iter()
+            .map(|class| {
+                let closure = subclass_closure(ds, &class);
+                (class, closure)
+            })
+            .collect();
+        Self {
+            rdf_type_id: resolve_id(ds, &Term::NamedNode(NamedNode::from(rdf::TYPE))),
+            class_closures,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn rdf_type_id(&self) -> Option<TermId> {
+        self.rdf_type_id
+    }
+
+    #[inline]
+    pub(crate) fn class_closure(&self, class: &NamedNode) -> &IdSet {
+        self.class_closures
+            .get(class)
+            .expect("every reachable sh:class and sh:targetClass is planned")
+    }
+}
+
+fn collect_shape_classes(shape: &Shape, classes: &mut FastSet<NamedNode>) {
+    for target in &shape.targets {
+        match target {
+            Target::Class(class) => {
+                classes.insert(class.clone());
+            }
+            Target::ImplicitClass(Term::NamedNode(class)) => {
+                classes.insert(class.clone());
+            }
+            Target::SubjectsOf(_)
+            | Target::ObjectsOf(_)
+            | Target::Node(_)
+            | Target::ImplicitClass(_)
+            | Target::Sparql { .. } => {}
+        }
+    }
+    collect_constraints_classes(&shape.constraints, classes);
+    for property in &shape.property_shapes {
+        collect_property_classes(property, classes);
+    }
+}
+
+fn collect_property_classes(property: &PropertyShape, classes: &mut FastSet<NamedNode>) {
+    collect_constraints_classes(&property.constraints, classes);
+    for nested in &property.property_shapes {
+        collect_property_classes(nested, classes);
+    }
+    for reifier_shape in &property.reifier_shapes {
+        collect_shape_classes(reifier_shape, classes);
+    }
+}
+
+fn collect_constraints_classes(constraints: &[Constraint], classes: &mut FastSet<NamedNode>) {
+    for constraint in constraints {
+        match constraint {
+            Constraint::Class(class) => {
+                classes.insert(class.clone());
+            }
+            Constraint::Not(shape) | Constraint::Node(shape) => {
+                collect_shape_classes(shape, classes);
+            }
+            Constraint::And(shapes) | Constraint::Or(shapes) | Constraint::Xone(shapes) => {
+                for shape in shapes {
+                    collect_shape_classes(shape, classes);
+                }
+            }
+            Constraint::QualifiedValueShape {
+                shape, siblings, ..
+            } => {
+                collect_shape_classes(shape, classes);
+                for sibling in siblings {
+                    collect_shape_classes(sibling, classes);
+                }
+            }
+            Constraint::Expression { expr, .. } => collect_expression_classes(expr, classes),
+            Constraint::Datatype(_)
+            | Constraint::NodeKind(_)
+            | Constraint::MinCount(_)
+            | Constraint::MaxCount(_)
+            | Constraint::In(_)
+            | Constraint::HasValue(_)
+            | Constraint::Pattern { .. }
+            | Constraint::MinLength(_)
+            | Constraint::MaxLength(_)
+            | Constraint::UniqueLang(_)
+            | Constraint::LanguageIn(_)
+            | Constraint::Closed { .. }
+            | Constraint::MinInclusive(_)
+            | Constraint::MaxInclusive(_)
+            | Constraint::MinExclusive(_)
+            | Constraint::MaxExclusive(_)
+            | Constraint::Sparql { .. }
+            | Constraint::Equals(_)
+            | Constraint::Disjoint(_)
+            | Constraint::LessThan(_)
+            | Constraint::LessThanOrEquals(_)
+            | Constraint::Component { .. } => {}
+        }
+    }
+}
+
+fn collect_expression_classes(expr: &NodeExpr, classes: &mut FastSet<NamedNode>) {
+    match expr {
+        NodeExpr::Constant(_) | NodeExpr::This | NodeExpr::Path(_) => {}
+        NodeExpr::Filter { nodes, shape } => {
+            collect_expression_classes(nodes, classes);
+            collect_shape_classes(shape, classes);
+        }
+        NodeExpr::Union(items) | NodeExpr::Intersection(items) => {
+            for item in items {
+                collect_expression_classes(item, classes);
+            }
+        }
+        NodeExpr::If { cond, then, els } => {
+            collect_expression_classes(cond, classes);
+            collect_expression_classes(then, classes);
+            collect_expression_classes(els, classes);
+        }
+        NodeExpr::Count { of, .. }
+        | NodeExpr::Distinct(of)
+        | NodeExpr::Min(of)
+        | NodeExpr::Max(of)
+        | NodeExpr::Sum(of)
+        | NodeExpr::Limit { of, .. }
+        | NodeExpr::Offset { of, .. }
+        | NodeExpr::Exists(of) => collect_expression_classes(of, classes),
+        NodeExpr::OrderBy { of, key, .. } => {
+            collect_expression_classes(of, classes);
+            collect_expression_classes(key, classes);
+        }
+        NodeExpr::Call(call) => {
+            let args = match call {
+                FnCall::Builtin { args, .. } | FnCall::UserDefined { args, .. } => args,
+            };
+            for arg in args {
+                collect_expression_classes(arg, classes);
+            }
+        }
+    }
+}
+
 /// Collect subjects that are SHACL instances of `class_iri`: nodes with an
 /// `rdf:type` to `class_iri` or to any asserted (transitive) subclass of it.
 ///
-/// `closure_memo` is a per-`validate_with` call cache keyed by class IRI; the
-/// subclass BFS is performed at most once per distinct class across all shapes.
+/// `plan` carries every dataset-bound subclass closure used by the shape tree;
+/// focus resolution performs no graph-wide closure walk.
 fn instances_of_class(
     ds: &RdfDataset,
     class_iri: &NamedNode,
-    closure_memo: &mut FastMap<NamedNode, IdSet>,
-) -> Vec<Term> {
-    let Some(rdf_type) = resolve_id(ds, &Term::NamedNode(NamedNode::from(rdf::TYPE))) else {
+    plan: &ValidationPlan,
+) -> Vec<TermId> {
+    let Some(rdf_type) = plan.rdf_type_id() else {
         return Vec::new();
     };
-    // Compute the subclass closure at most once per class IRI; clone the key only
-    // on a memo miss (insert requires ownership), never on a hit.
-    if !closure_memo.contains_key(class_iri) {
-        let closure = subclass_closure(ds, class_iri);
-        closure_memo.insert(class_iri.clone(), closure);
-    }
-    let classes = &closure_memo[class_iri];
+    let classes = plan.class_closure(class_iri);
     let mut seen: IdSet = IdSet::default();
     let mut result = Vec::new();
     // Iterate the memoized id set by reference — never clone the whole set per call.
@@ -120,62 +288,101 @@ fn instances_of_class(
         for q in quads_for_pattern_ids(ds, None, Some(rdf_type), Some(class), GraphFilter::AnyGraph)
         {
             if seen.insert(q.s) {
-                result.push(term_id_to_native(ds, q.s));
+                result.push(q.s);
             }
         }
     }
     result
 }
 
+/// A resolved focus node carrying its already-known interned identity.
+#[derive(Debug, Clone)]
+pub(crate) struct FocusNode {
+    term: Term,
+    id: Option<TermId>,
+}
+
+impl FocusNode {
+    #[inline]
+    pub(crate) fn term(&self) -> &Term {
+        &self.term
+    }
+
+    #[inline]
+    pub(crate) fn id(&self) -> Option<TermId> {
+        self.id
+    }
+
+    #[inline]
+    pub(crate) fn into_term(self) -> Term {
+        self.term
+    }
+}
+
 /// Resolve the focus node set for a single shape from its target declarations.
 ///
-/// Results are deduped by `Term` identity and sorted for a stable order.
-///
-/// `closure_memo` is threaded through to [`instances_of_class`] so the subclass
-/// BFS is performed at most once per class IRI per `validate_with` call.
+/// Interned targets are deduplicated in id space and resolved to an owned term
+/// exactly once. Results retain that id for constraint and path evaluation and
+/// are sorted canonically before return.
 pub(crate) fn resolve_focus_nodes(
     data: &ShaclData,
     targets: &[Target],
-    closure_memo: &mut FastMap<NamedNode, IdSet>,
-) -> Result<Vec<Term>, String> {
+    plan: &ValidationPlan,
+) -> Result<Vec<FocusNode>, String> {
     let ds = data.core();
-    let mut seen: FastSet<Term> = FastSet::default();
-    let mut nodes: Vec<Term> = Vec::new();
+    let mut seen_ids: IdSet = IdSet::default();
+    let mut seen_foreign: FastSet<Term> = FastSet::default();
+    let mut nodes: Vec<FocusNode> = Vec::new();
 
     for target in targets {
-        let candidates: Vec<Term> = match target {
-            Target::Class(class_iri) => instances_of_class(ds, class_iri, closure_memo),
-            Target::SubjectsOf(pred) => subjects_of(ds, pred),
-            Target::ObjectsOf(pred) => objects_of(ds, pred),
-            Target::Node(t) => vec![t.clone()],
-            Target::ImplicitClass(t) => {
-                // Same semantics as Class: subjects of (?, rdf:type, t)
-                if let Term::NamedNode(nn) = t {
-                    instances_of_class(ds, nn, closure_memo)
-                } else {
-                    vec![]
+        let ids = match target {
+            Target::Class(class_iri) => Some(instances_of_class(ds, class_iri, plan)),
+            Target::SubjectsOf(pred) => Some(subjects_of(ds, pred)),
+            Target::ObjectsOf(pred) => Some(objects_of(ds, pred)),
+            Target::ImplicitClass(Term::NamedNode(class)) => {
+                Some(instances_of_class(ds, class, plan))
+            }
+            Target::ImplicitClass(_) => Some(Vec::new()),
+            Target::Node(_) | Target::Sparql { .. } => None,
+        };
+        if let Some(ids) = ids {
+            for id in ids {
+                if seen_ids.insert(id) {
+                    nodes.push(FocusNode {
+                        term: term_id_to_native(ds, id),
+                        id: Some(id),
+                    });
                 }
             }
-            // sh:SPARQLTarget: execute the pre-parsed SELECT and collect ?this over
-            // the native SPARQL engine, reading the IR dataset directly.
-            // SELECT-form is enforced at shape-load (shapes.rs rejects
-            // non-SELECT); a residual evaluation failure is surfaced as a hard
-            // validation error rather than a panic.
+            continue;
+        }
+
+        let candidates = match target {
+            Target::Node(term) => vec![term.clone()],
+            // SELECT-form is enforced at shape-load; residual evaluation failures
+            // remain hard validation errors.
             Target::Sparql {
                 select,
                 substitutions,
             } => crate::sparql::eval_target(data.sparql(), select, substitutions)
                 .map_err(|e| format!("sh:target SPARQLTarget failed: {e}"))?,
+            Target::Class(_)
+            | Target::SubjectsOf(_)
+            | Target::ObjectsOf(_)
+            | Target::ImplicitClass(_) => unreachable!("id-native target handled above"),
         };
-        for node in candidates {
-            if seen.insert(node.clone()) {
-                nodes.push(node);
+        for term in candidates {
+            if let Some(id) = resolve_id(ds, &term) {
+                if seen_ids.insert(id) {
+                    nodes.push(FocusNode { term, id: Some(id) });
+                }
+            } else if seen_foreign.insert(term.clone()) {
+                nodes.push(FocusNode { term, id: None });
             }
         }
     }
 
-    // Sort for a stable, deterministic ordering across iterations.
-    crate::term::sort_canonical(&mut nodes);
+    nodes.sort_by_cached_key(|node| node.term.to_string());
     Ok(nodes)
 }
 
@@ -224,19 +431,15 @@ where
     // functions; the guard restores the previous table on drop.
     let _function_scope = crate::sparql::enter_function_scope(Arc::clone(&shapes.functions));
 
+    let plan = ValidationPlan::for_shapes(data.core(), shapes);
     let mut all_results = Vec::new();
-    // Per-call subclass-closure memo: keyed by class IRI, value is the full
-    // transitive closure (interned ids) of asserted rdfs:subClassOf edges below
-    // that class. Shared across all shapes in this validation run; each distinct
-    // class IRI is BFS-walked AT MOST ONCE regardless of how many shapes target it.
-    let mut closure_memo: FastMap<NamedNode, IdSet> = FastMap::default();
 
     for shape in &shapes.node_shapes {
         if shape.deactivated {
             continue;
         }
 
-        let focus_nodes = resolve_focus_nodes(data, &shape.targets, &mut closure_memo)?;
+        let focus_nodes = resolve_focus_nodes(data, &shape.targets, &plan)?;
 
         // Per-focus constraint evaluation stays SERIAL. A rayon `par_iter` over the
         // focus loop was measured on `shacl_validate/large_hierarchy` (3000 focus
@@ -248,14 +451,16 @@ where
         // i.e. once SHACL-SPARQL constraints are common or the IR-native backend runs
         // end-to-end (dropping the shared-`Store` contention). See the issue tracker (item 2).
         for focus in &focus_nodes {
-            if !include_focus(shape, focus) {
+            if !include_focus(shape, focus.term()) {
                 continue;
             }
-            all_results.extend(crate::constraints::validate_shape_with(
+            all_results.extend(crate::constraints::validate_shape_with_plan_at(
                 data,
-                focus,
+                focus.term(),
+                focus.id(),
                 shape,
                 shapes.box_role_vocab.as_ref(),
+                &plan,
             )?);
         }
     }
@@ -1142,6 +1347,43 @@ mod tests {
         assert_eq!(
             unique_lang, 2,
             "fixture must yield two uniqueLang violations (dup @en and @fr)"
+        );
+    }
+
+    #[test]
+    fn validation_plan_collects_target_property_and_nested_classes() {
+        let shapes_ttl = format!(
+            r"{PREFIXES}
+            ex:PlannedShape a sh:NodeShape ;
+                sh:targetClass ex:Root ;
+                sh:property [
+                    sh:path ex:member ;
+                    sh:class ex:Value ;
+                    sh:node [ sh:class ex:Nested ] ;
+                ] .
+            "
+        );
+        let data = load_data_nt(
+            "<http://example.org/ns#Child> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://example.org/ns#Root> .\n\
+             <http://example.org/ns#Leaf> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://example.org/ns#Value> .\n",
+        );
+        let shapes = load_shapes_ttl(&shapes_ttl);
+        let plan = ValidationPlan::for_shapes(data.as_ref(), &shapes);
+
+        assert_eq!(plan.class_closures.len(), 3);
+        assert_eq!(
+            plan.class_closure(&NamedNode::from("http://example.org/ns#Root"))
+                .len(),
+            2
+        );
+        assert_eq!(
+            plan.class_closure(&NamedNode::from("http://example.org/ns#Value"))
+                .len(),
+            2
+        );
+        assert!(
+            plan.class_closure(&NamedNode::from("http://example.org/ns#Nested"))
+                .is_empty()
         );
     }
 }

--- a/crates/shapes/src/engine.rs
+++ b/crates/shapes/src/engine.rs
@@ -58,10 +58,8 @@ fn objects_of(ds: &RdfDataset, pred: &NamedNode) -> Vec<TermId> {
     result
 }
 
-/// The transitive closure of asserted `rdfs:subClassOf` at or below `class_iri`,
-/// as interned [`TermId`]s: the set containing `class_iri` itself plus every class
-/// that is a (transitive) subclass of it via `rdfs:subClassOf` triples **asserted
-/// in the data graph**.
+/// Compute the transitive closures of asserted `rdfs:subClassOf` below every
+/// requested class as interned [`TermId`]s.
 ///
 /// This implements SHACL class-membership semantics (§4.2.5), which honor the
 /// subclass relationships present in the data. It is NOT OWL/RDFS inference: we
@@ -69,29 +67,64 @@ fn objects_of(ds: &RdfDataset, pred: &NamedNode) -> Vec<TermId> {
 /// "no-inference contract" means no reasoner is run, not that asserted subclass
 /// edges are ignored.) See the issue tracker.
 ///
-/// A class IRI not interned in `ds` (mentioned by no triple) yields an empty set:
-/// nothing can be typed to it, so it has no SHACL instances.
-pub(crate) fn subclass_closure(ds: &RdfDataset, class_iri: &NamedNode) -> IdSet {
-    let mut closure: IdSet = IdSet::default();
-    let Some(start) = resolve_id(ds, &Term::NamedNode(class_iri.clone())) else {
-        return closure;
+/// A class IRI not interned in `ds` yields an empty set: nothing can be typed to
+/// it, so it has no SHACL instances.
+///
+/// Building a general OSP permutation index merely to read a small class
+/// hierarchy dominates preparation on million-node ABox snapshots. A single
+/// sequential pass is O(quads), allocation-proportional only to actual hierarchy
+/// edges, and is shared by every class used anywhere in the shapes tree.
+fn subclass_closures(
+    ds: &RdfDataset,
+    classes: impl IntoIterator<Item = NamedNode>,
+) -> FastMap<NamedNode, IdSet> {
+    let resolved: Vec<(NamedNode, Option<TermId>)> = classes
+        .into_iter()
+        .map(|class| {
+            let id = ds.term_id_by_iri(class.as_str());
+            (class, id)
+        })
+        .collect();
+    let Some(subclass_predicate) = ds.term_id_by_iri(rdfs::SUB_CLASS_OF) else {
+        return resolved
+            .into_iter()
+            .map(|(class, id)| (class, id.into_iter().collect()))
+            .collect();
     };
-    closure.insert(start);
-    let Some(sco) = resolve_id(ds, &Term::NamedNode(NamedNode::from(rdfs::SUB_CLASS_OF))) else {
-        // No `rdfs:subClassOf` edges in the data: the closure is just the class.
-        return closure;
-    };
-    let mut frontier = vec![start];
-    while let Some(superclass) = frontier.pop() {
-        // Any X with `X rdfs:subClassOf superclass` is a subclass to descend into.
-        for q in quads_for_pattern_ids(ds, None, Some(sco), Some(superclass), GraphFilter::AnyGraph)
-        {
-            if closure.insert(q.s) {
-                frontier.push(q.s);
-            }
+    if !resolved.iter().any(|(_, id)| id.is_some()) {
+        return resolved
+            .into_iter()
+            .map(|(class, _)| (class, IdSet::default()))
+            .collect();
+    }
+
+    let mut subclasses: FastMap<TermId, Vec<TermId>> = FastMap::default();
+    for quad in ds.quads() {
+        if quad.p == subclass_predicate {
+            subclasses.entry(quad.o).or_default().push(quad.s);
         }
     }
-    closure
+
+    resolved
+        .into_iter()
+        .map(|(class, start)| {
+            let mut closure = IdSet::default();
+            if let Some(start) = start {
+                closure.insert(start);
+                let mut frontier = vec![start];
+                while let Some(superclass) = frontier.pop() {
+                    if let Some(direct) = subclasses.get(&superclass) {
+                        for &subclass in direct {
+                            if closure.insert(subclass) {
+                                frontier.push(subclass);
+                            }
+                        }
+                    }
+                }
+            }
+            (class, closure)
+        })
+        .collect()
 }
 
 /// Dataset-bound invariant state shared by every focus evaluation in one pass.
@@ -120,13 +153,7 @@ impl ValidationPlan {
         for shape in shapes {
             collect_shape_classes(shape, &mut classes);
         }
-        let class_closures = classes
-            .into_iter()
-            .map(|class| {
-                let closure = subclass_closure(ds, &class);
-                (class, closure)
-            })
-            .collect();
+        let class_closures = subclass_closures(ds, classes);
         Self {
             rdf_type_id: resolve_id(ds, &Term::NamedNode(NamedNode::from(rdf::TYPE))),
             class_closures,
@@ -386,7 +413,485 @@ pub(crate) fn resolve_focus_nodes(
     Ok(nodes)
 }
 
+/// Dataset-bound target predicates used by [`PreparedValidator`].
+///
+/// Core targets are retained as compact membership indexes instead of eagerly
+/// expanding every target node. A bounded request can therefore test only its
+/// supplied candidates. Explicit and SHACL-SPARQL target results are resolved
+/// once at preparation because they cannot be answered through a Core pattern
+/// lookup.
+#[derive(Debug, Default)]
+struct PreparedTargets {
+    explicit_ids: IdSet,
+    explicit_foreign: FastSet<Term>,
+    target_class_ids: IdSet,
+    subject_predicates: IdSet,
+    object_predicates: IdSet,
+}
+
+impl PreparedTargets {
+    fn for_shape(data: &ShaclData, shape: &Shape, plan: &ValidationPlan) -> Result<Self, String> {
+        let mut prepared = Self::default();
+        for target in &shape.targets {
+            match target {
+                Target::Class(class) => {
+                    prepared
+                        .target_class_ids
+                        .extend(plan.class_closure(class).iter().copied());
+                }
+                Target::ImplicitClass(Term::NamedNode(class)) => {
+                    prepared
+                        .target_class_ids
+                        .extend(plan.class_closure(class).iter().copied());
+                }
+                Target::SubjectsOf(predicate) => {
+                    if let Some(id) = resolve_pred(data.core(), predicate) {
+                        prepared.subject_predicates.insert(id);
+                    }
+                }
+                Target::ObjectsOf(predicate) => {
+                    if let Some(id) = resolve_pred(data.core(), predicate) {
+                        prepared.object_predicates.insert(id);
+                    }
+                }
+                Target::Node(term) => prepared.insert_explicit(data.core(), term.clone()),
+                Target::Sparql {
+                    select,
+                    substitutions,
+                } => {
+                    let candidates =
+                        crate::sparql::eval_target(data.sparql(), select, substitutions)
+                            .map_err(|error| format!("sh:target SPARQLTarget failed: {error}"))?;
+                    for candidate in candidates {
+                        prepared.insert_explicit(data.core(), candidate);
+                    }
+                }
+                Target::ImplicitClass(_) => {}
+            }
+        }
+        Ok(prepared)
+    }
+
+    fn insert_explicit(&mut self, dataset: &RdfDataset, term: Term) {
+        if let Some(id) = resolve_id(dataset, &term) {
+            self.explicit_ids.insert(id);
+        } else {
+            self.explicit_foreign.insert(term);
+        }
+    }
+
+    #[inline]
+    fn contains(&self, data: &ShaclData, plan: &ValidationPlan, focus: &FocusNode) -> bool {
+        let Some(id) = focus.id() else {
+            return self.explicit_foreign.contains(focus.term());
+        };
+        if self.explicit_ids.contains(&id) {
+            return true;
+        }
+
+        let dataset = data.core();
+        if let Some(rdf_type) = plan.rdf_type_id()
+            && !self.target_class_ids.is_empty()
+            && quads_for_pattern_ids(
+                dataset,
+                Some(id),
+                Some(rdf_type),
+                None,
+                GraphFilter::AnyGraph,
+            )
+            .any(|quad| self.target_class_ids.contains(&quad.o))
+        {
+            return true;
+        }
+        if !self.subject_predicates.is_empty()
+            && quads_for_pattern_ids(dataset, Some(id), None, None, GraphFilter::AnyGraph)
+                .any(|quad| self.subject_predicates.contains(&quad.p))
+        {
+            return true;
+        }
+        !self.object_predicates.is_empty()
+            && quads_for_pattern_ids(dataset, None, None, Some(id), GraphFilter::AnyGraph)
+                .any(|quad| self.object_predicates.contains(&quad.p))
+    }
+
+    fn resolve_all(&self, data: &ShaclData, plan: &ValidationPlan) -> Vec<FocusNode> {
+        let dataset = data.core();
+        let mut seen_ids = self.explicit_ids.clone();
+        let mut nodes: Vec<FocusNode> = self
+            .explicit_ids
+            .iter()
+            .copied()
+            .map(|id| FocusNode {
+                term: term_id_to_native(dataset, id),
+                id: Some(id),
+            })
+            .collect();
+
+        if let Some(rdf_type) = plan.rdf_type_id() {
+            for &class in &self.target_class_ids {
+                for quad in quads_for_pattern_ids(
+                    dataset,
+                    None,
+                    Some(rdf_type),
+                    Some(class),
+                    GraphFilter::AnyGraph,
+                ) {
+                    if seen_ids.insert(quad.s) {
+                        nodes.push(FocusNode {
+                            term: term_id_to_native(dataset, quad.s),
+                            id: Some(quad.s),
+                        });
+                    }
+                }
+            }
+        }
+        for &predicate in &self.subject_predicates {
+            for quad in
+                quads_for_pattern_ids(dataset, None, Some(predicate), None, GraphFilter::AnyGraph)
+            {
+                if seen_ids.insert(quad.s) {
+                    nodes.push(FocusNode {
+                        term: term_id_to_native(dataset, quad.s),
+                        id: Some(quad.s),
+                    });
+                }
+            }
+        }
+        for &predicate in &self.object_predicates {
+            for quad in
+                quads_for_pattern_ids(dataset, None, Some(predicate), None, GraphFilter::AnyGraph)
+            {
+                if seen_ids.insert(quad.o) {
+                    nodes.push(FocusNode {
+                        term: term_id_to_native(dataset, quad.o),
+                        id: Some(quad.o),
+                    });
+                }
+            }
+        }
+        nodes.extend(
+            self.explicit_foreign
+                .iter()
+                .cloned()
+                .map(|term| FocusNode { term, id: None }),
+        );
+        nodes.sort_by_cached_key(|node| node.term.to_string());
+        nodes
+    }
+}
+
+fn evaluate_shape_focus_nodes(
+    data: &ShaclData,
+    shapes: &Shapes,
+    shape: &Shape,
+    plan: &ValidationPlan,
+    focus_nodes: &[FocusNode],
+    include_focus: impl Fn(&FocusNode) -> bool + Sync,
+) -> Result<Vec<crate::report::ValidationResult>, String> {
+    crate::parallel::try_map_chunks(
+        focus_nodes,
+        || crate::sparql::enter_function_scope(Arc::clone(&shapes.functions)),
+        |_function_scope, out, focus| {
+            if include_focus(focus) {
+                out.extend(crate::constraints::validate_shape_with_plan_at(
+                    data,
+                    focus.term(),
+                    focus.id(),
+                    shape,
+                    shapes.box_role_vocab.as_ref(),
+                    plan,
+                )?);
+            }
+            Ok::<(), String>(())
+        },
+    )
+}
+
+fn finish_report(mut results: Vec<crate::report::ValidationResult>) -> ValidationReport {
+    // Deterministic sort key: (focus_node, component, source_shape, path, value,
+    // message, severity). The message and severity tiebreakers make the ordering
+    // TOTAL: two results that agree on the first five components (e.g. several
+    // `sh:uniqueLang` violations on one focus, which differ only in their message
+    // text) would otherwise keep their push order, which is a `FastMap`/`FastSet`
+    // iteration order and thus not guaranteed stable across ahash versions or
+    // targets. Sorting on the full serialized identity closes that leak so report
+    // bytes are invariant under data-insertion order and platform.
+    let sort_key = |result: &crate::report::ValidationResult| {
+        (
+            result.focus_node.to_string(),
+            result.source_constraint_component.to_string(),
+            result.source_shape.to_string(),
+            result
+                .result_path
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_default(),
+            result
+                .value
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_default(),
+            result.message.clone().unwrap_or_default(),
+            result.severity.clone(),
+        )
+    };
+    results.sort_by_cached_key(sort_key);
+    ValidationReport {
+        conforms: results.is_empty(),
+        results,
+    }
+}
+
+fn validate_with_plan_and_focus_filter<F>(
+    data: &ShaclData,
+    shapes: &Shapes,
+    plan: &ValidationPlan,
+    mut include_focus: F,
+) -> Result<ValidationReport, String>
+where
+    F: FnMut(&Shape, &Term) -> bool,
+{
+    // This orchestration-thread scope covers target resolution; each focus chunk
+    // installs the same SHACL-AF function registry on its worker.
+    let _function_scope = crate::sparql::enter_function_scope(Arc::clone(&shapes.functions));
+    let mut all_results = Vec::new();
+
+    for shape in &shapes.node_shapes {
+        if shape.deactivated {
+            continue;
+        }
+        let mut focus_nodes = resolve_focus_nodes(data, &shape.targets, plan)?;
+        // `FnMut` is intentionally applied serially in canonical focus order, so
+        // existing callers observe the same calls even when evaluation dispatches
+        // the retained set to workers.
+        focus_nodes.retain(|focus| include_focus(shape, focus.term()));
+        all_results.extend(evaluate_shape_focus_nodes(
+            data,
+            shapes,
+            shape,
+            plan,
+            &focus_nodes,
+            |_| true,
+        )?);
+    }
+    Ok(finish_report(all_results))
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
+
+/// Reusable validation state for one immutable projected dataset and shapes graph.
+///
+/// Preparation memoizes every dataset-bound class closure, resolves target
+/// predicates, and evaluates explicit SHACL-SPARQL targets once. Core targets are
+/// kept as compact membership predicates: [`Self::validate_focus_nodes`] and
+/// [`Self::validate_focus_node_ids`] inspect only the caller-supplied candidates
+/// and never enumerate every target node in the dataset. This is the preferred
+/// surface for realtime validation over a large immutable snapshot.
+///
+/// A prepared validator is tied to the exact dataset snapshot it owns. Prepare a
+/// new value after publishing an overlay or replacement snapshot.
+#[derive(Debug)]
+pub struct PreparedValidator {
+    data: ShaclData,
+    shapes: Arc<Shapes>,
+    plan: ValidationPlan,
+    targets: Vec<PreparedTargets>,
+}
+
+impl PreparedValidator {
+    /// Prepare an already-assembled [`ShaclData`] holder and parsed shapes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when an active SHACL-SPARQL target cannot be evaluated.
+    pub fn new(data: ShaclData, shapes: Arc<Shapes>) -> Result<Self, String> {
+        let _function_scope = crate::sparql::enter_function_scope(Arc::clone(&shapes.functions));
+        let plan = ValidationPlan::for_shapes(data.core(), &shapes);
+        let targets = shapes
+            .node_shapes
+            .iter()
+            .map(|shape| {
+                if shape.deactivated {
+                    Ok(PreparedTargets::default())
+                } else {
+                    PreparedTargets::for_shape(&data, shape, &plan)
+                }
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        Ok(Self {
+            data,
+            shapes,
+            plan,
+            targets,
+        })
+    }
+
+    /// Project and prepare a frozen dataset.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when projection fails or an active SHACL-SPARQL target
+    /// cannot be evaluated.
+    pub fn from_dataset(data: &RdfDataset, shapes: Arc<Shapes>) -> Result<Self, String> {
+        Self::from_projected_dataset(project_dataset(data)?, shapes)
+    }
+
+    /// Prepare an already-SHACL-projected frozen dataset.
+    ///
+    /// Core and SHACL-SPARQL lookups share the same immutable dataset.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when an active SHACL-SPARQL target cannot be evaluated.
+    pub fn from_projected_dataset(
+        projected: Arc<RdfDataset>,
+        shapes: Arc<Shapes>,
+    ) -> Result<Self, String> {
+        let data = ShaclData::new(Arc::clone(&projected), projected, None);
+        Self::new(data, shapes)
+    }
+
+    /// Prepare an already-projected dataset with the shapes graph exposed to
+    /// SHACL-SPARQL paths as a named graph.
+    ///
+    /// `shapes_graph_iri` overrides [`Shapes::shapes_graph`] when supplied.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the combined dataset cannot be frozen or an active
+    /// SHACL-SPARQL target cannot be evaluated.
+    pub fn from_projected_dataset_with_shapes_graph(
+        projected: Arc<RdfDataset>,
+        shapes: Arc<Shapes>,
+        shapes_graph_iri: Option<&str>,
+    ) -> Result<Self, String> {
+        let (sparql, shapes_graph_iri) =
+            build_sparql_dataset(Arc::clone(&projected), &shapes, shapes_graph_iri)?;
+        Self::new(ShaclData::new(projected, sparql, shapes_graph_iri), shapes)
+    }
+
+    /// Validate every target node using the prepared target plan.
+    ///
+    /// Core target sets are enumerated for this whole-bundle operation, but class
+    /// closures, predicate identities, and SHACL-SPARQL target results are reused.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a constraint evaluation hard-fails.
+    pub fn validate(&self) -> Result<ValidationReport, String> {
+        let mut all_results = Vec::new();
+        for (shape, targets) in self.shapes.node_shapes.iter().zip(&self.targets) {
+            if shape.deactivated {
+                continue;
+            }
+            let focus_nodes = targets.resolve_all(&self.data, &self.plan);
+            all_results.extend(evaluate_shape_focus_nodes(
+                &self.data,
+                &self.shapes,
+                shape,
+                &self.plan,
+                &focus_nodes,
+                |_| true,
+            )?);
+        }
+        Ok(finish_report(all_results))
+    }
+
+    /// Validate only the supplied candidate focus nodes that match each shape's
+    /// prepared targets.
+    ///
+    /// Candidates are deduplicated and canonically ordered. Target membership is
+    /// answered through direct IR index probes; whole target sets are not built.
+    /// The caller remains responsible for expanding a graph change into every
+    /// potentially affected focus node (for example, an inverse-path dependency).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a constraint evaluation hard-fails.
+    pub fn validate_focus_nodes(&self, focus_nodes: &[Term]) -> Result<ValidationReport, String> {
+        let focus_nodes = self.normalize_focus_nodes(focus_nodes);
+        self.validate_bounded(&focus_nodes)
+    }
+
+    /// Id-native twin of [`Self::validate_focus_nodes`] for callers already using
+    /// the prepared dataset's interned identities.
+    ///
+    /// [`TermId`] values are dataset-local. Passing an id from another dataset is a
+    /// caller error; out-of-range ids are rejected before lookup.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an out-of-range id or when constraint evaluation
+    /// hard-fails.
+    pub fn validate_focus_node_ids(
+        &self,
+        focus_node_ids: &[TermId],
+    ) -> Result<ValidationReport, String> {
+        let mut seen = IdSet::default();
+        let mut focus_nodes = Vec::with_capacity(focus_node_ids.len());
+        for &id in focus_node_ids {
+            if id.index() >= self.data.core().term_count() {
+                return Err(format!(
+                    "focus node TermId {} is outside the prepared dataset's {}-term table",
+                    id.index(),
+                    self.data.core().term_count()
+                ));
+            }
+            if seen.insert(id) {
+                focus_nodes.push(FocusNode {
+                    term: term_id_to_native(self.data.core(), id),
+                    id: Some(id),
+                });
+            }
+        }
+        focus_nodes.sort_by_cached_key(|focus| focus.term.to_string());
+        self.validate_bounded(&focus_nodes)
+    }
+
+    fn normalize_focus_nodes(&self, focus_nodes: &[Term]) -> Vec<FocusNode> {
+        let mut seen_ids = IdSet::default();
+        let mut seen_foreign = FastSet::default();
+        let mut normalized = Vec::with_capacity(focus_nodes.len());
+        for term in focus_nodes {
+            if let Some(id) = resolve_id(self.data.core(), term) {
+                if seen_ids.insert(id) {
+                    normalized.push(FocusNode {
+                        term: term_id_to_native(self.data.core(), id),
+                        id: Some(id),
+                    });
+                }
+            } else if seen_foreign.insert(term.clone()) {
+                normalized.push(FocusNode {
+                    term: term.clone(),
+                    id: None,
+                });
+            }
+        }
+        normalized.sort_by_cached_key(|focus| focus.term.to_string());
+        normalized
+    }
+
+    fn validate_bounded(&self, focus_nodes: &[FocusNode]) -> Result<ValidationReport, String> {
+        if focus_nodes.is_empty() {
+            return Ok(finish_report(Vec::new()));
+        }
+        let mut all_results = Vec::new();
+        for (shape, targets) in self.shapes.node_shapes.iter().zip(&self.targets) {
+            if shape.deactivated {
+                continue;
+            }
+            all_results.extend(evaluate_shape_focus_nodes(
+                &self.data,
+                &self.shapes,
+                shape,
+                &self.plan,
+                focus_nodes,
+                |focus| targets.contains(&self.data, &self.plan, focus),
+            )?);
+        }
+        Ok(finish_report(all_results))
+    }
+}
 
 /// Validate a [`ShaclData`] holder against `shapes`.
 ///
@@ -412,7 +917,9 @@ pub fn validate_with(data: &ShaclData, shapes: &Shapes) -> Result<ValidationRepo
 /// The filter is called after target resolution and before constraint evaluation.
 /// It lets callers that already know only a bounded set of focus nodes changed
 /// avoid rechecking the clean base graph, while still resolving targets against
-/// the full data graph.
+/// the full data graph. Because this compatibility surface still enumerates each
+/// whole target set, realtime callers should prepare a [`PreparedValidator`] and
+/// use [`PreparedValidator::validate_focus_nodes`] instead.
 ///
 /// # Errors
 ///
@@ -425,76 +932,8 @@ pub fn validate_with_focus_filter<F>(
 where
     F: FnMut(&Shape, &Term) -> bool,
 {
-    // Install the shapes graph's SHACL-AF function table (`sh:SPARQLFunction`) for
-    // this whole validation pass. This orchestration-thread scope covers target
-    // resolution; each focus chunk installs the same registry on its worker.
-    let _function_scope = crate::sparql::enter_function_scope(Arc::clone(&shapes.functions));
-
     let plan = ValidationPlan::for_shapes(data.core(), shapes);
-    let mut all_results = Vec::new();
-
-    for shape in &shapes.node_shapes {
-        if shape.deactivated {
-            continue;
-        }
-
-        let mut focus_nodes = resolve_focus_nodes(data, &shape.targets, &plan)?;
-        // `FnMut` is intentionally applied serially in canonical focus order, so
-        // existing callers observe the same calls even when evaluation dispatches
-        // the retained set to workers.
-        focus_nodes.retain(|focus| include_focus(shape, focus.term()));
-
-        let shape_results = crate::parallel::try_map_chunks(
-            &focus_nodes,
-            || crate::sparql::enter_function_scope(Arc::clone(&shapes.functions)),
-            |_function_scope, out, focus| {
-                out.extend(crate::constraints::validate_shape_with_plan_at(
-                    data,
-                    focus.term(),
-                    focus.id(),
-                    shape,
-                    shapes.box_role_vocab.as_ref(),
-                    &plan,
-                )?);
-                Ok::<(), String>(())
-            },
-        )?;
-        all_results.extend(shape_results);
-    }
-
-    // Deterministic sort key: (focus_node, component, source_shape, path, value,
-    // message, severity). The message and severity tiebreakers make the ordering
-    // TOTAL: two results that agree on the first five components (e.g. several
-    // `sh:uniqueLang` violations on one focus, which differ only in their message
-    // text) would otherwise keep their push order, which is a `FastMap`/`FastSet`
-    // iteration order and thus not guaranteed stable across ahash versions or
-    // targets. Sorting on the full serialized identity closes that leak so report
-    // bytes are invariant under data-insertion order and platform.
-    let sort_key = |r: &crate::report::ValidationResult| {
-        (
-            r.focus_node.to_string(),
-            r.source_constraint_component.to_string(),
-            r.source_shape.to_string(),
-            r.result_path
-                .as_ref()
-                .map(ToString::to_string)
-                .unwrap_or_default(),
-            r.value
-                .as_ref()
-                .map(ToString::to_string)
-                .unwrap_or_default(),
-            r.message.clone().unwrap_or_default(),
-            r.severity.clone(),
-        )
-    };
-    all_results.sort_by_cached_key(sort_key);
-
-    let conforms = all_results.is_empty();
-
-    Ok(ValidationReport {
-        conforms,
-        results: all_results,
-    })
+    validate_with_plan_and_focus_filter(data, shapes, &plan, &mut include_focus)
 }
 
 /// Validate a frozen [`::purrdf::RdfDataset`] against parsed SHACL shapes, IR-natively.
@@ -1382,6 +1821,113 @@ mod tests {
             plan.class_closure(&NamedNode::from("http://example.org/ns#Nested"))
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn prepared_bounded_validation_matches_filtered_and_whole_reports() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<PreparedValidator>();
+
+        let data = load_data_nt(concat!(
+            "<http://example.org/ns#alice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/ns#Person> .\n",
+            "<http://example.org/ns#alice> <http://example.org/ns#knows> <http://example.org/ns#bob> .\n",
+            "<http://example.org/ns#bob> <http://example.org/ns#knows> <http://example.org/ns#alice> .\n",
+        ));
+        let projected = project_dataset(data.as_ref()).expect("projection must succeed");
+        let shapes = Arc::new(load_shapes_ttl(&format!(
+            r#"{PREFIXES}
+			ex:ClassShape a sh:NodeShape ;
+				sh:targetClass ex:Person ;
+				sh:property [ sh:path ex:required ; sh:minCount 1 ] .
+			ex:SubjectsShape a sh:NodeShape ;
+				sh:targetSubjectsOf ex:knows ;
+				sh:property [ sh:path ex:required ; sh:minCount 1 ] .
+			ex:ObjectsShape a sh:NodeShape ;
+				sh:targetObjectsOf ex:knows ;
+				sh:property [ sh:path ex:required ; sh:minCount 1 ] .
+			ex:NodeShape a sh:NodeShape ;
+				sh:targetNode ex:alice ;
+				sh:property [ sh:path ex:required ; sh:minCount 1 ] .
+			ex:SparqlTargetShape a sh:NodeShape ;
+				sh:target [
+					a sh:SPARQLTarget ;
+					sh:select "SELECT ?this WHERE {{ ?this a <http://example.org/ns#Person> }}" ;
+				] ;
+				sh:property [ sh:path ex:required ; sh:minCount 1 ] .
+			"#,
+        )));
+        let alice = NamedNode::new_unchecked("http://example.org/ns#alice").into_term();
+        let carol = NamedNode::new_unchecked("http://example.org/ns#carol").into_term();
+
+        let expected_bounded = validate_projected_dataset_with_focus_filter(
+            Arc::clone(&projected),
+            &shapes,
+            |_, focus| focus == &alice,
+        )
+        .expect("filtered validation must succeed");
+        let expected_whole = validate_projected_dataset(Arc::clone(&projected), &shapes)
+            .expect("whole validation must succeed");
+        let prepared =
+            PreparedValidator::from_projected_dataset(Arc::clone(&projected), Arc::clone(&shapes))
+                .expect("preparation must succeed");
+
+        let bounded = prepared
+            .validate_focus_nodes(&[alice.clone(), alice])
+            .expect("bounded validation must succeed");
+        assert_eq!(bounded.results.len(), 5, "alice matches every target kind");
+        assert_eq!(bounded.to_ntriples(), expected_bounded.to_ntriples());
+        assert_eq!(
+            prepared
+                .validate()
+                .expect("prepared whole validation")
+                .to_ntriples(),
+            expected_whole.to_ntriples()
+        );
+
+        let alice_id = projected
+            .term_id_by_iri("http://example.org/ns#alice")
+            .expect("alice must be interned");
+        assert_eq!(
+            prepared
+                .validate_focus_node_ids(&[alice_id, alice_id])
+                .expect("id-native bounded validation")
+                .to_ntriples(),
+            expected_bounded.to_ntriples()
+        );
+        assert!(
+            prepared
+                .validate_focus_nodes(&[carol])
+                .expect("untargeted bounded validation")
+                .conforms
+        );
+
+        let invalid = TermId::from_index(
+            u32::try_from(projected.term_count()).expect("small test term table"),
+        );
+        assert!(
+            prepared.validate_focus_node_ids(&[invalid]).is_err(),
+            "out-of-range ids must fail before dataset lookup"
+        );
+    }
+
+    #[test]
+    fn prepared_bounded_validation_keeps_foreign_explicit_targets() {
+        let data = load_data_nt("");
+        let projected = project_dataset(data.as_ref()).expect("projection must succeed");
+        let shapes = Arc::new(load_shapes_ttl(&format!(
+            "{PREFIXES}\n\
+			 ex:ForeignShape a sh:NodeShape ;\n\
+			     sh:targetNode ex:absent ;\n\
+			     sh:property [ sh:path ex:required ; sh:minCount 1 ] ."
+        )));
+        let absent = NamedNode::new_unchecked("http://example.org/ns#absent").into_term();
+        let prepared = PreparedValidator::from_projected_dataset(projected, shapes)
+            .expect("preparation must succeed");
+        let report = prepared
+            .validate_focus_nodes(&[absent])
+            .expect("foreign explicit target must validate");
+        assert_eq!(report.results.len(), 1);
+        assert!(!report.conforms);
     }
 
     #[test]

--- a/crates/shapes/src/engine.rs
+++ b/crates/shapes/src/engine.rs
@@ -16,9 +16,23 @@ use crate::expression::{FnCall, NodeExpr};
 use crate::model::{rdf, rdfs};
 use crate::report::ValidationReport;
 use crate::shapes::{Constraint, PropertyShape, Shape, Shapes, Target};
-use crate::term::{NamedNode, Term, term_id_to_native};
+use crate::term::{NamedNode, Term, canonical_cmp, term_id_to_native};
 
 // ── Target resolution helpers ─────────────────────────────────────────────────
+
+/// Canonically order focus nodes without allocating one rendered key per node.
+/// Large target sets use Rayon's deterministic stable parallel merge sort; small
+/// bounded requests avoid scheduler overhead.
+fn sort_focus_nodes(nodes: &mut [FocusNode]) {
+    const PARALLEL_SORT_MIN_NODES: usize = 4_096;
+
+    if nodes.len() >= PARALLEL_SORT_MIN_NODES && rayon::current_num_threads() > 1 {
+        use rayon::prelude::*;
+        nodes.par_sort_by(|left, right| canonical_cmp(&left.term, &right.term));
+    } else {
+        nodes.sort_by(|left, right| canonical_cmp(&left.term, &right.term));
+    }
+}
 
 /// Resolve a predicate IRI to its interned id in the Core dataset, if present.
 #[inline]
@@ -409,7 +423,7 @@ pub(crate) fn resolve_focus_nodes(
         }
     }
 
-    nodes.sort_by_cached_key(|node| node.term.to_string());
+    sort_focus_nodes(&mut nodes);
     Ok(nodes)
 }
 
@@ -575,7 +589,7 @@ impl PreparedTargets {
                 .cloned()
                 .map(|term| FocusNode { term, id: None }),
         );
-        nodes.sort_by_cached_key(|node| node.term.to_string());
+        sort_focus_nodes(&mut nodes);
         nodes
     }
 }
@@ -844,7 +858,7 @@ impl PreparedValidator {
                 });
             }
         }
-        focus_nodes.sort_by_cached_key(|focus| focus.term.to_string());
+        sort_focus_nodes(&mut focus_nodes);
         self.validate_bounded(&focus_nodes)
     }
 
@@ -867,7 +881,7 @@ impl PreparedValidator {
                 });
             }
         }
-        normalized.sort_by_cached_key(|focus| focus.term.to_string());
+        sort_focus_nodes(&mut normalized);
         normalized
     }
 

--- a/crates/shapes/src/engine.rs
+++ b/crates/shapes/src/engine.rs
@@ -79,7 +79,7 @@ fn objects_of(ds: &RdfDataset, pred: &NamedNode) -> Vec<TermId> {
 /// subclass relationships present in the data. It is NOT OWL/RDFS inference: we
 /// read `rdfs:subClassOf` triples that exist and materialize nothing. (The
 /// "no-inference contract" means no reasoner is run, not that asserted subclass
-/// edges are ignored.) See the issue tracker.
+/// edges are ignored.)
 ///
 /// A class IRI not interned in `ds` yields an empty set: nothing can be typed to
 /// it, so it has no SHACL instances.
@@ -704,6 +704,48 @@ where
 ///
 /// A prepared validator is tied to the exact dataset snapshot it owns. Prepare a
 /// new value after publishing an overlay or replacement snapshot.
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+///
+/// use purrdf::RdfDatasetBuilder;
+/// use purrdf_shapes::engine::{PreparedValidator, parse_shapes};
+///
+/// # fn main() -> Result<(), String> {
+/// let mut builder = RdfDatasetBuilder::new();
+/// let rdf_type = builder.intern_iri(
+///     "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+/// );
+/// let person = builder.intern_iri("https://example.org/Person");
+/// let required = builder.intern_iri("https://example.org/required");
+/// let alice = builder.intern_iri("https://example.org/alice");
+/// let present = builder.intern_iri("https://example.org/present");
+/// builder.push_quad(alice, rdf_type, person, None);
+/// builder.push_quad(alice, required, present, None);
+/// let dataset = Arc::new(builder.freeze().map_err(|error| error.to_string())?);
+///
+/// let shapes = Arc::new(parse_shapes(
+///     r#"
+///     @prefix sh: <http://www.w3.org/ns/shacl#> .
+///     @prefix ex: <https://example.org/> .
+///     ex:PersonShape a sh:NodeShape ;
+///         sh:targetClass ex:Person ;
+///         sh:property [ sh:path ex:required ; sh:minCount 1 ] .
+///     "#,
+/// )?);
+/// let validator = PreparedValidator::from_projected_dataset(
+///     Arc::clone(&dataset),
+///     shapes,
+/// )?;
+///
+/// // Reuse `validator` for each affected focus set in this immutable snapshot.
+/// let report = validator.validate_focus_node_ids(&[alice])?;
+/// assert!(report.conforms);
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug)]
 pub struct PreparedValidator {
     data: ShaclData,
@@ -1146,9 +1188,8 @@ pub fn parse_shapes_with_config(
     // the oxigraph `io` parser. The native codec drops document prefixes once it folds to
     // the IR, so we recover the `@prefix`/SPARQL `PREFIX` map by scanning the
     // source text: SHACL-AF sh:select queries (and pySHACL) rely on prefixed
-    // names. See the issue tracker. A syntax error is reported per-statement so
-    // a SHACL author sees the full list in one pass (item 4), not the
-    // fix-one-rerun-find-the-next loop.
+    // names. Syntax failures are accumulated per independently recoverable
+    // statement so a SHACL author sees the complete actionable set in one pass.
     let shapes_dataset = crate::text_ingest::parse_turtle_to_dataset(shapes_ttl)
         .map_err(|errors| errors.join("\n"))?;
     let doc_prefixes = crate::text_ingest::extract_prefixes(shapes_ttl);
@@ -1164,10 +1205,10 @@ pub fn parse_shapes_with_config(
 /// The data graph is loaded with the **lenient** RDF parser. A validator must be
 /// able to ingest the data graph before it can validate any shapes against it,
 /// and RDF lexical well-formedness is a separate concern from SHACL conformance.
-/// The purrdf ontology carries private-use `@x-purrdf-*` language tags whose
-/// subtag exceeds BCP-47's 8-char limit (e.g. `@x-purrdf-afrikaans`); the strict
-/// parser rejects the entire file on these, which would make the real ontology
-/// un-validatable. Lenient parsing skips that check so the data ingests. See the issue tracker.
+/// Caller datasets can carry private-use language tags whose subtags exceed
+/// BCP-47's eight-character limit. The strict parser rejects the complete graph
+/// on those lexical forms; lenient parsing keeps RDF ingestion separate from the
+/// SHACL conformance decision.
 ///
 /// # Errors
 ///
@@ -1188,9 +1229,9 @@ pub fn validate_graphs_with_config(
     shapes_ttl: &str,
     box_role_vocab: Option<crate::model::BoxRoleVocab>,
 ) -> Result<ValidationReport, String> {
-    // Parse the data graph via the native codecs. Every malformed
-    // N-Triples line is reported in one pass — same multi-error contract as
-    // `parse_shapes`. See the issue tracker (item 4).
+    // Parse the data graph via the native codecs. Every independently malformed
+    // N-Triples line is reported in one pass, matching `parse_shapes`' complete
+    // syntax-diagnostic contract.
     let data = crate::text_ingest::parse_ntriples_to_dataset(data_nt)
         .map_err(|errors| errors.join("\n"))?;
 
@@ -1266,7 +1307,7 @@ mod tests {
         validate_dataset(data.as_ref(), shapes).expect("validate_dataset must succeed")
     }
 
-    // ── Multi-error syntax reporting (item 4) ─────────────────────────────
+    // ── Multi-error syntax reporting ──────────────────────────────────────
 
     #[test]
     fn parse_shapes_reports_all_syntax_errors() {
@@ -1276,8 +1317,8 @@ mod tests {
         // real, not a one-element surface. (A lexer-level break such as an
         // unterminated string literal instead consumes to EOF and yields a single
         // error; that is correct, not a regression. The recoverable case below is
-        // what proves multi-error reporting works.) If this regresses to a single
-        // error on recoverable input, item 4's premise has broken.
+        // what proves multi-error reporting works.) A regression to a single
+        // error on recoverable input would violate the public diagnostic contract.
         let bad = concat!(
             "@prefix ex: <http://example.org/ns#> .\n",
             "ex:a ex:p .\n",                // missing object → recoverable error
@@ -1295,8 +1336,7 @@ mod tests {
     #[test]
     fn validate_graphs_reports_all_data_syntax_errors() {
         // Multiple malformed N-Triples lines must all be reported in one pass
-        // rather than short-circuiting on the first (the single-error
-        // load-into-store behavior item 4 replaced).
+        // rather than short-circuiting on the first.
         let bad_data = concat!(
             "this is not a triple\n",
             "<http://example.org/s> <http://example.org/p> .\n",
@@ -1493,10 +1533,9 @@ mod tests {
         );
     }
 
-    // Test 4: sh:targetClass honors ASSERTED rdfs:subClassOf (SHACL §4.2.5).
+    // sh:targetClass honors ASSERTED rdfs:subClassOf (SHACL §4.2.5).
     // This is NOT OWL inference — the subclass edge is asserted in the data; we
-    // read it, materialize nothing. (Inverted from the former no-subclass
-    // contract; see the issue tracker.)
+    // read it and materialize nothing.
     #[test]
     fn target_class_honors_asserted_subclass() {
         let shapes_ttl = format!(

--- a/crates/shapes/src/engine.rs
+++ b/crates/shapes/src/engine.rs
@@ -426,9 +426,8 @@ where
     F: FnMut(&Shape, &Term) -> bool,
 {
     // Install the shapes graph's SHACL-AF function table (`sh:SPARQLFunction`) for
-    // this whole validation pass. Held on the serial validation thread so every
-    // `sh:sparql`/`sh:SPARQLTarget`/`sh:expression` query resolves declared user
-    // functions; the guard restores the previous table on drop.
+    // this whole validation pass. This orchestration-thread scope covers target
+    // resolution; each focus chunk installs the same registry on its worker.
     let _function_scope = crate::sparql::enter_function_scope(Arc::clone(&shapes.functions));
 
     let plan = ValidationPlan::for_shapes(data.core(), shapes);
@@ -439,30 +438,28 @@ where
             continue;
         }
 
-        let focus_nodes = resolve_focus_nodes(data, &shape.targets, &plan)?;
+        let mut focus_nodes = resolve_focus_nodes(data, &shape.targets, &plan)?;
+        // `FnMut` is intentionally applied serially in canonical focus order, so
+        // existing callers observe the same calls even when evaluation dispatches
+        // the retained set to workers.
+        focus_nodes.retain(|focus| include_focus(shape, focus.term()));
 
-        // Per-focus constraint evaluation stays SERIAL. A rayon `par_iter` over the
-        // focus loop was measured on `shacl_validate/large_hierarchy` (3000 focus
-        // nodes) and REGRESSED ~9% (15.71 ms → 16.43 ms), confirming that per-focus
-        // work (~5 µs: an rdfs:subClassOf BFS-backed lookup + a `sh:pattern` regex)
-        // is dwarfed by thread-pool dispatch and shared-`Store` read contention. The
-        // frozen `RdfDataset` is `Sync`, so the seam stays ready, but the
-        // parallel path waits on the re-entry condition: per-focus cost >50–100 µs,
-        // i.e. once SHACL-SPARQL constraints are common or the IR-native backend runs
-        // end-to-end (dropping the shared-`Store` contention). See the issue tracker (item 2).
-        for focus in &focus_nodes {
-            if !include_focus(shape, focus.term()) {
-                continue;
-            }
-            all_results.extend(crate::constraints::validate_shape_with_plan_at(
-                data,
-                focus.term(),
-                focus.id(),
-                shape,
-                shapes.box_role_vocab.as_ref(),
-                &plan,
-            )?);
-        }
+        let shape_results = crate::parallel::try_map_chunks(
+            &focus_nodes,
+            || crate::sparql::enter_function_scope(Arc::clone(&shapes.functions)),
+            |_function_scope, out, focus| {
+                out.extend(crate::constraints::validate_shape_with_plan_at(
+                    data,
+                    focus.term(),
+                    focus.id(),
+                    shape,
+                    shapes.box_role_vocab.as_ref(),
+                    &plan,
+                )?);
+                Ok::<(), String>(())
+            },
+        )?;
+        all_results.extend(shape_results);
     }
 
     // Deterministic sort key: (focus_node, component, source_shape, path, value,
@@ -1385,5 +1382,42 @@ mod tests {
             plan.class_closure(&NamedNode::from("http://example.org/ns#Nested"))
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn forced_parallel_matches_serial_with_user_functions() {
+        use std::fmt::Write as _;
+
+        let mut data_nt = String::new();
+        for index in 0..24 {
+            write!(
+                data_nt,
+                "<http://example.org/ns#item{index}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/ns#Person> .\n\
+                 <http://example.org/ns#item{index}> <http://example.org/ns#amount> \"1\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n"
+            )
+            .expect("writing to a String cannot fail");
+        }
+        let shapes_ttl = format!(
+            r#"{PREFIXES}
+            ex:tripled a sh:SPARQLFunction ;
+                sh:parameter [ sh:path ex:x ; sh:datatype xsd:integer ] ;
+                sh:returnType xsd:integer ;
+                sh:select "SELECT ((?x * 3) AS ?result) WHERE {{}}" .
+
+            ex:ParallelShape a sh:NodeShape ;
+                sh:targetClass ex:Person ;
+                sh:sparql [
+                    sh:select "SELECT $this WHERE {{ $this <http://example.org/ns#amount> ?amount . FILTER(<http://example.org/ns#tripled>(?amount) > 2) }}" ;
+                ] .
+            "#
+        );
+        let data = load_data_nt(&data_nt);
+        let shapes = load_shapes_ttl(&shapes_ttl);
+        let render = |parallel| {
+            let _guard = crate::parallel::force_parallel_for_test(parallel);
+            validate(&data, &shapes).to_ntriples()
+        };
+
+        assert_eq!(render(false), render(true));
     }
 }

--- a/crates/shapes/src/expression.rs
+++ b/crates/shapes/src/expression.rs
@@ -40,9 +40,9 @@
 //! # Determinism
 //!
 //! [`Term`] is intentionally not `Ord`, so this module orders any set-shaped
-//! output with `crate::term::sort_canonical(&mut v); v.dedup();` (caching the
-//! rendered key once per element; the sibling [`crate::sparql::eval_target`]
-//! sorts the same set-shaped way via the canonical cached-key sorter). The evaluator is
+//! output with `crate::term::sort_terms_canonical(&mut v); v.dedup();`, using the
+//! allocation-free canonical term comparator. The sibling
+//! [`crate::sparql::eval_target`] uses the same ordering. The evaluator is
 //! wasm32-clean: no clocks, threads, RNG, or filesystem.
 
 use ::purrdf::{FastMap, FastSet};
@@ -334,7 +334,7 @@ pub fn eval_node_expr(
             // deterministic. `path::eval`'s crate-wide first-seen iteration order
             // is left untouched (it is used elsewhere for path traversal).
             let mut v = path::eval(store.core(), focus, p);
-            crate::term::sort_canonical(&mut v);
+            crate::term::sort_terms_canonical(&mut v);
             v.dedup();
             Ok(v)
         }
@@ -343,7 +343,7 @@ pub fn eval_node_expr(
             for sub in exprs {
                 out.extend(eval_node_expr(store, focus, sub, guard)?);
             }
-            crate::term::sort_canonical(&mut out);
+            crate::term::sort_terms_canonical(&mut out);
             out.dedup();
             Ok(out)
         }
@@ -364,7 +364,7 @@ pub fn eval_node_expr(
                 acc.retain(|t| next.contains(t));
             }
             let mut out: Vec<Term> = acc.into_iter().collect();
-            crate::term::sort_canonical(&mut out);
+            crate::term::sort_terms_canonical(&mut out);
             out.dedup();
             Ok(out)
         }
@@ -475,20 +475,20 @@ pub fn eval_node_expr(
             }
             // Canonicalize the unioned result (sort+dedup) like every other
             // set-shaped node-expression output.
-            crate::term::sort_canonical(&mut out);
+            crate::term::sort_terms_canonical(&mut out);
             out.dedup();
             Ok(out)
         }
         NodeExpr::Distinct(of) => {
             let mut out = eval_node_expr(store, focus, of, guard)?;
-            crate::term::sort_canonical(&mut out);
+            crate::term::sort_terms_canonical(&mut out);
             out.dedup();
             Ok(out)
         }
         NodeExpr::Count { distinct, of } => {
             let mut out = eval_node_expr(store, focus, of, guard)?;
             if *distinct {
-                crate::term::sort_canonical(&mut out);
+                crate::term::sort_terms_canonical(&mut out);
                 out.dedup();
             }
             // Element count as a canonical `xsd:integer`. `usize::to_string`
@@ -531,7 +531,7 @@ pub fn eval_node_expr(
             // canonical term string) so value-equal keys still yield a
             // byte-stable total order (tie-break).
             let mut distinct: Vec<Term> = keyed.iter().map(|(_, k)| k.clone()).collect();
-            crate::term::sort_canonical(&mut distinct);
+            crate::term::sort_terms_canonical(&mut distinct);
             distinct.dedup();
             let ranked = crate::sparql::eval_order(store.sparql(), &distinct, false)?;
             let mut rank: FastMap<String, usize> = FastMap::default();
@@ -603,7 +603,7 @@ pub fn eval_node_expr(
             // Canonicalize the node-expression set output here (sort+dedup) so
             // sh:offset / sh:limit over a bare Filter set are deterministic
             // rather than store-iteration-order dependent.
-            crate::term::sort_canonical(&mut kept);
+            crate::term::sort_terms_canonical(&mut kept);
             kept.dedup();
             Ok(kept)
         }
@@ -717,7 +717,7 @@ mod tests {
         assert_eq!(result, vec![ex("b"), ex("c")]);
         let sorted = {
             let mut v = result.clone();
-            crate::term::sort_canonical(&mut v);
+            crate::term::sort_terms_canonical(&mut v);
             v
         };
         assert_eq!(result, sorted, "Path result must be returned sorted");
@@ -772,7 +772,7 @@ mod tests {
         // Explicitly assert deterministic (sorted) order.
         let sorted = {
             let mut v = result.clone();
-            crate::term::sort_canonical(&mut v);
+            crate::term::sort_terms_canonical(&mut v);
             v
         };
         assert_eq!(result, sorted);

--- a/crates/shapes/src/instance.rs
+++ b/crates/shapes/src/instance.rs
@@ -70,7 +70,7 @@ fn project_graph_data(data: &RdfDataset, ns: &Namespaces) -> Value {
             }
         }
     }
-    crate::term::sort_canonical(&mut subjects);
+    crate::term::sort_terms_canonical(&mut subjects);
 
     let mut nodes: Vec<Value> = Vec::with_capacity(subjects.len());
     for subj in &subjects {
@@ -143,7 +143,7 @@ fn project_subject_data(data: &RdfDataset, ns: &Namespaces, subject: &Term) -> V
     }
 
     for (key, mut objects) in by_pred {
-        crate::term::sort_canonical(&mut objects);
+        crate::term::sort_terms_canonical(&mut objects);
         let values: Vec<Value> = objects.iter().map(|t| project_value(t, ns)).collect();
         let v = if values.len() == 1 {
             values.into_iter().next().unwrap()

--- a/crates/shapes/src/lib.rs
+++ b/crates/shapes/src/lib.rs
@@ -37,6 +37,7 @@ pub mod instance;
 pub mod json_schema;
 pub mod linkml;
 pub mod model;
+pub(crate) mod parallel;
 pub mod path;
 pub(crate) mod prebinding;
 pub mod pydantic;

--- a/crates/shapes/src/parallel.rs
+++ b/crates/shapes/src/parallel.rs
@@ -29,24 +29,30 @@ std::thread_local! {
     static FORCE_CHUNK_SIZE: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
 }
 
-/// Force the scheduler branch for a deterministic equivalence test.
+/// Force both scheduler branch and chunk geometry for an equivalence test.
 #[cfg(test)]
 #[must_use]
-pub(crate) fn force_parallel_for_test(force: bool) -> ForceParallelGuard {
-    let previous = FORCE_PARALLEL.with(|cell| cell.replace(Some(force)));
-    ForceParallelGuard { previous }
+pub(crate) fn force_scheduler_for_test(parallel: bool, chunk_size: usize) -> ForceSchedulerGuard {
+    let previous_parallel = FORCE_PARALLEL.with(|cell| cell.replace(Some(parallel)));
+    let previous_chunk_size = FORCE_CHUNK_SIZE.with(|cell| cell.replace(Some(chunk_size.max(1))));
+    ForceSchedulerGuard {
+        previous_parallel,
+        previous_chunk_size,
+    }
 }
 
-/// Restores the production scheduler decision when a test scope ends.
+/// Restores both production scheduler decisions when a test scope ends.
 #[cfg(test)]
-pub(crate) struct ForceParallelGuard {
-    previous: Option<bool>,
+pub(crate) struct ForceSchedulerGuard {
+    previous_parallel: Option<bool>,
+    previous_chunk_size: Option<usize>,
 }
 
 #[cfg(test)]
-impl Drop for ForceParallelGuard {
+impl Drop for ForceSchedulerGuard {
     fn drop(&mut self) {
-        FORCE_PARALLEL.with(|cell| cell.set(self.previous));
+        FORCE_PARALLEL.with(|cell| cell.set(self.previous_parallel));
+        FORCE_CHUNK_SIZE.with(|cell| cell.set(self.previous_chunk_size));
     }
 }
 
@@ -112,31 +118,8 @@ where
 mod tests {
     use super::*;
 
-    struct OverrideGuard {
-        parallel: Option<bool>,
-        chunk_size: Option<usize>,
-    }
-
-    impl OverrideGuard {
-        fn new(parallel: bool, chunk_size: usize) -> Self {
-            let previous_parallel = FORCE_PARALLEL.with(|cell| cell.replace(Some(parallel)));
-            let previous_chunk = FORCE_CHUNK_SIZE.with(|cell| cell.replace(Some(chunk_size)));
-            Self {
-                parallel: previous_parallel,
-                chunk_size: previous_chunk,
-            }
-        }
-    }
-
-    impl Drop for OverrideGuard {
-        fn drop(&mut self) {
-            FORCE_PARALLEL.with(|cell| cell.set(self.parallel));
-            FORCE_CHUNK_SIZE.with(|cell| cell.set(self.chunk_size));
-        }
-    }
-
     fn run(items: &[usize], parallel: bool) -> Result<Vec<usize>, usize> {
-        let _guard = OverrideGuard::new(parallel, 3);
+        let _guard = force_scheduler_for_test(parallel, 3);
         try_map_chunks(
             items,
             || (),
@@ -162,6 +145,89 @@ mod tests {
         let items: Vec<usize> = (0..16).collect();
         assert_eq!(run(&items, false), Err(7));
         assert_eq!(run(&items, true), Err(7));
+    }
+
+    #[test]
+    fn exact_error_is_stable_across_workers_and_chunks() {
+        let items: Vec<usize> = (0..32).collect();
+        let run = |threads, parallel, chunk_size| {
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build()
+                .expect("test pool must build")
+                .install(|| {
+                    let _guard = force_scheduler_for_test(parallel, chunk_size);
+                    try_map_chunks(
+                        &items,
+                        || (),
+                        |(), out, item| {
+                            if *item == 7 || *item == 11 {
+                                Err(format!("focus-{item} failed"))
+                            } else {
+                                out.push(*item);
+                                Ok(())
+                            }
+                        },
+                    )
+                })
+        };
+        let expected = run(1, false, 1);
+        assert_eq!(expected, Err("focus-7 failed".to_owned()));
+        for threads in [2, 4] {
+            for chunk_size in [1, 2, 3, 8, 64] {
+                assert_eq!(
+                    run(threads, true, chunk_size),
+                    expected,
+                    "error drifted with {threads} workers and chunk size {chunk_size}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn forced_parallel_path_uses_multiple_workers() {
+        use std::collections::BTreeSet;
+        use std::sync::{Barrier, Mutex};
+
+        const WORKERS: usize = 4;
+        let items: Vec<usize> = (0..256).collect();
+        let workers = Mutex::new(BTreeSet::new());
+        let rendezvous = Barrier::new(WORKERS);
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(WORKERS)
+            .build()
+            .expect("test pool must build");
+        let output = pool
+            .install(|| {
+                let _guard = force_scheduler_for_test(true, 1);
+                try_map_chunks(
+                    &items,
+                    || (),
+                    |(), out, item| {
+                        let worker = rayon::current_thread_index()
+                            .expect("parallel work must run on the configured pool");
+                        let first_visit = workers
+                            .lock()
+                            .expect("worker set lock must remain healthy")
+                            .insert(worker);
+                        if first_visit {
+                            rendezvous.wait();
+                        }
+                        out.push(*item);
+                        Ok::<(), String>(())
+                    },
+                )
+            })
+            .expect("forced parallel work must succeed");
+
+        assert_eq!(output, items);
+        assert_eq!(
+            workers
+                .into_inner()
+                .expect("worker set lock must remain healthy")
+                .len(),
+            WORKERS
+        );
     }
 
     #[test]

--- a/crates/shapes/src/parallel.rs
+++ b/crates/shapes/src/parallel.rs
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Deterministic adaptive scheduling for independent SHACL focus nodes.
+//!
+//! Work is split with rayon's indexed `par_chunks`, evaluated in source order
+//! inside each chunk, and reduced strictly in chunk order. Output and hard-error
+//! selection therefore match the serial traversal regardless of worker timing.
+
+/// Focus sets at or below this stay serial. The value is benchmark-tuned against
+/// both inexpensive Core constraints and SHACL-SPARQL focus evaluation.
+pub(crate) const PARALLEL_MIN_FOCUS_NODES: usize = 1_024;
+
+/// Avoid handing workers fragments dominated by scope setup and result staging.
+const PARALLEL_MIN_CHUNK_ITEMS: usize = 64;
+
+fn chunk_size_for(len: usize) -> usize {
+    #[cfg(test)]
+    if let Some(forced) = FORCE_CHUNK_SIZE.with(std::cell::Cell::get) {
+        return forced.max(1);
+    }
+    let threads = rayon::current_num_threads().max(1);
+    (len / (threads * 4).max(1)).max(PARALLEL_MIN_CHUNK_ITEMS)
+}
+
+#[cfg(test)]
+std::thread_local! {
+    static FORCE_PARALLEL: std::cell::Cell<Option<bool>> = const { std::cell::Cell::new(None) };
+    static FORCE_CHUNK_SIZE: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+}
+
+/// Force the scheduler branch for a deterministic equivalence test.
+#[cfg(test)]
+#[must_use]
+pub(crate) fn force_parallel_for_test(force: bool) -> ForceParallelGuard {
+    let previous = FORCE_PARALLEL.with(|cell| cell.replace(Some(force)));
+    ForceParallelGuard { previous }
+}
+
+/// Restores the production scheduler decision when a test scope ends.
+#[cfg(test)]
+pub(crate) struct ForceParallelGuard {
+    previous: Option<bool>,
+}
+
+#[cfg(test)]
+impl Drop for ForceParallelGuard {
+    fn drop(&mut self) {
+        FORCE_PARALLEL.with(|cell| cell.set(self.previous));
+    }
+}
+
+fn should_parallelize(work_items: usize) -> bool {
+    #[cfg(test)]
+    if let Some(forced) = FORCE_PARALLEL.with(std::cell::Cell::get) {
+        return forced;
+    }
+    work_items > PARALLEL_MIN_FOCUS_NODES && rayon::current_num_threads() > 1
+}
+
+/// Evaluate independent items with one worker-local state per chunk.
+///
+/// The first error by source chunk (and, within it, source item) wins. Successful
+/// outputs concatenate in exact source order.
+pub(crate) fn try_map_chunks<T, S, R, E>(
+    items: &[T],
+    init: impl Fn() -> S + Sync,
+    push: impl Fn(&mut S, &mut Vec<R>, &T) -> Result<(), E> + Sync,
+) -> Result<Vec<R>, E>
+where
+    T: Sync,
+    R: Send,
+    E: Send,
+{
+    if !should_parallelize(items.len()) {
+        let mut state = init();
+        let mut out = Vec::new();
+        for item in items {
+            push(&mut state, &mut out, item)?;
+        }
+        return Ok(out);
+    }
+
+    use rayon::prelude::*;
+
+    let chunk_size = chunk_size_for(items.len());
+    let per_chunk: Vec<Result<Vec<R>, E>> = items
+        .par_chunks(chunk_size)
+        .map(|chunk| {
+            let mut state = init();
+            let mut out = Vec::new();
+            for item in chunk {
+                push(&mut state, &mut out, item)?;
+            }
+            Ok(out)
+        })
+        .collect();
+
+    let mut out = Vec::with_capacity(
+        per_chunk
+            .iter()
+            .map(|result| result.as_ref().map_or(0, Vec::len))
+            .sum(),
+    );
+    for result in per_chunk {
+        out.extend(result?);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct OverrideGuard {
+        parallel: Option<bool>,
+        chunk_size: Option<usize>,
+    }
+
+    impl OverrideGuard {
+        fn new(parallel: bool, chunk_size: usize) -> Self {
+            let previous_parallel = FORCE_PARALLEL.with(|cell| cell.replace(Some(parallel)));
+            let previous_chunk = FORCE_CHUNK_SIZE.with(|cell| cell.replace(Some(chunk_size)));
+            Self {
+                parallel: previous_parallel,
+                chunk_size: previous_chunk,
+            }
+        }
+    }
+
+    impl Drop for OverrideGuard {
+        fn drop(&mut self) {
+            FORCE_PARALLEL.with(|cell| cell.set(self.parallel));
+            FORCE_CHUNK_SIZE.with(|cell| cell.set(self.chunk_size));
+        }
+    }
+
+    fn run(items: &[usize], parallel: bool) -> Result<Vec<usize>, usize> {
+        let _guard = OverrideGuard::new(parallel, 3);
+        try_map_chunks(
+            items,
+            || (),
+            |(), out, item| {
+                if *item == 7 || *item == 11 {
+                    Err(*item)
+                } else {
+                    out.extend([*item, item * 2]);
+                    Ok(())
+                }
+            },
+        )
+    }
+
+    #[test]
+    fn parallel_output_matches_serial_source_order() {
+        let items: Vec<usize> = (0..7).collect();
+        assert_eq!(run(&items, false), run(&items, true));
+    }
+
+    #[test]
+    fn earliest_source_error_wins() {
+        let items: Vec<usize> = (0..16).collect();
+        assert_eq!(run(&items, false), Err(7));
+        assert_eq!(run(&items, true), Err(7));
+    }
+
+    #[test]
+    fn threshold_boundary_is_strict() {
+        assert!(!should_parallelize(PARALLEL_MIN_FOCUS_NODES));
+    }
+}

--- a/crates/shapes/src/path.rs
+++ b/crates/shapes/src/path.rs
@@ -86,6 +86,16 @@ pub fn eval(ds: &RdfDataset, focus: &Term, path: &Path) -> Vec<Term> {
 /// [`eval`]; that owned-term fallback is a genuine necessity, not optionality.
 pub fn eval_ids(ds: &RdfDataset, focus: &Term, path: &Path) -> Option<IdVec> {
     let focus_id = resolve_id(ds, focus)?;
+    Some(eval_ids_from_id(ds, focus_id, path))
+}
+
+/// Id-native value-node producer for a focus node whose interned identity is
+/// already known.
+///
+/// This is the validation hot-path entry point: a focus node is resolved once
+/// when its shape evaluation begins, then every property shape reuses the same
+/// [`TermId`] instead of repeating an interner lookup.
+pub(crate) fn eval_ids_from_id(ds: &RdfDataset, focus_id: TermId, path: &Path) -> IdVec {
     let ids = eval_inner_ids(ds, focus_id, path);
     let mut seen: IdSet = IdSet::default();
     let mut out: IdVec = IdVec::with_capacity(ids.len());
@@ -94,7 +104,7 @@ pub fn eval_ids(ds: &RdfDataset, focus: &Term, path: &Path) -> Option<IdVec> {
             out.push(id);
         }
     }
-    Some(out)
+    out
 }
 
 /// Whether a SHACL property path matches the zero-length (reflexive) path — i.e.

--- a/crates/shapes/src/path.rs
+++ b/crates/shapes/src/path.rs
@@ -388,7 +388,7 @@ mod tests {
         let focus = nn("http://example.org/ns#a");
         let path = Path::Predicate(NamedNode::new_unchecked("http://example.org/ns#p"));
         let mut result = eval(&data, &focus, &path);
-        crate::term::sort_canonical(&mut result);
+        crate::term::sort_terms_canonical(&mut result);
         assert_eq!(result.len(), 2);
         assert!(result.contains(&nn("http://example.org/ns#b")));
         assert!(result.contains(&nn("http://example.org/ns#c")));
@@ -437,7 +437,7 @@ mod tests {
         let focus = nn("http://example.org/ns#a");
         let path = Path::Sequence(vec![pred("p"), pred("q")]);
         let mut result = eval(&data, &focus, &path);
-        crate::term::sort_canonical(&mut result);
+        crate::term::sort_terms_canonical(&mut result);
         assert_eq!(
             result,
             vec![nn("http://example.org/ns#c"), nn("http://example.org/ns#d")]
@@ -472,7 +472,7 @@ mod tests {
         let focus = nn("http://example.org/ns#a");
         let path = Path::Alternative(vec![pred("p"), pred("q")]);
         let mut result = eval(&data, &focus, &path);
-        crate::term::sort_canonical(&mut result);
+        crate::term::sort_terms_canonical(&mut result);
         // ex:c is reachable via both branches but reported once (set semantics).
         assert_eq!(
             result,
@@ -494,7 +494,7 @@ mod tests {
         let focus = nn("http://example.org/ns#a");
         let path = Path::ZeroOrMore(Box::new(pred("next")));
         let mut result = eval(&data, &focus, &path);
-        crate::term::sort_canonical(&mut result);
+        crate::term::sort_terms_canonical(&mut result);
         assert_eq!(
             result,
             vec![
@@ -517,7 +517,7 @@ mod tests {
         let focus = nn("http://example.org/ns#a");
         let path = Path::OneOrMore(Box::new(pred("next")));
         let mut result = eval(&data, &focus, &path);
-        crate::term::sort_canonical(&mut result);
+        crate::term::sort_terms_canonical(&mut result);
         assert_eq!(
             result,
             vec![nn("http://example.org/ns#b"), nn("http://example.org/ns#c")]
@@ -536,7 +536,7 @@ mod tests {
         let focus = nn("http://example.org/ns#a");
         let path = Path::OneOrMore(Box::new(pred("next")));
         let mut result = eval(&data, &focus, &path);
-        crate::term::sort_canonical(&mut result);
+        crate::term::sort_terms_canonical(&mut result);
         assert_eq!(
             result,
             vec![nn("http://example.org/ns#a"), nn("http://example.org/ns#b")]
@@ -554,7 +554,7 @@ mod tests {
         let focus = nn("http://example.org/ns#a");
         let path = Path::ZeroOrOne(Box::new(pred("next")));
         let mut result = eval(&data, &focus, &path);
-        crate::term::sort_canonical(&mut result);
+        crate::term::sort_terms_canonical(&mut result);
         // Focus itself (zero steps) plus one step; c (two steps) excluded.
         assert_eq!(
             result,
@@ -580,7 +580,7 @@ mod tests {
             Path::ZeroOrMore(Box::new(pred("r"))),
         ]);
         let mut result = eval(&data, &focus, &path);
-        crate::term::sort_canonical(&mut result);
+        crate::term::sort_terms_canonical(&mut result);
         assert_eq!(
             result,
             vec![
@@ -620,7 +620,7 @@ mod tests {
         let focus = nn("http://example.org/ns#b");
         let path = Path::Inverse(Box::new(Path::ZeroOrMore(Box::new(pred("next")))));
         let mut result = eval(&data, &focus, &path);
-        crate::term::sort_canonical(&mut result);
+        crate::term::sort_terms_canonical(&mut result);
         assert_eq!(
             result,
             vec![nn("http://example.org/ns#a"), nn("http://example.org/ns#b")]

--- a/crates/shapes/src/rules.rs
+++ b/crates/shapes/src/rules.rs
@@ -37,14 +37,14 @@
 
 use std::sync::Arc;
 
-use ::purrdf::{FastMap, FastSet, IdSet, RdfDataset, RdfDatasetBuilder, RdfQuad, RdfTerm};
+use ::purrdf::{FastMap, FastSet, RdfDataset, RdfDatasetBuilder, RdfQuad, RdfTerm};
 
 use crate::constraints::conforms;
 use crate::data::{GraphFilter, ShaclData, quads_for_pattern_ids};
-use crate::engine::resolve_focus_nodes;
+use crate::engine::{FocusNode, ValidationPlan, resolve_focus_nodes};
 use crate::expression::{NodeExpr, RecursionGuard, eval_node_expr};
 use crate::shapes::{Shape, Shapes};
-use crate::term::{NamedNode, Term, Triple, term_id_to_native};
+use crate::term::{Term, Triple, term_id_to_native};
 
 // ── Model ───────────────────────────────────────────────────────────────────────
 
@@ -469,8 +469,9 @@ fn sparql_rule_producer(
 
 /// Resolve the focus nodes of `shape` against the current dataset.
 fn focus_nodes(data: &ShaclData, shape: &Shape) -> Result<Vec<Term>, String> {
-    let mut memo: FastMap<NamedNode, IdSet> = FastMap::default();
-    resolve_focus_nodes(data, &shape.targets, &mut memo)
+    let plan = ValidationPlan::for_shape(data.core(), shape);
+    resolve_focus_nodes(data, &shape.targets, &plan)
+        .map(|nodes| nodes.into_iter().map(FocusNode::into_term).collect())
 }
 
 /// Whether `focus` conforms to every `sh:condition` shape (resolved against the

--- a/crates/shapes/src/schema_import.rs
+++ b/crates/shapes/src/schema_import.rs
@@ -964,7 +964,7 @@ impl ImportContext<'_> {
                     terms.push(term);
                 }
             }
-            crate::term::sort_canonical(&mut terms);
+            crate::term::sort_terms_canonical(&mut terms);
             terms.dedup();
             constraints.push(Constraint::In(terms));
             handled.insert("enum");
@@ -1098,7 +1098,7 @@ impl ImportContext<'_> {
                     terms.push(term);
                 }
             }
-            crate::term::sort_canonical(&mut terms);
+            crate::term::sort_terms_canonical(&mut terms);
             terms.dedup();
             constraints.push(Constraint::In(terms));
             self.record("non-object-definition-dropped", &definition_path(&key));

--- a/crates/shapes/src/shapes.rs
+++ b/crates/shapes/src/shapes.rs
@@ -655,7 +655,7 @@ impl<'s> Parser<'s> {
         // are wrapped in a single-property Shape carrying the node's targets.
         let mut node_shapes: Vec<Shape> = Vec::new();
         let mut ids: Vec<Term> = shape_ids.into_iter().collect();
-        crate::term::sort_canonical(&mut ids);
+        crate::term::sort_terms_canonical(&mut ids);
         for term in ids {
             let shape = if self.first_object_of(&term, sh::PATH).is_some() {
                 self.parse_standalone_property_shape(term.clone())?
@@ -891,7 +891,7 @@ impl<'s> Parser<'s> {
 
         // -- Property shapes (via sh:property) --
         let mut property_shape_nodes: Vec<Term> = self.objects_of(id, sh::PROPERTY);
-        crate::term::sort_canonical(&mut property_shape_nodes);
+        crate::term::sort_terms_canonical(&mut property_shape_nodes);
         let mut property_shapes = Vec::new();
         for ps_node in property_shape_nodes {
             property_shapes.push(self.parse_property_shape(&ps_node)?);
@@ -964,7 +964,7 @@ impl<'s> Parser<'s> {
 
         // sh:targetNode
         let mut tn: Vec<Term> = self.objects_of(id, sh::TARGET_NODE);
-        crate::term::sort_canonical(&mut tn);
+        crate::term::sort_terms_canonical(&mut tn);
         for t in tn {
             targets.push(Target::Node(t));
         }
@@ -979,7 +979,7 @@ impl<'s> Parser<'s> {
         // sh:target — SHACL-AF extension targets. Supports plain sh:SPARQLTarget
         // and parameterized sh:SPARQLTargetType instances.
         let mut sparql_targets: Vec<Term> = self.objects_of(id, sh::TARGET);
-        crate::term::sort_canonical(&mut sparql_targets);
+        crate::term::sort_terms_canonical(&mut sparql_targets);
         for t_node in sparql_targets {
             if self.has_type(&t_node, sh::SPARQL_TARGET) {
                 // Plain sh:SPARQLTarget: sh:select is required on the blank node.
@@ -1134,7 +1134,7 @@ impl<'s> Parser<'s> {
         // skipping a shape already being parsed (mirrors parse_node_shape's
         // cycle stub).
         let mut nested_nodes: Vec<Term> = self.objects_of(ps_node, sh::PROPERTY);
-        crate::term::sort_canonical(&mut nested_nodes);
+        crate::term::sort_terms_canonical(&mut nested_nodes);
         let mut property_shapes: Vec<PropertyShape> = Vec::new();
         if !nested_nodes.is_empty() {
             self.in_flight.insert(ps_str.clone());
@@ -1160,7 +1160,7 @@ impl<'s> Parser<'s> {
             .any(|t| matches!(t, Term::Literal(lit) if lit.value() == "true"));
 
         let mut reifier_shape_nodes: Vec<Term> = self.objects_of(ps_node, sh::REIFIER_SHAPE);
-        crate::term::sort_canonical(&mut reifier_shape_nodes);
+        crate::term::sort_terms_canonical(&mut reifier_shape_nodes);
         if (!reifier_shape_nodes.is_empty() || reification_required)
             && !matches!(path, Path::Predicate(_))
         {

--- a/crates/shapes/src/shapes/parser/functions.rs
+++ b/crates/shapes/src/shapes/parser/functions.rs
@@ -35,7 +35,7 @@ impl Parser<'_> {
             .chain(self.quads_with(None, Some(rdf::TYPE), Some(sh::FUNCTION)))
             .map(|(subject, _, _)| subject)
             .collect();
-        crate::term::sort_canonical(&mut fn_ids);
+        crate::term::sort_terms_canonical(&mut fn_ids);
         fn_ids.dedup();
 
         let mut registry = UserFunctionRegistry::new();

--- a/crates/shapes/src/shapes/parser/node_expr.rs
+++ b/crates/shapes/src/shapes/parser/node_expr.rs
@@ -101,7 +101,7 @@ impl Parser<'_> {
 
         // sh:languageIn — an RDF list of language-tag string literals
         let mut lang_in_lists: Vec<Term> = self.objects_of(id, sh::LANGUAGE_IN);
-        crate::term::sort_canonical(&mut lang_in_lists);
+        crate::term::sort_terms_canonical(&mut lang_in_lists);
         for list_head in lang_in_lists {
             let items = self.walk_rdf_list(&list_head, id)?;
             let mut tags: Vec<String> = Vec::with_capacity(items.len());
@@ -120,7 +120,7 @@ impl Parser<'_> {
 
         // sh:not — a single nested shape (mirrors sh:node)
         let mut not_refs: Vec<Term> = self.objects_of(id, sh::NOT);
-        crate::term::sort_canonical(&mut not_refs);
+        crate::term::sort_terms_canonical(&mut not_refs);
         for not_ref in not_refs {
             let inner = self.parse_node_shape(not_ref)?;
             constraints.push(Constraint::Not(Box::new(inner)));
@@ -137,7 +137,7 @@ impl Parser<'_> {
         if is_closed {
             let mut ignored: Vec<NamedNode> = Vec::new();
             let mut ignored_lists: Vec<Term> = self.objects_of(id, sh::IGNORED_PROPERTIES);
-            crate::term::sort_canonical(&mut ignored_lists);
+            crate::term::sort_terms_canonical(&mut ignored_lists);
             for list_head in ignored_lists {
                 for item in self.walk_rdf_list(&list_head, id)? {
                     match item {
@@ -168,40 +168,40 @@ impl Parser<'_> {
 
         // sh:minInclusive / sh:maxInclusive
         let mut min_inc: Vec<Term> = self.objects_of(id, sh::MIN_INCLUSIVE);
-        crate::term::sort_canonical(&mut min_inc);
+        crate::term::sort_terms_canonical(&mut min_inc);
         for t in min_inc {
             constraints.push(Constraint::MinInclusive(t));
         }
 
         let mut max_inc: Vec<Term> = self.objects_of(id, sh::MAX_INCLUSIVE);
-        crate::term::sort_canonical(&mut max_inc);
+        crate::term::sort_terms_canonical(&mut max_inc);
         for t in max_inc {
             constraints.push(Constraint::MaxInclusive(t));
         }
 
         // sh:minExclusive / sh:maxExclusive
         let mut min_exc: Vec<Term> = self.objects_of(id, sh::MIN_EXCLUSIVE);
-        crate::term::sort_canonical(&mut min_exc);
+        crate::term::sort_terms_canonical(&mut min_exc);
         for t in min_exc {
             constraints.push(Constraint::MinExclusive(t));
         }
 
         let mut max_exc: Vec<Term> = self.objects_of(id, sh::MAX_EXCLUSIVE);
-        crate::term::sort_canonical(&mut max_exc);
+        crate::term::sort_terms_canonical(&mut max_exc);
         for t in max_exc {
             constraints.push(Constraint::MaxExclusive(t));
         }
 
         // sh:hasValue
         let mut hv: Vec<Term> = self.objects_of(id, sh::HAS_VALUE);
-        crate::term::sort_canonical(&mut hv);
+        crate::term::sort_terms_canonical(&mut hv);
         for t in hv {
             constraints.push(Constraint::HasValue(t));
         }
 
         // sh:in
         let mut in_lists: Vec<Term> = self.objects_of(id, sh::IN);
-        crate::term::sort_canonical(&mut in_lists);
+        crate::term::sort_terms_canonical(&mut in_lists);
         for list_head in in_lists {
             let items = self.walk_rdf_list(&list_head, id)?;
             constraints.push(Constraint::In(items));
@@ -235,21 +235,21 @@ impl Parser<'_> {
 
         // sh:and / sh:or / sh:xone — each is an RDF list of shape nodes
         let mut and_lists: Vec<Term> = self.objects_of(id, sh::AND);
-        crate::term::sort_canonical(&mut and_lists);
+        crate::term::sort_terms_canonical(&mut and_lists);
         for list_head in and_lists {
             let members = self.parse_shape_list(&list_head, id)?;
             constraints.push(Constraint::And(members));
         }
 
         let mut or_lists: Vec<Term> = self.objects_of(id, sh::OR);
-        crate::term::sort_canonical(&mut or_lists);
+        crate::term::sort_terms_canonical(&mut or_lists);
         for list_head in or_lists {
             let members = self.parse_shape_list(&list_head, id)?;
             constraints.push(Constraint::Or(members));
         }
 
         let mut xone_lists: Vec<Term> = self.objects_of(id, sh::XONE);
-        crate::term::sort_canonical(&mut xone_lists);
+        crate::term::sort_terms_canonical(&mut xone_lists);
         for list_head in xone_lists {
             let members = self.parse_shape_list(&list_head, id)?;
             constraints.push(Constraint::Xone(members));
@@ -257,7 +257,7 @@ impl Parser<'_> {
 
         // sh:node
         let mut node_refs: Vec<Term> = self.objects_of(id, sh::NODE);
-        crate::term::sort_canonical(&mut node_refs);
+        crate::term::sort_terms_canonical(&mut node_refs);
         for node_ref in node_refs {
             let inner = self.parse_node_shape(node_ref)?;
             constraints.push(Constraint::Node(Box::new(inner)));
@@ -267,7 +267,7 @@ impl Parser<'_> {
         // The blank node may or may not carry rdf:type sh:SPARQLConstraint;
         // we require only sh:select (which must be a SELECT query).
         let mut sparql_cnodes: Vec<Term> = self.objects_of(id, sh::SPARQL);
-        crate::term::sort_canonical(&mut sparql_cnodes);
+        crate::term::sort_terms_canonical(&mut sparql_cnodes);
         for c_node in sparql_cnodes {
             // sh:select is required.
             let raw_select = self
@@ -338,7 +338,7 @@ impl Parser<'_> {
         // sh:message / sh:severity on the expression node override the shape
         // defaults at eval time (mirroring sh:sparql).
         let mut expr_nodes: Vec<Term> = self.objects_of(id, sh::EXPRESSION);
-        crate::term::sort_canonical(&mut expr_nodes);
+        crate::term::sort_terms_canonical(&mut expr_nodes);
         for expr_node in expr_nodes {
             let expr = self.parse_node_expr(&expr_node)?;
 
@@ -508,7 +508,7 @@ impl Parser<'_> {
     /// parents of `id`, minus the constraint's own shape) are parsed and stored.
     fn parse_qualified_value_shapes(&mut self, id: &Term) -> Result<Vec<Constraint>, String> {
         let mut qvs_nodes: Vec<Term> = self.objects_of(id, sh::QUALIFIED_VALUE_SHAPE);
-        crate::term::sort_canonical(&mut qvs_nodes);
+        crate::term::sort_terms_canonical(&mut qvs_nodes);
 
         let min_count = match self.first_object_of(id, sh::QUALIFIED_MIN_COUNT) {
             Some(t) => Some(crate::shapes::parse_u64(&t).ok_or_else(|| {
@@ -582,14 +582,14 @@ impl Parser<'_> {
         .into_iter()
         .map(|(subject, _, _)| subject)
         .collect();
-        crate::term::sort_canonical(&mut parents);
+        crate::term::sort_terms_canonical(&mut parents);
         parents.dedup();
         for parent in &parents {
             let mut sibling_ps: Vec<Term> = self.objects_of(parent, sh::PROPERTY);
-            crate::term::sort_canonical(&mut sibling_ps);
+            crate::term::sort_terms_canonical(&mut sibling_ps);
             for ps in sibling_ps {
                 let mut qvs: Vec<Term> = self.objects_of(&ps, sh::QUALIFIED_VALUE_SHAPE);
-                crate::term::sort_canonical(&mut qvs);
+                crate::term::sort_terms_canonical(&mut qvs);
                 for q in qvs {
                     if &q != own_qvs && seen.insert(q.clone()) {
                         sibling_nodes.push(q);

--- a/crates/shapes/src/shapes/parser/rule_parse.rs
+++ b/crates/shapes/src/shapes/parser/rule_parse.rs
@@ -24,7 +24,7 @@ impl Parser<'_> {
     /// the pre-binding restrictions, or a non-numeric `sh:order`.
     pub(crate) fn parse_rules(&mut self, id: &Term) -> Result<Vec<Rule>, String> {
         let mut rule_nodes: Vec<Term> = self.objects_of(id, sh::RULE);
-        crate::term::sort_canonical(&mut rule_nodes);
+        crate::term::sort_terms_canonical(&mut rule_nodes);
         let mut rules: Vec<Rule> = Vec::with_capacity(rule_nodes.len());
         for rule_node in rule_nodes {
             rules.push(self.parse_rule(id, &rule_node)?);
@@ -57,7 +57,7 @@ impl Parser<'_> {
         };
 
         let mut conditions: Vec<Term> = self.objects_of(rule_node, sh::CONDITION);
-        crate::term::sort_canonical(&mut conditions);
+        crate::term::sort_terms_canonical(&mut conditions);
 
         // Dispatch on rule kind: an explicit rdf:type OR the presence of the
         // kind's structural keys. A node that is both (or neither) is malformed.

--- a/crates/shapes/src/shapes/parser/target_types.rs
+++ b/crates/shapes/src/shapes/parser/target_types.rs
@@ -29,7 +29,7 @@ impl Parser<'_> {
             .into_iter()
             .map(|(subject, _, _)| subject)
             .collect();
-        crate::term::sort_canonical(&mut ids);
+        crate::term::sort_terms_canonical(&mut ids);
         ids.dedup();
 
         let mut registry: BTreeMap<String, SparqlTargetType> = BTreeMap::new();

--- a/crates/shapes/src/sparql.rs
+++ b/crates/shapes/src/sparql.rs
@@ -70,7 +70,7 @@ pub fn eval_target(
         }
     }
 
-    crate::term::sort_canonical(&mut nodes);
+    crate::term::sort_terms_canonical(&mut nodes);
     nodes.dedup();
     Ok(nodes)
 }
@@ -650,7 +650,7 @@ mod tests {
         // Verify sorted order.
         let sorted = {
             let mut v = nodes.clone();
-            crate::term::sort_canonical(&mut v);
+            crate::term::sort_terms_canonical(&mut v);
             v
         };
         assert_eq!(nodes, sorted, "result must be sorted");

--- a/crates/shapes/src/sparql.rs
+++ b/crates/shapes/src/sparql.rs
@@ -14,6 +14,8 @@
 //! `PreparedSparqlQuery::substitute_variable`,  GAP-A).
 
 use std::cell::RefCell;
+use std::marker::PhantomData;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use ::purrdf::RdfDataset;
@@ -377,17 +379,18 @@ thread_local! {
     /// query plan cache memoizes each `sh:select`/`sh:SPARQLTarget` parse across the
     /// many focus-node calls of one validation (the oxigraph path kept a pre-parsed
     /// `PreparedSparqlQuery`; a fresh engine per call would re-parse every time — a
-    /// per-focus blowup on the whole-ontology conformance shapes). Validation is
-    /// serial, and the cache is keyed on `(base, query text)`, so reuse is sound.
+    /// per-focus blowup on the whole-ontology conformance shapes). Each focus
+    /// worker reuses its own cache, keyed on `(base, query text)`.
     static SPARQL_ENGINE: NativeSparqlEngine = NativeSparqlEngine::new();
 
     /// The SHACL-AF function registry (`sh:SPARQLFunction`) in scope for the current
     /// validation, set by [`enter_function_scope`]. `run_select_generic` reads it to decide
     /// whether a call-position IRI can resolve to a user function. Kept alongside the
-    /// engine (this module's established thread-local pattern) because validation is
-    /// serial: a single guard on the validation thread covers every `run_select_generic` on
-    /// that thread. Parallel FILTER workers inside the engine do NOT read this — they
-    /// receive the registry through `EvalCtx` (propagated in `fork_for_worker`).
+    /// engine (this module's established thread-local pattern). Whole-bundle
+    /// validation installs one guard per focus chunk, so every rayon worker sees
+    /// the same registry without shared mutation. Parallel FILTER workers inside
+    /// the SPARQL engine do NOT read this — they receive the registry through
+    /// `EvalCtx` (propagated in `fork_for_worker`).
     static CURRENT_FUNCTIONS: RefCell<Option<Arc<UserFunctionRegistry>>> = const { RefCell::new(None) };
 }
 
@@ -398,6 +401,9 @@ thread_local! {
 #[derive(Debug)]
 pub struct FunctionScope {
     previous: Option<Arc<UserFunctionRegistry>>,
+    /// A thread-local restoration guard must be dropped on the thread where it
+    /// was created; this marker makes that invariant compile-time enforced.
+    _not_send: PhantomData<Rc<()>>,
 }
 
 impl Drop for FunctionScope {
@@ -411,7 +417,10 @@ impl Drop for FunctionScope {
 /// restores the previous table when dropped.
 pub fn enter_function_scope(registry: Arc<UserFunctionRegistry>) -> FunctionScope {
     let previous = CURRENT_FUNCTIONS.with(|slot| slot.borrow_mut().replace(registry));
-    FunctionScope { previous }
+    FunctionScope {
+        previous,
+        _not_send: PhantomData,
+    }
 }
 
 /// Run a SELECT query over the dataset using the generic SPARQL `query` path

--- a/crates/shapes/src/term.rs
+++ b/crates/shapes/src/term.rs
@@ -26,8 +26,11 @@
 //! Literal lexical forms escape `\\ \" \n \r \t` plus C0 control chars as `\u00XX`,
 //! exactly as oxigraph's N-Triples literal writer.
 
+use std::cmp::Ordering;
+
 use ::purrdf::{RdfDataset, TermRef};
 use ::purrdf::{RdfTextDirection, TermId, TermValue};
+use smallvec::SmallVec;
 
 const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
 const RDF_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
@@ -36,6 +39,11 @@ const RDF_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langSt
 /// byte-level ordering contract. Each key is rendered exactly once.
 pub(crate) fn sort_canonical<T: ToString>(values: &mut [T]) {
     values.sort_by_cached_key(ToString::to_string);
+}
+
+/// Stable canonical ordering for RDF terms without materializing display keys.
+pub(crate) fn sort_terms_canonical(values: &mut [Term]) {
+    values.sort_by(canonical_cmp);
 }
 
 /// A native RDF term IRI (named node). Wraps a `String`; mirrors the slice of the
@@ -211,6 +219,197 @@ pub enum Term {
     Literal(Literal),
     /// A quoted triple (RDF 1.2).
     Triple(Box<Triple>),
+}
+
+#[derive(Clone, Copy)]
+enum CanonicalPart<'a> {
+    Raw(&'a [u8]),
+    Escaped(&'a [u8]),
+    Term(&'a Term),
+}
+
+/// Allocation-free iterator over the canonical display bytes of a valid IR term.
+///
+/// The IR limits quoted-triple nesting to 16 levels. The inline stack therefore
+/// covers every dataset term without spilling; manually-constructed terms beyond
+/// that bound remain correct and may spill to the `SmallVec` backing allocation.
+struct CanonicalBytes<'a> {
+    parts: SmallVec<[CanonicalPart<'a>; 96]>,
+    pending_escape: [u8; 6],
+    pending_len: u8,
+    pending_pos: u8,
+}
+
+impl<'a> CanonicalBytes<'a> {
+    fn new(term: &'a Term) -> Self {
+        let mut bytes = Self {
+            parts: SmallVec::new(),
+            pending_escape: [0; 6],
+            pending_len: 0,
+            pending_pos: 0,
+        };
+        bytes.parts.push(CanonicalPart::Term(term));
+        bytes
+    }
+
+    #[inline]
+    fn queue_escape(&mut self, replacement: &[u8]) {
+        self.pending_escape[..replacement.len()].copy_from_slice(replacement);
+        self.pending_len = u8::try_from(replacement.len()).expect("escape fits in six bytes");
+        self.pending_pos = 0;
+    }
+
+    #[inline]
+    fn queue_control_escape(&mut self, byte: u8) {
+        const HEX: &[u8; 16] = b"0123456789ABCDEF";
+        self.pending_escape = [
+            b'\\',
+            b'u',
+            b'0',
+            b'0',
+            HEX[usize::from(byte >> 4)],
+            HEX[usize::from(byte & 0x0f)],
+        ];
+        self.pending_len = 6;
+        self.pending_pos = 0;
+    }
+
+    fn expand_term(&mut self, term: &'a Term) {
+        match term {
+            Term::NamedNode(node) => {
+                self.parts.push(CanonicalPart::Raw(b">"));
+                self.parts.push(CanonicalPart::Raw(node.0.as_bytes()));
+                self.parts.push(CanonicalPart::Raw(b"<"));
+            }
+            Term::BlankNode(label) => {
+                self.parts.push(CanonicalPart::Raw(label.as_bytes()));
+                self.parts.push(CanonicalPart::Raw(b"_:"));
+            }
+            Term::Literal(literal) => {
+                if let Some(language) = &literal.language {
+                    if let Some(direction) = literal.direction {
+                        self.parts.push(CanonicalPart::Raw(match direction {
+                            RdfTextDirection::Ltr => b"--ltr",
+                            RdfTextDirection::Rtl => b"--rtl",
+                        }));
+                    }
+                    self.parts.push(CanonicalPart::Raw(language.as_bytes()));
+                    self.parts.push(CanonicalPart::Raw(b"\"@"));
+                } else if literal.datatype == XSD_STRING || literal.datatype == RDF_LANG_STRING {
+                    self.parts.push(CanonicalPart::Raw(b"\""));
+                } else {
+                    self.parts.push(CanonicalPart::Raw(b">"));
+                    self.parts
+                        .push(CanonicalPart::Raw(literal.datatype.as_bytes()));
+                    self.parts.push(CanonicalPart::Raw(b"\"^^<"));
+                }
+                self.parts
+                    .push(CanonicalPart::Escaped(literal.lexical.as_bytes()));
+                self.parts.push(CanonicalPart::Raw(b"\""));
+            }
+            Term::Triple(triple) => {
+                self.parts.push(CanonicalPart::Raw(b" )>>"));
+                self.parts.push(CanonicalPart::Term(&triple.object));
+                self.parts.push(CanonicalPart::Raw(b"> "));
+                self.parts
+                    .push(CanonicalPart::Raw(triple.predicate.0.as_bytes()));
+                self.parts.push(CanonicalPart::Raw(b" <"));
+                self.parts.push(CanonicalPart::Term(&triple.subject));
+                self.parts.push(CanonicalPart::Raw(b"<<( "));
+            }
+        }
+    }
+}
+
+impl Iterator for CanonicalBytes<'_> {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.pending_pos < self.pending_len {
+                let byte = self.pending_escape[usize::from(self.pending_pos)];
+                self.pending_pos += 1;
+                return Some(byte);
+            }
+
+            let part = self.parts.last_mut()?;
+            match part {
+                CanonicalPart::Raw(bytes) => {
+                    let Some((&byte, remaining)) = bytes.split_first() else {
+                        self.parts.pop();
+                        continue;
+                    };
+                    *bytes = remaining;
+                    return Some(byte);
+                }
+                CanonicalPart::Escaped(bytes) => {
+                    let Some((&byte, remaining)) = bytes.split_first() else {
+                        self.parts.pop();
+                        continue;
+                    };
+                    *bytes = remaining;
+                    match byte {
+                        b'\\' => self.queue_escape(b"\\\\"),
+                        b'\"' => self.queue_escape(b"\\\""),
+                        b'\n' => self.queue_escape(b"\\n"),
+                        b'\r' => self.queue_escape(b"\\r"),
+                        b'\t' => self.queue_escape(b"\\t"),
+                        control if control < 0x20 => self.queue_control_escape(control),
+                        other => return Some(other),
+                    }
+                }
+                CanonicalPart::Term(term) => {
+                    let term = *term;
+                    self.parts.pop();
+                    self.expand_term(term);
+                }
+            }
+        }
+    }
+}
+
+/// Compare two terms by the exact bytes produced by [`Term::to_string`] without
+/// materializing either rendered value.
+pub(crate) fn canonical_cmp(left: &Term, right: &Term) -> Ordering {
+    match (left, right) {
+        // These two cases cover the overwhelmingly common focus-node terms and
+        // avoid constructing even the inline rendering cursor.
+        (Term::BlankNode(left), Term::BlankNode(right)) => left.cmp(right),
+        (Term::NamedNode(left_node), Term::NamedNode(right_node)) => {
+            let left_iri = left_node.0.as_bytes();
+            let right_iri = right_node.0.as_bytes();
+            let shared = left_iri.len().min(right_iri.len());
+            match left_iri[..shared].cmp(&right_iri[..shared]) {
+                Ordering::Equal if left_iri.len() == right_iri.len() => Ordering::Equal,
+                Ordering::Equal if left_iri.len() < right_iri.len() => {
+                    match b'>'.cmp(&right_iri[shared]) {
+                        // `>` is forbidden inside a valid IRI. Preserve exact behavior
+                        // for manually-constructed unchecked terms nonetheless.
+                        Ordering::Equal => {
+                            CanonicalBytes::new(left).cmp(CanonicalBytes::new(right))
+                        }
+                        order => order,
+                    }
+                }
+                Ordering::Equal => match left_iri[shared].cmp(&b'>') {
+                    Ordering::Equal => CanonicalBytes::new(left).cmp(CanonicalBytes::new(right)),
+                    order => order,
+                },
+                order => order,
+            }
+        }
+        (Term::Literal(_), Term::Literal(_)) => {
+            CanonicalBytes::new(left).cmp(CanonicalBytes::new(right))
+        }
+        // The leading rendering byte establishes these cross-kind orders.
+        (Term::Literal(_), _) => Ordering::Less,
+        (_, Term::Literal(_)) => Ordering::Greater,
+        (Term::BlankNode(_), _) => Ordering::Greater,
+        (_, Term::BlankNode(_)) => Ordering::Less,
+        // IRI-vs-triple and same-kind compound values share a leading byte, so
+        // stream their complete canonical renderings.
+        _ => CanonicalBytes::new(left).cmp(CanonicalBytes::new(right)),
+    }
 }
 
 impl Term {
@@ -472,8 +671,6 @@ pub fn term_value_to_native(value: &TermValue) -> Term {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
-
     use super::*;
 
     fn nn(iri: &str) -> Term {
@@ -536,35 +733,68 @@ mod tests {
     }
 
     #[test]
-    fn canonical_sort_renders_each_key_once() {
-        struct Counted<'a> {
-            key: &'static str,
-            calls: &'a Cell<usize>,
-        }
-        impl std::fmt::Display for Counted<'_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                self.calls.set(self.calls.get() + 1);
-                f.write_str(self.key)
+    fn canonical_comparator_matches_rendered_byte_order() {
+        let plain_lang_string = Term::Literal(Literal {
+            lexical: "plain".to_owned(),
+            datatype: RDF_LANG_STRING.to_owned(),
+            language: None,
+            direction: None,
+        });
+        let triple = Term::Triple(Box::new(Triple::new(
+            nn("http://e/s"),
+            NamedNode::new_unchecked("http://e/p"),
+            Term::Literal(Literal::new_simple_literal("quoted\nvalue")),
+        )));
+        let nested_triple = Term::Triple(Box::new(Triple::new(
+            triple.clone(),
+            NamedNode::new_unchecked("http://e/p2"),
+            Term::blank("nested"),
+        )));
+        let terms = vec![
+            nn("http://e/a"),
+            nn("http://e/a/"),
+            nn("http://e/z"),
+            Term::blank("a"),
+            Term::blank("z"),
+            Term::Literal(Literal::new_simple_literal("")),
+            Term::Literal(Literal::new_simple_literal("a\"b\\c\n\r\t\u{0000}\u{001f}")),
+            Term::Literal(Literal::new_simple_literal("é🐈")),
+            Term::Literal(Literal::new_typed_literal(
+                "42",
+                NamedNode::new_unchecked("http://www.w3.org/2001/XMLSchema#integer"),
+            )),
+            Term::Literal(Literal::new_language_tagged_literal_unchecked(
+                "bonjour", "fr",
+            )),
+            Term::Literal(Literal::new_directional_language_tagged_literal_unchecked(
+                "مرحبا",
+                "ar",
+                RdfTextDirection::Rtl,
+            )),
+            Term::Literal(Literal::new_directional_language_tagged_literal_unchecked(
+                "hello",
+                "en",
+                RdfTextDirection::Ltr,
+            )),
+            plain_lang_string,
+            triple,
+            nested_triple,
+        ];
+
+        for left in &terms {
+            for right in &terms {
+                assert_eq!(
+                    canonical_cmp(left, right),
+                    left.to_string().cmp(&right.to_string()),
+                    "canonical comparison drifted for {left:?} and {right:?}"
+                );
             }
         }
 
-        let calls = Cell::new(0);
-        let mut values = [
-            Counted {
-                key: "c",
-                calls: &calls,
-            },
-            Counted {
-                key: "a",
-                calls: &calls,
-            },
-            Counted {
-                key: "b",
-                calls: &calls,
-            },
-        ];
-        sort_canonical(&mut values);
-        assert_eq!(calls.get(), values.len());
-        assert_eq!(values.map(|value| value.key), ["a", "b", "c"]);
+        let mut expected = terms.clone();
+        expected.sort_by_cached_key(ToString::to_string);
+        let mut actual = terms;
+        sort_terms_canonical(&mut actual);
+        assert_eq!(actual, expected);
     }
 }

--- a/crates/shapes/src/text_ingest.rs
+++ b/crates/shapes/src/text_ingest.rs
@@ -7,13 +7,12 @@
 //! the data graph (N-Triples). It used to drive the oxigraph `io` RDF parser
 //! directly so it could (a) recover the document `@prefix` map — oxigraph stores
 //! drop prefixes, but SHACL-AF `sh:select` queries reference prefixed names — and
-//! (b) accumulate EVERY syntax error in one pass (item 4) instead of
+//! (b) accumulate every independently recoverable syntax error in one pass instead of
 //! short-circuiting on the first.
 //!
 //! This module reproduces both capabilities on top of the native purrdf
-//! codecs ([`::purrdf::parse_dataset`]), which are lenient on the PurRDF
-//! ontology's private-use `@x-purrdf-*` language tags (long BCP-47 subtags) and
-//! carry no oxigraph `io` dependency:
+//! codecs ([`::purrdf::parse_dataset`]), which are lenient on private-use
+//! language tags with long BCP-47 subtags and carry no oxigraph `io` dependency:
 //!
 //! - **Prefix recovery** ([`extract_prefixes`]) re-derives the `(prefix,
 //!   namespace)` pairs by scanning the source text's `@prefix` / SPARQL `PREFIX`
@@ -79,8 +78,8 @@ fn scan_prefixes(text: &str) -> impl Iterator<Item = (String, String)> + '_ {
 ///
 /// On a clean parse the dataset is returned. On a syntax error the document is
 /// re-parsed one top-level statement at a time so EVERY independently-malformed
-/// statement is reported (the multi-error contract, item 4); the returned
-/// `Err` is the list of per-statement error strings.
+/// statement is reported; the returned `Err` is the list of per-statement error
+/// strings.
 pub fn parse_turtle_to_dataset(ttl: &str) -> Result<Arc<RdfDataset>, Vec<String>> {
     if ttl.is_empty() {
         return Ok(empty_dataset());

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -214,6 +214,69 @@ These observations are report-only. They establish reproducible workloads and
 make regressions visible; they do not impose latency, throughput, recall, or
 memory thresholds.
 
+### SHACL validation hot paths
+
+The `validate` benchmark contains four deterministic SHACL workloads:
+
+| Group | Fixed fixture and measured boundary |
+| --- | --- |
+| `shacl_validate/corpus_all` | All 69 committed first-party conformance cases, including text ingestion, shapes parsing, target resolution, constraint evaluation, and report assembly. |
+| `shacl_focus_core` | 512, 1,024, 2,048, 3,000, 100,000, and 1,000,000 target nodes. Each node contributes four quads; the shapes exercise a 40-level asserted subclass hierarchy, pattern, datatype, and class constraints. |
+| `shacl_focus_sparql` | 64, 512, and 4,096 target nodes with two quads per node and a caller-declared SHACL-SPARQL function. |
+| `shacl_focus_realtime` | One prepared 1,000,000-node snapshot (4,000,079 quads and 3,000,088 terms), a compatibility focus filter over one node, and id-native prepared requests containing 1, 8, 64, 512, or 4,096 focus nodes. Dataset and shapes preparation stays outside each request's timed loop. |
+
+Run the complete suite, one group, one large bulk case, or the largest bounded
+request with:
+
+```sh
+cargo bench -p purrdf-shapes --bench validate --locked
+cargo bench -p purrdf-shapes --bench validate --locked -- shacl_focus
+cargo bench -p purrdf-shapes --bench validate --locked -- shacl_focus_core/1000000
+cargo bench -p purrdf-shapes --bench validate --locked -- 'shacl_focus_realtime/prepared_ids/4096'
+```
+
+Appending `--test` performs a single-sample smoke run and prints the fixture,
+thread, elapsed-time, allocation-call, and requested-byte probe. It is useful for
+correctness and allocation inspection, not a substitute for Criterion's sampled
+estimates.
+
+`PreparedValidator` is the realtime surface. Preparation owns the immutable
+projected snapshot and parsed shapes, precomputes class closures and target
+identities, and evaluates SHACL-SPARQL targets once. Callers that already hold
+the projected snapshot should use `from_projected_dataset` and pass that exact
+snapshot's dataset-local `TermId` values to `validate_focus_node_ids`. The
+compatibility focus-filter entry point must enumerate whole target sets before
+discarding unrelated nodes and is intentionally retained as a comparison, not
+as the realtime path. Publishing an overlay or replacement snapshot requires a
+new prepared validator.
+
+The production scheduler preserves serial semantics. At 1,024 or fewer focus
+nodes it stays serial. Above that boundary, a multi-threaded build uses indexed
+Rayon chunks with a 64-node minimum and approximately four chunks per worker.
+Each chunk evaluates in canonical source order; chunk outputs are reduced in
+that same order, so report bytes and the selected earliest hard error do not
+depend on worker timing. Canonical focus sorting also stays serial below 4,096
+nodes and uses deterministic stable parallel sorting for larger sets. Unit tests
+force serial and parallel execution across all 69 corpus cases, 2- and 4-worker
+pools, several chunk geometries, SHACL-AF user functions, and competing hard
+errors; a separate test proves genuine four-worker participation.
+
+The following selected one-operation probes were observed on 2026-07-20 with
+rustc 1.97.1, Linux 7.1.4, 32 Rayon workers, and an AMD Ryzen AI MAX+ 395. They
+are report-only host observations, rounded from the emitted probes:
+
+| Operation | Earlier baseline | Current observation |
+| --- | ---: | ---: |
+| Whole-bundle Core validation, 1,000,000 focus nodes | 14.143 s | 339.85 ms |
+| SHACL-SPARQL validation, 4,096 focus nodes | 1.892 s | 79.05 ms |
+| Prepare the 1,000,000-node projected snapshot | not available | 2.31 ms; 119 allocation calls; 14,940 requested bytes |
+| Prepared id-native validation, 4,096 focus nodes | not available | 1.352 ms |
+| Compatibility focus filter, one retained node | not available | 266.93 ms |
+
+The comparison records the workload evolution rather than promising a speedup:
+reproduce it on the target deployment hardware, with the consumer's actual
+shapes and affected-focus expansion, before choosing latency budgets.
+
 ### SHACL schema import
 
 The `shacl_schema_import` group constructs a compact, deterministic draft


### PR DESCRIPTION
Closes #153.

## Summary

- benchmark whole-bundle SHACL execution through the production projected-dataset path at up to one million focus nodes
- compile dataset-bound validation invariants once, including batched asserted-subclass closures
- use a deterministic adaptive Rayon scheduler for sufficiently large focus sets while retaining the serial path for small work
- add `PreparedValidator` for repeated realtime validation against one immutable snapshot, with bounded `Term` and dataset-local `TermId` entry points
- retain the builder's compact store-once term index in frozen datasets so cold preparation does not rebuild a million-term reverse map

Core target membership in bounded calls is answered by direct IR index probes; it does not enumerate the dataset's full target sets. Generic SHACL-SPARQL targets are evaluated once during preparation and retained exactly, avoiding query rewrites that could change `ORDER`, `LIMIT`, aggregate, or subquery semantics. All result paths end in the same total canonical sort, so parallel completion order cannot affect report bytes.

The retained term index is derived and non-serialized, stores only dense `u32` entries, and is never read by byte-producing paths. There are no new Cargo features, optional dependencies, vocabulary defaults, or generated/golden changes.

## Performance

Measured in optimized Criterion runs with 32 Rayon threads:

| Workload | Before | After | Improvement |
|---|---:|---:|---:|
| Whole Core, 1,000,000 focus nodes | 14.143 s | 416.83 ms | 33.9x |
| Whole Core, 100,000 focus nodes | 1.2177 s | 31.24 ms | 39.0x |
| Whole SHACL-SPARQL, 4,096 focus nodes | 1.8923 s | 79.05 ms | 23.9x |
| Realtime compatibility filter, 1 of 1,000,000 | 266.93 ms | 1.15 us prepared | about 232,000x |

On the 1,000,000-focus / 4,000,079-quad realtime fixture, cold preparation fell from about 1.205 s and 3,000,129 allocations / 210 MB transient allocation to about 1.70 ms and 119 allocations / 14.9 KB. Prepared bounded validation measured 10.1 us for 8 focus nodes, 83.9 us for 64, 683.5 us for 512, and 1.55 ms for 4,096.

## Correctness

- bounded term/ID reports match the compatibility-filter report byte-for-byte across `sh:targetClass`, `sh:targetSubjectsOf`, `sh:targetObjectsOf`, `sh:targetNode`, and `sh:SPARQLTarget`
- prepared whole-bundle output matches the existing whole-validation report byte-for-byte
- duplicate candidates, foreign explicit targets, invalid IDs, deterministic parallel output, and worker-thread SHACL-AF function scope are covered
- the prepared value is compile-checked as `Send + Sync`

## Validation

- `make check`
- `make conformance` — 2,876 pass, 10 strictly ledgered xfail/skip, 0 failures
- `make doc` with rustdoc warnings denied
- `make wasm-pkg-size` — 7,771,699 / 8,030,000 bytes; 52,018 SIMD opcodes verified; budget unchanged
- `make wasm-pkg-test` — TypeScript, 60 Node tests, and package/tarball smoke green
- focused 460 `purrdf-core` and 518 `purrdf-shapes` unit tests plus warning-free clippy
