### PR TITLE
chore(release): 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to the PurRDF crate suite are recorded here. The suite
 ships one lockstep version across crates.io, PyPI, and npm; pre-1.0, a minor
 bump may carry breaking changes and a patch bump is bugfix-only.
 
+## [0.8.3] - 2026-07-23
+
+### Bug Fixes
+
+- **rdf:** Make JSON-LD byte budgets target independent
+- **rdf:** Harden JSON-LD size arithmetic
+- **capi:** Refresh generated package version
+- **rdf:** Complete JSON-LD portability audit
+- **rdf:** Make JSON-LD byte budgets portable
+
+### CI & Build
+
+- **release:** Gate coordinated tags on full checks
+- **release:** Validate every published surface
+
+### Other
+
+- **shapes:** Restore canonical formatting
+
+### Testing
+
+- **rdf:** Use inclusive multiplicity range
+
+## [0.8.2] - 2026-07-22
+
+### Bug Fixes
+
+- **shapes:** Make SHACL-AF function scope re-entrancy-safe under parallel validation
+- **shapes:** Disambiguate ontology classes named after reserved JSON-Schema $def keys
+- **rdf:** Raise JSON-LD carrier/document row ceilings to 2^23 for large bundles
+- **rdf:** Size the JSON-LD carrier envelope for a whole-ontology bundle
+- **rdf:** Raise JSON-LD output/document byte ceilings for whole-ontology bundles
+
 ## [0.8.1] - 2026-07-21
 
 ### Bug Fixes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,8 +21,8 @@ authors:
   - family-names: "Audley"
     given-names: "Patrick"
     orcid: "https://orcid.org/0000-0003-4382-7625"
-version: "0.8.2"
-date-released: "2026-07-21"
+version: "0.8.3"
+date-released: "2026-07-23"
 license:
   - Apache-2.0
   - MIT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "purrdf-columnar",
  "purrdf-entail",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-cli"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "clap",
  "memmap2",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-columnar"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "ahash",
  "criterion",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "ahash",
  "criterion",
@@ -1349,11 +1349,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "0.8.2"
+version = "0.8.3"
 
 [[package]]
 name = "purrdf-gts"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "ahash",
  "boon",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "boon",
  "criterion",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "criterion",
  "hex",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "criterion",
  "insta",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "ahash",
  "criterion",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "criterion",
  "insta",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -45,22 +45,22 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "0.8.2" }
-purrdf-columnar = { path = "crates/columnar", version = "0.8.2" }
-purrdf-core = { path = "crates/rdf-core", version = "0.8.2" }
-purrdf-entail = { path = "crates/entail", version = "0.8.2" }
-purrdf-events = { path = "crates/rdf-events", version = "0.8.2" }
-purrdf-gts = { path = "crates/gts", version = "0.8.2" }
-purrdf-iri = { path = "crates/iri", version = "0.8.2" }
-purrdf-rdf = { path = "crates/rdf", version = "0.8.2" }
-purrdf-shapes = { path = "crates/shapes", version = "0.8.2" }
-purrdf-shex = { path = "crates/shex", version = "0.8.2" }
-purrdf-slice = { path = "crates/slice", version = "0.8.2" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.8.2" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.8.2" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "0.8.2" }
-purrdf-validate = { path = "crates/validate", version = "0.8.2" }
-purrdf-xsd = { path = "crates/xsd", version = "0.8.2" }
+purrdf = { path = "crates/purrdf", version = "0.8.3" }
+purrdf-columnar = { path = "crates/columnar", version = "0.8.3" }
+purrdf-core = { path = "crates/rdf-core", version = "0.8.3" }
+purrdf-entail = { path = "crates/entail", version = "0.8.3" }
+purrdf-events = { path = "crates/rdf-events", version = "0.8.3" }
+purrdf-gts = { path = "crates/gts", version = "0.8.3" }
+purrdf-iri = { path = "crates/iri", version = "0.8.3" }
+purrdf-rdf = { path = "crates/rdf", version = "0.8.3" }
+purrdf-shapes = { path = "crates/shapes", version = "0.8.3" }
+purrdf-shex = { path = "crates/shex", version = "0.8.3" }
+purrdf-slice = { path = "crates/slice", version = "0.8.3" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.8.3" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.8.3" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "0.8.3" }
+purrdf-validate = { path = "crates/validate", version = "0.8.3" }
+purrdf-xsd = { path = "crates/xsd", version = "0.8.3" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "0.8.2"
+version = "0.8.3"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.8.2" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.8.3" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -82,4 +82,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "0.8.2"
+version = "0.8.3"

--- a/crates/rdf-capi/include/purrdf.h
+++ b/crates/rdf-capi/include/purrdf.h
@@ -10,7 +10,7 @@
 /* WARNING: generated file — edit crates/rdf-capi instead. */
 #define PURRDF_MAJOR 0
 #define PURRDF_MINOR 8
-#define PURRDF_PATCH 2
+#define PURRDF_PATCH 3
 
 
 #include <stdarg.h>

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -58,7 +58,7 @@ purrdf-iri = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.8.2" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.8.3" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.8.2" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.8.3" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.


### PR DESCRIPTION
## Summary

- bump every published PurRDF surface to 0.8.3
- regenerate Cargo and Python locks, the C header, and the canonical changelog
- prepare coordinated Rust, Python, and npm publication of the JSON-LD portability fix and audit

## Validation

- `cargo fmt --all --check`
- `python3 scripts/check-versions.py`
- `bash scripts/check-generated.sh`
- `UV_CACHE_DIR=/tmp/uv-cache make capi-check`
- `git diff --check`

## Release

Tag publication is performed from the signed squash commit by `make release-tags VERSION=0.8.3`, which gates all three coordinated tags on the full cross-surface release preflight and pushes them atomically.
