### PR TITLE
ci: run the brand-casing gate in the workspace job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,9 @@ jobs:
       - name: Check for stale issue references in comments/docs
         run: python3 scripts/check-issue-refs.py
 
+      - name: Check brand casing (PurRDF in prose, `purrdf` only in identifiers)
+        run: python3 scripts/check-brand-casing.py
+
       - name: Check no first-party extension is attributed to a SPARQL specification
         run: python3 scripts/check-spec-attribution.py --self-test
 

--- a/README.md
+++ b/README.md
@@ -477,3 +477,5 @@ Licensed under either of [Apache License 2.0](./LICENSE-APACHE) or
 [`LICENSING.md`](./LICENSING.md).
 
 If you use PurRDF in research, please cite it — see [`CITATION.cff`](./CITATION.cff).
+
+This sentence is a throwaway gate probe: purrdf is written bare in prose here so the brand-casing CI step must refuse it.

--- a/README.md
+++ b/README.md
@@ -477,5 +477,3 @@ Licensed under either of [Apache License 2.0](./LICENSE-APACHE) or
 [`LICENSING.md`](./LICENSING.md).
 
 If you use PurRDF in research, please cite it — see [`CITATION.cff`](./CITATION.cff).
-
-This sentence is a throwaway gate probe: purrdf is written bare in prose here so the brand-casing CI step must refuse it.


### PR DESCRIPTION
## Why

`scripts/check-brand-casing.py` enforces the "PurRDF in prose, `purrdf` only in identifiers" rule. It runs in local `make check` (`Makefile` lines 50 and 65) but was **never invoked by `.github/workflows/ci.yaml`**. On the development machine local `make check` cannot complete at all (no rustup shim, no wasm32 std), so in practice the gate has been unenforced. This closes that hole before the 0.14.0 tag.

Verified by reading, not trusting: `grep -n "check-brand-casing" .github/workflows/ci.yaml` returned nothing on `origin/main`. The sibling `check-toolchain-pin.py` (PR #231) was checked for the same gap and is already in CI (lines 42 and 45, including its `--self-test`), so nothing is added for it.

## What

One step in the `workspace` job, in the same one-step-per-gate shape its siblings use and in the Makefile `check` order (after issue-refs, before spec-attribution):

```yaml
      - name: Check brand casing (PurRDF in prose, `purrdf` only in identifiers)
        run: python3 scripts/check-brand-casing.py
```

`workspace` doc-gate steps before: check-generated.sh (which runs check-doc-claims.py), check-issue-refs.py, check-spec-attribution.py. After: the same, plus check-brand-casing.py as step 13 of 18. Action pins and the pinned toolchain are untouched. No `CHANGELOG.md` entry, mirroring PR #231 which added its CI gate without one.

## Proof the gate is not vacuous in CI

The script enumerates files with `git ls-files`. The `workspace` job checks out with stock `actions/checkout@v7` (no `sparse-checkout`), so the full tree at HEAD is materialised. Rather than assert that, this branch proves the step can refuse, with three runs on three commits kept in the history (the probe is reverted by a real `git revert`, not erased):

| commit | run | `workspace` | brand-casing step log line |
| --- | --- | --- | --- |
| `cc739d49` gate added | [33682325475](https://github.com/Blackcat-Informatics/purrdf/actions/runs/33682325475) | success | `OK: no bare 'purrdf' prose outside identifiers/code spans (84 pre-existing file(s) registered).` |
| `21df98e4` PROBE: one bare `purrdf` in README prose | [33682373559](https://github.com/Blackcat-Informatics/purrdf/actions/runs/33682373559) | **failure** | `README.md:481:42: bare 'purrdf' in prose — use 'PurRDF' for the project/brand, or wrap `purrdf` in backticks if it names the facade crate` then `##[error]Process completed with exit code 1.` |
| `2cd7227e` Revert PROBE | [33686207318](https://github.com/Blackcat-Informatics/purrdf/actions/runs/33686207318) | success | `OK: no bare 'purrdf' prose outside identifiers/code spans (84 pre-existing file(s) registered).` |

Per CLAUDE.md the refusal was also exercised both ways locally before pushing: the probe line with bare `purrdf` exits 1 at `README.md:481:42`; the same line with `PurRDF` exits 0.

## Local output

```
$ python3 scripts/check-brand-casing.py
OK: no bare 'purrdf' prose outside identifiers/code spans (84 pre-existing file(s) registered).
```

Also green locally: `check-toolchain-pin.py`, `check-issue-refs.py`, `check-doc-claims.py`, `check-no-features.py`, `check-spec-attribution.py --self-test`, `actionlint`. `.deficiencies` is empty.
