### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 - **build:** Make Cargo target fallback safe
 - **capi:** Honor active smoke-test profile
 - **build:** Harden Cargo target discovery
+- **release:** Deduplicate generated changelog entries
 
 ### CI & Build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,148 @@ All notable changes to the PurRDF crate suite are recorded here. The suite
 ships one lockstep version across crates.io, PyPI, and npm; pre-1.0, a minor
 bump may carry breaking changes and a patch bump is bugfix-only.
 
+## [0.8.0] - 2026-07-20
+
+### Bug Fixes
+
+- Harden purremb contracts and lookups
+- **shapes:** Standardize schema input blanks apart
+- **shapes:** Return typed schema key errors
+- **shapes:** Admit identifier-only ontology ranges
+- **shapes:** Retain custom datatype ranges
+- **shapes:** Bound propagated schema facts
+- **shapes:** Lower unsafe LinkML slots deterministically
+- **shapes:** Bound schema parsing during construction
+- **shapes:** Reject initializer module components
+- **jsonld:** Preserve active-context option semantics
+- **jsonld:** Preserve compact carrier round trips
+- **jsonld:** Bound derived context validation
+- **cli:** Bound JSON-LD options input
+- **python:** Isolate generated namespace bindings
+- **playground:** Route configured JSON-LD formats
+- **capi:** Update projection example scope
+- **wasm:** Update projection scope fixtures
+- **csvw:** Preserve W3C RDF conversion
+- **capi:** Refresh generated projection header
+- **build:** Measure OKF wasm package growth
+- **capi:** Close smoke fixture on seek failure
+- **build:** Make Cargo target fallback safe
+- **capi:** Honor active smoke-test profile
+- **build:** Harden Cargo target discovery
+
+### CI & Build
+
+- **wasm:** Rebaseline scoped projection budgets
+
+### Documentation
+
+- **rdf-core:** Specify the PURREMB v1 format
+- **shapes:** Expose ontology schema workflow
+- **shapes:** Publish LinkML slot migration contract
+- **shapes:** Document rich Pydantic package emission
+- **shapes:** Qualify flat byte compatibility
+- **jsonld:** Document deterministic context compaction
+- **conformance:** Refresh compatibility count
+- **conformance:** Refresh Python parity count
+- **csvw:** Guide curated terms projection
+- **cli:** Enumerate liftable profiles
+- **wasm:** Refresh optimized size measurement
+- **conformance:** Refresh compatibility count
+- **conformance:** Refresh compatibility count
+- **cli:** Explain OKF lift rejection
+- **conformance:** Account for attached parity test
+
+### Features
+
+- **rdf-core:** Add deterministic PURREMB writing
+- **rdf-core:** Add borrowed PURREMB reading
+- **rdf-core:** Add PURREMB binding verification
+- **rdf-core:** Add deterministic .purremb companion format
+- **sssom:** Model set-level document comments
+- **sssom:** Retain parsed document envelopes
+- **sssom:** Serialize typed document envelopes
+- **shapes:** Define ontology schema compilation contract
+- **shapes:** Derive deterministic ontology schema surface
+- **shapes:** Emit ontology-complete schema carriers
+- **shapes:** Define LinkML slot naming contract
+- **shapes:** Verify LinkML slot reports on import
+- **shapes:** Define deterministic Pydantic package topology
+- **shapes:** Emit routed rich Pydantic packages
+- **rdf:** Compile JSON-LD active contexts
+- **rdf:** Compact JSON-LD through a typed carrier
+- **rdf:** Derive deterministic JSON-LD contexts
+- **cli:** Expose configured JSON-LD serialization
+- **bindings:** Expose compiled JSON-LD contexts
+- **lpg:** Require explicit projection scope
+- **lpg:** Stream projection artifacts
+- **lpg:** Expose scoped streaming hosts
+- **csvw:** Define curated terms profile
+- **csvw:** Project scoped curated term tables
+- **projection:** Expose curated CSVW terms
+- **rdf:** Define OKF terms projection contract
+- **rdf:** Generate deterministic OKF term bundles
+- **rdf:** Expose OKF terms across hosts
+- **rdf:** Add attached RO-Crate assets
+- **bindings:** Expose attached RO-Crate packaging
+
+### Other
+
+- Compile ontology-complete developer schema surfaces
+- Make LinkML slot lowering deterministic and reversible
+- Emit deterministic rich Pydantic packages
+- **jsonld:** Document scoped lint exceptions
+- Add deterministic context compaction
+- Preserve typed SSSOM set comments
+- Add scoped streaming LPG projections
+- Add caller-configured curated CSVW projections
+- Add deterministic caller-configured OKF term bundles
+- Add deterministic attached RO-Crate payload packages
+- Add native DCAT and VoID dataset descriptions
+- Benchmark whole-bundle SHACL focus execution
+- Optimize SHACL focus validation invariants
+- Parallelize SHACL focus evaluation deterministically
+- Prepare bounded SHACL validation for realtime use
+- Eliminate SHACL canonical sort key allocations
+- Preserve interned IDs through recursive SHACL checks
+- Prove deterministic SHACL parallel execution
+- Document realtime SHACL validation operations
+- Optimize realtime and whole-bundle SHACL validation
+
+### Performance
+
+- **rdf-core:** Benchmark PURREMB access paths
+- **sssom:** Streamline column selection
+- **shapes:** Cache ontology row sort keys
+- **shapes:** Borrow unchanged LinkML slot locals
+- **shapes:** Reuse Pydantic path buffers
+- **shapes:** Avoid duplicate schema limit traversal
+- **shapes:** Index routed definition owners
+- **jsonld:** Remove carrier hot-path allocation
+- **lpg:** Measure scoped streaming carriers
+- **projection:** Coalesce artifact sink writes
+- **csvw:** Reuse URI expansion allocations
+- **csvw:** Remove curated selection temporaries
+- **csvw:** Borrow curated table memberships
+- **rdf:** Remove OKF classifier scratch allocations
+- **rdf:** Remove attached crate loop allocations
+
+### Refactor
+
+- **shapes:** Clarify routed name guard
+- **jsonld:** Unify context processing
+
+### Testing
+
+- **rdf-core:** Harden PURREMB conformance coverage
+- **shapes:** Prove ontology surface across emitters
+- **shapes:** Keep namespace fixture vocabulary neutral
+- **shapes:** Prove emitter-specific ownership
+- **shapes:** Harden LinkML slot lowering
+- **shapes:** Exercise routed Pydantic packages
+- **jsonld:** Freeze expanded codec baseline
+- **rdf:** Pin OKF terms cross-host parity
+- **rdf:** Freeze attached crate host parity
+
 ## [0.7.0] - 2026-07-17
 
 ### Benchmarks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,6 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 - **csvw:** Guide curated terms projection
 - **cli:** Enumerate liftable profiles
 - **wasm:** Refresh optimized size measurement
