### PR TITLE
fix(core,sparql-algebra)!: three silent-success defects the pre-release sweep reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ called out below with what a consumer must do.
   all still parse. The vendored `lang-basedir/langdir-literal-invalid.rq` could not catch this:
   it spells its projection `AS v`, which is a syntax error on its own, so the harness refused it
   for the wrong reason.
+- **core:** The `pack_query` dictionary benchmark measures again. Its literal-heavy fixture
+  (added by the pre-release sweep) asserted a quoted triple term as a quad's SUBJECT, which
+  RDF 1.2 does not admit and the freeze gate refuses (`rdf-ir-triple-subject`), so the fixture
+  panicked and the report-only `benchmarks` CI job had been red on `main` since `b4f99093`. The
+  triple term is now asserted in the object position (`s q <<s p plain>>`), the one place the
+  model puts it, and the dictionary closure still resolves one triple term per row.
 - **core:** `MutableDataset` no longer fabricates a literal datatype. When a base literal's
   datatype id resolved to something other than an IRI, `base_value_of` rendered that term's
   `Debug` form and used it as the datatype IRI, where `RdfDataset::term_value` states the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,42 @@ called out below with what a consumer must do.
 
 ### Bug Fixes
 
+- **BREAKING** **core:** `check_provenance` now measures the sidecar against the dataset in BOTH
+  directions, and an empty quad set means "the dataset is empty", not "check nothing". Rule 3
+  (every dataset quad has at least one occurrence) previously ran only when the handle slice was
+  non-empty, so a caller that forgot to collect its handles — or passed `&[]` to mean "skip" —
+  got an `Ok(())` indistinguishable from a real pass. The parameter is now the dataset's
+  complete quad-handle set, rule 3 runs unconditionally, and a new rule 4 refuses every
+  occurrence whose quad is not in that set with
+  `ProvenanceError::DanglingQuad { occurrence_index, quad_index }` — the quad-axis twin of
+  `UnknownUnit` / `UnknownArtifact`. An empty sidecar for an empty dataset still passes (every
+  rule ran over zero elements, which is a checked pass); a non-empty sidecar checked against
+  `&[]` now fails, as does an occurrence for a quad outside a non-empty set. A caller that passed
+  a subset of its quads, or `&[]` to run rules 1–2 alone, must now pass the full set. The
+  signature is unchanged and `ProvenanceError` is `#[non_exhaustive]`, so the new variant is
+  not itself a source break; the accepted-input set is what changed.
+- **sparql-algebra:** A language tag's base direction is exactly `ltr` or `rtl`, lower case, and
+  anything else is a syntax error. SPARQL 1.2 §2.3.1: "The base direction is restricted to
+  either `ltr` or `rtl`. Unlike a language tag, it is always lower case." The parser SILENTLY
+  DROPPED an unrecognised `--` suffix — `"x"@en--foo` parsed as `"x"@en`, and `"x"@en--LTR` as
+  `"x"@en--ltr` — where the W3C rdf-tests pin both spellings as negative syntax ("undefined base
+  direction", "upper case LTR"), and the pre-release sweep had folded the comparison to
+  `eq_ignore_ascii_case`, which the specification forbids. The language half is now held to the
+  `LANG_DIR` production `[a-zA-Z]+ ('-' [a-zA-Z0-9]+)*` at the same site, so `@en-`, `@en--`,
+  `@1en` and `@en--x--ltr` are refused too, while `@en`, `@en-US`, `@zh-Hant-TW`, `@x-klingon`,
+  `@en--ltr`, `@ar--rtl`, `@en-US--rtl` and `@EN--ltr` (only the DIRECTION is case-restricted)
+  all still parse. The vendored `lang-basedir/langdir-literal-invalid.rq` could not catch this:
+  it spells its projection `AS v`, which is a syntax error on its own, so the harness refused it
+  for the wrong reason.
+- **core:** `MutableDataset` no longer fabricates a literal datatype. When a base literal's
+  datatype id resolved to something other than an IRI, `base_value_of` rendered that term's
+  `Debug` form and used it as the datatype IRI, where `RdfDataset::term_value` states the same
+  invariant with `unreachable!`. The fabricated value could not fail at the site; it would
+  surface later as an `IriError` about a string nobody wrote. The path is unreachable from the
+  public API (the builder interns every datatype through `intern_iri`, and the pack decoder
+  refuses a non-IRI datatype entry before a pack becomes a dataset), so the two sites now agree
+  on `unreachable!` with the invariant stated, and a test pins that `base_value_of` and
+  `term_value` agree on every literal shape.
 - **BREAKING** **sparql-eval,geo:** A host function registered through
   `UserFunctionRegistry::register_native` can now raise a SPARQL **expression error** for one
   solution instead of failing the whole query. `NativeFnBody` returns

--- a/crates/rdf-core/benches/pack_query.rs
+++ b/crates/rdf-core/benches/pack_query.rs
@@ -74,6 +74,12 @@ const DICT_ROWS: u32 = 2_000;
 /// tagged, directional language-tagged, and long lexical forms — plus a quoted
 /// triple term per row (whose `s`/`p`/`o` the closure step must resolve), so
 /// [`PackDict::encode`]'s record encoder and closure worklist are both busy.
+///
+/// The triple term is asserted in the OBJECT position (`s q <<s p plain>>`): RDF
+/// 1.2 admits a triple term only there, and the freeze gate refuses it as a
+/// subject (`rdf-ir-triple-subject`). The fixture that shipped with the sweep
+/// asserted it as the subject, so `freeze` panicked and the bench measured
+/// nothing.
 fn build_literal_heavy_dataset() -> Arc<RdfDataset> {
     let mut b = RdfDatasetBuilder::new();
     let p = b.intern_iri("http://example.org/p");
@@ -106,7 +112,7 @@ fn build_literal_heavy_dataset() -> Arc<RdfDataset> {
         b.push_quad(s, p, directional, None);
         b.push_quad(s, p, long, None);
         let quoted = b.intern_triple(s, p, plain);
-        b.push_quad(quoted, q, typed, None);
+        b.push_quad(s, q, quoted, None);
     }
 
     b.freeze()

--- a/crates/rdf-core/src/ir/mutable.rs
+++ b/crates/rdf-core/src/ir/mutable.rs
@@ -252,11 +252,17 @@ impl MutableDataset {
                 direction,
             } => {
                 // The datatype id is a base IRI term; resolve it to its IRI string.
+                // A frozen dataset's literal datatype is an IRI by construction:
+                // `RdfDatasetBuilder::intern_literal` mints it through `intern_iri`,
+                // and the pack decoder refuses a datatype entry that is not an IRI
+                // before a pack ever becomes a dataset. Any other shape is a broken
+                // invariant, stated exactly as `RdfDataset::term_value` states it —
+                // never rendered into a datatype string, because a `Debug` rendering
+                // used as an IRI does not fail HERE; it fails later as an `IriError`
+                // about text nobody wrote.
                 let datatype = match base.resolve(datatype) {
                     TermRef::Iri(dt) => dt.to_string(),
-                    // Unreachable for a validated dataset (a literal datatype is always
-                    // an IRI); fall back to a debug string rather than panic.
-                    other => format!("{other:?}"),
+                    other => unreachable!("literal datatype must resolve to an IRI, got {other:?}"),
                 };
                 TermValue::Literal {
                     lexical_form: lexical.to_string(),
@@ -1036,6 +1042,61 @@ mod tests {
             .iter()
             .map(|q| format!("{:?}|{:?}|{:?}|{:?}", q.s, q.p, q.o, q.g))
             .collect()
+    }
+
+    /// `base_value_of` and [`RdfDataset::term_value`] are the two resolvers of a
+    /// frozen literal's datatype, and they must agree on every literal shape: the
+    /// datatype handed back is the IRI that was interned, never a rendering of some
+    /// other term. A non-IRI datatype id is unreachable from the public API (the
+    /// builder interns every datatype through `intern_iri`; the pack decoder refuses
+    /// a non-IRI datatype entry), so the pinned behaviour is the agreement itself —
+    /// both sites state the invariant with `unreachable!`, and neither fabricates a
+    /// value that would only fail later as an `IriError` about text nobody wrote.
+    #[test]
+    fn base_value_of_agrees_with_term_value_on_every_literal_shape() {
+        use crate::model::RdfTextDirection;
+
+        let mut b = RdfDatasetBuilder::new();
+        let s = b.intern_iri("http://example.org/s");
+        let p = b.intern_iri("http://example.org/p");
+        let plain = b.intern_literal(RdfLiteral::simple("plain"));
+        let typed = b.intern_literal(RdfLiteral::typed(
+            "1",
+            "http://www.w3.org/2001/XMLSchema#integer",
+        ));
+        let lang = b.intern_literal(RdfLiteral::language_tagged("hi", "en"));
+        let directional = b.intern_literal(RdfLiteral {
+            direction: Some(RdfTextDirection::Rtl),
+            ..RdfLiteral::language_tagged("مرحبا", "ar")
+        });
+        // A literal nested inside a triple term resolves through the recursive arm.
+        let nested = b.intern_triple(s, p, typed);
+        for o in [plain, typed, lang, directional, nested] {
+            b.push_quad(s, p, o, None);
+        }
+        let base = b.freeze().expect("base freezes");
+
+        let mut literal_datatypes = Vec::new();
+        for index in 0..base.term_count() {
+            let id = TermId::from_index(u32::try_from(index).expect("small fixture"));
+            let via_mutable = MutableDataset::base_value_of(&base, id);
+            assert_eq!(via_mutable, base.term_value(id), "term {index}");
+            if let TermValue::Literal { datatype, .. } = via_mutable {
+                literal_datatypes.push(datatype);
+            }
+        }
+        literal_datatypes.sort();
+        assert_eq!(
+            literal_datatypes,
+            [
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString",
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString",
+                "http://www.w3.org/2001/XMLSchema#integer",
+                "http://www.w3.org/2001/XMLSchema#string",
+            ]
+            .map(str::to_owned),
+            "every literal datatype is the interned IRI, never a Debug rendering"
+        );
     }
 
     // -- the four mutation rules ------------------------------------------------------

--- a/crates/rdf-core/src/provenance.rs
+++ b/crates/rdf-core/src/provenance.rs
@@ -612,10 +612,20 @@ pub enum ProvenanceError {
         /// The out-of-range artifact id.
         artifact: ArtifactId,
     },
-    /// A `QuadHandle` has zero occurrences but the gate was asked to enforce
-    /// full coverage (every semantic quad must have ≥1 occurrence).
+    /// A `QuadHandle` of the dataset has zero occurrences (every semantic quad
+    /// must have ≥1 occurrence).
     MissingOccurrence {
         /// The dense quad ordinal with no assertion occurrence.
+        quad_index: usize,
+    },
+    /// An occurrence references a `QuadHandle` that is not a quad of the
+    /// dataset — the sidecar describes an assertion the dataset does not hold.
+    /// The quad-axis mirror of [`UnknownUnit`](Self::UnknownUnit) and
+    /// [`UnknownArtifact`](Self::UnknownArtifact).
+    DanglingQuad {
+        /// The index of the offending occurrence in the occurrence table.
+        occurrence_index: usize,
+        /// The quad handle no dataset quad answers to.
         quad_index: usize,
     },
 }
@@ -643,20 +653,42 @@ impl fmt::Display for ProvenanceError {
                 "quad handle {quad_index} has no assertion occurrence \
                  (every semantic quad must have ≥1 occurrence)"
             ),
+            Self::DanglingQuad {
+                occurrence_index,
+                quad_index,
+            } => write!(
+                f,
+                "occurrence[{occurrence_index}] references quad handle {quad_index} \
+                 which is not a quad of the dataset"
+            ),
         }
     }
 }
 
 impl std::error::Error for ProvenanceError {}
 
