### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,120 @@ All notable changes to the PurRDF crate suite are recorded here. The suite
 ships one lockstep version across crates.io, PyPI, and npm; pre-1.0, a minor
 bump may carry breaking changes and a patch bump is bugfix-only.
 
+## [0.10.0] - 2026-07-31
+
+### Bug Fixes
+
+- **BREAKING** **datalog:** Carry the predicate as data so meta-rules are expressible
+- **entail:** Stop fabricating rdfs:Resource for a derived triple term
+- **entail:** Drop the tableau's unique name assumption for nominals
+- Accept D from the CLI, close the umbrella gap, correct shipped strings
+- **release,docs:** Refuse a half-publish, and make documented numbers checkable
+- **entail:** Make the certificate real, and grade the rules against W3C
+- **entail:** Make the overclaim state unrepresentable, and surface the certificate everywhere
+- **entail:** Derive the DL certificate's completeness instead of storing it
+- **wasm:** Reach every reasoner service from the npm package root
+- **docs:** Unbreak the rustdoc gate and name the Python suite row for what it runs
+- **bindings:** Make the shipped type stub match the extension, and gate what published numbers claim
+- **docs:** Gate the numbers that recurred, and stop promising a component this workspace does not have
+- Make three gates inspect what they claimed to, and cover a tableau clash nothing reached
+- **docs:** Correct eight published figures and gate the surfaces that carried them
+- **docs:** Close three ways this pass's own gates could be satisfied without checking anything
+- **entail:** Refuse explain-conclusion per conclusion, not per regime
+- **BREAKING** **docs:** Name the DL fragment SHOIQ(D), date the exclusion emitters, and correct three provenance claims
+- **docs:** A concept ledger over repo-wide facts, and twenty corrected figures
+- **BREAKING** **entail:** Refuse the unrepresentable cardinality, bound the counting search, and state what the blocking evidence shows
+- **BREAKING** **entail:** Make the combined approach reachable, sound on every result form, and honest about its fragment
+- **docs:** The figure sweep — thirty corrected claims, three gate holes closed
+- **hygiene:** The issue-reference ban could not see string literals or SPARQL
+- **playground:** The console offered seven codecs while the engine registers nine
+- **entail:** The counting/inverse limit keyed on spelling, not on meaning
+- **python:** `uv run mypy` checked nothing and exited on a usage error
+- **wasm:** The session handle needs Debug and Self, as the lint table requires
+- **hygiene:** The wasm export gate read the export block and not the imports
+- **datalog:** Make the SLG budget bound the work, not just the output
+- **datalog:** Keep freshen_clause's doc on freshen_clause, and collapse the filter's ifs
+
+### CI & Build
+
+- **wasm:** Record the session's 8,882 bytes
+
+### Documentation
+
+- **entail:** Generate the rule inventory and correct every stale claim
+- Fix two intra-doc links that failed the rustdoc gate
+- **conformance:** Grade the rules against W3C, and gate every number
+- Date the DL exclusion tally, which is a recorded measurement rather than a live one
+- **provenance:** Record the cutover as it stands, the slme port, and the revision reachability
+- Published text carried internal program codes
+- The session's three Python tests and its bytes reach the recorded figures
+- **conformance:** The prose scoreboard row lagged the generated block
+- **provenance:** Say which generated projections this repo can actually regenerate
+- Say why the backward resolver has no caller, and stop claiming it has one
+- State the backward check's boundary as the cost it is, with numbers that reproduce
+- **validate:** The skip test's own doc still told the story the code disproved
+
+### Features
+
+- **BREAKING** **datalog:** Add the purrdf-datalog crate and wire every release gate
+- **datalog:** Port the physical primitives — branded ids, arena, bitset, binding patterns
+- **datalog:** Port the relation store, cursors, and index-selection planner
+- **datalog:** Port the semi-naive evaluator with analytic goldens and hard budgets
+- **datalog:** Replace the provisional rule IR with the DL-clause IR
+- **entail:** Add the machine-readable rule inventory
+- **datalog:** Add checkable proof terms and a contract hash
+- **BREAKING** **entail:** Return a reasoning certificate from every materialize call
+- **validate:** Add the shared entailment-regime string boundary
+- **entail:** Seed the finite axiomatic triples and add four RDFS rules
+- **python:** Expose entailment regimes as purrdf.entail
+- **entail:** Add RDF-list materialization and the prp, cax and scm rules
+- **wasm,capi:** Expose entailment regimes to WebAssembly and the C ABI
+- **entail:** Complete OWL 2 RL — all 78 rules, and make D materializable
+- **entail:** Stop dropping OWL axioms silently, and add the existential chase
+- **entail:** Expose the DL reasoner services behind a certified facade
+- **entail:** Dataset semantics, reifier interactions, and explanations
+- **entail:** Reach every reasoner service from every host
+- **entail:** Close the last W3C entailment gap, wire the plan cache, report termination
+- **entail:** Bind the extension inventory on every host and gate its disclosure
+- **BREAKING** **entail:** Decide OWL 2 data ranges, and check the tableau against a model-enumeration oracle
+- **xsd:** Decide the rational-decimal identity exactly, and write the gmeow cutover guide
+- **BREAKING** **entail:** Certain answers by the combined approach, over a ported SLG-WFS resolver
+- **BREAKING** **entail:** A clause-based hypertableau is the OWL-Direct decision core
+- **entail:** The nominal/inverse/counting limit is a named boundary, not buried prose
+- **validate:** A reasoning session, so asking twice costs one parse
+- **python:** Expose the reasoning session as `entail.Reasoner`
+- **wasm:** Expose the reasoning session as `Reasoner`
+- **capi:** Expose the reasoning session as `PurrdfReasoner`
+- **purrdf:** Surface the reasoning session on the Rust facade, and gate all four hosts
+- **entail:** Cross-check every chase explanation against backward resolution
+- **entail:** Re-derive every chase explanation backward, and report the outcome
+- **BREAKING** **entail:** Complete the entailment surface — 78/78 OWL 2 RL, certified runs, four language hosts
+
+### Other
+
+- Revert "feat(entail): cross-check every chase explanation against backward resolution"
+
+### Performance
+
+- **BREAKING** **entail:** Classify by one saturation instead of a tableau run per class pair
+- **datalog:** Reject impossible clause/call pairs before freshening them
+
+### Refactor
+
+- **BREAKING** **entail:** Run the declared clause program instead of a hand-written chase
+- **entail:** Split the calculus into one module per rule family
+- **BREAKING** **entail:** Make materialization total over every regime
+
+### Testing
+
+- **entail:** Capture the chase's behaviour as a golden oracle
+- **conformance:** Vendor the W3C OWL 2 suite and give entailment its own row
+- **entail:** Check the OWL 2 RL closure against an independent second implementation
+- **entail:** Assert the tableau is not over-permissive where that is decidable
+- **entail:** Pin the owlrl divergence triples, and cover the value class that separates two language-tagged values
+- **entail:** Pin the divergence triple count so a regeneration cannot absorb a regression
+- Carry the per-conclusion explain contract to the remaining two hosts
+
 ## [0.9.0] - 2026-07-28
 
 ### Bug Fixes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,8 +21,8 @@ authors:
   - family-names: "Audley"
     given-names: "Patrick"
     orcid: "https://orcid.org/0000-0003-4382-7625"
