### PR TITLE
fix(rdf): make JSON-LD byte budgets portable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,9 +166,9 @@ jobs:
       - name: Set up the pinned wasm toolchain (wasm-bindgen + binaryen) and cache
         uses: ./.github/actions/wasm-toolchain
 
-      - name: Check release crates on wasm32
+      - name: Build release crates on wasm32
         run: |
-          cargo check --locked --target wasm32-unknown-unknown --lib \
+          cargo build --locked --release --target wasm32-unknown-unknown --lib \
             -p purrdf-events \
             -p purrdf-iri \
             -p purrdf-xsd \

--- a/Makefile
+++ b/Makefile
@@ -226,9 +226,9 @@ rdf-core-hygiene: ## Prove the kernel ring-fence: no oxigraph/PyO3 in purrdf-cor
 		echo "OK: $$leaf is zero-dependency"; \
 	done
 
-wasm: ## Prove the release crates build for wasm32-unknown-unknown (SKIP locally if target absent; CI hard-fails).
+wasm: ## Build the release crates for wasm32-unknown-unknown (SKIP locally if target absent; CI hard-fails).
 	@if rustup target list --installed 2>/dev/null | grep -qx wasm32-unknown-unknown; then \
-		cargo check --locked --target wasm32-unknown-unknown --lib \
+		cargo build --locked --release --target wasm32-unknown-unknown --lib \
 			-p purrdf-events -p purrdf-iri -p purrdf-xsd -p purrdf-gts -p purrdf-core -p purrdf-columnar \
 			-p purrdf-sparql-algebra -p purrdf-sparql-results -p purrdf-sparql-eval \
 			-p purrdf-rdf -p purrdf-slice -p purrdf-shapes -p purrdf-shex -p purrdf-entail \

--- a/Makefile
+++ b/Makefile
@@ -117,10 +117,26 @@ release-tags: ## Cut + push rust-v/py-v/npm-v tags for VERSION after coherence c
 		flag { print } \
 	' CHANGELOG.md); \
 		test -n "$$(printf '%s' "$$notes" | tr -d '[:space:]')" || { echo "ERROR: CHANGELOG.md has no release-notes section for [$(VERSION)] — run 'make changelog' and commit it before tagging"; exit 1; }
+	@git fetch --quiet origin main
+	@test "$$(git rev-parse HEAD)" = "$$(git rev-parse refs/remotes/origin/main)" || { echo "ERROR: main is not synchronized with origin/main"; exit 1; }
+	@for tag in "rust-v$(VERSION)" "py-v$(VERSION)" "npm-v$(VERSION)"; do \
+		! git rev-parse --quiet --verify "refs/tags/$$tag" >/dev/null || { echo "ERROR: local tag $$tag already exists"; exit 1; }; \
+		! git ls-remote --exit-code --tags origin "refs/tags/$$tag" >/dev/null 2>&1 || { echo "ERROR: remote tag $$tag already exists"; exit 1; }; \
+	done
+	@echo "Running the complete release preflight before creating any tags..."
+	@$(MAKE) check
+	@test -z "$$(git status --porcelain)" || { echo "ERROR: full release preflight changed the working tree"; exit 1; }
+	@branch=$$(git branch --show-current); test "$$branch" = "main" || { echo "ERROR: branch changed during release preflight (currently on $$branch)"; exit 1; }
+	@git fetch --quiet origin main
+	@test "$$(git rev-parse HEAD)" = "$$(git rev-parse refs/remotes/origin/main)" || { echo "ERROR: main moved during release preflight; update main and rerun"; exit 1; }
+	@for tag in "rust-v$(VERSION)" "py-v$(VERSION)" "npm-v$(VERSION)"; do \
+		! git rev-parse --quiet --verify "refs/tags/$$tag" >/dev/null || { echo "ERROR: local tag $$tag appeared during release preflight"; exit 1; }; \
+		! git ls-remote --exit-code --tags origin "refs/tags/$$tag" >/dev/null 2>&1 || { echo "ERROR: remote tag $$tag appeared during release preflight"; exit 1; }; \
+	done
 	git tag "rust-v$(VERSION)"
 	git tag "py-v$(VERSION)"
 	git tag "npm-v$(VERSION)"
-	git push origin "rust-v$(VERSION)" "py-v$(VERSION)" "npm-v$(VERSION)"
+	git push --atomic origin "rust-v$(VERSION)" "py-v$(VERSION)" "npm-v$(VERSION)"
 	@echo "OK: pushed rust-v$(VERSION), py-v$(VERSION), npm-v$(VERSION)"
 
 test: ## Run the workspace test suite.

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,9 @@ release-tags: ## Cut + push rust-v/py-v/npm-v tags for VERSION after coherence c
 	done
 	@echo "Running the complete release preflight before creating any tags..."
 	@$(MAKE) check
+	@$(MAKE) capi-check
+	@$(MAKE) pytest
+	@$(MAKE) wasm-pkg-test
 	@test -z "$$(git status --porcelain)" || { echo "ERROR: full release preflight changed the working tree"; exit 1; }
 	@branch=$$(git branch --show-current); test "$$branch" = "main" || { echo "ERROR: branch changed during release preflight (currently on $$branch)"; exit 1; }
 	@git fetch --quiet origin main
@@ -312,7 +315,7 @@ wasm-pkg-size: wasm-pkg ## Gate the optimized wasm artifact byte size against WA
 	 fi; \
 	 echo "OK: wasm artifact within budget"
 
-wasm-pkg-test: wasm-pkg ## Build the wasm package and run the npm package-root gate.
+wasm-pkg-test: wasm-pkg-size ## Build, size-gate, and test the optimized npm/wasm package.
 	cd crates/rdf-wasm/js && npm ci --ignore-scripts --no-audit --no-fund && npm run check
 
 wasm-pkg-bench: wasm-pkg ## Build the wasm package and run the Node parse-throughput benchmark (report-only; never a gate).

--- a/crates/rdf-capi/include/purrdf.h
+++ b/crates/rdf-capi/include/purrdf.h
@@ -10,7 +10,7 @@
 /* WARNING: generated file — edit crates/rdf-capi instead. */
 #define PURRDF_MAJOR 0
 #define PURRDF_MINOR 8
