### PR TITLE
build(toolchain): pin the dated nightly rust-2026-09-02 and make the workspace clean under it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+        with:
+          toolchain: "nightly-2026-09-02" # keep in sync with rust-toolchain.toml
 
       - name: Format
         run: cargo fmt --all --check
@@ -35,6 +37,12 @@ jobs:
 
       - name: Enforce no Cargo features
         run: python3 scripts/check-no-features.py
+
+      - name: Check every workflow installs the toolchain rust-toolchain.toml pins
+        run: python3 scripts/check-toolchain-pin.py
+
+      - name: Check the toolchain-pin gate can still fail
+        run: python3 scripts/check-toolchain-pin.py --self-test
 
       - name: Check vendored-corpus license hygiene
         run: python3 scripts/check-licenses.py
@@ -73,7 +81,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+        with:
+          toolchain: "nightly-2026-09-02" # keep in sync with rust-toolchain.toml
 
       - name: Run workspace tests (includes doc tests)
         run: cargo test --workspace --locked
@@ -88,7 +98,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+        with:
+          toolchain: "nightly-2026-09-02" # keep in sync with rust-toolchain.toml
 
       - name: Install uv
         run: |
@@ -114,7 +126,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+        with:
+          toolchain: "nightly-2026-09-02" # keep in sync with rust-toolchain.toml
 
       - name: Install cargo-c (the pinned header-contract generator)
         # Pinned to the exact cargo-c whose bundled cbindgen the committed
@@ -135,7 +149,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+        with:
+          toolchain: "nightly-2026-09-02" # keep in sync with rust-toolchain.toml
 
       # Document exactly the 18 publishable crates with rustdoc lints promoted
       # to errors. The four publish=false crates are excluded
@@ -154,12 +170,36 @@ jobs:
           persist-credentials: false
 
       - name: Install MSRV Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
         with:
           toolchain: "1.96"
 
+      # RUSTUP_TOOLCHAIN is mandatory here, not belt-and-braces. The action
+      # selects a toolchain with `rustup default`, which sits at the BOTTOM of
+      # rustup's precedence order — below `rust-toolchain.toml`. So the install
+      # step above alone does not make cargo use 1.96 inside this repo; the
+      # repo pin wins and the job silently measures the dev toolchain instead.
+      # `RUSTUP_TOOLCHAIN` outranks the file, so this is what actually holds the
+      # floor at 1.96 and proves no nightly-only feature has crept in.
       - name: Check workspace on MSRV
         run: cargo check --workspace --lib --locked
+        env:
+          RUSTUP_TOOLCHAIN: "1.96"
+
+      # Prove the guard is live: if the toolchain selection above ever regresses
+      # to the repo pin, this fails loudly instead of the job quietly passing on
+      # a compiler that is not the MSRV.
+      - name: Assert the MSRV job really ran on 1.96
+        run: |
+          set -euo pipefail
+          version=$(rustc --version)
+          echo "$version"
+          case "$version" in
+            "rustc 1.96."*) ;;
+            *) echo "::error::MSRV job resolved '$version', expected rustc 1.96.x" >&2; exit 1 ;;
+          esac
+        env:
+          RUSTUP_TOOLCHAIN: "1.96"
 
   wasm:
     runs-on: ubuntu-latest
@@ -171,8 +211,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
         with:
+          toolchain: "nightly-2026-09-02" # keep in sync with rust-toolchain.toml
           targets: wasm32-unknown-unknown
 
       - name: Set up the pinned wasm toolchain (wasm-bindgen + binaryen) and cache
@@ -244,7 +285,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+        with:
+          toolchain: "nightly-2026-09-02" # keep in sync with rust-toolchain.toml
 
       - name: Install uv
         run: |
@@ -304,7 +347,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+        with:
+          toolchain: "nightly-2026-09-02" # keep in sync with rust-toolchain.toml
 
       - name: Install uv
         run: |
@@ -340,7 +385,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+        with:
+          toolchain: "nightly-2026-09-02" # keep in sync with rust-toolchain.toml
 
       - name: Install uv
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -43,8 +43,9 @@ jobs:
       # release publishes; it ships as a /playground subpath of the single Pages
       # artifact (GitHub Pages allows only one deployment, already owned here).
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
         with:
+          toolchain: "nightly-2026-09-02" # keep in sync with rust-toolchain.toml
           targets: wasm32-unknown-unknown
 
       - name: Set up the pinned wasm toolchain (wasm-bindgen + binaryen) and cache

--- a/.github/workflows/release-cargo.yaml
+++ b/.github/workflows/release-cargo.yaml
@@ -23,6 +23,15 @@ concurrency:
 permissions:
   contents: read
 
+# Release artifacts are built on STABLE, not on the dated nightly that
+# `rust-toolchain.toml` pins for development and CI gates. This env var is load
+# bearing: the `dtolnay/rust-toolchain` action selects with `rustup default`,
+# which ranks BELOW `rust-toolchain.toml` in rustup's precedence order, so
+# without `RUSTUP_TOOLCHAIN` every cargo invocation here would silently use the
+# nightly pin no matter what the install step says.
+env:
+  RUSTUP_TOOLCHAIN: stable
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -37,9 +46,16 @@ jobs:
         with:
           persist-credentials: false
 
+      # Nightly is pinned in rust-toolchain.toml for its sharper lint surface;
+      # that buys nothing for an artifact a consumer installs, and shipping one
+      # compiled by an unreleased compiler is risk without upside. The workspace
+      # uses no nightly features (the `msrv` CI job holds that floor at 1.96),
+      # so stable always builds. See the workflow-level `env` above for why
+      # RUSTUP_TOOLCHAIN, not this input, is what actually selects stable.
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
         with:
+          toolchain: stable
           targets: wasm32-unknown-unknown
 
       - name: Verify tag matches workspace crate versions

--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -29,6 +29,15 @@ permissions:
   id-token: write
   attestations: write
 
+# Release artifacts are built on STABLE, not on the dated nightly that
+# `rust-toolchain.toml` pins for development and CI gates. This env var is load
+# bearing: the `dtolnay/rust-toolchain` action selects with `rustup default`,
+# which ranks BELOW `rust-toolchain.toml` in rustup's precedence order, so
+# without `RUSTUP_TOOLCHAIN` every cargo invocation here would silently use the
+# nightly pin no matter what the install step says.
+env:
+  RUSTUP_TOOLCHAIN: stable
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -49,9 +58,13 @@ jobs:
             exit 1
           fi
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      # Stable, not the dated nightly in rust-toolchain.toml: this step builds
+      # the wasm artifact that ships to npm consumers. See the workflow-level
+      # `env` above for why RUSTUP_TOOLCHAIN, not this input, selects it.
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
         with:
+          toolchain: stable
           targets: wasm32-unknown-unknown
 
       - name: Set up the pinned wasm toolchain (wasm-bindgen + binaryen) and cache

--- a/.github/workflows/release-pypi.yaml
+++ b/.github/workflows/release-pypi.yaml
@@ -17,6 +17,15 @@ on:
     tags:
       - "py-v*"
 
+# Release artifacts are built on STABLE, not on the dated nightly that
+# `rust-toolchain.toml` pins for development and CI gates. This env var is load
+# bearing: the `dtolnay/rust-toolchain` action selects with `rustup default`,
+# which ranks BELOW `rust-toolchain.toml` in rustup's precedence order, so
+# without `RUSTUP_TOOLCHAIN` every cargo invocation here would silently use the
+# nightly pin no matter what the install step says.
+env:
+  RUSTUP_TOOLCHAIN: stable
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -37,8 +46,11 @@ jobs:
         with:
           python-version: "3.13"
 
+      # Stable, not the dated nightly in rust-toolchain.toml: this step builds
+      # the wheels that ship to PyPI consumers. See the workflow-level `env`
+      # above for why RUSTUP_TOOLCHAIN, not this input, actually selects it.
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
         with:
           toolchain: stable
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,10 +113,37 @@ make metadata   # regenerate + verify generated artifacts
 make bench      # criterion benchmarks (report-only; not a gate)
 ```
 
-Toolchain: `rust-toolchain.toml` pins **stable** and the workspace is
-nightly-free by policy (`rust-version` in `Cargo.toml` is the enforced MSRV
-floor). Never introduce a nightly-only feature; rustup obeys the repo pin in
-CI too, so a nightly-ism would make the MSRV job a lie.
+Toolchain: `rust-toolchain.toml` pins a **dated nightly** for development and
+for every CI gate. That is a lint decision, not a licence: nightly clippy and
+rustdoc carry lints stable lacks, so a finding is a real finding rather than a
+channel artifact. The date is mandatory — a floating `nightly` would re-resolve
+to a different compiler daily, which no workspace with byte-deterministic
+serializers, a byte-deterministic GTS writer, frozen corpora, and
+content-addressed goldens can accept. Bump it deliberately, in its own commit,
+with the gates re-run.
+
+**The source stays nightly-free.** There are zero `#![feature(...)]` attributes
+in `crates/` and `bindings/`, and adding one is forbidden. What consumers need
+is `rust-version` in `Cargo.toml` (the MSRV, currently 1.96) — a *lower* floor on
+the *stable* channel — enforced by the dedicated `msrv` CI job. Never "align" the
+MSRV to the dev pin; they answer different questions.
+
+Two traps, both load-bearing:
+
+* `dtolnay/rust-toolchain` selects with `rustup default`, which ranks **below**
+  `rust-toolchain.toml`. A workflow that installs one toolchain while the repo
+  pins another does not fail — it silently runs the pin. Only
+  `RUSTUP_TOOLCHAIN` outranks the file, which is why the `msrv` job and the
+  release lanes set it explicitly, and why the `msrv` job also asserts
+  `rustc --version` really is 1.96.x.
+* `scripts/check-toolchain-pin.py` (in `make check` and CI) fails on any
+  workflow whose install step disagrees with the pin without that explicit
+  escape, and on a floating channel.
+
+Release lanes (`release-cargo`, `release-npm`, `release-pypi`) build on
+**stable** on purpose: nightly's sharper lints buy nothing for an artifact a
+consumer installs, and shipping one from an unreleased compiler is risk without
+upside.
 
 ## 4. Performance discipline
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,10 +53,20 @@ and the `CITATION.cff` citation record share **one** workspace version and ship 
 lockstep — CI runs a version-coherence check that fails if the four sources
 disagree.
 
-**MSRV.** The workspace pins **stable** in `rust-toolchain.toml` and is nightly-free
-by policy; the supported floor is `rust-version` in `Cargo.toml` (currently **1.96**),
-which CI enforces with a dedicated MSRV job. Raising the MSRV is a notable, changelog-
-recorded change that, pre-1.0, rides a minor bump.
+**MSRV.** The supported floor is `rust-version` in `Cargo.toml` (currently **1.96**)
+on the **stable** channel, and CI enforces it with a dedicated MSRV job. That floor
+is what you build against as a consumer; it is unaffected by the toolchain
+contributors run. Raising the MSRV is a notable, changelog-recorded change that,
+pre-1.0, rides a minor bump.
+
+**Development toolchain.** `rust-toolchain.toml` pins a **dated nightly** for local
+work and CI gates, because nightly clippy and rustdoc carry lints stable lacks —
+so a gate finding is a real finding, not a channel artifact. The *source* stays
+nightly-free: there are no `#![feature(...)]` attributes anywhere in the workspace
+and adding one is rejected, which is exactly what the MSRV job proves on every PR.
+Release artifacts are built on stable. If you have `rustup` installed, the pin
+applies automatically; `scripts/check-toolchain-pin.py` (part of `make check`)
+fails if a CI workflow ever drifts from it.
 
 **Changelog.** Write **conventional-commit messages** (`type(scope): summary`, e.g.
 `feat(sparql): ...`, `fix(gts): ...`) — they feed the generated changelog, so their

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,10 @@ unsafe_op_in_unsafe_fn = "warn"
 missing_debug_implementations = "warn"
 unreachable_pub = "warn"
 unused_qualifications = "warn"
-rust-2018-idioms = { level = "warn", priority = -1 }
+# Underscore spelling, not `rust-2018-idioms`: cargo deprecated the dashed form
+# and will stop honouring it in a future edition, at which point the whole lint
+# GROUP would silently stop applying. Nightly cargo already warns about it.
+rust_2018_idioms = { level = "warn", priority = -1 }
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ check: ## The full local gate: fmt, clippy, build, tests, hygiene.
 	cargo clippy --workspace --all-targets --locked -- -D warnings
 	cargo check --workspace --lib --tests --locked
 	python3 scripts/check-no-features.py
+	python3 scripts/check-toolchain-pin.py
 	python3 scripts/check-iri-resolver-singleton.py
 	python3 scripts/check-licenses.py
 	python3 scripts/check-corpus-frozen.py

--- a/README.md
+++ b/README.md
@@ -362,10 +362,16 @@ released in lockstep. That coherence is enforced in CI: a version-coherence chec
 fails the build if the three version sources disagree.
 
 **MSRV policy.** The supported minimum Rust is `rust-version` in the root
-`Cargo.toml` (currently **1.96**), pinned to the **stable** toolchain (nightly-free)
-and enforced by a dedicated CI MSRV job. Raising the MSRV is a notable change
-recorded in the changelog and, pre-1.0, rides a minor bump. The README MSRV badge
-is maintained by hand and must be bumped together with `rust-version`.
+`Cargo.toml` (currently **1.96**) on the **stable** channel, enforced by a dedicated
+CI MSRV job, and release artifacts are built on stable. Raising the MSRV is a
+notable change recorded in the changelog and, pre-1.0, rides a minor bump. The
+README MSRV badge is maintained by hand and must be bumped together with
+`rust-version`.
+
+Contributors run a dated nightly (`rust-toolchain.toml`) for its sharper clippy and
+rustdoc lint surface, but the workspace contains **no nightly-only features** — the
+MSRV job is what proves that on every change. Building PurRDF needs nothing beyond
+stable 1.96.
 
 ## The GMEOW family
 

--- a/bindings/python/src/py_entail.rs
+++ b/bindings/python/src/py_entail.rs
@@ -84,7 +84,7 @@ use crate::py_gts_dataset::PyRdfDataset;
 /// total map onto [`Regime`]. Every entry point in this module also accepts the
 /// regime's CLI spelling as a plain `str` (`"owl-rl"`), so one spelling works from
 /// the command line, through the C ABI, through WASM and from Python.
-#[pyclass(name = "Regime", eq, eq_int, from_py_object)]
+#[pyclass(name = "Regime", eq, eq_int, skip_from_py_object)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[allow(
@@ -1053,6 +1053,30 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(check_proof, m)?)?;
     m.add_function(wrap_pyfunction!(proof_services, m)?)?;
     Ok(())
+}
+
+// `skip_from_py_object` + this hand-written impl, rather than `from_py_object`.
+//
+// `#[pyclass(from_py_object)]` generates exactly this impl with
+// `Clone::clone(&*guard)` as the body. `PyRegime` is `Copy`, so that clone is a copy
+// wearing a `.clone()` -- a real `clippy::clone_on_copy`, and one no `#[allow]`
+// on the enum can reach, because the macro emits the impl as a SIBLING item
+// outside the enum's attribute scope. Writing the impl out and dereferencing
+// through `Copy` removes the clone at its source instead of hiding it.
+//
+// This is a transcription of the pyo3 0.29 expansion, not a redesign: same
+// `Error` type, same `PyClassGuard` extraction, same error path. The
+// `INPUT_TYPE` associated const the macro can also emit is gated on pyo3's
+// `experimental-inspect` feature, which is off here, so there is nothing else to
+// carry over. The Python-visible behaviour is unchanged.
+impl<'a, 'py> FromPyObject<'a, 'py> for PyRegime {
+    type Error = pyo3::pyclass::PyClassGuardError<'a, 'py>;
+
+    fn extract(
+        obj: Borrowed<'a, 'py, PyAny>,
+    ) -> Result<Self, <Self as FromPyObject<'a, 'py>>::Error> {
+        Ok(*obj.extract::<PyClassGuard<'_, Self>>()?)
+    }
 }
 
 #[cfg(test)]

--- a/bindings/python/src/py_store/canon.rs
+++ b/bindings/python/src/py_store/canon.rs
@@ -19,7 +19,7 @@ use crate::{RdfDataset, RdfQuad, RdfTerm, RdfTriple, flat_dataset_from_quads};
 
 /// The graph canonicalization algorithms. Mirrors the oxigraph Python
 /// `CanonicalizationAlgorithm` so the Python surface is unchanged.
-#[pyclass(name = "CanonicalizationAlgorithm", eq, eq_int, from_py_object)]
+#[pyclass(name = "CanonicalizationAlgorithm", eq, eq_int, skip_from_py_object)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[allow(
@@ -100,6 +100,30 @@ fn relabel_term(term: &RdfTerm, map: &HashMap<String, String>) -> RdfTerm {
             t.predicate.clone(),
             relabel_term(&t.object, map),
         )),
