### PR TITLE
chore(release): 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to the PurRDF crate suite are recorded here. The suite
 ships one lockstep version across crates.io, PyPI, and npm; pre-1.0, a minor
 bump may carry breaking changes and a patch bump is bugfix-only.
 
+## [0.11.0] - 2026-08-02
+
+### Bug Fixes
+
+- **entail:** Make the survey's three-way early exit reachable
+- **docs:** Hold the xfail sentence to the count the matrix generates
+- **wasm:** Assert an error names a term, do not compile the term into a pattern
+- **BREAKING** **entail:** `?name` in any position, including the one it was refused in
+- **entail:** A boundary that meant two things, and two claims about rule heads that were false
+- **python:** Give each newline one way to match, not two
+- **wasm:** Assert a refusal names a term exactly, by neither of the two wrong ways
+- **wasm:** Pin the whole refusal, so the IRI reaches no matcher at all
+- **BREAKING** **entail:** A variable is not a datatype IRI, and a withheld predicate is not a smaller question
+- **BREAKING** **entail:** One IRI is one answer, and one variable name is one variable
+- **gates:** Two gates that could not fail, and two guards that could not see
+- **docs:** Derive which documents the overclaim ban sweeps, from the ban itself
+- **docs:** Make the derived sweep total, rather than saying it is
+- **docs:** Let the gate's own guards be mutated, and refuse the mutations
+- **docs:** Compose the ban patterns around their markers, rather than checking they contain one
+- **BREAKING** **entail:** A deep input must be an error, not a dead process
+- **BREAKING** **rdf:** Bound term nesting where it is parsed, and survey every position the merge writes
+- **entail:** Five reviewer findings — a lossy diagnostic, a split precedence, and three claims nothing checked
+
+### Documentation
+
+- **entail:** The doc gate is not `make check`, and it found six broken links
+- **rdf:** The XML-literal walk adds no bound; something in front of it does
+
+### Features
+
+- **entail:** A conclusion-directed entailment service over the RL chase
+- **entail:** Close the negative-conclusion lane by refutation over the chase
+- **entail:** Decide a schema axiom by freezing its body and chasing the head
+- **entail:** Comprehend the anonymous class expressions a conclusion names
+- **entail:** Read a reflexive property's self-loops off the conclusion, not the closure
+- **BREAKING** **entail:** Decide an rdfs:range axiom by datatype containment
+- **entail:** Vendor the document the last unreached premise names
+- **BREAKING** **entail:** Return the run that answered, not the verdict alone
+- **entail:** The conclusion-directed surface reaches all four hosts
+- **conformance:** Print the split an empty ledger makes trivially true
+- **BREAKING** **entail:** A conclusion graph is a conjunction, and entailment is monotone over one
+- **BREAKING** **entail:** A lane not run is a limit, not a silence
+- **BREAKING** **entail:** The import map is the caller's, on every host that has the service
+- **cli:** The binary can ask the question, not only compute the closure
+- **conformance:** Print what the twenty-three negative agreements are made of
+- **BREAKING** **entail:** Close the 16 ledgered W3C OWL 2 RL entailment-corpus gaps
+
 ## [0.10.0] - 2026-07-31
 
 ### Bug Fixes
@@ -37,10 +84,13 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 - **hygiene:** The wasm export gate read the export block and not the imports
 - **datalog:** Make the SLG budget bound the work, not just the output
 - **datalog:** Keep freshen_clause's doc on freshen_clause, and collapse the filter's ifs
+- **build:** Make the wasm artifact's size independent of who built it
 
 ### CI & Build
 
 - **wasm:** Record the session's 8,882 bytes
+- **wasm:** Raise the ceiling 25% and stop failing on the exact byte count
+- **npm:** Raise the package ceilings 25% and stop failing on the exact byte count
 
 ### Documentation
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,8 +21,8 @@ authors:
   - family-names: "Audley"
     given-names: "Patrick"
     orcid: "https://orcid.org/0000-0003-4382-7625"
-version: "0.10.0"
-date-released: "2026-07-30"
+version: "0.11.0"
+date-released: "2026-08-02"
 license:
   - Apache-2.0
   - MIT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "purrdf-columnar",
  "purrdf-datalog",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "clap",
  "memmap2",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-columnar"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-datalog"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -1366,11 +1366,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "purrdf-gts"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash",
  "boon",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "boon",
  "criterion",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "hex",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -46,23 +46,23 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "0.10.0" }