-- **conformance:** Refresh compatibility count
-- **conformance:** Refresh compatibility count
 - **cli:** Explain OKF lift rejection
 - **conformance:** Account for attached parity test
 
@@ -246,7 +244,6 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 - **shapes:** Emit deterministic TypeScript declarations
 - **core:** Register GraphQL loss profile
 - **shapes:** Emit deterministic GraphQL SDL
-- **shapes:** Emit deterministic GraphQL SDL
 - **rdf:** Add projection carrier foundations
 - **rdf:** Add canonical LPG mapping
 - **rdf:** Add LPG CSV adapters
@@ -379,7 +376,6 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 - **shapes:** Resolve sh:class / rdfs:range value-vocab refs to enum $defs
 - **sparql-eval:** Native Rust-closure user-function registry + dispatch
 - **sparql-eval:** Native Rust-closure user-function registry
-- **shapes:** Project value vocabularies to enum $defs (projection-only)
 - **gts:** Two-inventory replication diff, splice reconstruction, and diff_json
 - **gts:** Surface per-frame provenance (content-id + byte range) on the streaming read path
 - **gts:** Stream GTS frames into an RdfEventSink with per-frame provenance
@@ -592,7 +588,6 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 ### CI & Build
 
 - **release:** Edition 2024, publish purrdf-entail, expose entail+validate, bump 0.3.1