+    }
+}
+
+// `skip_from_py_object` + this hand-written impl, rather than `from_py_object`.
+//
+// `#[pyclass(from_py_object)]` generates exactly this impl with
+// `Clone::clone(&*guard)` as the body. `PyCanonicalizationAlgorithm` is `Copy`, so that clone is a copy
+// wearing a `.clone()` -- a real `clippy::clone_on_copy`, and one no `#[allow]`
+// on the enum can reach, because the macro emits the impl as a SIBLING item
+// outside the enum's attribute scope. Writing the impl out and dereferencing
+// through `Copy` removes the clone at its source instead of hiding it.
+//
+// This is a transcription of the pyo3 0.29 expansion, not a redesign: same
+// `Error` type, same `PyClassGuard` extraction, same error path. The
+// `INPUT_TYPE` associated const the macro can also emit is gated on pyo3's
+// `experimental-inspect` feature, which is off here, so there is nothing else to
+// carry over. The Python-visible behaviour is unchanged.
+impl<'a, 'py> FromPyObject<'a, 'py> for PyCanonicalizationAlgorithm {
+    type Error = pyo3::pyclass::PyClassGuardError<'a, 'py>;
+
+    fn extract(
+        obj: Borrowed<'a, 'py, PyAny>,
+    ) -> Result<Self, <Self as FromPyObject<'a, 'py>>::Error> {
+        Ok(*obj.extract::<PyClassGuard<'_, Self>>()?)
     }
 }
 

--- a/bindings/python/src/py_store/io.rs
+++ b/bindings/python/src/py_store/io.rs
@@ -30,7 +30,7 @@ use crate::{
 ///
 /// Mirrors the oxigraph Python `RdfFormat`; the members keep the SCREAMING_SNAKE Python
 /// spelling (`RdfFormat.TURTLE`).
-#[pyclass(name = "RdfFormat", eq, eq_int, from_py_object)]
+#[pyclass(name = "RdfFormat", eq, eq_int, skip_from_py_object)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[allow(
@@ -390,6 +390,30 @@ pub(crate) fn read_input(
         return Ok(text.to_str()?.as_bytes().to_vec());
     }
     Err(PyTypeError::new_err("input must be bytes or str"))
+}
+
+// `skip_from_py_object` + this hand-written impl, rather than `from_py_object`.
+//
+// `#[pyclass(from_py_object)]` generates exactly this impl with
+// `Clone::clone(&*guard)` as the body. `PyRdfFormat` is `Copy`, so that clone is a copy
+// wearing a `.clone()` -- a real `clippy::clone_on_copy`, and one no `#[allow]`
+// on the enum can reach, because the macro emits the impl as a SIBLING item
+// outside the enum's attribute scope. Writing the impl out and dereferencing
+// through `Copy` removes the clone at its source instead of hiding it.
+//
+// This is a transcription of the pyo3 0.29 expansion, not a redesign: same
+// `Error` type, same `PyClassGuard` extraction, same error path. The
+// `INPUT_TYPE` associated const the macro can also emit is gated on pyo3's
+// `experimental-inspect` feature, which is off here, so there is nothing else to
+// carry over. The Python-visible behaviour is unchanged.
+impl<'a, 'py> FromPyObject<'a, 'py> for PyRdfFormat {
+    type Error = pyo3::pyclass::PyClassGuardError<'a, 'py>;
+
+    fn extract(
+        obj: Borrowed<'a, 'py, PyAny>,
+    ) -> Result<Self, <Self as FromPyObject<'a, 'py>>::Error> {
+        Ok(*obj.extract::<PyClassGuard<'_, Self>>()?)
+    }
 }
 
 #[cfg(test)]

--- a/bindings/python/src/py_store/store.rs
+++ b/bindings/python/src/py_store/store.rs
@@ -824,7 +824,15 @@ impl PyStore {
     /// frozen `Arc` taken now, a later `add`/`remove`/`update` on this `Store` leaves
     /// the snapshot a consumer already holds untouched (snapshot-vs-mutation aliasing
     /// safety).
-    fn _store_capsule<'py>(slf: &Bound<'py, Self>) -> PyResult<Bound<'py, PyCapsule>> {
+    /// The leading underscore belongs to the PYTHON name, not the Rust one: it is
+    /// the cross-package protocol `purrdf_shapes` calls by string
+    /// (`data.call_method0("_store_capsule")`), and Python spells "internal" with
+    /// an underscore. Naming the Rust item `_store_capsule` too would make it an
+    /// underscore-prefixed item that the crate then uses — the convention for
+    /// "deliberately unused" — so the Python spelling is carried by
+    /// `#[pyo3(name = ...)]` and the Rust item keeps an ordinary name.
+    #[pyo3(name = "_store_capsule")]
+    fn store_capsule<'py>(slf: &Bound<'py, Self>) -> PyResult<Bound<'py, PyCapsule>> {
         let py = slf.py();
         let guard = slf.borrow();
         let inner = &guard.inner;

--- a/crates/cli/src/governors.rs
+++ b/crates/cli/src/governors.rs
@@ -420,7 +420,7 @@ mod tests {
             max_remote_requests: None,
         };
         assert!(!none.is_engaged());
-        assert!(none.named().is_empty());
+        assert_eq!(none.named(), [] as [&str; 0]);
         assert!(!none.to_governors().is_engaged());
 
         let all = GovernorFlags {

--- a/crates/cli/src/immutable.rs
+++ b/crates/cli/src/immutable.rs
@@ -385,7 +385,7 @@ mod tests {
     fn empty_disk_file_is_acquired_as_owned_empty() {
         let file = temp_with(&[]);
         let input = ImmutableInput::from_disk_path(path_of(&file)).expect("acquire");
-        assert!(input.as_bytes().is_empty());
+        assert_eq!(input.as_bytes(), [] as [u8; 0]);
         assert_eq!(input.tier(), InputTier::Owned);
     }
 

--- a/crates/cli/tests/describe_cli.rs
+++ b/crates/cli/tests/describe_cli.rs
@@ -313,7 +313,7 @@ fn every_native_source_format_reaches_the_same_description() {
     ]);
     assert_eq!(code(&baseline), 0, "{}", stderr(&baseline));
     let expected = stdout(&baseline);
-    assert!(!expected.is_empty());
+    assert_ne!(expected, "");
 
     for (token, extension) in [
         ("turtle", "ttl"),
@@ -1050,5 +1050,5 @@ fn a_named_graph_description_is_refused_by_a_single_graph_target() {
         &plain,
     ]);
     assert_eq!(code(&flat), 0, "{}", stderr(&flat));
-    assert!(!stdout(&flat).is_empty());
+    assert_ne!(stdout(&flat), "");
 }

--- a/crates/cli/tests/projection_cli.rs
+++ b/crates/cli/tests/projection_cli.rs
@@ -147,7 +147,7 @@ fn project_is_byte_deterministic_and_lift_round_trips_with_ledgers() {
         "project failed: {}",
         String::from_utf8_lossy(&projected.stderr)
     );
-    assert!(projected.stdout.is_empty());
+    assert_eq!(projected.stdout, [] as [u8; 0]);
     let ledger: serde_json::Value =
         serde_json::from_slice(&projected.stderr).expect("project ledger JSON");
     assert_eq!(ledger["schema_version"], 1);
@@ -198,7 +198,10 @@ fn project_is_byte_deterministic_and_lift_round_trips_with_ledgers() {
     let ledger: serde_json::Value =
         serde_json::from_slice(&lifted.stderr).expect("lift ledger JSON");
     assert_eq!(ledger["schema_version"], 1);
-    assert!(!ledger["losses"].as_array().expect("loss array").is_empty());
+    assert_ne!(
+        ledger["losses"].as_array().expect("loss array").as_slice(),
+        [] as [serde_json::Value; 0]
+    );
 }
 
 /// `--base` resolves relative IRIs on parse; the native pack container stores
@@ -272,7 +275,7 @@ fn stdin_stdout_paths_keep_binary_and_rdf_streams_clean() {
         "project stdin failed: {}",
         String::from_utf8_lossy(&projected.stderr)
     );
-    assert!(projected.stderr.is_empty());
+    assert_eq!(projected.stderr, [] as [u8; 0]);
     assert!(projected.stdout.len() >= 1_536);
 
     let lifted = run_with_stdin(
@@ -294,7 +297,7 @@ fn stdin_stdout_paths_keep_binary_and_rdf_streams_clean() {
         "lift stdin failed: {}",
         String::from_utf8_lossy(&lifted.stderr)
     );
-    assert!(lifted.stderr.is_empty());
+    assert_eq!(lifted.stderr, [] as [u8; 0]);
     let turtle = String::from_utf8(lifted.stdout).expect("Turtle");
     assert!(turtle.contains("https://example.org/s"));
 }

--- a/crates/cli/tests/shex_cli.rs
+++ b/crates/cli/tests/shex_cli.rs
@@ -703,7 +703,7 @@ fn a_map_naming_an_undeclared_shape_is_refused_rather_than_reported_nonconforman
     ]);
     assert_eq!(code(&start), 1, "{}", stderr(&start));
     assert!(stderr(&start).contains("START"), "{}", stderr(&start));
-    assert!(stdout(&start).is_empty());
+    assert_eq!(stdout(&start), "");
 
     // The refusal is decided from the map and the schema alone, so a selector that matches
     // NOTHING is refused too — otherwise the mistake would be invisible exactly when the
@@ -821,7 +821,7 @@ fn a_structurally_invalid_schema_is_refused() {
         "the refusal cites the structural requirements: {}",
         stderr(&out)
     );
-    assert!(stdout(&out).is_empty());
+    assert_eq!(stdout(&out), "");
 }
 
 /// An `EXTERNAL` shape is refused by name rather than reported as `nonconformant`.
@@ -888,7 +888,7 @@ fn a_semantic_action_is_refused_rather_than_treated_as_an_inert_success() {
         "and says why reporting it would be wrong: {}",
         stderr(&out)
     );
-    assert!(stdout(&out).is_empty());
+    assert_eq!(stdout(&out), "");
 }
 
 /// `--import IRI=FILE` folds an imported schema in; an import with no pair is refused by name;

