### PR TITLE
chore(release): 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to the PurRDF crate suite are recorded here. The suite
 ships one lockstep version across crates.io, PyPI, and npm; pre-1.0, a minor
 bump may carry breaking changes and a patch bump is bugfix-only.
 
+## [0.12.0] - 2026-08-02
+
+### Bug Fixes
+
+- **BREAKING** **canon:** Reserve the overlay's namespace by refusal, not by assertion
+
+### Features
+
+- **BREAKING** Let a new enum variant stop being a breaking change
+- **errors:** Let the standard chain reach the failure underneath
+- **canon:** Name and version the canonicalization profile, with a frozen vector corpus
+
+### Performance
+
+- **datalog:** Keep the join's binding frame off the heap
+- **sparql-eval:** Reject a candidate before paying to copy the row
+- **rdf:** Write the text serializers into one buffer instead of many
+- **rdf:** Write TriG in place, blocks and all
+- **rdf:** Sort the canonical order through a comparator, not through keys
+- **rdf:** Cut allocations on the hot paths; fix(canon)!: collision-safe RDF 1.2 canonicalization profile
+
+### Refactor
+
+- **BREAKING** **rdf:** The codec's serializer takes the caller's buffer
+
+### Testing
+
+- **datalog:** Give the semi-naive join a bench of its own
+- **conformance:** Put the canonicalization profile on the scoreboard
+
 ## [0.11.0] - 2026-08-02
 
 ### Bug Fixes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,7 +21,7 @@ authors:
   - family-names: "Audley"
     given-names: "Patrick"
     orcid: "https://orcid.org/0000-0003-4382-7625"
-version: "0.11.0"
+version: "0.12.0"
 date-released: "2026-08-02"
 license:
   - Apache-2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "purrdf-columnar",
  "purrdf-datalog",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "memmap2",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-columnar"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-datalog"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -1368,11 +1368,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "purrdf-gts"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "boon",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "boon",
  "criterion",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "hex",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -46,23 +46,23 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "0.11.0" }
-purrdf-columnar = { path = "crates/columnar", version = "0.11.0" }
-purrdf-core = { path = "crates/rdf-core", version = "0.11.0" }
-purrdf-datalog = { path = "crates/datalog", version = "0.11.0" }
-purrdf-entail = { path = "crates/entail", version = "0.11.0" }
-purrdf-events = { path = "crates/rdf-events", version = "0.11.0" }
-purrdf-gts = { path = "crates/gts", version = "0.11.0" }
-purrdf-iri = { path = "crates/iri", version = "0.11.0" }
-purrdf-rdf = { path = "crates/rdf", version = "0.11.0" }
-purrdf-shapes = { path = "crates/shapes", version = "0.11.0" }
-purrdf-shex = { path = "crates/shex", version = "0.11.0" }
-purrdf-slice = { path = "crates/slice", version = "0.11.0" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.11.0" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.11.0" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "0.11.0" }
-purrdf-validate = { path = "crates/validate", version = "0.11.0" }
-purrdf-xsd = { path = "crates/xsd", version = "0.11.0" }
+purrdf = { path = "crates/purrdf", version = "0.12.0" }
+purrdf-columnar = { path = "crates/columnar", version = "0.12.0" }
+purrdf-core = { path = "crates/rdf-core", version = "0.12.0" }
+purrdf-datalog = { path = "crates/datalog", version = "0.12.0" }
+purrdf-entail = { path = "crates/entail", version = "0.12.0" }
+purrdf-events = { path = "crates/rdf-events", version = "0.12.0" }
+purrdf-gts = { path = "crates/gts", version = "0.12.0" }
+purrdf-iri = { path = "crates/iri", version = "0.12.0" }
+purrdf-rdf = { path = "crates/rdf", version = "0.12.0" }
+purrdf-shapes = { path = "crates/shapes", version = "0.12.0" }
+purrdf-shex = { path = "crates/shex", version = "0.12.0" }
+purrdf-slice = { path = "crates/slice", version = "0.12.0" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.12.0" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.12.0" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "0.12.0" }
+purrdf-validate = { path = "crates/validate", version = "0.12.0" }
+purrdf-xsd = { path = "crates/xsd", version = "0.12.0" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "0.11.0"
+version = "0.12.0"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.11.0" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.12.0" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -82,4 +82,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "0.11.0"
+version = "0.12.0"

--- a/crates/rdf-capi/include/purrdf.h
+++ b/crates/rdf-capi/include/purrdf.h
@@ -9,7 +9,7 @@
 
 /* WARNING: generated file — edit crates/rdf-capi instead. */
 #define PURRDF_MAJOR 0
-#define PURRDF_MINOR 11
+#define PURRDF_MINOR 12
 #define PURRDF_PATCH 0
 
 

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -58,7 +58,7 @@ purrdf-iri = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.11.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.12.0" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.11.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.12.0" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.


### PR DESCRIPTION
Version stamped across crates.io, PyPI and npm (18 publishable crates, 20 internal path-dep pins), `Cargo.lock` refreshed, `purrdf.h` regenerated by cbindgen, CHANGELOG section generated.

A MAJOR-in-spirit minor: 0.x, so breaking changes ride a minor bump — but there are several.

## The one to read: canonicalization

An RDF 1.2 identity-collision is closed. The overlay's sentinel IRIs were reserved *by assertion* — the module claimed no real dataset could occupy them — and nothing made that true. A dataset asserting the lowered form literally canonicalized to the same bytes as a genuine reifier structure, which for a content-addressed consumer is an identity-forgery primitive.

The reservation is now enforced over the whole `urn:purrdf:rdfc:` namespace, by refusal.

`purrdf-rdfc12` v1 ships alongside it: a named, versioned profile with a frozen, content-addressed vector corpus, so canonical bytes are something a consumer can *pin and verify* rather than infer from a revision.

## Breaking changes

| Change | Impact |
|---|---|
| `try_canonicalize`/`_with` return `CanonError` | was `BudgetExceeded`; reserved-vocabulary refusals are now distinguishable from budget ones |
| `PackError::CanonBudgetExceeded` → `CanonRefused(CanonError)` | same for `CertifyError` |
| `PackError` no longer `Copy` | a refusal that names an IRI cannot be; ripple was zero call sites |
| `canonicalize`/`_with` panic on reserved vocabulary | as they already did on budget exhaustion; both now carry a `# Panics` contract |
| 41 enums gain `#[non_exhaustive]` | downstream matches need a wildcard. Paid once — after this a new variant is no longer breaking |
| `RdfCodec` implementors provide `serialize_into` | crate-internal trait |

## Verification

`make check` · `make doc` · `make capi-check` — all green on the release commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Released version 0.12.0 across supported packages and language bindings.
  - Updated version metadata and published changelog information.
  - Includes bug fixes, new features, performance improvements, serializer updates, and testing enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->