### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to the PurRDF crate suite are recorded here. The suite
 ships one lockstep version across crates.io, PyPI, and npm; pre-1.0, a minor
 bump may carry breaking changes and a patch bump is bugfix-only.
 
+## [0.9.0] - 2026-07-28
+
+### Bug Fixes
+
+- **gts:** Use neutral fixtures, drop an unreachable guard, surface breaking changes
+
+### CI & Build
+
+- **changelog:** Mark a breaking release when the squash duplicates a subject
+
+### Documentation
+
+- **gts:** Name the real undicted plan in the frozen-vector test
+
+### Features
+
+- **BREAKING** **gts:** Pin caller-supplied in-band dictionary bytes in a compaction plan
+
+### Testing
+
+- **gts:** Say what the mixed-plan header assertion can actually observe
+
 ## [0.8.5] - 2026-07-26
 
 ### Bug Fixes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,8 +21,8 @@ authors:
   - family-names: "Audley"
     given-names: "Patrick"
     orcid: "https://orcid.org/0000-0003-4382-7625"
-version: "0.8.5"
-date-released: "2026-07-26"
+version: "0.9.0"
+date-released: "2026-07-28"
 license:
   - Apache-2.0
   - MIT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "purrdf-columnar",
  "purrdf-entail",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-cli"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "clap",
  "memmap2",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-columnar"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1349,11 +1349,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "0.8.5"
+version = "0.9.0"
 
 [[package]]
 name = "purrdf-gts"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "ahash",
  "boon",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "boon",
  "criterion",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "hex",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.5"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -45,22 +45,22 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "0.8.5" }
