### PR TITLE
feat(gts)!: pin caller-supplied in-band dictionary bytes in a compaction plan

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -11,6 +11,11 @@
 # Exact rendered scope/message pairs are emitted once per release group. Multiple
 # implementation commits can legitimately share a conventional subject, but one
 # repeated user-facing release-note bullet carries no additional information.
+#
+# A conventional `type(scope)!:` subject or a `BREAKING CHANGE:` footer renders a
+# leading **BREAKING** marker on its bullet. Pre-1.0 the suite ships breaking
+# changes under a minor bump, so the changelog is the only place a consumer can
+# see that a bump carries one — it must never be silent.
 
 [changelog]
 header = """
@@ -37,7 +42,7 @@ body = """
 {% set entry_key = entry_scope ~ "::" ~ entry_message -%}
 {% if entry_key not in rendered_entries -%}
 {% set_global rendered_entries = rendered_entries | concat(with=entry_key) -%}
-- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | upper_first | trim }}
+- {% if commit.breaking %}**BREAKING** {% endif %}{% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | upper_first | trim }}
 {% endif -%}
 {% endfor %}
 
@@ -80,7 +85,9 @@ commit_parsers = [
   { message = ".*", group = "Other" },
 ]
 
-protect_breaking_commits = false
+# A breaking commit is never dropped by a `skip = true` parser: pre-1.0 a minor
+# bump MAY carry breaking changes, so the marker must always reach the changelog.
+protect_breaking_commits = true
 filter_commits = false
 # Only the canonical crates.io release tags mark releases; the parallel
 # `py-v*` / `npm-v*` tags carry the same version and are not release boundaries.

--- a/crates/gts/src/compact.rs
+++ b/crates/gts/src/compact.rs
@@ -36,25 +36,54 @@ const XSD_DATETIME: &str = "http://www.w3.org/2001/XMLSchema#dateTime";
 
 /// The conventional in-band pack dictionary name for a single-dictionary plan.
 pub const DEFAULT_DICT_NAME: &str = "pack";
-/// Target size of a pinned pack dictionary. FastCOVER/raw-content truncate the
-/// content to fit; a fixed value keeps compaction byte-deterministic.
+/// Target size of a DERIVED in-band pack dictionary. FastCOVER/raw-content
+/// truncate the corpus to fit; a fixed value keeps compaction
+/// byte-deterministic. [`DictStrategy::Pinned`] bytes are never truncated — they
+/// are the caller's, verbatim.
 const DICT_TARGET_LEN: usize = 16 * 1024;
 
-/// How one named in-band dictionary's bytes are derived from the content-blob
-/// corpus (§8.5 `dct`).
+/// Where one named in-band dictionary's bytes come from (§8.5 `dct`).
 ///
-/// Both are byte-deterministic; the trained strategy is the production default
-/// (Req 3 headline is "trained"), and the raw-content strategy is a named
-/// alternate. The choice affects only the pinned dictionary bytes, never the
-/// fold — a reader decodes the in-band dictionary either way. "No dictionary"
-/// is NOT a strategy: it is an empty [`DictPlan::dicts`], so a plan can never
-/// name a dictionary that produces nothing.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// [`Self::Trained`] and [`Self::RawContent`] DERIVE the bytes from the pack's
+/// own content-blob corpus. [`Self::Pinned`] carries caller-supplied bytes used
+/// VERBATIM. All three end up pinned in the header `"dct"` map — the variant
+/// names where the bytes come from, not whether they are stored in-band.
+///
+/// The derived strategies are byte-deterministic functions of the corpus: the
+/// trained one is the production default (Req 3 headline is "trained"), the
+/// raw-content one a named alternate. [`Self::Pinned`] exists because a derived
+/// dictionary cannot honour an EXTERNAL dictionary id: a consumer that ships
+/// named dictionaries and asks for a pack "under dictionary X" must get X's
+/// actual bytes, not a pack-local re-derivation wearing X's name — otherwise one
+/// id resolves to many byte sequences and stops identifying a decodable
+/// dictionary at all.
+///
+/// The choice affects only the dictionary bytes, never the fold — a reader
+/// decodes the in-band dictionary either way. "No dictionary" is NOT a strategy:
+/// it is an empty [`DictPlan::dicts`], so a plan can never name a dictionary
+/// that produces nothing.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DictStrategy {
-    /// FastCOVER-trained dictionary (the production default).
+    /// FastCOVER-trained over the content-blob corpus (the production default).
     Trained,
-    /// Raw-content dictionary (canonical trailing window of the corpus).
+    /// Raw-content over the content-blob corpus (its canonical trailing window).
     RawContent,
+    /// Caller-supplied finalized zstd dictionary bytes, used verbatim: no
+    /// training, no corpus derivation, no truncation. These exact bytes ride the
+    /// header `"dct"` map under the plan's name, so the pinned name resolves to
+    /// exactly the dictionary the caller shipped.
+    Pinned(Vec<u8>),
+}
+
+impl DictStrategy {
+    /// Whether this strategy DERIVES its bytes from the pack's content-blob
+    /// corpus — and therefore requires the pack to have one.
+    fn derives_from_corpus(&self) -> bool {
+        match self {
+            Self::Trained | Self::RawContent => true,
+            Self::Pinned(_) => false,
+        }
+    }
 }
 
 /// Which in-band dictionary primes a frame — TOTAL, never `Option`.