-- **release:** Edition 2024, publish purrdf-entail, expose entail+validate, bump 0.3.1
 
 ### Documentation
 
@@ -628,7 +623,6 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 - **sparql-eval:** Correct correlated-EXISTS over address-keyed cache reuse
 - **rdf:** Verify content-chain inclusion via blob/segment-head/MMR-leaf union
 - **shex:** Route numeric_value through the XSD-1.0 float/double restriction
-- **rdf:** Accept empty predicateObjectList item in Turtle parser
 - **rdf:** Accept empty predicateObjectList item in Turtle parser
 - **shex:** Fire group semantic actions only for participating groups
 - **shex:** Make result-shape-map JSON fully round-trip through parse_shape_map
@@ -838,7 +832,6 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 - **sparql-eval:** Single-threaded optimization backlog (items 3–7 + ORDER BY triple residual)
 - **wasm-pkg:** Add Node parse-throughput benchmark
 - **wasm-pkg:** Build the npm artifact with +simd128
-- **wasm-pkg:** Build the npm artifact with +simd128
 - **sparql-eval:** Parallelize BGP inner loop and read-only join probes
 - **sparql-eval:** Parallelize FILTER/filtered-left-join with forked per-worker contexts
 - **sparql-eval:** Parallelize UNION, BIND, and per-group aggregates with deterministic scratch merge
@@ -870,7 +863,6 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 - **entail:** Split reasoner into vocab/interner/rdfs modules + Regime::Rif scaffolding
 - **shapes:** Collapse the non-interned path walker to reflexive inclusion
 - **validate:** Hoist shared validate-to-SARIF helper into purrdf-validate
-- **rdf:** Centralize native-codec format dispatch behind an RdfCodec trait
 - **rdf:** Centralize native-codec format dispatch behind an RdfCodec trait
 
 ### Testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 - **capi:** Honor active smoke-test profile
 - **build:** Harden Cargo target discovery
 - **release:** Deduplicate generated changelog entries
+- **capi:** Regenerate header for 0.8.0
 
 ### CI & Build
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,8 +21,8 @@ authors:
   - family-names: "Audley"
     given-names: "Patrick"
     orcid: "https://orcid.org/0000-0003-4382-7625"
-version: "0.7.0"
-date-released: "2026-07-17"
+version: "0.8.0"
+date-released: "2026-07-20"
 license:
   - Apache-2.0
   - MIT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "purrdf-columnar",
  "purrdf-entail",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "memmap2",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-columnar"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1349,11 +1349,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "0.7.0"
+version = "0.8.0"
 
 [[package]]
 name = "purrdf-gts"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ahash",
  "boon",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "boon",
  "criterion",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "hex",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -45,22 +45,22 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "0.7.0" }