-#define PURRDF_PATCH 0
+#define PURRDF_PATCH 2
 
 
 #include <stdarg.h>

--- a/crates/rdf/src/native_codecs/jsonld.rs
+++ b/crates/rdf/src/native_codecs/jsonld.rs
@@ -962,29 +962,34 @@ fn carrier_term_footprint(
 }
 
 fn fold_document_rdf_lists(document: &mut CarrierDocument) {
-    let mut graph_usage = Vec::with_capacity(document.named_graphs.len() + 1);
-    graph_usage.push(carrier_node_usage(&document.default_nodes));
-    graph_usage.extend(
-        document
-            .named_graphs
-            .iter()
-            .map(|graph| carrier_node_usage(&graph.nodes)),
-    );
-    for (index, graph) in document.named_graphs.iter().enumerate() {
-        graph_usage[index + 1].insert(graph.id.clone());
+    let mut graph_usage = std::iter::once(carrier_node_usage(&document.default_nodes))
+        .chain(
+            document
+                .named_graphs
+                .iter()
+                .map(|graph| carrier_node_usage(&graph.nodes)),
+        )
+        .collect::<Vec<_>>();
+    let (default_usage, named_usage) = graph_usage
+        .split_first_mut()
+        .expect("default graph usage is always present");
+    for (usage, graph) in named_usage.iter_mut().zip(&document.named_graphs) {
+        usage.insert(graph.id.clone());
     }
-    let mut usage_counts: FixedHashMap<String, usize> = FixedHashMap::default();
-    for usage in &graph_usage {
+    // Only zero, one, and many are semantically distinct. Capping at two avoids
+    // pointer-sized occurrence arithmetic while preserving that distinction.
+    let mut usage_counts: FixedHashMap<String, u8> = FixedHashMap::default();
+    for usage in std::iter::once(&*default_usage).chain(named_usage.iter()) {
         for id in usage {
-            *usage_counts.entry(id.clone()).or_default() += 1;
+            let count = usage_counts.entry(id.clone()).or_default();
+            increment_multiplicity(count);
         }
     }
 
     fold_rdf_lists(&mut document.default_nodes, |id| {
-        used_in_another_graph(id, &graph_usage[0], &usage_counts)
+        used_in_another_graph(id, default_usage, &usage_counts)
     });
-    for (index, graph) in document.named_graphs.iter_mut().enumerate() {
-        let current_usage = &graph_usage[index + 1];
+    for (graph, current_usage) in document.named_graphs.iter_mut().zip(named_usage) {
         // A graph name and a node/list identifier inhabit the same RDF blank-node
         // identity space.  Keep that identity explicit even when the only other use
         // of the identifier is as the name of the graph currently being folded.
@@ -998,9 +1003,15 @@ fn fold_document_rdf_lists(document: &mut CarrierDocument) {
 fn used_in_another_graph(
     id: &str,
     current_usage: &FixedHashSet<String>,
-    usage_counts: &FixedHashMap<String, usize>,
+    usage_counts: &FixedHashMap<String, u8>,
 ) -> bool {
-    usage_counts.get(id).copied().unwrap_or_default() > usize::from(current_usage.contains(id))
+    usage_counts.get(id).copied().unwrap_or_default() > u8::from(current_usage.contains(id))
+}
+
+fn increment_multiplicity(count: &mut u8) {
+    if *count < 2 {
+        *count += 1;
+    }
 }
 
 fn carrier_node_usage(nodes: &[CarrierNode]) -> FixedHashSet<String> {
@@ -1082,7 +1093,10 @@ fn fold_rdf_lists(nodes: &mut Vec<CarrierNode>, externally_used: impl Fn(&str) -
         .map(|node| node.id.clone())
         .collect();
 
-    let mut incoming: BTreeMap<String, usize> = BTreeMap::new();
+    // List folding only needs to distinguish a unique incoming edge from
+    // multiple edges, so retain a bounded cardinality instead of an unbounded
+    // pointer-sized counter.
+    let mut incoming: BTreeMap<String, u8> = BTreeMap::new();
     let mut external_heads = BTreeSet::new();
     for node in nodes.iter() {
         for (property, values) in &node.properties {
@@ -1171,7 +1185,7 @@ fn collect_annotation_subjects(node: &CarrierNode, output: &mut BTreeSet<String>
 fn count_list_references(
     value: &CarrierValue,
     candidates: &BTreeSet<String>,
-    incoming: &mut BTreeMap<String, usize>,
+    incoming: &mut BTreeMap<String, u8>,
     external_heads: &mut BTreeSet<String>,
     direct_rest: bool,
 ) {
@@ -1194,13 +1208,14 @@ fn count_list_references(
 fn count_list_term_references(
     term: &CarrierTerm,
     candidates: &BTreeSet<String>,
-    incoming: &mut BTreeMap<String, usize>,
+    incoming: &mut BTreeMap<String, u8>,
     external_heads: &mut BTreeSet<String>,
     direct_rest: bool,
 ) {
     match term {
         CarrierTerm::Id(id) if candidates.contains(id) => {
-            *incoming.entry(id.clone()).or_default() += 1;
+            let count = incoming.entry(id.clone()).or_default();
+            increment_multiplicity(count);
             if !direct_rest {
                 external_heads.insert(id.clone());
             }
@@ -1815,6 +1830,15 @@ mod carrier_law_tests {
             })
             .is_none()
         );
+    }
+
+    #[test]
+    fn reference_multiplicity_is_bounded_at_many() {
+        let mut count = 0;
+        for _ in 0..usize::from(u8::MAX) + 1 {
+            increment_multiplicity(&mut count);
+        }
+        assert_eq!(count, 2);
     }
 
     fn assert_exact_carrier_lens(dataset: &RdfDataset, context_value: &Value) {

--- a/crates/rdf/src/native_codecs/jsonld.rs
+++ b/crates/rdf/src/native_codecs/jsonld.rs
@@ -62,27 +62,67 @@ const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
 /// `schemas-archive/purrdf.schema.json`, so a bare member name resolves inside the
 /// bundle.
 const BUNDLED_SCHEMA_REF: &str = "purrdf.schema.json";
-// The serialized JSON-LD output ceiling. A whole-ontology bundle serializes to well over
-// 256MB (occurrence-repeated IRIs over tens of millions of statements); raised to 4 GiB so a
-// large bundle export is admitted while the ceiling still bounds a runaway serialization.
-const MAX_JSON_LD_OUTPUT_BYTES: usize = 4 * 1024 * 1024 * 1024;
+// Logical byte ceilings use u64 through ByteLimit rather than pointer-sized usize. This keeps
+// the carrier contract identical on wasm32 and native targets even when a ceiling exceeds the
+// target address space.
+const MAX_JSON_LD_DOCUMENT_BYTES: ByteLimit = ByteLimit::new(4_u64 * 1024 * 1024 * 1024);
 // The carrier row budget (terms + quads + reifiers + annotations). Raised to 2^25 so a
 // large whole-ontology bundle (tens of millions of composed statements — the authored graph
 // + the RDF-1.2 statement layer + the reasoned closure + bundle-internal named graphs) stays
 // within the decode envelope; the estimated working footprint keeps this a memory-safe
 // ceiling, not an unbounded one.
-const MAX_JSON_LD_CARRIER_ROWS: usize = 33_554_432;
+const MAX_JSON_LD_CARRIER_ROWS: u64 = 33_554_432;
 // Source-carrier retained-text budget: the interned text actually held once.
-const MAX_JSON_LD_CARRIER_TEXT_BYTES: usize = 256 * 1024 * 1024;
+const MAX_JSON_LD_CARRIER_TEXT_BYTES: ByteLimit = ByteLimit::new(256_u64 * 1024 * 1024);
 // Materialized-carrier WORKING-memory budget. The construction estimate
 // (`rows * ESTIMATED_CARRIER_ROW_BYTES + text`) * `COMPACTED_CARRIER_WORKING_COPIES` is a large
 // multiple of the retained text, so a whole-ontology bundle of tens of millions of occurrences
 // estimates into tens of GB even though real materialization stays far lower (the previous
 // codec generation materialized the same bundle unchecked). Kept DISTINCT from the source-text
 // budget so a legitimate large bundle is admitted rather than rejected by a text-sized cap.
-const MAX_JSON_LD_CARRIER_WORKING_BYTES: usize = 32 * 1024 * 1024 * 1024;
-const ESTIMATED_CARRIER_ROW_BYTES: usize = 256;
-const COMPACTED_CARRIER_WORKING_COPIES: usize = 3;
+const MAX_JSON_LD_CARRIER_WORKING_BYTES: ByteLimit = ByteLimit::new(32_u64 * 1024 * 1024 * 1024);
+const ESTIMATED_CARRIER_ROW_BYTES: u64 = 256;
+const COMPACTED_CARRIER_WORKING_COPIES: u64 = 3;
+
+/// A target-independent logical byte ceiling.
+///
+/// Actual buffers remain indexed by `usize`; converting their lengths to `u64` is exact on
+/// every Rust target PurRDF supports. Saturating on a hypothetical wider-pointer target keeps
+/// comparisons fail-closed rather than truncating.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ByteLimit(u64);
+
+impl ByteLimit {
+    const fn new(bytes: u64) -> Self {
+        Self(bytes)
+    }
+
+    fn from_usize(bytes: usize) -> Self {
+        Self(usize_to_u64(bytes))
+    }
+
+    const fn bytes(self) -> u64 {
+        self.0
+    }
+
+    fn admits_usize(self, bytes: usize) -> bool {
+        usize_to_u64(bytes) <= self.bytes()
+    }
+
+    const fn admits_u64(self, bytes: u64) -> bool {
+        bytes <= self.bytes()
+    }
+}
+
+impl std::fmt::Display for ByteLimit {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.bytes().fmt(formatter)
+    }
+}
+
+fn usize_to_u64(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
 
 /// RDF 1.2 reifier predicate.
 pub const RDF_REIFIES: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies";
@@ -309,7 +349,7 @@ pub(crate) fn serialize_ser_graph_with_options(
 }
 
 fn serialize_carrier_expanded(carrier: &CarrierDocument) -> Result<String, RdfDiagnostic> {
-    let mut output = BoundedJsonOutput::new(MAX_JSON_LD_OUTPUT_BYTES);
+    let mut output = BoundedJsonOutput::new(MAX_JSON_LD_DOCUMENT_BYTES);
     carrier.write_expanded_json(&mut output, &build_context())?;
     finish_json_output(output)
 }
@@ -318,7 +358,7 @@ fn serialize_carrier_compacted(
     carrier: &CarrierDocument,
     context: &CompiledJsonLdContext,
 ) -> Result<String, RdfDiagnostic> {
-    let mut output = BoundedJsonOutput::new(MAX_JSON_LD_OUTPUT_BYTES);
+    let mut output = BoundedJsonOutput::new(MAX_JSON_LD_DOCUMENT_BYTES);
     carrier.write_compacted_json(&mut output, context)?;
     finish_json_output(output)
 }
@@ -330,11 +370,11 @@ fn finish_json_output(output: BoundedJsonOutput) -> Result<String, RdfDiagnostic
 
 struct BoundedJsonOutput {
     bytes: Vec<u8>,
-    limit: usize,
+    limit: ByteLimit,
 }
 
 impl BoundedJsonOutput {
-    fn new(limit: usize) -> Self {
+    fn new(limit: ByteLimit) -> Self {
         Self {
             bytes: Vec::new(),
             limit,
@@ -353,7 +393,7 @@ impl IoWrite for BoundedJsonOutput {
             .len()
             .checked_add(bytes.len())
             .ok_or_else(|| std::io::Error::other("JSON-LD output length overflow"))?;
-        if next > self.limit {
+        if !self.limit.admits_usize(next) {
             return Err(std::io::Error::other(format!(
                 "JSON-LD output exceeds {} bytes",
                 self.limit
@@ -652,19 +692,21 @@ fn build_carrier(graph: &SerGraph, fold_lists: bool) -> Result<CarrierDocument, 
 }
 
 fn validate_source_carrier_budget(graph: &SerGraph) -> Result<(), RdfDiagnostic> {
-    let rows = graph
-        .terms
-        .len()
-        .checked_add(graph.quads.len())
-        .and_then(|count| count.checked_add(graph.reifiers.len()))
-        .and_then(|count| count.checked_add(graph.annotations.len()))
-        .ok_or_else(|| decode("JSON-LD carrier row count overflow"))?;
+    let rows = [
+        graph.terms.len(),
+        graph.quads.len(),
+        graph.reifiers.len(),
+        graph.annotations.len(),
+    ]
+    .into_iter()
+    .try_fold(0_u64, |total, count| total.checked_add(usize_to_u64(count)))
+    .ok_or_else(|| decode("JSON-LD carrier row count overflow"))?;
     if rows > MAX_JSON_LD_CARRIER_ROWS {
         return Err(decode(format!(
             "JSON-LD carrier requires {rows} rows; limit is {MAX_JSON_LD_CARRIER_ROWS}"
         )));
     }
-    let retained_text = graph.terms.iter().try_fold(0usize, |total, term| {
+    let retained_text = graph.terms.iter().try_fold(0_u64, |total, term| {
         [
             term.value.as_deref(),
             term.lang.as_deref(),
@@ -672,11 +714,13 @@ fn validate_source_carrier_budget(graph: &SerGraph) -> Result<(), RdfDiagnostic>
         ]
         .into_iter()
         .flatten()
-        .try_fold(total, |total, value| total.checked_add(value.len()))
+        .try_fold(total, |total, value| {
+            total.checked_add(usize_to_u64(value.len()))
+        })
     });
     let retained_text =
         retained_text.ok_or_else(|| decode("JSON-LD carrier retained-text byte count overflow"))?;
-    if retained_text > MAX_JSON_LD_CARRIER_TEXT_BYTES {
+    if !MAX_JSON_LD_CARRIER_TEXT_BYTES.admits_u64(retained_text) {
         return Err(decode(format!(
             "JSON-LD carrier retains {retained_text} text bytes; limit is \
              {MAX_JSON_LD_CARRIER_TEXT_BYTES}"
@@ -687,8 +731,8 @@ fn validate_source_carrier_budget(graph: &SerGraph) -> Result<(), RdfDiagnostic>
 
 #[derive(Debug, Clone, Copy, Default)]
 struct CarrierFootprint {
-    rows: usize,
-    text_bytes: usize,
+    rows: u64,
+    text_bytes: u64,
 }
 
 impl CarrierFootprint {
@@ -738,8 +782,8 @@ fn validate_materialized_carrier_budget(
 fn validate_materialized_carrier_budget_with_limits(
     graph: &SerGraph,
     annotations_of: &AnnotationIndex,
-    max_rows: usize,
-    max_working_bytes: usize,
+    max_rows: u64,
+    max_working_bytes: ByteLimit,
 ) -> Result<(), RdfDiagnostic> {
     let mut footprint = CarrierFootprint::default();
     let mut memo = BTreeMap::new();
@@ -822,13 +866,9 @@ fn validate_materialized_carrier_budget_with_limits(
         )?;
     }
 
-    let structural_bytes = footprint
-        .rows
-        .checked_mul(ESTIMATED_CARRIER_ROW_BYTES)
-        .and_then(|bytes| bytes.checked_add(footprint.text_bytes))
-        .and_then(|bytes| bytes.checked_mul(COMPACTED_CARRIER_WORKING_COPIES))
+    let structural_bytes = estimated_carrier_working_bytes(footprint)
         .ok_or_else(|| decode("JSON-LD carrier working-byte estimate overflow"))?;
-    if footprint.rows > max_rows || structural_bytes > max_working_bytes {
+    if footprint.rows > max_rows || !max_working_bytes.admits_u64(structural_bytes) {
         return Err(decode(format!(
             "JSON-LD materialized carrier requires {} rows and {structural_bytes} working bytes; \
              limits are {max_rows} rows and {max_working_bytes} bytes",
@@ -836,6 +876,14 @@ fn validate_materialized_carrier_budget_with_limits(
         )));
     }
     Ok(())
+}
+
+fn estimated_carrier_working_bytes(footprint: CarrierFootprint) -> Option<u64> {
+    footprint
+        .rows
+        .checked_mul(ESTIMATED_CARRIER_ROW_BYTES)
+        .and_then(|bytes| bytes.checked_add(footprint.text_bytes))
+        .and_then(|bytes| bytes.checked_mul(COMPACTED_CARRIER_WORKING_COPIES))
 }
 
 fn add_annotation_footprint(
@@ -880,13 +928,17 @@ fn carrier_term_footprint(
     })?;
     let mut footprint = CarrierFootprint {
         rows: 1,
-        text_bytes: term
-            .value
-            .as_deref()
-            .map_or(0, str::len)
-            .checked_add(term.lang.as_deref().map_or(0, str::len))
-            .and_then(|bytes| bytes.checked_add(term.direction.as_deref().map_or(0, str::len)))
-            .ok_or_else(|| decode("JSON-LD materialized carrier text count overflow"))?,
+        text_bytes: [
+            term.value.as_deref(),
+            term.lang.as_deref(),
+            term.direction.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .try_fold(0_u64, |total, value| {
+            total.checked_add(usize_to_u64(value.len()))
+        })
+        .ok_or_else(|| decode("JSON-LD materialized carrier text count overflow"))?,
     };
     if term.kind == SerTermKind::Bnode {
         footprint.text_bytes = footprint
@@ -1723,10 +1775,47 @@ fn parse(message: impl Into<String>) -> RdfDiagnostic {
 
 #[cfg(test)]
 mod carrier_law_tests {
+    use std::io::Write as _;
+
     use proptest::prelude::*;
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn logical_byte_budgets_are_target_independent_and_exact() {
+        assert_eq!(MAX_JSON_LD_DOCUMENT_BYTES.bytes(), u64::from(u32::MAX) + 1);
+        assert_eq!(
+            MAX_JSON_LD_CARRIER_WORKING_BYTES.bytes(),
+            32_u64 * 1024 * 1024 * 1024
+        );
+
+        let mut output = BoundedJsonOutput::new(ByteLimit::new(4));
+        output.write_all(b"null").expect("exact output boundary");
+        let error = output
+            .write_all(b" ")
+            .expect_err("one byte over output boundary");
+        assert!(error.to_string().contains("exceeds 4 bytes"));
+    }
+
+    #[test]
+    fn carrier_working_estimate_uses_checked_u64_arithmetic() {
+        let above_u32 = u64::from(u32::MAX) + 1;
+        assert_eq!(
+            estimated_carrier_working_bytes(CarrierFootprint {
+                rows: 0,
+                text_bytes: above_u32,
+            }),
+            above_u32.checked_mul(COMPACTED_CARRIER_WORKING_COPIES)
+        );
+        assert!(
+            estimated_carrier_working_bytes(CarrierFootprint {
+                rows: u64::MAX,
+                text_bytes: 0,
+            })
+            .is_none()
+        );
+    }
 
     fn assert_exact_carrier_lens(dataset: &RdfDataset, context_value: &Value) {
         let graph = build_ser_graph(
@@ -1796,7 +1885,7 @@ mod carrier_law_tests {
                 &build(&one),
                 &annotations,
                 MAX_JSON_LD_CARRIER_ROWS,
-                10_000,
+                ByteLimit::new(10_000),
             )
             .is_ok()
         );
@@ -1804,7 +1893,7 @@ mod carrier_law_tests {
             &build(&many),
             &annotations,
             MAX_JSON_LD_CARRIER_ROWS,
-            10_000,
+            ByteLimit::new(10_000),
         )
         .expect_err("reused literal clones exceed materialized budget");
         assert_eq!(error.code, "native-jsonld-decode");

--- a/crates/rdf/src/native_codecs/jsonld.rs
+++ b/crates/rdf/src/native_codecs/jsonld.rs
@@ -1835,7 +1835,7 @@ mod carrier_law_tests {
     #[test]
     fn reference_multiplicity_is_bounded_at_many() {
         let mut count = 0;
-        for _ in 0..usize::from(u8::MAX) + 1 {
+        for _ in 0..=usize::from(u8::MAX) {
             increment_multiplicity(&mut count);
         }
         assert_eq!(count, 2);

--- a/crates/rdf/src/native_codecs/jsonld/carrier.rs
+++ b/crates/rdf/src/native_codecs/jsonld/carrier.rs
@@ -19,7 +19,7 @@ use serde_json::Value as JsonValue;
 use super::{
     CompiledJsonLdContext, JsonLdContainer, JsonLdDirection, JsonLdNullable, JsonLdTermDefinition,
     JsonLdTermSelection, JsonLdTermSelectionKind, JsonLdTypeMapping, RdfDiagnostic, decode,
-    to_json_object,
+    increment_multiplicity, to_json_object,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -403,7 +403,7 @@ fn plan_graph_index_scope(
     scope: Option<&str>,
     nodes: &[Node],
     named_by_id: &BTreeMap<&str, &NamedGraph>,
-    references: &BTreeMap<String, usize>,
+    references: &BTreeMap<String, u8>,
     context: &CompiledJsonLdContext,
     selection: &JsonLdTermSelection,
     plans: &mut GraphIndexPlans,
@@ -505,7 +505,7 @@ fn consume_graph_index_metadata(
     nodes.retain(|node| !consumed.contains(node.id.as_str()));
 }
 
-fn document_id_reference_counts(document: &Document) -> BTreeMap<String, usize> {
+fn document_id_reference_counts(document: &Document) -> BTreeMap<String, u8> {
     let mut counts = BTreeMap::new();
     for node in document.default_nodes.iter().chain(
         document
@@ -518,7 +518,7 @@ fn document_id_reference_counts(document: &Document) -> BTreeMap<String, usize> 
     counts
 }
 
-fn count_node_term_ids(node: &Node, counts: &mut BTreeMap<String, usize>) {
+fn count_node_term_ids(node: &Node, counts: &mut BTreeMap<String, u8>) {
     for values in node
         .properties
         .values()
@@ -530,17 +530,21 @@ fn count_node_term_ids(node: &Node, counts: &mut BTreeMap<String, usize>) {
     }
 }
 
-fn count_value_term_ids(value: &Value, counts: &mut BTreeMap<String, usize>) {
+fn count_value_term_ids(value: &Value, counts: &mut BTreeMap<String, u8>) {
     count_term_ids(&value.term, counts);
     for annotation in &value.annotations {
-        *counts.entry(annotation.id.clone()).or_default() += 1;
+        let count = counts.entry(annotation.id.clone()).or_default();
+        increment_multiplicity(count);
         count_node_term_ids(annotation, counts);
     }
 }
 
-fn count_term_ids(term: &Term, counts: &mut BTreeMap<String, usize>) {
+fn count_term_ids(term: &Term, counts: &mut BTreeMap<String, u8>) {
     match term {
-        Term::Id(id) => *counts.entry(id.clone()).or_default() += 1,
+        Term::Id(id) => {
+            let count = counts.entry(id.clone()).or_default();
+            increment_multiplicity(count);
+        }
         Term::Triple(triple) => {
             count_term_ids(&triple.subject, counts);
             count_term_ids(&triple.object, counts);
@@ -1722,5 +1726,21 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn graph_container_reference_counts_are_bounded_at_many() {
+        let mut node = Node::new("urn:subject".to_owned());
+        node.properties.insert(
+            "urn:property".to_owned(),
+            (0..=u8::MAX)
+                .map(|_| Value::plain(Term::Id("_:graph".to_owned())))
+                .collect(),
+        );
+        let counts = document_id_reference_counts(&Document {
+            default_nodes: vec![node],
+            named_graphs: Vec::new(),
+        });
+        assert_eq!(counts.get("_:graph"), Some(&2));
     }
 }

--- a/crates/rdf/src/native_codecs/jsonld/carrier.rs
+++ b/crates/rdf/src/native_codecs/jsonld/carrier.rs
@@ -97,8 +97,13 @@ struct ExpandedGraph<'a>(&'a Document);
 
 impl Serialize for ExpandedGraph<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut graph = serializer
-            .serialize_seq(Some(self.0.default_nodes.len() + self.0.named_graphs.len()))?;
+        let graph_len = self
+            .0
+            .default_nodes
+            .len()
+            .checked_add(self.0.named_graphs.len())
+            .ok_or_else(|| S::Error::custom("JSON-LD expanded graph length overflow"))?;
+        let mut graph = serializer.serialize_seq(Some(graph_len))?;
         let mut nodes = self.0.default_nodes.iter().peekable();
         let mut named = self.0.named_graphs.iter().peekable();
         while nodes.peek().is_some() || named.peek().is_some() {

--- a/crates/rdf/src/native_codecs/jsonld/context/mod.rs
+++ b/crates/rdf/src/native_codecs/jsonld/context/mod.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use serde_json::Value;
 
+use super::{ByteLimit, MAX_JSON_LD_DOCUMENT_BYTES};
 use crate::RdfDiagnostic;
 
 pub use options::{JsonLdSerializeMode, JsonLdSerializeOptions};
@@ -35,9 +36,6 @@ const DEFAULT_MAX_TERMS: usize = 4_096;
 const DEFAULT_MAX_NESTING: usize = 64;
 const DEFAULT_MAX_EXPANSION_WORK: usize = 262_144;
 const DEFAULT_MAX_DEFINITION_COMPLEXITY: usize = 131_072;
-// Raised to 4 GiB in lock-step with `MAX_JSON_LD_OUTPUT_BYTES`: a whole-ontology JSON-LD
-// document (the round-tripped bundle export) decodes from well over 256MB.
-const MAX_JSON_LD_DOCUMENT_BYTES: usize = 4 * 1024 * 1024 * 1024;
 const MAX_JSON_LD_DOCUMENT_DEPTH: usize = 128;
 // Raised to 2^25 in lock-step with `MAX_JSON_LD_CARRIER_ROWS`: a large whole-ontology
 // document expands to tens of millions of values, still inside the memory-safe decode envelope.
@@ -106,7 +104,7 @@ impl JsonLdContextLimits {
 
     fn strict_json(self) -> StrictJsonLimits {
         StrictJsonLimits {
-            bytes: self.context_bytes,
+            bytes: ByteLimit::from_usize(self.context_bytes),
             depth: self.nesting,
             values: self.expansion_work,
         }
@@ -114,7 +112,7 @@ impl JsonLdContextLimits {
 
     fn strict_options_json(self) -> StrictJsonLimits {
         StrictJsonLimits {
-            bytes: self.max_options_bytes(),
+            bytes: ByteLimit::from_usize(self.max_options_bytes()),
             depth: self.nesting,
             values: self.expansion_work,
         }

--- a/crates/rdf/src/native_codecs/jsonld/context/strict.rs
+++ b/crates/rdf/src/native_codecs/jsonld/context/strict.rs
@@ -8,11 +8,12 @@ use std::cell::Cell;
 use serde::de::{DeserializeSeed, Error as _, MapAccess, SeqAccess, Visitor};
 use serde_json::{Map, Number, Value};
 
+use super::super::ByteLimit;
 use crate::RdfDiagnostic;
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct StrictJsonLimits {
-    pub(super) bytes: usize,
+    pub(super) bytes: ByteLimit,
     pub(super) depth: usize,
     pub(super) values: usize,
 }
@@ -22,7 +23,7 @@ pub(super) fn parse_strict_json(
     limits: StrictJsonLimits,
     description: &str,
 ) -> Result<Value, RdfDiagnostic> {
-    if bytes.len() > limits.bytes {
+    if !limits.bytes.admits_usize(bytes.len()) {
         return Err(error(format!(
             "{description} is {} bytes; limit is {}",
             bytes.len(),

--- a/crates/rdf/src/native_codecs/jsonld/context/tests.rs
+++ b/crates/rdf/src/native_codecs/jsonld/context/tests.rs
@@ -677,7 +677,7 @@ fn fixed_limits_accept_exact_boundaries_and_reject_one_over() {
     assert_eq!(one_over_work.code, "jsonld-context-limit");
 
     let strict = StrictJsonLimits {
-        bytes: 4,
+        bytes: ByteLimit::new(4),
         depth: 1,
         values: 1,
     };

--- a/crates/rdf/src/native_codecs/jsonld/derived.rs
+++ b/crates/rdf/src/native_codecs/jsonld/derived.rs
@@ -64,15 +64,20 @@ impl CandidateStats {
 
     fn is_profitable(self, alias: &str, namespace: &str) -> Result<bool, RdfDiagnostic> {
         let compacted_bytes = self
-            .occurrences
-            .checked_mul(alias.len() + 1)
-            .and_then(|bytes| bytes.checked_add(self.suffix_bytes))
+            .compacted_bytes(alias.len())
             .ok_or_else(|| derived_limit("derived namespace compacted-byte count overflow"))?;
         let context_cost = prefix_definition_cost(alias, namespace)?;
         Ok(self
             .expanded_bytes
             .checked_sub(compacted_bytes)
             .is_some_and(|saving| saving > context_cost))
+    }
+
+    fn compacted_bytes(self, alias_bytes: usize) -> Option<usize> {
+        alias_bytes
+            .checked_add(1)
+            .and_then(|width| self.occurrences.checked_mul(width))
+            .and_then(|bytes| bytes.checked_add(self.suffix_bytes))
     }
 }
 
@@ -281,7 +286,7 @@ fn namespace_boundary(iri: &str) -> Option<&str> {
     if !parsed.has_scheme() || parsed.query().is_some() {
         return None;
     }
-    let scheme_end = parsed.scheme()?.len() + 1;
+    let scheme_end = parsed.scheme()?.len().checked_add(1)?;
     let boundary = iri
         .rfind('#')
         .filter(|index| *index >= scheme_end)
@@ -332,6 +337,17 @@ mod tests {
         (0..count)
             .map(|index| format!("{namespace}term{index}"))
             .collect()
+    }
+
+    #[test]
+    fn compacted_byte_estimate_checks_alias_width_before_multiplication() {
+        let stats = CandidateStats {
+            expanded_bytes: usize::MAX,
+            suffix_bytes: 0,
+            occurrences: 1,
+        };
+        assert_eq!(stats.compacted_bytes(0), Some(1));
+        assert_eq!(stats.compacted_bytes(usize::MAX), None);
     }
 
     #[test]

--- a/crates/rdf/src/native_codecs/jsonld/expand.rs
+++ b/crates/rdf/src/native_codecs/jsonld/expand.rs
@@ -65,7 +65,7 @@ enum NodeDisposition {
 struct Builder {
     graphs: BTreeMap<Option<String>, BTreeMap<String, Node>>,
     reserved_blank_nodes: BTreeSet<String>,
-    next_blank_node: usize,
+    next_blank_node: u64,
 }
 
 impl Builder {
@@ -1208,7 +1208,7 @@ fn collect_blank_node_ids(value: &JsonValue, output: &mut BTreeSet<String>) {
 struct Lowerer {
     quads: Vec<RdfQuad>,
     reserved_blank_nodes: BTreeSet<String>,
-    next_list: usize,
+    next_list: u64,
 }
 
 impl Lowerer {
@@ -1450,4 +1450,18 @@ fn lower_literal(literal: &Literal) -> Result<RdfTerm, RdfDiagnostic> {
         (None, None, None) => RdfLiteral::simple(literal.lexical.clone()),
     };
     Ok(RdfTerm::literal(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_blank_node_sequence_is_not_pointer_width_limited() {
+        let mut builder = Builder::new(&JsonValue::Null);
+        builder.next_blank_node = u64::from(u32::MAX);
+
+        assert_eq!(builder.fresh_blank_node(), "_:jsonld4294967295");
+        assert_eq!(builder.next_blank_node, u64::from(u32::MAX) + 1);
+    }
 }

--- a/crates/shapes/src/json_schema.rs
+++ b/crates/shapes/src/json_schema.rs
@@ -1859,7 +1859,12 @@ const RESERVED_DEF_KEYS: &[&str] = &["Annotation", "Node"];
 fn reserved_key_seed() -> BTreeMap<String, String> {
     RESERVED_DEF_KEYS
         .iter()
-        .map(|k| ((*k).to_owned(), "JSON Schema reserved definition".to_owned()))
+        .map(|k| {
+            (
+                (*k).to_owned(),
+                "JSON Schema reserved definition".to_owned(),
+            )
+        })
         .collect()
 }
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -37,18 +37,19 @@ make changelog
 # 3. Review, then commit the release bump + changelog.
 git add -A && git commit -m "chore(release): 0.2.2"
 
-# 4. Gate: fmt, clippy, tests, hygiene, and the version-coherence + wasm checks.
-make check
-
-# 5. From an up-to-date main, cut and push all three tags in one command.
+# 4. From an up-to-date main, run the full gate, then cut and push all three tags.
 make release-tags VERSION=0.2.2
 ```
 
 `make release-tags` refuses to run unless the working tree is clean, the branch
-is `main`, `scripts/check-versions.py` passes, and `VERSION` matches the tree —
-then it creates and pushes `rust-v0.2.2`, `py-v0.2.2`, and `npm-v0.2.2`
-together. Each tag triggers its own lane (below); the cargo lane additionally
-publishes a GitHub Release built from the committed `CHANGELOG.md`.
+is `main` and synchronized with `origin/main`, `scripts/check-versions.py`
+passes, `VERSION` matches the tree, the release-notes section exists, and none
+of the three tags already exists locally or remotely. It then runs the complete
+`make check` gate itself, rechecks the clean synchronized state, and atomically
+pushes `rust-v0.2.2`, `py-v0.2.2`, and `npm-v0.2.2` together. No tag is created
+before the full gate passes. Each tag triggers its own lane (below); the cargo
+lane additionally publishes a GitHub Release built from the committed
+`CHANGELOG.md`.
 
 The per-lane tag commands in the sections below remain valid for a single-lane
 re-release, but the coherent path above is the default.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -31,25 +31,30 @@ is a single coherent flow from `main`, using the version-coherence gate and the
 # 1. Bump all three version sources in lockstep (fails unless they end up equal).
 make bump VERSION=0.2.2
 
-# 2. Regenerate the changelog from the conventional-commit history.
+# 2. Regenerate the committed C-ABI header from the bumped crate version.
+make capi-header
+
+# 3. Regenerate the changelog from the conventional-commit history.
 make changelog
 
-# 3. Review, then commit the release bump + changelog.
+# 4. Review, then commit the release bump, generated header, and changelog.
 git add -A && git commit -m "chore(release): 0.2.2"
 
-# 4. From an up-to-date main, run the full gate, then cut and push all three tags.
+# 5. From an up-to-date main, run every release gate, then push all three tags.
 make release-tags VERSION=0.2.2
 ```
 
 `make release-tags` refuses to run unless the working tree is clean, the branch
 is `main` and synchronized with `origin/main`, `scripts/check-versions.py`
 passes, `VERSION` matches the tree, the release-notes section exists, and none
-of the three tags already exists locally or remotely. It then runs the complete
-`make check` gate itself, rechecks the clean synchronized state, and atomically
-pushes `rust-v0.2.2`, `py-v0.2.2`, and `npm-v0.2.2` together. No tag is created
-before the full gate passes. Each tag triggers its own lane (below); the cargo
-lane additionally publishes a GitHub Release built from the committed
-`CHANGELOG.md`.
+of the three tags already exists locally or remotely. It then runs the Rust and
+wasm workspace gate, the generated C-ABI/header check, the native Python binding
+suite, and the optimized size-gated npm/wasm package tests. Only after every
+surface passes does it recheck the clean synchronized state and atomically push
+`rust-v0.2.2`, `py-v0.2.2`, and `npm-v0.2.2` together. No tag is created before
+the complete cross-surface preflight passes. Each tag triggers its own lane
+(below); the cargo lane additionally publishes a GitHub Release built from the
+committed `CHANGELOG.md`.
 
 The per-lane tag commands in the sections below remain valid for a single-lane
 re-release, but the coherent path above is the default.

--- a/docs/book/src/project/releases.md
+++ b/docs/book/src/project/releases.md
@@ -64,18 +64,19 @@ make changelog
 # 3. Review, then commit the release bump + changelog.
 git add -A && git commit -m "chore(release): 0.2.2"
 
-# 4. Gate: fmt, clippy, tests, hygiene, and the version-coherence + wasm checks.
-make check
-
-# 5. From an up-to-date main, cut and push all three tags in one command.
+# 4. From an up-to-date main, run the full gate, then cut and push all three tags.
 make release-tags VERSION=0.2.2
 ```
 
 `make release-tags` refuses to run unless the working tree is clean, the
-branch is `main`, the version check passes, and `VERSION` matches the tree —
-then it creates and pushes the `rust-v`, `py-v`, and `npm-v` tags together.
-Each tag triggers its own lane, and the cargo lane additionally publishes a
-GitHub Release built from the committed `CHANGELOG.md`.
+branch is `main` and synchronized with `origin/main`, the version check passes,
+`VERSION` matches the tree, the release-notes section exists, and none of the
+three tags already exists locally or remotely. It then runs the complete
+`make check` gate itself, rechecks the clean synchronized state, and atomically
+pushes the `rust-v`, `py-v`, and `npm-v` tags together. No tag is created before
+the full gate passes. Each tag triggers its own lane, and the cargo lane
+additionally publishes a GitHub Release built from the committed
+`CHANGELOG.md`.
 
 ## Citing PurRDF
 

--- a/docs/book/src/project/releases.md
+++ b/docs/book/src/project/releases.md
@@ -58,24 +58,29 @@ never drift:
 # 1. Bump all three version sources in lockstep (fails unless they end up equal).
 make bump VERSION=0.2.2
 
-# 2. Regenerate the changelog from the conventional-commit history.
+# 2. Regenerate the committed C-ABI header from the bumped crate version.
+make capi-header
+
+# 3. Regenerate the changelog from the conventional-commit history.
 make changelog
 
-# 3. Review, then commit the release bump + changelog.
+# 4. Review, then commit the release bump, generated header, and changelog.
 git add -A && git commit -m "chore(release): 0.2.2"
 
-# 4. From an up-to-date main, run the full gate, then cut and push all three tags.
+# 5. From an up-to-date main, run every release gate, then push all three tags.
 make release-tags VERSION=0.2.2
 ```
 
 `make release-tags` refuses to run unless the working tree is clean, the
 branch is `main` and synchronized with `origin/main`, the version check passes,
 `VERSION` matches the tree, the release-notes section exists, and none of the
-three tags already exists locally or remotely. It then runs the complete
-`make check` gate itself, rechecks the clean synchronized state, and atomically
-pushes the `rust-v`, `py-v`, and `npm-v` tags together. No tag is created before
-the full gate passes. Each tag triggers its own lane, and the cargo lane
-additionally publishes a GitHub Release built from the committed
+three tags already exists locally or remotely. It then runs the Rust and wasm
+workspace gate, the generated C-ABI/header check, the native Python binding
+suite, and the optimized size-gated npm/wasm package tests. Only after every
+surface passes does it recheck the clean synchronized state and atomically push
+the `rust-v`, `py-v`, and `npm-v` tags together. No tag is created before the
+complete cross-surface preflight passes. Each tag triggers its own lane, and the
+cargo lane additionally publishes a GitHub Release built from the committed
 `CHANGELOG.md`.
 
 ## Citing PurRDF


### PR DESCRIPTION
Closes #160.

## Summary

- represent JSON-LD byte ceilings with a target-independent private `u64` value type, preserving the 4 GiB document and 32 GiB logical working limits on wasm32
- calculate carrier footprints with checked `u64` arithmetic and fail closed on estimate overflow
- harden the wider JSON-LD arithmetic surface: checked expanded-graph aggregation and derived-context sizing, index-free graph pairing, bounded zero/one/many reference multiplicities, and target-independent generated blank-node sequences
- make the standard wasm gate perform optimized code generation for all 17 release crates so const-evaluation/codegen failures are caught before publication
- require Rust/wasm, generated C-ABI, native Python, and size-gated npm/wasm checks on synchronized `main` before release tags exist, then push the Rust, Python, and npm tags atomically
- refresh the generated C header to the canonical 0.8.2 package version and require regeneration after each release bump
- restore the pre-existing SHACL JSON Schema rustfmt drift that blocked the release gate

## Audit result

The three overflowing constants were not the only portability risk. The materialized carrier estimate also used pointer-sized arithmetic before comparing against its 32 GiB logical ceiling. The complete JSON-LD audit additionally found unchecked aggregate calculations, pointer-sized counters whose semantics only require zero/one/many, and generated-identifier counters unnecessarily coupled to pointer width. All are resolved here.

No other JSON-LD `usize` constant exceeds the wasm32 range. Remaining additions are proven by enclosing invariants: slice/string indices advance only while strictly below their lengths; context recursion and term-definition counts have small fixed private ceilings; and sort-key growth is bounded by its four-field representation.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache make check`
- `UV_CACHE_DIR=/tmp/uv-cache make wasm-pkg-test`
- `UV_CACHE_DIR=/tmp/uv-cache make pytest`
- `UV_CACHE_DIR=/tmp/uv-cache make capi-check`
- `cargo build -p purrdf-rdf --target wasm32-unknown-unknown --release --locked`
- `cargo test -p purrdf-rdf --test jsonld_w3c_conformance --locked`
- `actionlint .github/workflows/ci.yaml`

The full gate includes workspace-wide clippy with warnings denied, the complete native test and doctest corpus, generated and frozen-artifact checks, the kernel dependency ring-fence, and optimized wasm32 builds for all 17 published crates. The optimized npm package test verified 55,051 SIMD opcodes, stayed inside the raw wasm and packed-package size budgets, passed 60 Node tests, and passed the packed-tarball install smoke. The native Python suite passed 390 tests with its declared skip/xfail ledger, and the regenerated C header passed byte-exact comparison plus the linked smoke test.
