### PR TITLE
chore(release): 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to the PurRDF crate suite are recorded here. The suite
 ships one lockstep version across crates.io, PyPI, and npm; pre-1.0, a minor
 bump may carry breaking changes and a patch bump is bugfix-only.
 
+## [0.8.1] - 2026-07-21
+
+### Bug Fixes
+
+- **wasm:** Align npm package size budgets
+
+### CI & Build
+
+- **wasm:** Budget shared SHACL membership view
+
+### Documentation
+
+- **wasm:** Record optimized membership artifact
+- **conformance:** Record subclass corpus case
+
+### Features
+
+- **shapes:** Add subclass membership view
+- **shapes:** Unify subclass membership semantics
+
+### Other
+
+- Unify SHACL subclass membership across native and SPARQL validation
+
+### Performance
+
+- **shapes:** Benchmark subclass membership hot path
+- **shapes:** Prune inactive membership rows
+
+### Testing
+
+- **shapes:** Freeze subclass membership semantics
+- **shapes:** Freeze subclass corpus hashes
+
 ## [0.8.0] - 2026-07-20
 
 ### Bug Fixes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,7 +21,7 @@ authors:
   - family-names: "Audley"
     given-names: "Patrick"
     orcid: "https://orcid.org/0000-0003-4382-7625"
-version: "0.8.0"
+version: "0.8.1"
 date-released: "2026-07-20"
 license:
   - Apache-2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "purrdf-columnar",
  "purrdf-entail",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "clap",
  "memmap2",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-columnar"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -1349,11 +1349,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "0.8.0"
+version = "0.8.1"
 
 [[package]]
 name = "purrdf-gts"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ahash",
  "boon",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "boon",
  "criterion",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "hex",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "insta",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ahash",
  "criterion",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "insta",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -45,22 +45,22 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "0.8.0" }
-purrdf-columnar = { path = "crates/columnar", version = "0.8.0" }
-purrdf-core = { path = "crates/rdf-core", version = "0.8.0" }
-purrdf-entail = { path = "crates/entail", version = "0.8.0" }
-purrdf-events = { path = "crates/rdf-events", version = "0.8.0" }
-purrdf-gts = { path = "crates/gts", version = "0.8.0" }
-purrdf-iri = { path = "crates/iri", version = "0.8.0" }
-purrdf-rdf = { path = "crates/rdf", version = "0.8.0" }
-purrdf-shapes = { path = "crates/shapes", version = "0.8.0" }
-purrdf-shex = { path = "crates/shex", version = "0.8.0" }
-purrdf-slice = { path = "crates/slice", version = "0.8.0" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.8.0" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.8.0" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "0.8.0" }
-purrdf-validate = { path = "crates/validate", version = "0.8.0" }
-purrdf-xsd = { path = "crates/xsd", version = "0.8.0" }
+purrdf = { path = "crates/purrdf", version = "0.8.1" }
+purrdf-columnar = { path = "crates/columnar", version = "0.8.1" }
+purrdf-core = { path = "crates/rdf-core", version = "0.8.1" }
+purrdf-entail = { path = "crates/entail", version = "0.8.1" }
+purrdf-events = { path = "crates/rdf-events", version = "0.8.1" }
+purrdf-gts = { path = "crates/gts", version = "0.8.1" }
+purrdf-iri = { path = "crates/iri", version = "0.8.1" }
+purrdf-rdf = { path = "crates/rdf", version = "0.8.1" }
+purrdf-shapes = { path = "crates/shapes", version = "0.8.1" }
+purrdf-shex = { path = "crates/shex", version = "0.8.1" }
+purrdf-slice = { path = "crates/slice", version = "0.8.1" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.8.1" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.8.1" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "0.8.1" }
+purrdf-validate = { path = "crates/validate", version = "0.8.1" }
+purrdf-xsd = { path = "crates/xsd", version = "0.8.1" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "0.8.0"
+version = "0.8.1"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.8.0" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.8.1" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -82,4 +82,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "0.8.0"
+version = "0.8.1"

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -58,7 +58,7 @@ purrdf-iri = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.8.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.8.1" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.8.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.8.1" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.


### PR DESCRIPTION
## Summary

- bump the coherent Rust, Python, and npm release version to 0.8.1
- refresh Cargo and Python lock metadata for the release version
- generate the deterministic 0.8.1 changelog from the commits merged since 0.8.0

## Release impact

After this PR merges, the coordinated rust-v0.8.1, py-v0.8.1, and npm-v0.8.1 tags will publish the same PurRDF implementation across crates.io, PyPI, and npm.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache make check`
- `make wasm-pkg-test`
- `python3 scripts/check-versions.py`

The WASM/npm gate passed all 60 tests, verified SIMD opcodes, and kept both packed and unpacked artifacts within their size budgets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for multiple SHACL subclass membership views and improved semantic unification.
  - Added related benchmarking and pruning improvements.

- **Performance**
  - Reduced WebAssembly and package size.

- **Bug Fixes**
  - Improved SHACL membership artifact handling and behavior.

- **Testing**
  - Expanded test coverage for subclass membership functionality.

- **Documentation**
  - Added release notes for version 0.8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->