-/// Validate the provenance sidecar against a set of expected quad handles.
+/// Validate the provenance sidecar against the dataset it describes.
 ///
-/// Enforces:
+/// `dataset_quads` is the dataset's **complete** quad-handle set — the sidecar
+/// is checked against it in both directions, so the gate always measures
+/// something:
+///
 /// 1. Every `AssertionOccurrence` references a `UnitId` with a registered kind
 ///    (no-optionality: there is no `Unknown` variant).
 /// 2. Every `AssertionOccurrence` references an `ArtifactId` in range.
-/// 3. If `expected_quads` is non-empty, every quad handle in that set has at
-///    least one occurrence.
+/// 3. Every quad in `dataset_quads` has at least one occurrence
+///    ([`MissingOccurrence`](ProvenanceError::MissingOccurrence)).
+/// 4. Every occurrence references a quad in `dataset_quads`
+///    ([`DanglingQuad`](ProvenanceError::DanglingQuad)).
+///
+/// An **empty** `dataset_quads` therefore means "the dataset is empty", not
+/// "check nothing": rule 3 has no quad to cover, and rule 4 then refuses every
+/// occurrence, because a sidecar with assertions for an empty dataset describes
+/// quads the dataset does not hold. An empty sidecar for an empty dataset
+/// passes — after every rule ran over zero elements, which is a checked pass,
+/// not a skipped one. There is no way to ask for rules 1–2 alone: a call that
+/// forgets to collect its quad handles fails loudly the moment the sidecar
+/// holds anything, rather than passing vacuously.
 ///
 /// Non-`Source` units (`RootOntology`, `Import`, `Generated`, `RuntimeInput`)
 /// are explicitly representable and pass the gate without error.
