### PR TITLE
fix(shapes,sparql-eval): restore the workspace to compiling under its own nightly pin

### DIFF
--- a/crates/shapes/src/rules.rs
+++ b/crates/shapes/src/rules.rs
@@ -1147,7 +1147,11 @@ mod tests {
         assert!(matches!(shape.rules[0].body, RuleBody::Triple { .. }));
         assert!(!shape.rules[0].deactivated);
         assert!(shape.rules[0].order.is_none());
-        assert_eq!(shape.rules[0].conditions, [] as [_; 0]);
+        // `conditions` is `Vec<Shape>` — conditions resolve to parsed shapes at
+        // shapes-load, not to IRI strings — and `Shape` is not `PartialEq`, so the
+        // `[] as [_; 0]` spelling the rest of the workspace uses does not compile
+        // here. Asserting the length is the same claim and is equally lint-clean.
+        assert_eq!(shape.rules[0].conditions.len(), 0);
     }
 
     #[test]

--- a/crates/sparql-eval/src/service.rs
+++ b/crates/sparql-eval/src/service.rs
@@ -1070,7 +1070,7 @@ mod tests {
         let ungranted =
             ServiceProfile::new(ServiceCapabilities::granting([ServiceCapability::Query]))
                 .with_credential(ServiceCredential::Bearer("t".to_owned()));
-        assert!(ungranted.request_headers().is_empty());
+        assert_eq!(ungranted.request_headers(), [] as [_; 0]);
     }
 
     #[test]


### PR DESCRIPTION
## What broke

`main` does not build under its own toolchain pin. Two independent regressions, both from the same collision pattern.

**1. A compile error** — `cargo check`/`clippy` both die:

```
crates/shapes/src/rules.rs:1150: error[E0369]: binary operation `==` cannot be
applied to type `Vec<shapes::Shape>`: std::vec::Vec<shapes::Shape>, [_; 0]
```

**2. A denied lint** — `cargo clippy --workspace --all-targets -- -D warnings`:

```
crates/sparql-eval/src/service.rs:1073: error: used `assert!` to check that a value is empty
```

Between them, `workspace`, `test`, `capi`, `wasm` and `conformance` are red on `main`.

## Why they got through

#231 (the nightly pin) mechanically rewrote `assert!(x.is_empty())` into `assert_eq!(x, [] as [_; 0])` at all 78 then-existing sites, to satisfy `clippy::assert_is_empty`. Two PRs then landed within minutes of it, each green on its own base, neither able to see the sweep:

- **#227** changed `Rule::conditions` from `Vec<String>` to `Vec<Shape>` — a `sh:condition` now resolves to a parsed shape at shapes-load rather than by IRI-string lookup at rule-firing time. `Vec<String> == []` type-checks; `Vec<Shape> == []` does not, because `Shape` is not `PartialEq`. The sweep's rewrite of that one site stopped compiling.
- **#186** added a *new* `assert!(…is_empty())`, in the spelling the sweep had just finished removing everywhere else.

Both merges were textually clean — different lines, no conflict — so the breakage exists only in the combined tree, which no PR's CI ever built.

## The fix

Two lines, each taking the spelling that fits its own type:

- `crates/shapes/src/rules.rs` — `assert_eq!(…conditions.len(), 0)`. The same claim, equally free of `clippy::assert_is_empty`, and already what this workspace uses wherever the element type is not `PartialEq` (e.g. `crates/rdf-core/src/ir/pack/bits.rs:1142`). A comment at the site records why the array form cannot be used there, so the next sweep does not re-break it.
- `crates/sparql-eval/src/service.rs` — `assert_eq!(…request_headers(), [] as [_; 0])`. `Vec<(String, String)>` *is* `PartialEq`, so this one takes the dominant spelling, matching the sibling assertion twenty lines above.

No test is weakened: both assertions make exactly the claim they made before.

## Verification

On `nightly-2026-09-01` (one day behind the pin, same lint surface):

- `cargo clippy --workspace --all-targets --locked -- -D warnings` — **clean, exit 0**. Run across the whole workspace, so these two are confirmed to be the only collisions the sweep left behind.
- `cargo test -p purrdf-shapes --locked` — 599 lib tests pass, 0 failures, including `rules::tests::parses_order_deactivated_and_conditions`, which carries the first assertion.