-purrdf-columnar = { path = "crates/columnar", version = "0.10.0" }
-purrdf-core = { path = "crates/rdf-core", version = "0.10.0" }
-purrdf-datalog = { path = "crates/datalog", version = "0.10.0" }
-purrdf-entail = { path = "crates/entail", version = "0.10.0" }
-purrdf-events = { path = "crates/rdf-events", version = "0.10.0" }
-purrdf-gts = { path = "crates/gts", version = "0.10.0" }
-purrdf-iri = { path = "crates/iri", version = "0.10.0" }
-purrdf-rdf = { path = "crates/rdf", version = "0.10.0" }
-purrdf-shapes = { path = "crates/shapes", version = "0.10.0" }
-purrdf-shex = { path = "crates/shex", version = "0.10.0" }
-purrdf-slice = { path = "crates/slice", version = "0.10.0" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.10.0" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.10.0" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "0.10.0" }
-purrdf-validate = { path = "crates/validate", version = "0.10.0" }
-purrdf-xsd = { path = "crates/xsd", version = "0.10.0" }
+purrdf = { path = "crates/purrdf", version = "0.11.0" }
+purrdf-columnar = { path = "crates/columnar", version = "0.11.0" }
+purrdf-core = { path = "crates/rdf-core", version = "0.11.0" }
+purrdf-datalog = { path = "crates/datalog", version = "0.11.0" }
+purrdf-entail = { path = "crates/entail", version = "0.11.0" }
+purrdf-events = { path = "crates/rdf-events", version = "0.11.0" }
+purrdf-gts = { path = "crates/gts", version = "0.11.0" }
+purrdf-iri = { path = "crates/iri", version = "0.11.0" }
+purrdf-rdf = { path = "crates/rdf", version = "0.11.0" }
+purrdf-shapes = { path = "crates/shapes", version = "0.11.0" }
+purrdf-shex = { path = "crates/shex", version = "0.11.0" }
+purrdf-slice = { path = "crates/slice", version = "0.11.0" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.11.0" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.11.0" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "0.11.0" }
+purrdf-validate = { path = "crates/validate", version = "0.11.0" }
+purrdf-xsd = { path = "crates/xsd", version = "0.11.0" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "0.10.0"
+version = "0.11.0"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.10.0" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.11.0" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -82,4 +82,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "0.10.0"
+version = "0.11.0"

--- a/crates/rdf-capi/include/purrdf.h
+++ b/crates/rdf-capi/include/purrdf.h
@@ -9,7 +9,7 @@
 
 /* WARNING: generated file — edit crates/rdf-capi instead. */
 #define PURRDF_MAJOR 0
-#define PURRDF_MINOR 10
+#define PURRDF_MINOR 11
 #define PURRDF_PATCH 0
 
 

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -58,7 +58,7 @@ purrdf-iri = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.10.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.11.0" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.10.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.11.0" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.


### PR DESCRIPTION
Cuts **0.11.0** across crates.io, PyPI and npm.

## Why 0.11.0 and not 0.10.1

The only thing this release carries beyond `0.10.0` is the OWL 2 RL entailment-corpus work, whose
squash commit is marked `feat(entail)!` with a `BREAKING CHANGE:` footer. The changelog's own
preamble states the rule a patch bump would have broken:

> pre-1.0, a minor bump may carry breaking changes and **a patch bump is bugfix-only**.

What breaks:

* `EntailmentMechanism` gains `Composite`; `EntailmentWarrant` gains `Composite(CompositeWarrant)`;
  `UndecidedReason` gains `ConclusionOutsideRl`, `ConstructNotRead` and `OpenPredicate`; `QNode`
  gains `Triple` — exhaustive matches over any of the four need a new arm.
* All three conclusion-directed services gain a **required** import-map parameter on every host.
  This is **ABI-breaking on the C surface**: callers must recompile.
* `CertainAnswers::report().mechanism()` is no longer always `StrictTable`.
* A variable in a literal's datatype is refused by name.
* An OWL class expression nested deeper than 256, a cyclic `owl:datatypeComplementOf`, and any
  document nesting terms or XML elements deeper than 128 are now named errors — each previously
  killed the process.

Released as a patch, every consumer on `^0.10` / `~=0.10.0` would have been upgraded into it
automatically and their build would have broken.

## What the release commit contains

Exactly the four steps in `docs/RELEASE.md`, nothing else:

1. `make bump VERSION=0.11.0` — 18 publishable crates plus 20 internal path-dep pins, `CITATION.cff`,
   `pyproject.toml`, `uv.lock`, the capi manifest and `package.json`, all in lockstep.
2. `cargo update --workspace --offline` — `make bump` rewrites the manifests and does **not** touch
   `Cargo.lock`, so a `--locked` build against the bumped tree fails until the member versions are
   carried across. This is a known trap in this repo, not a discretionary change.
3. `make capi-header` — the regenerated header diff is exactly `PURRDF_MINOR 10` → `11`.
4. `make changelog` — stamps `## [0.11.0] - 2026-08-02`, with `0.10.0` still appearing exactly once
   (git-cliff mis-buckets when the release branch carries a merge commit; this branch is linear off
   `main`, and the section was verified rather than assumed).

No source change. No behaviour change.

## Gates

`make check` · `make doc` · `make conformance` (VERDICT: GREEN) · `make capi-check` ·
`scripts/check-versions.py` (*"version 0.11.0 coherent across crates.io/PyPI/npm; release lane
publishes all 18 publishable crates"*) · `scripts/check-doc-claims.py` (87 claims) — all exit 0.

## After merge

`make release-tags VERSION=0.11.0` from `main`, which re-runs the full cross-surface preflight and
then atomically pushes `rust-v0.11.0`, `py-v0.11.0` and `npm-v0.11.0` together. No tag is created
before every surface passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Released version 0.11.0 across the Rust, Python, C, and WebAssembly packages.
  - Updated version and citation metadata for the new release.

- **Documentation**
  - Added release notes covering improvements and fixes across entailment, RDF, WebAssembly, Python, gates, CLI, and conformance.
  - Documented updated WebAssembly and npm artifact size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->