### PR TITLE
docs: state the value proposition — one engine instead of three databases

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,7 +16,10 @@ abstract: >-
   deterministic full-text search with exact fixed-point BM25 ranking; exact,
   float-free GeoSPARQL 1.1; embedding nearest-neighbour search over the PURREMB
   companion format; and the GTS single-file, content-addressed, append-only graph
-  transport. The workspace deliberately exposes no optional Cargo features — as a
+  transport. Together, the full-text, GeoSPARQL and nearest-neighbour surfaces
+  answer from SPARQL, in-process and over one dataset, the three queries for
+  which an RDF project has usually run PostgreSQL beside its triple store, with
+  the same result natively and on WebAssembly. The workspace deliberately exposes no optional Cargo features — as a
   data carrier it guarantees byte-identical semantics for every consumer — and
   its behavior is gated by W3C SPARQL, SHACL, shexTest, OWL 2, RDFC-1.0, and
   frozen cross-language GTS conformance corpora.

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ triple pattern.
   scratch bytes, remote requests, deadline) that trips with certified rows
   rather than a wrong answer, and `--explain` returns a per-algebra-node charge
   ledger beside the cost planner's estimates. The normative charge schedule and
-  the frozen 49-case governor corpus live in
+  the frozen 50-case governor corpus live in
   [`docs/SPARQL-GOVERNOR-PROFILE.md`](./docs/SPARQL-GOVERNOR-PROFILE.md).
 - **SHACL validation** — a native validator with the complete SHACL Core feature
   set (all constraint components, full property paths, qualified value shapes,

--- a/README.md
+++ b/README.md
@@ -34,6 +34,26 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 
 ---
 
+PurRDF is an [RDF 1.2](https://www.w3.org/TR/rdf12-concepts/) toolkit —
+primitives, codecs, SPARQL 1.1/1.2, SHACL, ShEx, entailment regimes, and the
+GTS graph transport — implemented once in Rust and carried verbatim into
+Python, WebAssembly/JavaScript, and C. Every published crate builds for
+`wasm32-unknown-unknown`, so the engine that answers a query on a server
+answers it, byte for byte, in a browser tab.
+
+**What it removes from your architecture.** The three jobs that usually keep
+a PostgreSQL instance running beside a triple store — ranked full-text search,
+spatial predicates, and vector similarity — are answered inside PurRDF:
+in-process, over the same dataset, from the same SPARQL query, with no second
+database, no sync job, and no question split between SPARQL and SQL. Each
+answer is exact and deterministic — the same rows, in the same order, with the
+same score lexicals, natively and on wasm32 — which is a guarantee a Postgres
+stack does not make across machines. This is not a projection: these query
+surfaces have already removed a whole PostgreSQL requirement from one RDF
+project. The verified capability table, the boundary of each surface, and an
+architectural before/after are in
+[One engine instead of three databases](#one-engine-instead-of-three-databases).
+
 ## Why does this exist?
 
 RDF tooling fragments along two axes.
@@ -57,6 +77,86 @@ byte-identical semantics.
 PurRDF is the data backbone of the [GMEOW](https://github.com/Blackcat-Informatics/gmeow-ontology)
 stack and the reference home of the [GTS](./docs/GTS-SPEC.md) graph-transport engine,
 but it assumes nothing about your ontology or application.
+
+## One engine instead of three databases
+
+An RDF project that needs ranked text search, spatial predicates, or
+nearest-neighbour search has usually run PostgreSQL beside its triple store for
+exactly those three jobs. PurRDF answers all three from SPARQL, over the
+dataset already in memory, through the evaluator's caller-keyed
+property-function and scalar-function seams. Every capability below is one you
+can open a crate and find; every boundary is one its tests pin.
+
+| You needed | Usually from | Now inside PurRDF | Where it stops |
+| --- | --- | --- | --- |
+| Ranked full-text search | PostgreSQL `tsvector`/`tsquery` | [`purrdf-text`](./crates/text/): an inverted index over RDF 1.2 literals (annotation layer included), Unicode case folding and word-boundary segmentation, and BM25 ranking in exact `i128` base-10 fixed point with **no floating point in the crate** (`#![deny(clippy::float_arithmetic)]`). Two relations: `?doc <iri> ( "needle" ?score ?rank ?lang ?matched )` for ranked retrieval and `?doc <iri> ( "term" ?lang ?position )` for term occurrence, from which phrase and proximity compose in plain SPARQL. | BM25 ranking, not a Lucene: no stemming, no stop-word lists, no query dialect; `k1` and `b` are fixed constants; the index is in-memory and built once over a frozen dataset (`TextIndex::from_dataset`). |
+| Spatial predicates | PostGIS | [`purrdf-geo`](./crates/geo/): GeoSPARQL 1.1 (OGC 22-047r1) — WKT and GeoJSON literals read as exact rationals, every Simple Features, Egenhofer and RCC8 relation decided over an exact DE-9IM, the `geof:` functions on the scalar seam and the Query Rewrite relations (`?a geo:sfWithin ?b` between features) on the property-function seam. No GEOS, no PROJ, no float arithmetic; the one float boundary is the `xsd:double` result literal. | Topological predicates, accessors, and the exactly computable measures and constructors over vector geometry, not a PostGIS: `geof:transform` hard-errors by name (there is no CRS database), a `metric*` measure answers only in a CRS the caller declared in metres (there is no ellipsoidal geodesic), and `buffer`, `concaveHull`, `boundingCircle`, the overlay set operations (`intersection`/`union`/`difference`/`symDifference`) and the GML/KML/DGGS encodings are registered and hard-error by name. No raster, no persistent spatial index. |
+| Vector similarity | pgvector | Embedding kNN in [`purrdf-sparql-eval`](./crates/sparql-eval/): `?neighbour <space> ( ?seed k ?distance )` over a [PURREMB](./docs/PURREMB.md) embedding space (`EmbeddingSpace::from_artifact`, `EmbeddingKnnRelation`), exact top-k under the metric the artifact declares, in binary64 with a pinned accumulation order and no fused multiply-add, ties broken by content-derived row order. | Exact search — every candidate is scored, there is no pruning and no approximate index — bounded by a caller-supplied `KnnGuard` (largest space, largest `k`; refusals, not clamps). Three metrics: cosine, negative dot, squared Euclidean. PurRDF computes no embeddings and runs no ANN payload: the vectors arrive in a PURREMB artifact the caller produced. |
+
+Two more capabilities landed on the same seam in this release: **path
+witnesses**, a property function that binds a traversal hop by hop with every
+traversed statement as an RDF 1.2 triple term, and the **SEP-0009 composite
+datatypes** (`cdt:List`/`cdt:Map`, with `FOLD` and `UNFOLD`). One divergence in
+the latter is stated rather than hidden: PurRDF admits RDF 1.2 triple terms and
+directional language-tagged literals as composite elements, a lexical superset
+that a conformant SEP-0009 reader will call ill-formed, emitted only for values
+SEP-0009 cannot express at all.
+
+**Deterministic, and therefore portable.** A Postgres stack gives one answer
+per build: `ts_rank` and pgvector distances are floating point, and PostGIS
+predicates run on GEOS's floating-point geometry. PurRDF's three surfaces are pure
+functions of their input on every target — BM25 in `i128` fixed point with a
+fixed-iteration integer logarithm, geometry as exact rationals with integer
+DE-9IM decisions, kNN in binary64 with one sequential accumulation order — and
+every ordering is canonical: document ids are assigned after sorting on
+`(graph, subject, language)`, spatial rows sort in `TermValue`'s total order,
+and kNN ties break on the content-derived `TargetId`. The claim is executed,
+not argued: the text and kNN determinism tests are one body carrying both
+`#[test]` and `#[wasm_bindgen_test]`, run natively by `cargo test` and on
+`wasm32-unknown-unknown` by `make wasm-test`, and `make geo-determinism` runs
+the same corpus on both targets and compares bytes.
+
+**In the browser.** All three crates are `wasm32-unknown-unknown`-clean and
+their determinism tests execute there — which none of the three Postgres
+extensions can do at all. They are Rust-host seams: a host builds an index or
+opens a space and registers it under its own IRIs, and that host may itself be
+compiled to wasm32 (that is how the wasm tests run). The shipped
+`@blackcatinformatics/purrdf` npm package and the `purrdf` Python wheel do not
+yet expose these three relations; the data-shaped property functions (frozen
+tables, graph-backed tables, path witnesses) are what cross those boundaries
+today.
+
+**Illustrative before/after** (the project is real; it is not named here):
+
+- *Before* — a triple store for the graph, and a PostgreSQL instance beside it
+  for `tsvector`/`tsquery` over labels and abstracts, PostGIS
+  `ST_Within`/`ST_Intersects` over feature geometries, and pgvector `<->` over
+  document embeddings: three copies of the data, one sync job to keep them
+  aligned, and every question that spanned them written half in SPARQL and
+  half in SQL.
+- *After* — one PurRDF dataset; one `PropertyFunctionRegistry` holding a
+  `TextSearchRelation`, the `geo:` Query Rewrite relations, and an
+  `EmbeddingKnnRelation`, each under the project's own IRIs; one SPARQL query
+  joining all three through basic graph patterns; and no PostgreSQL. The answer
+  is the same on the server and in the browser.
+
+```sparql
+PREFIX ex:  <https://example.org/>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+
+SELECT ?doc ?score ?distance WHERE {
+  ?doc ex:search ( "harbour dredging" ?score ?rank ?lang ?matched ) .
+  ?doc ex:locatedIn ?feature .
+  ?feature geo:sfWithin ex:PortDistrict .
+  ?doc ex:nearest ( ex:doc-42 5 ?distance )
+}
+ORDER BY ?rank
+```
+
+Each predicate above is the caller's: PurRDF mints no vocabulary, so
+`ex:search`, `ex:nearest` and the CRS behind `geo:sfWithin` are registrations
+the host supplies, and a query naming an IRI nobody registered is an ordinary
+triple pattern.
 
 ## What's inside
 
@@ -133,9 +233,11 @@ but it assumes nothing about your ontology or application.
     exactly-computable measures and constructors, with no GEOS, no PROJ and no
     float arithmetic (the one float boundary is the `xsd:double` result
     literal). The `geof:` family lands on the scalar seam and the spatial
-    relations rewrite through the property-function seam; `geof:transform` and
-    the geodesic `metric*` family are registered but **hard-error by name**
-    rather than answering a default.
+    relations rewrite through the property-function seam; `geof:transform`,
+    the buffers, hulls, overlay set operations and GML/KML/DGGS encodings are
+    registered but **hard-error by name** rather than answering a default, and
+    a `metric*` measure answers only in a CRS the caller declared in metres
+    (there is no ellipsoidal geodesic).
   - **Embedding kNN** — nearest-neighbour search over a
     [PURREMB](./docs/PURREMB.md) embedding space as a property function
     (`?neighbour <space> ( ?seed k ?distance )`): an exact search under the

--- a/docs/book/src/concepts/codecs.md
+++ b/docs/book/src/concepts/codecs.md
@@ -196,8 +196,8 @@ for every field and the deliberately narrow Parquet profile.
 ## Conformance
 
 The codecs are gated by the W3C `rdf-tests` syntax corpus, vendored and frozen
-in-repo — 250/250 round-trip cases across N-Quads, N-Triples, RDF/XML, TriG,
-and Turtle at the time of writing. The live scoreboard is
+in-repo — 264/264 round-trip cases across N-Quads, N-Triples, RDF/XML, TriG,
+and Turtle. The live scoreboard is
 [`docs/CONFORMANCE.md`](https://github.com/Blackcat-Informatics/purrdf/blob/main/docs/CONFORMANCE.md).
 
 ## Related

--- a/docs/book/src/getting-started/javascript.md
+++ b/docs/book/src/getting-started/javascript.md
@@ -100,8 +100,14 @@ More on the RDF/JS mapping in [RDF/JS in JavaScript](../interop/rdfjs.md).
 - **In-memory only.** SPARQL queries run over the in-memory dataset;
   this package provides no network resolver, so remote `SERVICE` and `LOAD`
   fail explicitly.
-- A quoted-triple term as a quad **object** currently round-trips only through
-  **N-Quads** (a current native serializer limitation for the other formats).
+- **Triple terms per format.** `serialize` is the writer-native lane: an
+  object-position quoted-triple term and the RDF 1.2 statement layer survive
+  Turtle, N-Triples, N-Quads and TriG (as `<<( … )>>`), RDF/XML (as
+  `rdf:parseType="Triple"`), and JSON-LD / YAML-LD (as `@triple`). TriX and
+  HexTuples have no triple-term surface, so serializing a dataset that carries
+  one to either of them **throws** rather than dropping the layer silently.
+  Single-graph targets (Turtle, N-Triples, RDF/XML) emit the default graph
+  alone.
 
 ## Building from source
 

--- a/docs/book/src/getting-started/python.md
+++ b/docs/book/src/getting-started/python.md
@@ -31,9 +31,9 @@ Rust `purrdf` umbrella crate — never through the internal `purrdf_native`
 extension module directly:
 
 ```python
-from purrdf import shacl, shex
+from purrdf import shapes, shex
 
-report = shacl.validate(shapes_ttl=my_shapes, data_nt=my_data)
+report = shapes.validate(shapes_ttl=my_shapes, data_nt=my_data)
 print(report["conforms"])
 
 results = shex.validate(my_schema_shexc, my_data_ttl,

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -8,10 +8,22 @@ SPDX-License-Identifier: CC-BY-4.0
 **PurRDF** is an [RDF 1.2](https://www.w3.org/TR/rdf12-concepts/) toolkit:
 primitives, codecs, SPARQL, SHACL, ShEx, entailment, and graph transport,
 implemented once in Rust and carried verbatim into Python, WebAssembly/JavaScript,
-and C. It is developed by Blackcat Informatics® Inc. and published under
+and C. Every published crate builds for `wasm32-unknown-unknown`, so the engine
+that answers a query on a server answers it, byte for byte, in a browser tab.
+It is developed by Blackcat Informatics® Inc. and published under
 MIT OR Apache-2.0.
 
 > **One RDF engine. One behavior. Every language.**
+
+**What it removes from your architecture.** The three jobs that usually keep a
+PostgreSQL instance running beside a triple store — ranked full-text search,
+spatial predicates, and vector similarity — are answered inside PurRDF:
+in-process, over the same dataset, from the same SPARQL query, with no second
+database and no sync job. Each answer is exact and deterministic, natively and
+on wasm32. This is not a projection: these query surfaces have already removed
+a whole PostgreSQL requirement from one RDF project. See
+[One engine instead of three databases](#one-engine-instead-of-three-databases)
+below.
 
 ## Why does PurRDF exist?
 
@@ -53,7 +65,10 @@ reimplemented per language.
   SHA-3 hash builtins (`SHA3-224`/`256`/`384`/`512`), quad templates that
   `CONSTRUCT` into named graphs (a first-party extension, not a SPARQL 1.2
   feature), the SEP-0009 composite datatypes (`cdt:List`/`cdt:Map`, `FOLD`,
-  `UNFOLD`), caller-registered aggregates and property functions (including
+  `UNFOLD` — with one stated divergence: PurRDF admits RDF 1.2 triple terms
+  and directional language-tagged literals as composite elements, a lexical
+  superset a conformant SEP-0009 reader will call ill-formed), caller-registered
+  aggregates and property functions (including
   path witnesses that bind a traversal hop by hop), governed execution with
   per-node explain receipts, and `SERVICE` federation through a host-injected
   resolver carrying per-service context, gated by the W3C conformance suites.
@@ -78,6 +93,29 @@ reimplemented per language.
   See [GTS Graph Transport](gts.md).
 - **Slices, mappings, and provenance** — a slice catalog, an explicit RDF↔GTS
   loss ledger, SSSOM, and FnO. See [Slices, Mappings & Provenance](slices.md).
+
+## One engine instead of three databases
+
+An RDF project that needs ranked text search, spatial predicates, or
+nearest-neighbour search has usually run PostgreSQL beside its triple store
+for exactly those three jobs. PurRDF answers all three from SPARQL, over the
+dataset already in memory, through the evaluator's caller-keyed extension seams
+— and each page below opens with what its surface replaces and where it stops.
+
+| You needed | Usually from | Now inside PurRDF | Where it stops |
+| --- | --- | --- | --- |
+| Ranked full-text search | PostgreSQL `tsvector`/`tsquery` | [Full-Text Search](sparql/full-text.md): `purrdf-text`, an inverted index over RDF 1.2 literals with BM25 ranking in exact `i128` fixed point and no floating point in the crate. | BM25 ranking, not a Lucene: no stemming, no stop-word lists, no query dialect; an in-memory index built once over a frozen dataset. |
+| Spatial predicates | PostGIS | [GeoSPARQL](sparql/geosparql.md): `purrdf-geo`, GeoSPARQL 1.1 with WKT and GeoJSON as exact rationals and every Simple Features, Egenhofer and RCC8 relation over an exact DE-9IM; no GEOS, no PROJ. | Topological predicates, accessors and exactly computable measures over vector geometry, not a PostGIS: no CRS transform, no ellipsoidal geodesic, no buffers, hulls, overlay set operations or raster — each unimplemented function hard-errors by name. |
+| Vector similarity | pgvector | [Embedding Nearest Neighbours](sparql/embedding-knn.md): exact top-k over a PURREMB embedding space, binary64 in a pinned accumulation order. | Exact scan bounded by a caller-supplied `KnnGuard`, three metrics, no approximate index; PurRDF computes no embeddings — the vectors arrive in an artifact the caller produced. |
+
+All three are pure functions of their input on every target — fixed point,
+exact rationals, or a pinned binary64 order, with canonical tie-breaks — and
+the claim is executed rather than argued: the text and kNN determinism tests
+run the same body natively and on `wasm32-unknown-unknown`, and
+`make geo-determinism` compares the two targets byte for byte. They are
+Rust-host seams: a host registers an index or space under its own IRIs, and
+that host may itself be compiled to wasm32. The shipped npm package and Python
+wheel do not yet expose these three relations.
 
 ## Two design rules worth knowing on day one
 

--- a/docs/book/src/sparql/embedding-knn.md
+++ b/docs/book/src/sparql/embedding-knn.md
@@ -5,6 +5,16 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Embedding Nearest Neighbours
 
+**What it replaces, and where it stops.** This is the surface that lets an RDF
+project drop the pgvector it kept beside its triple store for nearest-neighbour
+search: `?neighbour <space> ( ?seed k ?distance )` answered in-process, exact
+top-k under the metric the artifact declares, and byte-identical natively and
+on wasm32. It is an exact scan — every candidate scored, no pruning, no
+approximate index — bounded by a caller-supplied `KnnGuard`, under three
+metrics (cosine, negative dot, squared Euclidean), over a PURREMB embedding
+space. PurRDF computes no embeddings and runs no ANN payload: the vectors
+arrive in an artifact the caller produced.
+
 The PURREMB layer in `purrdf-core` (see
 [Deterministic embedding companions](../concepts/codecs.md#deterministic-embedding-companions)
 and [`docs/PURREMB.md`](https://github.com/Blackcat-Informatics/purrdf/blob/main/docs/PURREMB.md))

--- a/docs/book/src/sparql/full-text.md
+++ b/docs/book/src/sparql/full-text.md
@@ -5,6 +5,16 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Full-Text Search
 
+**What it replaces, and where it stops.** This is the surface that lets an RDF
+project drop the PostgreSQL `tsvector`/`tsquery` it kept beside its triple
+store for ranked text search: the question becomes a property-function call in
+the SPARQL query that already holds the graph, in-process, over the same
+dataset, and the answer is byte-identical natively and on wasm32. It is BM25
+ranking, not a Lucene — Unicode case folding and word-boundary segmentation,
+no stemming, no stop-word lists, no query dialect (phrase and proximity compose
+in SPARQL from the term-occurrence relation), fixed `k1`/`b`, and an in-memory
+index built once over a frozen dataset.
+
 `purrdf-text` (`purrdf::text` from the umbrella crate) is PurRDF's
 deterministic full-text index. It reads RDF 1.2 literals out of a frozen
 dataset, tokenizes them by the Unicode standard's own rules, and answers ranked

--- a/docs/book/src/sparql/geosparql.md
+++ b/docs/book/src/sparql/geosparql.md
@@ -5,6 +5,18 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # GeoSPARQL
 
+**What it replaces, and where it stops.** This is the surface that lets an RDF
+project drop the PostGIS it kept beside its triple store for spatial
+predicates: `?a geo:sfWithin ?b` and its Simple Features, Egenhofer and RCC8
+siblings, plus the `geof:` functions, answered in-process over the dataset the
+query already holds, exactly, with no GEOS or PROJ, and byte-identical natively
+and on wasm32. It is GeoSPARQL 1.1's topological predicates, accessors, and
+exactly computable measures and constructors over vector geometry, not a
+PostGIS: `geof:transform` hard-errors by name (there is no CRS database), a
+`metric*` measure answers only in a CRS the caller declared in metres (there is
+no ellipsoidal geodesic), and buffers, hulls, the overlay set operations and
+the GML/KML/DGGS encodings are registered and hard-error by name. No raster.
+
 `purrdf-geo` (`purrdf::geo` from the umbrella crate) implements GeoSPARQL 1.1
 (OGC 22-047r1) for PurRDF: exact, float-free geometry reached from SPARQL
 through the evaluator's two existing extension seams. It parses

--- a/docs/book/src/sparql/querying.md
+++ b/docs/book/src/sparql/querying.md
@@ -109,7 +109,7 @@ Anything outside this surface — and every malformed query — is a typed
   with certified rows rather than a wrong answer, and `explain_query` returns
   a `QueryExplanation` whose ledger decomposes the fuel spent per algebra node
   and per charge point, beside the cost planner's estimate for each basic
-  graph pattern. The normative charge schedule and the frozen 49-case governor
+  graph pattern. The normative charge schedule and the frozen 50-case governor
   corpus are documented in
   [`docs/SPARQL-GOVERNOR-PROFILE.md`](https://github.com/Blackcat-Informatics/purrdf/blob/main/docs/SPARQL-GOVERNOR-PROFILE.md).
 - **Hard-fail** — an out-of-scope algebra node or unimplemented builtin is a

--- a/scripts/check-doc-claims.py
+++ b/scripts/check-doc-claims.py
@@ -4540,6 +4540,36 @@ def build_claims(
             {"total": corpus_pass},
             mat,
         ),
+        # The codecs chapter restates the syntax-codec round-trip count in prose.
+        # It said 250/250 while the generated matrix block and the root README's
+        # gated scoreboard row both said 264 — the same ungated-prose drift this
+        # script exists to catch, on a page its claim list did not name.
+        Claim(
+            "the codecs chapter's W3C round-trip count",
+            _REPO / "docs" / "book" / "src" / "concepts" / "codecs.md",
+            _flow(r"(?P<pass>\d+)/(?P<total>\d+) round-trip cases across"),
+            {"pass": codec_pass, "total": codec_pass},
+            mat,
+        ),
+        # The governor corpus size is restated in running prose on two front pages
+        # ("the frozen N-case governor corpus"), two hundred lines from the gated
+        # scoreboard row in the README's case. Both said 49 against a 50-case
+        # manifest; `governor_corpus_count_claim` gates the scoreboard and the
+        # profile document, and these two gate the prose mentions.
+        Claim(
+            "the root README's governor-corpus size in prose",
+            _README,
+            _flow(r"the frozen (?P<total>\d+)-case governor corpus"),
+            {"total": governor_pass},
+            mat,
+        ),
+        Claim(
+            "the querying chapter's governor-corpus size in prose",
+            _REPO / "docs" / "book" / "src" / "sparql" / "querying.md",
+            _flow(r"the frozen (?P<total>\d+)-case governor corpus"),
+            {"total": governor_pass},
+            mat,
+        ),
     ]
     claims += [
         Claim(


### PR DESCRIPTION
## What

Leads the README, the book introduction, the three surface pages and the citation abstract with what PurRDF removes from an architecture: the full-text, spatial and vector-similarity queries an RDF project usually kept PostgreSQL beside its triple store for, answered from SPARQL, in-process, over one dataset, deterministically on native and wasm32. Also applied a new GitHub repo description. Nothing in `README.zh-Hans.md` or any `.po` file was touched; the translator was messaged with the commit SHA and a map of what moved.

## Verified capability table

| Surface | Claim in the docs | Establishing code | Test that exercises it |
| --- | --- | --- | --- |
| `purrdf-text` — BM25 in exact `i128` base-10 fixed point, no floating point in the crate | `crates/text/src/lib.rs:67` `#![deny(clippy::float_arithmetic)]`; `crates/text/src/fixed.rs:110` `pub struct Fixed(i128)`; `crates/text/src/fixed.rs:83` integer `ln` series | `crates/text/tests/fixed_point.rs`, `crates/text/tests/scoring.rs` |
| `purrdf-text` — ranked retrieval `?doc <iri> ( "needle" ?score ?rank ?lang ?matched )` and term occurrence `?doc <iri> ( "term" ?lang ?position )` | `crates/text/src/relation.rs:63-79` position constants, `SEARCH_MODE = "fbffff"`; public names `TextIndex`, `TextIndexConfig`, `GraphSelector`, `TextSearchRelation`, `TermOccurrenceRelation` (`crates/text/src/lib.rs:78-85`) | `crates/text/tests/search_property_function.rs::ranked_rows_for_a_needle` (l.303), `::a_document_subject_joins_back_by_bgp` (l.599), `::order_by_rank_is_the_reproducing_idiom` (l.568); `crates/text/tests/phrase_composition.rs` |
| `purrdf-text` — annotation layer indexed | `crates/text/src/index.rs:31-49` | `search_property_function.rs::annotation_text_is_searchable_through_sparql` (l.359) |
| `purrdf-text` — byte-identical native and wasm32 | `crates/text/tests/wasm_determinism.rs:152-153` one body with `#[test]` + `#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]` | `::the_pinned_ranking_is_reproduced_on_this_target`; `make wasm-test` |
| `purrdf-geo` — WKT/GeoJSON as exact rationals, SF/Egenhofer/RCC8 over exact DE-9IM, no GEOS/PROJ, no float arithmetic | `crates/geo/src/lib.rs:88` `#![deny(clippy::float_arithmetic)]`; `exact::Rat::parse_decimal`, `exact::Rat::to_f64` (lib.rs rustdoc l.36-52); `RelationFamily` (`relations.rs`) | `crates/geo/tests/scalar_functions_e2e.rs`; `crates/geo/tests/query_rewrite_e2e.rs::the_rewritten_within_predicate_answers_exactly_the_entailed_rows_from_query_text` (l.446), `::contains_is_the_converse_of_within_over_the_same_data` (l.589) |
| `purrdf-geo` — `geof:` on the scalar seam, Query Rewrite relations on the property-function seam | `crates/geo/src/functions.rs` `register`; `crates/geo/src/relation.rs` `GeoIndex::from_dataset`, `GeoIndexConfig::new` (l.300), `register` | same e2e files; `query_rewrite_e2e.rs::all_four_rewrite_branches_are_reachable_from_query_text` (l.476) |
| `purrdf-geo` — same bytes native and wasm32 | `scripts/check-geo-determinism.sh` (native vs `wasm32-unknown-unknown` cdylib in Node) | `crates/geo/tests/determinism.rs::the_native_digest_is_the_pinned_golden` (l.42); `make geo-determinism` |
| Embedding kNN — `?neighbour <space> ( ?seed k ?distance )`, exact top-k, rank order | `crates/sparql-eval/src/knn/mod.rs:52-59` ("every candidate row is scored … there is no candidate pruning anywhere"); `KNN_MODE = "fbbf"` (l.~113); `EmbeddingSpace::from_artifact`, `EmbeddingKnnRelation::new`, `KnnGuard::new` | `crates/sparql-eval/tests/embedding_knn_e2e.rs::the_k_returned_are_the_true_k_nearest_of_a_crowded_space` (l.596), `::a_registered_space_answers_a_knn_query_in_rank_order` (l.245), `::a_limit_yields_the_prefix_of_the_unlimited_answer_at_every_k` (l.307) |
| Embedding kNN — binary64, pinned accumulation order, no FMA, content-derived tie-break | `crates/sparql-eval/src/knn/metric.rs` module doc + `Kernel`; `mod.rs` "Determinism" section | `embedding_knn_e2e.rs::the_answer_is_byte_identical_across_two_independently_built_artifacts` (l.327); `crates/sparql-eval/tests/knn_wasm_determinism.rs::the_pinned_answer_is_reproduced_on_this_target` (l.275, `#[test]` + `wasm_bindgen_test`) |

## Boundary statements, and the line that establishes each

- **`purrdf-text` is BM25 ranking, not a Lucene.** No stemming and no stop-word lists: `grep -ri 'stem\|stopword' crates/text/src` is empty. No query dialect: phrase/proximity compose in SPARQL (`crates/text/src/relation.rs` module doc; `tests/phrase_composition.rs`). `k1`/`b` are crate constants (`crates/text/src/score.rs` `K1`, `B`, re-exported at `lib.rs:82`). In-memory, built once over a frozen dataset: `TextIndex::from_dataset` (`crates/text/src/index.rs:439`); `verify_binding` closes the stale-index channel.
- **`purrdf-geo` is GeoSPARQL 1.1 topological predicates + accessors + exactly computable measures/constructors, not a PostGIS.** `crates/geo/src/functions.rs:187-209` lists `transform`, `buffer`, `metricBuffer`, `boundingCircle`, `concaveHull`, `intersection`, `union`, `difference`, `symDifference`, `asGML`, `asKML`, `asDGGS` as "registered, unimplemented, hard-errors by name", with reasons at `unsupported_reason` (l.441). `metric*` measures are **not** hard-errors: `metric_measure` (`functions.rs:1179-1187`) calls `vocab.require_metre(literal.crs())` and answers in a metre-declared CRS — so the README's previous "the geodesic `metric*` family hard-errors by name" was an over-refusal claim and this PR corrects it in the one bullet that said it. GML/KML/DGGS literals are `GeoError::Unsupported` (`relation.rs:55-59`). No raster anywhere in the crate.
- **Embedding kNN is an exact bounded scan over a caller-produced PURREMB space; PurRDF computes no embeddings and runs no ANN.** Exactness: `knn/mod.rs:52-59`. No ANN: `knn/mod.rs:69-73` ("it is not an ANN algorithm PurRDF can run. So this surface does not pretend to run one"). Bound: `KnnGuard` (`mod.rs` ~l.130-190; `max_candidates` refuses at construction, `max_neighbours` refuses per call). Three metrics only: `metric.rs` `Kernel::{Cosine, NegativeDot, SquaredEuclidean}`, `Kernel::of` returns `None` for an extension metric. No embedding computation: `docs/PURREMB.md:52` ("PURREMB v1 does not store corpus text, select or train a model…"); the e2e test builds the artifact with `EmbeddingBuilder` from caller vectors.
- **All three are Rust-host seams; the shipped npm and Python packages do not expose them.** `crates/rdf-wasm/Cargo.toml` and `bindings/python/Cargo.toml` carry no `purrdf-text`/`purrdf-geo` dependency and no `knn` reference (`grep` empty); only `crates/purrdf/Cargo.toml:54,59` (the umbrella) does. The README's "In the browser" paragraph says exactly this.
- **SEP-0009 divergence** restated in the new README section and added to the book introduction's SPARQL bullet (it was previously missing there).

## Repo description

Before:
> PurRDF — one RDF 1.2 engine, one behavior, every language: interned primitives, native codecs, RDFC-1.0, SPARQL 1.1/1.2 with deterministic full-text search and GeoSPARQL, SHACL, ShEx, entailment, GTS graph transport, and Python/WebAssembly/C bindings.

After (347 chars, applied with `gh repo edit --description`):
> PurRDF — one RDF 1.2 engine, one behavior, in Rust, Python, WebAssembly and C. Deterministic BM25 full-text search, exact GeoSPARQL 1.1 and embedding kNN answered from SPARQL, in-process, over one dataset: the three jobs a triple store usually kept PostgreSQL beside it for. Plus native codecs, RDFC-1.0, SHACL, ShEx, entailment and GTS transport.

## Message sent to the translator coordinator

> README.md restructure pushed on branch paudley/value-prop at commit 869f1a28496fbeaa2219cb4c4ef6920eb0109839 — the Chinese translator should re-base onto this version, not the old opening. What moved: (1) new lead prose after the badges; (2) "Why does this exist?" unchanged, now after the lead; (3) new "## One engine instead of three databases" section between it and "What's inside" (table, path-witness/CDT paragraph with the divergence, "Deterministic, and therefore portable", "In the browser", illustrative before/after, one ```sparql block, closing paragraph); (4) one sentence in the GeoSPARQL bullet under "Out-of-core SPARQL extensions" (the `geof:transform`/`metric*` boundary). Everything from "## What's inside" onward is byte-identical to origin/main. Also changed: docs/book/src/introduction.md, the three sparql/*.md openings, one CITATION.cff sentence. README.zh-Hans.md and .po files untouched.

## Gates

- `scripts/check-issue-refs.py`, `check-brand-casing.py`, `check-spec-attribution.py --self-test`, `check-doc-claims.py`, `check-licenses.py`: all OK after `git add`.
- `mdbook build docs/book`: OK.
- `cargo test -p purrdf-sparql-algebra --test serializer_roundtrip_sweep`: OK (the new fenced ```sparql block parses).
- `make check`: running; result posted before merge.
- `.deficiencies` untouched (notice + marker only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the README and user guide with an overview of RDF 1.2 support and in-process full-text, geospatial, and vector-search capabilities.
  - Documented browser/WebAssembly support and consistent native/WebAssembly results.
  - Added guidance for full-text search, GeoSPARQL, and embedding kNN queries, including supported metrics, limits, and current constraints.
  - Added capability comparisons, migration guidance, examples, and details on unsupported geospatial operations and raster data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->