-purrdf-columnar = { path = "crates/columnar", version = "0.7.0" }
-purrdf-core = { path = "crates/rdf-core", version = "0.7.0" }
-purrdf-entail = { path = "crates/entail", version = "0.7.0" }
-purrdf-events = { path = "crates/rdf-events", version = "0.7.0" }
-purrdf-gts = { path = "crates/gts", version = "0.7.0" }
-purrdf-iri = { path = "crates/iri", version = "0.7.0" }
-purrdf-rdf = { path = "crates/rdf", version = "0.7.0" }
-purrdf-shapes = { path = "crates/shapes", version = "0.7.0" }
-purrdf-shex = { path = "crates/shex", version = "0.7.0" }
-purrdf-slice = { path = "crates/slice", version = "0.7.0" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.7.0" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.7.0" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "0.7.0" }
-purrdf-validate = { path = "crates/validate", version = "0.7.0" }
-purrdf-xsd = { path = "crates/xsd", version = "0.7.0" }
+purrdf = { path = "crates/purrdf", version = "0.8.0" }
+purrdf-columnar = { path = "crates/columnar", version = "0.8.0" }
+purrdf-core = { path = "crates/rdf-core", version = "0.8.0" }
+purrdf-entail = { path = "crates/entail", version = "0.8.0" }
+purrdf-events = { path = "crates/rdf-events", version = "0.8.0" }
+purrdf-gts = { path = "crates/gts", version = "0.8.0" }
+purrdf-iri = { path = "crates/iri", version = "0.8.0" }
+purrdf-rdf = { path = "crates/rdf", version = "0.8.0" }
+purrdf-shapes = { path = "crates/shapes", version = "0.8.0" }
+purrdf-shex = { path = "crates/shex", version = "0.8.0" }
+purrdf-slice = { path = "crates/slice", version = "0.8.0" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.8.0" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.8.0" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "0.8.0" }
+purrdf-validate = { path = "crates/validate", version = "0.8.0" }
+purrdf-xsd = { path = "crates/xsd", version = "0.8.0" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "0.7.0"
+version = "0.8.0"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/cliff.toml
+++ b/cliff.toml
@@ -8,6 +8,9 @@
 # no author/PR links), and the preprocessors strip every `#NNN` issue/PR token
 # so the committed CHANGELOG.md stays clean under the repo's issue-reference
 # lint (scripts/check-issue-refs.py, which scans root *.md).
+# Exact rendered scope/message pairs are emitted once per release group. Multiple
+# implementation commits can legitimately share a conventional subject, but one
+# repeated user-facing release-note bullet carries no additional information.
 
 [changelog]
 header = """
@@ -26,9 +29,17 @@ body = """
 {% endif -%}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
-{% for commit in commits %}
+
+{% set_global rendered_entries = [] -%}
+{% for commit in commits -%}
+{% set entry_message = commit.message | split(pat="\n") | first | upper_first | trim -%}
+{% set entry_scope = commit.scope | default(value="") -%}
+{% set entry_key = entry_scope ~ "::" ~ entry_message -%}
+{% if entry_key not in rendered_entries -%}
+{% set_global rendered_entries = rendered_entries | concat(with=entry_key) -%}
 - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | upper_first | trim }}