-version: "0.9.0"
-date-released: "2026-07-28"
+version: "0.10.0"
+date-released: "2026-07-30"
 license:
   - Apache-2.0
   - MIT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "purrdf-columnar",
  "purrdf-datalog",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "clap",
  "memmap2",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-columnar"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-datalog"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -1366,11 +1366,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "0.9.0"
+version = "0.10.0"
 
 [[package]]
 name = "purrdf-gts"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ahash",
  "boon",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "boon",
  "criterion",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "hex",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -46,23 +46,23 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "0.9.0" }
-purrdf-columnar = { path = "crates/columnar", version = "0.9.0" }
-purrdf-core = { path = "crates/rdf-core", version = "0.9.0" }
-purrdf-datalog = { path = "crates/datalog", version = "0.9.0" }
-purrdf-entail = { path = "crates/entail", version = "0.9.0" }
-purrdf-events = { path = "crates/rdf-events", version = "0.9.0" }
-purrdf-gts = { path = "crates/gts", version = "0.9.0" }
-purrdf-iri = { path = "crates/iri", version = "0.9.0" }
-purrdf-rdf = { path = "crates/rdf", version = "0.9.0" }
-purrdf-shapes = { path = "crates/shapes", version = "0.9.0" }
-purrdf-shex = { path = "crates/shex", version = "0.9.0" }
-purrdf-slice = { path = "crates/slice", version = "0.9.0" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.9.0" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.9.0" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "0.9.0" }
-purrdf-validate = { path = "crates/validate", version = "0.9.0" }
-purrdf-xsd = { path = "crates/xsd", version = "0.9.0" }
+purrdf = { path = "crates/purrdf", version = "0.10.0" }
+purrdf-columnar = { path = "crates/columnar", version = "0.10.0" }
+purrdf-core = { path = "crates/rdf-core", version = "0.10.0" }
+purrdf-datalog = { path = "crates/datalog", version = "0.10.0" }
+purrdf-entail = { path = "crates/entail", version = "0.10.0" }
+purrdf-events = { path = "crates/rdf-events", version = "0.10.0" }
+purrdf-gts = { path = "crates/gts", version = "0.10.0" }
+purrdf-iri = { path = "crates/iri", version = "0.10.0" }
+purrdf-rdf = { path = "crates/rdf", version = "0.10.0" }
+purrdf-shapes = { path = "crates/shapes", version = "0.10.0" }
+purrdf-shex = { path = "crates/shex", version = "0.10.0" }
+purrdf-slice = { path = "crates/slice", version = "0.10.0" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.10.0" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.10.0" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "0.10.0" }
+purrdf-validate = { path = "crates/validate", version = "0.10.0" }
+purrdf-xsd = { path = "crates/xsd", version = "0.10.0" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ BINARYEN_VERSION := 130
 # context/options/registry engine, validation-scoped asserted-subclass
 # membership shared by native SHACL and SHACL-SPARQL, and now the entailment
 # engine, the nine OWL reasoner services AND the concrete domain — measures
-# 9_506_455 bytes against the 9_690_000 ceiling, which is 1.89% headroom. That
+# 9_504_607 bytes against the 9_690_000 ceiling, which is 1.91% headroom. That
 # figure is RECORDED AS A GATED CONSTANT below (WASM_SIZE_MEASURED_BYTES), not as
 # prose: it had already drifted 139_211 bytes behind the build once, because a
 # comment is the one part of this file nothing checks.
@@ -122,6 +122,10 @@ WASM_SIZE_BUDGET_BYTES := 9690000
 # ordinary codegen jitter from the touched-but-still-linked `Construct` enum
 # and id-brand additions rather than a capability moving the artifact at all.
 #
+# The change 9_506_455 -> 9_504_607 is the 0.10.0 version bump alone: the version
+# string is embedded in the artifact and the crate metadata around it repacks
+# slightly smaller. No capability moved; the figure is re-recorded because this gate
+# checks EQUALITY, so even a shrink has to be acknowledged rather than ignored.
 # The increase 9_405_331 -> 9_506_455 is the backward cross-check reaching the
 # artifact: every chase explanation is now re-derived by SLG resolution over the same
 # clause program, so `resolve_fol` and `unify` link in. It is the largest single
@@ -150,7 +154,7 @@ WASM_SIZE_BUDGET_BYTES := 9690000
 # is shared by both, so it is linked exactly once either way.
 #
 # The measured constant below is the CURRENT size, not that intermediate figure.
-WASM_SIZE_MEASURED_BYTES := 9506455
+WASM_SIZE_MEASURED_BYTES := 9504607
 
 help: ## Show this help.
 	@grep -E '^[a-zA-Z_-]+:.*## ' $(MAKEFILE_LIST) | awk -F':.*## ' '{printf "  %-18s %s\n", $$1, $$2}'

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "0.9.0"
+version = "0.10.0"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.9.0" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.10.0" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -82,4 +82,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "0.9.0"
+version = "0.10.0"

--- a/crates/rdf-capi/include/purrdf.h
+++ b/crates/rdf-capi/include/purrdf.h
@@ -9,7 +9,7 @@
 
 /* WARNING: generated file — edit crates/rdf-capi instead. */
 #define PURRDF_MAJOR 0
-#define PURRDF_MINOR 9
+#define PURRDF_MINOR 10
 #define PURRDF_PATCH 0
 
 

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -58,7 +58,7 @@ purrdf-iri = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.9.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.10.0" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.9.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.10.0" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -129,7 +129,7 @@ is not permitted to perform. Do it once, from a clean local checkout, before the
 next `rust-v*` tag:
 
 ```sh
-CARGO_REGISTRY_TOKEN="${CARGO_TOKEN}" scripts/bootstrap-crates-io.sh 0.9.1
+CARGO_REGISTRY_TOKEN="${CARGO_TOKEN}" scripts/bootstrap-crates-io.sh 0.10.0
 ```
 
 The bootstrap script prints its full plan — which crates it will skip, publish,


### PR DESCRIPTION
Cuts **0.10.0**.

## Why a minor, not the point rev that was asked for

Thirteen changelog entries in this range are marked BREAKING and six commits carry the `!` marker, including the entailment-surface squash. CONTRIBUTING's pre-1.0 rule:

> While the version is `0.x`, a **minor** bump may carry breaking API changes; a **patch** bump is bugfix-only and API-compatible.

A point release would have shipped breaking API changes to crates.io, PyPI and npm under a version that promises it did not — and publishing is irreversible.

## What moved

Version 0.10.0 across crates.io / PyPI / npm / `CITATION.cff`, `Cargo.lock` and the 20 internal path-dep pins refreshed, CHANGELOG regenerated.

Two artifacts carry the version and had to move with it:

* `crates/rdf-capi/include/purrdf.h` embeds `PURRDF_MINOR` — regenerated from the crate, not hand-edited.
* The wasm artifact repacks **1,848 bytes smaller** (9,506,455 → 9,504,607) on the version string alone. No capability moved; re-recorded because that gate checks *equality*, so a shrink has to be acknowledged too. Headroom now 1.91%.

`docs/RELEASE.md`'s bootstrap command names the version it publishes, so it moves to 0.10.0 as well.

## Blocker for the tag — maintainer action required

`purrdf-datalog`, the new crate this release introduces, **has no crates.io record**. It is seventh in publish order, so `rust-v0.10.0` would irreversibly publish the six crates ahead of it and then fail.

The lane already refuses rather than half-publishing — `scripts/check-crates-io-records.sh` runs before any packaging — so nothing is at risk. But the tag will not proceed until, from a clean checkout:

```sh
CARGO_REGISTRY_TOKEN="${CARGO_TOKEN}" scripts/bootstrap-crates-io.sh 0.10.0
```

then the Trusted Publisher entry for `purrdf-datalog` (GitHub Actions / Blackcat-Informatics / purrdf / release-cargo.yaml / no environment).

## Verification

`make check` · `make doc` · `make conformance` (GREEN) · `make capi-check` · `make wasm-pkg-size` · `make pytest` (501 passed) · `check-doc-claims.py` (82 claims) · `check-issue-refs.py` · `check-versions.py` — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Published version 0.10.0 across the core package, Python package, C API, and WebAssembly package.
  - Updated release dates and public version metadata for consistency.

- **Documentation**
  - Added comprehensive 0.10.0 release notes covering fixes, features, performance improvements, and testing updates.
  - Updated release instructions to reference the new version.

- **Performance**
  - Recorded a small reduction in the optimized WebAssembly artifact size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->