-purrdf-columnar = { path = "crates/columnar", version = "0.8.5" }
-purrdf-core = { path = "crates/rdf-core", version = "0.8.5" }
-purrdf-entail = { path = "crates/entail", version = "0.8.5" }
-purrdf-events = { path = "crates/rdf-events", version = "0.8.5" }
-purrdf-gts = { path = "crates/gts", version = "0.8.5" }
-purrdf-iri = { path = "crates/iri", version = "0.8.5" }
-purrdf-rdf = { path = "crates/rdf", version = "0.8.5" }
-purrdf-shapes = { path = "crates/shapes", version = "0.8.5" }
-purrdf-shex = { path = "crates/shex", version = "0.8.5" }
-purrdf-slice = { path = "crates/slice", version = "0.8.5" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.8.5" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.8.5" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "0.8.5" }
-purrdf-validate = { path = "crates/validate", version = "0.8.5" }
-purrdf-xsd = { path = "crates/xsd", version = "0.8.5" }
+purrdf = { path = "crates/purrdf", version = "0.9.0" }
+purrdf-columnar = { path = "crates/columnar", version = "0.9.0" }
+purrdf-core = { path = "crates/rdf-core", version = "0.9.0" }
+purrdf-entail = { path = "crates/entail", version = "0.9.0" }
+purrdf-events = { path = "crates/rdf-events", version = "0.9.0" }
+purrdf-gts = { path = "crates/gts", version = "0.9.0" }
+purrdf-iri = { path = "crates/iri", version = "0.9.0" }
+purrdf-rdf = { path = "crates/rdf", version = "0.9.0" }
+purrdf-shapes = { path = "crates/shapes", version = "0.9.0" }
+purrdf-shex = { path = "crates/shex", version = "0.9.0" }
+purrdf-slice = { path = "crates/slice", version = "0.9.0" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.9.0" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.9.0" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "0.9.0" }
+purrdf-validate = { path = "crates/validate", version = "0.9.0" }
+purrdf-xsd = { path = "crates/xsd", version = "0.9.0" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "0.8.5"
+version = "0.9.0"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "0.8.5"
+version = "0.9.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/cliff.toml
+++ b/cliff.toml
@@ -16,6 +16,14 @@
 # leading **BREAKING** marker on its bullet. Pre-1.0 the suite ships breaking
 # changes under a minor bump, so the changelog is the only place a consumer can
 # see that a bump carries one — it must never be silent.
+#
+# The marker is resolved over the release's WHOLE commit set before any bullet is
+# rendered, because the squash merge keeps the branch history as a second parent:
+# the squash subject `feat(gts)!: X` and the branch commit `feat(gts): X` reduce
+# to the same scope/message pair once the `(#NNN)` is preprocessed away, and the
+# dedup above keeps whichever git-cliff sorts first — the NON-breaking one. A
+# per-commit `commit.breaking` test on the surviving bullet therefore renders no
+# marker at all on exactly the releases that need it most.
 
 [changelog]
 header = """
@@ -32,6 +40,15 @@ body = """
 {% else -%}
 ## [Unreleased]
 {% endif -%}
+{% set_global breaking_keys = [] -%}
+{% for commit in commits -%}
+{% if commit.breaking -%}
+{% set breaking_message = commit.message | split(pat="\n") | first | upper_first | trim -%}
+{% set breaking_scope = commit.scope | default(value="") -%}
+{% set breaking_key = breaking_scope ~ "::" ~ breaking_message -%}
+{% set_global breaking_keys = breaking_keys | concat(with=breaking_key) -%}
+{% endif -%}
+{% endfor -%}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
 
@@ -42,7 +59,7 @@ body = """
 {% set entry_key = entry_scope ~ "::" ~ entry_message -%}
 {% if entry_key not in rendered_entries -%}
 {% set_global rendered_entries = rendered_entries | concat(with=entry_key) -%}
-- {% if commit.breaking %}**BREAKING** {% endif %}{% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | upper_first | trim }}
+- {% if entry_key in breaking_keys %}**BREAKING** {% endif %}{% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | upper_first | trim }}
 {% endif -%}
 {% endfor %}
 

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.8.5" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.9.0" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -82,4 +82,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "0.8.5"
+version = "0.9.0"

--- a/crates/rdf-capi/include/purrdf.h
+++ b/crates/rdf-capi/include/purrdf.h
@@ -9,8 +9,8 @@
 
 /* WARNING: generated file — edit crates/rdf-capi instead. */
 #define PURRDF_MAJOR 0
-#define PURRDF_MINOR 8
-#define PURRDF_PATCH 5
+#define PURRDF_MINOR 9
+#define PURRDF_PATCH 0
 
 
 #include <stdarg.h>

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -58,7 +58,7 @@ purrdf-iri = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.8.5" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.9.0" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.8.5" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.9.0" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.


### PR DESCRIPTION
Cuts **0.9.0**, the first release of the suite that carries a source-breaking change.

## Why minor, not patch

`CHANGELOG.md` states: *"pre-1.0, a minor bump may carry breaking changes and a patch bump is bugfix-only."* PR #168 made `purrdf_gts::compact::DictStrategy` gain a `Pinned(Vec<u8>)` variant and lose `Copy` — source-breaking for downstream exhaustive `match` arms and any use-after-move. A patch bump would misreport that to `gmeow-ontology` and every other consumer, and crates.io/PyPI/npm publishes are irreversible.

The version was put to the maintainer as a blocking question before implementation; the recorded answer was "0.9.0 — minor", chosen over the offered "0.8.6 — patch".

## Changelog tooling fix (first commit)

The `**BREAKING**` marker added in #168 **could never appear on the release that needed it**, and this was caught by generating against real history rather than a synthetic repo.

The structured squash merge keeps branch history as a second parent, so the release contains both the squash subject `feat(gts)!: X (#168)` and the original branch commit `feat(gts): X`. The `(#NNN)` is stripped by the issue-reference preprocessor, so both reduce to the same scope/message dedup key; `sort_commits = "oldest"` keeps the **non-breaking** one, whose `commit.breaking` is false. The marker vanished on exactly the releases that carry a break.

Breaking-ness is now resolved over the release's whole commit set before any bullet renders. Proven inert otherwise: rendering full history at `--tag rust-v0.9.0` with the old and new config differs by exactly the one marker line.

## Generated artifacts

`make bump VERSION=0.9.0` (all three version sources in lockstep), `make capi-header`, `make changelog`. File set matches the established release shape (cf. release 0.8.5): `Cargo.toml`, `Cargo.lock`, `CITATION.cff`, `bindings/python/pyproject.toml`, `uv.lock`, `crates/rdf-capi/Cargo.toml` + `include/purrdf.h`, `crates/rdf-wasm/js/package.json`, `crates/shapes/Cargo.toml`, `crates/slice/Cargo.toml`, `CHANGELOG.md`.

The generated `## [0.9.0]` section carries `- **BREAKING** **gts:** Pin caller-supplied in-band dictionary bytes in a compaction plan`.

## Gates

`make check` exit 0 (150 suites, 0 failures), `make doc` exit 0, `scripts/check-versions.py` OK.

`make release-tags VERSION=0.9.0` runs from `main` after this merges — it re-runs the Rust/wasm gate, the C-ABI header check, the native Python suite, and the size-gated npm/wasm package tests before atomically pushing `rust-v0.9.0`, `py-v0.9.0`, and `npm-v0.9.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Version 0.9.0 is now available across supported packages and language bindings.
  - The C interface and WebAssembly package report the updated semantic version.

- **Features**
  - Includes new functionality documented in the 0.9.0 release notes.
  - Highlights a breaking change related to `gts`.

- **Bug Fixes**
  - Includes fixes listed in the 0.9.0 changelog.

- **Documentation**
  - Added comprehensive release notes covering changes, testing, and build updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->