-{%- endfor %}
+{% endif -%}
+{% endfor %}
 
 {% endfor %}
 """

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.7.0" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.8.0" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -82,4 +82,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "0.7.0"
+version = "0.8.0"

--- a/crates/rdf-capi/include/purrdf.h
+++ b/crates/rdf-capi/include/purrdf.h
@@ -9,7 +9,7 @@
 
 /* WARNING: generated file — edit crates/rdf-capi instead. */
 #define PURRDF_MAJOR 0
-#define PURRDF_MINOR 7
+#define PURRDF_MINOR 8
 #define PURRDF_PATCH 0
 
 

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -58,7 +58,7 @@ purrdf-iri = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.7.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.8.0" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.7.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.8.0" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.


### PR DESCRIPTION
## Outcome

Prepare PurRDF 0.8.0 as one coherent crates.io, PyPI, and npm release from the complete post-0.7.0 `main` history. Every package, internal dependency requirement, registry surface, development lock, C ABI version, and citation record is in lockstep, and the committed changelog section is ready to become the cargo lane's GitHub Release notes verbatim.

## Release changes

- Bump all 21 workspace packages from 0.7.0 to 0.8.0.
- Bump all 19 internal path-dependency requirements to 0.8.0 so published crates cannot resolve against the previous suite.
- Bump the Python project and editable lock, npm package, C ABI library metadata, and citation metadata to 0.8.0.
- Regenerate the committed C ABI header from the 0.8.0 crate so its public version macros match the library metadata.
- Stamp `CITATION.cff` with the 2026-07-20 release date.
- Refresh only the 21 PurRDF workspace entries in `Cargo.lock`; no external package name, version, source, checksum, or dependency graph changes.
- Regenerate `CHANGELOG.md` with repository-pinned git-cliff 2.13.1, producing a populated and deterministic 0.8.0 release-notes section.
- Deduplicate exact rendered scope/message pairs in the canonical git-cliff template so repeated implementation subjects produce one user-facing release-note bullet in first-occurrence order.

## Files and purpose

- `Cargo.toml`, `crates/{rdf-capi,shapes,slice}/Cargo.toml`: canonical workspace version, all internal dependency floors, and C ABI metadata.
- `Cargo.lock`: the 21 workspace package versions only.
- `bindings/python/{pyproject.toml,uv.lock}`: PyPI and editable-development package versions.
- `crates/rdf-wasm/js/package.json`: npm package version.
- `crates/rdf-capi/include/purrdf.h`: generated public C ABI contract with the 0.8.0 minor-version macro.
- `CITATION.cff`: cited version and release date.
- `CHANGELOG.md`: deterministic 0.8.0 release notes generated from conventional commits since `rust-v0.7.0`.
- `cliff.toml`: deterministic per-group deduplication of identical rendered release-note entries.
- No runtime Rust source, workflow, dependency, feature, ABI function surface, conformance vector, or frozen wire artifact changed.

## Validation

- `UV_CACHE_DIR=/tmp/purrdf-release-uv-cache CARGO_BUILD_JOBS=2 make check`: green, including formatting, warning-denied workspace Clippy, locked builds, generated-artifact and repository hygiene gates, complete workspace tests and doctests, C ABI smoke, kernel/foundation dependency ring fences, and all 17 release crates on `wasm32-unknown-unknown`.
- `make capi-check`: the regenerated committed header matches cbindgen output and the linked C smoke test passes.
- `python3 scripts/check-versions.py`: version 0.8.0 coherent across crates.io, PyPI, npm, citation metadata, all publishable crates, both release publish lists, and every internal dependency floor.
- `cargo metadata --locked --no-deps --format-version 1`: green against the refreshed lock.
- Repeating `make changelog` produced byte-identical final output with SHA-256 `1ea22fa0bbeea71b950fda61ce3cb36735827d1c0a38ee7cf0f62d9b6264d977`; a release/group scan found no duplicate rendered bullet.
- The Cargo lock diff contains exactly 21 `0.7.0` to `0.8.0` workspace version replacements and no external dependency metadata change.
- `git diff --check` passed; all five branch commits (`3e624ba5`, `446c2331`, `8af361d1`, `a7268b8b`, and `4e60465e`) have verified repository signatures and the pushed worktree is clean.

## Standing constraints

- The release remains one low-optionality version across all three registries and every published Rust dependency floor.
- No semantic Cargo feature, optional dependency, vocabulary IRI/default, runtime behavior, serializer byte path, or nondeterministic input was introduced.
- Kernel and foundation dependency ring fences remain intact and all published crates remain wasm-buildable.
- The release branch changes metadata, the generated C ABI version macro, generated release notes, and their canonical deduplication rule only; RDF 1.2/RDF-star runtime behavior is unchanged from the validated `main` source.

## Deferral gate

The release diff contains no deferred, stubbed, placeholder, TODO, FIXME, follow-up, or future-work item. The complete coherent release metadata and changelog are present.

## Base synchronization

The release branch was created directly from `origin/main` at `50466c0779e6fc930b362744fc1aa6af19624215`. A final fetch confirmed that `origin/main` remains at that commit; merging it reported `Already up to date`, with no conflicts or head change.

## Hosted validation

GitHub validated exact head `4e60465ed3dd3e34af3258a508909d6c3ff367f2`. CodeQL, workspace, MSRV, conformance, projection oracles, Python bindings and schema oracles, C ABI/header contract, workspace tests and doctests, wasm/npm/package-size gates, rustdoc, and the PurRDF book all passed. The benchmark job is report-only and was still running its Criterion suites at the final merge-readiness audit.