@@ -89,8 +118,12 @@ impl DictSelection {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DictPlan {
     /// Named dictionaries to pin in the header `"dct"` map, each with the
-    /// producer deriving its bytes from the content-blob corpus. Empty pins no
-    /// dictionary at all.
+    /// strategy that supplies its bytes — derived from the content-blob corpus
+    /// ([`DictStrategy::Trained`]/[`DictStrategy::RawContent`]) or supplied
+    /// verbatim by the caller ([`DictStrategy::Pinned`]). The two kinds may be
+    /// MIXED in one plan: each entry's bytes are obtained independently, and a
+    /// corpus is required only if some entry actually derives from one. Empty
+    /// pins no dictionary at all.
     pub dicts: Vec<(String, DictStrategy)>,
     /// Which pinned dictionary primes the content-blob frames.
     pub content: DictSelection,
@@ -141,17 +174,37 @@ impl DictPlan {
         }
     }
 
-    /// Validate the plan's internal consistency (unique non-empty names, every
-    /// selection naming a pinned dictionary, a dictionary only where a
-    /// zstd-family transform can consume it).
+    /// Validate the plan's internal consistency (unique non-empty names, usable
+    /// caller-supplied dictionary bytes, every selection naming a pinned
+    /// dictionary, a dictionary only where a zstd-family transform can consume
+    /// it).
     fn validate(&self) -> Result<(), CompactRefusedError> {
         let mut seen: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
-        for (name, _) in &self.dicts {
+        for (name, strategy) in &self.dicts {
             if name.is_empty() {
                 return refuse("an in-band dictionary name must be non-empty".to_string());
             }
             if !seen.insert(name.as_str()) {
                 return refuse(format!("duplicate in-band dictionary name {name:?}"));
+            }
+            // Refuse-don't-trust on the ONE input the compactor does not
+            // produce itself: caller-supplied bytes are used verbatim, so they
+            // must actually be a finalized zstd dictionary a frame can be primed
+            // with and a reader can resolve. A derived strategy cannot reach
+            // here — its producer already finalizes.
+            if let DictStrategy::Pinned(bytes) = strategy {
+                let id = dict::dictionary_id(bytes).map_err(|err| {
+                    CompactRefusedError(format!(
+                        "the pinned dictionary {name:?} is not a parseable finalized zstd \
+                         dictionary: {err}"
+                    ))
+                })?;
+                if id == 0 {
+                    return refuse(format!(
+                        "the pinned dictionary {name:?} declares Dictionary_ID 0, which cannot \
+                         prime a zstd encoder (§8.5 dct)"
+                    ));
+                }
             }
         }
         let zstd_family = self
@@ -816,15 +869,24 @@ fn value_idx(v: &Value) -> Option<usize> {
     }
 }
 
-/// Build every in-band pack dictionary the plan names, over the batched
-/// content-blob corpus.
+/// Obtain every in-band pack dictionary the plan names: derived entries over the
+/// batched content-blob corpus, [`DictStrategy::Pinned`] entries verbatim.
 ///
 /// The corpus is every content blob's decoded bytes (the sealed original — the
 /// whole source log — is excluded, it is not "content"). A pack with no content
-/// blobs has no corpus to build from; a plan that nonetheless NAMES a dictionary
-/// is refused rather than silently downgraded to an undicted pack, because the
+/// blobs has no corpus to DERIVE from; a plan whose entries derive is therefore
+/// refused rather than silently downgraded to an undicted pack, because the
 /// caller asked for a density guarantee the pack could not then honour.
-/// The producers are order-independent, so the emitted `dct` bytes equal
+///
+/// That refusal is a consequence of derivation, not of pinning a dictionary at
+/// all: caller-supplied bytes exist independently of the pack's content, so a
+/// wholly-[`DictStrategy::Pinned`] plan never touches the corpus and compacts a
+/// blob-less input (a terms/quads-only log) exactly as it compacts any other. A
+/// MIXED plan is accepted and each entry is obtained on its own terms — but its
+/// derived entries still need a corpus, so a mixed plan over a blob-less input
+/// hits the same refusal.
+///
+/// The derived producers are order-independent, so the emitted `dct` bytes equal
 /// `trained_dict`/`raw_content_dict` of the corpus regardless of iteration order.
 fn build_pack_dicts(
     g: &Graph,
@@ -835,21 +897,30 @@ fn build_pack_dicts(
     if plan.dicts.is_empty() {
         return Ok(Vec::new());
     }
+    // Only DERIVED entries need the corpus; decoding every content blob for a
+    // wholly-pinned plan would be pure waste, and demanding one would be the
+    // very refusal this function must no longer raise.
+    let derives = plan
+        .dicts
+        .iter()
+        .any(|(_, strategy)| strategy.derives_from_corpus());
     let mut corpus: Vec<Vec<u8>> = Vec::new();
-    for digest in blob_order {
-        if Some(digest.as_str()) == sealed_digest {
-            continue;
+    if derives {
+        for digest in blob_order {
+            if Some(digest.as_str()) == sealed_digest {
+                continue;
+            }
+            if let Some(bytes) = blob_bytes(g, digest)? {
+                corpus.push(bytes.into_owned());
+            }
         }
-        if let Some(bytes) = blob_bytes(g, digest)? {
-            corpus.push(bytes.into_owned());
+        if corpus.is_empty() {
+            return refuse(
+                "the plan pins in-band dictionaries but the input has no content blobs to \
+                 build them from (§8.5 dct)"
+                    .to_string(),
+            );
         }
-    }
-    if corpus.is_empty() {
-        return refuse(
-            "the plan pins in-band dictionaries but the input has no content blobs to \
-             build them from (§8.5 dct)"
-                .to_string(),
-        );
     }
     let refs: Vec<&[u8]> = corpus.iter().map(Vec::as_slice).collect();
     let mut out = Vec::with_capacity(plan.dicts.len());
@@ -861,6 +932,9 @@ fn build_pack_dicts(
                 dict::trained_dict(&refs, DICT_TARGET_LEN, dict::DictSeed::FromCorpus)
             }
             DictStrategy::RawContent => dict::raw_content_dict(&refs, DICT_TARGET_LEN),
+            // Verbatim: the caller's bytes ARE the dictionary. Validated as a
+            // parseable finalized dictionary by `DictPlan::validate`.
+            DictStrategy::Pinned(bytes) => Ok(bytes.clone()),
         }
         .map_err(|err| {
             CompactRefusedError(format!("cannot build the pack dictionary {name:?}: {err}"))
@@ -881,8 +955,9 @@ pub struct CompactionParams<'a> {
     /// `"source"` — REQUIRED for `evidence` input.
     pub seal_original: bool,
     /// The named multi-dictionary + transform plan: which dictionaries the
-    /// pack pins, which one primes which frames, the transform chain every
-    /// authored frame rides, and the declared zstd level.
+    /// pack pins (derived from the pack's own corpus, or supplied verbatim by
+    /// the caller — see [`DictStrategy`]), which one primes which frames, the
+    /// transform chain every authored frame rides, and the declared zstd level.
     pub plan: DictPlan,
     /// When supplied by the certifying authoring wrapper, embedded as
     /// `stream:contentRefoldDigest` provenance so a repack certifies without
@@ -909,8 +984,10 @@ pub struct CompactionParams<'a> {
 ///
 /// # Errors
 /// Returns [`CompactRefusedError`] when the input is not safely compactable, a
-/// blob cannot be decoded, the pack dictionary cannot be built, or the writer
-/// rejects the configuration.
+/// blob cannot be decoded, a pinned dictionary's caller-supplied bytes are not a
+/// usable finalized zstd dictionary, a DERIVED pack dictionary cannot be built
+/// (including when the input carries no content-blob corpus to derive one from),
+/// or the writer rejects the configuration.
 pub fn compact_streamable(
     data: &[u8],
     params: CompactionParams<'_>,
@@ -950,8 +1027,9 @@ pub fn compact_streamable(
         None
     };
 
-    // Pack dictionaries built over the batched content-blob corpus (the sealed
-    // original — the whole source — is excluded). The dict producers are
+    // Pack dictionaries: derived entries built over the batched content-blob
+    // corpus (the sealed original — the whole source — is excluded), pinned
+    // entries taken verbatim from the plan. The derived producers are
     // order-independent, so blob-delivery order need not be threaded here.
     let dicts = build_pack_dicts(&g, &blob_order, sealed_digest.as_deref(), &plan)?;
 

--- a/crates/gts/src/compact.rs
+++ b/crates/gts/src/compact.rs
@@ -192,19 +192,19 @@ impl DictPlan {
             // must actually be a finalized zstd dictionary a frame can be primed
             // with and a reader can resolve. A derived strategy cannot reach
             // here — its producer already finalizes.
+            //
+            // The parse IS the whole gate: `dictionary_id` decodes the finalized
+            // dictionary, and that decode already rejects a zero `Dictionary_ID`
+            // (§8.5 `dct` — a zero id cannot prime a zstd encoder). A separate
+            // `id == 0` branch here would be unreachable, and an unreachable
+            // guard advertises an invariant it does not enforce.
             if let DictStrategy::Pinned(bytes) = strategy {
-                let id = dict::dictionary_id(bytes).map_err(|err| {
+                dict::dictionary_id(bytes).map_err(|err| {
                     CompactRefusedError(format!(
                         "the pinned dictionary {name:?} is not a parseable finalized zstd \
                          dictionary: {err}"
                     ))
                 })?;
-                if id == 0 {
-                    return refuse(format!(
-                        "the pinned dictionary {name:?} declares Dictionary_ID 0, which cannot \
-                         prime a zstd encoder (§8.5 dct)"
-                    ));
-                }
             }
         }
         let zstd_family = self

--- a/crates/gts/tests/pinned_dict_compaction.rs
+++ b/crates/gts/tests/pinned_dict_compaction.rs
@@ -37,7 +37,7 @@ use purrdf_gts::wire::{iter_items, map_get};
 use purrdf_gts::writer::Writer;
 
 /// The name the caller pins its shipped dictionary under.
-const PINNED_NAME: &str = "gmeow-bundle-v1";
+const PINNED_NAME: &str = "shipped-bundle-v1";
 /// The zstd level the pinned plans declare (§8.5 `level?`).
 const LEVEL: i32 = 12;
 /// The fixed rewrite timestamp — never ambient time (§14.1).
@@ -55,7 +55,7 @@ fn shipped_dictionary() -> Vec<u8> {
     let corpus: Vec<Vec<u8>> = (0..400u32)
         .map(|i| {
             format!(
-                "<https://gmeow.example/slice/logic#c{}> <https://gmeow.example/p/grounds> \
+                "<https://example.org/slice/logic#c{}> <https://example.org/p/grounds> \
                  \"a shipped-vocabulary sentence unrelated to any packed content, {}\" .\n",
                 i % 23,
                 i
@@ -489,10 +489,17 @@ fn a_mixed_plan_pins_the_callers_bytes_and_derives_the_rest() {
     let pack = compact_streamable(&source, params(mixed)).expect("a mixed plan compacts");
 
     let dct = header_dct(&pack);
+    // The header `"dct"` map is ordered by NAME, never by plan order — that is
+    // what keeps the emitted bytes a function of the dictionary SET rather than
+    // of how the caller happened to sequence the plan. Sort the expectation
+    // rather than hard-coding one arrangement, so renaming a fixture dictionary
+    // cannot quietly turn this into an assertion about alphabetical luck.
+    let mut expected_names = vec![PINNED_NAME, "pack-local"];
+    expected_names.sort_unstable();
     assert_eq!(
         dct.keys().collect::<Vec<_>>(),
-        vec![PINNED_NAME, "pack-local"],
-        "both dictionaries must be pinned in the header"
+        expected_names,
+        "both dictionaries must be pinned in the header, ordered by name"
     );
     assert_eq!(
         dct[PINNED_NAME], shipped,
@@ -559,6 +566,43 @@ fn a_mixed_plan_pins_the_callers_bytes_and_derives_the_rest() {
         decoded_blobs(&folded),
         decoded_blobs(&read(&source, true, None)),
         "every blob decodes against the dictionary it was primed with"
+    );
+}
+
+/// The emitted bytes are a function of the dictionary SET, not of the order the
+/// caller listed it in. Catalog ids are assigned over the SORTED (codec,
+/// dict-name) set and the header `"dct"` map is name-ordered, so sequencing the
+/// same two dictionaries the other way round must reproduce the pack byte for
+/// byte. Without this, "compaction is deterministic" would hold only for callers
+/// who happen to build their plan in the same order twice.
+#[test]
+fn the_order_dictionaries_appear_in_a_plan_does_not_change_the_bytes() {
+    let shipped = shipped_dictionary();
+    let source = source_with_blobs();
+    let plan = |reversed: bool| {
+        let pinned = (
+            PINNED_NAME.to_string(),
+            DictStrategy::Pinned(shipped.clone()),
+        );
+        let derived = ("pack-local".to_string(), DictStrategy::RawContent);
+        DictPlan {
+            dicts: if reversed {
+                vec![derived, pinned]
+            } else {
+                vec![pinned, derived]
+            },
+            content: DictSelection::Named(PINNED_NAME.to_string()),
+            index: DictSelection::Named("pack-local".to_string()),
+            transform: vec!["zstd-rsyncable".to_string()],
+            zstd_level: Some(LEVEL),
+        }
+    };
+
+    let forward = compact_streamable(&source, params(plan(false))).expect("forward plan compacts");
+    let reversed = compact_streamable(&source, params(plan(true))).expect("reversed plan compacts");
+    assert_eq!(
+        forward, reversed,
+        "the same dictionary set listed in either order must compact to identical bytes"
     );
 }
 

--- a/crates/gts/tests/pinned_dict_compaction.rs
+++ b/crates/gts/tests/pinned_dict_compaction.rs
@@ -489,17 +489,21 @@ fn a_mixed_plan_pins_the_callers_bytes_and_derives_the_rest() {
     let pack = compact_streamable(&source, params(mixed)).expect("a mixed plan compacts");
 
     let dct = header_dct(&pack);
-    // The header `"dct"` map is ordered by NAME, never by plan order — that is
-    // what keeps the emitted bytes a function of the dictionary SET rather than
-    // of how the caller happened to sequence the plan. Sort the expectation
-    // rather than hard-coding one arrangement, so renaming a fixture dictionary
-    // cannot quietly turn this into an assertion about alphabetical luck.
+    // WHICH dictionaries are pinned, and exactly how many — nothing about their
+    // arrangement. `header_dct` funnels the wire entries through a `BTreeMap`,
+    // so its key order is sorted by construction and this assertion could not
+    // observe the wire's ordering even if it wanted to. Sort the expectation to
+    // say so honestly, rather than hard-coding one arrangement and leaving a
+    // future fixture rename to discover it was asserting alphabetical luck.
+    // Order-independence is a claim about BYTES, and
+    // `the_order_dictionaries_appear_in_a_plan_does_not_change_the_bytes` is
+    // where it is actually tested.
     let mut expected_names = vec![PINNED_NAME, "pack-local"];
     expected_names.sort_unstable();
     assert_eq!(
         dct.keys().collect::<Vec<_>>(),
         expected_names,
-        "both dictionaries must be pinned in the header, ordered by name"
+        "exactly these two dictionaries must be pinned in the header"
     );
     assert_eq!(
         dct[PINNED_NAME], shipped,

--- a/crates/gts/tests/pinned_dict_compaction.rs
+++ b/crates/gts/tests/pinned_dict_compaction.rs
@@ -1,0 +1,612 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Compaction under a PINNED dictionary (GTS-SPEC §5 header `"dct"`, §8.5
+//! `zstd`/`zstd-rsyncable` `dct`, §10.1).
+//!
+//! [`DictStrategy::Trained`]/[`DictStrategy::RawContent`] derive a dictionary
+//! from the pack's own content-blob corpus, so the bytes behind a dictionary
+//! NAME are a function of whatever that pack happened to contain. A consumer
+//! that ships named dictionaries and pins them in a bundle header needs the
+//! opposite guarantee: one id must resolve to ONE byte sequence, everywhere,
+//! forever. [`DictStrategy::Pinned`] is that guarantee, and these tests hold it
+//! to the wire:
+//!
+//! - (a) the header `"dct"` map carries the caller's bytes BYTE-FOR-BYTE;
+//! - (b) every primed frame names that catalog entry and every zstd frame
+//!   header declares the pinned dictionary's finalized `Dictionary_ID`;
+//! - (c) a blob-less log (the agent-memory shape) compacts under a wholly
+//!   pinned plan, and still refuses under a derived one;
+//! - (d) the same input + plan is byte-reproducible;
+//! - (e) the pack folds back to the source's content;
+//! - (f) MIXED plans (some pinned, some derived) are supported, each entry
+//!   obtained on its own terms.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use ciborium::value::Value;
+use ed25519_dalek::SigningKey;
+use purrdf_gts::codec::zstd_block_layout;
+use purrdf_gts::compact::{
+    CompactionParams, DictPlan, DictSelection, DictStrategy, compact_streamable,
+};
+use purrdf_gts::dict::{dictionary_id, raw_content_dict};
+use purrdf_gts::model::{Graph, Term, TermKind};
+use purrdf_gts::reader::{read, segment_append_state};
+use purrdf_gts::wire::{iter_items, map_get};
+use purrdf_gts::writer::Writer;
+
+/// The name the caller pins its shipped dictionary under.
+const PINNED_NAME: &str = "gmeow-bundle-v1";
+/// The zstd level the pinned plans declare (§8.5 `level?`).
+const LEVEL: i32 = 12;
+/// The fixed rewrite timestamp — never ambient time (§14.1).
+const TIMESTAMP: &str = "2026-01-01T00:00:00Z";
+
+/// A fixed, deterministic Ed25519 packaging key.
+fn packaging_key() -> SigningKey {
+    SigningKey::from_bytes(&[11u8; 32])
+}
+
+/// The caller's SHIPPED dictionary: derived from a corpus that has nothing to do
+/// with any pack compacted below, so "the pack pinned my bytes" cannot pass by
+/// accidentally re-deriving the same thing.
+fn shipped_dictionary() -> Vec<u8> {
+    let corpus: Vec<Vec<u8>> = (0..400u32)
+        .map(|i| {
+            format!(
+                "<https://gmeow.example/slice/logic#c{}> <https://gmeow.example/p/grounds> \
+                 \"a shipped-vocabulary sentence unrelated to any packed content, {}\" .\n",
+                i % 23,
+                i
+            )
+            .into_bytes()
+        })
+        .collect();
+    let refs: Vec<&[u8]> = corpus.iter().map(Vec::as_slice).collect();
+    raw_content_dict(&refs, 8192).expect("the shipped dictionary builds")
+}
+
+/// A source log with content blobs of repeated structure.
+fn source_with_blobs() -> Vec<u8> {
+    let mut w = Writer::new("purrdf.gts");
+    for i in 0..64u32 {
+        let blob = format!(
+            "<https://example.org/s{}> <https://example.org/p> \"claim {} about cats\" .\n",
+            i % 37,
+            i
+        )
+        .into_bytes();
+        w.add_blob_owned(blob, Some("text/plain"), None);
+    }
+    w.add_index();
+    w.into_bytes()
+}
+
+/// A BLOB-LESS source log: terms and quads only, closed with an `index` footer —
+/// the agent-memory shape, and the shape that has no dictionary corpus at all.
+fn blobless_source() -> Vec<u8> {
+    let mut w = Writer::new("purrdf.gts");
+    let mut terms: Vec<Term> = Vec::new();
+    for i in 0..24u32 {
+        terms.push(iri(&format!("https://example.org/memory/claim{i}")));
+    }
+    terms.push(iri("https://example.org/memory/recalls"));
+    terms.push(iri("https://example.org/memory/session"));
+    w.add_terms(&terms);
+    let predicate = 24;
+    let object = 25;
+    let quads: Vec<(usize, usize, usize, Option<usize>)> =
+        (0..24usize).map(|s| (s, predicate, object, None)).collect();
+    w.add_quads(&quads);
+    w.add_index();
+    w.into_bytes()
+}
+
+fn iri(value: &str) -> Term {
+    Term {
+        kind: TermKind::Iri,
+        value: Some(value.to_string()),
+        datatype: None,
+        lang: None,
+        direction: None,
+        reifier: None,
+    }
+}
+
+/// A plan pinning exactly the caller's bytes under [`PINNED_NAME`], priming
+/// every authored frame through a level-12 `zstd-rsyncable` chain.
+fn pinned_plan(dict: Vec<u8>) -> DictPlan {
+    DictPlan::rsyncable(PINNED_NAME, DictStrategy::Pinned(dict), LEVEL)
+}
+
+fn params(plan: DictPlan) -> CompactionParams<'static> {
+    CompactionParams {
+        timestamp: TIMESTAMP,
+        seal_original: false,
+        plan,
+        content_digest: None,
+        packaging_signer: (packaging_key(), "pack-test".to_string()),
+    }
+}
+
+/// The header `"dct"` map read straight off the wire as `name -> bytes`, with no
+/// digesting, no re-derivation, and no reader convenience in between.
+fn header_dct(bytes: &[u8]) -> BTreeMap<String, Vec<u8>> {
+    let (items, _torn) = iter_items(bytes);
+    let (_, first) = items.first().expect("a pack starts with a header item");
+    let inner = match first {
+        Value::Tag(_, inner) => inner.as_ref(),
+        other => other,
+    };
+    let Value::Map(entries) = inner else {
+        panic!("the GTS header is a CBOR map (§5)");
+    };
+    let Some(Value::Map(dct)) = map_get(entries, "dct") else {
+        panic!("the header must pin a \"dct\" map (§5)");
+    };
+    dct.iter()
+        .map(|(key, value)| match (key, value) {
+            (Value::Text(name), Value::Bytes(raw)) => (name.clone(), raw.clone()),
+            other => panic!("\"dct\" is tstr => bstr (§5), got {other:?}"),
+        })
+        .collect()
+}
+
+/// `catalog id -> dictionary name` for a pack's last segment header.
+fn dict_by_catalog_id(bytes: &[u8]) -> BTreeMap<i64, Option<String>> {
+    segment_append_state(bytes)
+        .expect("the pack header parses")
+        .catalog
+        .into_iter()
+        .map(|row| (row.id, row.dct))
+        .collect()
+}
+
+/// What one TRANSFORMED frame is observably primed by: the dictionary names its
+/// `"x"` chain resolves to, and the `Dictionary_ID` every zstd frame in its
+/// payload declares. Sets, so "exactly one dictionary, every block" is a
+/// cardinality assertion rather than a hand-rolled scan.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct FramePriming {
+    /// The `dct` names the frame's catalog references resolve to.
+    names: BTreeSet<Option<String>>,
+    /// The `Dictionary_ID` declared by each zstd frame header in the payload.
+    dictionary_ids: BTreeSet<Option<u32>>,
+}
+
+/// One [`FramePriming`] per transformed frame, in file order.
+fn primed_frames(bytes: &[u8]) -> Vec<FramePriming> {
+    let by_id = dict_by_catalog_id(bytes);
+    let (items, _torn) = iter_items(bytes);
+    let mut out = Vec::new();
+    for (_, item) in items.iter().skip(1) {
+        let Value::Map(frame) = item else { continue };
+        let Some(Value::Array(ids)) = map_get(frame, "x") else {
+            continue;
+        };
+        let names: BTreeSet<Option<String>> = ids
+            .iter()
+            .map(|id| {
+                let Value::Integer(raw) = id else {
+                    panic!("a catalog reference is an integer")
+                };
+                let id = i64::try_from(i128::from(*raw)).expect("a catalog id fits i64");
+                by_id
+                    .get(&id)
+                    .unwrap_or_else(|| panic!("frame names catalog id {id}, which is not declared"))
+                    .clone()
+            })
+            .collect();
+        let Some(Value::Bytes(data)) = map_get(frame, "d") else {
+            panic!("a transformed frame carries its payload in \"d\"");
+        };
+        let dictionary_ids: BTreeSet<Option<u32>> = zstd_block_layout(data)
+            .expect("a zstd-family payload is an exact sequence of zstd frames")
+            .into_iter()
+            .map(|block| block.dictionary_id)
+            .collect();
+        out.push(FramePriming {
+            names,
+            dictionary_ids,
+        });
+    }
+    out
+}
+
+/// Sorted decoded blob content — an order- and codec-independent identity.
+fn decoded_blobs(g: &Graph) -> Vec<Vec<u8>> {
+    let mut out: Vec<Vec<u8>> = g
+        .blobs
+        .iter()
+        .map(|(digest, entry)| {
+            entry
+                .decoded_vec()
+                .unwrap_or_else(|err| panic!("blob {digest} decodes: {err}"))
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+/// Every quad as a resolved `(subject, predicate, object)` value triple, so two
+/// folds can be compared without depending on term-id assignment.
+fn quad_values(g: &Graph) -> BTreeSet<(String, String, String)> {
+    let value = |tid: usize| -> String {
+        g.terms
+            .get(tid)
+            .and_then(|term| term.value.clone())
+            .unwrap_or_else(|| panic!("term {tid} has a value"))
+    };
+    g.quads
+        .iter()
+        .map(|&(s, p, o, _)| (value(s), value(p), value(o)))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// (a) The caller's bytes, verbatim, under the caller's name.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_pinned_plan_carries_the_callers_exact_dictionary_bytes_in_the_header() {
+    let shipped = shipped_dictionary();
+    let pack = compact_streamable(&source_with_blobs(), params(pinned_plan(shipped.clone())))
+        .expect("a pinned-dictionary compaction succeeds");
+
+    let dct = header_dct(&pack);
+    assert_eq!(
+        dct.keys().collect::<Vec<_>>(),
+        vec![PINNED_NAME],
+        "the pack pins exactly the dictionary the plan named"
+    );
+    let on_the_wire = &dct[PINNED_NAME];
+    assert_eq!(
+        on_the_wire, &shipped,
+        "the header \"dct\" entry must be the caller's dictionary BYTE-FOR-BYTE: an id that \
+         resolves to re-derived bytes does not identify a decodable dictionary"
+    );
+
+    // Anti-tautology: a derived plan over this same source pins something else
+    // entirely, so byte-equality above is a real property of pinning.
+    let derived = compact_streamable(
+        &source_with_blobs(),
+        params(DictPlan::rsyncable(
+            PINNED_NAME,
+            DictStrategy::RawContent,
+            LEVEL,
+        )),
+    )
+    .expect("a derived compaction succeeds over a blob-carrying source");
+    assert_ne!(
+        header_dct(&derived)[PINNED_NAME],
+        shipped,
+        "the derived strategy must genuinely produce different bytes under the same name"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (b) Every primed frame names the pinned entry, and declares its id on the wire.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_primed_frame_names_the_pinned_catalog_entry_and_declares_its_dictionary_id() {
+    let shipped = shipped_dictionary();
+    let expected_id = dictionary_id(&shipped).expect("a finalized dictionary carries an id");
+    let pack = compact_streamable(&source_with_blobs(), params(pinned_plan(shipped)))
+        .expect("a pinned-dictionary compaction succeeds");
+
+    let frames = primed_frames(&pack);
+    assert!(
+        frames.len() > 1,
+        "the pack must carry several transformed frames (index + content + blobs)"
+    );
+    for frame in &frames {
+        assert_eq!(
+            frame.names,
+            BTreeSet::from([Some(PINNED_NAME.to_string())]),
+            "every transformed frame's chain must resolve to the pinned dictionary's \
+             catalog entry"
+        );
+        assert_eq!(
+            frame.dictionary_ids,
+            BTreeSet::from([Some(expected_id)]),
+            "every zstd frame header must declare the PINNED dictionary's finalized \
+             Dictionary_ID ({expected_id}) — the id must identify these exact bytes"
+        );
+    }
+
+    // The catalog binds the pinned name, and declares the plan's level.
+    let rows = segment_append_state(&pack)
+        .expect("the pack header parses")
+        .catalog;
+    assert!(
+        rows.iter()
+            .any(|row| row.dct.as_deref() == Some(PINNED_NAME)),
+        "the catalog must carry an entry bound to the pinned dictionary"
+    );
+    for row in rows
+        .iter()
+        .filter(|row| matches!(row.name.as_str(), "zstd" | "zstd-rsyncable"))
+    {
+        assert_eq!(
+            row.level,
+            Some(LEVEL),
+            "catalog id {} must declare the plan's level (§8.5 level?)",
+            row.id
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (c) A blob-less log compacts under a pinned plan — and still refuses a derived one.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_blobless_log_compacts_under_a_wholly_pinned_plan() {
+    let source = blobless_source();
+    let folded_source = read(&source, true, None);
+    assert!(
+        folded_source.blobs.is_empty(),
+        "the fixture must genuinely have NO content blobs"
+    );
+
+    let shipped = shipped_dictionary();
+    let pack = compact_streamable(&source, params(pinned_plan(shipped.clone())))
+        .expect("a wholly-pinned plan needs no content-blob corpus");
+
+    assert_eq!(
+        header_dct(&pack)[PINNED_NAME],
+        shipped,
+        "the blob-less pack pins the caller's exact bytes"
+    );
+    let folded = read(&pack, true, None);
+    assert!(
+        folded.diagnostics.is_empty(),
+        "the blob-less pack must fold cleanly (the pinned dictionary resolves): {:?}",
+        folded.diagnostics
+    );
+    assert!(
+        quad_values(&folded).is_superset(&quad_values(&folded_source)),
+        "every source quad survives compaction of a blob-less log"
+    );
+    // The dictionary is not dead weight: the terms/quads frames are primed by it.
+    let frames = primed_frames(&pack);
+    assert!(!frames.is_empty(), "the pack must carry primed frames");
+    for frame in &frames {
+        assert_eq!(frame.names, BTreeSet::from([Some(PINNED_NAME.to_string())]));
+    }
+}
+
+#[test]
+fn a_blobless_log_still_refuses_a_derived_plan_with_the_named_refusal() {
+    let source = blobless_source();
+    for strategy in [DictStrategy::Trained, DictStrategy::RawContent] {
+        let err = compact_streamable(
+            &source,
+            params(DictPlan::rsyncable(PINNED_NAME, strategy.clone(), LEVEL)),
+        )
+        .expect_err("a derived plan has no corpus on a blob-less log");
+        assert!(
+            err.to_string().contains("no content blobs"),
+            "the refusal must still name the missing corpus for {strategy:?}: {err}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (d) Determinism — the format's foundational invariant (§14.1).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_same_input_and_pinned_plan_compact_to_byte_identical_packs() {
+    let shipped = shipped_dictionary();
+    let source = source_with_blobs();
+    let a = compact_streamable(&source, params(pinned_plan(shipped.clone())))
+        .expect("first compaction succeeds");
+    let b = compact_streamable(&source, params(pinned_plan(shipped.clone())))
+        .expect("second compaction succeeds");
+    assert_eq!(a, b, "a pinned compaction must be byte-reproducible");
+
+    // Blob-less too: the path that skips the corpus entirely is equally frozen.
+    let memory = blobless_source();
+    let c = compact_streamable(&memory, params(pinned_plan(shipped.clone())))
+        .expect("first blob-less compaction succeeds");
+    let d = compact_streamable(&memory, params(pinned_plan(shipped)))
+        .expect("second blob-less compaction succeeds");
+    assert_eq!(
+        c, d,
+        "a blob-less pinned compaction must be byte-reproducible"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (e) Round trip — the dictionary is a compression detail, invisible to the fold.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_pinned_pack_folds_to_the_same_content_as_its_source() {
+    let source = source_with_blobs();
+    let pack = compact_streamable(&source, params(pinned_plan(shipped_dictionary())))
+        .expect("a pinned-dictionary compaction succeeds");
+
+    let before = read(&source, true, None);
+    let after = read(&pack, true, None);
+    assert!(
+        after.diagnostics.is_empty(),
+        "the pinned pack must fold cleanly: {:?}",
+        after.diagnostics
+    );
+    assert_eq!(
+        decoded_blobs(&after),
+        decoded_blobs(&before),
+        "every blob must decode against the pinned dictionary to its ORIGINAL bytes"
+    );
+    assert!(
+        quad_values(&after).is_superset(&quad_values(&before)),
+        "every source quad survives the rewrite"
+    );
+
+    // The same content also folds out of an UNDICTED pack: the pinned
+    // dictionary changes the bytes on disk and nothing about the graph.
+    let undicted = compact_streamable(&source, params(DictPlan::undicted()))
+        .expect("an undicted compaction succeeds");
+    assert_ne!(pack, undicted, "pinning a dictionary changes the bytes");
+    assert_eq!(
+        decoded_blobs(&read(&undicted, true, None)),
+        decoded_blobs(&after),
+        "the pinned dictionary is invisible to the fold"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (f) MIXED plans: pinned and derived entries in one pack, each on its own terms.
+// ---------------------------------------------------------------------------
+
+/// The RULING: a mixed plan is SUPPORTED, not refused. Pinning and deriving are
+/// per-entry questions — a pinned entry's bytes exist independently of the pack,
+/// a derived entry's are a function of its corpus — and nothing about one
+/// constrains the other. Refusing the combination would forbid the natural
+/// migration shape (ship a stable dictionary for the content frames, derive a
+/// pack-local one for the index frames) for no invariant's sake.
+#[test]
+fn a_mixed_plan_pins_the_callers_bytes_and_derives_the_rest() {
+    let shipped = shipped_dictionary();
+    let source = source_with_blobs();
+    let mixed = DictPlan {
+        dicts: vec![
+            (
+                PINNED_NAME.to_string(),
+                DictStrategy::Pinned(shipped.clone()),
+            ),
+            ("pack-local".to_string(), DictStrategy::RawContent),
+        ],
+        content: DictSelection::Named(PINNED_NAME.to_string()),
+        index: DictSelection::Named("pack-local".to_string()),
+        transform: vec!["zstd-rsyncable".to_string()],
+        zstd_level: Some(LEVEL),
+    };
+    let pack = compact_streamable(&source, params(mixed)).expect("a mixed plan compacts");
+
+    let dct = header_dct(&pack);
+    assert_eq!(
+        dct.keys().collect::<Vec<_>>(),
+        vec![PINNED_NAME, "pack-local"],
+        "both dictionaries must be pinned in the header"
+    );
+    assert_eq!(
+        dct[PINNED_NAME], shipped,
+        "the pinned entry is the caller's bytes, verbatim, even alongside a derived one"
+    );
+
+    // The derived entry is EXACTLY what a wholly-derived plan produces from the
+    // same corpus — the pinned neighbour perturbs nothing.
+    let derived_only = compact_streamable(
+        &source,
+        params(DictPlan::rsyncable(
+            "pack-local",
+            DictStrategy::RawContent,
+            LEVEL,
+        )),
+    )
+    .expect("the derived-only plan compacts");
+    assert_eq!(
+        dct["pack-local"],
+        header_dct(&derived_only)["pack-local"],
+        "a derived entry in a mixed plan must equal the same entry derived alone"
+    );
+    assert_ne!(
+        dct["pack-local"], shipped,
+        "anti-tautology: the two dictionaries genuinely differ"
+    );
+
+    // Both are live: the blob frames ride the pinned one, the index frames the
+    // derived one, and each declares its own dictionary's id on the wire.
+    let pinned_id = dictionary_id(&shipped).expect("pinned dictionary id");
+    let derived_id = dictionary_id(&dct["pack-local"]).expect("derived dictionary id");
+    assert_ne!(pinned_id, derived_id);
+    let used: BTreeSet<(Option<String>, Option<u32>)> = primed_frames(&pack)
+        .into_iter()
+        .map(|frame| {
+            assert_eq!(frame.names.len(), 1, "one dictionary per frame");
+            assert_eq!(
+                frame.dictionary_ids.len(),
+                1,
+                "one dictionary per frame, every block"
+            );
+            (
+                frame.names.into_iter().next().expect("one name"),
+                frame.dictionary_ids.into_iter().next().expect("one id"),
+            )
+        })
+        .collect();
+    assert_eq!(
+        used,
+        BTreeSet::from([
+            (Some(PINNED_NAME.to_string()), Some(pinned_id)),
+            (Some("pack-local".to_string()), Some(derived_id)),
+        ]),
+        "each frame group must ride the dictionary the plan selected for it"
+    );
+
+    let folded = read(&pack, true, None);
+    assert!(
+        folded.diagnostics.is_empty(),
+        "a mixed-dictionary pack must fold cleanly: {:?}",
+        folded.diagnostics
+    );
+    assert_eq!(
+        decoded_blobs(&folded),
+        decoded_blobs(&read(&source, true, None)),
+        "every blob decodes against the dictionary it was primed with"
+    );
+}
+
+/// A mixed plan's DERIVED half still needs a corpus, so a blob-less log refuses
+/// it — the refusal is a property of derivation, never of pinning.
+#[test]
+fn a_mixed_plan_over_a_blobless_log_refuses_for_its_derived_entry() {
+    let mixed = DictPlan {
+        dicts: vec![
+            (
+                PINNED_NAME.to_string(),
+                DictStrategy::Pinned(shipped_dictionary()),
+            ),
+            ("pack-local".to_string(), DictStrategy::RawContent),
+        ],
+        content: DictSelection::Named(PINNED_NAME.to_string()),
+        index: DictSelection::Named("pack-local".to_string()),
+        transform: vec!["zstd-rsyncable".to_string()],
+        zstd_level: Some(LEVEL),
+    };
+    let err = compact_streamable(&blobless_source(), params(mixed))
+        .expect_err("the derived half of a mixed plan has no corpus on a blob-less log");
+    assert!(
+        err.to_string().contains("no content blobs"),
+        "the refusal must name the missing corpus: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Refuse-don't-trust on the one input the compactor does not produce itself.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pinned_bytes_that_are_not_a_finalized_dictionary_are_refused() {
+    for (label, bytes) in [
+        ("empty", Vec::new()),
+        (
+            "not a dictionary",
+            b"just some bytes, not a zstd dict".to_vec(),
+        ),
+        ("raw content only", vec![b'a'; 4096]),
+    ] {
+        let err = compact_streamable(&source_with_blobs(), params(pinned_plan(bytes)))
+            .expect_err("unusable pinned bytes must hard-fail");
+        let text = err.to_string();
+        assert!(
+            text.contains(PINNED_NAME) && text.contains("finalized zstd dictionary"),
+            "the refusal must name the offending dictionary for the {label} case: {text}"
+        );
+    }
+}

--- a/crates/rdf/tests/pinned_dict_compaction.rs
+++ b/crates/rdf/tests/pinned_dict_compaction.rs
@@ -26,7 +26,7 @@ use purrdf_rdf::gts_certify::{compact_and_certify, refold_digest, verify_compact
 use purrdf_rdf::gts_dict_vectors::{TIMESTAMP, VECTOR_ZSTD_LEVEL, authorship_key, fixed_source};
 
 /// The name the caller pins its shipped dictionary under.
-const PINNED_NAME: &str = "gmeow-bundle-v1";
+const PINNED_NAME: &str = "shipped-bundle-v1";
 
 fn packaging_key() -> ed25519_dalek::SigningKey {
     ed25519_dalek::SigningKey::from_bytes(&[7u8; 32])
@@ -45,7 +45,7 @@ fn shipped_dictionary() -> Vec<u8> {
     let corpus: Vec<Vec<u8>> = (0..400u32)
         .map(|i| {
             format!(
-                "<https://gmeow.example/slice/logic#c{}> <https://gmeow.example/p/grounds> \
+                "<https://example.org/slice/logic#c{}> <https://example.org/p/grounds> \
                  \"a shipped-vocabulary sentence unrelated to any packed content, {}\" .\n",
                 i % 23,
                 i

--- a/crates/rdf/tests/pinned_dict_compaction.rs
+++ b/crates/rdf/tests/pinned_dict_compaction.rs
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! A PINNED in-band dictionary through the CERTIFYING authoring path.
+//!
+//! `crates/gts/tests/pinned_dict_compaction.rs` holds the wire-level contract
+//! (the caller's exact bytes in the header `"dct"` map, the `Dictionary_ID`
+//! every primed frame declares, the blob-less and mixed-plan rulings). This
+//! file adds the strongest round-trip instrument the workspace has: the
+//! RDFC-1.0 content-refold digest, computed before and after the rewrite by
+//! `compact_and_certify`, and independently re-checked by `verify_compaction`
+//! together with the carried authorship signatures and the mandatory packaging
+//! signature.
+//!
+//! "Folds to the same graph" is asserted at canonical-graph identity, not at
+//! blob-bytes identity — a pinned dictionary must be a pure compression detail.
+
+use std::collections::HashMap;
+
+use purrdf_gts::compact::{DictPlan, DictStrategy};
+use purrdf_gts::dict::raw_content_dict;
+use purrdf_gts::model::{Term, TermKind};
+use purrdf_gts::reader::{read, segment_append_state};
+use purrdf_gts::writer::Writer;
+use purrdf_rdf::gts_certify::{compact_and_certify, refold_digest, verify_compaction};
+use purrdf_rdf::gts_dict_vectors::{TIMESTAMP, VECTOR_ZSTD_LEVEL, authorship_key, fixed_source};
+
+/// The name the caller pins its shipped dictionary under.
+const PINNED_NAME: &str = "gmeow-bundle-v1";
+
+fn packaging_key() -> ed25519_dalek::SigningKey {
+    ed25519_dalek::SigningKey::from_bytes(&[7u8; 32])
+}
+
+fn keyring() -> HashMap<String, ed25519_dalek::VerifyingKey> {
+    HashMap::from([
+        ("authorA".to_string(), authorship_key().verifying_key()),
+        ("pack".to_string(), packaging_key().verifying_key()),
+    ])
+}
+
+/// The caller's SHIPPED dictionary, derived from a vocabulary unrelated to any
+/// source compacted here so a re-derivation could never reproduce it.
+fn shipped_dictionary() -> Vec<u8> {
+    let corpus: Vec<Vec<u8>> = (0..400u32)
+        .map(|i| {
+            format!(
+                "<https://gmeow.example/slice/logic#c{}> <https://gmeow.example/p/grounds> \
+                 \"a shipped-vocabulary sentence unrelated to any packed content, {}\" .\n",
+                i % 23,
+                i
+            )
+            .into_bytes()
+        })
+        .collect();
+    let refs: Vec<&[u8]> = corpus.iter().map(Vec::as_slice).collect();
+    raw_content_dict(&refs, 8192).expect("the shipped dictionary builds")
+}
+
+/// A signed, BLOB-LESS source log: terms and quads only — the agent-memory
+/// shape, which has no dictionary corpus at all.
+fn blobless_source() -> Vec<u8> {
+    let mut w = Writer::new("purrdf.gts");
+    w.sign_with(authorship_key(), "authorA");
+    let iri = |value: &str| Term {
+        kind: TermKind::Iri,
+        value: Some(value.to_string()),
+        datatype: None,
+        lang: None,
+        direction: None,
+        reifier: None,
+    };
+    let mut terms: Vec<Term> = (0..24u32)
+        .map(|i| iri(&format!("https://example.org/memory/claim{i}")))
+        .collect();
+    terms.push(iri("https://example.org/memory/recalls"));
+    terms.push(iri("https://example.org/memory/session"));
+    w.add_terms(&terms);
+    let quads: Vec<(usize, usize, usize, Option<usize>)> =
+        (0..24usize).map(|s| (s, 24, 25, None)).collect();
+    w.add_quads(&quads);
+    w.add_index();
+    w.into_bytes()
+}
+
+/// The header `"dct"` bytes a pack actually pinned, by name.
+fn header_dicts(bytes: &[u8]) -> std::collections::BTreeMap<String, Vec<u8>> {
+    segment_append_state(bytes)
+        .expect("the pack header parses")
+        .dicts
+}
+
+fn pinned_plan(dict: Vec<u8>) -> DictPlan {
+    DictPlan::rsyncable(PINNED_NAME, DictStrategy::Pinned(dict), VECTOR_ZSTD_LEVEL)
+}
+
+fn certify(source: &[u8], plan: DictPlan) -> Vec<u8> {
+    let (pack, cert) = compact_and_certify(
+        source,
+        plan,
+        TIMESTAMP,
+        false,
+        (packaging_key(), "pack".to_string()),
+    )
+    .expect("a pinned-dictionary compaction certifies");
+    assert_eq!(
+        cert.pre_refold_digest, cert.post_refold_digest,
+        "the certifying wrapper's own pre/post content-refold digests must agree"
+    );
+    pack
+}
+
+#[test]
+fn a_pinned_pack_round_trips_at_canonical_graph_identity_and_verifies() {
+    let shipped = shipped_dictionary();
+    let source = fixed_source();
+    let pack = certify(&source, pinned_plan(shipped.clone()));
+
+    assert_eq!(
+        header_dicts(&pack)[PINNED_NAME],
+        shipped,
+        "the certifying path pins the caller's exact bytes too"
+    );
+
+    let before = read(&source, true, None);
+    let after = read(&pack, true, None);
+    assert!(
+        after.diagnostics.is_empty(),
+        "the pinned pack must fold cleanly: {:?}",
+        after.diagnostics
+    );
+    assert_eq!(
+        refold_digest(&before).expect("source content-refold digest"),
+        refold_digest(&after).expect("pack content-refold digest"),
+        "the pack must fold to the SAME RDFC-1.0 canonical graph as its source"
+    );
+
+    let report = verify_compaction(&source, &pack, &keyring()).expect("verify_compaction runs");
+    assert!(
+        report.all_ok(),
+        "a pinned-dictionary pack must independently verify — content equivalence, carried \
+         authorship signatures, and the mandatory packaging signature: {report:?}"
+    );
+}
+
+#[test]
+fn a_blobless_pinned_pack_round_trips_and_verifies() {
+    let shipped = shipped_dictionary();
+    let source = blobless_source();
+    assert!(
+        read(&source, true, None).blobs.is_empty(),
+        "the fixture must genuinely have NO content blobs"
+    );
+
+    let pack = certify(&source, pinned_plan(shipped.clone()));
+    assert_eq!(
+        header_dicts(&pack)[PINNED_NAME],
+        shipped,
+        "a blob-less pack pins the caller's exact bytes with no corpus in sight"
+    );
+
+    let report = verify_compaction(&source, &pack, &keyring()).expect("verify_compaction runs");
+    assert!(
+        report.all_ok(),
+        "a blob-less pinned pack must independently verify: {report:?}"
+    );
+}
+
+/// The frozen dict vectors are authored through this same wrapper: a pinned plan
+/// must not perturb what a DERIVED plan produces over the same source.
+#[test]
+fn pinning_a_dictionary_does_not_perturb_a_derived_compaction_of_the_same_source() {
+    let source = fixed_source();
+    let derived_plan =
+        || DictPlan::rsyncable(PINNED_NAME, DictStrategy::RawContent, VECTOR_ZSTD_LEVEL);
+    let a = certify(&source, derived_plan());
+    let _pinned = certify(&source, pinned_plan(shipped_dictionary()));
+    let b = certify(&source, derived_plan());
+    assert_eq!(
+        a, b,
+        "a derived compaction is byte-identical regardless of any pinned compaction \
+         performed between the two"
+    );
+    assert_ne!(
+        header_dicts(&a)[PINNED_NAME],
+        shipped_dictionary(),
+        "anti-tautology: the derived dictionary is not the shipped one"
+    );
+}

--- a/crates/rdf/tests/streamable_vectors.rs
+++ b/crates/rdf/tests/streamable_vectors.rs
@@ -158,7 +158,7 @@ fn frozen_vector_pins_no_pack_dictionary() {
     // decoded bytes) — not the repeated-structure corpus a pack dictionary has
     // anything real to train on (that is what `30-dict-rawcontent`/
     // `31-dict-trained` freeze). `gen_streamable_vectors` deliberately compacts
-    // with `DictStrategy::None`, so the frozen pack carries no `"dct"` header
+    // with `DictPlan::undicted()`, so the frozen pack carries no `"dct"` header
     // entry and no zstd-compressed frames.
     let frozen = read_vector("25b-streamable-compacted.gts");
 
@@ -170,7 +170,7 @@ fn frozen_vector_pins_no_pack_dictionary() {
     assert!(
         !header_carries_dct_entry(&frozen),
         "25b-streamable-compacted.gts header must carry no \"dct\" entry \
-         (DictStrategy::None pins no in-band pack dictionary)"
+         (DictPlan::undicted pins no in-band pack dictionary)"
     );
 
     // Separate codec-behavior check: with no dictionary pinned, this frozen
@@ -187,6 +187,6 @@ fn frozen_vector_pins_no_pack_dictionary() {
     assert_eq!(
         zstd_frames, 0,
         "25b-streamable-compacted.gts must carry no zstd-compressed frames \
-         (DictStrategy::None, no in-band pack dictionary)"
+         (DictPlan::undicted, no in-band pack dictionary)"
     );
 }


### PR DESCRIPTION
## What this fixes

`DictPlan` could only name dictionaries the compactor **derived** from the pack's own
content-blob corpus (`DictStrategy::Trained` / `DictStrategy::RawContent`). A consumer that
ships named dictionaries and pins them in a bundle header therefore could not get what it
asked for: compacting "under dictionary X" produced a pack primed with a pack-local
derivation carrying X's **name** but not X's **bytes**.

That is a defect in the id→bytes function, not a missing preference — one dictionary id
resolved to many byte sequences and stopped identifying a decodable dictionary at all.

## The change

`DictStrategy::Pinned(Vec<u8>)` — caller-supplied bytes used verbatim: no training, no corpus
derivation, no truncation. They ride the header `"dct"` map under the plan's name exactly like
`WriterOptions.dicts`, so a reader resolves them the normal way and every primed frame's zstd
header declares that dictionary's own finalized `Dictionary_ID`.

A **variant** rather than a second `dicts_bytes` field on `DictPlan`, so there stays **one**
list of named dictionaries: one name-uniqueness check, one selection-resolution rule, one loop
in `build_pack_dicts`, and mixed plans expressible without a second ordering to reconcile.

### Derivation, not pinning, is what needs a corpus

The blob-less refusal is now a consequence of **derivation**: the corpus is collected only when
some entry derives from it, so a wholly-pinned plan compacts a terms/quads-only log (the
agent-memory shape) with no corpus in sight. `Trained`/`RawContent` plans keep the existing
refusal verbatim.

**Mixed plans (some pinned, some derived) are supported, not refused.** Pinning and deriving are
per-entry questions and neither constrains the other; a mixed plan over a blob-less log still
hits the derived half's corpus refusal.

### Refuse-don't-trust

Every other §10.1 gate is untouched, and one is added for the only input the compactor does not
produce itself: pinned bytes must parse as a finalized zstd dictionary with a non-zero
`Dictionary_ID`, refused **by name** rather than surfacing as a deep codec failure.

## Determinism and frozen vectors

Pinned bytes are an input, and catalog id assignment remains a pure function of the sorted
(codec, dict-name) set. **No frozen vector changed** — `vectors/25b`, `27`, `30`–`33` and their
byte-identity regeneration tests all pass untouched, because the derived path is bit-for-bit as
it was.

## Breaking change

`DictStrategy` loses `Copy` (it now owns bytes) and gains a variant. Every in-tree call site
passes a fresh literal, so nothing else changed here — but this is source-breaking for
downstream exhaustive `match` arms and any use-after-move, and is released as a **minor** bump
per the pre-1.0 policy in `CHANGELOG.md`.

## Coverage

New: `crates/gts/tests/pinned_dict_compaction.rs`, `crates/rdf/tests/pinned_dict_compaction.rs`

- the header `"dct"` entry asserted **byte-for-byte** against the caller's bytes, with a
  derived-plan anti-tautology so the assertion cannot pass vacuously
- every primed frame resolving to the pinned catalog entry and declaring its `Dictionary_ID`
- a blob-less log compacting under a pinned plan and still refusing a derived one
- byte-identical output across two in-process runs
- round-trip at RDFC-1.0 canonical-graph identity plus full `verify_compaction`
- the mixed-plan ruling in both directions
- unusable pinned bytes refused

## Also in this PR

`docs(gts):` — `frozen_vector_pins_no_pack_dictionary` attributed the 25b vector's absent `"dct"`
header to `DictStrategy::None` in three places (a comment and two assertion messages). No such
variant has ever existed; the generator compacts with `DictPlan::undicted()`. Prose only, no
assertion logic touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pinned compression dictionaries, preserving caller-provided dictionary bytes verbatim in compacted pack headers.
  * Supports plans mixing pinned and derived dictionaries, including blob-less inputs.
* **Bug Fixes**
  * Validates pinned dictionary bytes as finalized zstd dictionaries; rejects empty/non-dictionary/non-finalized content and enforces clearer failure when derived content blobs are required but missing.
* **Documentation**
  * Updated compact streamable guidance with the new derived-vs-pinned sourcing and failure modes.
* **Tests**
  * Added/extended integration tests for pinned and mixed dictionary compaction across GTS and RDF, including fold/digest and byte-preservation checks.
* **Chores**
  * Adjusted changelog templating to reliably preserve breaking-change markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->