@@ -666,7 +698,7 @@ impl std::error::Error for ProvenanceError {}
 /// Returns all violations found (not just the first).
 pub fn check_provenance(
     prov: &DatasetProvenance,
-    expected_quads: &[QuadHandle],
+    dataset_quads: &[QuadHandle],
 ) -> Result<(), Vec<ProvenanceError>> {
     let mut errors: Vec<ProvenanceError> = Vec::new();
 
@@ -686,17 +718,29 @@ pub fn check_provenance(
         }
     }
 
-    // 3: every expected quad handle has ≥1 occurrence.
-    if !expected_quads.is_empty() {
-        // Build a set of handles that appear in at least one occurrence.
-        let covered: std::collections::HashSet<usize> =
-            prov.occurrences.iter().map(|o| o.quad.index()).collect();
-        for handle in expected_quads {
-            if !covered.contains(&handle.index()) {
-                errors.push(ProvenanceError::MissingOccurrence {
-                    quad_index: handle.index(),
-                });
-            }
+    // 3: every dataset quad has ≥1 occurrence. Runs unconditionally: an empty
+    // dataset simply has nothing to cover, and rule 4 is what gives that case
+    // teeth.
+    let covered: std::collections::HashSet<usize> =
+        prov.occurrences.iter().map(|o| o.quad.index()).collect();
+    for handle in dataset_quads {
+        if !covered.contains(&handle.index()) {
+            errors.push(ProvenanceError::MissingOccurrence {
+                quad_index: handle.index(),
+            });
+        }
+    }
+
+    // 4: every occurrence references a dataset quad — the mirror of rule 3, and
+    // the quad-axis twin of rules 1 and 2.
+    let dataset: std::collections::HashSet<usize> =
+        dataset_quads.iter().map(|h| h.index()).collect();
+    for (idx, occ) in prov.occurrences.iter().enumerate() {
+        if !dataset.contains(&occ.quad.index()) {
+            errors.push(ProvenanceError::DanglingQuad {
+                occurrence_index: idx,
+                quad_index: occ.quad.index(),
+            });
         }
     }
 
@@ -1039,14 +1083,74 @@ mod tests {
             location: None,
         });
 
-        let result = check_provenance(&prov, &[]);
+        let result = check_provenance(&prov, &[q]);
         assert!(result.is_err());
         let errs = result.unwrap_err();
-        assert!(
-            errs.iter().any(
-                |e| matches!(e, ProvenanceError::UnknownUnit { unit, .. } if unit.index() == 99)
-            ),
-            "expected UnknownUnit error for forged id"
+        assert_eq!(
+            errs,
+            vec![ProvenanceError::UnknownUnit {
+                occurrence_index: 0,
+                unit: bad_unit,
+            }],
+            "exactly the forged-unit error: the quad itself is covered and not dangling"
+        );
+    }
+
+    /// An empty `dataset_quads` means "the dataset is empty", and the gate must
+    /// still MEASURE that: a sidecar holding an occurrence for an empty dataset
+    /// describes a quad the dataset does not have. Against the pre-fix code this
+    /// call passed vacuously — rule 3 was skipped on an empty set, and nothing
+    /// looked at the occurrence.
+    #[test]
+    fn gate_rejects_occurrences_for_an_empty_dataset() {
+        let mut prov = DatasetProvenance::new();
+        let unit = prov.register_unit("slices/core/a", OriginKind::Source);
+        let artifact = prov.register_artifact("a/a.ttl");
+        prov.record_occurrence(qh(0), unit, artifact, None);
+
+        let errs = check_provenance(&prov, &[]).expect_err("an occurrence with no dataset quad");
+        assert_eq!(
+            errs,
+            vec![ProvenanceError::DanglingQuad {
+                occurrence_index: 0,
+                quad_index: 0,
+            }]
+        );
+        assert_eq!(
+            errs[0].to_string(),
+            "occurrence[0] references quad handle 0 which is not a quad of the dataset"
+        );
+    }
+
+    /// The neighbouring VALID case of the refusal above: an empty sidecar for an
+    /// empty dataset is a checked pass (every rule ran over zero elements).
+    #[test]
+    fn gate_passes_empty_sidecar_for_empty_dataset() {
+        let prov = DatasetProvenance::new();
+        assert_eq!(check_provenance(&prov, &[]), Ok(()));
+    }
+
+    /// Rule 4 is not special to the empty case: an occurrence for a quad OUTSIDE
+    /// a non-empty dataset is dangling too, and it is reported alongside — not
+    /// instead of — a missing occurrence for a quad inside it.
+    #[test]
+    fn gate_reports_dangling_and_missing_together() {
+        let mut prov = DatasetProvenance::new();
+        let unit = prov.register_unit("slices/core/a", OriginKind::Source);
+        let artifact = prov.register_artifact("a/a.ttl");
+        prov.record_occurrence(qh(0), unit, artifact, None);
+        prov.record_occurrence(qh(7), unit, artifact, None); // not a dataset quad
+
+        let errs = check_provenance(&prov, &[qh(0), qh(1)]).expect_err("two violations");
+        assert_eq!(
+            errs,
+            vec![
+                ProvenanceError::MissingOccurrence { quad_index: 1 },
+                ProvenanceError::DanglingQuad {
+                    occurrence_index: 1,
+                    quad_index: 7,
+                },
+            ]
         );
     }
 

--- a/crates/sparql-algebra/src/parser.rs
+++ b/crates/sparql-algebra/src/parser.rs
@@ -3404,10 +3404,11 @@ impl<'a> Parser<'a, '_> {
             }
             Some(Token::StringLit(s) | Token::LongStringLit(s)) if sign.is_none() => {
                 if let Some(Token::LangTag(_)) = self.peek() {
+                    let at = self.span();
                     let Some(Token::LangTag(tag)) = self.bump() else {
                         unreachable!()
                     };
-                    let (lang, dir) = split_lang_dir(tag);
+                    let (lang, dir) = split_lang_dir(tag, at)?;
                     Ok(Literal::new_lang(s, lang, dir))
                 } else if self.eat(&Token::HatHat) {
                     let dt = self.expect_iri_node()?;
@@ -5376,23 +5377,56 @@ fn is_modifier_terminator_word(w: &str) -> bool {
         .any(|kw| w.eq_ignore_ascii_case(kw))
 }
 
-/// Split a lang tag into the language and an optional RDF 1.2 base direction
-/// (`en--ltr` → (`en`, Ltr)).
-fn split_lang_dir(tag: &str) -> (String, Option<BaseDirection>) {
-    if let Some((lang, dir)) = tag.split_once("--") {
-        // In-place ASCII case folding: same match as `to_ascii_lowercase()`
-        // against the two ASCII spellings, without the lower-cased copy.
-        let dir = if dir.eq_ignore_ascii_case("ltr") {
-            Some(BaseDirection::Ltr)
-        } else if dir.eq_ignore_ascii_case("rtl") {
-            Some(BaseDirection::Rtl)
-        } else {
-            None
-        };
-        (lang.to_owned(), dir)
-    } else {
-        (tag.to_owned(), None)
+/// Split a `LANG_DIR` token into the language tag and its optional RDF 1.2
+/// base direction (`en--ltr` → (`en`, `Ltr`)), refusing anything the
+/// production does not admit.
+///
+/// The terminal is `LANG_DIR ::= '@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)* ('--'
+/// [a-zA-Z]+)?` (Turtle 1.2 rule [42]; SPARQL 1.2 shares it), narrowed by
+/// prose: SPARQL 1.2 §2.3.1 — "The base direction is restricted to either
+/// `ltr` or `rtl`. Unlike a language tag, it is always lower case." — and
+/// Turtle 1.2 §7.2 — "If present, the initial text direction MUST be either
+/// `ltr` or `rtl`." The W3C rdf-tests pin both halves as negative syntax:
+/// `@en--unk` ("undefined base direction") and `@en--LTR` ("upper case LTR").
+///
+/// The lexer hands over the raw `[a-zA-Z0-9-]+` run after `@`, so this is the
+/// one site that enforces the production. An unknown or wrongly-cased suffix
+/// is a syntax error here — never silently dropped to a plain `@en`, and never
+/// folded into the language tag as `en--foo`. The split is on the FIRST `--`:
+/// the production admits exactly one, so `en--x--ltr` is refused as a bad
+/// direction (`x--ltr`) rather than read as language `en--x`.
+fn split_lang_dir(tag: &str, at: usize) -> Result<(String, Option<BaseDirection>)> {
+    let (lang, dir) = match tag.split_once("--") {
+        Some((lang, "ltr")) => (lang, Some(BaseDirection::Ltr)),
+        Some((lang, "rtl")) => (lang, Some(BaseDirection::Rtl)),
+        Some((_, dir)) => {
+            return Err(ParseError::syntax(
+                format!(
+                    "invalid base direction `--{dir}` in `@{tag}`: \
+                     must be exactly `ltr` or `rtl` (lower case)"
+                ),
+                at,
+            ));
+        }
+        None => (tag, None),
+    };
+    if !is_langtag(lang) {
+        return Err(ParseError::syntax(
+            format!("invalid language tag `@{tag}`: expected [a-zA-Z]+ ('-' [a-zA-Z0-9]+)*"),
+            at,
+        ));
     }
+    Ok((lang.to_owned(), dir))
+}
+
+/// The language half of `LANG_DIR`: `[a-zA-Z]+ ('-' [a-zA-Z0-9]+)*`.
+fn is_langtag(lang: &str) -> bool {
+    let mut subtags = lang.split('-');
+    let primary_ok = subtags.next().is_some_and(|primary| {
+        !primary.is_empty() && primary.bytes().all(|b| b.is_ascii_alphabetic())
+    });
+    primary_ok
+        && subtags.all(|sub| !sub.is_empty() && sub.bytes().all(|b| b.is_ascii_alphanumeric()))
 }
 
 fn expect_arity(args: &[Expression], n: usize, name: &str, at: usize) -> Result<()> {
@@ -5536,6 +5570,82 @@ mod tests {
 
     fn parse(q: &str) -> Query {
         SparqlParser::new().parse_query(q).expect("parse")
+    }
+
+    // -- LANG_DIR: the base direction is exactly `ltr` / `rtl` -----------------------
+
+    /// A well-formed query whose only variable part is the language tag, so a
+    /// refusal can come from nothing but the tag. (The vendored W3C
+    /// `lang-basedir/langdir-literal-invalid.rq` spells its projection `AS v`,
+    /// which is itself a syntax error — so that negative test cannot tell a
+    /// refused direction from a refused projection. This shape can.)
+    fn parse_lang_literal(tag: &str) -> Result<Query> {
+        SparqlParser::new().parse_query(&format!("SELECT (\"x\"@{tag} AS ?v) WHERE {{}}"))
+    }
+
+    /// Every valid neighbour of the refusals below still parses, with the
+    /// direction the grammar assigns it. `EN--ltr` is valid: only the DIRECTION
+    /// is case-restricted, the language tag is not.
+    #[test]
+    fn lang_dir_accepts_every_grammar_admitted_shape() {
+        for (tag, lang, dir) in [
+            ("en", "en", None),
+            ("en-US", "en-US", None),
+            ("zh-Hant-TW", "zh-Hant-TW", None),
+            ("x-klingon", "x-klingon", None),
+            ("en-a1", "en-a1", None),
+            ("en--ltr", "en", Some(BaseDirection::Ltr)),
+            ("ar--rtl", "ar", Some(BaseDirection::Rtl)),
+            ("en-US--rtl", "en-US", Some(BaseDirection::Rtl)),
+            ("EN--ltr", "EN", Some(BaseDirection::Ltr)),
+        ] {
+            assert_eq!(
+                split_lang_dir(tag, 0).expect(tag),
+                (lang.to_owned(), dir),
+                "@{tag}"
+            );
+            parse_lang_literal(tag).unwrap_or_else(|e| panic!("@{tag} must parse: {e}"));
+        }
+    }
+
+    /// An unknown or wrongly-cased base direction is a SYNTAX ERROR, never a
+    /// silently dropped suffix: before this pin, `"x"@en--foo` parsed as a plain
+    /// `"x"@en` and `"x"@en--LTR` as `"x"@en--ltr`. The two vendored W3C
+    /// rdf-tests spellings are first (`@en--unk`, `@en--LTR`), then the shapes
+    /// the raw `[a-zA-Z0-9-]+` lexer run lets through that the production does
+    /// not: an empty direction, a doubled one, a stray hyphen, an empty subtag,
+    /// and a digit-led primary subtag.
+    #[test]
+    fn lang_dir_refuses_what_the_production_does_not_admit() {
+        for tag in [
+            "en--unk",
+            "en--LTR",
+            "en--foo",
+            "en--Rtl",
+            "en--",
+            "en--ltr--ltr",
+            "en--x--ltr",
+            "en---ltr",
+            "en-",
+            "en--ltr-x",
+            "-en",
+            "en--ltr-",
+            "1en",
+            "en-.us",
+        ] {
+            let err = split_lang_dir(tag, 0).expect_err(tag);
+            assert!(
+                err.to_string().contains("invalid"),
+                "@{tag}: diagnostic names the refusal, got {err}"
+            );
+            assert!(parse_lang_literal(tag).is_err(), "@{tag} must not parse");
+        }
+        let err = parse_lang_literal("en--foo").expect_err("unknown direction");
+        assert!(
+            err.to_string()
+                .contains("invalid base direction `--foo` in `@en--foo`"),
+            "the diagnostic names the suffix and the tag: {err}"
+        );
     }
 
     fn select_pattern(q: &str) -> GraphPattern {


### PR DESCRIPTION
Three findings PR #239 (`b4f99093`) reported rather than fixed. Each was verified against the code before changing it; two are the silent-success class this project hunts hardest.

## D1 — a fabricated value (`crates/rdf-core/src/ir/mutable.rs`, `base_value_of`)

**Verified.** `other => format!("{other:?}")` rendered a non-IRI literal datatype's `Debug` form and used it as the datatype IRI, while `RdfDataset::term_value` / `to_owned_term`, `pack::certify` and `pack::dict` state the same invariant with `unreachable!`. The string could not fail at the site; it would surface later as an `IriError` about text nobody wrote.

**Decision: `unreachable!`, matching `dataset.rs`.** The path is not reachable from any public API: `RdfDatasetBuilder::intern_literal` mints every datatype through `intern_iri`, `RdfDataset.terms` is private with only a `pub(crate) from_parts`, and the pack decoder refuses a non-IRI datatype entry (`dict.rs` "literal datatype id does not reference an IRI") before a pack becomes a dataset. A real diagnostic would be a code for a condition no caller can produce. Test: `base_value_of_agrees_with_term_value_on_every_literal_shape` pins that the two resolvers agree on plain/typed/lang/directional/nested literals and hand back the interned IRI.

## D2 — a check that measured nothing (`crates/rdf-core/src/provenance.rs`, `check_provenance`)

**Verified.** `if !expected_quads.is_empty() { … rule 3 … }` — an empty slice skipped rule 3 and returned `Ok(())`, indistinguishable from a real pass. No in-tree production caller; the one in-tree use of `&[]` was a unit test using it as "rules 1–2 only".

**Decision: an empty set means "the dataset is empty", and the gate measures it.** The parameter is the dataset's complete quad set; rule 3 runs unconditionally; new rule 4 refuses every occurrence whose quad is not in the set with `ProvenanceError::DanglingQuad { occurrence_index, quad_index }` (the quad-axis twin of `UnknownUnit`/`UnknownArtifact`). Empty sidecar + empty dataset is a checked pass. There is deliberately no way to ask for rules 1–2 alone.

- Fails against old code: `gate_rejects_occurrences_for_an_empty_dataset`, `gate_reports_dangling_and_missing_together` (both confirmed FAILED with the old body restored).
- Valid neighbours still pass: `gate_passes_empty_sidecar_for_empty_dataset`, and every pre-existing non-empty gate test.

**BREAKING** (documented by hand in `CHANGELOG.md`): the signature is unchanged and `ProvenanceError` is `#[non_exhaustive]`, but a call passing `&[]` or a subset of the dataset's quads now fails.

## D3 — a silently dropped input (`crates/sparql-algebra/src/parser.rs`, `split_lang_dir`)

**Verified.** An unrecognised `--` suffix mapped to `None`, so `"x"@en--foo` parsed as `"x"@en`, and the sweep's `eq_ignore_ascii_case` made `"x"@en--LTR` parse as `"x"@en--ltr`.

**Grammar.** SPARQL 1.2 §2.3.1: *"The base direction is restricted to either `ltr` or `rtl`. Unlike a language tag, it is always lower case."* Turtle 1.2 `[42] LANG_DIR ::= '@' [a-zA-Z]+ ('-' [a-zA-Z0-9]+)* ('--' [a-zA-Z]+)?` with §7.2 *"If present, the initial text direction MUST be either `ltr` or `rtl`."* The vendored W3C rdf-tests pin both: `ntriples-langdir-bad-1` `@en--unk` "undefined base direction", `ntriples-langdir-bad-2` `@en--LTR` "upper case LTR" (Turtle/N-Quads twins likewise). So it is a syntax error, and case matters — the sweep's case fold was the wrong direction.

**Decision: syntax error**, exact `ltr`/`rtl`, and the language half held to the `LANG_DIR` production at the same site (the lexer hands over a raw `[a-zA-Z0-9-]+` run). Mirrors `text_parse.rs::split_lang_direction`.

- Fails against old code: `lang_dir_refuses_what_the_production_does_not_admit` (confirmed FAILED with the old body restored) — `@en--unk`, `@en--LTR`, `@en--foo`, `@en--Rtl`, `@en--`, `@en--ltr--ltr`, `@en--x--ltr`, `@en-`, `@1en`, …
- Over-refusal counter-cases executed and passing: `@en`, `@en-US`, `@zh-Hant-TW`, `@x-klingon`, `@en-a1`, `@en--ltr`, `@ar--rtl`, `@en-US--rtl`, `@EN--ltr` (only the direction is case-restricted).

Note: the vendored `lang-basedir/langdir-literal-invalid.rq` (`SELECT ("foo"@en--foo AS v) WHERE {}`) could not catch this — `AS v` is a syntax error on its own, so the harness refused it for the wrong reason. My test uses the well-formed shape.

## D4 — a bench that measured nothing (`crates/rdf-core/benches/pack_query.rs`, `build_literal_heavy_dataset`)

**Verified.** Line 113, `b.push_quad(quoted, q, typed, None)`, asserts a quad whose SUBJECT is the triple term `<<s p plain>>`. RDF 1.2 admits a triple term only as an object; the freeze gate's `require_asserted_subject` refuses it with `rdf-ir-triple-subject` ("an asserted statement cannot have a quoted triple as its subject"), so `freeze().expect(...)` panicked and the report-only `benchmarks` job has been red on `main` since #239 (`git log` attributes the fixture to `b4f99093`; the bench was green at `e7330501`).

**Decision: fix the fixture, not the invariant.** The triple term is now asserted in the object position, `b.push_quad(s, q, quoted, None)`, which keeps what the fixture was built to exercise — one triple term per row for the dictionary closure to resolve — in the one place the model puts it.

**Proven to construct, not merely to compile.** `cargo bench -p purrdf-core --bench pack_query --no-run --locked` builds; `cargo bench -p purrdf-core --bench pack_query --locked -- --warm-up-time 1 --measurement-time 1` ran every group:

```
[pack_query_dict_encode] 14005 terms, 206107 value bytes
pack_query_dict_encode/literal_heavy_2k_rows
pack_query_build_bytes/build_bytes
pack_query_from_bytes/from_bytes
pack_query_restore/restore_pack
pack_query_pattern/subject_bound
pack_query_pattern/predicate_bound
pack_query_pattern/object_bound
pack_query_pattern/full_scan
pack_query_verify/verify_pack
```

(14 005 = 2 000 rows × 7 terms + `p`, `q`, and the three datatype IRIs.)

**CI evidence, before:** the `benchmarks` job for the previous head `f8114852` (which had D1–D3 but not this fix) failed exactly here — job `100412328125`, log lines 2581–2586:

```
Running benches/pack_query.rs (target/release/build/purrdf-core/.../pack_query-af4b6d11512eb2d5)
thread 'main' (43985) panicked at crates/rdf-core/benches/pack_query.rs:113:10:
literal-heavy dataset is structurally valid: RdfDiagnostic { severity: Error, code: "rdf-ir-triple-subject", message: "quad #5 subject must be an IRI or blank node; an asserted statement cannot have a quoted triple as its subject", detail: None, location: None }
error: bench failed, to rerun pass `-p purrdf-core --bench pack_query`
```

**CI evidence, after:** for head `8df38793` the job (`100419186053`) has step 5 "Compile benchmark harnesses" `success` and step 6 "Run native criterion suites" in progress; GitHub does not expose a step's log blob until the step completes (`/logs` answers `BlobNotFound`), and the previous run took ~45 min to reach `pack_query` inside that step. The job is report-only (`continue-on-error`), so the merge is not blocked on it; the post-fix `pack_query` log lines will be appended here when the step completes. `cargo clippy -p purrdf-core --all-targets -D warnings` is clean over the bench.

## Gates

`cargo test` for `purrdf-core`, `purrdf-sparql-algebra`, `purrdf-sparql-conformance` (all green); `cargo clippy --workspace --all-targets --locked -- -D warnings` (clean); `make doc`; `make conformance` (scoreboard unchanged); `make pytest` (768 passed, 4 xfailed). `.deficiencies` untouched. No features, no new deps, no `#[allow]`.