--- a/crates/cli/tests/update_cli.rs
+++ b/crates/cli/tests/update_cli.rs
@@ -33,7 +33,7 @@ fn update_applies_then_serializes_the_committed_dataset() {
     let output = run(&["update", "--data", &input, "--to", "ntriples", INSERT]);
 
     assert_eq!(output.status.code(), Some(0));
-    assert!(output.stderr.is_empty());
+    assert_eq!(output.stderr, [] as [_; 0]);
     let body = String::from_utf8(output.stdout).expect("UTF-8 output");
     assert!(body.contains("<http://example.org/old>"), "{body}");
     assert!(body.contains("<http://example.org/new>"), "{body}");

--- a/crates/cli/tests/validate_cli.rs
+++ b/crates/cli/tests/validate_cli.rs
@@ -640,7 +640,7 @@ fn malformed_documents_are_runtime_failures() {
 
     let data_failure = run(&["validate", "--shapes", &good_shapes, &bad_data]);
     assert_eq!(code(&data_failure), 1, "{}", stderr(&data_failure));
-    assert!(stdout(&data_failure).is_empty());
+    assert_eq!(stdout(&data_failure), "");
 }
 
 /// An unsupported SHACL construct hard-fails rather than being skipped.
@@ -979,7 +979,7 @@ fn an_unknown_format_token_is_a_usage_error() {
 
     let out = run(&["validate", "--shapes", &shapes, "--format", "yaml", &data]);
     assert_eq!(code(&out), 2, "clap rejects an unknown value with exit 2");
-    assert!(!stderr(&out).is_empty());
+    assert_ne!(stderr(&out), "");
 }
 
 /// `--shapes` is required: `validate` never invents an empty shapes graph (which would

--- a/crates/columnar/src/schema.rs
+++ b/crates/columnar/src/schema.rs
@@ -212,7 +212,7 @@ mod tests {
     #[test]
     fn schema_uses_only_the_closed_physical_type_set() {
         for table in Table::ALL {
-            assert!(!table.schema().columns.is_empty());
+            assert_ne!(table.schema().columns, []);
             for column in table.schema().columns {
                 assert!(matches!(
                     column.physical_type,

--- a/crates/datalog/src/cache.rs
+++ b/crates/datalog/src/cache.rs
@@ -1218,6 +1218,6 @@ mod tests {
             &rule_hash,
             "the plan address is not the bare clause digest"
         );
-        assert!(!PLAN_SOLVER_VERSION.is_empty());
+        assert_ne!(PLAN_SOLVER_VERSION, "");
     }
 }

--- a/crates/datalog/src/chase.rs
+++ b/crates/datalog/src/chase.rs
@@ -1852,7 +1852,7 @@ mod tests {
         let ChaseTermination::Unbounded { violations } = &termination else {
             panic!("expected an unbounded verdict: {termination:?}");
         };
-        assert!(!violations.is_empty());
+        assert_ne!(violations.as_slice(), [] as [String; 0]);
         let mut sorted = violations.clone();
         sorted.sort();
         sorted.dedup();
@@ -2265,7 +2265,7 @@ mod tests {
     #[test]
     fn an_empty_program_derives_nothing() {
         let outcome = run(&[], store_of(&[("a", TYPE, A)]));
-        assert!(outcome.derived().is_empty());
+        assert_eq!(outcome.derived(), []);
         assert!(outcome.witnesses().is_empty());
         assert_eq!(outcome.facts().row_count(), 1);
         assert_eq!(

--- a/crates/datalog/src/clause.rs
+++ b/crates/datalog/src/clause.rs
@@ -804,7 +804,7 @@ mod tests {
             clause.head_atoms().collect::<Vec<_>>(),
             [&atom("?X", R, "?Y")]
         );
-        assert!(clause.existentials().is_empty());
+        assert_eq!(clause.existentials(), [] as [String; 0]);
         assert_eq!(clause.body().len(), 2);
         assert!(!clause.body()[0].is_negated());
         assert!(clause.body()[1].is_negated());
@@ -888,7 +888,7 @@ mod tests {
         ]);
         assert_eq!(clause.head_form(), HeadForm::Inconsistency);
         assert!(!clause.head_form().is_datalog());
-        assert!(clause.head_disjuncts().is_empty());
+        assert_eq!(clause.head_disjuncts(), []);
         assert_eq!(clause.head_atoms().count(), 0);
         assert_eq!(clause.datalog_head(), None);
         assert_eq!(clause.body().len(), 2);
@@ -1037,11 +1037,9 @@ mod tests {
         assert_eq!(default.iri_value(), None);
         assert!(!ClauseTerm::iri("https://example.org/g").is_default_graph());
         // Every other constant's surface is non-empty, so nothing can alias it.
-        assert!(
-            !ClauseTerm::iri("")
-                .surface()
-                .expect("an IRI has a surface")
-                .is_empty()
+        assert_ne!(
+            ClauseTerm::iri("").surface().expect("an IRI has a surface"),
+            ""
         );
     }
 

--- a/crates/datalog/src/cursor.rs
+++ b/crates/datalog/src/cursor.rs
@@ -664,7 +664,7 @@ mod tests {
         assert_eq!(g5, [pair("a", "o005")].into());
         // An interned term that is never an object of p selects nothing.
         let a = s.term_id(&iri("a")).expect("a interned");
-        assert!(drain(select(&s, P, Bound::Object(a))).is_empty());
+        assert_eq!(drain(select(&s, P, Bound::Object(a))), [] as [_; 0]);
     }
 
     #[test]
@@ -708,7 +708,10 @@ mod tests {
     #[test]
     fn cursor_unknown_predicate_is_an_empty_cursor() {
         let s = big_store();
-        assert!(drain(select(&s, "<https://example.org/absent>", Bound::Any)).is_empty());
+        assert_eq!(
+            drain(select(&s, "<https://example.org/absent>", Bound::Any)),
+            [] as [_; 0]
+        );
         assert_eq!(
             partition_of(&s, "<https://example.org/absent>")
                 .map_or(0, |p| p.values_subject(None).count()),
@@ -792,7 +795,7 @@ mod tests {
             .values_object(None);
         cursor.seek(target);
         let rows: Vec<_> = cursor.collect();
-        assert!(!rows.is_empty());
+        assert_ne!(rows, [] as [_; 0]);
         assert!(rows.iter().all(|&(value, _)| value >= target));
         assert_eq!(rows[0].0, target);
     }

--- a/crates/datalog/src/id.rs
+++ b/crates/datalog/src/id.rs
@@ -133,32 +133,42 @@ impl<C> fmt::Debug for Id<C> {
 }
 
 // ── Brand markers (uninhabited: pure type-level tags, never constructed) ─────────
+//
+// Each brand wraps `Infallible` in a private field rather than being an empty
+// `enum`. Both spellings are uninhabited, but the wrapper is the form the
+// compiler's `empty_enums` lint asks for, and it keeps the intent legible: the
+// private `Infallible` field is a value that cannot exist, so the brand cannot be
+// constructed here or by any consumer. The `!` type the lint mentions first is
+// still unstable, and this workspace uses no nightly-only features, so the
+// wrapper is the only spelling available at the declared MSRV.
+
+use core::convert::Infallible;
 
 /// Brand: an interned atomic-term handle. See [`TermId`].
 #[derive(Debug)]
-pub enum Term {}
+pub struct Term(Infallible);
 /// Brand: a relation-partition handle. See [`PartitionId`].
 #[derive(Debug)]
-pub enum Partition {}
+pub struct Partition(Infallible);
 /// Brand: a rule handle. See [`RuleId`].
 #[derive(Debug)]
-pub enum Rule {}
+pub struct Rule(Infallible);
 /// Brand: a materialised-row handle. See [`RowId`].
 #[derive(Debug)]
-pub enum Row {}
+pub struct Row(Infallible);
 /// Brand: a hash-consed proof-term handle. See [`ProofId`].
 #[derive(Debug)]
-pub enum Proof {}
+pub struct Proof(Infallible);
 /// Brand: a hash-consed compound-term arena node handle. See [`NodeId`].
 #[derive(Debug)]
-pub enum Node {}
+pub struct Node(Infallible);
 /// Brand: a unification metavariable handle. See [`MetaId`].
 #[derive(Debug)]
-pub enum Meta {}
+pub struct Meta(Infallible);
 /// Brand: an interned atomic-symbol handle (a compound term's leaf/free lexical
 /// surface), distinct from `TermId`'s own atomic-fact-term interner. See [`SymId`].
 #[derive(Debug)]
-pub enum Sym {}
+pub struct Sym(Infallible);
 
 /// A dense per-interner atomic-term handle.
 pub type TermId = Id<Term>;

--- a/crates/datalog/src/plan.rs
+++ b/crates/datalog/src/plan.rs
@@ -1555,7 +1555,7 @@ mod tests {
                 "{shape:?}"
             );
             assert_eq!(shape.graph(), &PositionPlan::Constant(String::new()));
-            assert!(shape.equalities().is_empty());
+            assert_eq!(shape.equalities(), []);
         }
         assert_eq!(shapes[3].adornment().code(), "bbbb", "a ground probe");
     }
@@ -1727,7 +1727,7 @@ mod tests {
     #[test]
     fn restore_body_order_swaps_is_a_correct_in_place_program() {
         let identity: Vec<usize> = (0..7).collect();
-        assert!(restore_body_order_swaps(&identity).is_empty());
+        assert_eq!(restore_body_order_swaps(&identity), [] as [_; 0]);
         for seed in 0..32u64 {
             let order = permute(&identity, seed);
             let swaps = restore_body_order_swaps(&order);
@@ -1766,7 +1766,7 @@ mod tests {
         assert_eq!(cyclic.atoms()[0].body_index(), 0);
         assert_eq!(cyclic.variables(), ["?X", "?Y", "?Z"]);
         assert_eq!(cyclic.variable_slots(), [0, 1, 2]);
-        assert!(plan.hybrid_source_order_swaps().is_empty());
+        assert_eq!(plan.hybrid_source_order_swaps(), []);
     }
 
     /// A tree (every edge a bridge) is never promoted, and neither is a body whose only

--- a/crates/datalog/src/proof.rs
+++ b/crates/datalog/src/proof.rs
@@ -1764,7 +1764,7 @@ mod tests {
         let proofs = EvaluationProofs::of(&evaluation);
         let edb = seed();
         let ctx = ProofContext::new(&rules, &edb, evaluation.facts());
-        assert!(!proofs.roots().is_empty());
+        assert_ne!(proofs.roots(), []);
         for (derived, root) in proofs.roots() {
             assert_eq!(proofs.arena().check(*root, &ctx).as_ref(), Ok(derived));
         }
@@ -1806,7 +1806,7 @@ mod tests {
         let premise = arena.premises(root)[0];
         assert!(arena.is_axiom(premise));
         assert_eq!(arena.rule(premise), None);
-        assert!(arena.premises(premise).is_empty());
+        assert_eq!(arena.premises(premise), []);
         assert_eq!(arena.goal(premise), &fact("a", P, "b"));
     }
 

--- a/crates/datalog/src/resolve_fol.rs
+++ b/crates/datalog/src/resolve_fol.rs
@@ -2568,7 +2568,7 @@ mod tests {
         let (dag, clauses, proof) = peano_answer_proof();
         // The top of the derivation is the recursive rule.
         assert!(!proof.is_assert(), "the sum step is a rule firing");
-        assert!(!proof.rule_identity().is_empty());
+        assert_ne!(proof.rule_identity(), "");
 
         // Walk down the single-premise chain to the base fact: it is an Assert.
         let mut node = &proof;
@@ -2580,7 +2580,7 @@ mod tests {
             "the base `add(z, Y, Y)` fact is an unconditional Assert leaf"
         );
         assert_eq!(node.rule(), 0);
-        assert!(!node.rule_identity().is_empty());
+        assert_ne!(node.rule_identity(), "");
         // The carried identity is exactly the clause's re-derived content address.
         assert_eq!(
             node.rule_identity(),

--- a/crates/datalog/src/seminaive.rs
+++ b/crates/datalog/src/seminaive.rs
@@ -3660,7 +3660,7 @@ mod tests {
         )];
         let edb = store_of(&[("a", P, "b")]);
         let evaluation = run(rules, edb);
-        assert!(evaluation.derivations().is_empty());
+        assert_eq!(evaluation.derivations(), []);
     }
 
     /// A fully ground body atom is a membership probe.
@@ -3683,7 +3683,7 @@ mod tests {
         assert_eq!(evaluation.derivations().len(), 1);
 
         let evaluation = run(vec![present], store_of(&[("x", P, "y")]));
-        assert!(evaluation.derivations().is_empty());
+        assert_eq!(evaluation.derivations(), []);
     }
 
     /// An empty program over a seeded store is the store itself.
@@ -3691,7 +3691,7 @@ mod tests {
     fn an_empty_program_derives_nothing() {
         let edb = store_of(&[("a", P, "b")]);
         let evaluation = run(Vec::new(), edb);
-        assert!(evaluation.derivations().is_empty());
+        assert_eq!(evaluation.derivations(), []);
         assert_eq!(evaluation.facts().row_count(), 1);
         assert_eq!(evaluation.budget().join_steps(), 0);
     }

--- a/crates/datalog/src/store.rs
+++ b/crates/datalog/src/store.rs
@@ -1296,7 +1296,7 @@ mod tests {
         assert_eq!(resolved_set(&s, &got), [pair("a", "c")].into());
 
         // A both-bound miss (b is interned but (b,b) is not a tuple) yields nothing.
-        assert!(select_rows(&s, KNOWS, Bound::Both(b, b)).is_empty());
+        assert_eq!(select_rows(&s, KNOWS, Bound::Both(b, b)), [] as [_; 0]);
     }
 
     #[test]

--- a/crates/datalog/src/term.rs
+++ b/crates/datalog/src/term.rs
@@ -416,9 +416,9 @@ mod tests {
         let leaf = dag.intern_leaf("a");
         let free = dag.intern_free("x");
         let bound = dag.intern_bound(0, 0);
-        assert!(dag.free_meta(leaf).is_empty());
-        assert!(dag.free_meta(free).is_empty());
-        assert!(dag.free_meta(bound).is_empty());
+        assert_eq!(dag.free_meta(leaf), []);
+        assert_eq!(dag.free_meta(free), []);
+        assert_eq!(dag.free_meta(bound), []);
     }
 
     /// `symbol`/`intern_symbol` round-trip, and interning the same string twice

--- a/crates/entail/src/calculus/mod.rs
+++ b/crates/entail/src/calculus/mod.rs
@@ -709,7 +709,7 @@ mod tests {
         }
         assert!(lowered > 0, "no constraint was exercised");
         // Two lanes declare constraints, and only two.
-        assert!(declared_constraints(Regime::Rdfs).is_empty());
+        assert_eq!(declared_constraints(Regime::Rdfs), [] as [_; 0]);
         assert_eq!(declared_constraints(Regime::OwlRl).len(), 17);
         assert_eq!(declared_constraints(Regime::D).len(), 1);
     }

--- a/crates/entail/src/datatypes.rs
+++ b/crates/entail/src/datatypes.rs
@@ -329,9 +329,9 @@ mod tests {
             rows(&index, DT_ILL_TYPED_RELATION),
             vec![("bad".to_owned(), format!("<{XSD_INTEGER}>"))]
         );
-        assert!(rows(&index, DT_VALUE_RELATION).is_empty());
-        assert!(rows(&index, DT_EQUAL_RELATION).is_empty());
-        assert!(rows(&index, super::DT_DIFFERENT_RELATION).is_empty());
+        assert_eq!(rows(&index, DT_VALUE_RELATION), [] as [_; 0]);
+        assert_eq!(rows(&index, DT_EQUAL_RELATION), [] as [_; 0]);
+        assert_eq!(rows(&index, super::DT_DIFFERENT_RELATION), [] as [_; 0]);
     }
 
     /// A datatype `purrdf-xsd` does not model is not JUDGED: no typing, no clash.
@@ -342,7 +342,7 @@ mod tests {
             "<p/>",
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral",
         )]);
-        assert!(index.materialize().is_empty());
+        assert_eq!(index.materialize(), [] as [_; 0]);
         // …and neither is a language-tagged literal, which is not recorded at all.
         let mut tagged = LiteralIndex::default();
         tagged.observe(
@@ -351,6 +351,6 @@ mod tests {
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString",
             true,
         );
-        assert!(tagged.materialize().is_empty());
+        assert_eq!(tagged.materialize(), [] as [_; 0]);
     }
 }

--- a/crates/entail/src/entails/comprehension.rs
+++ b/crates/entail/src/entails/comprehension.rs
@@ -1169,8 +1169,11 @@ mod tests {
             ]],
             "the operand's own typing is the licence"
         );
-        assert!(!comprehended.minted().is_empty());
-        assert!(!comprehended.to_string().is_empty());
+        assert_ne!(
+            comprehended.minted(),
+            [] as [crate::entails::graph::Triple; 0]
+        );
+        assert_ne!(comprehended.to_string(), "");
         assert!(verify(&warrant, &premise, &conclusion));
     }
 

--- a/crates/entail/src/entails/datarange.rs
+++ b/crates/entail/src/entails/datarange.rs
@@ -520,7 +520,7 @@ mod tests {
         assert_eq!(ranged.regime(), Regime::OwlRl);
         assert_eq!(ranged.containments().len(), 1);
         assert_eq!(ranged.containments()[0].declarations().len(), 1);
-        assert!(!ranged.containments()[0].to_string().is_empty());
+        assert_ne!(ranged.containments()[0].to_string(), "");
         assert!(verify(&warrant, &premise, &conclusion));
     }
 

--- a/crates/entail/src/entails/freeze.rs
+++ b/crates/entail/src/entails/freeze.rs
@@ -1288,7 +1288,7 @@ mod tests {
         let conclusion = graph(&[(A, RDF_TYPE, OWL_CLASS)]);
         let reading = read(&default_graph_triples(&conclusion), &all_of(&conclusion));
         assert!(reading.axioms.is_empty());
-        assert!(reading.declined.is_empty());
+        assert_eq!(reading.declined, [] as [String; 0]);
     }
 
     // ── The table, and the inventory ───────────────────────────────────────────────────

--- a/crates/entail/src/entails/mod.rs
+++ b/crates/entail/src/entails/mod.rs
@@ -1286,7 +1286,7 @@ mod tests {
         else {
             panic!("an existential in superclass position is outside OWL 2 RL");
         };
-        assert!(!violations.is_empty());
+        assert_ne!(violations, [] as [_; 0]);
     }
 
     /// AN INCONSISTENT PREMISE ENTAILS EVERYTHING, SO IT IS REFUSED.
@@ -1742,7 +1742,7 @@ mod tests {
             else {
                 panic!("an assertional conclusion over an RL premise is REFUTED, not shrugged at");
             };
-            assert!(!miss.summary().is_empty());
+            assert_ne!(miss.summary(), "");
         }
         // …and the same premise still refutes a negative fact the refutation lane RAN on:
         // there is no unique-name assumption, so nothing separates two unrelated individuals.
@@ -2166,7 +2166,7 @@ mod tests {
                 "nothing beyond the table was needed: {:?}",
                 answers.limits()
             );
-            assert!(!answers.rows().is_empty());
+            assert_ne!(answers.rows(), [] as [Vec<TermValue>; 0]);
             assert_eq!(answers.mechanism(), EntailmentMechanism::StrictTable);
         }
     }

--- a/crates/entail/src/entails/reflexivity.rs
+++ b/crates/entail/src/entails/reflexivity.rs
@@ -447,7 +447,7 @@ mod tests {
                 TermValue::iri(OWL_REFLEXIVEPROPERTY)
             ]]
         );
-        assert!(!reflexive.to_string().is_empty());
+        assert_ne!(reflexive.to_string(), "");
         assert!(verify(&warrant, &premise, &conclusion));
     }
 

--- a/crates/entail/src/lib.rs
+++ b/crates/entail/src/lib.rs
@@ -1049,7 +1049,7 @@ mod tests {
         // and the report makes both of them.
         let (_, simple) = materialize(&ds, Materialization::Simple).expect("simple");
         assert_eq!(simple.completeness(), Completeness::Exact);
-        assert!(rules(Regime::Simple).is_empty());
+        assert_eq!(rules(Regime::Simple), []);
         let (_, owl) = materialize(&ds, Materialization::OwlRl).expect("owl-rl");
         assert_eq!(
             owl.completeness(),
@@ -1058,7 +1058,7 @@ mod tests {
              not `Exact` either"
         );
         assert!(owl.completeness().is_exact());
-        assert!(!owl.boundaries().is_empty());
+        assert_ne!(owl.boundaries(), []);
     }
 
     /// The named missing rules are the right ones, not merely the right count — and for
@@ -1092,7 +1092,7 @@ mod tests {
         // not reach the answer, so the run is `ExactWithinBoundaries` and names the
         // `surrogate` boundary rather than saying `Exact`.
         let (_, rdfs) = materialize(&ds, Materialization::Rdfs).expect("rdfs");
-        assert!(rdfs.completeness().missing().is_empty());
+        assert_eq!(rdfs.completeness().missing(), []);
         assert_eq!(rdfs.completeness(), Completeness::ExactWithinBoundaries);
         for rule in [
             RuleId::RdfD1,
@@ -1214,7 +1214,7 @@ mod tests {
         // Everything else a caller needs to act on the refusal, measured rather than
         // stubbed: the calculus that refused, the constructs the run met, and the cost.
         assert_eq!(report.regime(), Regime::OwlRl);
-        assert!(!report.boundaries().is_empty());
+        assert_ne!(report.boundaries(), []);
         assert!(report.budget().join_steps() > 0, "the evaluation did work");
         // A consistent run over the same shape reports the absence, so `None` is a
         // finding rather than the only state the field has.
@@ -1316,7 +1316,7 @@ mod tests {
         // And no other lane gets it: `RDFS` says nothing about `owl:differentFrom`.
         let (rdfs, rdfs_report) = materialize(&ds, Materialization::Rdfs).expect("a closure");
         assert!(!has(&rdfs, Y, OWL_DIFFERENTFROM, X));
-        assert!(rdfs_report.extensions().is_empty());
+        assert_eq!(rdfs_report.extensions(), []);
     }
 
     /// THE EXTENSION REFUSES NOTHING THE TABLE DID NOT ALREADY REFUSE.
@@ -1518,13 +1518,13 @@ mod tests {
         // `Simple` copies faithfully, so it meets none of them — which is what makes its
         // `Exact` honest.
         let (_, simple) = materialize(&quoted, Materialization::Simple).expect("simple");
-        assert!(simple.boundaries().is_empty());
+        assert_eq!(simple.boundaries(), []);
 
         // Every boundary carries a technical reason naming what it blocks.
         let (_, report) = materialize(&quoted, Materialization::Rdfs).expect("rdfs");
-        assert!(!report.boundaries().is_empty());
+        assert_ne!(report.boundaries(), []);
         for boundary in report.boundaries() {
-            assert!(!boundary.reason().is_empty());
+            assert_ne!(boundary.reason(), "");
             assert_eq!(boundary.reason(), boundary.construct().reason());
         }
         // In `Construct` declaration order, deduplicated.
@@ -1581,7 +1581,7 @@ mod tests {
 
         // `Simple` infers nothing, so nothing fired — an empty list, not a zeroed one.
         let (_, simple) = materialize(&ds, Materialization::Simple).expect("simple");
-        assert!(simple.rules_fired().is_empty());
+        assert_eq!(simple.rules_fired(), []);
 
         // The OWL-RL lane really does credit the three RDFS-shaped rules by their RDFS
         // names, which is the honest reading of what it fires.

--- a/crates/entail/src/lists.rs
+++ b/crates/entail/src/lists.rs
@@ -551,7 +551,7 @@ mod tests {
         let mut index = ListIndex::default();
         index.observe(EX_L0, &s(RDF_FIRST), EX_A);
         // No rdf:rest at all, and no head points here.
-        assert!(index.materialize().expect("not walked").is_empty());
+        assert_eq!(index.materialize().expect("not walked"), [] as [_; 0]);
     }
 
     /// A CYCLE terminates with a refusal naming the cell, rather than running forever.

--- a/crates/entail/src/owl_dl/absorb.rs
+++ b/crates/entail/src/owl_dl/absorb.rs
@@ -37,7 +37,7 @@
 //! | antecedent | faithful? | why |
 //! |---|---|---|
 //! | `⊤` | yes | `⊤^I` is the whole ABSTRACT domain, and an unguarded clause fires at every abstract node |
-//! | `A` (named) | yes | `A^I` IS `{ x | A ∈ L(x) }` — that is what reading a model off a graph means |
+//! | `A` (named) | yes | `A^I` IS `{ x \| A ∈ L(x) }` — that is what reading a model off a graph means |
 //! | `{a}` (singleton nominal) | yes | `{a}^I` is the node denoting `a`, which [`BodyAtom::Denotes`] tests |
 //! | `∃r.F`, `≥1 r.F` with `F` faithful | yes | `x ∈ (∃r.F)^I` iff some `r`-neighbour of `x` is in `F^I`, which the edge join is |
 //! | `C₁ ⊓ … ⊓ Cₙ`, every `Cᵢ` faithful | yes | the conjunction of the guards |
@@ -667,7 +667,7 @@ mod tests {
             Concept::Some(Role::Named(R), Box::new(Concept::Named(C))),
             Concept::Named(A),
         );
-        assert!(meta.is_empty());
+        assert_eq!(meta, [] as [u32; 0]);
         assert_eq!(clauses.len(), 1);
         let c = table.intern(Concept::Named(C));
         let a = table.intern(Concept::Named(A));
@@ -728,7 +728,7 @@ mod tests {
             Concept::Some(Role::Named(R), Box::new(Concept::Top)),
             Concept::Named(A),
         );
-        assert!(meta.is_empty());
+        assert_eq!(meta, [] as [u32; 0]);
         let a = table.intern(Concept::Named(A));
         assert_eq!(
             clauses,
@@ -776,7 +776,7 @@ mod tests {
             Concept::Named(A),
             Concept::And(vec![Concept::Named(B), Concept::Named(C)]),
         );
-        assert!(meta.is_empty());
+        assert_eq!(meta, [] as [u32; 0]);
         assert_eq!(clauses.len(), 2, "one clause per conjunct: {clauses:?}");
         assert!(clauses.iter().all(|clause| clause.body.len() == 1));
     }
@@ -789,7 +789,7 @@ mod tests {
             Concept::Or(vec![Concept::Named(B), Concept::Named(C)]),
             Concept::Named(A),
         );
-        assert!(meta.is_empty());
+        assert_eq!(meta, [] as [u32; 0]);
         assert_eq!(clauses.len(), 2, "one clause per disjunct: {clauses:?}");
     }
 
@@ -797,7 +797,7 @@ mod tests {
     #[test]
     fn an_enumerated_antecedent_splits_into_one_clause_per_member() {
         let (clauses, meta, _) = absorbed(Concept::nominal(vec![IND, IND + 1]), Concept::Named(A));
-        assert!(meta.is_empty());
+        assert_eq!(meta, [] as [u32; 0]);
         assert_eq!(clauses.len(), 2);
         assert!(
             clauses
@@ -888,7 +888,7 @@ mod tests {
             || Ok::<(), std::convert::Infallible>(()),
         )
         .expect("infallible");
-        assert!(out.clauses.is_empty());
+        assert_eq!(out.clauses, [] as [_; 0]);
         assert_eq!(out.meta.len(), 1);
     }
 }

--- a/crates/entail/src/owl_dl/clause.rs
+++ b/crates/entail/src/owl_dl/clause.rs
@@ -996,7 +996,7 @@ mod tests {
         let asymmetry = clauses.clause(clauses.untriggered()[0]);
         assert_eq!(asymmetry.trigger(), None);
         assert_eq!(asymmetry.arity(), 2);
-        assert!(asymmetry.head.is_empty());
+        assert_eq!(asymmetry.head, [] as [Vec<HeadAtom>; 0]);
     }
 
     /// A SINGLETON nominal derives an atomic head — a deterministic identification — while a

--- a/crates/entail/src/owl_dl/oracle.rs
+++ b/crates/entail/src/owl_dl/oracle.rs
@@ -960,8 +960,12 @@ impl Case {
         };
         for role_code in 0..relation_codes.pow(self.sig.roles as u32) {
             let mut rest = role_code;
-            for slot in 0..self.sig.roles {
-                i.roles[slot] = Relation::decode(rest % relation_codes, size);
+            // `take(..)` rather than an index range: the arrays are sized by the
+            // full name tables, but only the signature's first `sig.roles` slots
+            // are live for this case. Iterating the live prefix directly keeps
+            // that bound in one place and drops the bounds check per write.
+            for role in i.roles.iter_mut().take(self.sig.roles) {
+                *role = Relation::decode(rest % relation_codes, size);
                 rest /= relation_codes;
             }
             if !self.role_axioms_hold(&i) {
@@ -969,14 +973,14 @@ impl Case {
             }
             for concept_code in 0..concept_codes.pow(self.sig.concepts as u32) {
                 let mut rest = concept_code;
-                for slot in 0..self.sig.concepts {
-                    i.concepts[slot] = (rest % concept_codes) as u32;
+                for concept in i.concepts.iter_mut().take(self.sig.concepts) {
+                    *concept = (rest % concept_codes) as u32;
                     rest /= concept_codes;
                 }
                 for individual_code in 0..elements.pow(self.sig.individuals as u32) {
                     let mut rest = individual_code;
-                    for slot in 0..self.sig.individuals {
-                        i.individuals[slot] = (rest % elements) as usize;
+                    for individual in i.individuals.iter_mut().take(self.sig.individuals) {
+                        *individual = (rest % elements) as usize;
                         rest /= elements;
                     }
                     if self.models(&i) {

--- a/crates/entail/src/rif/eval.rs
+++ b/crates/entail/src/rif/eval.rs
@@ -786,7 +786,7 @@ mod tests {
             "silver rule must not fire"
         );
         // A default-graph-only input met no construct this lane could not handle.
-        assert!(report.boundaries().is_empty());
+        assert_eq!(report.boundaries(), []);
         assert_eq!(report.completeness(), crate::Completeness::Exact);
     }
 
@@ -833,7 +833,7 @@ mod tests {
             .map(|boundary| boundary.construct())
             .collect();
         assert_eq!(constructs, vec![Construct::NamedGraph]);
-        assert!(!report.boundaries()[0].reason().is_empty());
+        assert_ne!(report.boundaries()[0].reason(), "");
         // A boundary beside a rule table that has nothing missing is
         // `ExactWithinBoundaries`, never plain `Exact`: the completeness is DERIVED from
         // this very boundary list, so the two cannot come apart.
@@ -861,7 +861,7 @@ mod tests {
             rules: Vec::new(),
         };
         let (_, report) = materialize_rif(&empty_ds(), &rules).expect("materialize");
-        assert!(report.boundaries().is_empty());
+        assert_eq!(report.boundaries(), []);
     }
 
     #[test]

--- a/crates/entail/tests/reasoner.rs
+++ b/crates/entail/tests/reasoner.rs
@@ -220,7 +220,7 @@ fn a_consistent_ontology_is_reported_consistent_and_decided() {
     assert_eq!(*answer.answer(), Verdict::True);
     let certificate = honest(&answer);
     assert_eq!(certificate.completeness(), DlCompleteness::Decided);
-    assert!(certificate.boundaries().is_empty());
+    assert_eq!(certificate.boundaries(), []);
     assert_eq!(certificate.decisions(), 1, "consistency is ONE decision");
     assert!(certificate.steps() > 0, "a decision consumes steps");
 }
@@ -309,7 +309,7 @@ fn an_empty_datatype_range_is_reported_inconsistent_and_decided() {
     assert_eq!(*answer.answer(), Verdict::False);
     let certificate = honest(&answer);
     assert_eq!(certificate.completeness(), DlCompleteness::Decided);
-    assert!(certificate.boundaries().is_empty());
+    assert_eq!(certificate.boundaries(), []);
 }
 
 /// …and the class ITSELF is unsatisfiable, which is the narrower question and the one that
@@ -382,7 +382,7 @@ fn a_satisfiable_datatype_range_is_reported_consistent_and_decided() {
     assert_eq!(*answer.answer(), Verdict::True);
     let certificate = honest(&answer);
     assert_eq!(certificate.completeness(), DlCompleteness::Decided);
-    assert!(certificate.boundaries().is_empty());
+    assert_eq!(certificate.boundaries(), []);
 }
 
 /// THE RESIDUE IS NAMED. An `xsd:pattern` facet is a regular-language question this layer
@@ -518,7 +518,7 @@ fn instance_retrieval_reaches_a_class_nothing_asserts() {
     // A class the ontology never mentions is an unconstrained atomic name, which is a real
     // answer rather than a rejection.
     let unknown = reasoner.instances(&iri("Vegetable")).expect("consistent");
-    assert!(unknown.answer().is_empty());
+    assert_eq!(unknown.answer().as_slice(), []);
     honest(&unknown);
 }
 
@@ -787,7 +787,7 @@ fn a_narrowed_budget_reports_unknown_rather_than_a_false_negative() {
     // Every aggregate service degrades the same way: an empty answer under an exhausted
     // certificate, rather than a confidently wrong one.
     let hierarchy = reasoner.classify().expect("not refused, just undecided");
-    assert!(hierarchy.answer().subsumptions().is_empty());
+    assert_eq!(hierarchy.answer().subsumptions(), []);
     assert_eq!(
         hierarchy.certificate().completeness(),
         DlCompleteness::BudgetExhausted
@@ -1465,7 +1465,7 @@ fn an_empty_seed_extracts_an_empty_module() {
         .expect("extract");
     assert_eq!(extracted.axioms(), 0);
     assert_eq!(extracted.module().quads().count(), 0);
-    assert!(extracted.conservative_keeps().is_empty());
+    assert_eq!(extracted.conservative_keeps(), []);
 }
 
 #[test]

--- a/crates/gts/src/dict.rs
+++ b/crates/gts/src/dict.rs
@@ -241,7 +241,7 @@ mod tests {
         let a = raw_content_dict(&corpus, 4096).expect("build");
         let b = raw_content_dict(&corpus, 4096).expect("build");
         assert_eq!(a, b, "raw-content dict must be byte-reproducible");
-        assert!(!a.is_empty());
+        assert_ne!(a, [] as [_; 0]);
         assert!(a.len() <= 4096, "must respect the target length bound");
         assert_is_valid_finalized_dict(&a);
     }
@@ -266,7 +266,7 @@ mod tests {
         let a = trained_dict(&corpus, 4096, DictSeed::FromCorpus).expect("training should succeed");
         let b = trained_dict(&corpus, 4096, DictSeed::FromCorpus).expect("training should succeed");
         assert_eq!(a, b, "seeded FastCOVER must be byte-reproducible");
-        assert!(!a.is_empty());
+        assert_ne!(a, [] as [_; 0]);
         assert_is_valid_finalized_dict(&a);
     }
 

--- a/crates/gts/src/transport.rs
+++ b/crates/gts/src/transport.rs
@@ -363,10 +363,10 @@ mod tests {
     fn a_stream_that_is_not_the_claimed_encoding_fails() {
         let err = decode_transport(b"plain text", TransportEncoding::Gzip)
             .expect_err("plain bytes are not gzip");
-        assert!(!err.to_string().is_empty());
+        assert_ne!(err.to_string(), "");
         let err = decode_transport(b"plain text", TransportEncoding::Zstd)
             .expect_err("plain bytes are not zstd");
-        assert!(!err.to_string().is_empty());
+        assert_ne!(err.to_string(), "");
     }
 
     #[test]

--- a/crates/gts/tests/replication_diff.rs
+++ b/crates/gts/tests/replication_diff.rs
@@ -63,7 +63,7 @@ fn diff_identical_is_current() {
     let (local, _remote) = append_fixture();
     let result = diff(&inventory(&local), &inventory(&local));
     assert_eq!(result.status, DiffStatus::Current);
-    assert!(result.fetch.is_empty());
+    assert_eq!(result.fetch, [] as [_; 0]);
     assert!(result.continuous);
 }
 
@@ -94,7 +94,7 @@ fn diff_remote_behind_is_current() {
     // Swap: the bigger file is now local, the smaller one is remote.
     let result = diff(&inventory(&remote), &inventory(&local));
     assert_eq!(result.status, DiffStatus::Current);
-    assert!(result.fetch.is_empty());
+    assert_eq!(result.fetch, [] as [_; 0]);
     assert!(result.continuous);
 }
 
@@ -140,7 +140,7 @@ fn diff_problem_inventory_is_error() {
     assert_eq!(result.status, DiffStatus::Error);
     assert!(!result.continuous);
     assert!(result.splice_offset.is_none());
-    assert!(result.fetch.is_empty());
+    assert_eq!(result.fetch, [] as [_; 0]);
     assert!(result.detail.is_some());
     assert!(splice(&torn, &remote, &result).is_err());
 }

--- a/crates/gts/tests/self_reaching_triple_terms.rs
+++ b/crates/gts/tests/self_reaching_triple_terms.rs
@@ -249,7 +249,7 @@ fn a_binding_that_makes_an_rf_triple_term_contain_itself_is_refused() {
         "{:?}",
         graph.diagnostics,
     );
-    assert!(graph.reifiers.is_empty());
+    assert_eq!(graph.reifiers, [] as [_; 0]);
     assert_eq!(graph.triple_of(2), None);
     assert_no_term_reaches_itself(&graph);
 }

--- a/crates/purrdf/src/lib.rs
+++ b/crates/purrdf/src/lib.rs
@@ -390,7 +390,7 @@ mod tests {
 
         // gts: the container engine (its `model`) and the rdf-level adapter
         // (`read_graph`) are both reachable under the one `gts` module.
-        assert!(!format!("{:?}", gts::model::TermKind::Iri).is_empty());
+        assert_ne!(format!("{:?}", gts::model::TermKind::Iri), "");
         let adapter: fn(&[u8], bool) -> _ = gts::read_graph;
         assert!(
             adapter(&[], false).is_err(),
@@ -398,11 +398,11 @@ mod tests {
         );
 
         // sparql: parser (algebra) + engine (eval) + results.
-        assert!(!format!("{:?}", sparql::SparqlResultsFormat::Json).is_empty());
+        assert_ne!(format!("{:?}", sparql::SparqlResultsFormat::Json), "");
 
         // foundations.
         assert!(iri::parse("https://example.org/x").is_ok());
-        assert!(!format!("{:?}", events::TextDirection::Ltr).is_empty());
+        assert_ne!(format!("{:?}", events::TextDirection::Ltr), "");
 
         // entail: the entailment regimes are reachable through the facade.
         assert_eq!(

--- a/crates/purrdf/tests/reasoning_facade.rs
+++ b/crates/purrdf/tests/reasoning_facade.rs
@@ -80,7 +80,7 @@ fn the_umbrella_names_every_type_the_reasoning_surface_carries() {
     let _ = missing.len();
     for boundary in report.boundaries() {
         let construct: Construct = boundary.construct();
-        assert!(!construct.as_str().is_empty());
+        assert_ne!(construct.as_str(), "");
     }
 
     // ── the error side, including its datalog payload ──────────────────────
@@ -129,7 +129,7 @@ fn the_umbrella_names_every_type_the_reasoning_surface_carries() {
 fn the_umbrella_reaches_the_datalog_engine_itself() {
     // Module paths, spelled through `purrdf::datalog` alone.
     let store: purrdf::datalog::store::RelationStore = purrdf::datalog::store::RelationStore::new();
-    assert!(!format!("{store:?}").is_empty());
+    assert_ne!(format!("{store:?}"), "");
     let mint: fn(&[purrdf::datalog::clause::DlClause]) -> ContractHash =
         purrdf::datalog::cache::contract_hash;
     // An empty program still has an identity, and it is a `ContractHash`.

--- a/crates/rdf-capi/src/entail.rs
+++ b/crates/rdf-capi/src/entail.rs
@@ -1888,7 +1888,7 @@ mod tests {
             .filter(|rule| !fired.lines().any(|f| f == *rule))
             .count();
         assert_eq!(missing, rdfs.lines().count() - fired.lines().count());
-        assert!(rules_bytes("simple").expect("known").is_empty());
+        assert_eq!(rules_bytes("simple").expect("known"), [] as [u8; 0]);
     }
 
     // ── The pointer surface ─────────────────────────────────────────────────

--- a/crates/rdf-capi/tests/abi.rs
+++ b/crates/rdf-capi/tests/abi.rs
@@ -262,7 +262,7 @@ fn projection_archive_and_ledger_round_trip_through_owned_c_handles() {
         assert!(error.is_null());
         let archive_bytes = buffer_bytes(archive);
         let ledger_bytes = buffer_bytes(project_ledger);
-        assert!(!archive_bytes.is_empty());
+        assert_ne!(archive_bytes, [] as [u8; 0]);
         let ledger = String::from_utf8(ledger_bytes).expect("ledger JSON");
         assert!(ledger.starts_with("{\n  \"schema_version\": 1,"));
 
@@ -425,7 +425,7 @@ fn every_research_object_profile_executes_through_the_c_abi() {
             );
             assert!(error.is_null());
             let archive_bytes = buffer_bytes(archive);
-            assert!(!archive_bytes.is_empty());
+            assert_ne!(archive_bytes, [] as [u8; 0]);
             purrdf_buffer_free(project_ledger);
             purrdf_buffer_free(archive);
 
@@ -1187,7 +1187,7 @@ fn parse_rejects_malformed_turtle_without_aborting() {
         assert!(!error.is_null());
         assert_eq!(purrdf_error_code(error), PurrdfStatus::ParseError as i32);
         let msg = std::ffi::CStr::from_ptr(purrdf_error_message(error));
-        assert!(!msg.to_bytes().is_empty());
+        assert_ne!(msg.to_bytes(), [] as [u8; 0]);
         purrdf_error_free(error);
     }
 }
@@ -2320,7 +2320,7 @@ fn gts_round_trips_a_plain_graph() {
     unsafe {
         let dataset = parse("application/n-triples", THREE_QUADS);
         let gts = to_gts(dataset);
-        assert!(!gts.is_empty());
+        assert_ne!(gts, [] as [u8; 0]);
         let restored = from_gts(&gts);
         assert_eq!(quad_count(restored), 3);
         purrdf_dataset_free(restored);
@@ -2343,7 +2343,7 @@ fn gts_star_roundtrip_preserves_the_statement_layer() {
         );
         let dataset = parse("application/n-triples", doc);
         let gts = to_gts(dataset);
-        assert!(!gts.is_empty());
+        assert_ne!(gts, [] as [u8; 0]);
 
         let mut restored: *mut PurrdfDataset = std::ptr::null_mut();
         let mut error: *mut PurrdfError = std::ptr::null_mut();

--- a/crates/rdf-capi/tests/c_smoke.rs
+++ b/crates/rdf-capi/tests/c_smoke.rs
@@ -54,16 +54,6 @@ fn c_abi_smoke() {
     let smoke_c = format!("{manifest}/tests/smoke.c");
     let header_dir = format!("{manifest}/include");
 
-    // The integration-test binary lives under `<profile>/deps/<name>-<hash>`,
-    // including when Cargo routes intermediates through a separate build dir,
-    // so its grandparent still names the active profile.
-    let test_exe = std::env::current_exe().expect("current_exe");
-    let test_profile_dir: PathBuf = test_exe
-        .parent()
-        .and_then(|deps| deps.parent())
-        .expect("profile dir")
-        .to_path_buf();
-
     // Build the platform-correct shared-library file name: `libpurrdf.so` on
     // Linux, `libpurrdf.dylib` on macOS, `purrdf.dll` on Windows. `DLL_SUFFIX`
     // already includes the leading dot.
@@ -77,20 +67,35 @@ fn c_abi_smoke() {
     // it before linkage: existence alone is insufficient because a prior test
     // run may have left a stale shared library for older Rust sources.
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-    let profile = test_profile_dir
-        .file_name()
-        .and_then(|name| name.to_str())
-        .expect("Cargo profile directory name");
+    // Which profile to build the cdylib under, read from THIS binary's own
+    // compilation rather than from where the binary happens to sit on disk.
+    //
+    // This used to be the grandparent directory of `current_exe()`, on the
+    // assumption that a test binary always lives in `<profile>/deps/`. Cargo's
+    // build-dir layout broke that: intermediates now land under a hash of the
+    // build configuration, so the grandparent is a name like `d9a41d75b93a9f20`
+    // and the nested build died on "profile `d9a41d75b93a9f20` is not defined".
+    // A directory layout is Cargo's to change whenever it likes; whether this
+    // compilation has debug assertions is a property of the compilation itself.
+    //
+    // The mapping is exact for every profile this workspace declares: `dev` is
+    // the only one leaving debug assertions on, and `bench` inherits `release`
+    // codegen. Matching is a build-time economy, not a correctness requirement —
+    // the cdylib is located from Cargo's JSON output below, never from this name.
+    let profile = if cfg!(debug_assertions) {
+        "dev"
+    } else {
+        "release"
+    };
     let mut cargo_build = Command::new(&cargo);
     cargo_build.args([
         "build",
         "-p",
         "purrdf-capi",
+        "--profile",
+        profile,
         "--message-format=json-render-diagnostics",
     ]);
-    if profile != "debug" {
-        cargo_build.args(["--profile", profile]);
-    }
     let output = cargo_build
         .output()
         .expect("failed to invoke cargo to build the libpurrdf cdylib");

--- a/crates/rdf-core/src/collections.rs
+++ b/crates/rdf-core/src/collections.rs
@@ -290,16 +290,17 @@ mod tests {
         let some_cell = b.intern_blank("c", BlankScope::DEFAULT);
         b.push_quad(some_cell, first, plain, None);
         let ds = b.freeze().expect("freeze");
-        assert!(ds.rdf_list(nil, GraphMatch::Any).expect("nil").is_empty());
-        assert!(
-            ds.rdf_list(plain, GraphMatch::Any)
-                .expect("plain")
-                .is_empty()
+        assert_eq!(
+            ds.rdf_list(nil, GraphMatch::Any).expect("nil"),
+            [] as [_; 0]
         );
-        assert!(
-            ds.rdf_list(lit, GraphMatch::Any)
-                .expect("literal")
-                .is_empty()
+        assert_eq!(
+            ds.rdf_list(plain, GraphMatch::Any).expect("plain"),
+            [] as [_; 0]
+        );
+        assert_eq!(
+            ds.rdf_list(lit, GraphMatch::Any).expect("literal"),
+            [] as [_; 0]
         );
     }
 
@@ -354,10 +355,9 @@ mod tests {
             ds.members(container, GraphMatch::Any).expect("container"),
             vec![x]
         );
-        assert!(
-            ds.members(plain, GraphMatch::Any)
-                .expect("neither")
-                .is_empty()
+        assert_eq!(
+            ds.members(plain, GraphMatch::Any).expect("neither"),
+            [] as [_; 0]
         );
     }
 
@@ -375,10 +375,10 @@ mod tests {
             vec![a]
         );
         assert_eq!(ds.rdf_list(head, GraphMatch::Any).expect("any"), vec![a]);
-        assert!(
+        assert_eq!(
             ds.rdf_list(head, GraphMatch::Default)
-                .expect("default empty")
-                .is_empty()
+                .expect("default empty"),
+            [] as [_; 0]
         );
     }
 }

--- a/crates/rdf-core/src/describe.rs
+++ b/crates/rdf-core/src/describe.rs
@@ -432,7 +432,7 @@ mod tests {
             vec!["https://e/o1".to_string(), "https://e/o2".to_string()]
         );
         // The unrelated OTHER subject's triple must NOT be pulled in.
-        assert!(objects_for(&scbd, OTHER, "https://e/p").is_empty());
+        assert_eq!(objects_for(&scbd, OTHER, "https://e/p"), [] as [String; 0]);
     }
 
     #[test]
@@ -456,7 +456,10 @@ mod tests {
         ]);
         let scbd = describe(&ds, S).unwrap();
         // The N -> deep triple is neither outgoing-from nor incoming-to S, so absent.
-        assert!(objects_for(&scbd, "https://e/n", "https://e/p").is_empty());
+        assert_eq!(
+            objects_for(&scbd, "https://e/n", "https://e/p"),
+            [] as [String; 0]
+        );
         assert_eq!(
             objects_for(&scbd, S, "https://e/p"),
             vec!["https://e/n".to_string()]

--- a/crates/rdf-core/src/ir/mutable.rs
+++ b/crates/rdf-core/src/ir/mutable.rs
@@ -1127,7 +1127,7 @@ mod tests {
             Some(&iri_val("b")),
             GraphMatchValue::Any,
         );
-        assert!(gone.is_empty());
+        assert_eq!(gone, [] as [_; 0]);
 
         // A bound value interned nowhere matches nothing.
         let nothing = m.quads_for_pattern(
@@ -1136,7 +1136,7 @@ mod tests {
             None,
             GraphMatchValue::Any,
         );
-        assert!(nothing.is_empty());
+        assert_eq!(nothing, [] as [_; 0]);
     }
 
     #[test]
@@ -1157,7 +1157,7 @@ mod tests {
 
         // Default-graph match excludes both named quads.
         let dflt = m.quads_for_pattern(None, None, None, GraphMatchValue::Default);
-        assert!(dflt.is_empty());
+        assert_eq!(dflt, [] as [_; 0]);
         // Any matches both.
         let any = m.quads_for_pattern(None, None, None, GraphMatchValue::Any);
         assert_eq!(any.len(), 2);
@@ -1188,7 +1188,7 @@ mod tests {
 
         // A graph value interned nowhere still matches nothing.
         let none = m.quads_for_pattern(None, None, None, GraphMatchValue::Named(&iri_val("nope")));
-        assert!(none.is_empty());
+        assert_eq!(none, [] as [_; 0]);
     }
 
     // -- freeze round-trip ------------------------------------------------------------

--- a/crates/rdf-core/src/ir/pack/bits.rs
+++ b/crates/rdf-core/src/ir/pack/bits.rs
@@ -1440,7 +1440,7 @@ mod tests {
         let decoded: Vec<u64> = DeltaListRef::new(&out, 0)
             .collect::<Result<_, _>>()
             .expect("decodes");
-        assert!(decoded.is_empty());
+        assert_eq!(decoded, [] as [_; 0]);
     }
 
     // -- proptest -----------------------------------------------------------------

--- a/crates/rdf-core/src/sssom.rs
+++ b/crates/rdf-core/src/sssom.rs
@@ -1559,7 +1559,7 @@ object_id\tx_extension\tsubject_id
 # empty mapping-set note
 ";
         let set = parse_tsv(doc).expect("parse");
-        assert!(set.mappings.is_empty());
+        assert_eq!(set.mappings, [] as [_; 0]);
         assert_eq!(
             set.column_layout.columns(),
             &["object_id", "x_extension", "subject_id"]
@@ -1778,7 +1778,7 @@ ex:A\tskos:exactMatch\tex:B
     #[test]
     fn validate_clean_doc_has_no_errors() {
         let set = parse_tsv(CLEAN).expect("parse");
-        assert!(validate(&set).is_empty());
+        assert_eq!(validate(&set), [] as [_; 0]);
     }
 
     #[test]
@@ -1849,7 +1849,7 @@ ex:A\tskos:exactMatch\tex:B
     fn to_rdf_emits_owl_reification_for_a_mapping() {
         let set = parse_tsv(CLEAN).expect("parse");
         let quads = to_rdf(&set);
-        assert!(!quads.is_empty());
+        assert_ne!(quads, [] as [_; 0]);
 
         let has = |pred: &str, obj: &str| {
             quads.iter().any(|q| {

--- a/crates/rdf-core/tests/paged_fallible.rs
+++ b/crates/rdf-core/tests/paged_fallible.rs
@@ -166,7 +166,7 @@ fn provider_failure_after_seal_is_sticky_and_never_panics() {
         "planning uses only seal-time metadata"
     );
     let planning_evidence = ready_evidence(view.operation_status());
-    assert!(planning_evidence.requested_pages.is_empty());
+    assert_eq!(planning_evidence.requested_pages, [] as [_; 0]);
     assert_eq!(planning_evidence.consumed_pages, 0);
     assert_eq!(planning_evidence.consumed_bytes, 0);
 
@@ -280,7 +280,7 @@ fn status_checkpoint_detects_drift_without_a_page_read() {
             actual: PageGeneration(15),
         }
     );
-    assert!(evidence.requested_pages.is_empty());
+    assert_eq!(evidence.requested_pages, [] as [_; 0]);
     assert_eq!(evidence.consumed_pages, 0);
     assert_eq!(evidence.consumed_bytes, 0);
     assert_eq!(
@@ -371,7 +371,7 @@ fn every_read_path_shares_one_operation_cache_and_evidence() {
         1
     );
     let planning_evidence = ready_evidence(view.operation_status());
-    assert!(planning_evidence.requested_pages.is_empty());
+    assert_eq!(planning_evidence.requested_pages, [] as [_; 0]);
     assert_eq!(planning_evidence.consumed_pages, 0);
     assert_eq!(planning_evidence.consumed_bytes, 0);
     assert_eq!(view.quads().count(), 1);

--- a/crates/rdf-events/src/lib.rs
+++ b/crates/rdf-events/src/lib.rs
@@ -909,7 +909,7 @@ mod tests {
             EventError::message("boom"),
         ];
         for case in cases {
-            assert!(!case.to_string().is_empty());
+            assert_ne!(case.to_string(), "");
         }
         // It really is a std::error::Error.
         fn assert_error<E: std::error::Error>(_: &E) {}

--- a/crates/rdf-wasm/src/entail.rs
+++ b/crates/rdf-wasm/src/entail.rs
@@ -1447,8 +1447,11 @@ mod tests {
             .count();
         assert_eq!(missing, defined.len() - implemented.len());
         // An empty table is an empty array, not a one-element array of "".
-        assert!(rules_impl("simple").expect("known").is_empty());
-        assert!(implemented_rules_impl("simple").expect("known").is_empty());
+        assert_eq!(rules_impl("simple").expect("known"), [] as [String; 0]);
+        assert_eq!(
+            implemented_rules_impl("simple").expect("known"),
+            [] as [String; 0]
+        );
     }
 
     // ── The Description-Logic reasoning services ────────────────────────────

--- a/crates/rdf/src/gts_view.rs
+++ b/crates/rdf/src/gts_view.rs
@@ -1178,7 +1178,7 @@ mod tests {
         assert_eq!(rows.quads.len(), view.graph().quads.len());
         assert_eq!(rows.reifiers, vec![(16, 0, 1, 2, None)]);
         assert_eq!(rows.annotations, vec![(16, 17, 18, None)]);
-        assert!(rows.blobs.is_empty());
+        assert_eq!(rows.blobs, [] as [_; 0]);
     }
 
     /// The relational projection keeps the statement layer's graph column. One

--- a/crates/rdf/src/native_codecs/text_parse.rs
+++ b/crates/rdf/src/native_codecs/text_parse.rs
@@ -2359,7 +2359,7 @@ mod tests {
                 );
             }
         }
-        assert!(split_line_chunks("", 8).is_empty());
+        assert_eq!(split_line_chunks("", 8), [] as [&str; 0]);
     }
 
     /// Error semantics: with an invalid line in an EARLY chunk and a different invalid

--- a/crates/rdf/src/projections/csvw/engine.rs
+++ b/crates/rdf/src/projections/csvw/engine.rs
@@ -108,7 +108,7 @@ mod tests {
         )
         .expect("input");
         let outcome = read_csvw(&input, &config(CsvwMode::Standard)).expect("CSVW");
-        assert!(outcome.warnings.is_empty());
+        assert_eq!(outcome.warnings, [] as [_; 0]);
         assert!(outcome.loss_ledger.is_empty());
         let expected = parse_dataset(
             br#"@prefix csvw: <http://www.w3.org/ns/csvw#> .
@@ -201,7 +201,7 @@ mod tests {
         .expect("input");
 
         let outcome = read_csvw(&input, &config).expect("private-use language tag");
-        assert!(outcome.warnings.is_empty());
+        assert_eq!(outcome.warnings, [] as [_; 0]);
         assert_eq!(
             outcome.group.tables[0].rows[0].cells[0].values[0]
                 .language

--- a/crates/rdf/src/projections/obo_graphs/mapping.rs
+++ b/crates/rdf/src/projections/obo_graphs/mapping.rs
@@ -2180,7 +2180,7 @@ mod tests {
         builder.declare_named_graph(graph);
         let dataset = builder.freeze().expect("empty named graph dataset");
         let projection = project_obo_graphs(dataset.as_ref(), &config(100)).expect("projection");
-        assert!(projection.document.graphs[0].nodes.is_empty());
+        assert_eq!(projection.document.graphs[0].nodes, [] as [_; 0]);
         assert_ledger_complete(&projection.loss_ledger, &[LOSS_OBO_NAMED_GRAPH_DROPPED]);
         assert_eq!(projection.loss_ledger.entries().len(), 1);
         assert_eq!(

--- a/crates/rdf/src/viz.rs
+++ b/crates/rdf/src/viz.rs
@@ -1881,8 +1881,8 @@ mod tests {
         };
         let projection = project_graph_input(&input, &VizSpec::default()).expect("project");
         assert_eq!(projection.statements.len(), 1);
-        assert!(projection.assertions.is_empty());
-        assert!(projection.statements[0].asserted_in.is_empty());
+        assert_eq!(projection.assertions, [] as [_; 0]);
+        assert_eq!(projection.statements[0].asserted_in, [] as [_; 0]);
         assert!(
             !projection.statements[0]
                 .roles
@@ -2235,7 +2235,7 @@ mod tests {
         };
         let projection = project_graph_input(&input, &spec).expect("project");
         assert_eq!(projection.assertions.len(), 2);
-        assert!(projection.relations.is_empty());
+        assert_eq!(projection.relations, [] as [_; 0]);
         assert!(
             projection
                 .graphs

--- a/crates/rdf/src/viz/scene.rs
+++ b/crates/rdf/src/viz/scene.rs
@@ -1699,8 +1699,8 @@ mod tests {
         let table = scene.table.expect("table");
         assert_eq!(table.fields, spec.table_fields);
         assert!(table.rows.iter().all(|row| row.cells.len() == 2));
-        assert!(scene.nodes.is_empty());
-        assert!(scene.edges.is_empty());
+        assert_eq!(scene.nodes, [] as [_; 0]);
+        assert_eq!(scene.edges, [] as [_; 0]);
     }
 
     #[test]

--- a/crates/rdf/src/viz/svg.rs
+++ b/crates/rdf/src/viz/svg.rs
@@ -1287,7 +1287,7 @@ mod tests {
             .expect("table");
         assert!(document.svg.contains("class=\"statement-table\""));
         assert!(!document.svg.contains("class=\"edge-path\""));
-        assert!(document.export.scene.nodes.is_empty());
+        assert_eq!(document.export.scene.nodes, [] as [_; 0]);
         assert!(document.export.layout.table.is_some());
     }
 
@@ -1307,9 +1307,9 @@ mod tests {
         .expect("second");
         assert_eq!(first, second);
         assert_eq!(first.export.schema_version, VIZ_EXPORT_SCHEMA_VERSION);
-        assert!(!first.export.spec_hash.is_empty());
-        assert!(!first.export.model_hash.is_empty());
-        assert!(!first.export.scene_hash.is_empty());
+        assert_ne!(first.export.spec_hash, "");
+        assert_ne!(first.export.model_hash, "");
+        assert_ne!(first.export.scene_hash, "");
     }
 
     #[test]

--- a/crates/rdf/tests/gts_authorship_census.rs
+++ b/crates/rdf/tests/gts_authorship_census.rs
@@ -435,7 +435,7 @@ mod tests {
     #[test]
     fn commented_out_call_sites_are_not_flagged() {
         let body = strip_line_comments("// let w = Writer::new(\"x\");\n/// Writer::new(\"y\")\n");
-        assert!(sites_in(&body).is_empty());
+        assert_eq!(sites_in(&body), [] as [String; 0]);
     }
 
     /// …and neither is one inside the trailing `#[cfg(test)]` module.

--- a/crates/rdf/tests/projection_streaming.rs
+++ b/crates/rdf/tests/projection_streaming.rs
@@ -56,7 +56,7 @@ impl ProjectionArtifactSink for RecordingSink {
     }
 
     fn write_chunk(&mut self, chunk: &[u8]) -> Result<(), ProjectionError> {
-        assert!(!chunk.is_empty());
+        assert_ne!(chunk, [] as [u8; 0]);
         assert!(chunk.len() <= SINK_CHUNK_BYTES);
         if self
             .fail_after_chunks

--- a/crates/shapes/src/constraints.rs
+++ b/crates/shapes/src/constraints.rs
@@ -2504,9 +2504,9 @@ mod tests {
 
         let results = validate_shape(&store, &ex("a"), &shape);
         assert_eq!(results.len(), 1, "the violation itself must still fire");
-        assert!(results[0].source_box_roles.is_empty());
-        assert!(results[0].path_box_roles.is_empty());
-        assert!(results[0].result_box_roles.is_empty());
+        assert_eq!(results[0].source_box_roles, [] as [_; 0]);
+        assert_eq!(results[0].path_box_roles, [] as [_; 0]);
+        assert_eq!(results[0].result_box_roles, [] as [_; 0]);
     }
 
     #[test]

--- a/crates/shapes/src/expression.rs
+++ b/crates/shapes/src/expression.rs
@@ -804,7 +804,7 @@ mod tests {
         let expr = NodeExpr::Intersection(vec![]);
         let result = eval_node_expr(&data.data(), &ex("a"), &expr, &mut guard)
             .expect("empty intersection evals");
-        assert!(result.is_empty());
+        assert_eq!(result, [] as [_; 0]);
     }
 
     #[test]

--- a/crates/shapes/src/linkml/projection.rs
+++ b/crates/shapes/src/linkml/projection.rs
@@ -2457,7 +2457,7 @@ mod tests {
         let mut valid_reasons = Vec::new();
         let valid = sanitized_local("already_valid", &mut valid_reasons);
         assert!(matches!(valid, Cow::Borrowed("already_valid")));
-        assert!(valid_reasons.is_empty());
+        assert_eq!(valid_reasons, [] as [_; 0]);
 
         let mut invalid_reasons = Vec::new();
         let invalid = sanitized_local("9 bad", &mut invalid_reasons);
@@ -2983,7 +2983,7 @@ mod tests {
             renamed.slot_renames[0].disposition,
             LinkmlSlotDisposition::IdentityPreserved
         );
-        assert!(renamed.slot_diagnostics.is_empty());
+        assert_eq!(renamed.slot_diagnostics, [] as [_; 0]);
 
         let source = compiled(&schema);
         let source_bytes = source.schema_json.clone();
@@ -2998,7 +2998,7 @@ mod tests {
         let attributes = &skipped.document.as_value()["classes"]["Person"]["attributes"];
         assert!(attributes.get("ex:a_b").is_none());
         assert_eq!(attributes["ex:safe"]["slot_uri"], "ex:safe");
-        assert!(skipped.slot_renames.is_empty());
+        assert_eq!(skipped.slot_renames, [] as [_; 0]);
         assert_eq!(skipped.slot_diagnostics.len(), 1);
         assert_eq!(
             skipped.slot_diagnostics[0].source_path,
@@ -3329,8 +3329,8 @@ mod tests {
             }
         });
         let output = emit(&compiled(&schema), &config()).expect("safe fixture emits");
-        assert!(output.slot_renames.is_empty());
-        assert!(output.slot_diagnostics.is_empty());
+        assert_eq!(output.slot_renames, [] as [_; 0]);
+        assert_eq!(output.slot_diagnostics, [] as [_; 0]);
         assert!(output.losses.is_empty());
         assert_eq!(
             output.element_names,

--- a/crates/shapes/src/path.rs
+++ b/crates/shapes/src/path.rs
@@ -411,7 +411,7 @@ mod tests {
         let data = load_data(DATA);
         let focus = Term::Literal(Literal::new_simple_literal("hello"));
         let path = Path::Predicate(NamedNode::new_unchecked("http://example.org/ns#p"));
-        assert!(eval(&data, &focus, &path).is_empty());
+        assert_eq!(eval(&data, &focus, &path), [] as [_; 0]);
     }
 
     #[test]

--- a/crates/shapes/src/rules.rs
+++ b/crates/shapes/src/rules.rs
@@ -763,7 +763,7 @@ mod tests {
         assert!(matches!(shape.rules[0].body, RuleBody::Triple { .. }));
         assert!(!shape.rules[0].deactivated);
         assert!(shape.rules[0].order.is_none());
-        assert!(shape.rules[0].conditions.is_empty());
+        assert_eq!(shape.rules[0].conditions, [] as [_; 0]);
     }
 
     #[test]

--- a/crates/shapes/src/schema_surface.rs
+++ b/crates/shapes/src/schema_surface.rs
@@ -207,7 +207,7 @@ impl SchemaSurface {
                     | OntologyPropertyKind::Annotation => {}
                 }
                 if property.functional {
-                    debug_assert!(!property.provenance.is_empty());
+                    debug_assert_ne!(property.provenance, [] as [_; 0]);
                 }
                 emitted += 1;
                 range_expressions += property.ranges.len();

--- a/crates/shapes/src/sparql.rs
+++ b/crates/shapes/src/sparql.rs
@@ -1139,10 +1139,9 @@ mod tests {
     #[test]
     fn eval_order_empty_is_empty() {
         let dataset = dataset_from_ntriples(&[]);
-        assert!(
-            eval_order(&dataset, &[], false)
-                .expect("empty order")
-                .is_empty()
+        assert_eq!(
+            eval_order(&dataset, &[], false).expect("empty order"),
+            [] as [_; 0]
         );
     }
 

--- a/crates/shex/tests/result_json_unit.rs
+++ b/crates/shex/tests/result_json_unit.rs
@@ -221,7 +221,7 @@ fn reason_strings_with_quotes_and_newlines_stay_valid_json() {
     let rendered = result.to_result_json();
     let json: serde_json::Value = serde_json::from_str(&rendered).expect("valid JSON");
     let reason = json[0]["reason"].as_str().expect("reason present");
-    assert!(!reason.is_empty());
+    assert_ne!(reason, "");
 
     // Force a reason containing a quote and a newline directly, bypassing
     // the matcher, to prove the JSON layer escapes arbitrary reason text.

--- a/crates/shex/tests/shapemap_unit.rs
+++ b/crates/shex/tests/shapemap_unit.rs
@@ -126,7 +126,7 @@ fn unknown_predicate_selects_nothing() {
         "{FOCUS <http://a.example/absent> _}@<http://a.example/S>",
         &data,
     );
-    assert!(got.is_empty());
+    assert_eq!(got, [] as [_; 0]);
 }
 
 // ── RDF-1.2 quoted-triple term parsing ──────────────────────────────────────

--- a/crates/slice/src/catalog.rs
+++ b/crates/slice/src/catalog.rs
@@ -597,7 +597,7 @@ ex:subject ex:predicate ex:object .
 
         let digest = compute_semantic_digest(relative, &path)
             .expect("a relative-IRI artifact resolves under its own retrieval IRI");
-        assert!(!digest.is_empty());
+        assert_ne!(digest, "");
 
         // The digest is of the RESOLVED graph: writing the same document with the
         // references already expanded against that base gives the same digest.

--- a/crates/slice/src/ownership.rs
+++ b/crates/slice/src/ownership.rs
@@ -1174,7 +1174,7 @@ mod rdf_fact_tests {
         // reference — which is precisely how the reference is silently dropped
         // at the ownership join.
         let facts = inspect_rdf_dataset(store.inner(), &SliceVocab::for_namespace(EX));
-        assert!(facts.is_defined_by.is_empty());
+        assert_eq!(facts.is_defined_by, [] as [_; 0]);
         assert!(facts.declared_terms.is_empty());
         assert!(facts.referenced_iris.contains(&quantity));
     }

--- a/crates/slice/src/rdf_query.rs
+++ b/crates/slice/src/rdf_query.rs
@@ -969,14 +969,14 @@ mod tests {
 
         // The default graph does NOT see the named-graph annotation.
         let default = ds.graph(GraphSel::Default);
-        assert!(
+        assert_eq!(
             default
                 .objects(
                     "https://example.org/ax",
                     "http://www.w3.org/2002/07/owl#annotatedSource",
                 )
-                .unwrap()
-                .is_empty()
+                .unwrap(),
+            [] as [_; 0]
         );
         // …but it does see the default-graph triple.
         assert_eq!(
@@ -1030,11 +1030,11 @@ mod tests {
         )
         .unwrap();
         let missing = ds.graph(GraphSel::Named("https://example.org/does-not-exist"));
-        assert!(
+        assert_eq!(
             missing
                 .objects("https://example.org/s", "https://example.org/p")
-                .unwrap()
-                .is_empty()
+                .unwrap(),
+            [] as [_; 0]
         );
         let mut hit = false;
         missing.for_each_quad(|_, _, _, _| hit = true);

--- a/crates/slice/tests/ownership_tests.rs
+++ b/crates/slice/tests/ownership_tests.rs
@@ -936,7 +936,7 @@ fn every_rdf_artifact_carries_a_semantic_digest_and_no_other_kind_does() {
 
     let catalog = SliceCatalog::discover(root, test_vocab()).expect("a clean slice discovers");
     let record = catalog.records().first().expect("one slice");
-    assert!(!record.artifacts.is_empty());
+    assert_ne!(record.artifacts, [] as [_; 0]);
     for artifact in &record.artifacts {
         // Read the artifact's KIND off the record's own media type rather than re-typing
         // the extension list the catalogue classifies with — a second copy of that list

--- a/crates/sparql-algebra/src/parser.rs
+++ b/crates/sparql-algebra/src/parser.rs
@@ -6384,7 +6384,7 @@ mod tests {
         );
         assert_eq!(agg.args.len(), 1);
         assert!(!agg.distinct);
-        assert!(agg.scalarvals.is_empty());
+        assert_eq!(agg.scalarvals, [] as [_; 0]);
     }
 
     #[test]
@@ -6666,7 +6666,7 @@ mod tests {
             panic!("expected Group under Extend");
         };
         assert_eq!(aggregates.len(), 1);
-        assert!(aggregates[0].1.args.is_empty());
+        assert_eq!(aggregates[0].1.args, [] as [_; 0]);
         assert!(aggregates[0].1.distinct);
         assert!(matches!(aggregates[0].1.function, AggregateFunction::Count));
     }
@@ -7048,7 +7048,7 @@ mod tests {
             panic!("expected DeleteInsert");
         };
         assert_eq!(delete.len(), 1);
-        assert!(insert.is_empty());
+        assert_eq!(insert.as_slice(), []);
         // The template IS the where pattern.
         assert!(matches!(**pattern, GraphPattern::Bgp { .. }));
     }
@@ -7128,7 +7128,7 @@ mod tests {
         assert_eq!(delete.len(), 1);
         assert_eq!(insert.len(), 1);
         assert!(with.is_none());
-        assert!(using.is_empty());
+        assert_eq!(using.as_slice(), []);
     }
 
     #[test]
@@ -7137,7 +7137,7 @@ mod tests {
         let GraphUpdateOperation::DeleteInsert { delete, insert, .. } = &u.operations[0] else {
             panic!("expected DeleteInsert");
         };
-        assert!(delete.is_empty());
+        assert_eq!(delete.as_slice(), []);
         assert_eq!(insert.len(), 1);
     }
 
@@ -7280,7 +7280,7 @@ mod tests {
         let u = SparqlParser::new()
             .parse_update("PREFIX ex: <http://e/>")
             .expect("prologue-only update");
-        assert!(u.operations.is_empty());
+        assert_eq!(u.operations, [] as [_; 0]);
     }
 
     #[test]
@@ -8682,7 +8682,10 @@ mod tests {
         // With NO configured namespace (the default) the extension seam is OFF:
         // a call-position IRI is an ordinary custom function — no error, no
         // special-casing, regardless of its local name.
-        assert!(ParserOptions::default().extension_fn_namespaces.is_empty());
+        assert_eq!(
+            ParserOptions::default().extension_fn_namespaces,
+            [] as [String; 0]
+        );
         let q = format!("{EXTP}SELECT ?h WHERE {{ ?r ?p ?o . BIND(g:heldIn(?r, ?s) AS ?h) }}");
         let Expression::FunctionCall(func, _) = bound_expr(&q) else {
             panic!("expected a FunctionCall");
@@ -9114,7 +9117,10 @@ mod tests {
     fn default_options_have_no_property_fn_namespaces() {
         // The seam is OFF by default: with no configured namespace the very same
         // query text parses to the ordinary BGP triple pattern it always did.
-        assert!(ParserOptions::default().property_fn_namespaces.is_empty());
+        assert_eq!(
+            ParserOptions::default().property_fn_namespaces,
+            [] as [String; 0]
+        );
         let q = "SELECT * WHERE { ?s pf:related ?o }";
         assert_eq!(
             pf_pattern_off(q),
@@ -9128,7 +9134,10 @@ mod tests {
                 }]
             }
         );
-        assert!(pf_calls(&pf_pattern_off(q)).is_empty());
+        assert_eq!(
+            pf_calls(&pf_pattern_off(q)),
+            [] as [&PropertyFunctionCall; 0]
+        );
     }
 
     #[test]
@@ -9232,8 +9241,8 @@ mod tests {
         // `()` denotes NO arguments on that side …
         let p = pf_pattern("SELECT * WHERE { () pf:solve ( ) }");
         let call = pf_only_call(&p);
-        assert!(call.subject_args.is_empty());
-        assert!(call.object_args.is_empty());
+        assert_eq!(call.subject_args, [] as [_; 0]);
+        assert_eq!(call.object_args, [] as [_; 0]);
     }
 
     #[test]
@@ -9244,7 +9253,7 @@ mod tests {
         let call = pf_only_call(&p);
         assert_eq!(call.subject_args, vec![pf_iri(RDF_NIL)]);
         let p2 = pf_pattern("SELECT * WHERE { () pf:solve ?o }");
-        assert!(pf_only_call(&p2).subject_args.is_empty());
+        assert_eq!(pf_only_call(&p2).subject_args, [] as [_; 0]);
         assert_ne!(call.subject_args, pf_only_call(&p2).subject_args);
     }
 
@@ -9409,7 +9418,7 @@ mod tests {
         // Even when the variable would bind to a configured-namespace IRI: only a
         // plain IRI predicate is recognized, at parse time.
         let p = pf_pattern("SELECT * WHERE { ?s ?p ?o }");
-        assert!(pf_calls(&p).is_empty());
+        assert_eq!(pf_calls(&p), [] as [&PropertyFunctionCall; 0]);
         assert_eq!(pf_triples(&p).len(), 1);
     }
 
@@ -9429,7 +9438,7 @@ mod tests {
         // collection, cons cells and all — identical to the seam-off parse.
         let q = "SELECT * WHERE { ( ?a ?b ) pf:related+ ?o }";
         assert_eq!(pf_pattern(q), pf_pattern_off(q));
-        assert!(pf_calls(&pf_pattern(q)).is_empty());
+        assert_eq!(pf_calls(&pf_pattern(q)), [] as [&PropertyFunctionCall; 0]);
     }
 
     #[test]
@@ -9565,7 +9574,7 @@ mod tests {
         // Only the PREDICATE position is the seam; the same IRI as a subject or
         // object is an ordinary term.
         let p = pf_pattern("SELECT * WHERE { pf:related ex:p pf:related }");
-        assert!(pf_calls(&p).is_empty());
+        assert_eq!(pf_calls(&p), [] as [&PropertyFunctionCall; 0]);
         let triples = pf_triples(&p);
         assert_eq!(triples.len(), 1);
         assert_eq!(triples[0].subject, pf_iri(&format!("{PF_NS}related")));

--- a/crates/sparql-eval/src/agg_fn.rs
+++ b/crates/sparql-eval/src/agg_fn.rs
@@ -1100,7 +1100,7 @@ mod tests {
             first, second,
             "the fingerprint is a pure function of contents"
         );
-        assert!(!first.is_empty());
+        assert_ne!(first, "");
     }
 
     /// GAP (registry instance identity): two INDEPENDENTLY constructed registries

--- a/crates/sparql-eval/src/bgp.rs
+++ b/crates/sparql-eval/src/bgp.rs
@@ -1794,7 +1794,7 @@ mod tests {
             var_pos("o"),
         )];
         let rows = run(&ds, &patterns, &["o"]);
-        assert!(rows.is_empty());
+        assert_eq!(rows, [] as [Vec<Option<TermValue>>; 0]);
     }
 
     #[test]
@@ -1972,7 +1972,7 @@ mod tests {
             ),
         )];
         let rows = run(&ds, &patterns, &["r"]);
-        assert!(rows.is_empty());
+        assert_eq!(rows, [] as [Vec<Option<TermValue>>; 0]);
     }
 
     /// A fully-open pattern `?r ?ap ?av` enumerates EVERY triple visible to the BGP:
@@ -2090,7 +2090,7 @@ mod tests {
             triple_obj(var_pos("x"), pred("http://ex/age"), var_pos("x")),
         )];
         let rows = run(&ds, &patterns, &["r", "x"]);
-        assert!(rows.is_empty());
+        assert_eq!(rows, [] as [Vec<Option<TermValue>>; 0]);
     }
 
     /// A dataset with no reifiers never interns `rdf:reifies`, so a reifies-pattern
@@ -2104,7 +2104,7 @@ mod tests {
             triple_obj(var_pos("s"), pred_var("p"), var_pos("o")),
         )];
         let rows = run(&ds, &patterns, &["r"]);
-        assert!(rows.is_empty());
+        assert_eq!(rows, [] as [Vec<Option<TermValue>>; 0]);
     }
 
     // ---- cost_based_order --------------------------------------------------

--- a/crates/sparql-eval/src/binop.rs
+++ b/crates/sparql-eval/src/binop.rs
@@ -1573,7 +1573,7 @@ mod tests {
             rows: vec![smallvec::smallvec![t(1)], smallvec::smallvec![t(2)]],
         };
         let (keyed2, wild2) = build_index(&inner2, &shared);
-        assert!(wild2.is_empty());
+        assert_eq!(wild2, [] as [_; 0]);
         assert!(
             !probe_has_match(&[t(9), None], &shared, &keyed2, &wild2, &inner2.rows),
             "bound probe with no keyed bucket and no wild row does not match"

--- a/crates/sparql-eval/src/engine.rs
+++ b/crates/sparql-eval/src/engine.rs
@@ -2668,7 +2668,7 @@ mod tests {
         assert_eq!(first.subject_arity, 1);
         assert_eq!(first.object_arity, 1);
         assert_eq!(first.volatility, crate::Volatility::Stable);
-        assert!(!first.modes.is_empty());
+        assert_ne!(first.modes, [] as [_; 0]);
 
         assert_ne!(
             left_receipt.render(),
@@ -2686,8 +2686,8 @@ mod tests {
         // With no registry EITHER block is present and empty — "nothing was in scope",
         // not "this build does not report what was".
         let bare = engine.explain_query(&ds, query, None).expect("explain");
-        assert!(bare.relations().is_empty());
-        assert!(bare.aggregates().is_empty());
+        assert_eq!(bare.relations(), []);
+        assert_eq!(bare.aggregates(), []);
         assert!(bare.render().contains("relations\naggregates\njoin-orders"));
     }
 
@@ -2811,7 +2811,7 @@ mod tests {
             receipt.render()
         );
         // The `relations` block is unaffected — this seam is aggregates-only.
-        assert!(receipt.relations().is_empty());
+        assert_eq!(receipt.relations(), []);
     }
 
     /// A query that needs BOTH a registered relation and a registered custom aggregate

--- a/crates/sparql-eval/src/expr.rs
+++ b/crates/sparql-eval/src/expr.rs
@@ -1137,16 +1137,23 @@ impl Drop for SuppressFirstWitnessWrapGuard {
 }
 
 /// Whether [`exists`]'s definition path should apply the first-witness
-/// `Slice{0, Some(1)}` wrap. Always `true` outside `cfg(test)` — the wrap is
-/// unconditional production behavior, never a runtime-configurable option; the
-/// `cfg(test)` branch lets [`suppress_first_witness_wrap_for_test`] force it off
-/// for the one differential test that needs an unwrapped control.
+/// `Slice{0, Some(1)}` wrap. Always `true` in a production build — the wrap is
+/// unconditional production behavior, never a runtime-configurable option.
+///
+/// Two `cfg`-selected definitions rather than one body with a `cfg`'d early
+/// return: the production answer is then a literal `true` with no thread-local
+/// in sight, which is the property this function exists to guarantee.
+#[cfg(not(test))]
 fn exists_apply_first_witness_wrap() -> bool {
-    #[cfg(test)]
-    if SUPPRESS_FIRST_WITNESS_WRAP.with(std::cell::Cell::get) {
-        return false;
-    }
     true
+}
+
+/// Test-build counterpart of [`exists_apply_first_witness_wrap`]: still `true` by
+/// default, but [`suppress_first_witness_wrap_for_test`] can force it off for the
+/// one differential test that needs an unwrapped control.
+#[cfg(test)]
+fn exists_apply_first_witness_wrap() -> bool {
+    !SUPPRESS_FIRST_WITNESS_WRAP.with(std::cell::Cell::get)
 }
 
 /// [`exists`]'s probe-vs-definition decision: `true` runs the memoized probe, `false`

--- a/crates/sparql-eval/src/knn/metric.rs
+++ b/crates/sparql-eval/src/knn/metric.rs
@@ -607,8 +607,8 @@ mod tests {
 
     #[test]
     fn selecting_from_nothing_is_empty_rather_than_an_error() {
-        assert!(best(5, Vec::new()).is_empty());
-        assert!(best(0, candidates()).is_empty());
+        assert_eq!(best(5, Vec::new()), [] as [_; 0]);
+        assert_eq!(best(0, candidates()), [] as [_; 0]);
     }
 
     #[test]

--- a/crates/sparql-eval/src/knn/tests.rs
+++ b/crates/sparql-eval/src/knn/tests.rs
@@ -866,14 +866,14 @@ fn a_negative_count_is_refused_and_zero_is_an_honest_empty_answer() {
 
     // Zero is the boundary a clamp-or-refuse rule gets wrong in both directions: it is a
     // well-formed request for nothing, answered with nothing.
-    assert!(
+    assert_eq!(
         invoke(
             &relation,
             &[None, Some(iri("a")), Some(count(0)), None],
             None
         )
-        .expect("k = 0 is a valid request")
-        .is_empty()
+        .expect("k = 0 is a valid request"),
+        [] as [Vec<TermValue>; 0]
     );
 }
 
@@ -911,14 +911,14 @@ fn a_seed_the_space_does_not_hold_is_empty_rather_than_an_error() {
         &DistanceMetric::SquaredEuclidean,
         &points(),
     )));
-    assert!(
+    assert_eq!(
         invoke(
             &relation,
             &[None, Some(iri("stranger")), Some(count(3)), None],
             None
         )
-        .expect("an unembedded seed is a question, not a mistake")
-        .is_empty()
+        .expect("an unembedded seed is a question, not a mistake"),
+        [] as [Vec<TermValue>; 0]
     );
     // And the neighbouring case still answers, so the emptiness above is about the seed.
     assert_eq!(

--- a/crates/sparql-eval/src/path_relation.rs
+++ b/crates/sparql-eval/src/path_relation.rs
@@ -3518,7 +3518,7 @@ mod tests {
             let mut bound = free();
             bound[POS_PATH_ID] = Some(id.clone());
             let rows = drained(&relation, &bound);
-            assert!(!rows.is_empty());
+            assert_ne!(rows, [] as [PfRow; 0]);
             assert!(rows.iter().all(|row| &row[POS_PATH_ID] == id));
             assert_eq!(path_ids(&rows).len(), 1);
         }

--- a/crates/sparql-eval/src/property_fn.rs
+++ b/crates/sparql-eval/src/property_fn.rs
@@ -1163,7 +1163,10 @@ mod tests {
             vec![vec![iri(EX_A), iri(EX_ONE)]]
         );
         // bb — both bound, disagreeing: no row.
-        assert!(invoke(&relation, &[Some(iri(EX_A)), Some(iri(EX_TWO))]).is_empty());
+        assert_eq!(
+            invoke(&relation, &[Some(iri(EX_A)), Some(iri(EX_TWO))]),
+            [] as [Vec<TermValue>; 0]
+        );
     }
 
     #[test]
@@ -1211,7 +1214,10 @@ mod tests {
         );
 
         // A ceiling of zero emits nothing at all, without a first pull into the table.
-        assert!(invoke_under_ceiling(&relation, Some(0)).is_empty());
+        assert_eq!(
+            invoke_under_ceiling(&relation, Some(0)),
+            [] as [Vec<TermValue>; 0]
+        );
         // A ceiling above the table is simply never reached.
         assert_eq!(invoke_under_ceiling(&relation, Some(1_000)).len(), 100);
     }

--- a/crates/sparql-eval/tests/fallible_query.rs
+++ b/crates/sparql-eval/tests/fallible_query.rs
@@ -81,7 +81,7 @@ fn successful_and_empty_results_are_explicitly_complete() {
         )
         .expect("a genuinely empty answer is complete");
     match empty.result {
-        SparqlResult::Solutions { rows, .. } => assert!(rows.is_empty()),
+        SparqlResult::Solutions { rows, .. } => assert_eq!(rows, [] as [Vec<Option<TermValue>>; 0]),
         other => panic!("expected empty SELECT solutions, got: {other:?}"),
     }
     assert!(
@@ -223,7 +223,7 @@ fn parse_failure_remains_an_ordinary_query_error_with_evidence() {
             evidence,
         } => {
             assert_eq!(diagnostic.code, "native-sparql-query-parse");
-            assert!(evidence.requested_pages.is_empty());
+            assert_eq!(evidence.requested_pages, [] as [_; 0]);
             assert_eq!(evidence.consumed_pages, 0);
         }
         FallibleSparqlError::Operational { error, .. } => {
@@ -575,7 +575,10 @@ fn operational_failure_taxonomy_is_not_an_empty_answer() {
             QueryOptions::EMPTY,
         )
         .expect("genuinely empty query is complete");
-    assert!(solution_parts(empty.result).1.is_empty());
+    assert_eq!(
+        solution_parts(empty.result).1,
+        [] as [Vec<Option<TermValue>>; 0]
+    );
 }
 
 #[test]
@@ -671,7 +674,7 @@ fn cold_and_warm_bgp_planning_have_identical_demand_paging_evidence() {
             .query_fallible_view(&view, query, QueryOptions::EMPTY)
             .expect("complete empty execution");
         let (_, rows) = solution_parts(complete.result);
-        assert!(rows.is_empty());
+        assert_eq!(rows, [] as [Vec<Option<TermValue>>; 0]);
         assert_eq!(complete.evidence.requested_pages, vec![PageId(0)]);
         assert_eq!(complete.evidence.consumed_pages, 1);
         assert_eq!(complete.evidence.consumed_bytes, 20);

--- a/crates/sparql-eval/tests/governed_query.rs
+++ b/crates/sparql-eval/tests/governed_query.rs
@@ -1504,7 +1504,7 @@ fn explain_reports_a_deterministic_per_node_ledger() {
     assert!(ledger.len() >= 4, "expected a multi-node plan: {ledger:?}");
     for (position, node) in ledger.iter().enumerate() {
         assert_eq!(node.ordinal, position, "ordinals are positional");
-        assert!(!node.label.is_empty());
+        assert_ne!(node.label, "");
     }
     assert_eq!(ledger[0].depth, 0, "the first node is the plan root");
 

--- a/crates/sparql-eval/tests/service_live.rs
+++ b/crates/sparql-eval/tests/service_live.rs
@@ -185,7 +185,7 @@ fn missing_named_graph_does_not_execute_its_inner_service() {
         panic!("SELECT must return a solution sequence");
     };
     assert_eq!(variables, ["x"]);
-    assert!(rows.is_empty());
+    assert_eq!(rows, [] as [Vec<Option<purrdf_core::TermValue>>; 0]);
     assert_eq!(posts.load(Ordering::Relaxed), 0);
 }
 

--- a/crates/validate/src/build.rs
+++ b/crates/validate/src/build.rs
@@ -992,7 +992,7 @@ mod tests {
             results: vec![],
         };
         let none = build_report_sarif(&report, &SarifOptions::default());
-        assert!(none.runs[0].invocations.is_empty());
+        assert_eq!(none.runs[0].invocations, [] as [_; 0]);
 
         let timed = build_report_sarif(
             &report,

--- a/crates/validate/src/regime.rs
+++ b/crates/validate/src/regime.rs
@@ -4695,7 +4695,7 @@ mod tests {
     #[test]
     fn the_golden_vector_is_well_formed() {
         let cases = regime_golden_vectors().expect("the artifact parses");
-        assert!(!cases.is_empty());
+        assert_ne!(cases, [] as [_; 0]);
         for case in &cases {
             parse_regime(case.regime()).expect("a case names a real regime");
             assert!(!case.input().is_empty(), "{}", case.name());
@@ -5180,10 +5180,10 @@ mod tests {
             .lines()
             .filter_map(|line| line.strip_prefix("boundary "))
             .collect();
-        assert!(!boundaries.is_empty());
+        assert_ne!(boundaries, [] as [&str; 0]);
         for boundary in boundaries {
             let (construct, reason) = boundary.split_once(' ').expect("a construct and a reason");
-            assert!(!construct.is_empty());
+            assert_ne!(construct, "");
             assert!(reason.len() > construct.len(), "{boundary}");
         }
         // `simple` copies faithfully, so it names none — and is therefore the one

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,9 +1,24 @@
 # SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-# The workspace is stable-Rust clean (no nightly features); this pin keeps
-# local dev, CI, and the declared `rust-version` (MSRV) on the same channel.
+# The DEVELOPMENT/CI toolchain, deliberately a *dated* nightly. This is not a
+# licence to use nightly-only language features: the workspace contains zero
+# `#![feature(...)]` attributes and must keep it that way. What nightly buys is
+# a single, sharper lint surface — nightly clippy and rustdoc carry lints stable
+# does not — so a finding here is a real finding and never a channel artifact.
+#
+# The date is mandatory. A floating `nightly` would re-resolve to a different
+# compiler every day, which is incompatible with a workspace whose serializers,
+# GTS writer, frozen corpora, and content-addressed goldens are all
+# byte-deterministic contracts. Bump the date deliberately, in its own commit,
+# with the gates re-run.
+#
+# What consumers actually need is `rust-version` in the root `Cargo.toml` (the
+# MSRV), which is a *lower* floor on the stable channel and is enforced by the
+# dedicated `msrv` CI job. That job — not this file — is the guard proving no
+# nightly-only feature has crept in; it pins its own toolchain via
+# `RUSTUP_TOOLCHAIN` precisely so this file cannot override it.
 [toolchain]
-channel = "stable"
+channel = "nightly-2026-09-02"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-unknown-unknown"]

--- a/scripts/check-toolchain-pin.py
+++ b/scripts/check-toolchain-pin.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""Hygiene gate: every CI job that runs a workspace gate must install the exact
+toolchain `rust-toolchain.toml` pins, and the two jobs that deliberately do NOT
+must say so out loud.
+
+The workspace pins a DATED nightly for development and CI. Nightly clippy and
+rustdoc carry lints stable lacks, so a finding is a real finding rather than a
+channel artifact -- but only while the compiler a developer runs and the compiler
+CI runs are the same build. A floating channel, or a CI job left on `stable`
+after the pin moved, reintroduces exactly the divergence the pin exists to
+remove: a gate that is green on one machine and red on another, with no way to
+tell a genuine failure from a channel difference.
+
+Drift here is invisible without a gate. `dtolnay/rust-toolchain` selects a
+toolchain with `rustup default`, which sits at the BOTTOM of rustup's precedence
+order -- below `rust-toolchain.toml`. So a workflow whose install step says one
+thing and whose repo pin says another does not fail; it silently runs the pin,
+and the workflow reads as if it tested something it never tested. The `msrv` job
+was doing precisely that: it installed 1.96, then every `cargo` invocation
+resolved back to the repo pin.
+
+Two escapes exist, and both must be explicit:
+
+* `RUSTUP_TOOLCHAIN` outranks `rust-toolchain.toml`, so a workflow that sets it
+  really does use the toolchain it names. That is how the `msrv` job holds the
+  1.96 floor and how the release lanes stay on stable.
+* Anything else -- an install step naming a toolchain the pin does not name,
+  with no `RUSTUP_TOOLCHAIN` to back it -- is drift, and fails here.
+
+Pure text over committed files: no cargo, no network, no rustup.
+Run standalone, or as part of `make check` / CI.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+TOOLCHAIN_FILE = REPO / "rust-toolchain.toml"
+WORKFLOW_DIR = REPO / ".github" / "workflows"
+
+CHANNEL_RE = re.compile(r'^\s*channel\s*=\s*"([^"]+)"\s*$', re.MULTILINE)
+ACTION_RE = re.compile(r"uses:\s*dtolnay/rust-toolchain@")
+LIST_ITEM_RE = re.compile(r"^(\s*)-\s")
+TOOLCHAIN_INPUT_RE = re.compile(r'^\s*toolchain:\s*"?([^"\s#]+)"?', re.MULTILINE)
+RUSTUP_ENV_RE = re.compile(r'^\s*RUSTUP_TOOLCHAIN:\s*"?([^"\s#]+)"?', re.MULTILINE)
+
+
+def steps(text: str) -> list[str]:
+    """Split a workflow into YAML sequence items (steps), by indentation.
+
+    Deliberately not a regex over the whole file: an earlier version captured
+    "every following indented line", which ran one step's body across the rest of
+    its job and let a NEIGHBOURING step's `RUSTUP_TOOLCHAIN` excuse a drifting
+    install. A step ends at the next `- ` at the same or shallower indent, or at
+    the next non-blank line indented less than the step marker.
+    """
+    lines = text.splitlines(keepends=True)
+    blocks: list[str] = []
+    current: list[str] | None = None
+    indent = 0
+    for line in lines:
+        item = LIST_ITEM_RE.match(line)
+        stripped = line.strip()
+        if current is not None:
+            ends = (item is not None and len(item.group(1)) <= indent) or (
+                stripped != ""
+                and len(line) - len(line.lstrip()) <= indent
+                and item is None
+            )
+            if ends:
+                blocks.append("".join(current))
+                current = None
+        if item is not None:
+            current = [line]
+            indent = len(item.group(1))
+        elif current is not None:
+            current.append(line)
+    if current is not None:
+        blocks.append("".join(current))
+    return blocks
+
+
+def pinned_channel(text: str) -> str:
+    """Return the channel `rust-toolchain.toml` pins, rejecting a floating one."""
+    match = CHANNEL_RE.search(text)
+    if match is None:
+        raise SystemExit("rust-toolchain.toml: no [toolchain] channel = \"...\" found")
+    channel = match.group(1)
+    if channel in {"nightly", "beta", "stable"}:
+        raise SystemExit(
+            f'rust-toolchain.toml: channel = "{channel}" floats. This workspace\n'
+            "has byte-deterministic serializers, a byte-deterministic GTS writer,\n"
+            "frozen corpora and content-addressed goldens; the compiler must not\n"
+            'change underneath them day to day. Pin a date, e.g. "nightly-2026-09-02",\n'
+            'or an exact release, e.g. "1.96.0".'
+        )
+    return channel
+
+
+def audit(text: str, channel: str) -> list[str]:
+    """Return one problem string per toolchain-install step that drifts.
+
+    A step's toolchain may be excused by `RUSTUP_TOOLCHAIN` set on the step
+    itself, on the run step that follows it, or at workflow level (which applies
+    to every step in the file). Anything else is silent drift.
+    """
+    problems: list[str] = []
+    blocks = steps(text)
+    # Workflow-level `env:` sits at column 0 and applies file-wide; step- and
+    # job-level `env:` are indented, so anchoring at column 0 separates them.
+    #
+    # The indented-line group is `[ \t][^\n]*\n`, deliberately NOT `[ \t]+[^\n]*\n`.
+    # The two match exactly the same lines, but the `+` version is ambiguous — a
+    # run of spaces can be split between `[ \t]+` and `[^\n]*` in exponentially
+    # many ways — so on an `env:` block with no `RUSTUP_TOOLCHAIN` in it the
+    # regex engine backtracks through every one of them before failing. One
+    # indent character followed by "rest of line" is unambiguous and linear.
+    file_escape = re.search(
+        r'^env:\n(?:[ \t][^\n]*\n)*?[ \t]+RUSTUP_TOOLCHAIN:\s*"?([^"\s#]+)"?',
+        text,
+        re.MULTILINE,
+    )
+    for index, body in enumerate(blocks):
+        if not ACTION_RE.search(body):
+            continue
+        requested = TOOLCHAIN_INPUT_RE.search(body)
+        if requested is None:
+            # No `toolchain:` input means the action's own default, `stable`,
+            # which is never what this workspace wants stated implicitly.
+            problems.append(
+                "installs the action default (stable) with no explicit `toolchain:` input"
+            )
+            continue
+        name = requested.group(1)
+        if name == channel:
+            continue
+        following = "".join(blocks[index + 1 : index + 4])
+        escape = (
+            RUSTUP_ENV_RE.search(body)
+            or RUSTUP_ENV_RE.search(following)
+            or file_escape
+        )
+        if escape is None:
+            problems.append(
+                f"installs `{name}` but the repo pins `{channel}`, and nothing sets\n"
+                "      RUSTUP_TOOLCHAIN -- `rustup default` loses to rust-toolchain.toml,\n"
+                f"      so cargo would silently run `{channel}` instead of `{name}`"
+            )
+        elif escape.group(1) != name:
+            problems.append(
+                f"installs `{name}` but RUSTUP_TOOLCHAIN selects `{escape.group(1)}`"
+            )
+    return problems
+
+
+def self_test() -> None:
+    """Prove the gate is capable of failing, per the repo's self-test convention."""
+    pin = "nightly-2026-09-02"
+    drifting = (
+        "jobs:\n  a:\n    steps:\n"
+        "      - uses: dtolnay/rust-toolchain@abc # v1\n"
+        "        with:\n"
+        '          toolchain: "1.96"\n'
+    )
+    assert audit(drifting, pin), "a drifting step must be caught"
+    assert not audit(
+        drifting + '        env:\n          RUSTUP_TOOLCHAIN: "1.96"\n', pin
+    ), "an escape on the install step itself must pass"
+    assert not audit(
+        drifting + "\n      - name: Check\n        run: cargo check\n"
+        '        env:\n          RUSTUP_TOOLCHAIN: "1.96"\n',
+        pin,
+    ), "an escape on the following run step must pass"
+    assert not audit(
+        'env:\n  RUSTUP_TOOLCHAIN: "1.96"\n\n' + drifting, pin
+    ), "a workflow-level escape must pass"
+    # An `env:` block that never reaches a `RUSTUP_TOOLCHAIN` is the worst case for
+    # the file-escape regex: it must fail, and it must fail in linear time. With the
+    # ambiguous `[ \t]+[^\n]*` spelling this input backtracked exponentially and hung.
+    # Timed rather than merely run, so a future "tidy-up" of the regex cannot quietly
+    # reintroduce the blow-up while still returning the right answer.
+    start = time.monotonic()
+    assert audit("env:\n" + " \t\n" * 40 + drifting, pin), (
+        "an env: block with no RUSTUP_TOOLCHAIN excuses nothing"
+    )
+    elapsed = time.monotonic() - start
+    assert elapsed < 1.0, f"file-escape regex backtracked catastrophically ({elapsed:.1f}s)"
+    # Regression: an earlier body regex captured every following indented line,
+    # so a LATER, unrelated job's `RUSTUP_TOOLCHAIN` silently excused this drift.
+    far_away = (
+        drifting
+        + "\n  b:\n    steps:\n      - name: Unrelated\n        run: true\n"
+        "      - name: Also unrelated\n        run: true\n"
+        "      - name: Still unrelated\n        run: true\n"
+        "      - name: Far away\n        run: true\n"
+        '        env:\n          RUSTUP_TOOLCHAIN: "1.96"\n'
+    )
+    assert audit(far_away, pin), "a distant job's env must NOT excuse this step"
+    implicit = "jobs:\n  a:\n    steps:\n      - uses: dtolnay/rust-toolchain@abc # v1\n\n"
+    assert audit(implicit, pin), "an implicit stable step must be caught"
+    matching = (
+        "jobs:\n  a:\n    steps:\n"
+        "      - uses: dtolnay/rust-toolchain@abc # v1\n"
+        "        with:\n"
+        f'          toolchain: "{pin}"\n'
+        "          targets: wasm32-unknown-unknown\n"
+    )
+    assert not audit(matching, pin), "a matching step must pass"
+    # A neighbouring VALID case: two matching steps in a row, the second of which
+    # would be a false positive if step splitting mis-attributed the first's
+    # `with:` block. Over-refusal is as much a bug as under-refusal.
+    assert not audit(matching + matching, pin), "back-to-back matching steps must pass"
+    for floating in ("nightly", "stable", "beta"):
+        try:
+            pinned_channel(f'[toolchain]\nchannel = "{floating}"\n')
+        except SystemExit:
+            pass
+        else:  # pragma: no cover - guards the guard
+            raise AssertionError(f"floating channel {floating!r} must be rejected")
+    assert pinned_channel('[toolchain]\nchannel = "nightly-2026-09-02"\n') == "nightly-2026-09-02"
+    print("check-toolchain-pin.py: self-test OK")
+
+
+def main(argv: list[str]) -> int:
+    if "--self-test" in argv:
+        self_test()
+        return 0
+    channel = pinned_channel(TOOLCHAIN_FILE.read_text(encoding="utf-8"))
+    failures: list[str] = []
+    for workflow in sorted(WORKFLOW_DIR.glob("*.y*ml")):
+        text = workflow.read_text(encoding="utf-8")
+        for problem in audit(text, channel):
+            failures.append(f"  {workflow.relative_to(REPO)}: {problem}")
+    if failures:
+        print(
+            f"Toolchain drift: rust-toolchain.toml pins `{channel}`, but:",
+            file=sys.stderr,
+        )
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+    print(f"check-toolchain-pin.py: every workflow agrees with the `{channel}` pin")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Why

`rust-toolchain.toml` pinned `channel = "stable"`, but the pin was **silently bypassed**: on the development machine `cargo`/`rustc` are symlinks straight into a toolchain rather than rustup shims, so the real compiler was `rustc 1.100.0-nightly (5db7f4be8 2026-09-01)`. A pin that cannot enforce itself is worse than none — everyone reasons from a false premise, and it has already cost hours of agents unable to tell a real failure from a channel artifact. The pin now follows reality.

Nightly is a **lint** decision, not a licence. Nightly clippy and rustdoc carry lints stable lacks, so a gate finding is a real finding.

## What

**1. `rust-toolchain.toml` pins `nightly-2026-09-02`.**

Dated, never floating — a floating channel re-resolves daily, which a workspace with byte-deterministic serializers, a byte-deterministic GTS writer, frozen corpora and content-addressed goldens cannot accept.

Note the date: `nightly-2026-09-02` is the channel that *ships* `rustc 1.100.0-nightly (5db7f4be8 2026-09-01)` (a nightly's channel date is one day after its commit date; `nightly-2026-09-01` would be a different, older compiler). Verified against the installed toolchains, not assumed.

**2. The source stays nightly-free.** Zero `#![feature(...)]` in `crates/` and `bindings/`, before and after. `rust-version = "1.96"` and the `msrv` CI job are **unchanged** — MSRV is a promise to consumers on stable; the dev toolchain is a tool choice. They are orthogonal.

**3. A latent CI bug, found on the way and fixed.** `dtolnay/rust-toolchain` selects with `rustup default`, which sits at the **bottom** of rustup's precedence order — *below* `rust-toolchain.toml`. So a workflow that installs one toolchain while the repo pins another does not fail; it silently runs the pin. **The `msrv` job was doing exactly that**: it installed 1.96, then every `cargo` invocation resolved back to the repo pin, so the job never measured the MSRV at all. It now sets `RUSTUP_TOOLCHAIN: "1.96"` (the only thing that outranks the file) and asserts `rustc --version` really is 1.96.x, so it fails loudly rather than passing on the wrong compiler.

**4. Release lanes build on stable, explicitly.** `release-cargo`, `release-npm` and `release-pypi` set `RUSTUP_TOOLCHAIN: stable` at workflow level. Nightly's sharper lints buy nothing for an artifact a consumer installs, and shipping one from an unreleased compiler is risk without upside.

**5. A new gate: `scripts/check-toolchain-pin.py`** (in `make check` and CI, with a `--self-test` step proving it can still fail). It rejects a floating channel and any workflow install step that disagrees with the pin without an explicit `RUSTUP_TOOLCHAIN` escape. Without it this drift is invisible by construction.

## Lints fixed (no `#[allow]`, no lint-allow table)

Suppressing these would recreate the very "gate that reports success while doing nothing" this PR exists to remove.

| Lint | n | Fix |
| --- | --- | --- |
| `clippy::assert_is_empty` | 35 | `assert!(!x.is_empty())` → `assert_ne!(x, [] as [T; 0])` / `assert_ne!(s, "")`; mechanical, shows the value on failure |
| `clippy::clone_on_copy` | 3 | pyo3's `#[pyclass(from_py_object)]` expands to `Clone::clone(&*guard)` on a `Copy` enum, as a **sibling item** no `#[allow]` on the enum can reach. Replaced with `skip_from_py_object` + a hand-written `FromPyObject` that dereferences through `Copy` — a transcription of the 0.29 expansion, same error type and path |
| `clippy::used_underscore_items` | 1 | `_store_capsule` is a cross-package protocol name Python calls by string. Rust item renamed; the Python spelling moved to `#[pyo3(name = "_store_capsule")]` |
| `clippy::empty_enums` | 1 | datalog id brands now wrap a private `Infallible` instead of being empty enums (still uninhabited; `!` is unstable and this workspace uses no nightly features) |
| `clippy::needless_range_loop` | 1 | `iter_mut().take(n)` |
| `clippy::needless_bool` | 1 | `exists_apply_first_witness_wrap` split into two `cfg`-selected definitions, so the production answer is a literal `true` with no thread-local in sight |
| cargo deprecation | 1 | `rust-2018-idioms` → `rust_2018_idioms`; cargo will stop honouring the dashed form, at which point the whole lint **group** would silently stop applying |

Docs corrected in `AGENTS.md`, `CONTRIBUTING.md`, `README.md` and the `rust-toolchain.toml` comment, all of which claimed stable-only.

## Gates

`make check`, `make test`, `make doc`, `make conformance`, `make pytest`. The **`msrv` job passing at 1.96 is the signal that matters** — it proves nightly leaked no feature. `.deficiencies` is empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified stable MSRV requirements, pinned nightly development workflows, release toolchains, and update procedures.

* **Chores**
  * Standardized CI and release workflows around explicit Rust toolchains.
  * Added checks to detect toolchain configuration drift.
  * Updated Rust lint configuration and validation checks.

* **Bug Fixes**
  * Improved Python integration compatibility while preserving existing behavior.
  * Improved reliability of C API smoke-test builds across development and release configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->