### PR TITLE
fix(slice): scope ownership by declared term namespaces, not the framework ns

### DIFF
--- a/crates/slice/src/ownership.rs
+++ b/crates/slice/src/ownership.rs
@@ -36,6 +36,7 @@ use crate::artifact::{ArtifactRecord, ArtifactRole};
 use crate::catalog::{SliceCatalog, SliceRecord};
 use crate::error::SliceError;
 use crate::rdf_query::{Dataset, NamedNode};
+use crate::vocab::SliceVocab;
 
 // ── Namespace constants ───────────────────────────────────────────────────────
 //
@@ -316,7 +317,7 @@ impl<'a> OwnershipAnalyzer<'a> {
                     continue;
                 }
                 let store = parse_rdf_artifact(artifact)?;
-                let facts = inspect_rdf_dataset(store.inner(), self.catalog.vocab().ns());
+                let facts = inspect_rdf_dataset(store.inner(), self.catalog.vocab());
                 // Collect rdfs:isDefinedBy claims.
                 for (subject, owner) in &facts.is_defined_by {
                     claims
@@ -484,10 +485,7 @@ impl<'a> OwnershipAnalyzer<'a> {
                     let Ok(store) = parse_rdf_artifact(artifact) else {
                         continue;
                     };
-                    entry.insert(inspect_rdf_dataset(
-                        store.inner(),
-                        self.catalog.vocab().ns(),
-                    ));
+                    entry.insert(inspect_rdf_dataset(store.inner(), self.catalog.vocab()));
                 }
                 let referenced = &rdf_facts[&key].referenced_iris;
                 collect_reference_evidence(
@@ -657,7 +655,15 @@ fn parse_rdf_artifact(artifact: &ArtifactRecord) -> Result<Dataset, SliceError> 
 
 /// Inspect one parsed RDF artifact once. Borrowed IRI slices are deduplicated
 /// while walking the interned IR, then only the unique retained values are owned.
-fn inspect_rdf_dataset(store: &RdfDataset, vocab_ns: &str) -> RdfArtifactFacts {
+/// Scan one parsed artifact for the three ownership-relevant fact sets.
+///
+/// `is_defined_by` and `declared_terms` are gated on [`SliceVocab::owns_term`]
+/// — the test is on the SUBJECT's own IRI, so a slice minting into a namespace
+/// the caller never declared contributes no ownership data and every reference
+/// to its terms later resolves to no owner. `referenced_iris` is deliberately
+/// ungated: a reference to an unowned IRI is simply dropped at the ownership
+/// join in [`collect_reference_evidence`].
+fn inspect_rdf_dataset(store: &RdfDataset, vocab: &SliceVocab) -> RdfArtifactFacts {
     let mut is_defined_by: BTreeSet<(&str, &str)> = BTreeSet::new();
     let mut declared_terms: BTreeSet<&str> = BTreeSet::new();
     let mut referenced_iris: BTreeSet<&str> = BTreeSet::new();
@@ -680,13 +686,10 @@ fn inspect_rdf_dataset(store: &RdfDataset, vocab_ns: &str) -> RdfArtifactFacts {
             continue;
         };
 
-        if predicate == RDFS_IS_DEFINED_BY && subject.starts_with(vocab_ns) {
+        if predicate == RDFS_IS_DEFINED_BY && vocab.owns_term(subject) {
             is_defined_by.insert((subject, object));
         }
-        if predicate == RDF_TYPE
-            && subject.starts_with(vocab_ns)
-            && VOCAB_TERM_TYPES.contains(&object)
-        {
+        if predicate == RDF_TYPE && vocab.owns_term(subject) && VOCAB_TERM_TYPES.contains(&object) {
             declared_terms.insert(subject);
         }
     }
@@ -1052,7 +1055,7 @@ mod rdf_fact_tests {
              ex:record ex:mentions <<( ex:term ex:edge \"value\"^^ex:datatype )>> .\n"
         );
         let store = Dataset::parse_turtle(input.as_bytes(), "facts.ttl").expect("valid RDF 1.2");
-        let facts = inspect_rdf_dataset(store.inner(), EX);
+        let facts = inspect_rdf_dataset(store.inner(), &SliceVocab::for_namespace(EX));
 
         assert_eq!(
             facts.is_defined_by,
@@ -1074,5 +1077,43 @@ mod rdf_fact_tests {
                 "missing {local}"
             );
         }
+    }
+
+    /// A slice minting into its own namespace carries ownership when — and only
+    /// when — the caller declared that namespace. Ownership is tested against
+    /// the SUBJECT's IRI, so an undeclared namespace makes the slice's entire
+    /// vocabulary invisible: no `isDefinedBy`, no declared terms, and hence no
+    /// dependency edge for any reference to it.
+    #[test]
+    fn ownership_follows_the_declared_term_namespaces() {
+        const MATH: &str = "https://example.org/math/";
+        let input = format!(
+            "@prefix ex: <{EX}> .\n\
+             @prefix math: <{MATH}> .\n\
+             @prefix owl: <http://www.w3.org/2002/07/owl#> .\n\
+             @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\
+             math:Quantity a owl:Class ; rdfs:isDefinedBy ex:slices/math .\n"
+        );
+        let store = Dataset::parse_turtle(input.as_bytes(), "facts.ttl").expect("valid RDF 1.2");
+        let quantity = NamedNode::new_unchecked(format!("{MATH}Quantity"));
+
+        // Declared: the term is owned, exactly as a framework-namespace term is.
+        let facts = inspect_rdf_dataset(
+            store.inner(),
+            &SliceVocab::for_namespace(EX).with_term_namespaces([MATH]),
+        );
+        assert_eq!(
+            facts.is_defined_by,
+            vec![(quantity.clone(), format!("{EX}slices/math"))]
+        );
+        assert!(facts.declared_terms.contains(&quantity));
+
+        // Undeclared: invisible to ownership, though still collected as a
+        // reference — which is precisely how the reference is silently dropped
+        // at the ownership join.
+        let facts = inspect_rdf_dataset(store.inner(), &SliceVocab::for_namespace(EX));
+        assert!(facts.is_defined_by.is_empty());
+        assert!(facts.declared_terms.is_empty());
+        assert!(facts.referenced_iris.contains(&quantity));
     }
 }

--- a/crates/slice/src/vocab.rs
+++ b/crates/slice/src/vocab.rs
@@ -20,22 +20,58 @@
 //! assert_eq!(vocab.prefix_name(), "vocab");
 //! assert_eq!(vocab.ontology_iri(), "https://example.org/vocab");
 //! ```
+//!
+//! ## Framework namespace vs. owned term namespaces
+//!
+//! Two distinct things are easy to conflate, and conflating them silently
+//! disables ownership analysis for part of a corpus:
+//!
+//! * The **framework namespace** ([`SliceVocab::ns`]) mints the slice-framework
+//!   terms themselves — `Slice`, `sliceTier`, `sliceDependsOn`, the
+//!   analysis-graph terms. There is exactly one.
+//! * The **owned term namespaces** ([`SliceVocab::term_namespaces`]) are the
+//!   namespaces the caller's slices mint ONTOLOGY terms into — the IRIs that
+//!   carry `rdfs:isDefinedBy` and that cross-slice references resolve against.
+//!   A corpus may mint into several, and a slice may mint into a namespace no
+//!   other slice uses.
+//!
+//! The framework namespace is always an owned term namespace, so a single-
+//! namespace caller needs no extra configuration. A caller whose slices mint
+//! elsewhere MUST declare those namespaces with
+//! [`SliceVocab::with_term_namespaces`] — a term in an undeclared namespace is
+//! invisible to the ownership analyzer, so every reference to it resolves to no
+//! owner and contributes no dependency edge.
+//!
+//! ```
+//! use purrdf_slice::SliceVocab;
+//! let vocab = SliceVocab::for_namespace("https://example.org/vocab/")
+//!     .with_term_namespaces(["https://example.org/math/"]);
+//! assert!(vocab.owns_term("https://example.org/vocab/Thing"));
+//! assert!(vocab.owns_term("https://example.org/math/Quantity"));
+//! assert!(!vocab.owns_term("http://www.w3.org/2002/07/owl#Class"));
+//! ```
 
-/// The caller's slice-framework vocabulary: a namespace all term IRIs are
-/// derived from by concatenation (`{ns}{localName}`), plus the CURIE prefix
-/// name used when emitting prefixed names.
+use std::collections::BTreeSet;
+
+/// The caller's slice-framework vocabulary: a namespace all framework term IRIs
+/// are derived from by concatenation (`{ns}{localName}`), the set of namespaces
+/// the caller's slices mint ontology terms into, plus the CURIE prefix name used
+/// when emitting prefixed names.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SliceVocab {
     ns: String,
+    term_namespaces: BTreeSet<String>,
     prefix_name: String,
 }
 
 impl SliceVocab {
-    /// Construct a vocabulary rooted at `ns` (every term is `{ns}{localName}`).
+    /// Construct a vocabulary rooted at `ns` (every framework term is
+    /// `{ns}{localName}`), owning terms in `ns` and no other namespace.
     ///
     /// The CURIE prefix name defaults to the last non-empty path segment of the
     /// namespace (e.g. `https://example.org/gm/` → `gm`); override it with
-    /// [`SliceVocab::with_prefix_name`].
+    /// [`SliceVocab::with_prefix_name`]. Declare additional term namespaces with
+    /// [`SliceVocab::with_term_namespaces`].
     #[must_use]
     pub fn for_namespace(ns: &str) -> Self {
         let trimmed = ns.trim_end_matches(['/', '#']);
@@ -47,8 +83,26 @@ impl SliceVocab {
             .to_owned();
         Self {
             ns: ns.to_owned(),
+            term_namespaces: BTreeSet::from([ns.to_owned()]),
             prefix_name,
         }
+    }
+
+    /// Declare additional namespaces the caller's slices mint ontology terms
+    /// into. The framework namespace is always owned and never removed.
+    ///
+    /// Ownership is tested against the TERM IRI itself, so a slice minting
+    /// exclusively into an undeclared namespace contributes no ownership data at
+    /// all and every reference to its terms resolves to no owner.
+    #[must_use]
+    pub fn with_term_namespaces<I, S>(mut self, namespaces: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.term_namespaces
+            .extend(namespaces.into_iter().map(|n| n.as_ref().to_owned()));
+        self
     }
 
     /// Override the CURIE prefix name used for prefixed-name emission.
@@ -58,10 +112,27 @@ impl SliceVocab {
         self
     }
 
-    /// The vocabulary namespace (as given, trailing separator preserved).
+    /// The framework vocabulary namespace (as given, trailing separator
+    /// preserved). This mints the slice-framework terms; it is NOT the test for
+    /// whether an arbitrary term IRI is owned — see [`SliceVocab::owns_term`].
     #[must_use]
     pub fn ns(&self) -> &str {
         &self.ns
+    }
+
+    /// Every namespace the caller's slices mint ontology terms into, including
+    /// the framework namespace. Sorted and deduplicated.
+    #[must_use]
+    pub fn term_namespaces(&self) -> &BTreeSet<String> {
+        &self.term_namespaces
+    }
+
+    /// Whether `iri` lies in one of the owned term namespaces — the single test
+    /// deciding whether a subject can carry ownership and whether a reference
+    /// can resolve to an owning slice.
+    #[must_use]
+    pub fn owns_term(&self, iri: &str) -> bool {
+        self.term_namespaces.iter().any(|ns| iri.starts_with(ns))
     }
 
     /// The CURIE prefix name for emitted prefixed names (`{prefix}:{local}`).
@@ -219,6 +290,31 @@ mod tests {
         let v = SliceVocab::for_namespace("https://example.org/vocab/").with_prefix_name("ex");
         assert_eq!(v.prefix_name(), "ex");
         assert_eq!(v.ns(), "https://example.org/vocab/");
+    }
+
+    #[test]
+    fn framework_namespace_is_always_an_owned_term_namespace() {
+        let v = SliceVocab::for_namespace("https://example.org/vocab/");
+        assert_eq!(
+            v.term_namespaces(),
+            &BTreeSet::from(["https://example.org/vocab/".to_owned()])
+        );
+        assert!(v.owns_term("https://example.org/vocab/Thing"));
+        assert!(!v.owns_term("https://example.org/math/Quantity"));
+    }
+
+    #[test]
+    fn additional_term_namespaces_are_owned_and_never_displace_the_framework_ns() {
+        let v = SliceVocab::for_namespace("https://example.org/vocab/")
+            .with_term_namespaces(["https://example.org/math/", "https://example.org/lang/"]);
+        assert!(v.owns_term("https://example.org/vocab/Slice"));
+        assert!(v.owns_term("https://example.org/math/Quantity"));
+        assert!(v.owns_term("https://example.org/lang/Rendering"));
+        assert!(!v.owns_term("http://www.w3.org/2002/07/owl#Class"));
+        // The framework namespace still mints the framework terms.
+        assert_eq!(v.ns(), "https://example.org/vocab/");
+        assert_eq!(v.slice_class(), "https://example.org/vocab/Slice");
+        assert_eq!(v.term_namespaces().len(), 3);
     }
 
     #[test]


### PR DESCRIPTION
## The defect

`inspect_rdf_dataset` gated `rdfs:isDefinedBy` claims and declared vocabulary terms on
`subject.starts_with(vocab.ns())` — the **framework** namespace, the one minting
`Slice` / `sliceTier` / `sliceDependsOn`. That is a different thing from the namespaces a
caller's slices mint **ontology terms** into. Reusing one string for both silently disables
ownership analysis for any slice that mints elsewhere.

The failure is invisible by construction. `referenced_iris` is *not* gated, so references to
such a slice's terms are collected and then dropped at the ownership join in
`collect_reference_evidence` (`validated_owner.get(term)` misses). A corpus where most slices
mint into the framework namespace produces plausible output everywhere except the slices that
don't — with no diagnostic, no `Unowned` finding, nothing.

Found via the gmeow-ontology corpus, where the `math` grounding slice mints 2537 subjects
entirely into its own namespace and zero into the framework namespace. Every dependency edge
into `math` was therefore uncomputable, and every `sliceDependsOn … math` declaration read as
permanently stale.

## The change

- `SliceVocab` gains `term_namespaces: BTreeSet<String>` — always containing the framework
  namespace — with a `with_term_namespaces` builder and an `owns_term(iri)` predicate.
- `inspect_rdf_dataset` takes the `&SliceVocab` and tests ownership through `owns_term`.
- `ns()` keeps its meaning (the framework vocabulary) and is documented as *not* the ownership
  test; the module docs now spell out the two-namespace distinction.

**Behaviour for existing callers is unchanged.** `for_namespace` seeds the set with `ns`, so a
single-namespace caller gets exactly today's semantics; multi-namespace ownership is opt-in.

## Tests

`ownership_follows_the_declared_term_namespaces` pins both directions — a term in a declared
namespace is owned exactly as a framework-namespace term is, and the same term with its
namespace undeclared is invisible to ownership *while still appearing as a reference*. That
second assertion characterizes the silent-drop path so it cannot regress unnoticed.

Two `vocab` tests cover the framework namespace always being owned and additional namespaces
never displacing it.

## Verification

- `cargo nextest run --workspace --exclude purrdf-python` → **3072 passed, 2 skipped**
- `cargo fmt --check -p purrdf-slice` clean; `cargo clippy -p purrdf-slice --all-targets` clean
- `purrdf-python` excluded only because its pyo3 test target fails to link in a fresh worktree
  without a local libpython; unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for declaring multiple namespaces as owned vocabulary terms.
  * Ownership detection now correctly recognizes terms from all configured namespaces.

* **Bug Fixes**
  * Improved RDF ownership classification to avoid incorrectly attributing unrelated terms.
  * Refined vocabulary term detection and `rdfs:isDefinedBy` handling for more accurate results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->