### PR TITLE
fix(sparql-eval,geo)!: carry the SPARQL expression-error channel on the native user-function seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@ called out below with what a consumer must do.
 
 ### Bug Fixes
 
+- **BREAKING** **sparql-eval,geo:** A host function registered through
+  `UserFunctionRegistry::register_native` can now raise a SPARQL **expression error** for one
+  solution instead of failing the whole query. `NativeFnBody` returns
+  `Result<Option<TermValue>, EvalError>` rather than `Result<TermValue, EvalError>` — the same
+  three-exit channel `register_expr`'s `ExprFnBody` already carried — so `Ok(None)` means "this
+  call has no value for this solution" and `Err` stays reserved for a query-fatal condition. The
+  evaluator, not the closure, then applies the outcome the calling context requires: a `FILTER`
+  eliminates that solution (SPARQL 1.1 §17), while a `BIND` or `SELECT` expression leaves the
+  variable unbound and continues (§10; algebra §18.5 `Extend`). Previously the seam had no
+  `Ok(None)` exit at all, so every domain refusal — a malformed literal, an out-of-range index, a
+  type mismatch — had to be spelled `Err` and aborted the query; one bad geometry anywhere in a
+  dataset failed every query that scanned past it. This was found while merging `purrdf-geo` and
+  affected every function on the seam, not just the `geof:` family. Callers with a
+  `register_native` body must wrap their success value in `Some` and should move argument-level
+  refusals from `Err` to `Ok(None)`.
+- **BREAKING** **geo:** `functions::evaluate` returns `Result<Option<TermValue>, EvalError>` (the
+  seam shape above) and maps `GeoError::Literal`/`GeoError::Domain` onto the per-solution
+  `Ok(None)`; `GeoError::Unsupported`, `GeoError::Config` and the new `GeoError::Arity` stay
+  query-fatal, because each holds for every solution alike and answering "no value" would empty a
+  result set and present that as the answer. `GeoError` gains an `Arity` variant (a wrong argument
+  count is nobody else's mistake — not the data's, not the wiring's) and a
+  `GeoError::is_expression_error` predicate that is the single site deciding how far a refusal
+  travels. A caller that needs the refusal itself — with its message and kind intact, which a
+  SPARQL expression error by construction cannot carry — calls the new `functions::compute`,
+  which answers in `Result<TermValue, GeoError>`.
 - **entail:** OWL-Direct now DECIDES the `SHOIQ` nominal / inverse-role / qualified-number-restriction
   corner. Both decision cores implement the nominal-introduction rule — Horrocks & Sattler's `NN`-rule
   in the `cfg(test)` concept-tree reference and Motik–Shearer–Horrocks' Table 5 `NI`-rule in the

--- a/crates/geo/src/error.rs
+++ b/crates/geo/src/error.rs
@@ -4,9 +4,14 @@
 //! The one failure channel this crate has, and the single site that maps it onto
 //! the evaluator's.
 //!
-//! Every refusal in `purrdf-geo` reduces to one of four kinds, and each kind
+//! Every refusal in `purrdf-geo` reduces to one of five kinds, and each kind
 //! answers a different question about *whose* mistake it was:
 //!
+//! * [`GeoError::Arity`] — the **call as written** supplies the wrong number of
+//!   arguments. Nothing about the data or the wiring is wrong; the query text is.
+//!   It is its own kind rather than a flavour of the four below precisely because
+//!   it belongs to nobody else: it cannot be repaired by fixing a literal, by
+//!   declaring a vocabulary term, or by implementing a function.
 //! * [`GeoError::Config`] — the **caller's wiring** is unusable as written: a
 //!   vocabulary with an empty IRI, a registration missing the datatype it is
 //!   supposed to recognize. Nothing about the data or the query is wrong yet.
@@ -37,16 +42,33 @@
 //! module in this crate constructs an [`EvalError`] directly, and every seam
 //! (scalar function, relation, cursor) reduces its failure to a [`GeoError`]
 //! first.
+//!
+//! # Two questions, not one
+//!
+//! *Which label* a failure wears (`From<GeoError> for EvalError`) and *how far it
+//! travels* ([`GeoError::is_expression_error`]) are separate decisions, and both are
+//! made here. SPARQL 1.1 has two failure distances: a per-solution **expression
+//! error**, which a `FILTER` turns into a dropped row and a `BIND` into an unbound
+//! variable, and a query-fatal error. Two of the five kinds above are the first
+//! ([`GeoError::Literal`], [`GeoError::Domain`] — both statements about *these
+//! arguments*) and three are the second ([`GeoError::Arity`],
+//! [`GeoError::Unsupported`], [`GeoError::Config`] — all conditions that hold for
+//! every solution alike, so answering "no value" would empty a result set and call
+//! it an answer). Putting the split in this module keeps it from being re-litigated
+//! once per call site, which is exactly how the two would drift.
 
 use purrdf_sparql_eval::EvalError;
 
 /// Why a `purrdf-geo` operation refused.
 ///
-/// See the module docs for what distinguishes the four kinds; the split is by
-/// *whose mistake it was*, not by which function raised it.
+/// See the module docs for what distinguishes the five kinds; the split is by
+/// *whose mistake it was*, not by which function raised it, and it is what
+/// [`Self::is_expression_error`] reads to decide how far a refusal travels.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum GeoError {
+    /// The call supplies the wrong number of arguments for the function named.
+    Arity(String),
     /// The caller's wiring is unusable as written (an empty IRI, a vocabulary
     /// missing a term a registered function needs).
     Config(String),
@@ -61,6 +83,11 @@ pub enum GeoError {
 }
 
 impl GeoError {
+    /// A [`GeoError::Arity`] with `what` as its detail.
+    pub fn arity(what: impl Into<String>) -> Self {
+        Self::Arity(what.into())
+    }
+
     /// A [`GeoError::Config`] with `what` as its detail.
     pub fn config(what: impl Into<String>) -> Self {
         Self::Config(what.into())
@@ -81,13 +108,56 @@ impl GeoError {
         Self::Domain(what.into())
     }
 
+    /// Whether this refusal is a SPARQL **expression error** — scoped to the one
+    /// solution being evaluated — rather than a condition that must abort the whole
+    /// query.
+    ///
+    /// This is the second half of the decision the `From<GeoError> for EvalError`
+    /// impl below makes, and it lives beside it for the same reason: a failure that
+    /// aborts a query on one call path and drops a row on another is a behaviour
+    /// nobody can rely on. [`crate::functions::evaluate`] is its only consumer, and
+    /// it is what makes the `geof:` seam obey SPARQL 1.1 §17.2 rather than treating
+    /// one bad row as a fatal query.
+    ///
+    /// * [`Domain`](Self::Domain) and [`Literal`](Self::Literal) are expression
+    ///   errors. Both are statements about *these arguments*: a geometry literal
+    ///   whose lexical form its datatype does not license is exactly SPARQL's
+    ///   ill-typed literal, and §17.2's "Functions invoked with an argument of the
+    ///   wrong type will produce a type error" puts it in the per-solution channel —
+    ///   the same channel `"abc"^^xsd:integer > 1` lands in. Making them fatal would
+    ///   mean one malformed geometry anywhere in a dataset kills every query that
+    ///   scans past it, which is a much larger claim than the data supports.
+    /// * [`Arity`](Self::Arity), [`Unsupported`](Self::Unsupported) and
+    ///   [`Config`](Self::Config) are NOT. Each holds for *every* solution alike, so
+    ///   answering "no value" would empty a result set and present that as the
+    ///   answer, reopening the silent-wrong-answer channel this crate exists to keep
+    ///   shut. A wrong argument count is a defect in the query text that no row can
+    ///   satisfy. An unimplemented function that answered "no
+    ///   value" would be dropped by a `FILTER` and left unbound by a `BIND` — in
+    ///   both cases indistinguishable from an honest negative result, with nothing
+    ///   downstream able to tell the difference. A `Config` refusal names a
+    ///   declaration the host never made — an undeclared linear unit, an absent
+    ///   Simple Features namespace — and the host is the only party who can make it;
+    ///   PurRDF fabricates no vocabulary defaults to fall back on. A row may be what
+    ///   *reveals* the gap, but leaving that row unbound would report "this geometry
+    ///   has no area" and hide it.
+    #[must_use]
+    pub const fn is_expression_error(&self) -> bool {
+        match self {
+            Self::Domain(_) | Self::Literal(_) => true,
+            Self::Arity(_) | Self::Unsupported(_) | Self::Config(_) => false,
+        }
+    }
+
     /// The detail message, without this error's own prefix.
     #[must_use]
     pub fn detail(&self) -> &str {
         match self {
-            Self::Config(msg) | Self::Literal(msg) | Self::Unsupported(msg) | Self::Domain(msg) => {
-                msg
-            }
+            Self::Arity(msg)
+            | Self::Config(msg)
+            | Self::Literal(msg)
+            | Self::Unsupported(msg)
+            | Self::Domain(msg) => msg,
         }
     }
 }
@@ -95,6 +165,7 @@ impl GeoError {
 impl core::fmt::Display for GeoError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            Self::Arity(msg) => write!(f, "wrong argument count: {msg}"),
             Self::Config(msg) => write!(f, "invalid geo configuration: {msg}"),
             Self::Literal(msg) => write!(f, "malformed geometry literal: {msg}"),
             Self::Unsupported(msg) => write!(f, "unsupported GeoSPARQL operation: {msg}"),
@@ -108,6 +179,9 @@ impl std::error::Error for GeoError {}
 impl From<GeoError> for EvalError {
     /// The single site that decides which evaluator label a geo failure wears.
     ///
+    /// * `Arity` becomes [`EvalError::function`]: the call could not be invoked as
+    ///   written, which is the same thing the evaluator's own pre-dispatch arity
+    ///   check reports through that label.
     /// * `Config` keeps its name: it is a statement about the host's wiring, which
     ///   is exactly what [`EvalError::config`] means.
     /// * `Literal` becomes [`EvalError::data`]: a geometry literal is *dataset
@@ -121,6 +195,7 @@ impl From<GeoError> for EvalError {
     ///   framing rather than this type's `Display`.
     fn from(err: GeoError) -> Self {
         match err {
+            GeoError::Arity(msg) => Self::function(msg),
             GeoError::Config(msg) => Self::config(msg),
             GeoError::Literal(msg) => Self::data(format!("malformed geometry literal: {msg}")),
             GeoError::Unsupported(msg) => {
@@ -138,6 +213,7 @@ mod tests {
 
     #[test]
     fn each_constructor_builds_its_own_variant() {
+        assert!(matches!(GeoError::arity("z"), GeoError::Arity(_)));
         assert!(matches!(GeoError::config("a"), GeoError::Config(_)));
         assert!(matches!(GeoError::literal("b"), GeoError::Literal(_)));
         assert!(matches!(
@@ -147,9 +223,51 @@ mod tests {
         assert!(matches!(GeoError::domain("d"), GeoError::Domain(_)));
     }
 
+    /// The two kinds that are statements about *these arguments* travel one
+    /// solution; the three that hold for every solution alike abort the query.
+    ///
+    /// Both halves are asserted, because each guards a different failure. If a
+    /// `Literal` or `Domain` refusal became fatal, one malformed geometry in a
+    /// dataset would fail every query that scanned past it. If an `Unsupported`,
+    /// `Config` or `Arity` refusal became per-solution, a `FILTER` would drop every
+    /// row and the caller would read that as an honest empty answer.
+    #[test]
+    fn only_the_argument_level_kinds_are_per_solution_expression_errors() {
+        for per_solution in [GeoError::literal("x"), GeoError::domain("x")] {
+            assert!(
+                per_solution.is_expression_error(),
+                "{per_solution} is about one call's arguments, so it must not fail the query"
+            );
+        }
+        for fatal in [
+            GeoError::arity("x"),
+            GeoError::unsupported("x"),
+            GeoError::config("x"),
+        ] {
+            assert!(
+                !fatal.is_expression_error(),
+                "{fatal} holds for every solution, so answering 'no value' would silently empty \
+                 the result set"
+            );
+        }
+    }
+
+    /// A wrong argument count reaches the evaluator as a function error — the same
+    /// label the evaluator's own pre-dispatch arity check uses.
+    #[test]
+    fn conversion_maps_arity_to_a_function_error() {
+        assert!(matches!(
+            EvalError::from(GeoError::arity(
+                "geof:sfEquals expects exactly 2 argument(s), got 1"
+            )),
+            EvalError::Function(_)
+        ));
+    }
+
     #[test]
     fn display_carries_the_detail_and_its_own_prefix() {
         for error in [
+            GeoError::arity("the detail"),
             GeoError::config("the detail"),
             GeoError::literal("the detail"),
             GeoError::unsupported("the detail"),
@@ -198,6 +316,7 @@ mod tests {
     #[test]
     fn conversion_preserves_the_detail() {
         for error in [
+            GeoError::arity("the detail"),
             GeoError::config("the detail"),
             GeoError::literal("the detail"),
             GeoError::unsupported("the detail"),

--- a/crates/geo/src/functions.rs
+++ b/crates/geo/src/functions.rs
@@ -36,6 +36,22 @@
 //! The six GeoSPARQL **aggregates** are the one thing deliberately *not*
 //! registered here; see [`GeofFunction::AGGREGATES`] for why.
 //!
+//! # A domain refusal is a per-solution error, not a failed query
+//!
+//! The opposite mistake is just as expensive, and it is the easier one to make:
+//! refusing too much. A `geof:` call whose *arguments* are unusable — a malformed
+//! WKT literal, a measure of an empty geometry, two geometries in different
+//! coordinate reference systems — is a SPARQL **expression error** (§17.2:
+//! "Functions invoked with an argument of the wrong type will produce a type
+//! error"), which the enclosing operator resolves per its own context: a `FILTER`
+//! drops that one solution, a `BIND`/`SELECT` expression leaves the variable
+//! unbound, and every other row is answered normally. Aborting the query instead
+//! would mean a single bad geometry anywhere in a dataset makes every query that
+//! scans past it fail — which is the mirror image of the silent-`false` bug above,
+//! and no less wrong. [`evaluate`] is where the two distances are separated, by
+//! asking [`GeoError::is_expression_error`]; [`compute`] is the same computation
+//! with the refusal itself still in hand.
+//!
 //! # Volatility
 //!
 //! Every registration is [`Volatility::Stable`]. Each body is pure arithmetic
@@ -529,11 +545,13 @@ pub fn register(registry: &mut UserFunctionRegistry, vocab: &GeoVocab) {
 // Dispatch
 // ---------------------------------------------------------------------------
 
-/// Run one `geof:` function over already-evaluated argument terms.
+/// Run one `geof:` function over already-evaluated argument terms, in the
+/// evaluator's own three-exit shape.
 ///
 /// This is literally the body [`register`] installs, exposed so a caller (and
 /// this module's own tests) can exercise a function without standing up an
-/// evaluator.
+/// evaluator. Use [`compute`] instead when you want the refusal itself rather than
+/// what the SPARQL seam does with it.
 ///
 /// The native seam checks [`GeofFunction::arity`] *before* it invokes a body and
 /// short-circuits an unbound argument before that, so a registered call always
@@ -542,28 +560,82 @@ pub fn register(registry: &mut UserFunctionRegistry, vocab: &GeoVocab) {
 /// and an out-of-bounds index would be a panic, which is precisely what a seam
 /// body must never do.
 ///
+/// # Which refusals travel how far
+///
+/// The seam has two failure distances and this function is where a [`GeoError`]
+/// picks one, by asking [`GeoError::is_expression_error`] (which is where the
+/// reasoning lives):
+///
+/// * `Ok(None)` — a **per-solution** SPARQL expression error, for a malformed or
+///   wrongly-typed geometry literal and for a domain refusal (mixed coordinate
+///   reference systems, a measure of an empty geometry, an out-of-range member
+///   index, an undeclared unit). SPARQL 1.1 §17.2: "Functions invoked with an
+///   argument of the wrong type will produce a type error." The enclosing operator
+///   then decides the outcome — a `FILTER` drops that solution, a `BIND` or
+///   `SELECT` expression leaves the variable unbound (§10, algebra §18.5 `Extend`)
+///   — and the rest of the query is unaffected. One bad geometry in one row is not
+///   a failed query.
+/// * `Err` — **query-fatal**, and deliberately still so for the three kinds that
+///   hold for every solution alike: a wrong argument count, an unimplemented
+///   function, and an unusable vocabulary. An unimplemented topological predicate
+///   that answered "no value" would be dropped by a `FILTER` exactly as an honest
+///   `false` is, which is the silent wrong answer this crate refuses to produce;
+///   the other two would empty a result set and present that as the answer.
+///
 /// # Errors
 ///
-/// [`EvalError::Function`] for an unimplemented function, a domain refusal (mixed
-/// coordinate reference systems, a measure of an empty geometry, an out-of-range
-/// member index, an undeclared unit) or a wrong argument count;
-/// [`EvalError::Data`] for a malformed or wrongly-typed geometry literal;
-/// [`EvalError::Config`] for a vocabulary that is missing a term the call needs.
-/// See [`GeoError`] for which kind means whose mistake it was.
+/// [`EvalError::Function`] for an unimplemented function or a wrong argument count;
+/// [`EvalError::Config`] for a vocabulary that is missing a term the call needs. See
+/// [`GeoError`] for which kind means whose mistake it was, and [`compute`] for the
+/// refusal itself rather than its seam-level effect.
 pub fn evaluate(
     function: GeofFunction,
     vocab: &GeoVocab,
     args: &[&TermValue],
-) -> Result<TermValue, EvalError> {
+) -> Result<Option<TermValue>, EvalError> {
+    match compute(function, vocab, args) {
+        Ok(value) => Ok(Some(value)),
+        Err(err) if err.is_expression_error() => Ok(None),
+        Err(err) => Err(EvalError::from(err)),
+    }
+}
+
+/// Run one `geof:` function over already-evaluated argument terms, in this crate's
+/// own error space.
+///
+/// The same computation [`evaluate`] performs, stopping one step earlier: every
+/// refusal arrives as the [`GeoError`] that was raised, with its detail message
+/// intact and its kind still legible. [`evaluate`] is the seam shape — it maps two
+/// of the five kinds onto SPARQL's per-solution `Ok(None)`, which by construction
+/// carries no message, because the specification gives an expression error nowhere
+/// to put one. A caller that wants to *report* why a geometry was rejected (a
+/// loader, a linter, a diagnostic pass) must call this; a caller that wants what a
+/// query would do must call [`evaluate`].
+///
+/// # Errors
+///
+/// [`GeoError::Arity`] for a wrong argument count, [`GeoError::Unsupported`] for a
+/// function this crate does not implement, [`GeoError::Literal`] for a malformed or
+/// wrongly-typed geometry literal, [`GeoError::Domain`] for well-formed arguments the
+/// operation is undefined on, and [`GeoError::Config`] for a vocabulary missing a
+/// term the call needs.
+pub fn compute(
+    function: GeofFunction,
+    vocab: &GeoVocab,
+    args: &[&TermValue],
+) -> Result<TermValue, GeoError> {
     if !arity_accepts(function.arity(), args.len()) {
-        return Err(EvalError::function(format!(
+        // Not an expression error: a call written with the wrong number of
+        // arguments cannot be evaluated for ANY solution, so softening it would
+        // turn a defect in the query text into a silently empty answer.
+        return Err(GeoError::arity(format!(
             "geof:{} expects {} argument(s), got {}",
             function.local_name(),
             function.arity(),
             args.len()
         )));
     }
-    dispatch(function, vocab, args).map_err(EvalError::from)
+    dispatch(function, vocab, args)
 }
 
 /// Whether `count` arguments satisfies `arity`.
@@ -1188,7 +1260,7 @@ mod tests {
         Arity, EvalError, NativeSparqlEngine, QueryOptions, UserFunctionRegistry,
     };
 
-    use super::{GeofFunction, evaluate, register};
+    use super::{GeoError, GeofFunction, compute, evaluate, register};
     use crate::geom::Crs;
     use crate::relations::SpatialRelation;
     use crate::vocab::{GeoTerm, GeoVocab, GeoVocabBuilder};
@@ -1259,17 +1331,24 @@ mod tests {
     /// missing, so every golden answer below also proves that the IRI is wired.
     /// The resolved [`NativeFunction`](purrdf_sparql_eval::NativeFunction)'s
     /// closure field is `pub(crate)` to `purrdf-sparql-eval` and therefore cannot
-    /// be called from this crate; [`evaluate`] is the *identical* body
-    /// [`register`] installs (see its one construction site), so calling it after
-    /// the resolve exercises the same code the seam runs. The end-to-end tests at
-    /// the bottom of this module close the remaining gap by running real SPARQL
-    /// through the engine.
+    /// be called from this crate; [`compute`] is the computation [`evaluate`] — the
+    /// body [`register`] installs (see its one construction site) — performs, so
+    /// calling it after the resolve exercises the same code the seam runs. The end-to-end
+    /// tests at the bottom of this module close the remaining gap by running real
+    /// SPARQL through the engine.
+    ///
+    /// It answers in [`GeoError`] space rather than through [`evaluate`] on purpose:
+    /// `evaluate` maps an expression error onto `Ok(None)`, which by construction
+    /// carries no message, so asserting *why* a call was refused is only possible on
+    /// this side of the mapping. Which side of it each refusal lands on is asserted
+    /// separately, by [`expression_error`]/[`fatal_refusal`] here and by real query
+    /// text in `tests/scalar_functions_e2e.rs`.
     fn call(
         registry: &UserFunctionRegistry,
         vocab: &GeoVocab,
         function: GeofFunction,
         args: &[TermValue],
-    ) -> Result<TermValue, EvalError> {
+    ) -> Result<TermValue, GeoError> {
         let iri = vocab.function(function.local_name());
         assert!(
             registry.resolve_native(&iri).is_some(),
@@ -1277,7 +1356,7 @@ mod tests {
             function.local_name()
         );
         let borrowed: Vec<&TermValue> = args.iter().collect();
-        evaluate(function, vocab, &borrowed)
+        compute(function, vocab, &borrowed)
     }
 
     /// [`call`] for the one-argument functions, which are most of them.
@@ -1286,7 +1365,7 @@ mod tests {
         vocab: &GeoVocab,
         function: GeofFunction,
         arg: &TermValue,
-    ) -> Result<TermValue, EvalError> {
+    ) -> Result<TermValue, GeoError> {
         call(registry, vocab, function, std::slice::from_ref(arg))
     }
 
@@ -1296,7 +1375,7 @@ mod tests {
     }
 
     /// The lexical form and datatype of a successful call.
-    fn ok_literal(result: Result<TermValue, EvalError>, what: &str) -> (String, String) {
+    fn ok_literal(result: Result<TermValue, GeoError>, what: &str) -> (String, String) {
         match result {
             Ok(TermValue::Literal {
                 lexical_form,
@@ -1310,7 +1389,7 @@ mod tests {
 
     /// Assert a call succeeded with an exact lexical form and datatype.
     fn assert_answer(
-        result: Result<TermValue, EvalError>,
+        result: Result<TermValue, GeoError>,
         what: &str,
         lexical: &str,
         datatype: &str,
@@ -1323,11 +1402,46 @@ mod tests {
         );
     }
 
-    /// Assert a call was refused, and return the rendered error.
-    fn refusal(result: Result<TermValue, EvalError>, what: &str) -> String {
+    /// Assert a call was refused **for these arguments only** — a SPARQL expression
+    /// error, which the seam reports as `Ok(None)` and which a `FILTER` turns into a
+    /// dropped solution and a `BIND` into an unbound variable — and return the
+    /// rendered message.
+    ///
+    /// The distance is asserted, not assumed: a refusal that quietly became fatal
+    /// would turn one bad literal into a failed query, and every caller of this
+    /// helper is a case where that must not happen.
+    fn expression_error(result: Result<TermValue, GeoError>, what: &str) -> String {
         match result {
             Ok(value) => panic!("{what} must be refused, but answered {value:?}"),
-            Err(err) => err.to_string(),
+            Err(err) => {
+                assert!(
+                    err.is_expression_error(),
+                    "{what} is a refusal about these arguments, so it must be a per-solution \
+                     expression error rather than a query-fatal one: {err}"
+                );
+                err.to_string()
+            }
+        }
+    }
+
+    /// Assert a call was refused **fatally** — the query cannot be answered at all —
+    /// and return the rendered message.
+    ///
+    /// The mirror of [`expression_error`], and the assertion that matters more: an
+    /// unimplemented function or an unusable vocabulary that softened into `Ok(None)`
+    /// would be dropped by a `FILTER` exactly as an honest `false` is, with nothing
+    /// downstream able to tell the two apart.
+    fn fatal_refusal(result: Result<TermValue, GeoError>, what: &str) -> String {
+        match result {
+            Ok(value) => panic!("{what} must be refused, but answered {value:?}"),
+            Err(err) => {
+                assert!(
+                    !err.is_expression_error(),
+                    "{what} must abort the query rather than leaving one solution without a \
+                     value: {err}"
+                );
+                err.to_string()
+            }
         }
     }
 
@@ -1934,8 +2048,20 @@ mod tests {
                 Err(err) => err,
             };
             assert!(
-                matches!(err, EvalError::Function(_)),
-                "geof:{} must refuse as EvalError::Function, got {err:?}",
+                matches!(err, GeoError::Unsupported(_)),
+                "geof:{} must refuse as GeoError::Unsupported, got {err:?}",
+                function.local_name()
+            );
+            assert!(
+                !err.is_expression_error(),
+                "geof:{} is unimplemented, so the refusal must abort the query rather than \
+                 leaving one solution without a value — a FILTER would drop that solution \
+                 exactly as it drops an honest false: {err:?}",
+                function.local_name()
+            );
+            assert!(
+                matches!(EvalError::from(err.clone()), EvalError::Function(_)),
+                "geof:{} must reach the evaluator as EvalError::Function, got {err:?}",
                 function.local_name()
             );
             let rendered = err.to_string();
@@ -1982,7 +2108,7 @@ mod tests {
     fn a_non_literal_argument_is_refused_and_a_literal_one_is_not() {
         let vocab = vocab();
         let registry = registry_of(&vocab);
-        let rendered = refusal(
+        let rendered = expression_error(
             call(
                 &registry,
                 &vocab,
@@ -2015,7 +2141,7 @@ mod tests {
     fn an_xsd_string_argument_is_refused_and_a_wkt_literal_is_not() {
         let vocab = vocab();
         let registry = registry_of(&vocab);
-        let rendered = refusal(
+        let rendered = expression_error(
             call(&registry, &vocab, named("isEmpty"), &[string("POINT(1 2)")]),
             "geof:isEmpty of an xsd:string",
         );
@@ -2060,7 +2186,13 @@ mod tests {
             GeoTerm::KmlLiteral,
             GeoTerm::DggsLiteral,
         ] {
-            let rendered = refusal(
+            // Fatal, not per-solution. This is the *codec* that is missing, not the
+            // literal that is bad: a dataset mixing WKT and GML geometries would
+            // otherwise have its GML rows quietly filtered away, and a query that
+            // silently answered about half a dataset is the failure this crate keeps
+            // closed. The gap has to be named so the caller learns which
+            // serialization purrdf-geo cannot read.
+            let rendered = fatal_refusal(
                 call(
                     &registry,
                     &vocab,
@@ -2105,8 +2237,14 @@ mod tests {
                 Err(err) => err,
             };
             assert!(
-                matches!(err, EvalError::Data(_)),
+                matches!(err, GeoError::Literal(_)),
                 "a malformed geometry literal is bad DATA, got {err:?} for {bad:?}"
+            );
+            assert!(
+                err.is_expression_error(),
+                "a malformed literal is a statement about ONE row's argument, so it must be a \
+                 per-solution expression error — otherwise one bad geometry anywhere in a \
+                 dataset fails every query that scans past it: {err:?} for {bad:?}"
             );
         }
         // The neighbouring VALID case.
@@ -2140,7 +2278,7 @@ mod tests {
         let registry = registry_of(&vocab);
         let here = wkt(&vocab, "POINT(0 0)");
         let elsewhere = wkt(&vocab, &format!("<{CRS_GEOJSON}> POINT(0 0)"));
-        let rendered = refusal(
+        let rendered = expression_error(
             call(
                 &registry,
                 &vocab,
@@ -2169,7 +2307,7 @@ mod tests {
         let vocab = vocab();
         let registry = registry_of(&vocab);
         for name in ["minZ", "maxZ"] {
-            let rendered = refusal(
+            let rendered = expression_error(
                 call(&registry, &vocab, named(name), &[wkt(&vocab, "POINT(1 2)")]),
                 &format!("geof:{name} of a planar point"),
             );
@@ -2210,7 +2348,7 @@ mod tests {
         let vocab = vocab();
         let registry = registry_of(&vocab);
         for name in ["minX", "maxX", "minY", "maxY"] {
-            let rendered = refusal(
+            let rendered = expression_error(
                 call(
                     &registry,
                     &vocab,
@@ -2246,7 +2384,7 @@ mod tests {
         let registry = registry_of(&vocab);
         let multi = wkt(&vocab, "MULTIPOINT((0 0),(1 1))");
         for index in [0_i64, 3, -1] {
-            let rendered = refusal(
+            let rendered = expression_error(
                 call(
                     &registry,
                     &vocab,
@@ -2289,7 +2427,7 @@ mod tests {
         let square = wkt(&vocab, "POLYGON((0 0,1 0,1 1,0 1,0 0))");
 
         // Declared for this system, but a different unit was asked for.
-        let rendered = refusal(
+        let rendered = expression_error(
             call(
                 &registry,
                 &vocab,
@@ -2303,8 +2441,13 @@ mod tests {
             "the refusal must name both units, got {rendered}"
         );
 
-        // A system with no declared unit at all.
-        let rendered = refusal(
+        // A system with no declared unit at all — fatal, unlike the unit MISMATCH
+        // just above. The mismatch is a statement about this call's two arguments;
+        // this is a declaration the host never made, and PurRDF ships no
+        // coordinate-reference-system database to fabricate one from. Leaving the
+        // measure unbound would report "this geometry has no area" and hide the
+        // wiring gap the host is the only party able to close.
+        let rendered = fatal_refusal(
             call(
                 &registry,
                 &vocab,
@@ -2344,7 +2487,7 @@ mod tests {
     fn metric_area_is_refused_in_degrees_and_answered_in_metres() {
         let vocab = vocab();
         let registry = registry_of(&vocab);
-        let rendered = refusal(
+        let rendered = expression_error(
             call(
                 &registry,
                 &vocab,
@@ -2375,7 +2518,7 @@ mod tests {
         // And the whole metric family behaves the same way.
         let degrees = wkt(&vocab, &format!("<{CRS_GEOJSON}> LINESTRING(0 0,3 4)"));
         for name in ["metricLength", "metricPerimeter"] {
-            let _ = refusal(
+            let _ = expression_error(
                 call1(&registry, &vocab, named(name), &degrees),
                 &format!("geof:{name} in a degree system"),
             );
@@ -2401,7 +2544,11 @@ mod tests {
             .expect("non-empty namespaces")
             .build();
         let registry = registry_of(&undeclared);
-        let rendered = refusal(
+        // Fatal, not per-solution: an undeclared vocabulary is the host's wiring,
+        // which no row is responsible for and no row can repair, so every solution
+        // would be refused for the same reason. Leaving the variable unbound would
+        // report "no geometry type" for geometries that plainly have one.
+        let rendered = fatal_refusal(
             call(
                 &registry,
                 &undeclared,
@@ -2438,7 +2585,7 @@ mod tests {
     fn as_geojson_is_refused_outside_the_geojson_crs_and_answered_inside_it() {
         let vocab = vocab();
         let registry = registry_of(&vocab);
-        let rendered = refusal(
+        let rendered = expression_error(
             call(
                 &registry,
                 &vocab,
@@ -2474,7 +2621,7 @@ mod tests {
         let square = wkt(&vocab, "POLYGON((0 0,1 0,1 1,0 1,0 0))");
 
         for bad in ["T*F**F**", "T*F**F****", "T*F**F**X", "", "TFFFTFFF3"] {
-            let rendered = refusal(
+            let rendered = expression_error(
                 call(
                     &registry,
                     &vocab,
@@ -2489,7 +2636,7 @@ mod tests {
             );
         }
         // A non-string pattern argument is refused too.
-        let _ = refusal(
+        let _ = expression_error(
             call(
                 &registry,
                 &vocab,
@@ -2571,7 +2718,10 @@ mod tests {
     }
 
     /// A wrong argument count is a clean error, not an out-of-bounds panic —
-    /// `evaluate` is public, so it cannot rely on the seam's own arity check.
+    /// `evaluate` is public, so it cannot rely on the seam's own arity check — and
+    /// it stays **fatal**: a call written with the wrong number of arguments cannot
+    /// be evaluated for any solution, so softening it would turn a defect in the
+    /// query text into a silently empty answer.
     #[test]
     fn a_direct_call_with_the_wrong_argument_count_is_refused_rather_than_panicking() {
         let vocab = vocab();
@@ -2582,10 +2732,20 @@ mod tests {
             matches!(err, EvalError::Function(_)),
             "a wrong argument count is a function error, got {err:?}"
         );
+        assert!(
+            matches!(
+                compute(named("sfEquals"), &vocab, &[&point]),
+                Err(GeoError::Arity(_))
+            ),
+            "and it is its own kind: nobody's data and nobody's wiring is wrong, the call is"
+        );
         // The neighbouring VALID case.
         assert!(
-            evaluate(named("sfEquals"), &vocab, &[&point, &point]).is_ok(),
-            "the two-argument call must still succeed"
+            matches!(
+                evaluate(named("sfEquals"), &vocab, &[&point, &point]),
+                Ok(Some(_))
+            ),
+            "the two-argument call must still answer with a value"
         );
     }
 

--- a/crates/geo/tests/scalar_functions_e2e.rs
+++ b/crates/geo/tests/scalar_functions_e2e.rs
@@ -95,6 +95,15 @@ const SMALL_SQUARE: &str = "POLYGON((0 0,2 0,2 2,0 2,0 0))";
 const POINT_INSIDE: &str = "POINT(1 1)";
 /// A point well outside [`SQUARE`].
 const POINT_OUTSIDE: &str = "POINT(9 9)";
+/// A `geo:wktLiteral` whose lexical form is not WKT at all — an unterminated
+/// point.
+///
+/// It sits in the fixture graph beside the three good geometries on purpose. Every
+/// query below that scans `ex:geom` therefore meets it, which is what makes the
+/// per-solution error channel a property of the fixture rather than of one test:
+/// a seam that turned this row's refusal into a query failure would take the whole
+/// file down with it.
+const MALFORMED: &str = "POINT(1";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -146,16 +155,27 @@ fn geojson_datatype() -> String {
     format!("{GEO}{}", GeoTerm::GeoJsonLiteral.local_name())
 }
 
-/// Three spatial objects carrying WKT literals under `ex:geom`: a point inside
-/// the square, a point outside it, and the square itself.
+/// Four spatial objects carrying WKT literals under `ex:geom`: a point inside the
+/// square, a point outside it, the square itself, and one whose lexical form is
+/// [`MALFORMED`].
 ///
 /// Ordinary data with ordinary predicates — the `geof:` family reads geometry
 /// out of *literals* it is handed, so nothing here is `geo:` vocabulary and
 /// nothing needs an index.
+///
+/// The malformed one is not an afterthought. Real datasets contain bad literals,
+/// and SPARQL 1.1 says a function handed one raises a per-solution error rather
+/// than failing the query (§17.2), so a fixture without one would let the whole
+/// file pass against a seam that aborted on the first bad geometry it met.
 fn dataset() -> Arc<RdfDataset> {
     let mut builder = RdfDatasetBuilder::new();
     let predicate = builder.intern_iri(&ex("geom"));
-    for (subject, lexical) in [("a", POINT_INSIDE), ("b", POINT_OUTSIDE), ("c", SQUARE)] {
+    for (subject, lexical) in [
+        ("a", POINT_INSIDE),
+        ("b", POINT_OUTSIDE),
+        ("c", SQUARE),
+        ("bad", MALFORMED),
+    ] {
         let s = builder.intern_iri(&ex(subject));
         let o = builder.intern_literal(RdfLiteral::typed(lexical, wkt_datatype()));
         builder.push_quad(s, predicate, o, None);
@@ -273,6 +293,12 @@ fn assert_projection(local_name: &str, args: &[String], lexical: &str, datatype:
 /// outside the square) and `ex:c` must be **kept** (`sfWithin` is reflexive, so
 /// the square is within itself). A filter that answered `false` for everything
 /// would drop `ex:b` too, and a lower-bound assertion would not notice.
+///
+/// `ex:bad` — whose literal is not WKT — is dropped for the third reason a
+/// solution can leave a `FILTER`: its predicate raised an expression error. That
+/// the query *answers at all* is the load-bearing half; see
+/// `a_malformed_geometry_in_a_filter_drops_only_that_solution` for the assertion
+/// that isolates it.
 #[test]
 fn a_filter_over_a_geof_relation_keeps_exactly_the_rows_the_relation_holds_for() {
     let query = format!(
@@ -479,7 +505,230 @@ fn the_unimplemented_geof_functions_abort_the_query_by_name_and_the_implemented_
 }
 
 // ---------------------------------------------------------------------------
-// 5 — one geometry, two serializations, one answer
+// 5 — a domain error is per-solution, and the three contexts differ
+// ---------------------------------------------------------------------------
+
+/// The subject local names of a one-column `?s` answer, sorted.
+fn subjects(query: &str) -> Vec<String> {
+    let mut names: Vec<String> = run(query)
+        .unwrap_or_else(|error| {
+            panic!("the query must evaluate, but was refused: {error}\n{query}")
+        })
+        .into_iter()
+        .map(|row| match row.into_iter().next().flatten() {
+            Some(TermValue::Iri(iri)) => iri.strip_prefix(EX).unwrap_or(&iri).to_owned(),
+            other => panic!("?s must be a bound IRI, got {other:?}"),
+        })
+        .collect();
+    names.sort();
+    names
+}
+
+/// A `geof:` call over a malformed geometry inside a `FILTER` **drops that one
+/// solution** and answers the rest — it does not fail the query.
+///
+/// SPARQL 1.1 §17: "FILTERs eliminate any solutions that, when substituted into
+/// the expression, either result in an effective boolean value of false or produce
+/// an error." `ex:bad` leaves for the second reason, `ex:b` for the first, and the
+/// two are indistinguishable from outside — which is exactly why the *other three*
+/// rows are what this test asserts. A seam that turned the malformed literal into a
+/// query failure answers nothing at all here.
+#[test]
+fn a_malformed_geometry_in_a_filter_drops_only_that_solution() {
+    // `geof:isEmpty` is total over well-formed geometries, so every good row
+    // survives and the only row that can leave is the one that errored.
+    let query = format!(
+        "SELECT ?s WHERE {{ ?s <{geom}> ?wkt . FILTER(!<{is_empty}>(?wkt)) }}",
+        geom = ex("geom"),
+        is_empty = geof("isEmpty"),
+    );
+    assert_eq!(
+        subjects(&query),
+        vec!["a".to_owned(), "b".to_owned(), "c".to_owned()],
+        "the three well-formed geometries must be answered; only the malformed one is dropped, \
+         and the query must not fail because one row of four could not be read"
+    );
+
+    // The neighbouring case that proves the drop is about the literal rather than
+    // about the predicate: with the sense inverted, `geof:isEmpty` is false for
+    // every good row, so ONLY the erroring row would be left if an expression error
+    // were somehow true — and the answer is empty instead.
+    let inverted = format!(
+        "SELECT ?s WHERE {{ ?s <{geom}> ?wkt . FILTER(<{is_empty}>(?wkt)) }}",
+        geom = ex("geom"),
+        is_empty = geof("isEmpty"),
+    );
+    assert!(
+        subjects(&inverted).is_empty(),
+        "an expression error is not `true`: the erroring row must not survive a FILTER whose \
+         every other answer is false"
+    );
+}
+
+/// A `geof:` call over a malformed geometry inside a `BIND` **leaves the variable
+/// unbound** for that solution and keeps the row.
+///
+/// This is the outcome that differs from the `FILTER` case, and the difference is
+/// the whole point of routing the error through the evaluator rather than deciding
+/// it in the host closure. SPARQL 1.1 §10: "If the evaluation of the expression
+/// produces an error, the variable remains unbound for that solution but the query
+/// evaluation continues"; algebra §18.5, `Extend(μ, var, expr) = μ if var not in
+/// dom(μ) and expr(μ) is an error`. All four rows are present, three carry a
+/// dimension, and `ex:bad` carries nothing.
+#[test]
+fn a_malformed_geometry_in_a_bind_leaves_the_variable_unbound_and_keeps_the_row() {
+    let query = format!(
+        "SELECT ?s ?d WHERE {{ ?s <{geom}> ?wkt . BIND(<{dimension}>(?wkt) AS ?d) }}",
+        geom = ex("geom"),
+        dimension = geof("dimension"),
+    );
+    let mut answered: Vec<(String, Option<String>)> = run(&query)
+        .expect("a malformed geometry in a BIND must not fail the query")
+        .into_iter()
+        .map(|row| {
+            let mut cells = row.into_iter();
+            let subject = match cells.next().flatten() {
+                Some(TermValue::Iri(iri)) => iri.strip_prefix(EX).unwrap_or(&iri).to_owned(),
+                other => panic!("?s must be a bound IRI, got {other:?}"),
+            };
+            let dimension = cells.next().flatten().map(|value| match value {
+                TermValue::Literal { lexical_form, .. } => lexical_form,
+                other => panic!("?d must be a literal when bound, got {other:?}"),
+            });
+            (subject, dimension)
+        })
+        .collect();
+    answered.sort();
+    assert_eq!(
+        answered,
+        vec![
+            ("a".to_owned(), Some("0".to_owned())),
+            ("b".to_owned(), Some("0".to_owned())),
+            ("bad".to_owned(), None),
+            ("c".to_owned(), Some("2".to_owned())),
+        ],
+        "every row survives the BIND; only the malformed geometry's ?d is unbound, and the two \
+         points and the polygon keep their own dimensions rather than a shared default"
+    );
+}
+
+/// A `geof:` call over a malformed geometry in a top-level `SELECT` expression —
+/// no graph pattern, nothing to drop — answers **one row with the variable
+/// unbound**.
+///
+/// The third context, and the one with no data behind it: the assignment form
+/// `(expression AS ?var)` is the same `Extend` the `BIND` case uses (SPARQL 1.1
+/// §10), so an expression error here can only mean an unbound variable. A seam that
+/// reported the malformed literal as a hard error would produce no rows at all, and
+/// a row count of zero is not the same answer as a row with nothing in it.
+#[test]
+fn a_malformed_geometry_in_a_top_level_select_expression_answers_one_unbound_row() {
+    let query = format!(
+        "SELECT ((<{dimension}>({bad})) AS ?v) WHERE {{}}",
+        dimension = geof("dimension"),
+        bad = wkt(MALFORMED),
+    );
+    let rows = run(&query).expect("a malformed geometry in a SELECT expression must not fail");
+    assert_eq!(
+        rows.len(),
+        1,
+        "the empty group pattern yields exactly one solution, error or not: {rows:?}"
+    );
+    assert!(
+        rows[0][0].is_none(),
+        "the expression errored, so ?v is unbound rather than absent, defaulted or fabricated: \
+         {:?}",
+        rows[0][0]
+    );
+
+    // The neighbouring VALID case: identical query shape, well-formed literal.
+    assert_eq!(
+        scalar(&format!(
+            "SELECT ((<{dimension}>({good})) AS ?v) WHERE {{}}",
+            dimension = geof("dimension"),
+            good = wkt(SMALL_SQUARE),
+        )),
+        ("2".to_owned(), XSD_INTEGER.to_owned()),
+        "the same call over a readable geometry must still answer, or the softening above has \
+         simply broken the function"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6 — what must STILL fail the query
+// ---------------------------------------------------------------------------
+
+/// The conditions a per-solution error channel must **not** swallow, each checked
+/// in a `FILTER` — the context where a softened failure is invisible, because a
+/// dropped row looks exactly like a row that did not match.
+///
+/// An unimplemented function, an unregistered IRI, a wrong argument count and an
+/// undeclared vocabulary term are all conditions that hold for *every* solution:
+/// answering "no value" would empty the result set and call it an answer. Each is
+/// paired with the neighbouring call that must still succeed, so the file cannot
+/// pass by refusing everything.
+#[test]
+fn the_query_fatal_conditions_still_abort_and_their_valid_neighbours_still_answer() {
+    let geom = ex("geom");
+    let filter =
+        |predicate: &str| format!("SELECT ?s WHERE {{ ?s <{geom}> ?wkt . FILTER({predicate}) }}");
+
+    let fatal = [
+        (
+            "an unimplemented function",
+            "union",
+            format!("<{}>(?wkt, ?wkt) = ?wkt", geof("union")),
+        ),
+        (
+            "an unregistered function IRI",
+            "notAFunction",
+            format!("<{}>(?wkt)", geof("notAFunction")),
+        ),
+        (
+            "a wrong argument count",
+            "sfWithin",
+            format!("<{}>(?wkt)", geof("sfWithin")),
+        ),
+        (
+            "a coordinate reference system with no declared unit",
+            CRS_OTHER,
+            format!(
+                "<{}>({}, <{METRE}>) > 0",
+                geof("area"),
+                wkt(&format!("<{CRS_OTHER}> POLYGON((0 0,1 0,1 1,0 1,0 0))"))
+            ),
+        ),
+    ];
+
+    for (what, named_in_message, predicate) in &fatal {
+        let error = match run(&filter(predicate)) {
+            Err(error) => error,
+            Ok(rows) => panic!(
+                "{what} must abort the query rather than quietly emptying it — a FILTER that \
+                 dropped every solution would be indistinguishable from an honest no-match, but \
+                 the query answered {rows:?}"
+            ),
+        };
+        assert!(
+            error.contains(named_in_message),
+            "the refusal must name {named_in_message} so the caller learns what to fix, got \
+             {error}"
+        );
+    }
+
+    // The neighbouring VALID case: the same FILTER shape with a call that is
+    // registered, implemented, correctly-arity'd and fully declared answers the
+    // three readable geometries. Without this the four refusals above would also
+    // pass against a seam that refused everything.
+    assert_eq!(
+        subjects(&filter(&format!("!<{}>(?wkt)", geof("isEmpty")))),
+        vec!["a".to_owned(), "b".to_owned(), "c".to_owned()],
+        "a well-formed call in the very same position must still answer"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7 — one geometry, two serializations, one answer
 // ---------------------------------------------------------------------------
 
 /// A GeoJSON literal and a WKT literal denoting the same geometry give the same

--- a/crates/sparql-eval/src/parallel.rs
+++ b/crates/sparql-eval/src/parallel.rs
@@ -1532,10 +1532,10 @@ mod tests {
 
     fn trivial_native_body() -> crate::user_fn::NativeFnBody {
         std::sync::Arc::new(|_args: &[&TermValue]| {
-            Ok(TermValue::typed_literal(
+            Ok(Some(TermValue::typed_literal(
                 "1",
                 "http://www.w3.org/2001/XMLSchema#integer",
-            ))
+            )))
         })
     }
 

--- a/crates/sparql-eval/src/user_fn.rs
+++ b/crates/sparql-eval/src/user_fn.rs
@@ -39,6 +39,18 @@
 //!   [`Arc<RdfDataset>`] rather than the context's own `D: DatasetView` (which is not
 //!   object-safe — it carries an associated `Id` type), and `eval_expr_function` for
 //!   the re-entrancy bound.
+//!
+//! # One error channel across all three kinds
+//!
+//! Every kind reports "this call has no value for this solution" the same way:
+//! `Ok(None)`, the SPARQL expression error of §17.2. `Err` is reserved for a hard
+//! failure that aborts the whole query. That uniformity is load-bearing rather than
+//! tidy — a seam without the `Ok(None)` exit forces a per-solution domain refusal
+//! (a malformed literal, an out-of-range index, a type mismatch) onto `Err`, which
+//! aborts a query the specification says should merely drop a row or leave a
+//! variable unbound. See [`NativeFnBody`] for the specification text and for why
+//! the enclosing operator, not the body, decides which of those two outcomes a
+//! given `Ok(None)` produces.
 
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
@@ -153,6 +165,39 @@ pub struct UserFunction {
 /// A native (host-Rust) user function body: a closure over the already-evaluated,
 /// dataset-independent argument values.
 ///
+/// # The three exits, and why there are three
+///
+/// A body returns one of exactly three things, and picking the wrong one is a
+/// specification violation rather than a matter of taste:
+///
+/// * `Ok(Some(value))` — the function's value for this call.
+/// * `Ok(None)` — a SPARQL **expression error**: the arguments are the wrong type,
+///   or the operation is undefined on them, so *this call* has no value. It is
+///   scoped to the one solution being evaluated. SPARQL 1.1 §17.2 puts extension
+///   functions squarely in this channel — "Functions invoked with an argument of
+///   the wrong type will produce a type error" — and the enclosing operator then
+///   decides the outcome: a `FILTER` **drops that solution** (§17 "FILTERs
+///   eliminate any solutions that, when substituted into the expression, either
+///   result in an effective boolean value of false or produce an error"), while a
+///   `BIND`/`SELECT`-expression **leaves the variable unbound** (§10 "If the
+///   evaluation of the expression produces an error, the variable remains unbound
+///   for that solution but the query evaluation continues"; algebra §18.5
+///   `Extend(μ, var, expr) = μ if var not in dom(μ) and expr(μ) is an error`).
+///   Those are two different outcomes from one signal, and the evaluator — not the
+///   host closure — is what knows which context the call sits in.
+/// * `Err(_)` — a **hard failure that aborts the whole query**, for a condition no
+///   per-solution outcome can honestly express: the host's wiring is unusable, or
+///   the function is registered but not implemented. `Ok(None)` there would be a
+///   silent wrong answer, because a dropped row and an unbound variable are
+///   indistinguishable from an honest empty result.
+///
+/// This is the same channel [`ExprFnBody`] carries, deliberately spelled the same
+/// way: the two seams differ in what the evaluator *hands* a body (see
+/// [`ExprFnCall`]), never in how a body reports that it has no value. A seam with
+/// no `Ok(None)` exit forces every domain refusal onto `Err`, which turns one bad
+/// literal in one row into a failed query — so there is no lossy variant of this
+/// type to pick by accident.
+///
 /// The arguments arrive as a slice of **borrows** (`&[&TermValue]`): every value
 /// already lives in the evaluator's per-call argument buffer for the duration of
 /// the call, so the dispatch path lends the closure those borrows rather than deep
@@ -168,7 +213,8 @@ pub struct UserFunction {
 /// gate relies on that declaration alone to decide whether the call may run across
 /// worker threads, so a closure that lies about its own volatility can silently
 /// diverge under parallel evaluation.
-pub type NativeFnBody = Arc<dyn Fn(&[&TermValue]) -> Result<TermValue, EvalError> + Send + Sync>;
+pub type NativeFnBody =
+    Arc<dyn Fn(&[&TermValue]) -> Result<Option<TermValue>, EvalError> + Send + Sync>;
 
 /// Everything a dataset-aware (expression-bodied) user function is given when it is
 /// called: the IRI it was called through, the already-evaluated arguments, the graph
@@ -217,9 +263,17 @@ pub struct ExprFnCall<'a> {
 /// [`ExprFnCall`]).
 ///
 /// `Ok(None)` is the SPARQL "expression error / no value" result, exactly as it is
-/// for [`NativeFnBody`]; `Err` is a hard failure that aborts the query. A body that
-/// cannot evaluate something MUST take one of those two exits — never a value it did
-/// not compute.
+/// for [`NativeFnBody`] — see that type's "three exits" section for the specification
+/// text and for why the *enclosing operator*, not the body, decides whether that
+/// becomes a dropped solution or an unbound variable. `Err` is a hard failure that
+/// aborts the query. A body that cannot evaluate something MUST take one of those two
+/// exits — never a value it did not compute.
+///
+/// The two body types differ ONLY in what they are handed ([`ExprFnCall`] adds the
+/// focus graph and the call depth; [`NativeFnBody`] sees values alone and carries a
+/// [`Volatility`] the fork-join gate reads). Their failure channels are identical, so
+/// neither is the "lossy" one and a host cannot pick the wrong seam and quietly lose
+/// per-solution error semantics.
 pub type ExprFnBody =
     Arc<dyn Fn(&ExprFnCall<'_>) -> Result<Option<TermValue>, EvalError> + Send + Sync>;
 
@@ -491,6 +545,15 @@ impl UserFunctionRegistry {
     /// registration of the same IRI as another native function replaces the
     /// earlier one ("last write wins").
     ///
+    /// The body reports a per-solution refusal as `Ok(None)` and a query-fatal one
+    /// as `Err` — the SAME channel [`Self::register_expr`]'s body carries, and the
+    /// reason a domain error here drops a row or leaves a variable unbound instead
+    /// of aborting the query. See [`NativeFnBody`] for the three exits and the
+    /// specification text behind them; the choice between this seam and
+    /// [`Self::register_expr`] is about what the body needs to be *handed* (values
+    /// alone, plus a volatility declaration, versus the calling query's focus graph
+    /// and call depth), never about how it reports failure.
+    ///
     /// # Panics
     ///
     /// Panics if `iri` is already registered as a SPARQL-bodied [`UserFunction`] or
@@ -715,13 +778,21 @@ pub(crate) fn eval_user_function<D: DatasetView + Sync>(
 /// result is a dataset-independent [`TermValue`]; the caller interns it into the
 /// parent context.
 ///
+/// A closure that answers `Ok(None)` has raised a SPARQL expression error for this
+/// one solution; it is propagated verbatim (never promoted to `Err`) so the
+/// enclosing operator applies the outcome its own context calls for — `FILTER`
+/// drops the solution, `BIND`/`SELECT`-expression leaves the variable unbound. See
+/// [`NativeFnBody`]'s "three exits" for the specification text.
+///
 /// # Errors
 ///
 /// [`EvalError::Function`] on an arity violation, on a panic inside the closure
 /// (converted to a fixed, payload-free error so the message is identical
 /// regardless of which worker thread panicked — mirrors the `native-codec-panic`
 /// guard in `purrdf_rdf::native_codecs::parse`), or propagated straight through
-/// from the closure's own `Err`.
+/// from the closure's own `Err`. An arity violation stays hard on purpose: the call
+/// as written cannot be evaluated at all, which is a defect in the query text
+/// rather than a value this row happens not to have.
 pub(crate) fn eval_native_function(
     native: &NativeFunction,
     iri: &str,
@@ -755,7 +826,7 @@ pub(crate) fn eval_native_function(
     // payload-free so it is identical no matter which worker panicked. Mirrors
     // `purrdf_rdf::native_codecs::parse`'s `native-codec-panic` guard.
     match catch_unwind(AssertUnwindSafe(|| (native.body)(&values))) {
-        Ok(inner_result) => inner_result.map(Some),
+        Ok(inner_result) => inner_result,
         Err(_) => Err(EvalError::function(format!(
             "native function <{iri}> panicked"
         ))),
@@ -874,19 +945,29 @@ mod tests {
     const EX_SUBJECT_PREFIX: &str = "http://example.org/ns#s";
     const EX_EXPR_COUNT: &str = "http://example.org/ns#exprCount";
 
+    const EX_NATIVE_EVEN: &str = "http://example.org/ns#nativeEven";
+
     const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
     const XSD_DOUBLE: &str = "http://www.w3.org/2001/XMLSchema#double";
+    const XSD_BOOLEAN: &str = "http://www.w3.org/2001/XMLSchema#boolean";
 
     /// A native closure that adds one to its sole integer-literal argument.
+    ///
+    /// Both argument refusals take the `Ok(None)` exit rather than `Err`: an
+    /// argument of the wrong type is a SPARQL expression error scoped to the one
+    /// solution ([`NativeFnBody`]), not a reason to fail the query.
     fn inc_native_body() -> NativeFnBody {
         Arc::new(|args: &[&TermValue]| {
             let TermValue::Literal { lexical_form, .. } = args[0] else {
-                return Err(EvalError::function("expected a literal argument"));
+                return Ok(None);
             };
-            let n: i64 = lexical_form
-                .parse()
-                .map_err(|_| EvalError::function("argument is not an integer"))?;
-            Ok(TermValue::typed_literal((n + 1).to_string(), XSD_INTEGER))
+            let Ok(n) = lexical_form.parse::<i64>() else {
+                return Ok(None);
+            };
+            Ok(Some(TermValue::typed_literal(
+                (n + 1).to_string(),
+                XSD_INTEGER,
+            )))
         })
     }
 
@@ -924,15 +1005,15 @@ mod tests {
     fn ratio_score_native_body(divisor: f64) -> NativeFnBody {
         Arc::new(move |args: &[&TermValue]| {
             let TermValue::Literal { lexical_form, .. } = args[0] else {
-                return Err(EvalError::function("expected a literal argument"));
+                return Ok(None);
             };
-            let n: f64 = lexical_form
-                .parse()
-                .map_err(|_| EvalError::function("argument is not numeric"))?;
-            Ok(TermValue::typed_literal(
+            let Ok(n) = lexical_form.parse::<f64>() else {
+                return Ok(None);
+            };
+            Ok(Some(TermValue::typed_literal(
                 (n / divisor).to_string(),
                 XSD_DOUBLE,
-            ))
+            )))
         })
     }
 
@@ -942,13 +1023,16 @@ mod tests {
     fn nan_score_native_body() -> NativeFnBody {
         Arc::new(|args: &[&TermValue]| {
             let TermValue::Literal { lexical_form, .. } = args[0] else {
-                return Err(EvalError::function("expected a literal argument"));
+                return Ok(None);
             };
-            let n: f64 = lexical_form
-                .parse()
-                .map_err(|_| EvalError::function("argument is not numeric"))?;
+            let Ok(n) = lexical_form.parse::<f64>() else {
+                return Ok(None);
+            };
             let score = if n <= 0.0 { f64::NAN } else { n / 5.0 };
-            Ok(TermValue::typed_literal(score.to_string(), XSD_DOUBLE))
+            Ok(Some(TermValue::typed_literal(
+                score.to_string(),
+                XSD_DOUBLE,
+            )))
         })
     }
 
@@ -1689,8 +1773,142 @@ mod tests {
         );
     }
 
+    /// A native closure answering `xsd:boolean` `true` for an even argument and
+    /// raising a SPARQL expression error (`Ok(None)`) for an odd one.
+    ///
+    /// The odd case is a *domain* refusal — the argument is a perfectly good
+    /// integer the function has no answer for — which is precisely the shape
+    /// [`NativeFnBody`] reserves `Ok(None)` for.
+    fn even_only_native_body() -> NativeFnBody {
+        Arc::new(|args: &[&TermValue]| {
+            let TermValue::Literal { lexical_form, .. } = args[0] else {
+                return Ok(None);
+            };
+            let Ok(n) = lexical_form.parse::<i64>() else {
+                return Ok(None);
+            };
+            if n % 2 == 0 {
+                Ok(Some(TermValue::typed_literal("true", XSD_BOOLEAN)))
+            } else {
+                Ok(None)
+            }
+        })
+    }
+
+    /// A registry holding [`even_only_native_body`] at [`EX_NATIVE_EVEN`].
+    fn even_only_registry() -> UserFunctionRegistry {
+        let mut registry = UserFunctionRegistry::new();
+        registry.register_native(
+            EX_NATIVE_EVEN,
+            Arity::Exact(1),
+            Volatility::Stable,
+            even_only_native_body(),
+        );
+        registry
+    }
+
+    /// A native closure's `Ok(None)` inside a `FILTER` **drops that solution** and
+    /// leaves every other one alone.
+    ///
+    /// SPARQL 1.1 §17: "FILTERs eliminate any solutions that, when substituted into
+    /// the expression, either result in an effective boolean value of false or
+    /// produce an error." A seam that had to spell this refusal as `Err` would fail
+    /// the whole query on the first odd row, answering nothing.
+    #[test]
+    fn native_expression_error_in_a_filter_drops_only_that_solution() {
+        let registry = even_only_registry();
+        let ds = scored_dataset(4);
+        let query = format!(
+            "SELECT ?s WHERE {{ ?s <{EX_VAL}> ?v . FILTER(<{EX_NATIVE_EVEN}>(?v)) }} ORDER BY ?s"
+        );
+        assert_eq!(
+            run_subject_rows(&ds, &query, &registry),
+            vec![
+                format!("{EX_SUBJECT_PREFIX}2"),
+                format!("{EX_SUBJECT_PREFIX}4"),
+            ],
+            "the two even rows survive; the two odd ones raise an expression error and are \
+             eliminated, and the query still answers"
+        );
+
+        // The neighbouring case: without the predicate every row is present, so the
+        // two absences above are the FILTER's doing rather than a broken scan.
+        let unfiltered = format!("SELECT ?s WHERE {{ ?s <{EX_VAL}> ?v }} ORDER BY ?s");
+        assert_eq!(
+            run_subject_rows(&ds, &unfiltered, &registry).len(),
+            4,
+            "all four subjects are in the dataset"
+        );
+    }
+
+    /// The same `Ok(None)`, in a `BIND`, **leaves the variable unbound** and keeps
+    /// the row — the other of the two outcomes one signal has to be able to produce.
+    ///
+    /// SPARQL 1.1 §10: "If the evaluation of the expression produces an error, the
+    /// variable remains unbound for that solution but the query evaluation
+    /// continues"; algebra §18.5, `Extend(μ, var, expr) = μ if var not in dom(μ) and
+    /// expr(μ) is an error`. The host closure does not and cannot know which of the
+    /// two contexts it was called from, which is exactly why the decision belongs to
+    /// the evaluator and the body reports only that it has no value.
+    #[test]
+    fn native_expression_error_in_a_bind_leaves_the_variable_unbound() {
+        let registry = even_only_registry();
+        let ds = scored_dataset(4);
+        let query = format!(
+            "SELECT ?v ?e WHERE {{ ?s <{EX_VAL}> ?v . BIND(<{EX_NATIVE_EVEN}>(?v) AS ?e) }} \
+             ORDER BY ?v"
+        );
+        let result = NativeSparqlEngine::new()
+            .query_with_options_view(
+                &ds,
+                SparqlRequest {
+                    query: &query,
+                    base_iri: None,
+                    substitutions: &[],
+                },
+                QueryOptions {
+                    functions: &registry,
+                    ..QueryOptions::EMPTY
+                },
+            )
+            .expect("an expression error in a BIND must not fail the query");
+        let SparqlResult::Solutions { rows, .. } = result else {
+            panic!("expected solutions, got {result:?}")
+        };
+        let observed: Vec<(String, Option<String>)> = rows
+            .into_iter()
+            .map(|row| {
+                let mut cells = row.into_iter();
+                let value = match cells.next().flatten() {
+                    Some(TermValue::Literal { lexical_form, .. }) => lexical_form,
+                    other => panic!("?v must be a bound literal, got {other:?}"),
+                };
+                let flag = cells.next().flatten().map(|term| match term {
+                    TermValue::Literal { lexical_form, .. } => lexical_form,
+                    other => panic!("?e must be a literal when bound, got {other:?}"),
+                });
+                (value, flag)
+            })
+            .collect();
+        assert_eq!(
+            observed,
+            vec![
+                ("1".to_owned(), None),
+                ("2".to_owned(), Some("true".to_owned())),
+                ("3".to_owned(), None),
+                ("4".to_owned(), Some("true".to_owned())),
+            ],
+            "all four rows survive the BIND and only the odd ones' ?e is unbound — the same \
+             signal that emptied two rows out of the FILTER above"
+        );
+    }
+
     /// A native closure's own `Err` return is a hard query failure, rendered
     /// through the generalized (no-longer-SHACL-AF-only) `Function` error text.
+    ///
+    /// The counterweight to the two tests above: softening the domain refusal must
+    /// not soften this. `Err` is what a host reaches for when no per-solution answer
+    /// would be honest, and it still aborts.
     #[test]
     fn native_function_error_is_a_hard_error() {
         let mut registry = UserFunctionRegistry::new();

--- a/docs/design/purrdf-geo-exactness.md
+++ b/docs/design/purrdf-geo-exactness.md
@@ -186,8 +186,8 @@ release cadence, and dragging one into a wasm-clean carrier crate would be the
 
 Two consequences, both refusals rather than guesses:
 
-* **A binary operation on two geometries in different systems is a hard error**
-  naming both systems. Coordinates in two systems are two different numbers
+* **A binary operation on two geometries in different systems is refused** by
+  name, naming both systems. Coordinates in two systems are two different numbers
   describing the same place; arithmetic across them is meaningless, and answering
   anyway would be plausible and silently wrong.
 * **A measurement is computed in the coordinate system's own unit.** The caller
@@ -198,7 +198,34 @@ Two consequences, both refusals rather than guesses:
   metre. A number in the wrong unit is the worst kind of wrong answer: plausible,
   silent, and off by a factor nobody can see.
 
-`geof:transform` is registered and hard-errors, naming the missing database.
+### How far a refusal travels
+
+"Refused" is two different outcomes, and which one a `geof:` call gets is decided
+by `GeoError::is_expression_error` — the single site in `crates/geo/src/error.rs`
+that answers it — rather than at each call site.
+
+A refusal that is a statement about *these arguments* (`GeoError::Literal`, a
+lexical form its datatype does not license; `GeoError::Domain`, well-formed
+arguments the operation is undefined on, which is where the mixed-system and
+undeclared-unit refusals above land) is a **SPARQL expression error**. SPARQL 1.1
+§17.2 puts it there — "Functions invoked with an argument of the wrong type will
+produce a type error" — and the enclosing operator resolves it: a `FILTER`
+eliminates that one solution (§17), a `BIND` or `SELECT` expression leaves the
+variable unbound and evaluation continues (§10). Every other row is answered
+normally. The alternative was tried and is worse: with no per-solution channel,
+one malformed geometry anywhere in a dataset fails every query that scans past it.
+
+A refusal that holds for *every* solution alike stays query-fatal, because
+answering "no value" would empty a result set and present that as the answer.
+Three kinds are in this class: `GeoError::Unsupported` (a function this crate does
+not implement — a `false` from an unimplemented predicate is indistinguishable
+from an honest `false`), `GeoError::Config` (a declaration the host never made,
+which no row can repair and PurRDF fabricates no default for), and
+`GeoError::Arity` (a wrong argument count, which is a defect in the query text
+that no row can satisfy).
+
+`geof:transform` is registered and hard-errors (`GeoError::Unsupported`, so
+query-fatal), naming the missing database.
 
 ---
 


### PR DESCRIPTION
## The defect

`UserFunctionRegistry::register_native`'s `NativeFnBody` had no `Ok(None)` exit:

```rust
pub type NativeFnBody = Arc<dyn Fn(&[&TermValue]) -> Result<TermValue, EvalError> + Send + Sync>;
```

Every per-solution domain refusal on that seam — a malformed literal, an
out-of-range argument, a type mismatch — therefore had to be spelled `Err`, and
`eval_native_function`'s `inner_result.map(Some)` guaranteed it aborted the whole
query. Found while merging `purrdf-geo`, but not geo-specific: it was a property
of the seam and affected every function registered through it.

## What the specification requires

* **§17 (Expressions and Testing Values)** — "FILTERs eliminate any solutions
  that, when substituted into the expression, either result in an effective
  boolean value of false or produce an error. … These errors have no effect
  outside of FILTER evaluation."
* **§17.2 (Filter Evaluation)** — "Functions invoked with an argument of the wrong
  type will produce a type error." / "Any expression other than logical-or (`||`)
  or logical-and (`&&`) that encounters an error will produce that error."
* **§17.6 (Extensible Value Testing)** — "A PrimaryExpression grammar rule can be
  a call to an extension function named by an IRI."
* **§10 (Assignment)** — "If the evaluation of the expression produces an error,
  the variable remains unbound for that solution but the query evaluation
  continues."
* **§18.5, Definition: Extend** — `Extend(μ, var, expr) = μ if var not in dom(μ)
  and expr(μ) is an error`.
* **§18.5, Definition: Filter** — `Filter(expr, Ω, D(G)) = { μ | μ in Ω and
  expr(μ) is an expression that has an effective boolean value of true }`.

One signal, two outcomes, and only the evaluator knows which context a call sits
in — which is why the decision cannot live in the host closure.

## The change

`NativeFnBody` now returns `Result<Option<TermValue>, EvalError>`, reusing the
channel `register_expr`'s `ExprFnBody` already carried rather than inventing a
second mechanism. The two seams are kept separate (they differ in what the
evaluator *hands* a body — values plus a `Volatility` declaration, versus the
calling query's focus graph and call depth) but their failure channels are now
identical, so neither is the lossy one; that is documented at both definitions
and in the module header.

`purrdf-geo` is the seam's only production caller. `GeoError` gains
`is_expression_error` — the single site deciding how far a refusal travels — and
an `Arity` variant, because a wrong argument count is nobody else's mistake.

## Over-refusal / under-refusal guard

Softening must not go too far. Three kinds stay query-fatal because each holds
for *every* solution alike, so answering "no value" would empty a result set and
present that as the answer:

| condition | before | after |
|---|---|---|
| malformed / wrongly-typed geometry literal (`GeoError::Literal`) | query aborts | per-solution error |
| domain refusal — mixed CRS, measure of an empty geometry, out-of-range index (`GeoError::Domain`) | query aborts | per-solution error |
| unimplemented function (`GeoError::Unsupported`) | query aborts | **still aborts** |
| undeclared vocabulary term (`GeoError::Config`) | query aborts | **still aborts** |
| wrong argument count (new `GeoError::Arity`) | query aborts | **still aborts** |
| unregistered function IRI | query aborts | **still aborts** |
| host closure's own `Err` | query aborts | **still aborts** |
| panicking host closure | clean error | **still a clean error** |

Every fatal case is asserted in a `FILTER` — the context where a softened failure
is invisible, since a dropped row looks exactly like a row that did not match —
and each is paired with a neighbouring valid call in the same position, so the
suite cannot pass by refusing everything.

## Break-on-purpose

* Re-promoting `Ok(None)` to `Err` in `eval_native_function` (the pre-fix seam):
  **7 tests fail** — 2 seam-level in `purrdf-sparql-eval`, 5 end-to-end in
  `purrdf-geo`.
* Making every `GeoError` fatal (over-refuse): **11 tests fail**.
* Making every `GeoError` per-solution (under-refuse): **6 tests fail**.

All three breaks were reverted and the suite re-verified green.

## Gates

`make check`, `make test`, `make doc`, `make conformance` (VERDICT: GREEN) and
`make pytest` (768 passed, 1 skipped, 4 xfailed) all exit 0. `make wasm` skips
locally on this host; the CI `wasm` job is the arbiter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expression errors can now be handled per result: `FILTER` drops only affected solutions, while `BIND` and `SELECT` preserve rows with unbound values.
  - Geo functions now distinguish recoverable expression issues from query-fatal errors, including clearer handling of invalid arguments and argument counts.
  - Added improved direct geo-function computation support.

- **Bug Fixes**
  - Prevented malformed literals, domain mismatches, and similar geo errors from aborting entire queries.

- **Documentation**
  - Clarified geo refusal behavior and outcomes across `FILTER`, `BIND`, and `SELECT`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->