### PR TITLE
ci(i18n): CJK-aware prose gates, pinned mdbook-i18n-helpers, and a gate over the rendered zh-Hans book (phase 0)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,9 @@ jobs:
       - name: Check no first-party extension is attributed to a SPARQL specification
         run: python3 scripts/check-spec-attribution.py --self-test
 
+      - name: Check the zh-Hans translation against its glossary
+        run: python3 scripts/check-i18n-glossary.py
+
       - name: Check cross-registry release coherence
         run: python3 scripts/check-versions.py
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,6 +8,14 @@ on:
       - "docs/book/**"
       - "docs/playground/**"
       - "crates/rdf-wasm/**"
+      # The zh-Hans gate renders the book and runs these over the rendering.
+      - "crates/sparql-algebra/**"
+      - "scripts/check-i18n-*.py"
+      - "scripts/po_catalog.py"
+      - "scripts/check-brand-casing.py"
+      - "scripts/check-issue-refs.py"
+      - "scripts/check-spec-attribution.py"
+      - "scripts/check-doc-claims.py"
       - "Makefile"
       - ".github/actions/wasm-toolchain/**"
       - ".github/workflows/docs.yaml"
@@ -15,7 +23,9 @@ on:
     branches:
       - main
 
-# Pinned so local (`make book`) and CI builds stay reproducible.
+# Pinned so local (`make book`) and CI builds stay reproducible. The second
+# pinned tool, mdbook-i18n-helpers, is read from the Makefile below
+# (MDBOOK_I18N_HELPERS_VERSION) so it has one source of truth.
 env:
   MDBOOK_VERSION: 0.5.3
 
@@ -36,12 +46,10 @@ jobs:
             | tar -xz -C "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Build book
-        run: mdbook build docs/book
-
-      # The RDF-1.2 console is a static surface built from the SAME wasm the npm
-      # release publishes; it ships as a /playground subpath of the single Pages
-      # artifact (GitHub Pages allows only one deployment, already owned here).
+      # Rust and the cached toolchain come BEFORE the book builds: the zh-Hans
+      # gate compiles a small example (the SPARQL fence parser) and the
+      # rust-cache the wasm-toolchain action sets up also restores ~/.cargo/bin,
+      # which is where the pinned mdbook-i18n-helpers lands.
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
         with:
@@ -50,6 +58,37 @@ jobs:
 
       - name: Set up the pinned wasm toolchain (wasm-bindgen + binaryen) and cache
         uses: ./.github/actions/wasm-toolchain
+
+      - name: Install mdbook-i18n-helpers (pinned in the Makefile)
+        run: |
+          set -euo pipefail
+          ver="$(grep -oP '^MDBOOK_I18N_HELPERS_VERSION := \K[0-9.]+' Makefile)"
+          test -n "$ver" || { echo "could not read MDBOOK_I18N_HELPERS_VERSION from Makefile"; exit 1; }
+          # Idempotent: an already-installed matching version is skipped, so a
+          # restored ~/.cargo/bin costs nothing and a cold runner builds it once.
+          cargo install mdbook-i18n-helpers --version "$ver" --locked
+          cargo install --list | grep -qx "mdbook-i18n-helpers v${ver}:" \
+            || { echo "mdbook-i18n-helpers ${ver} is not what cargo reports installed"; cargo install --list; exit 1; }
+          echo "mdbook-i18n-helpers ${ver} installed"
+
+      - name: Build book
+        run: mdbook build docs/book
+
+      # The translation catalogue is invisible to every other gate (no gate
+      # reads a .po), so the zh-Hans book is rendered to Markdown here and the
+      # four prose gates plus the SPARQL fence parser run over the rendering —
+      # after proving each arm can go red (--self-test inside `make check-i18n`).
+      - name: Gate the zh-Hans translation (render + prose gates + SPARQL fence parser)
+        run: make check-i18n
+
+      # Folded into the same Pages artifact at /zh-Hans/. Search is off on this
+      # build (see docs/book/book.toml): the index holds zero CJK tokens.
+      - name: Build the zh-Hans book into the Pages artifact at /zh-Hans
+        run: make book-zh
+
+      # The RDF-1.2 console is a static surface built from the SAME wasm the npm
+      # release publishes; it ships as a /playground subpath of the single Pages
+      # artifact (GitHub Pages allows only one deployment, already owned here).
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ $(error unable to resolve CARGO_TARGET_DIR; set it explicitly or ensure cargo me
 endif
 CAPI_HEADER := crates/rdf-capi/include/purrdf.h
 
-.PHONY: help metadata fmt check geo-determinism book book-samples check-issue-refs check-brand-casing check-spec-attribution changelog bump release-tags test doc bench bench-python columnar-oracle csvw-conformance csvw-oracle obographs-oracle projection-oracles pydantic-oracle linkml-oracle typescript-oracle graphql-oracle pytest conformance iri-resolver-hygiene rdf-core-hygiene wasm wasm-test wasm-pkg wasm-pkg-test wasm-pkg-bench playground playground-smoke \
+.PHONY: help metadata fmt check geo-determinism book book-samples book-pot book-po-update book-zh check-i18n check-issue-refs check-brand-casing check-spec-attribution changelog bump release-tags test doc bench bench-python columnar-oracle csvw-conformance csvw-oracle obographs-oracle projection-oracles pydantic-oracle linkml-oracle typescript-oracle graphql-oracle pytest conformance iri-resolver-hygiene rdf-core-hygiene wasm wasm-test wasm-pkg wasm-pkg-test wasm-pkg-bench playground playground-smoke \
 	capi-build capi-header capi-check capi-install
 
 # The changelog generator is pinned so the committed CHANGELOG.md and the notes
@@ -25,6 +25,15 @@ GIT_CLIFF_VERSION := 2.13.1
 # wasm-toolchain composite action reads this same value, so the pin lives in one
 # place.
 BINARYEN_VERSION := 130
+
+# mdbook-i18n-helpers — the gettext preprocessor, the .pot extractor and the
+# .po normalizer behind the zh-Hans book — is pinned so the extracted msgids
+# and the rendered translation are reproducible across machines, exactly like
+# git-cliff and binaryen above. `check-i18n` hard-fails unless
+# `cargo install --list` reports this version (the binaries carry no version
+# of their own, so the install record is the check); docs.yaml reads this same
+# value, so the pin lives in one place.
+MDBOOK_I18N_HELPERS_VERSION := 0.4.0
 
 help: ## Show this help.
 	@grep -E '^[a-zA-Z_-]+:.*## ' $(MAKEFILE_LIST) | awk -F':.*## ' '{printf "  %-18s %s\n", $$1, $$2}'
@@ -49,6 +58,7 @@ check: ## The full local gate: fmt, clippy, build, tests, hygiene.
 	python3 scripts/check-issue-refs.py
 	python3 scripts/check-brand-casing.py
 	python3 scripts/check-spec-attribution.py --self-test
+	python3 scripts/check-i18n-glossary.py
 	python3 scripts/check-versions.py
 	python3 scripts/check-publish-order.py
 	python3 scripts/check-wasm-js-exports.py
@@ -66,6 +76,10 @@ check-brand-casing: ## Reject bare lowercase 'purrdf' in prose (project is PurRD
 
 check-spec-attribution: ## Reject attributing a first-party extension (the quad template) to a SPARQL spec.
 	python3 scripts/check-spec-attribution.py --self-test
+
+check-i18n: ## Gate the zh-Hans translation: the glossary, then render it and run the prose gates + the SPARQL fence parser over the rendering (needs mdbook + the pinned mdbook-i18n-helpers).
+	python3 scripts/check-i18n-glossary.py
+	python3 scripts/check-i18n-render.py --self-test
 
 changelog: ## Regenerate the deterministic CHANGELOG.md from conventional-commit history.
 	@# git-cliff regenerates the WHOLE file from commit SUBJECTS and has no
@@ -161,6 +175,15 @@ book-samples: ## Regenerate deterministic SVG visualization samples embedded in 
 
 book: book-samples ## Build The PurRDF Book (mdBook user guide) into docs/book/book/.
 	mdbook build docs/book
+
+book-zh: ## Build the zh-Hans book into docs/book/book/zh-Hans/ (after `book`; search off — see book.toml).
+	MDBOOK_BOOK__LANGUAGE=zh-Hans MDBOOK_OUTPUT__HTML__SEARCH__ENABLE=false mdbook build -d docs/book/book/zh-Hans docs/book
+
+book-pot: ## Extract the translation template docs/book/po/messages.pot (ignored) from the English book.
+	MDBOOK_OUTPUT='{"xgettext": {"pot-file": "messages.pot"}}' mdbook build -d docs/book/po docs/book
+
+book-po-update: book-pot ## Refresh docs/book/po/zh-Hans.po against the current English source (msgmerge; fuzzy/obsolete entries render as English until retranslated).
+	msgmerge --quiet --update --backup=none docs/book/po/zh-Hans.po docs/book/po/messages.pot
 
 bench: ## Run criterion benchmarks (report-only; never a gate).
 	cargo bench -p purrdf-gts -p purrdf-core -p purrdf-columnar -p purrdf-rdf -p purrdf-sparql-eval -p purrdf-geo -p purrdf-text -p purrdf-shapes -p purrdf-wasm -p purrdf-entail -p purrdf-iri -p purrdf-xsd -p purrdf-sparql-algebra -p purrdf-sparql-results

--- a/crates/sparql-algebra/examples/sweep_sparql_fences.rs
+++ b/crates/sparql-algebra/examples/sweep_sparql_fences.rs
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Parse every fenced ` ```sparql ` block under one or more Markdown trees,
+//! and fail on the first that does not parse.
+//!
+//! The sibling of `tests/serializer_roundtrip_sweep.rs` for a tree that test
+//! cannot see: a RENDERED, TRANSLATED book. That test sweeps the fenced
+//! blocks under `docs/**` — the English source — and a gettext `.po` file is
+//! reached by no test and no script at all, so a translator who edits a code
+//! block (a translated keyword, a full-width `｛` or `。` inside the query)
+//! would ship a book whose examples no longer parse with every gate green.
+//! `scripts/check-i18n-render.py` renders the translated book to Markdown
+//! (`mdbook build` with the `markdown` renderer and the `gettext`
+//! preprocessor) and runs this over the result.
+//!
+//! Every block must parse, as a query or as an update — the same routing the
+//! round-trip sweep applies to a doc example — with no ceiling and no ledger:
+//! the English source's fences all parse (`shipped_sparql_examples.rs`
+//! hard-fails on the first that does not), an untranslated block renders as
+//! its English source, and a translated block that stops parsing is a
+//! translation defect, never a parser regression to be tallied. A tree with
+//! no fenced block at all is a failure too, not a pass: this program's whole
+//! failure mode is printing OK over a tree it never read.
+//!
+//! ```sh
+//! cargo run -p purrdf-sparql-algebra --example sweep_sparql_fences -- DIR [DIR ...]
+//! ```
+//!
+//! Exit status 0 when every block parsed, 1 otherwise (or on a usage error).
+//! Output goes to stdout; failures name the file and the block's ordinal.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use purrdf_sparql_algebra::SparqlParser;
+
+/// Every `.md` file under `dir`, recursively, in a stable (sorted) order.
+fn markdown_files(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let Ok(rd) = std::fs::read_dir(&d) else {
+            continue;
+        };
+        for entry in rd.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("md") {
+                out.push(path);
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Every fenced ` ```sparql ` block in `text`, whole, as `(ordinal, body)`.
+/// The same extraction `serializer_roundtrip_sweep.rs` applies: a fence
+/// opener whose info string starts with `sparql`, closed by the next fence.
+fn sparql_fences(text: &str) -> Vec<(usize, String)> {
+    let mut out = Vec::new();
+    let mut in_fence = false;
+    let mut body = String::new();
+    let mut ordinal = 0usize;
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        if in_fence {
+            if trimmed.starts_with("```") {
+                in_fence = false;
+                ordinal += 1;
+                out.push((ordinal, std::mem::take(&mut body)));
+            } else {
+                body.push_str(line);
+                body.push('\n');
+            }
+            continue;
+        }
+        if trimmed.starts_with("```sparql") {
+            in_fence = true;
+            body.clear();
+        }
+    }
+    out
+}
+
+/// Why a block did not parse: the query-lane error and the update-lane error,
+/// since a block is tried as both and neither succeeded.
+fn parse_failure(parser: &SparqlParser, text: &str) -> Option<String> {
+    let Err(query_err) = parser.parse_query(text) else {
+        return None;
+    };
+    match parser.parse_update(text) {
+        Ok(_) => None,
+        Err(update_err) => Some(format!(
+            "as a query: {query_err}\n    as an update: {update_err}"
+        )),
+    }
+}
+
+fn main() -> ExitCode {
+    let dirs: Vec<PathBuf> = std::env::args_os().skip(1).map(PathBuf::from).collect();
+    if dirs.is_empty() {
+        eprintln!("usage: sweep_sparql_fences DIR [DIR ...]");
+        return ExitCode::from(1);
+    }
+    // The same base the round-trip sweep parses with: a fixture-style relative
+    // IRI (`<g>`) in an example is a legitimate query, not a syntax error, and
+    // `example.org` is the repository's fixture convention.
+    let parser = SparqlParser::new().with_base_iri("https://example.org/corpus/");
+    let mut files = 0usize;
+    let mut blocks = 0usize;
+    let mut failures = Vec::new();
+    for dir in &dirs {
+        if !dir.is_dir() {
+            eprintln!("sweep_sparql_fences: {} is not a directory", dir.display());
+            return ExitCode::from(1);
+        }
+        for file in markdown_files(dir) {
+            files += 1;
+            let text = match std::fs::read_to_string(&file) {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("sweep_sparql_fences: read {}: {e}", file.display());
+                    return ExitCode::from(1);
+                }
+            };
+            for (ordinal, body) in sparql_fences(&text) {
+                blocks += 1;
+                if let Some(why) = parse_failure(&parser, &body) {
+                    failures.push(format!(
+                        "{}#sparql-block-{ordinal}: does not parse\n    {why}",
+                        file.display()
+                    ));
+                }
+            }
+        }
+    }
+    if blocks == 0 {
+        eprintln!(
+            "sweep_sparql_fences: no fenced ```sparql block in {files} Markdown file(s) under \
+             the given tree(s) — a sweep that read nothing proves nothing"
+        );
+        return ExitCode::from(1);
+    }
+    if !failures.is_empty() {
+        eprintln!(
+            "sweep_sparql_fences: {} of {blocks} fenced sparql block(s) do not parse:\n\n{}",
+            failures.len(),
+            failures.join("\n\n")
+        );
+        return ExitCode::from(1);
+    }
+    println!(
+        "sweep_sparql_fences: OK — {blocks} fenced sparql block(s) in {files} Markdown file(s) \
+         all parse as a query or an update"
+    );
+    ExitCode::SUCCESS
+}

--- a/docs/book/.gitignore
+++ b/docs/book/.gitignore
@@ -1,3 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 # SPDX-License-Identifier: CC-BY-4.0
 book/
+# Regenerated from src/ by `make book-pot`; the committed catalogue is po/zh-Hans.po.
+po/messages.pot

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -7,6 +7,30 @@ authors = ["Blackcat Informatics® Inc."]
 language = "en"
 src = "src"
 
+# Translations are gettext catalogues under po/ (mdbook-i18n-helpers, pinned by
+# MDBOOK_I18N_HELPERS_VERSION in the Makefile and .github/workflows/docs.yaml).
+# A build with MDBOOK_BOOK__LANGUAGE=zh-Hans applies po/zh-Hans.po; a msgid with
+# no translation renders as its English source, so translation lag is visible
+# to the reader paragraph by paragraph rather than hidden behind a stale page.
+# `after = ["links"]` so {{#include}} is expanded before extraction and lookup.
+# The English build finds no po/en.po and passes the book through unchanged.
+[preprocessor.gettext]
+after = ["links"]
+
 [output.html]
 git-repository-url = "https://github.com/Blackcat-Informatics/purrdf"
 edit-url-template = "https://github.com/Blackcat-Informatics/purrdf/edit/main/docs/book/src/{path}"
+
+# Search is ON for the English book and OFF for the zh-Hans build, which is
+# rendered with MDBOOK_OUTPUT__HTML__SEARCH__ENABLE=false (Makefile `book-zh`,
+# the single command docs.yaml also runs). Measured, not assumed: mdBook's
+# search is elasticlunr with the `/[\s\-]+/` tokenizer and the English
+# pipeline (trimmer, stop-word filter, stemmer), and on both mdBook 0.4.52 and
+# the CI-pinned 0.5.3 a Chinese page contributes ZERO CJK tokens to the index —
+# a heading of 三元组项与具体化 produces an empty `title` branch, and only the
+# Latin tokens (`rdf`, `sparql`, `1.2`) survive. A live search box that answers
+# every Chinese query with "no results" reads as "the book does not cover
+# this", which is a silent failure aimed at exactly the reader the translation
+# is for; so the zh-Hans build has no search box at all.
+[output.html.search]
+enable = true

--- a/docs/book/po/glossary-zh-Hans.md
+++ b/docs/book/po/glossary-zh-Hans.md
@@ -1,0 +1,95 @@
+<!--
+SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# zh-Hans glossary — a gate input, not a page
+
+This file is read by `scripts/check-i18n-glossary.py` (part of `make check`
+and CI). Every translated unit — each `msgstr` in `po/zh-Hans.po` and every
+line of every tracked Markdown file with `zh-Hans` in its path
+(`README.zh-Hans.md`, `docs/book/po/zh-Hans/**`) — is rejected if it uses a rendering listed in the
+**Rejected** column: a wrong or inconsistent rendering of a load-bearing term
+is worse than English with a gloss, and the gate is what keeps ten translators
+from producing four words for one concept.
+
+Policy, settled by the house page (<https://blackcatinformatics.ca/zh/> and
+its `/zh/purrdf/` page):
+
+1. Specification names and acronyms stay English: `PurRDF`, `GMEOW`, `GTS`,
+   RDF 1.2, SPARQL, SHACL, ShEx, OWL 2 DL, IRI, JSON-LD, Turtle. Every IRI,
+   prefixed name, keyword, diagnostic code, crate/module/API name, CLI flag,
+   file path, spec section number (`SEP-0009`, `RDFC-1.0`) and profile
+   identifier (`purrdf-rdfc12`) is invariant and appears in backticks where
+   the English does.
+2. Concepts with a settled mainland knowledge-graph (知识图谱) rendering use
+   it.
+3. A coined term (**C**) carries the English term in parentheses on its first
+   use on a page — 「蕴涵机制（entailment regime）」 — and stands alone
+   afterwards on that page.
+4. Where no rendering is confident (**K**), the English word stays inside the
+   Chinese sentence, as the house page does with `LLM` and `DevOps`, glossed
+   once.
+5. Typography: full-width CJK punctuation (。，：；「」), a half-width space
+   between a Latin run and a CJK run, code and identifiers in backticks.
+
+**Basis** legend — **E**: established mainland rendering; **H**: fixed by the
+house page; **C**: no established rendering, PurRDF coins one; **K**: keep
+English, gloss on first use.
+
+**Rejected** column syntax — entries separated by `、`; a plain entry is a
+substring the gate refuses anywhere in a translated unit; an entry written
+`/…/` is a Python regular expression, used where a wrong rendering would
+otherwise match across a word boundary (账本 inside 台账本身) or inside a
+right one (知识图 inside 知识图谱). Only list a rejection that is wrong
+*wherever it appears*: 来源 is not listed against *provenance* because it is
+the ordinary word for a data source, bare 闭包 is not listed against
+*closure* because 传递闭包, 宿主闭包 and 求闭包 are all correct, and a gate that
+refuses ordinary prose is a gate that gets switched off. Both of those were
+found by running the gate over the first translated drafts, not guessed.
+
+| # | Term | Rendering | Basis | Rejected | Note |
+|---:|---|---|---|---|---|
+| 1 | triple | 三元组 | E, H | — | universal in 知识图谱 literature |
+| 2 | quad | 四元组 | E | — | |
+| 3 | named graph | 命名图 | E | 具名图 | 具名图 is the zh-Hant rendering |
+| 4 | dataset | 数据集 | E, H | 资料集 | 资料集 is the zh-Hant rendering |
+| 5 | blank node | 空节点 | E | 空白节点 | |
+| 6 | literal | 字面量 | E | 字面值 | |
+| 7 | datatype | 数据类型 | E | 资料类型 | |
+| 8 | language tag | 语言标签 | E | 语言标记 | |
+| 9 | IRI | IRI | K | — | gloss 国际化资源标识符 once; never translate in running text |
+| 10 | ontology | 本体 | E, H | 本体论 | 本体论 is the philosophical sense |
+| 11 | knowledge graph | 知识图谱 | E | `/知识图(?!谱)/` | the audience's own term for the field |
+| 12 | reasoning / inference | 推理 | E, H | — | house: 「以推理为核心」 |
+| 13 | entailment | 蕴涵 | E (logic) | 蕴含 | 蕴含 also circulates; this book uses 蕴涵 only |
+| 14 | entailment regime | 蕴涵机制 | C | — | keep "(entailment regime)" on first use; no W3C precedent |
+| 15 | materialization | 物化 | E | 实体化 | database/KG usage |
+| 16 | closure (inference) | 推理闭包 | E, qualified | — | qualify on first use on a page; bare 闭包 is NOT gated, because 传递闭包 (transitive closure), 宿主闭包 (a host closure, the programming sense) and the verb phrase 求闭包 (compute the closure) are all correct and all contain it |
+| 17 | canonicalization | 规范化 | H | 标准化 | not 标准化; `RDFC-1.0` is invariant |
+| 18 | canonicalization profile | 规范化 profile | K + H | — | "profile" has no settled rendering (子集/概貌/配置 all circulate); keep English; `purrdf-rdfc12` is invariant |
+| 19 | codec / serialization | 编解码器 / 序列化 | H, E | — | |
+| 20 | round-trip | 往返（转换） | E | — | |
+| 21 | determinism | 确定性 | E | 决定性 | |
+| 22 | provenance | 溯源 | H | 出处 | house: 声明溯源; not 出处/来源 (来源 is not gated, see above) |
+| 23 | triple term (RDF 1.2) | 三元组项 | H | 三元组术语、三元组词项 | adopted by the house `/zh/purrdf/` page; W3C has none |
+| 24 | reifier / `rdf:reifies` | 具体化节点 / `rdf:reifies` | C | — | 具体化 (reification) is established; the noun for the subject is coined; the IRI never changes |
+| 25 | statement layer / annotation | 陈述层 / 注解 | C / E | — | 陈述 (statement) is established; 注解 for the `{| |}` annotation syntax |
+| 26 | base direction (`--ltr`/`--rtl`) | 基础方向 | C, with precedent | 基本方向 | W3C i18n articles in Chinese use 基础方向 for HTML/CSS base direction; the flags are invariant |
+| 27 | property function | 属性函数 | E (Jena usage) | — | Chinese Jena material uses 属性函数 |
+| 28 | composite datatype (`SEP-0009`) | 复合数据类型 | E | 组合数据类型 | natural DB rendering; the SEP number stays |
+| 29 | governor / budget | governor（执行调控器）/ 预算 | K / E | — | no settled rendering for "governor" in this sense; 预算 is established for resource budgets |
+| 30 | ledgered (`xfail` ledger) | 台账（预期失败台账） | E, qualified | `/(?<!台)账本/` | 台账 is the engineering register word; 账本 reads as blockchain. The lookbehind spares 台账本身 ("the ledger itself"), where 账本 straddles two words |
+| 31 | walk vs. path | 游走 vs. 路径 | E | — | the pair maps cleanly (随机游走 is standard); keep the distinction the code makes |
+| 32 | out-of-core | 核外 | E (HPC) | — | 核外计算 is standard |
+| 33 | interned / interner | 驻留 / 驻留表 | E (Python community) | — | |
+| 34 | fixpoint, semi-naive | 不动点, 半朴素 | E | — | |
+| 35 | embedding, kNN, full-text search | 嵌入（向量嵌入）, k 近邻, 全文检索 | E | 全文搜索 | the audience's core vocabulary |
+| 36 | slice | 切片 | E | — | |
+| 37 | shape, focus node, validation report | 形状, 焦点节点, 验证报告 | E | 校验报告 | SHACL Chinese usage; bare 校验 is not gated (校验和 is a checksum) |
+| 38 | quad template | 四元组模板 | C | — | a first-party extension that SPARQL 1.2 does not define; `check-spec-attribution.py` recognises this rendering as an anchor and the disclaimers 「并非 SPARQL 1.2 特性」/「SPARQL 1.2 并未定义」/「第一方扩展」 |
+| 39 | PurRDF | PurRDF | H | — | the brand is never translated or lower-cased in prose (`docs/BRAND.md`); `check-brand-casing.py` enforces it inside CJK text too |
+
+Add a row when a translation coins or settles a term; add a **Rejected**
+entry only for a rendering that is wrong wherever it appears. The gate reads
+this table by its header row, so keep the six columns.

--- a/docs/book/po/glossary-zh-Hans.md
+++ b/docs/book/po/glossary-zh-Hans.md
@@ -6,12 +6,13 @@ SPDX-License-Identifier: CC-BY-4.0
 # zh-Hans glossary — a gate input, not a page
 
 This file is read by `scripts/check-i18n-glossary.py` (part of `make check`
-and CI). Every translated unit — each `msgstr` in `po/zh-Hans.po` and every
-line of every tracked Markdown file with `zh-Hans` in its path
-(`README.zh-Hans.md`, `docs/book/po/zh-Hans/**`) — is rejected if it uses a rendering listed in the
-**Rejected** column: a wrong or inconsistent rendering of a load-bearing term
-is worse than English with a gloss, and the gate is what keeps ten translators
-from producing four words for one concept.
+and CI). It settles one rendering per load-bearing term and, per term, the
+renderings that are wrong **for that term**; the gate refuses a `msgstr` that
+uses one of them **when its `msgid` carries the term**. A wrong or
+inconsistent rendering of a load-bearing term is worse than English with a
+gloss, and the gate is what keeps ten translators from producing four words
+for one concept. Where this table and §5.4 of
+`docs/design/i18n-zh-assessment.md` differ (row 32), this table supersedes it.
 
 Policy, settled by the house page (<https://blackcatinformatics.ca/zh/> and
 its `/zh/purrdf/` page):
@@ -21,7 +22,9 @@ its `/zh/purrdf/` page):
    prefixed name, keyword, diagnostic code, crate/module/API name, CLI flag,
    file path, spec section number (`SEP-0009`, `RDFC-1.0`) and profile
    identifier (`purrdf-rdfc12`) is invariant and appears in backticks where
-   the English does.
+   the English does. Rows marked **K** below are *enforced*: when a `msgid`
+   carries one of the row's Anchor tokens, the `msgstr` must carry it
+   verbatim.
 2. Concepts with a settled mainland knowledge-graph (知识图谱) rendering use
    it.
 3. A coined term (**C**) carries the English term in parentheses on its first
@@ -35,68 +38,96 @@ its `/zh/purrdf/` page):
 
 **Basis** legend — **E**: established mainland rendering; **H**: fixed by the
 house page; **C**: no established rendering, PurRDF coins one; **K**: keep
-English, gloss on first use.
+English, gloss on first use (and enforced, see policy 1).
 
-**Rejected** column syntax — entries separated by `、`; a plain entry is a
-substring the gate refuses anywhere in a translated unit; an entry written
-`/…/` is a Python regular expression, used where a wrong rendering would
-otherwise match across a word boundary (账本 inside 台账本身) or inside a
-right one (知识图 inside 知识图谱). Only list a rejection that is wrong
-*wherever it appears*: 来源 is not listed against *provenance* because it is
-the ordinary word for a data source, bare 闭包 is not listed against
-*closure* because 传递闭包, 宿主闭包 and 求闭包 are all correct, and a gate that
-refuses ordinary prose is a gate that gets switched off. Both of those were
-found by running the gate over the first translated drafts, not guessed.
+How the gate reads the table:
 
-| # | Term | Rendering | Basis | Rejected | Note |
-|---:|---|---|---|---|---|
-| 1 | triple | 三元组 | E, H | — | universal in 知识图谱 literature |
-| 2 | quad | 四元组 | E | — | |
-| 3 | named graph | 命名图 | E | 具名图 | 具名图 is the zh-Hant rendering |
-| 4 | dataset | 数据集 | E, H | 资料集 | 资料集 is the zh-Hant rendering |
-| 5 | blank node | 空节点 | E | 空白节点 | |
-| 6 | literal | 字面量 | E | 字面值 | |
-| 7 | datatype | 数据类型 | E | 资料类型 | |
-| 8 | language tag | 语言标签 | E | 语言标记 | |
-| 9 | IRI | IRI | K | — | gloss 国际化资源标识符 once; never translate in running text |
-| 10 | ontology | 本体 | E, H | 本体论 | 本体论 is the philosophical sense |
-| 11 | knowledge graph | 知识图谱 | E | `/知识图(?!谱)/` | the audience's own term for the field |
-| 12 | reasoning / inference | 推理 | E, H | — | house: 「以推理为核心」 |
-| 13 | entailment | 蕴涵 | E (logic) | 蕴含 | 蕴含 also circulates; this book uses 蕴涵 only |
-| 14 | entailment regime | 蕴涵机制 | C | — | keep "(entailment regime)" on first use; no W3C precedent |
-| 15 | materialization | 物化 | E | 实体化 | database/KG usage |
-| 16 | closure (inference) | 推理闭包 | E, qualified | — | qualify on first use on a page; bare 闭包 is NOT gated, because 传递闭包 (transitive closure), 宿主闭包 (a host closure, the programming sense) and the verb phrase 求闭包 (compute the closure) are all correct and all contain it |
-| 17 | canonicalization | 规范化 | H | 标准化 | not 标准化; `RDFC-1.0` is invariant |
-| 18 | canonicalization profile | 规范化 profile | K + H | — | "profile" has no settled rendering (子集/概貌/配置 all circulate); keep English; `purrdf-rdfc12` is invariant |
-| 19 | codec / serialization | 编解码器 / 序列化 | H, E | — | |
-| 20 | round-trip | 往返（转换） | E | — | |
-| 21 | determinism | 确定性 | E | 决定性 | |
-| 22 | provenance | 溯源 | H | 出处 | house: 声明溯源; not 出处/来源 (来源 is not gated, see above) |
-| 23 | triple term (RDF 1.2) | 三元组项 | H | 三元组术语、三元组词项 | adopted by the house `/zh/purrdf/` page; W3C has none |
-| 24 | reifier / `rdf:reifies` | 具体化节点 / `rdf:reifies` | C | — | 具体化 (reification) is established; the noun for the subject is coined; the IRI never changes |
-| 25 | statement layer / annotation | 陈述层 / 注解 | C / E | — | 陈述 (statement) is established; 注解 for the `{| |}` annotation syntax |
-| 26 | base direction (`--ltr`/`--rtl`) | 基础方向 | C, with precedent | 基本方向 | W3C i18n articles in Chinese use 基础方向 for HTML/CSS base direction; the flags are invariant |
-| 27 | property function | 属性函数 | E (Jena usage) | — | Chinese Jena material uses 属性函数 |
-| 28 | composite datatype (`SEP-0009`) | 复合数据类型 | E | 组合数据类型 | natural DB rendering; the SEP number stays |
-| 29 | governor / budget | governor（执行调控器）/ 预算 | K / E | — | no settled rendering for "governor" in this sense; 预算 is established for resource budgets |
-| 30 | ledgered (`xfail` ledger) | 台账（预期失败台账） | E, qualified | `/(?<!台)账本/`、`/\d+\s*台账/` | 台账 is the engineering register word; 账本 reads as blockchain (the lookbehind spares 台账本身, "the ledger itself"). In COUNTS, 台账 may not follow a bare numeral: 「0 台账」 is "zero ledgers", a broken noun phrase; write 「0 例入账」, 「台账为空」, 「5 例入台账」 |
-| 31 | walk vs. path | 游走 vs. 路径 | E | — | the pair maps cleanly (随机游走 is standard); keep the distinction the code makes |
-| 32 | out-of-core (outside `purrdf-core`) | 核心之外 / 核心 crate 之外 | C | 核外 | The English is a PUN: "out-of-core" means outside the `purrdf-core` crate — capabilities that arrive as sibling crates through the extension seams — not the CS sense. 核外 / 核外计算 is exactly that CS sense (data larger than RAM, streamed from disk), so 「核外 SPARQL 扩展」 beside 「内存倒排索引」 two paragraphs later reads as a contradiction that the English does not have. Do not "correct" this row back to 核外 |
-| 33 | interned / interner | 驻留 / 驻留表 | E (Python community) | — | |
-| 34 | fixpoint, semi-naive | 不动点, 半朴素 | E | — | |
-| 35 | embedding, kNN, full-text search | 嵌入（向量嵌入）, k 近邻, 全文检索 | E | 全文搜索 | the audience's core vocabulary |
-| 36 | slice | 切片 | E | — | |
-| 37 | shape, focus node, validation report | 形状, 焦点节点, 验证报告 | E | 校验报告 | SHACL Chinese usage; bare 校验 is not gated (校验和 is a checksum) |
-| 38 | quad template | 四元组模板 | C | — | a first-party extension that SPARQL 1.2 does not define; `check-spec-attribution.py` recognises this rendering as an anchor and the disclaimers 「并非 SPARQL 1.2 特性」/「SPARQL 1.2 并未定义」/「第一方扩展」 |
-| 39 | PurRDF | PurRDF | H | — | the brand is never translated or lower-cased in prose (`docs/BRAND.md`); `check-brand-casing.py` enforces it inside CJK text too |
-| 40 | Research Object (RO-Crate) | Research Object（RO） | K | `/研究对象(?!（Research Object）)/` | a proper noun; 研究对象 means "the object of study". Keep English on first use per page, or at minimum gloss it as 研究对象（Research Object） — the bare word is refused |
-| 41 | realization (DL, of an individual) | 实现（realization） on first use / 实例归类 | C | — | bare 实现 collides with 实现 = "implementation", the far commoner sense in this book; gloss it or use 实例归类. Not gated: 实现 in the implementation sense is everywhere |
-| 42 | surface (API surface) | 接口 | E | `/表面(?!上)/` | technical, not literary: the English "surface" is the API surface. 表面上 ("ostensibly") is ordinary prose and spared; bare 表面 for an API is refused |
-| 43 | seam (extension seam) | 扩展点 | E | — | 接缝 is acceptable but 扩展点 reads naturally to the audience |
-| 44 | mint (an IRI, a witness, a blank node) | 生成 | E | 铸造 | technical, not literary: 铸造 ("cast, coin") is the English project idiom carried over and reads as metaphor in Chinese |
-| 45 | reach (a host, a surface) | 到达 | E | 抵达 | technical, not literary: 抵达 is the literary "arrive" |
-| 46 | dropped loudly | 显式报错丢弃 | E | 大声 | "loudly" is idiom: the drop is reported explicitly; 大声地丢弃 is nonsense in Chinese |
+* **Anchor** — the English word(s) whose presence in a `msgid` makes the row
+  apply, `、`-separated, matched case-insensitively at a word start and as a
+  prefix (`entail` covers *entails* and *entailment*; `canonical` covers
+  *canonicalize* and *canonicalization*). A rejection is tested against a
+  `msgstr` only when its row is anchored in the `msgstr`'s `msgid`: 标准化
+  is refused as a rendering of *canonicalization* and untouched as the
+  rendering of *standardized* (the English book says "no standardized
+  spelling exists"); 蕴含 is refused for *entailment* and untouched as the
+  ordinary verb *implies*. A row whose Anchor is `—` is **global**: its
+  rejections apply wherever they appear, and its Note must say why (only the
+  zh-Hant-register words qualify). A tracked `zh-Hans` Markdown file has no
+  `msgid`, so it is checked against the global rows only; the pour into the
+  catalogue is where the table is fully enforced.
+* **Rejected** — entries separated by `、`; a plain entry is a substring; an
+  entry written `/…/` is a Python regular expression, used where a wrong
+  rendering would otherwise match across a word boundary (账本 inside
+  台账本身) or inside a right one (知识图 inside 知识图谱). Code spans and
+  fenced blocks in a `msgstr` are never matched (a page may write
+  「不要写 `蕴含`」).
+* **K rows** — every Anchor token is an invariant: if the `msgid` carries it
+  (case-sensitively, at a word start), the `msgstr` must contain it verbatim.
+  研究物件 for *Research Object* or 吉猫协议 for *GMEOW* is refused by this
+  arm even though no Rejected entry names it.
 
-Add a row when a translation coins or settles a term; add a **Rejected**
-entry only for a rendering that is wrong wherever it appears. The gate reads
-this table by its header row, so keep the six columns.
+The gate's `--self-test` executes, for every rejection, the refused form
+under an anchored `msgid`, the row's own rendering under the same `msgid`,
+the rejected word in its *other* sense under an unrelated `msgid` (which
+must pass), and the rejected word inside a code span (which must pass); for
+every K token, a translation that drops it (refused) and one that keeps it
+(passes). A rejection without an ordinary-prose neighbour in the script is a
+self-test failure, so the table cannot grow a refusal that is proven only one
+way.
+
+| # | Term | Anchor | Rendering | Basis | Rejected | Note |
+|---:|---|---|---|---|---|---|
+| 1 | triple | triple | 三元组 | E, H | — | universal in 知识图谱 literature |
+| 2 | quad | quad | 四元组 | E | — | |
+| 3 | named graph | — | 命名图 | E | 具名图 | GLOBAL: 具名图 is the zh-Hant rendering, wrong anywhere in a zh-Hans book |
+| 4 | dataset | — | 数据集 | E, H | 资料集 | GLOBAL: 资料集 is the zh-Hant rendering, wrong anywhere in a zh-Hans book |
+| 5 | blank node | blank node | 空节点 | E | 空白节点 | 空白节点 is fine for an empty DOM node elsewhere |
+| 6 | literal | literal | 字面量 | E | 字面值 | 字面值 is fine for a constant's literal value elsewhere |
+| 7 | datatype | — | 数据类型 | E | 资料类型 | GLOBAL: 资料类型 is the zh-Hant rendering, wrong anywhere in a zh-Hans book |
+| 8 | language tag | language tag | 语言标签 | E | 语言标记 | |
+| 9 | IRI | IRI | IRI | K | — | invariant; gloss 国际化资源标识符 once beside it, never instead of it |
+| 10 | ontology | ontology | 本体 | E, H | 本体论 | 本体论 is the philosophical sense |
+| 11 | knowledge graph | knowledge graph | 知识图谱 | E | `/知识图(?!谱)/` | the audience's own term for the field |
+| 12 | reasoning / inference | reasoning、inference | 推理 | E, H | — | house: 「以推理为核心」 |
+| 13 | entailment | entail | 蕴涵 | E (logic) | 蕴含 | 蕴含 also circulates for entailment; this book uses 蕴涵 only. As the ordinary verb "implies" it is untouched |
+| 14 | entailment regime | entailment regime | 蕴涵机制 | C | — | keep "(entailment regime)" on first use; no W3C precedent |
+| 15 | materialization | materialization、materialize | 物化 | E | 实体化 | database/KG usage |
+| 16 | closure (inference) | closure | 推理闭包 | E, qualified | — | qualify on first use on a page; bare 闭包 is NOT gated, because 传递闭包 (transitive closure), 宿主闭包 (a host closure, the programming sense) and the verb phrase 求闭包 (compute the closure) are all correct and all contain it |
+| 17 | canonicalization | canonical | 规范化 | H | 标准化 | not 标准化 for canonicalization; `RDFC-1.0` is invariant. 标准化 for "standardized" is untouched |
+| 18 | canonicalization profile | profile | 规范化 profile | K + H | — | "profile" has no settled rendering (子集/概貌/配置 all circulate); keep English; `purrdf-rdfc12` is invariant |
+| 19 | codec / serialization | codec、serialization、serialize | 编解码器 / 序列化 | H, E | — | |
+| 20 | round-trip | round-trip | 往返（转换） | E | — | |
+| 21 | determinism | determinism、deterministic | 确定性 | E | 决定性 | 决定性 is "decisive" elsewhere |
+| 22 | provenance | provenance | 溯源 | H | 出处 | house: 声明溯源; not 出处/来源 (来源 is not gated: it is the ordinary word for a data source) |
+| 23 | triple term (RDF 1.2) | triple term | 三元组项 | H | 三元组术语、三元组词项 | adopted by the house `/zh/purrdf/` page; W3C has none |
+| 24 | reifier / `rdf:reifies` | reifier、reifies | 具体化节点 / `rdf:reifies` | C | — | 具体化 (reification) is established; the noun for the subject is coined; the IRI never changes |
+| 25 | statement layer / annotation | statement layer、annotation | 陈述层 / 注解 | C / E | — | 陈述 (statement) is established; 注解 for the `{| |}` annotation syntax |
+| 26 | base direction (`--ltr`/`--rtl`) | base direction | 基础方向 | C, with precedent | 基本方向 | W3C i18n articles in Chinese use 基础方向 for HTML/CSS base direction; the flags are invariant |
+| 27 | property function | property function | 属性函数 | E (Jena usage) | — | Chinese Jena material uses 属性函数 |
+| 28 | composite datatype (`SEP-0009`) | composite datatype | 复合数据类型 | E | 组合数据类型 | natural DB rendering; the SEP number stays |
+| 29 | governor / budget | governor | governor（执行调控器）/ 预算 | K / E | — | no settled rendering for "governor" in this sense; 预算 is established for resource budgets |
+| 30 | ledger (`xfail` ledger) | ledger | 台账（预期失败台账） | E, qualified | `/(?<!台)账本/` | 台账 is the engineering register word; 账本 reads as blockchain (the lookbehind spares 台账本身, "the ledger itself"). Usage, not gated: in a COUNT, 台账 may not follow a bare numeral — 「0 台账」 is "zero ledgers"; write 「0 例入账」, 「台账为空」, 「5 例入台账」. (A numeral before 台账 is also a section number or a table reference, so no regex can tell a count from those) |
+| 31 | walk vs. path | walk | 游走 vs. 路径 | E | — | the pair maps cleanly (随机游走 is standard); keep the distinction the code makes |
+| 32 | out-of-core (outside `purrdf-core`) | out-of-core | 核心之外 / 核心 crate 之外 | C | 核外 | The English is a PUN: "out-of-core" means outside the `purrdf-core` crate — capabilities that arrive as sibling crates through the extension seams — not the CS sense. 核外 / 核外计算 is exactly that CS sense (data larger than RAM, streamed from disk), so 「核外 SPARQL 扩展」 beside 「内存倒排索引」 two paragraphs later reads as a contradiction that the English does not have. Supersedes §5.4 row 32 of the assessment. 核外 elsewhere (核外电子) is untouched |
+| 33 | interned / interner | intern | 驻留 / 驻留表 | E (Python community) | — | |
+| 34 | fixpoint, semi-naive | fixpoint、semi-naive | 不动点, 半朴素 | E | — | |
+| 35 | embedding, kNN | embedding、kNN | 嵌入（向量嵌入）, k 近邻 | E | — | the audience's core vocabulary |
+| 36 | slice | slice | 切片 | E | — | |
+| 37 | shape, focus node | shape、focus node | 形状, 焦点节点 | E | — | SHACL Chinese usage |
+| 38 | quad template | quad template | 四元组模板 | C | — | a first-party extension that SPARQL 1.2 does not define. `check-spec-attribution.py` treats 四元组模板 and `CONSTRUCT 模板` as anchors and accepts the Chinese disclaimers listed in its `DISCLAIMERS` tuple — 「并非 SPARQL 1.2 特性」, 「SPARQL 1.2 并未定义」, 「第一方扩展」, 「PurRDF 的扩展」, 「不属于 SPARQL 1.2」, 「没有四元组模板」 among them; an exact wording is required, as for the English list |
+| 39 | PurRDF | PurRDF | PurRDF | K | — | the brand is never translated or lower-cased in prose (`docs/BRAND.md`); `check-brand-casing.py` enforces the casing inside CJK text, this row enforces survival |
+| 40 | Research Object (RO-Crate) | Research Object | Research Object（RO） | K | `/研究对象(?![（(]Research Object)/` | a proper noun; 研究对象 means "the object of study". Keep English, or gloss it as 研究对象（Research Object） / 研究对象（Research Object，RO） — the bare word is refused where the msgid carries the term |
+| 41 | realization (DL, of an individual) | realization | 实现（realization） on first use / 实例归类 | C | — | bare 实现 collides with 实现 = "implementation", the far commoner sense in this book; gloss it or use 实例归类. Not gated: 实现 in the implementation sense is everywhere |
+| 42 | surface (API surface) | surface | 接口 | E | `/表面(?!上\|看来\|来看)/` | technical, not literary: the English "surface" is the API surface. 表面上 / 表面看来 / 从表面来看 ("ostensibly") are spared; 表面 in other senses (表面张力) is untouched by anchoring |
+| 43 | seam (extension seam) | seam | 扩展点 | E | — | 接缝 is acceptable but 扩展点 reads naturally to the audience |
+| 44 | mint (an IRI, a witness, a blank node) | mint | 生成 | E | 铸造 | technical, not literary: 铸造 ("cast, coin") is the English project idiom carried over; as bronze casting it is untouched |
+| 45 | reach (a host, a surface) | reach | 到达 | E | 抵达 | technical, not literary: 抵达 is the literary "arrive" |
+| 46 | dropped loudly | loudly | 显式报错丢弃 | E | 大声 | "loudly" is idiom: the drop is reported explicitly; 大声地丢弃 is nonsense in Chinese |
+| 47 | full-text search | full-text | 全文检索 | E | 全文搜索 | the audience's core vocabulary |
+| 48 | validation report | validation report | 验证报告 | E | 校验报告 | SHACL Chinese usage; bare 校验 is not gated (校验和 is a checksum) |
+| 49 | specification and product names | GMEOW、GTS、RDF、SPARQL、SHACL、ShEx、OWL、JSON-LD、Turtle、TriG、N-Triples、N-Quads、RDFC、PostgreSQL、Rust、Python、WebAssembly、JavaScript、TypeScript | as written | K | — | invariant: each survives verbatim, case-sensitively, into the msgstr of any msgid that carries it (吉猫协议 for GMEOW or 波斯特格雷 for PostgreSQL is refused) |
+
+Add a row when a translation coins or settles a term; give it an Anchor,
+add a **Rejected** entry only for a rendering that is wrong *for that term*,
+and add its ordinary-prose neighbour to the gate's self-test. The gate reads
+this table by its header row, so keep the seven columns.

--- a/docs/book/po/glossary-zh-Hans.md
+++ b/docs/book/po/glossary-zh-Hans.md
@@ -91,7 +91,7 @@ found by running the gate over the first translated drafts, not guessed.
 | 39 | PurRDF | PurRDF | H | — | the brand is never translated or lower-cased in prose (`docs/BRAND.md`); `check-brand-casing.py` enforces it inside CJK text too |
 | 40 | Research Object (RO-Crate) | Research Object（RO） | K | `/研究对象(?!（Research Object）)/` | a proper noun; 研究对象 means "the object of study". Keep English on first use per page, or at minimum gloss it as 研究对象（Research Object） — the bare word is refused |
 | 41 | realization (DL, of an individual) | 实现（realization） on first use / 实例归类 | C | — | bare 实现 collides with 实现 = "implementation", the far commoner sense in this book; gloss it or use 实例归类. Not gated: 实现 in the implementation sense is everywhere |
-| 42 | surface (API surface) | 接口 / 表面 (API 表面 only when "surface" is the exact term) | E | `/表面(?!上)/` | technical, not literary: the English "surface" is the API surface. 表面上 ("ostensibly") is ordinary prose and spared; bare 表面 for an API is refused |
+| 42 | surface (API surface) | 接口 | E | `/表面(?!上)/` | technical, not literary: the English "surface" is the API surface. 表面上 ("ostensibly") is ordinary prose and spared; bare 表面 for an API is refused |
 | 43 | seam (extension seam) | 扩展点 | E | — | 接缝 is acceptable but 扩展点 reads naturally to the audience |
 | 44 | mint (an IRI, a witness, a blank node) | 生成 | E | 铸造 | technical, not literary: 铸造 ("cast, coin") is the English project idiom carried over and reads as metaphor in Chinese |
 | 45 | reach (a host, a surface) | 到达 | E | 抵达 | technical, not literary: 抵达 is the literary "arrive" |

--- a/docs/book/po/glossary-zh-Hans.md
+++ b/docs/book/po/glossary-zh-Hans.md
@@ -79,9 +79,9 @@ found by running the gate over the first translated drafts, not guessed.
 | 27 | property function | 属性函数 | E (Jena usage) | — | Chinese Jena material uses 属性函数 |
 | 28 | composite datatype (`SEP-0009`) | 复合数据类型 | E | 组合数据类型 | natural DB rendering; the SEP number stays |
 | 29 | governor / budget | governor（执行调控器）/ 预算 | K / E | — | no settled rendering for "governor" in this sense; 预算 is established for resource budgets |
-| 30 | ledgered (`xfail` ledger) | 台账（预期失败台账） | E, qualified | `/(?<!台)账本/` | 台账 is the engineering register word; 账本 reads as blockchain. The lookbehind spares 台账本身 ("the ledger itself"), where 账本 straddles two words |
+| 30 | ledgered (`xfail` ledger) | 台账（预期失败台账） | E, qualified | `/(?<!台)账本/`、`/\d+\s*台账/` | 台账 is the engineering register word; 账本 reads as blockchain (the lookbehind spares 台账本身, "the ledger itself"). In COUNTS, 台账 may not follow a bare numeral: 「0 台账」 is "zero ledgers", a broken noun phrase; write 「0 例入账」, 「台账为空」, 「5 例入台账」 |
 | 31 | walk vs. path | 游走 vs. 路径 | E | — | the pair maps cleanly (随机游走 is standard); keep the distinction the code makes |
-| 32 | out-of-core | 核外 | E (HPC) | — | 核外计算 is standard |
+| 32 | out-of-core (outside `purrdf-core`) | 核心之外 / 核心 crate 之外 | C | 核外 | The English is a PUN: "out-of-core" means outside the `purrdf-core` crate — capabilities that arrive as sibling crates through the extension seams — not the CS sense. 核外 / 核外计算 is exactly that CS sense (data larger than RAM, streamed from disk), so 「核外 SPARQL 扩展」 beside 「内存倒排索引」 two paragraphs later reads as a contradiction that the English does not have. Do not "correct" this row back to 核外 |
 | 33 | interned / interner | 驻留 / 驻留表 | E (Python community) | — | |
 | 34 | fixpoint, semi-naive | 不动点, 半朴素 | E | — | |
 | 35 | embedding, kNN, full-text search | 嵌入（向量嵌入）, k 近邻, 全文检索 | E | 全文搜索 | the audience's core vocabulary |
@@ -89,6 +89,13 @@ found by running the gate over the first translated drafts, not guessed.
 | 37 | shape, focus node, validation report | 形状, 焦点节点, 验证报告 | E | 校验报告 | SHACL Chinese usage; bare 校验 is not gated (校验和 is a checksum) |
 | 38 | quad template | 四元组模板 | C | — | a first-party extension that SPARQL 1.2 does not define; `check-spec-attribution.py` recognises this rendering as an anchor and the disclaimers 「并非 SPARQL 1.2 特性」/「SPARQL 1.2 并未定义」/「第一方扩展」 |
 | 39 | PurRDF | PurRDF | H | — | the brand is never translated or lower-cased in prose (`docs/BRAND.md`); `check-brand-casing.py` enforces it inside CJK text too |
+| 40 | Research Object (RO-Crate) | Research Object（RO） | K | `/研究对象(?!（Research Object）)/` | a proper noun; 研究对象 means "the object of study". Keep English on first use per page, or at minimum gloss it as 研究对象（Research Object） — the bare word is refused |
+| 41 | realization (DL, of an individual) | 实现（realization） on first use / 实例归类 | C | — | bare 实现 collides with 实现 = "implementation", the far commoner sense in this book; gloss it or use 实例归类. Not gated: 实现 in the implementation sense is everywhere |
+| 42 | surface (API surface) | 接口 / 表面 (API 表面 only when "surface" is the exact term) | E | `/表面(?!上)/` | technical, not literary: the English "surface" is the API surface. 表面上 ("ostensibly") is ordinary prose and spared; bare 表面 for an API is refused |
+| 43 | seam (extension seam) | 扩展点 | E | — | 接缝 is acceptable but 扩展点 reads naturally to the audience |
+| 44 | mint (an IRI, a witness, a blank node) | 生成 | E | 铸造 | technical, not literary: 铸造 ("cast, coin") is the English project idiom carried over and reads as metaphor in Chinese |
+| 45 | reach (a host, a surface) | 到达 | E | 抵达 | technical, not literary: 抵达 is the literary "arrive" |
+| 46 | dropped loudly | 显式报错丢弃 | E | 大声 | "loudly" is idiom: the drop is reported explicitly; 大声地丢弃 is nonsense in Chinese |
 
 Add a row when a translation coins or settles a term; add a **Rejected**
 entry only for a rendering that is wrong wherever it appears. The gate reads

--- a/docs/book/po/zh-Hans.po
+++ b/docs/book/po/zh-Hans.po
@@ -11,7 +11,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: The PurRDF Book\n"
-"POT-Creation-Date: 2026-09-02T15:58:27-06:00\n"
+"POT-Creation-Date: 2026-09-02T16:37:33-06:00\n"
 "PO-Revision-Date: 2026-09-02T15:58:27-06:00\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -188,23 +188,38 @@ msgid ""
 "**PurRDF** is an [RDF 1.2](https://www.w3.org/TR/rdf12-concepts/) toolkit: "
 "primitives, codecs, SPARQL, SHACL, ShEx, entailment, and graph transport, "
 "implemented once in Rust and carried verbatim into Python, WebAssembly/"
-"JavaScript, and C. It is developed by Blackcat Informatics® Inc. and "
-"published under MIT OR Apache-2.0."
-msgstr ""
-
-#: src/introduction.md:14
-msgid "**One RDF engine. One behavior. Every language.**"
+"JavaScript, and C. Every published crate builds for `wasm32-unknown-"
+"unknown`, so the engine that answers a query on a server answers it, byte "
+"for byte, in a browser tab. It is developed by Blackcat Informatics® Inc. "
+"and published under MIT OR Apache-2.0."
 msgstr ""
 
 #: src/introduction.md:16
-msgid "Why does PurRDF exist?"
+msgid "**One RDF engine. One behavior. Every language.**"
 msgstr ""
 
 #: src/introduction.md:18
+msgid ""
+"**What it removes from your architecture.** The three jobs that usually keep "
+"a PostgreSQL instance running beside a triple store — ranked full-text "
+"search, spatial predicates, and vector similarity — are answered inside "
+"PurRDF: in-process, over the same dataset, from the same SPARQL query, with "
+"no second database and no sync job. Each answer is exact and deterministic, "
+"natively and on wasm32. This is not a projection: these query surfaces have "
+"already removed a whole PostgreSQL requirement from one RDF project. See "
+"[One engine instead of three databases](#one-engine-instead-of-three-"
+"databases) below."
+msgstr ""
+
+#: src/introduction.md:28
+msgid "Why does PurRDF exist?"
+msgstr ""
+
+#: src/introduction.md:30
 msgid "RDF tooling fragments along two axes."
 msgstr ""
 
-#: src/introduction.md:20
+#: src/introduction.md:32
 msgid ""
 "**Across languages**: every ecosystem has its own parser, with its own bugs, "
 "its own corner-case interpretations, and its own subset of the spec. Move a "
@@ -212,14 +227,14 @@ msgid ""
 "silently changed what the data means three times."
 msgstr ""
 
-#: src/introduction.md:25
+#: src/introduction.md:37
 msgid ""
 "**Across time**: RDF 1.2 — triple terms, reifiers, base-direction literals — "
 "is the current revision of the standard, and almost no incumbent library "
 "carries it."
 msgstr ""
 
-#: src/introduction.md:28
+#: src/introduction.md:40
 msgid ""
 "PurRDF exists so that a graph is **the same graph everywhere**. It is a from-"
 "scratch, dependency-light Rust core — parser to SPARQL engine to SHACL "
@@ -227,11 +242,11 @@ msgid ""
 "reimplemented per language."
 msgstr ""
 
-#: src/introduction.md:33
+#: src/introduction.md:45
 msgid "What's inside"
 msgstr ""
 
-#: src/introduction.md:35
+#: src/introduction.md:47
 msgid ""
 "**RDF 1.2 primitives** — an immutable, value-interned dataset IR (`TermId` "
 "space, string arena, copy-on-write mutation), with triple terms in object "
@@ -239,7 +254,7 @@ msgid ""
 "[The Interned Dataset IR](concepts/interned-dataset.md)."
 msgstr ""
 
-#: src/introduction.md:39
+#: src/introduction.md:51
 msgid ""
 "**Native codecs** — first-party parsers/serializers for Turtle, TriG, N-"
 "Triples, N-Quads, RDF/XML, TriX, HexTuples, JSON-LD (star), and YAML-LD, "
@@ -249,13 +264,13 @@ msgid ""
 "See [Base IRIs & Relative References](concepts/base-iris.md)."
 msgstr ""
 
-#: src/introduction.md:45
+#: src/introduction.md:57
 msgid ""
 "**Canonicalization** — W3C RDFC-1.0 plus dataset diff and isomorphism. See "
 "[Canonicalization & Diff](concepts/canonicalization.md)."
 msgstr ""
 
-#: src/introduction.md:47
+#: src/introduction.md:59
 msgid ""
 "**Projections & carriers** — deterministic LPG, CSVW, OBO Graphs, dataset-"
 "description, and research-object projections, each with a located loss "
@@ -263,21 +278,24 @@ msgid ""
 "projections.md)."
 msgstr ""
 
-#: src/introduction.md:51
+#: src/introduction.md:63
 msgid ""
 "**SPARQL 1.1/1.2** — native parser → algebra → multiset evaluator, with full "
 "Update, SEP-0002 temporal arithmetic, `LATERAL` (SEP-0006), the SEP-0008 "
 "SHA-3 hash builtins (`SHA3-224`/`256`/`384`/`512`), quad templates that "
 "`CONSTRUCT` into named graphs (a first-party extension, not a SPARQL 1.2 "
 "feature), the SEP-0009 composite datatypes (`cdt:List`/`cdt:Map`, `FOLD`, "
-"`UNFOLD`), caller-registered aggregates and property functions (including "
-"path witnesses that bind a traversal hop by hop), governed execution with "
-"per-node explain receipts, and `SERVICE` federation through a host-injected "
-"resolver carrying per-service context, gated by the W3C conformance suites. "
-"See [SPARQL](sparql/querying.md)."
+"`UNFOLD` — with one stated divergence: PurRDF admits RDF 1.2 triple terms "
+"and directional language-tagged literals as composite elements, a lexical "
+"superset a conformant SEP-0009 reader will call ill-formed), caller-"
+"registered aggregates and property functions (including path witnesses that "
+"bind a traversal hop by hop), governed execution with per-node explain "
+"receipts, and `SERVICE` federation through a host-injected resolver carrying "
+"per-service context, gated by the W3C conformance suites. See [SPARQL]"
+"(sparql/querying.md)."
 msgstr ""
 
-#: src/introduction.md:61
+#: src/introduction.md:76
 msgid ""
 "**Out-of-core SPARQL extensions** — deterministic full-text search with "
 "exact fixed-point BM25 ([Full-Text Search](sparql/full-text.md)), exact and "
@@ -287,7 +305,7 @@ msgid ""
 "seams, registered under IRIs the caller supplies."
 msgstr ""
 
-#: src/introduction.md:67
+#: src/introduction.md:82
 msgid ""
 "**SHACL and ShEx** — native validators for both shape languages; the SHACL "
 "engine covers Core, SHACL-SPARQL and SHACL-AF, aligned with the SHACL 1.2 "
@@ -295,7 +313,7 @@ msgid ""
 "shacl.md)."
 msgstr ""
 
-#: src/introduction.md:70
+#: src/introduction.md:85
 msgid ""
 "**Entailment** — Simple/RDF/RDFS/OWL-RL/D materialization (all 78 OWL 2 RL "
 "rules implemented — rule-table coverage, distinct from entailment "
@@ -305,24 +323,131 @@ msgid ""
 "(entailment.md), evaluated on the [Datalog fixpoint engine](datalog.md)."
 msgstr ""
 
-#: src/introduction.md:76
+#: src/introduction.md:91
 msgid ""
 "**GTS graph transport** — a single-file, content-addressed, append-only "
 "container for RDF 1.2 graphs and binary payloads. See [GTS Graph Transport]"
 "(gts.md)."
 msgstr ""
 
-#: src/introduction.md:79
+#: src/introduction.md:94
 msgid ""
 "**Slices, mappings, and provenance** — a slice catalog, an explicit RDF↔GTS "
 "loss ledger, SSSOM, and FnO. See [Slices, Mappings & Provenance](slices.md)."
 msgstr ""
 
-#: src/introduction.md:82
+#: src/introduction.md:97
+msgid "One engine instead of three databases"
+msgstr ""
+
+#: src/introduction.md:99
+msgid ""
+"An RDF project that needs ranked text search, spatial predicates, or nearest-"
+"neighbour search has usually run PostgreSQL beside its triple store for "
+"exactly those three jobs. PurRDF answers all three from SPARQL, over the "
+"dataset already in memory, through the evaluator's caller-keyed extension "
+"seams — and each page below opens with what its surface replaces and where "
+"it stops."
+msgstr ""
+
+#: src/introduction.md:105
+msgid "You needed"
+msgstr ""
+
+#: src/introduction.md:105
+msgid "Usually from"
+msgstr ""
+
+#: src/introduction.md:105
+msgid "Now inside PurRDF"
+msgstr ""
+
+#: src/introduction.md:105
+msgid "Where it stops"
+msgstr ""
+
+#: src/introduction.md:107
+msgid "Ranked full-text search"
+msgstr ""
+
+#: src/introduction.md:107
+msgid "PostgreSQL `tsvector`/`tsquery`"
+msgstr ""
+
+#: src/introduction.md:107
+msgid ""
+"[Full-Text Search](sparql/full-text.md): `purrdf-text`, an inverted index "
+"over RDF 1.2 literals with BM25 ranking in exact `i128` fixed point and no "
+"floating point in the crate."
+msgstr ""
+
+#: src/introduction.md:107
+msgid ""
+"BM25 ranking, not a Lucene: no stemming, no stop-word lists, no query "
+"dialect; an in-memory index built once over a frozen dataset."
+msgstr ""
+
+#: src/introduction.md:108
+msgid "Spatial predicates"
+msgstr ""
+
+#: src/introduction.md:108
+msgid "PostGIS"
+msgstr ""
+
+#: src/introduction.md:108
+msgid ""
+"[GeoSPARQL](sparql/geosparql.md): `purrdf-geo`, GeoSPARQL 1.1 with WKT and "
+"GeoJSON as exact rationals and every Simple Features, Egenhofer and RCC8 "
+"relation over an exact DE-9IM; no GEOS, no PROJ."
+msgstr ""
+
+#: src/introduction.md:108
+msgid ""
+"Topological predicates, accessors and exactly computable measures over "
+"vector geometry, not a PostGIS: no CRS transform, no ellipsoidal geodesic, "
+"no buffers, hulls, overlay set operations or raster — each unimplemented "
+"function hard-errors by name."
+msgstr ""
+
+#: src/introduction.md:109
+msgid "Vector similarity"
+msgstr ""
+
+#: src/introduction.md:109
+msgid "pgvector"
+msgstr ""
+
+#: src/introduction.md:109
+msgid ""
+"[Embedding Nearest Neighbours](sparql/embedding-knn.md): exact top-k over a "
+"PURREMB embedding space, binary64 in a pinned accumulation order."
+msgstr ""
+
+#: src/introduction.md:109
+msgid ""
+"Exact scan bounded by a caller-supplied `KnnGuard`, three metrics, no "
+"approximate index; PurRDF computes no embeddings — the vectors arrive in an "
+"artifact the caller produced."
+msgstr ""
+
+#: src/introduction.md:111
+msgid ""
+"All three are pure functions of their input on every target — fixed point, "
+"exact rationals, or a pinned binary64 order, with canonical tie-breaks — and "
+"the claim is executed rather than argued: the text and kNN determinism tests "
+"run the same body natively and on `wasm32-unknown-unknown`, and `make geo-"
+"determinism` compares the two targets byte for byte. They are Rust-host "
+"seams: a host registers an index or space under its own IRIs, and that host "
+"may itself be compiled to wasm32. The shipped npm package and Python wheel "
+"do not yet expose these three relations."
+msgstr ""
+
+#: src/introduction.md:120
 msgid "Two design rules worth knowing on day one"
 msgstr ""
 
-#: src/introduction.md:84
+#: src/introduction.md:122
 msgid ""
 "**No feature flags — ever.** There are deliberately no Cargo feature flags "
 "anywhere in the workspace, and CI enforces this. A data carrier must not "
@@ -330,7 +455,7 @@ msgid ""
 "consumer gets the same byte-identical semantics instead."
 msgstr ""
 
-#: src/introduction.md:89
+#: src/introduction.md:127
 msgid ""
 "**PurRDF is a toolkit, not an ontology — it mints no vocabulary IRIs.** "
 "Every vocabulary the library reads or writes is caller-supplied "
@@ -339,17 +464,17 @@ msgid ""
 "(Test fixtures use `example.org`.)"
 msgstr ""
 
-#: src/introduction.md:95
+#: src/introduction.md:133
 msgid ""
 "The full invariant list is in [Design Rules & Invariants](project/design-"
 "rules.md)."
 msgstr ""
 
-#: src/introduction.md:98
+#: src/introduction.md:136
 msgid "Why RDF 1.2?"
 msgstr ""
 
-#: src/introduction.md:100
+#: src/introduction.md:138
 msgid ""
 "RDF 1.2 (and SPARQL 1.2) add first-class statement-level metadata to the "
 "data model: **triple terms** that can appear in object position, "
@@ -360,11 +485,11 @@ msgid ""
 "transport. See [RDF 1.2 Features](concepts/rdf12.md)."
 msgstr ""
 
-#: src/introduction.md:108
+#: src/introduction.md:146
 msgid "Where PurRDF sits"
 msgstr ""
 
-#: src/introduction.md:110
+#: src/introduction.md:148
 msgid ""
 "PurRDF is the library layer of a small family of linked-data projects: it is "
 "the data backbone of the [GMEOW](https://github.com/Blackcat-Informatics/"
@@ -372,36 +497,36 @@ msgid ""
 "engine — but it assumes nothing about your ontology or application."
 msgstr ""
 
-#: src/introduction.md:116
+#: src/introduction.md:154
 msgid "How to read this book"
 msgstr ""
 
-#: src/introduction.md:118
+#: src/introduction.md:156
 msgid ""
 "New users: start with [Getting Started](getting-started/rust.md) in your "
 "language, then read the [Concepts](concepts/interned-dataset.md) chapters."
 msgstr ""
 
-#: src/introduction.md:120
+#: src/introduction.md:158
 msgid ""
 "Engine users: jump to [SPARQL](sparql/querying.md), [Validation](validation/"
 "shacl.md), or [Entailment](entailment.md)."
 msgstr ""
 
-#: src/introduction.md:122
+#: src/introduction.md:160
 msgid ""
 "Integrators: see [Interop](interop/rdflib.md) and [GTS Graph Transport]"
 "(gts.md)."
 msgstr ""
 
-#: src/introduction.md:124
+#: src/introduction.md:162
 msgid ""
 "Contributors: read the [Project](project/design-rules.md) chapters, then "
 "[AGENTS.md](https://github.com/Blackcat-Informatics/purrdf/blob/main/"
 "AGENTS.md) in the repository."
 msgstr ""
 
-#: src/introduction.md:128
+#: src/introduction.md:166
 msgid ""
 "API reference documentation lives on [docs.rs/purrdf](https://docs.rs/"
 "purrdf); the repository is [github.com/Blackcat-Informatics/purrdf](https://"
@@ -945,32 +1070,38 @@ msgid ""
 "explicitly."
 msgstr ""
 
-#: src/getting-started/javascript.md:103 src/interop/rdfjs.md:108
+#: src/getting-started/javascript.md:103
 msgid ""
-"A quoted-triple term as a quad **object** currently round-trips only through "
-"**N-Quads** (a current native serializer limitation for the other formats)."
+"**Triple terms per format.** `serialize` is the writer-native lane: an "
+"object-position quoted-triple term and the RDF 1.2 statement layer survive "
+"Turtle, N-Triples, N-Quads and TriG (as `<<( … )>>`), RDF/XML (as "
+"`rdf:parseType=\"Triple\"`), and JSON-LD / YAML-LD (as `@triple`). TriX and "
+"HexTuples have no triple-term surface, so serializing a dataset that carries "
+"one to either of them **throws** rather than dropping the layer silently. "
+"Single-graph targets (Turtle, N-Triples, RDF/XML) emit the default graph "
+"alone."
 msgstr ""
 
-#: src/getting-started/javascript.md:106
+#: src/getting-started/javascript.md:112
 msgid "Building from source"
 msgstr ""
 
-#: src/getting-started/javascript.md:108
+#: src/getting-started/javascript.md:114
 msgid ""
 "The Rust cdylib lives in [`crates/rdf-wasm`](https://github.com/Blackcat-"
 "Informatics/purrdf/tree/main/crates/rdf-wasm); the published ESM package is "
 "generated from it:"
 msgstr ""
 
-#: src/getting-started/javascript.md:113
+#: src/getting-started/javascript.md:119
 msgid "# release wasm + wasm-bindgen ESM bindings → js/pkg/\n"
 msgstr ""
 
-#: src/getting-started/javascript.md:114
+#: src/getting-started/javascript.md:120
 msgid "# the above + TypeScript, Node, and packed-tarball gates\n"
 msgstr ""
 
-#: src/getting-started/javascript.md:117
+#: src/getting-started/javascript.md:123
 msgid ""
 "This requires the `wasm32-unknown-unknown` Rust target and a `wasm-bindgen-"
 "cli` pinned to the crate's `wasm-bindgen` version."
@@ -3262,10 +3393,10 @@ msgstr ""
 #: src/concepts/codecs.md:198
 msgid ""
 "The codecs are gated by the W3C `rdf-tests` syntax corpus, vendored and "
-"frozen in-repo — 250/250 round-trip cases across N-Quads, N-Triples, RDF/"
-"XML, TriG, and Turtle at the time of writing. The live scoreboard is [`docs/"
-"CONFORMANCE.md`](https://github.com/Blackcat-Informatics/purrdf/blob/main/"
-"docs/CONFORMANCE.md)."
+"frozen in-repo — 264/264 round-trip cases across N-Quads, N-Triples, RDF/"
+"XML, TriG, and Turtle. The live scoreboard is [`docs/CONFORMANCE.md`]"
+"(https://github.com/Blackcat-Informatics/purrdf/blob/main/docs/"
+"CONFORMANCE.md)."
 msgstr ""
 
 #: src/concepts/codecs.md:203 src/sparql/results.md:103 src/gts.md:91
@@ -3329,7 +3460,7 @@ msgstr ""
 #: src/concepts/base-iris.md:27 src/sparql/querying.md:935
 #: src/sparql/querying.md:936 src/sparql/querying.md:937
 #: src/sparql/querying.md:938 src/sparql/querying.md:941
-#: src/sparql/embedding-knn.md:34
+#: src/sparql/embedding-knn.md:44
 msgid "1"
 msgstr ""
 
@@ -3349,7 +3480,7 @@ msgstr ""
 
 #: src/concepts/base-iris.md:28 src/sparql/querying.md:933
 #: src/sparql/querying.md:934 src/sparql/querying.md:940
-#: src/sparql/querying.md:944 src/sparql/embedding-knn.md:35
+#: src/sparql/querying.md:944 src/sparql/embedding-knn.md:45
 msgid "2"
 msgstr ""
 
@@ -3365,7 +3496,7 @@ msgstr ""
 msgid "the `base` argument to `parse_dataset`, the CLI's `--base`"
 msgstr ""
 
-#: src/concepts/base-iris.md:29 src/sparql/embedding-knn.md:36
+#: src/concepts/base-iris.md:29 src/sparql/embedding-knn.md:46
 #: src/entailment.md:144 src/entailment-rules.md:61
 msgid "3"
 msgstr ""
@@ -4352,7 +4483,7 @@ msgid ""
 "with certified rows rather than a wrong answer, and `explain_query` returns "
 "a `QueryExplanation` whose ledger decomposes the fuel spent per algebra node "
 "and per charge point, beside the cost planner's estimate for each basic "
-"graph pattern. The normative charge schedule and the frozen 49-case governor "
+"graph pattern. The normative charge schedule and the frozen 50-case governor "
 "corpus are documented in [`docs/SPARQL-GOVERNOR-PROFILE.md`](https://"
 "github.com/Blackcat-Informatics/purrdf/blob/main/docs/SPARQL-GOVERNOR-"
 "PROFILE.md)."
@@ -7442,6 +7573,19 @@ msgstr ""
 
 #: src/sparql/full-text.md:8
 msgid ""
+"**What it replaces, and where it stops.** This is the surface that lets an "
+"RDF project drop the PostgreSQL `tsvector`/`tsquery` it kept beside its "
+"triple store for ranked text search: the question becomes a property-"
+"function call in the SPARQL query that already holds the graph, in-process, "
+"over the same dataset, and the answer is byte-identical natively and on "
+"wasm32. It is BM25 ranking, not a Lucene — Unicode case folding and word-"
+"boundary segmentation, no stemming, no stop-word lists, no query dialect "
+"(phrase and proximity compose in SPARQL from the term-occurrence relation), "
+"fixed `k1`/`b`, and an in-memory index built once over a frozen dataset."
+msgstr ""
+
+#: src/sparql/full-text.md:18
+msgid ""
 "`purrdf-text` (`purrdf::text` from the umbrella crate) is PurRDF's "
 "deterministic full-text index. It reads RDF 1.2 literals out of a frozen "
 "dataset, tokenizes them by the Unicode standard's own rules, and answers "
@@ -7449,7 +7593,7 @@ msgid ""
 "evaluator's property-function seam, under IRIs the caller supplies."
 msgstr ""
 
-#: src/sparql/full-text.md:14
+#: src/sparql/full-text.md:24
 msgid ""
 "It is an **out-of-core sibling crate**, not a kernel change: nothing in "
 "`purrdf-core`, `purrdf-sparql-algebra` or the property-function seam itself "
@@ -7457,17 +7601,17 @@ msgid ""
 "takes."
 msgstr ""
 
-#: src/sparql/full-text.md:18
+#: src/sparql/full-text.md:28
 msgid "Two relations, one index"
 msgstr ""
 
-#: src/sparql/full-text.md:20
+#: src/sparql/full-text.md:30
 msgid ""
 "An index is built once over a dataset and shared by two property functions, "
 "which are two distinct types rather than one type with a mode switch:"
 msgstr ""
 
-#: src/sparql/full-text.md:23
+#: src/sparql/full-text.md:33
 msgid ""
 "```text\n"
 "?doc <caller-iri>  ( \"needle\" ?score ?rank ?lang ?matched )   # ranked "
@@ -7477,7 +7621,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/sparql/full-text.md:28
+#: src/sparql/full-text.md:38
 msgid ""
 "**Ranked retrieval** (`TextSearchRelation`) emits one row per matching "
 "document. `?score` is an `xsd:decimal` carrying the exact BM25 value, `?"
@@ -7486,13 +7630,13 @@ msgid ""
 "how many distinct needle terms the document holds."
 msgstr ""
 
-#: src/sparql/full-text.md:33
+#: src/sparql/full-text.md:43
 msgid ""
 "**Term occurrence** (`TermOccurrenceRelation`) emits one row per occurrence "
 "of a single term, with its token `?position`."
 msgstr ""
 
-#: src/sparql/full-text.md:36
+#: src/sparql/full-text.md:46
 msgid ""
 "Phrase and proximity search are delivered by composition in SPARQL rather "
 "than by an embedded query dialect — an embedded syntax would have minted one "
@@ -7500,7 +7644,7 @@ msgid ""
 "do:"
 msgstr ""
 
-#: src/sparql/full-text.md:40
+#: src/sparql/full-text.md:50
 msgid ""
 "```sparql\n"
 "# \"quick\" immediately followed by \"brown\"\n"
@@ -7512,17 +7656,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/sparql/full-text.md:49
+#: src/sparql/full-text.md:59
 msgid ""
 "`FILTER(ABS(?p2 - ?p1) <= 3)` is proximity; `FILTER(?matched = 2)` on the "
 "ranked relation is conjunctive retrieval."
 msgstr ""
 
-#: src/sparql/full-text.md:52
+#: src/sparql/full-text.md:62
 msgid "Wiring it from Rust"
 msgstr ""
 
-#: src/sparql/full-text.md:54
+#: src/sparql/full-text.md:64
 msgid ""
 "The index takes the predicates whose literals it should read and a graph "
 "selector — `GraphSelector::Any`, `Default`, or `Named(iri)` — and PurRDF "
@@ -7530,27 +7674,27 @@ msgid ""
 "typed `TextError::Config`, not a guess."
 msgstr ""
 
-#: src/sparql/full-text.md:66
+#: src/sparql/full-text.md:76
 msgid "// Which literals to index: the caller names the predicates.\n"
 msgstr ""
 
-#: src/sparql/full-text.md:69
+#: src/sparql/full-text.md:79
 msgid "\"https://example.org/note\""
 msgstr ""
 
-#: src/sparql/full-text.md:73
+#: src/sparql/full-text.md:83
 msgid "// Which IRIs a query calls the index by: the caller names those too.\n"
 msgstr ""
 
-#: src/sparql/full-text.md:77
+#: src/sparql/full-text.md:87
 msgid "\"https://example.org/pf/search\""
 msgstr ""
 
-#: src/sparql/full-text.md:81
+#: src/sparql/full-text.md:91
 msgid "\"https://example.org/pf/occurs\""
 msgstr ""
 
-#: src/sparql/full-text.md:88
+#: src/sparql/full-text.md:98
 msgid ""
 "r#\"SELECT ?doc ?score ?rank WHERE {\n"
 "                    ?doc <https://example.org/pf/search> ( \"quick brown\" ?"
@@ -7558,7 +7702,7 @@ msgid ""
 "                  } LIMIT 3\"#"
 msgstr ""
 
-#: src/sparql/full-text.md:98
+#: src/sparql/full-text.md:108
 msgid ""
 "A registered IRI is recognized in predicate position exactly, so no parser "
 "option is needed to reach it. An IRI a query names that is declared through "
@@ -7566,7 +7710,7 @@ msgid ""
 "neither stays an ordinary triple pattern."
 msgstr ""
 
-#: src/sparql/full-text.md:103
+#: src/sparql/full-text.md:113
 msgid ""
 "This is a Rust-host seam. The index and its relations are host closures, so "
 "they do not cross the Python, WebAssembly or C boundary — only the data-"
@@ -7575,18 +7719,18 @@ msgid ""
 "(querying.md#reaching-extensions-from-other-hosts)."
 msgstr ""
 
-#: src/sparql/full-text.md:108
+#: src/sparql/full-text.md:118
 msgid "Every score is exact, and identical on every target"
 msgstr ""
 
-#: src/sparql/full-text.md:110
+#: src/sparql/full-text.md:120
 msgid ""
 "Ranking is done entirely in base-10 fixed-point integer arithmetic (`i128`, "
 "twelve fractional digits). No floating-point value enters the crate: its "
 "root denies `clippy::float_arithmetic`, so none can."
 msgstr ""
 
-#: src/sparql/full-text.md:114
+#: src/sparql/full-text.md:124
 msgid ""
 "That is a correctness requirement, not a preference. BM25 needs a natural "
 "logarithm, and a libm `ln` may differ by a unit in the last place between "
@@ -7601,7 +7745,7 @@ msgid ""
 "wasm32 against the same expectations `cargo test` asserts natively."
 msgstr ""
 
-#: src/sparql/full-text.md:126
+#: src/sparql/full-text.md:136
 msgid ""
 "The BM25 constants `k1 = 1.2` and `b = 0.75` are crate constants rather than "
 "caller parameters. PurRDF is a carrier, and optionality that changes "
@@ -7609,11 +7753,11 @@ msgid ""
 "ranks out of the same index and the same needle."
 msgstr ""
 
-#: src/sparql/full-text.md:131
+#: src/sparql/full-text.md:141
 msgid "Ordering, and the idioms that reproduce it"
 msgstr ""
 
-#: src/sparql/full-text.md:133
+#: src/sparql/full-text.md:143
 msgid ""
 "Corpus statistics are computed per `(graph, language)` partition, so a score "
 "is a number relative to one corpus and `?rank` is a position within that "
@@ -7625,11 +7769,11 @@ msgid ""
 "through the selector) or builds a single-partition index."
 msgstr ""
 
-#: src/sparql/full-text.md:142
+#: src/sparql/full-text.md:152
 msgid "Two consequences worth knowing:"
 msgstr ""
 
-#: src/sparql/full-text.md:144
+#: src/sparql/full-text.md:154
 msgid ""
 "**Bare `LIMIT k` is top-k.** Emission order _is_ rank order, so the "
 "evaluator's row-ceiling licence applies and the relation stops after `k` "
@@ -7638,7 +7782,7 @@ msgid ""
 "`ORDER BY` is redundant anyway."
 msgstr ""
 
-#: src/sparql/full-text.md:149
+#: src/sparql/full-text.md:159
 msgid ""
 "**`ORDER BY ?rank` is the reproducing idiom.** A score reaches the consumer "
 "as a decimal of fixed width, so two rows can report the same `?score` while "
@@ -7646,11 +7790,11 @@ msgid ""
 "with the exact internal order, and `?rank` cannot."
 msgstr ""
 
-#: src/sparql/full-text.md:154
+#: src/sparql/full-text.md:164
 msgid "RDF 1.2 first class"
 msgstr ""
 
-#: src/sparql/full-text.md:156
+#: src/sparql/full-text.md:166
 msgid ""
 "`RdfDataset::quads()` returns only the asserted triple table; annotations "
 "live in a separate side table. The index reads both layers, so text carried "
@@ -7660,18 +7804,18 @@ msgid ""
 "against exactly that."
 msgstr ""
 
-#: src/sparql/full-text.md:162
+#: src/sparql/full-text.md:172
 msgid "Stated limits"
 msgstr ""
 
-#: src/sparql/full-text.md:164
+#: src/sparql/full-text.md:174
 msgid ""
 "Document ids are a function of content _except_ through blank-node labels, "
 "which are a parsing artifact: two isomorphic datasets with different labels "
 "produce different index fingerprints."
 msgstr ""
 
-#: src/sparql/full-text.md:167
+#: src/sparql/full-text.md:177
 msgid ""
 "The index is in-memory and built over a frozen dataset. `verify_binding` "
 "checks that the index a query runs against was built over the dataset in "
@@ -7679,7 +7823,7 @@ msgid ""
 "that join back to zero rows."
 msgstr ""
 
-#: src/sparql/full-text.md:172
+#: src/sparql/full-text.md:182
 msgid ""
 "The scoring design record — including the fixed-point logarithm and the "
 "Unicode table versions folded into the index fingerprint — is [`docs/design/"
@@ -7688,6 +7832,22 @@ msgid ""
 msgstr ""
 
 #: src/sparql/geosparql.md:8
+msgid ""
+"**What it replaces, and where it stops.** This is the surface that lets an "
+"RDF project drop the PostGIS it kept beside its triple store for spatial "
+"predicates: `?a geo:sfWithin ?b` and its Simple Features, Egenhofer and RCC8 "
+"siblings, plus the `geof:` functions, answered in-process over the dataset "
+"the query already holds, exactly, with no GEOS or PROJ, and byte-identical "
+"natively and on wasm32. It is GeoSPARQL 1.1's topological predicates, "
+"accessors, and exactly computable measures and constructors over vector "
+"geometry, not a PostGIS: `geof:transform` hard-errors by name (there is no "
+"CRS database), a `metric*` measure answers only in a CRS the caller declared "
+"in metres (there is no ellipsoidal geodesic), and buffers, hulls, the "
+"overlay set operations and the GML/KML/DGGS encodings are registered and "
+"hard-error by name. No raster."
+msgstr ""
+
+#: src/sparql/geosparql.md:20
 msgid ""
 "`purrdf-geo` (`purrdf::geo` from the umbrella crate) implements GeoSPARQL "
 "1.1 (OGC 22-047r1) for PurRDF: exact, float-free geometry reached from "
@@ -7702,11 +7862,11 @@ msgid ""
 "unknown`."
 msgstr ""
 
-#: src/sparql/geosparql.md:19
+#: src/sparql/geosparql.md:31
 msgid "It mints no vocabulary"
 msgstr ""
 
-#: src/sparql/geosparql.md:21
+#: src/sparql/geosparql.md:33
 msgid ""
 "GeoSPARQL's IRIs are OGC's, not PurRDF's. Every IRI the crate reads or "
 "writes — the two literal datatypes, the `geof:` function names, the `geo:` "
@@ -7716,52 +7876,52 @@ msgid ""
 "makes the feature that needs it a hard error, never a fabricated fallback."
 msgstr ""
 
-#: src/sparql/geosparql.md:31
+#: src/sparql/geosparql.md:43
 msgid "\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\""
 msgstr ""
 
-#: src/sparql/geosparql.md:33
+#: src/sparql/geosparql.md:45
 msgid "\"http://www.opengis.net/ont/geosparql#\""
 msgstr ""
 
-#: src/sparql/geosparql.md:33
+#: src/sparql/geosparql.md:45
 msgid ""
 "// geo:\n"
 "    \"http://www.opengis.net/def/function/geosparql/\""
 msgstr ""
 
-#: src/sparql/geosparql.md:34
+#: src/sparql/geosparql.md:46
 msgid "// geof:\n"
 msgstr ""
 
-#: src/sparql/geosparql.md:35
+#: src/sparql/geosparql.md:47
 msgid "// the CRS a bare WKT literal means\n"
 msgstr ""
 
-#: src/sparql/geosparql.md:36
+#: src/sparql/geosparql.md:48
 msgid "// the CRS GeoJSON is in\n"
 msgstr ""
 
-#: src/sparql/geosparql.md:38 src/sparql/geosparql.md:39
+#: src/sparql/geosparql.md:50 src/sparql/geosparql.md:51
 msgid "\"http://www.opengis.net/def/uom/OGC/1.0/metre\""
 msgstr ""
 
-#: src/sparql/geosparql.md:40
+#: src/sparql/geosparql.md:52
 msgid "\"http://www.opengis.net/ont/sf#\""
 msgstr ""
 
-#: src/sparql/geosparql.md:44
+#: src/sparql/geosparql.md:56
 msgid "The `geof:` family on the scalar seam"
 msgstr ""
 
-#: src/sparql/geosparql.md:46
+#: src/sparql/geosparql.md:58
 msgid ""
 "`functions::register` installs every `geof:` function into a "
 "`UserFunctionRegistry` under the vocabulary's function namespace, and the "
 "registry is handed to the engine through `QueryOptions::functions`:"
 msgstr ""
 
-#: src/sparql/geosparql.md:61
+#: src/sparql/geosparql.md:73
 msgid ""
 "r#\"PREFIX geof: <http://www.opengis.net/def/function/geosparql/>\n"
 "                  PREFIX geo:  <http://www.opengis.net/ont/geosparql#>\n"
@@ -7772,7 +7932,7 @@ msgid ""
 "                  }\"#"
 msgstr ""
 
-#: src/sparql/geosparql.md:75
+#: src/sparql/geosparql.md:87
 msgid ""
 "A function's refusals travel exactly as far as SPARQL says they should. A "
 "malformed literal or a domain refusal — mixed CRSs, the measure of an empty "
@@ -7786,11 +7946,11 @@ msgid ""
 "`functions::compute`."
 msgstr ""
 
-#: src/sparql/geosparql.md:85
+#: src/sparql/geosparql.md:97
 msgid "Spatial relations on the property-function seam"
 msgstr ""
 
-#: src/sparql/geosparql.md:87
+#: src/sparql/geosparql.md:99
 msgid ""
 "GeoSPARQL's Query Rewrite rules let `?a geo:sfWithin ?b` hold between "
 "_features_ whose geometries satisfy the relation, not only where a triple "
@@ -7803,25 +7963,25 @@ msgid ""
 "matched nothing."
 msgstr ""
 
-#: src/sparql/geosparql.md:111
+#: src/sparql/geosparql.md:123
 msgid ""
 "// The parser must claim `geo:sfWithin` in predicate position; the "
 "registry's\n"
 "// own descriptors are exactly the IRIs it should claim.\n"
 msgstr ""
 
-#: src/sparql/geosparql.md:121
+#: src/sparql/geosparql.md:133
 msgid ""
 "An asserted `geo:sfWithin` triple matches whether or not the geometries "
 "satisfy it — the rewrite rules are entailments, not definitions — and a "
 "relation the index refutes contributes no row beyond what the data asserts."
 msgstr ""
 
-#: src/sparql/geosparql.md:125
+#: src/sparql/geosparql.md:137
 msgid "Every answer is exact, and identical on every target"
 msgstr ""
 
-#: src/sparql/geosparql.md:127
+#: src/sparql/geosparql.md:139
 msgid ""
 "Geometry is where floating point normally destroys reproducibility: `f64` "
 "addition is not associative, so a different traversal order gives a "
@@ -7830,14 +7990,14 @@ msgid ""
 "than mitigating it."
 msgstr ""
 
-#: src/sparql/geosparql.md:133
+#: src/sparql/geosparql.md:145
 msgid ""
 "**Coordinates are read as exact rationals.** A lexical decimal is parsed "
 "digit by digit into an exact numerator and denominator; nothing is rounded "
 "on the way in."
 msgstr ""
 
-#: src/sparql/geosparql.md:136
+#: src/sparql/geosparql.md:148
 msgid ""
 "**Every geometric decision is integer arithmetic.** Orientation, segment "
 "intersection, point-in-ring, ring winding and the DE-9IM matrix are "
@@ -7845,14 +8005,14 @@ msgid ""
 "specifies completely and identically on every target."
 msgstr ""
 
-#: src/sparql/geosparql.md:140
+#: src/sparql/geosparql.md:152
 msgid ""
 "**Irrational measures are integer square roots** at a fixed internal scale, "
 "summed as integers — one rounding, at the end, of a value that was exact "
 "until then."
 msgstr ""
 
-#: src/sparql/geosparql.md:143
+#: src/sparql/geosparql.md:155
 msgid ""
 "**The single float boundary is the result literal.** An `xsd:double` result "
 "is the correctly rounded nearest double, computed with integer arithmetic "
@@ -7860,17 +8020,17 @@ msgid ""
 "`clippy::float_arithmetic`, so there is no second float path to find."
 msgstr ""
 
-#: src/sparql/geosparql.md:148
+#: src/sparql/geosparql.md:160
 msgid ""
 "The cross-target claim is executed, not argued: `make geo-determinism` runs "
 "the same corpus natively and on wasm32 and compares bytes."
 msgstr ""
 
-#: src/sparql/geosparql.md:151
+#: src/sparql/geosparql.md:163
 msgid "What is here, and what is not"
 msgstr ""
 
-#: src/sparql/geosparql.md:153
+#: src/sparql/geosparql.md:165
 msgid ""
 "Implemented: the WKT and GeoJSON codecs (with CRS and coordinate-dimension "
 "support); every topological relation of the Simple Features, Egenhofer and "
@@ -7878,7 +8038,7 @@ msgid ""
 "constructors that are exactly computable."
 msgstr ""
 
-#: src/sparql/geosparql.md:158
+#: src/sparql/geosparql.md:170
 msgid ""
 "Registered but **hard-erroring by name**: the operations that would require "
 "facilities the crate deliberately does not have — a coordinate-reference-"
@@ -7890,7 +8050,7 @@ msgid ""
 "exists to keep out."
 msgstr ""
 
-#: src/sparql/geosparql.md:166
+#: src/sparql/geosparql.md:178
 msgid ""
 "Like the full-text index, this is a Rust-host seam: the registrations are "
 "host closures and do not cross the Python, WebAssembly or C boundary. The "
@@ -7900,6 +8060,19 @@ msgid ""
 msgstr ""
 
 #: src/sparql/embedding-knn.md:8
+msgid ""
+"**What it replaces, and where it stops.** This is the surface that lets an "
+"RDF project drop the pgvector it kept beside its triple store for nearest-"
+"neighbour search: `?neighbour <space> ( ?seed k ?distance )` answered in-"
+"process, exact top-k under the metric the artifact declares, and byte-"
+"identical natively and on wasm32. It is an exact scan — every candidate "
+"scored, no pruning, no approximate index — bounded by a caller-supplied "
+"`KnnGuard`, under three metrics (cosine, negative dot, squared Euclidean), "
+"over a PURREMB embedding space. PurRDF computes no embeddings and runs no "
+"ANN payload: the vectors arrive in an artifact the caller produced."
+msgstr ""
+
+#: src/sparql/embedding-knn.md:18
 msgid ""
 "The PURREMB layer in `purrdf-core` (see [Deterministic embedding companions]"
 "(../concepts/codecs.md#deterministic-embedding-companions) and [`docs/"
@@ -7912,11 +8085,11 @@ msgid ""
 "property-function seam."
 msgstr ""
 
-#: src/sparql/embedding-knn.md:18
+#: src/sparql/embedding-knn.md:28
 msgid "The call shape"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:20
+#: src/sparql/embedding-knn.md:30
 msgid ""
 "```sparql\n"
 "PREFIX knn: <https://example.org/space/>\n"
@@ -7928,62 +8101,62 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:29
+#: src/sparql/embedding-knn.md:39
 msgid ""
 "Four flattened positions — one on the subject side, three on the object side:"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:31
+#: src/sparql/embedding-knn.md:41
 msgid "position"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:31
+#: src/sparql/embedding-knn.md:41
 msgid "name"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:31
+#: src/sparql/embedding-knn.md:41
 msgid "role"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:33 src/entailment.md:143 src/entailment.md:148
+#: src/sparql/embedding-knn.md:43 src/entailment.md:143 src/entailment.md:148
 #: src/entailment.md:149 src/entailment-rules.md:60 src/entailment-rules.md:64
 #: src/entailment-rules.md:65
 msgid "0"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:33
+#: src/sparql/embedding-knn.md:43
 msgid "`?neighbour`"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:33
+#: src/sparql/embedding-knn.md:43
 msgid "**out**: the RDF term whose vector was retrieved"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:34
+#: src/sparql/embedding-knn.md:44
 msgid "`?query`"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:34
+#: src/sparql/embedding-knn.md:44
 msgid "**in**: the term whose vector seeds the search"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:35
+#: src/sparql/embedding-knn.md:45
 msgid "`k`"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:35
+#: src/sparql/embedding-knn.md:45
 msgid "**in**: how many neighbours to retrieve"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:36
+#: src/sparql/embedding-knn.md:46
 msgid "`?distance`"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:36
+#: src/sparql/embedding-knn.md:46
 msgid "**out**: the distance, as `xsd:double`"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:38
+#: src/sparql/embedding-knn.md:48
 msgid ""
 "The one declared mode is `fbbf`: the seed and `k` are inputs the relation "
 "cannot enumerate, while `?neighbour` and `?distance` may each be bound or "
@@ -7994,11 +8167,11 @@ msgid ""
 "terms would die."
 msgstr ""
 
-#: src/sparql/embedding-knn.md:46
+#: src/sparql/embedding-knn.md:56
 msgid "PurRDF mints no IRI for this"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:48
+#: src/sparql/embedding-knn.md:58
 msgid ""
 "The predicate is the caller's, and it is how a query names a space: a host "
 "builds one `EmbeddingSpace` per `(artifact, target set, vector space)` "
@@ -8009,43 +8182,43 @@ msgid ""
 "an honest row bound off the space that will actually be searched."
 msgstr ""
 
-#: src/sparql/embedding-knn.md:59
+#: src/sparql/embedding-knn.md:69
 msgid ""
 "// The guard is caller-supplied configuration with no default: the largest\n"
 "// space one invocation may scan, and the largest `k` it may request.\n"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:62
+#: src/sparql/embedding-knn.md:72
 msgid "/* max_candidates */"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:62
+#: src/sparql/embedding-knn.md:72
 msgid "/* max_neighbours */"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:63
+#: src/sparql/embedding-knn.md:73
 msgid ""
 "// `bindings` names the RDF term each PURREMB row stands for. A row with no\n"
 "// term is a construction-time refusal, not a skipped row — a top-k over a\n"
 "// silently smaller candidate set would be the top-k of a subset.\n"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:73
+#: src/sparql/embedding-knn.md:83
 msgid "\"https://example.org/space/points\""
 msgstr ""
 
-#: src/sparql/embedding-knn.md:78
+#: src/sparql/embedding-knn.md:88
 msgid ""
 "The registry then reaches the engine through "
 "`QueryOptions::property_functions` exactly as on the [full-text](full-"
 "text.md) page. This is a Rust-host seam."
 msgstr ""
 
-#: src/sparql/embedding-knn.md:81
+#: src/sparql/embedding-knn.md:91
 msgid "Exact search, ordered under the declared metric"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:83
+#: src/sparql/embedding-knn.md:93
 msgid ""
 "The search is **exact**: every candidate row is scored under the metric the "
 "space's family contract declares (`FamilyView::metric()` — cosine or squared "
@@ -8058,7 +8231,7 @@ msgid ""
 "than a property of a tuning parameter."
 msgstr ""
 
-#: src/sparql/embedding-knn.md:93
+#: src/sparql/embedding-knn.md:103
 msgid ""
 "Rank order is `(distance ASC, row ASC)`. Row numbers are distinct, so the "
 "order is strict and total, and the tie-break is meaningful: a PURREMB target "
@@ -8068,11 +8241,11 @@ msgid ""
 "answer byte for byte, serialized JSON included."
 msgstr ""
 
-#: src/sparql/embedding-knn.md:100
+#: src/sparql/embedding-knn.md:110
 msgid "Binary64, in a pinned order"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:102
+#: src/sparql/embedding-knn.md:112
 msgid ""
 "The workspace's other ranked-retrieval surface forbids floating point "
 "entirely, because BM25 needs a logarithm and IEEE-754 does not require `ln` "
@@ -8085,7 +8258,7 @@ msgid ""
 "quantization step the format does not have."
 msgstr ""
 
-#: src/sparql/embedding-knn.md:112
+#: src/sparql/embedding-knn.md:122
 msgid ""
 "The two residual hazards are closed structurally: every fold runs over "
 "ascending component index in one sequential loop, never split across workers "
@@ -8097,7 +8270,7 @@ msgid ""
 "divergence this is about."
 msgstr ""
 
-#: src/sparql/embedding-knn.md:120
+#: src/sparql/embedding-knn.md:130
 msgid ""
 "One limit, stated rather than hidden: cosine self-distance is not exactly "
 "zero (`dot(v, v)` and `|v|·|v|` are two roundings of one real number), so a "
@@ -8105,11 +8278,11 @@ msgid ""
 "that is not there."
 msgstr ""
 
-#: src/sparql/embedding-knn.md:125
+#: src/sparql/embedding-knn.md:135
 msgid "What a search costs"
 msgstr ""
 
-#: src/sparql/embedding-knn.md:127
+#: src/sparql/embedding-knn.md:137
 msgid ""
 "The governor's earlier charge points priced a host relation by invocations "
 "driven and rows accepted. For a generator, neither is where the cost is: a "
@@ -8121,7 +8294,7 @@ msgid ""
 "and the planner's row bound honest."
 msgstr ""
 
-#: src/sparql/embedding-knn.md:136
+#: src/sparql/embedding-knn.md:146
 msgid ""
 "The design record — the four decisions that were not obvious and what fixed "
 "each — is [`docs/design/purrdf-embedding-knn.md`](https://github.com/"
@@ -11076,6 +11249,12 @@ msgid ""
 "The engine is **in-memory**; there is no persistent store in the wasm build. "
 "SPARQL runs over the in-memory dataset; this package provides no network "
 "resolver, so remote `SERVICE` and `LOAD` fail explicitly."
+msgstr ""
+
+#: src/interop/rdfjs.md:108
+msgid ""
+"A quoted-triple term as a quad **object** currently round-trips only through "
+"**N-Quads** (a current native serializer limitation for the other formats)."
 msgstr ""
 
 #: src/interop/rdfjs.md:114

--- a/docs/book/po/zh-Hans.po
+++ b/docs/book/po/zh-Hans.po
@@ -1,0 +1,11812 @@
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: CC-BY-4.0
+#
+# Simplified Chinese (zh-Hans) translation of The PurRDF Book.
+#
+# Every msgid is a unit of docs/book/src/ as mdbook-xgettext extracts it; an
+# empty msgstr renders as the English source (translation lag is visible to the
+# reader by construction). Gated by scripts/check-i18n-glossary.py (make check)
+# and scripts/check-i18n-render.py (make check-i18n; the docs workflow).
+# Refresh the msgids after the English source changes: make book-po-update.
+msgid ""
+msgstr ""
+"Project-Id-Version: The PurRDF Book\n"
+"POT-Creation-Date: 2026-09-02T15:58:27-06:00\n"
+"PO-Revision-Date: 2026-09-02T15:58:27-06:00\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/SUMMARY.md:6
+msgid "Summary"
+msgstr ""
+
+#: src/SUMMARY.md:8 src/introduction.md:6
+msgid "Introduction"
+msgstr ""
+
+#: src/SUMMARY.md:10
+msgid "Getting Started"
+msgstr ""
+
+#: src/SUMMARY.md:12 src/concepts/projections.md:449 src/concepts/jsonld.md:36
+#: src/entailment.md:49 src/entailment.md:94
+msgid "Rust"
+msgstr ""
+
+#: src/SUMMARY.md:13 src/concepts/projections.md:451
+#: src/concepts/base-iris.md:55 src/concepts/jsonld.md:74 src/entailment.md:51
+#: src/entailment.md:96
+msgid "Python"
+msgstr ""
+
+#: src/SUMMARY.md:14 src/entailment.md:52 src/entailment.md:97
+msgid "JavaScript / WebAssembly"
+msgstr ""
+
+#: src/SUMMARY.md:15 src/concepts/projections.md:453 src/concepts/jsonld.md:114
+#: src/entailment.md:53 src/entailment.md:98
+msgid "C"
+msgstr ""
+
+#: src/SUMMARY.md:17
+msgid "Concepts"
+msgstr ""
+
+#: src/SUMMARY.md:19 src/concepts/interned-dataset.md:6
+msgid "The Interned Dataset IR"
+msgstr ""
+
+#: src/SUMMARY.md:20 src/concepts/rdf12.md:6
+msgid "RDF 1.2 Features"
+msgstr ""
+
+#: src/SUMMARY.md:21 src/concepts/visualization.md:6
+msgid "RDF 1.2 Visualization"
+msgstr ""
+
+#: src/SUMMARY.md:22
+msgid "Graph, Tabular & Research-Object Projections"
+msgstr ""
+
+#: src/SUMMARY.md:23 src/concepts/codecs.md:6
+msgid "Codecs & Determinism"
+msgstr ""
+
+#: src/SUMMARY.md:24 src/concepts/base-iris.md:6
+msgid "Base IRIs & Relative References"
+msgstr ""
+
+#: src/SUMMARY.md:25 src/concepts/jsonld.md:6
+msgid "JSON-LD Contexts & Compaction"
+msgstr ""
+
+#: src/SUMMARY.md:26 src/concepts/canonicalization.md:6
+msgid "Canonicalization & Diff"
+msgstr ""
+
+#: src/SUMMARY.md:28 src/concepts/rdf12.md:70 src/interop/rdfjs.md:60
+msgid "SPARQL"
+msgstr ""
+
+#: src/SUMMARY.md:30
+msgid "Querying"
+msgstr ""
+
+#: src/SUMMARY.md:31
+msgid "Result Formats"
+msgstr ""
+
+#: src/SUMMARY.md:32 src/sparql/full-text.md:6
+msgid "Full-Text Search"
+msgstr ""
+
+#: src/SUMMARY.md:33 src/sparql/geosparql.md:6
+msgid "GeoSPARQL"
+msgstr ""
+
+#: src/SUMMARY.md:34 src/sparql/embedding-knn.md:6
+msgid "Embedding Nearest Neighbours"
+msgstr ""
+
+#: src/SUMMARY.md:36
+msgid "Validation"
+msgstr ""
+
+#: src/SUMMARY.md:38 src/concepts/rdf12.md:70 src/validation/shacl.md:6
+#: src/project/conformance.md:43
+msgid "SHACL"
+msgstr ""
+
+#: src/SUMMARY.md:39 src/validation/shex.md:6
+msgid "ShEx"
+msgstr ""
+
+#: src/SUMMARY.md:41
+msgid "Reasoning & Transport"
+msgstr ""
+
+#: src/SUMMARY.md:43 src/getting-started/python.md:48 src/entailment.md:6
+#: src/project/conformance.md:45
+msgid "Entailment"
+msgstr ""
+
+#: src/SUMMARY.md:44 src/entailment-rules.md:6
+msgid "Entailment Rule Inventory"
+msgstr ""
+
+#: src/SUMMARY.md:45 src/datalog.md:6
+msgid "Datalog: the Fixpoint Engine"
+msgstr ""
+
+#: src/SUMMARY.md:46 src/gts.md:6
+msgid "GTS Graph Transport"
+msgstr ""
+
+#: src/SUMMARY.md:47 src/slices.md:6
+msgid "Slices, Mappings & Provenance"
+msgstr ""
+
+#: src/SUMMARY.md:49
+msgid "Interop"
+msgstr ""
+
+#: src/SUMMARY.md:51 src/interop/rdflib.md:6
+msgid "rdflib Compatibility"
+msgstr ""
+
+#: src/SUMMARY.md:52 src/interop/rdfjs.md:6
+msgid "RDF/JS in JavaScript"
+msgstr ""
+
+#: src/SUMMARY.md:54
+msgid "Project"
+msgstr ""
+
+#: src/SUMMARY.md:56 src/project/design-rules.md:6
+msgid "Design Rules & Invariants"
+msgstr ""
+
+#: src/SUMMARY.md:57 src/project/conformance.md:6
+msgid "Conformance & Testing"
+msgstr ""
+
+#: src/SUMMARY.md:58 src/interop/rdflib.md:66 src/project/performance.md:6
+msgid "Performance"
+msgstr ""
+
+#: src/SUMMARY.md:59 src/project/releases.md:6
+msgid "Versioning & Releases"
+msgstr ""
+
+#: src/introduction.md:8
+msgid ""
+"**PurRDF** is an [RDF 1.2](https://www.w3.org/TR/rdf12-concepts/) toolkit: "
+"primitives, codecs, SPARQL, SHACL, ShEx, entailment, and graph transport, "
+"implemented once in Rust and carried verbatim into Python, WebAssembly/"
+"JavaScript, and C. It is developed by Blackcat Informatics® Inc. and "
+"published under MIT OR Apache-2.0."
+msgstr ""
+
+#: src/introduction.md:14
+msgid "**One RDF engine. One behavior. Every language.**"
+msgstr ""
+
+#: src/introduction.md:16
+msgid "Why does PurRDF exist?"
+msgstr ""
+
+#: src/introduction.md:18
+msgid "RDF tooling fragments along two axes."
+msgstr ""
+
+#: src/introduction.md:20
+msgid ""
+"**Across languages**: every ecosystem has its own parser, with its own bugs, "
+"its own corner-case interpretations, and its own subset of the spec. Move a "
+"graph from a Rust service to a Python pipeline to a browser and you have "
+"silently changed what the data means three times."
+msgstr ""
+
+#: src/introduction.md:25
+msgid ""
+"**Across time**: RDF 1.2 — triple terms, reifiers, base-direction literals — "
+"is the current revision of the standard, and almost no incumbent library "
+"carries it."
+msgstr ""
+
+#: src/introduction.md:28
+msgid ""
+"PurRDF exists so that a graph is **the same graph everywhere**. It is a from-"
+"scratch, dependency-light Rust core — parser to SPARQL engine to SHACL "
+"validator to binary transport — exposed through native bindings rather than "
+"reimplemented per language."
+msgstr ""
+
+#: src/introduction.md:33
+msgid "What's inside"
+msgstr ""
+
+#: src/introduction.md:35
+msgid ""
+"**RDF 1.2 primitives** — an immutable, value-interned dataset IR (`TermId` "
+"space, string arena, copy-on-write mutation), with triple terms in object "
+"position, reifier/annotation side-tables, and base-direction literals. See "
+"[The Interned Dataset IR](concepts/interned-dataset.md)."
+msgstr ""
+
+#: src/introduction.md:39
+msgid ""
+"**Native codecs** — first-party parsers/serializers for Turtle, TriG, N-"
+"Triples, N-Quads, RDF/XML, TriX, HexTuples, JSON-LD (star), and YAML-LD, "
+"with byte-deterministic output. See [Codecs & Determinism](concepts/"
+"codecs.md). Every syntax resolves relative IRI references through one RFC "
+"3986 layer, and a relative reference with no base in scope is a hard error. "
+"See [Base IRIs & Relative References](concepts/base-iris.md)."
+msgstr ""
+
+#: src/introduction.md:45
+msgid ""
+"**Canonicalization** — W3C RDFC-1.0 plus dataset diff and isomorphism. See "
+"[Canonicalization & Diff](concepts/canonicalization.md)."
+msgstr ""
+
+#: src/introduction.md:47
+msgid ""
+"**Projections & carriers** — deterministic LPG, CSVW, OBO Graphs, dataset-"
+"description, and research-object projections, each with a located loss "
+"ledger. See [Graph, Tabular & Research-Object Projections](concepts/"
+"projections.md)."
+msgstr ""
+
+#: src/introduction.md:51
+msgid ""
+"**SPARQL 1.1/1.2** — native parser → algebra → multiset evaluator, with full "
+"Update, SEP-0002 temporal arithmetic, `LATERAL` (SEP-0006), the SEP-0008 "
+"SHA-3 hash builtins (`SHA3-224`/`256`/`384`/`512`), quad templates that "
+"`CONSTRUCT` into named graphs (a first-party extension, not a SPARQL 1.2 "
+"feature), the SEP-0009 composite datatypes (`cdt:List`/`cdt:Map`, `FOLD`, "
+"`UNFOLD`), caller-registered aggregates and property functions (including "
+"path witnesses that bind a traversal hop by hop), governed execution with "
+"per-node explain receipts, and `SERVICE` federation through a host-injected "
+"resolver carrying per-service context, gated by the W3C conformance suites. "
+"See [SPARQL](sparql/querying.md)."
+msgstr ""
+
+#: src/introduction.md:61
+msgid ""
+"**Out-of-core SPARQL extensions** — deterministic full-text search with "
+"exact fixed-point BM25 ([Full-Text Search](sparql/full-text.md)), exact and "
+"float-free GeoSPARQL 1.1 ([GeoSPARQL](sparql/geosparql.md)), and nearest-"
+"neighbour search over a PURREMB embedding space ([Embedding Nearest "
+"Neighbours](sparql/embedding-knn.md)) — each a consumer of the extension "
+"seams, registered under IRIs the caller supplies."
+msgstr ""
+
+#: src/introduction.md:67
+msgid ""
+"**SHACL and ShEx** — native validators for both shape languages; the SHACL "
+"engine covers Core, SHACL-SPARQL and SHACL-AF, aligned with the SHACL 1.2 "
+"node-expression and rule-layering drafts. See [Validation](validation/"
+"shacl.md)."
+msgstr ""
+
+#: src/introduction.md:70
+msgid ""
+"**Entailment** — Simple/RDF/RDFS/OWL-RL/D materialization (all 78 OWL 2 RL "
+"rules implemented — rule-table coverage, distinct from entailment "
+"conformance, where the OWL 2 RL entailment tests score 27 of 27 positive and "
+"23 of 23 negative on this vendored W3C corpus), an OWL-Direct tableau, and "
+"RIF-Core rules, with a reasoning report on every closure. See [Entailment]"
+"(entailment.md), evaluated on the [Datalog fixpoint engine](datalog.md)."
+msgstr ""
+
+#: src/introduction.md:76
+msgid ""
+"**GTS graph transport** — a single-file, content-addressed, append-only "
+"container for RDF 1.2 graphs and binary payloads. See [GTS Graph Transport]"
+"(gts.md)."
+msgstr ""
+
+#: src/introduction.md:79
+msgid ""
+"**Slices, mappings, and provenance** — a slice catalog, an explicit RDF↔GTS "
+"loss ledger, SSSOM, and FnO. See [Slices, Mappings & Provenance](slices.md)."
+msgstr ""
+
+#: src/introduction.md:82
+msgid "Two design rules worth knowing on day one"
+msgstr ""
+
+#: src/introduction.md:84
+msgid ""
+"**No feature flags — ever.** There are deliberately no Cargo feature flags "
+"anywhere in the workspace, and CI enforces this. A data carrier must not "
+"have optional behavior: optionality changes semantics per consumer, so every "
+"consumer gets the same byte-identical semantics instead."
+msgstr ""
+
+#: src/introduction.md:89
+msgid ""
+"**PurRDF is a toolkit, not an ontology — it mints no vocabulary IRIs.** "
+"Every vocabulary the library reads or writes is caller-supplied "
+"configuration with no fabricated default. A feature exercised without its "
+"vocabulary hard-errors or stays inactive; it never invents an IRI for you. "
+"(Test fixtures use `example.org`.)"
+msgstr ""
+
+#: src/introduction.md:95
+msgid ""
+"The full invariant list is in [Design Rules & Invariants](project/design-"
+"rules.md)."
+msgstr ""
+
+#: src/introduction.md:98
+msgid "Why RDF 1.2?"
+msgstr ""
+
+#: src/introduction.md:100
+msgid ""
+"RDF 1.2 (and SPARQL 1.2) add first-class statement-level metadata to the "
+"data model: **triple terms** that can appear in object position, "
+"**reifiers** that name occurrences of a triple, and **base-direction "
+"literals** (`rdf:dirLangString`) for bidirectional text. PurRDF treats these "
+"as core data model, not an extension: they flow through the IR, the codecs, "
+"SPARQL, SHACL (a scoped SHACL 1.2 feature), the RDF/JS surface, and the GTS "
+"transport. See [RDF 1.2 Features](concepts/rdf12.md)."
+msgstr ""
+
+#: src/introduction.md:108
+msgid "Where PurRDF sits"
+msgstr ""
+
+#: src/introduction.md:110
+msgid ""
+"PurRDF is the library layer of a small family of linked-data projects: it is "
+"the data backbone of the [GMEOW](https://github.com/Blackcat-Informatics/"
+"gmeow-ontology) stack and the reference home of the Rust [GTS](gts.md) "
+"engine — but it assumes nothing about your ontology or application."
+msgstr ""
+
+#: src/introduction.md:116
+msgid "How to read this book"
+msgstr ""
+
+#: src/introduction.md:118
+msgid ""
+"New users: start with [Getting Started](getting-started/rust.md) in your "
+"language, then read the [Concepts](concepts/interned-dataset.md) chapters."
+msgstr ""
+
+#: src/introduction.md:120
+msgid ""
+"Engine users: jump to [SPARQL](sparql/querying.md), [Validation](validation/"
+"shacl.md), or [Entailment](entailment.md)."
+msgstr ""
+
+#: src/introduction.md:122
+msgid ""
+"Integrators: see [Interop](interop/rdflib.md) and [GTS Graph Transport]"
+"(gts.md)."
+msgstr ""
+
+#: src/introduction.md:124
+msgid ""
+"Contributors: read the [Project](project/design-rules.md) chapters, then "
+"[AGENTS.md](https://github.com/Blackcat-Informatics/purrdf/blob/main/"
+"AGENTS.md) in the repository."
+msgstr ""
+
+#: src/introduction.md:128
+msgid ""
+"API reference documentation lives on [docs.rs/purrdf](https://docs.rs/"
+"purrdf); the repository is [github.com/Blackcat-Informatics/purrdf](https://"
+"github.com/Blackcat-Informatics/purrdf)."
+msgstr ""
+
+#: src/getting-started/rust.md:6
+msgid "Getting Started: Rust"
+msgstr ""
+
+#: src/getting-started/rust.md:8
+msgid ""
+"The single dependency a Rust downstream needs is the umbrella [`purrdf`]"
+"(https://crates.io/crates/purrdf) crate. It re-exports the RDF 1.2 "
+"implementation surface at its root and carries every other published crate "
+"under a stable module (`purrdf::sparql`, `purrdf::shapes`, `purrdf::shex`, "
+"`purrdf::gts`, `purrdf::entail`, `purrdf::validate`, `purrdf::slice`, "
+"`purrdf::iri`, `purrdf::xsd`, `purrdf::events`) — anything a consumer "
+"legitimately imports is reachable from `purrdf` alone, never by reaching "
+"into a sub-crate."
+msgstr ""
+
+#: src/getting-started/rust.md:21
+msgid ""
+"The MSRV is Rust **1.96** (stable toolchain only; the workspace is nightly-"
+"free by policy)."
+msgstr ""
+
+#: src/getting-started/rust.md:24
+msgid "Build, freeze, serialize, parse"
+msgstr ""
+
+#: src/getting-started/rust.md:28
+msgid "// Build a dataset in interned TermId space.\n"
+msgstr ""
+
+#: src/getting-started/rust.md:31 src/getting-started/python.md:40
+#: src/validation/shex.md:60
+msgid "\"https://example.org/alice\""
+msgstr ""
+
+#: src/getting-started/rust.md:32
+msgid "\"http://xmlns.com/foaf/0.1/knows\""
+msgstr ""
+
+#: src/getting-started/rust.md:33
+msgid "\"https://example.org/bob\""
+msgstr ""
+
+#: src/getting-started/rust.md:34
+msgid "\"http://xmlns.com/foaf/0.1/name\""
+msgstr ""
+
+#: src/getting-started/rust.md:35
+msgid "\"Alice\""
+msgstr ""
+
+#: src/getting-started/rust.md:38 src/sparql/querying.md:35
+msgid "\"freeze\""
+msgstr ""
+
+#: src/getting-started/rust.md:39
+msgid "// Serialize to any native codec and parse back, losslessly.\n"
+msgstr ""
+
+#: src/getting-started/rust.md:41 src/getting-started/rust.md:42
+#: src/getting-started/rust.md:58 src/getting-started/c.md:45
+#: src/concepts/projections.md:419 src/concepts/codecs.md:35
+msgid "\"text/turtle\""
+msgstr ""
+
+#: src/getting-started/rust.md:46
+msgid ""
+"The builder→freeze split is the heart of the API: you intern terms and push "
+"quads on a mutable `RdfDatasetBuilder`, then `freeze()` into an immutable, "
+"indexed `RdfDataset` that every engine (SPARQL, SHACL, ShEx, entailment) "
+"evaluates over. See [The Interned Dataset IR](../concepts/interned-"
+"dataset.md)."
+msgstr ""
+
+#: src/getting-started/rust.md:51
+msgid "Parsing text directly"
+msgstr ""
+
+#: src/getting-started/rust.md:54
+msgid ""
+"r#\"\n"
+"    @prefix ex: <https://example.org/> .\n"
+"    ex:cat ex:says \"meow\" .\n"
+"\"#"
+msgstr ""
+
+#: src/getting-started/rust.md:59 src/concepts/codecs.md:35
+msgid "\"valid Turtle\""
+msgstr ""
+
+#: src/getting-started/rust.md:63
+msgid ""
+"Malformed input is a typed `RdfDiagnostic` with a source location where the "
+"codec can provide one — never a silent partial parse."
+msgstr ""
+
+#: src/getting-started/rust.md:66
+msgid "Reaching the other engines"
+msgstr ""
+
+#: src/getting-started/rust.md:68
+msgid ""
+"Every engine hangs off the same facade. For example, the zero-dependency IRI "
+"leaf and the ShEx schema layer:"
+msgstr ""
+
+#: src/getting-started/rust.md:72 src/getting-started/rust.md:73
+#: src/concepts/interned-dataset.md:32 src/sparql/querying.md:31
+msgid "\"https://example.org/cat\""
+msgstr ""
+
+#: src/getting-started/rust.md:72
+msgid "\"valid IRI\""
+msgstr ""
+
+#: src/getting-started/rust.md:76
+msgid "\"PREFIX ex: <https://example.org/>\\nex:Cat { ex:says . }\""
+msgstr ""
+
+#: src/getting-started/rust.md:78
+msgid "\"valid ShExC\""
+msgstr ""
+
+#: src/getting-started/rust.md:81
+msgid "When to depend on a sub-crate instead"
+msgstr ""
+
+#: src/getting-started/rust.md:83
+msgid ""
+"Most applications should stop at `purrdf`. The sub-crates (`purrdf-core`, "
+"`purrdf-rdf`, `purrdf-columnar`, `purrdf-sparql-algebra`, `purrdf-sparql-"
+"eval`, `purrdf-sparql-results`, `purrdf-cdt`, `purrdf-shapes`, `purrdf-"
+"shex`, `purrdf-gts`, `purrdf-datalog`, `purrdf-entail`, `purrdf-geo`, "
+"`purrdf-text`, `purrdf-validate`, `purrdf-slice`, `purrdf-iri`, `purrdf-"
+"xsd`, `purrdf-events`, `purrdf-wasm`) exist for consumers that want exactly "
+"one engine — for example, a tool that only needs IRI parsing can depend on "
+"the zero-dependency `purrdf-iri` alone. The crate map is in the [repository "
+"README](https://github.com/Blackcat-Informatics/purrdf#crate-map)."
+msgstr ""
+
+#: src/getting-started/rust.md:94
+msgid ""
+"Every release crate builds cleanly for `wasm32-unknown-unknown`, so the same "
+"Rust code paths work in native and wasm hosts."
+msgstr ""
+
+#: src/getting-started/rust.md:97 src/getting-started/python.md:127
+msgid "Next steps"
+msgstr ""
+
+#: src/getting-started/rust.md:99
+msgid ""
+"[The Interned Dataset IR](../concepts/interned-dataset.md) — how the IR "
+"works and why it is fast."
+msgstr ""
+
+#: src/getting-started/rust.md:101
+msgid ""
+"[Graph, Tabular & Research-Object Projections](../concepts/projections.md) — "
+"deterministic LPG, CSVW, OBO Graphs, SKOS, and research-object carriers "
+"through the umbrella crate."
+msgstr ""
+
+#: src/getting-started/rust.md:103
+msgid ""
+"[SPARQL: Querying](../sparql/querying.md) — running queries over a frozen "
+"dataset."
+msgstr ""
+
+#: src/getting-started/rust.md:105
+msgid "[docs.rs/purrdf](https://docs.rs/purrdf) — the full API reference."
+msgstr ""
+
+#: src/getting-started/python.md:6
+msgid "Getting Started: Python"
+msgstr ""
+
+#: src/getting-started/python.md:8
+msgid ""
+"The Python package wraps the same native Rust engine — not a "
+"reimplementation — so parsing, serialization, SPARQL, and validation behave "
+"identically to the Rust, JavaScript, and C surfaces."
+msgstr ""
+
+#: src/getting-started/python.md:16
+msgid "Parsing"
+msgstr ""
+
+#: src/getting-started/python.md:22
+msgid ""
+"'<https://example.org/alice> <http://xmlns.com/foaf/0.1/name> \"Alice\" .'"
+msgstr ""
+
+#: src/getting-started/python.md:27
+msgid "Validation: SHACL and ShEx"
+msgstr ""
+
+#: src/getting-started/python.md:29
+msgid ""
+"The native validation engines are exposed as top-level submodules mirroring "
+"the Rust `purrdf` umbrella crate — never through the internal "
+"`purrdf_native` extension module directly:"
+msgstr ""
+
+#: src/getting-started/python.md:37 src/validation/shacl.md:326
+msgid "\"conforms\""
+msgstr ""
+
+#: src/getting-started/python.md:40 src/validation/shex.md:60
+msgid "\"https://example.org/PersonShape\""
+msgstr ""
+
+#: src/getting-started/python.md:41 src/validation/shex.md:61
+msgid "\"conformant\""
+msgstr ""
+
+#: src/getting-started/python.md:44
+msgid ""
+"SHACL result dicts keep the stable keys `focus`, `path`, `value`, "
+"`severity`, `component`, `source_shape`, and `message`. See [SHACL](../"
+"validation/shacl.md) and [ShEx](../validation/shex.md) for what the engines "
+"cover."
+msgstr ""
+
+#: src/getting-started/python.md:50
+msgid ""
+"`purrdf.entail` closes a dataset under a SPARQL entailment regime. It is not "
+"`purrdf.shapes.entail`, which applies the SHACL-AF `sh:rule`s a _shapes_ "
+"graph declares; this one takes no shapes and uses the regime's own "
+"specification rule table."
+msgstr ""
+
+#: src/getting-started/python.md:60
+msgid "\"rdfs\""
+msgstr ""
+
+#: src/getting-started/python.md:60
+msgid "\"\""
+msgstr ""
+
+#: src/getting-started/python.md:62
+msgid "# what fired, what did not, boundaries, budget, contract hash\n"
+msgstr ""
+
+#: src/getting-started/python.md:65
+msgid ""
+"The report is the second return value and is never optional — the same "
+"discipline the Rust, WebAssembly, and C surfaces enforce. "
+"`entail.materialize_nt(text, regime)` is the text-in/text-out twin for "
+"callers holding an N-Triples/N-Quads document."
+msgstr ""
+
+#: src/getting-started/python.md:69
+msgid ""
+"Coverage is measurable rather than asserted: `entail.rules(regime)` is the "
+"rule table the specification defines the regime by, and "
+"`entail.implemented_rules(regime)` is the subset that fires. `\"owl-"
+"direct\"` and `\"rif\"` return `[]` here — neither has a specification rule "
+"table of its own, since one decides through the tableau and the other "
+"entails under the caller's own rules — not a raised error. See [Entailment]"
+"(../entailment.md) for the full picture and the [rule inventory](../"
+"entailment-rules.md) for the per-rule table."
+msgstr ""
+
+#: src/getting-started/python.md:78
+msgid "rdflib compatibility"
+msgstr ""
+
+#: src/getting-started/python.md:80
+msgid "The package ships an rdflib compatibility layer:"
+msgstr ""
+
+#: src/getting-started/python.md:86
+msgid "For a literal, zero-change `import rdflib`, there is an opt-in extra:"
+msgstr ""
+
+#: src/getting-started/python.md:92 src/interop/rdflib.md:37
+msgid ""
+"This pulls in the separate `purrdf-rdflib` distribution, whose top-level "
+"`rdflib` package re-exports the compat surface, so existing third-party code "
+"doing `import rdflib` / `from rdflib.namespace import RDF` transparently "
+"runs on purrdf. **Caveat:** that shadow claims the `rdflib` import name and "
+"must never be installed alongside the genuine [`rdflib`](https://pypi.org/"
+"project/rdflib/) — the two cannot co-inhabit one environment. It is a "
+"separate distribution (never bundled into the main `purrdf` wheel) precisely "
+"so environments that need the real rdflib simply omit it."
+msgstr ""
+
+#: src/getting-started/python.md:102
+msgid ""
+"The compat layer is gated in CI against rdflib 7.6's own vendored test suite "
+"plus a first-party differential parity suite — see [rdflib Compatibility](../"
+"interop/rdflib.md) for details and the known, ledgered divergences."
+msgstr ""
+
+#: src/getting-started/python.md:107
+msgid "GTS relational exports"
+msgstr ""
+
+#: src/getting-started/python.md:109
+msgid ""
+"The Python package also ships GTS relational exports for analytics pipelines:"
+msgstr ""
+
+#: src/getting-started/python.md:115
+msgid ""
+"These project a [GTS container](../gts.md) into SQLite, DuckDB, or Parquet "
+"tables."
+msgstr ""
+
+#: src/getting-started/python.md:118
+msgid "Graph, tabular, and research-object archives"
+msgstr ""
+
+#: src/getting-started/python.md:120
+msgid ""
+"`purrdf.project(data, format=..., profile=..., config=...)` returns "
+"canonical USTAR bytes and structured loss records. `purrdf.lift(archive, "
+"profile=..., config=...)` reconstructs RDF for the ten bidirectional "
+"profiles. The same strict configuration and deterministic Rust code paths "
+"are used in every host; see [Graph, Tabular & Research-Object Projections]"
+"(../concepts/projections.md) for profiles and a complete example."
+msgstr ""
+
+#: src/getting-started/python.md:129
+msgid ""
+"[rdflib Compatibility](../interop/rdflib.md) — the drop-in story in depth."
+msgstr ""
+
+#: src/getting-started/python.md:130
+msgid "[Validation](../validation/shacl.md) — SHACL and ShEx from Python."
+msgstr ""
+
+#: src/getting-started/python.md:131
+msgid ""
+"[Entailment](../entailment.md) — the regimes, the report, and what each "
+"fires."
+msgstr ""
+
+#: src/getting-started/python.md:132
+msgid ""
+"[GTS Graph Transport](../gts.md) — the container format the exports read."
+msgstr ""
+
+#: src/getting-started/python.md:133
+msgid ""
+"[Graph, Tabular & Research-Object Projections](../concepts/projections.md) — "
+"LPG, CSVW, OBO, SKOS, and five research-object carriers."
+msgstr ""
+
+#: src/getting-started/javascript.md:6
+msgid "Getting Started: JavaScript / WebAssembly"
+msgstr ""
+
+#: src/getting-started/javascript.md:8
+msgid ""
+"The npm package [`@blackcatinformatics/purrdf`](https://www.npmjs.com/"
+"package/@blackcatinformatics/purrdf) is the same Rust engine compiled to "
+"`wasm32` and surfaced through an [RDF/JS](https://rdf.js.org/)\\-shaped API "
+"(`DataFactory`, `DatasetCore`, `Stream`/`Sink`). It runs in the browser and "
+"in Node, entirely in memory."
+msgstr ""
+
+#: src/getting-started/javascript.md:18
+msgid ""
+"Prefer to try it before installing anything? The [RDF-1.2 playground]"
+"(https://blackcat-informatics.github.io/purrdf/playground/) runs this exact "
+"wasm build in your browser — parse, SPARQL, SHACL, serialize, and "
+"canonicalize/compare RDF-1.2 graphs client-side, with no toolchain and no "
+"server."
+msgstr ""
+
+#: src/getting-started/javascript.md:23
+msgid "First dataset"
+msgstr ""
+
+#: src/getting-started/javascript.md:25
+msgid ""
+"Await `ready()` once before anything else — it performs the one-time async "
+"wasm instantiation:"
+msgstr ""
+
+#: src/getting-started/javascript.md:29 src/interop/rdfjs.md:23
+#: src/interop/rdfjs.md:67
+msgid "\"@blackcatinformatics/purrdf\""
+msgstr ""
+
+#: src/getting-started/javascript.md:31
+msgid "// one-time async wasm instantiation\n"
+msgstr ""
+
+#: src/getting-started/javascript.md:34 src/getting-started/javascript.md:60
+#: src/concepts/rdf12.md:51 src/interop/rdfjs.md:36
+msgid "\"مرحبا\""
+msgstr ""
+
+#: src/getting-started/javascript.md:34 src/getting-started/javascript.md:60
+#: src/concepts/rdf12.md:51 src/interop/rdfjs.md:36
+msgid "\"ar\""
+msgstr ""
+
+#: src/getting-started/javascript.md:34 src/getting-started/javascript.md:60
+#: src/concepts/rdf12.md:51 src/interop/rdfjs.md:36
+msgid "\"rtl\""
+msgstr ""
+
+#: src/getting-started/javascript.md:37
+msgid "\"https://ex/s\""
+msgstr ""
+
+#: src/getting-started/javascript.md:37
+msgid "\"https://ex/says\""
+msgstr ""
+
+#: src/getting-started/javascript.md:39 src/getting-started/javascript.md:40
+msgid "\"nquads\""
+msgstr ""
+
+#: src/getting-started/javascript.md:39
+msgid "// directions survive the round-trip\n"
+msgstr ""
+
+#: src/getting-started/javascript.md:43
+msgid "\"ASK { <https://ex/s> <https://ex/says> ?msg }\""
+msgstr ""
+
+#: src/getting-started/javascript.md:46
+msgid "The RDF 1.2 wedge"
+msgstr ""
+
+#: src/getting-started/javascript.md:48
+msgid ""
+"No incumbent RDF/JS library carries RDF 1.2 **quoted-triple terms** or "
+"**directional literals**. PurRDF's `DataFactory` exposes both:"
+msgstr ""
+
+#: src/getting-started/javascript.md:52
+msgid "// A quoted triple, usable as a subject/object (RDF-star / RDF 1.2).\n"
+msgstr ""
+
+#: src/getting-started/javascript.md:54 src/interop/rdfjs.md:29
+msgid "\"https://ex/alice\""
+msgstr ""
+
+#: src/getting-started/javascript.md:55 src/interop/rdfjs.md:30
+msgid "\"https://ex/knows\""
+msgstr ""
+
+#: src/getting-started/javascript.md:56 src/interop/rdfjs.md:31
+msgid "\"https://ex/bob\""
+msgstr ""
+
+#: src/getting-started/javascript.md:58
+msgid "// A base-direction literal (rdf:dirLangString).\n"
+msgstr ""
+
+#: src/getting-started/javascript.md:63
+msgid "API surface"
+msgstr ""
+
+#: src/getting-started/javascript.md:65
+msgid "**`ready(bytesOrUrl?)`** — await once before anything else."
+msgstr ""
+
+#: src/getting-started/javascript.md:66
+msgid ""
+"**`DataFactory`** — `namedNode`, `blankNode`, `literal(value, "
+"languageOrDatatype?)`, `typedLiteral`, `directionalLiteral`, `variable`, "
+"`defaultGraph`, `quad`, `quotedTriple`, `fromTerm`, `fromQuad`."
+msgstr ""
+
+#: src/getting-started/javascript.md:70
+msgid ""
+"**`Dataset`** (RDF/JS `DatasetCore`) — `Dataset.parse(input, format, "
+"base?)`, `serialize(format)`, `add`/`delete`/`has`/`match`/`quads`/`size`, "
+"and iteration (`for (const quad of dataset)`). Formats: `turtle`, "
+"`ntriples`, `nquads`, `trig`, `rdfxml` (or their media types); `serialize` "
+"additionally accepts `jsonld`."
+msgstr ""
+
+#: src/getting-started/javascript.md:75
+msgid ""
+"**Graph identity** — `Dataset.canonicalize()` returns the RDFC-1.0 "
+"canonical, flat N-Quads for the graph; `Dataset.isomorphic(other)` decides "
+"RDF graph equality under blank-node relabeling (an exact oracle backed by "
+"full RDFC-1.0 canonicalization)."
+msgstr ""
+
+#: src/getting-started/javascript.md:79
+msgid ""
+"**Graph/tabular/research-object carriers** — `Dataset.project(profile, "
+"configJson)` returns canonical USTAR bytes and loss-ledger JSON; "
+"`Dataset.projectWithAssets(\"ro-crate-1.3\", configJson, payloadArchive)` "
+"adds bounded attached RO-Crate payloads; `liftProjection(...)` reconstructs "
+"RDF for the bidirectional profiles. See [Graph, Tabular & Research-Object "
+"Projections](../concepts/projections.md)."
+msgstr ""
+
+#: src/getting-started/javascript.md:84
+msgid ""
+"**SPARQL** — `QueryEngine` keeps the native plan cache alive across calls "
+"and exposes typed `select` / `ask` / `construct` / `describe`, atomic "
+"`update`, and `queryRaw` serialization. `Dataset.query(...)` remains the "
+"compatibility raw-string helper."
+msgstr ""
+
+#: src/getting-started/javascript.md:88
+msgid ""
+"**SHACL** — `shaclValidateToSarif(shapesTtl, dataNt)` validates an N-Triples "
+"data graph against a Turtle shapes graph and returns a SARIF 2.1.0 report; "
+"`shaclEntail(shapesTtl, dataNt)` materializes the SHACL-AF `sh:rule` "
+"inferences as N-Triples."
+msgstr ""
+
+#: src/getting-started/javascript.md:92
+msgid ""
+"**`Sink`** — a streaming consumer (`push(quad)` / `finish() → Dataset`); "
+"`datasetToStream` / `streamToDataset` are the async RDF/JS Stream/Sink "
+"helpers."
+msgstr ""
+
+#: src/getting-started/javascript.md:96
+msgid ""
+"More on the RDF/JS mapping in [RDF/JS in JavaScript](../interop/rdfjs.md)."
+msgstr ""
+
+#: src/getting-started/javascript.md:98
+msgid "Scope and current limitations"
+msgstr ""
+
+#: src/getting-started/javascript.md:100
+msgid ""
+"**In-memory only.** SPARQL queries run over the in-memory dataset; this "
+"package provides no network resolver, so remote `SERVICE` and `LOAD` fail "
+"explicitly."
+msgstr ""
+
+#: src/getting-started/javascript.md:103 src/interop/rdfjs.md:108
+msgid ""
+"A quoted-triple term as a quad **object** currently round-trips only through "
+"**N-Quads** (a current native serializer limitation for the other formats)."
+msgstr ""
+
+#: src/getting-started/javascript.md:106
+msgid "Building from source"
+msgstr ""
+
+#: src/getting-started/javascript.md:108
+msgid ""
+"The Rust cdylib lives in [`crates/rdf-wasm`](https://github.com/Blackcat-"
+"Informatics/purrdf/tree/main/crates/rdf-wasm); the published ESM package is "
+"generated from it:"
+msgstr ""
+
+#: src/getting-started/javascript.md:113
+msgid "# release wasm + wasm-bindgen ESM bindings → js/pkg/\n"
+msgstr ""
+
+#: src/getting-started/javascript.md:114
+msgid "# the above + TypeScript, Node, and packed-tarball gates\n"
+msgstr ""
+
+#: src/getting-started/javascript.md:117
+msgid ""
+"This requires the `wasm32-unknown-unknown` Rust target and a `wasm-bindgen-"
+"cli` pinned to the crate's `wasm-bindgen` version."
+msgstr ""
+
+#: src/getting-started/c.md:6
+msgid "Getting Started: C"
+msgstr ""
+
+#: src/getting-started/c.md:8
+msgid ""
+"`libpurrdf` is a stable, SemVer-disciplined `extern \"C\"` surface over the "
+"native PurRDF stack: parse, serialize, pattern iteration, copy-on-write "
+"mutation, SPARQL, SHACL validation/entailment, and GTS container round-"
+"trips. The committed, reproducible header [`include/purrdf.h`](https://"
+"github.com/Blackcat-Informatics/purrdf/blob/main/crates/rdf-capi/include/"
+"purrdf.h) **is the ABI contract** — CI fails if it drifts from the crate."
+msgstr ""
+
+#: src/getting-started/c.md:15
+msgid ""
+"It is one shared library: `libpurrdf` statically reuses the `purrdf-gts` "
+"Rust crate, so a language shim links `libpurrdf` alone and still reads/"
+"writes `.gts` containers."
+msgstr ""
+
+#: src/getting-started/c.md:19
+msgid "Building"
+msgstr ""
+
+#: src/getting-started/c.md:21
+msgid ""
+"The library, header, and pkg-config file are produced by [`cargo-c`](https://"
+"github.com/lu-zero/cargo-c):"
+msgstr ""
+
+#: src/getting-started/c.md:25
+msgid "# cargo capi build: libpurrdf.{so,a} + purrdf.h + purrdf.pc\n"
+msgstr ""
+
+#: src/getting-started/c.md:26
+msgid "# cargo capi install into a prefix\n"
+msgstr ""
+
+#: src/getting-started/c.md:27
+msgid "# verify the committed header is current + run the C smoke\n"
+msgstr ""
+
+#: src/getting-started/c.md:30
+msgid "A first program"
+msgstr ""
+
+#: src/getting-started/c.md:32
+msgid ""
+"Adapted from the repository's C smoke test ([`crates/rdf-capi/tests/smoke.c`]"
+"(https://github.com/Blackcat-Informatics/purrdf/blob/main/crates/rdf-capi/"
+"tests/smoke.c)):"
+msgstr ""
+
+#: src/getting-started/c.md:36
+msgid "\"purrdf.h\""
+msgstr ""
+
+#: src/getting-started/c.md:41
+msgid "\"<http://a> <http://b> <http://c> .\""
+msgstr ""
+
+#: src/getting-started/c.md:51
+msgid "\"%zu quad(s)\\n\""
+msgstr ""
+
+#: src/getting-started/c.md:53
+msgid "/* Iterate every quad through a pattern cursor. */"
+msgstr ""
+
+#: src/getting-started/c.md:63
+msgid "\"subject=%.*s\\n\""
+msgstr ""
+
+#: src/getting-started/c.md:71
+msgid ""
+"`purrdf_project` and `purrdf_lift` add deterministic graph/tabular/research-"
+"object carrier archives to this same handle model. Project returns "
+"independent archive and loss-ledger buffers; lift returns a dataset plus a "
+"ledger buffer. The compiled `purrdf_project_with_assets` entry point accepts "
+"a bounded payload-only USTAR and emits an attached RO-Crate with "
+"deterministic metadata and preview. The compiled `crates/rdf-capi/examples/"
+"projection_roundtrip.c` example demonstrates the full ownership/free order. "
+"Profiles and configuration are described in [Graph, Tabular & Research-"
+"Object Projections](../concepts/projections.md)."
+msgstr ""
+
+#: src/getting-started/c.md:80
+msgid "The ABI contract"
+msgstr ""
+
+#: src/getting-started/c.md:82
+msgid ""
+"**No unwinding across the boundary.** Every function runs inside "
+"`catch_unwind`; a caught panic becomes `PURRDF_STATUS_PANIC`, never a "
+"process abort across FFI."
+msgstr ""
+
+#: src/getting-started/c.md:85
+msgid ""
+"**`int32_t` status + out-params.** Fallible functions return a "
+"`PurrdfStatus` value and write results through out-pointers. "
+"`PURRDF_STATUS_CURSOR_EXHAUSTED` is the (non-error) end-of-rows signal."
+msgstr ""
+
+#: src/getting-started/c.md:88
+msgid ""
+"**SemVer-frozen ABI.** The status enum is append-only; new fields and "
+"functions are additive. `purrdf_abi_version` reports the current ABI version "
+"at runtime; the `PURRDF_ABI_MAJOR`/`_MINOR`/`_PATCH` macros give the same "
+"triple for the header you compiled against, and comparing the two is how you "
+"check a library you did not build. The minor number tracks the exported "
+"signatures: any change to a parameter list, a return contract, or the "
+"documented behaviour of an exported symbol bumps it, additive parameters "
+"included, because an additive parameter is still a recompile for every C "
+"consumer."
+msgstr ""
+
+#: src/getting-started/c.md:98
+msgid "Ownership and lifetimes"
+msgstr ""
+
+#: src/getting-started/c.md:100
+msgid ""
+"Every handle/buffer/error/cursor has **exactly one matching `*_free`** "
+"(`purrdf_dataset_free`, `purrdf_graph_free`, `purrdf_cursor_free`, "
+"`purrdf_rowcursor_free`, `purrdf_buffer_free`, `purrdf_error_free`). Freeing "
+"`NULL` is a no-op."
+msgstr ""
+
+#: src/getting-started/c.md:104
+msgid ""
+"**The C side never `free()`s a `PurrdfStr.ptr`** — it borrows library-owned "
+"memory; copy the bytes out if they must outlive the borrow. Term views from "
+"`purrdf_cursor_next` are valid until the next `purrdf_cursor_next` on that "
+"cursor or `purrdf_cursor_free`."
+msgstr ""
+
+#: src/getting-started/c.md:108
+msgid ""
+"Pattern cursors pin the dataset and pull rows lazily from the selected core "
+"index; opening a cursor does not allocate a matching-row snapshot."
+msgstr ""
+
+#: src/getting-started/c.md:110
+msgid ""
+"`PurrdfDataset` is frozen and `Send + Sync` — readable concurrently from "
+"many threads. `PurrdfGraph` (the copy-on-write mutable delta) and cursors "
+"are single-threaded."
+msgstr ""
+
+#: src/getting-started/c.md:114
+msgid "GTS star-layer round-trip"
+msgstr ""
+
+#: src/getting-started/c.md:116
+msgid ""
+"The GTS **star layer** round-trip (`purrdf_to_gts` → `purrdf_from_gts` of a "
+"dataset containing quoted triples / reifier bindings) succeeds with "
+"`PURRDF_STATUS_OK`, the same as a star-free round-trip. The C ABI calls the "
+"canonical kernel path (`to_gts` → `read_graph` → `import_gts_graph`); a "
+"characterization test, `gts_star_roundtrip_preserves_the_statement_layer` in "
+"`crates/rdf-capi/tests/abi.rs`, pins the restored dataset's quoted triple "
+"and reifier binding so a regression in either layer fails there."
+msgstr ""
+
+#: src/getting-started/c.md:125
+msgid ""
+"Full contract details — status codes, term crossing representations, thread-"
+"safety per handle — are in the [`purrdf-capi` README](https://github.com/"
+"Blackcat-Informatics/purrdf/blob/main/crates/rdf-capi/README.md)."
+msgstr ""
+
+#: src/concepts/interned-dataset.md:8
+msgid ""
+"Everything in PurRDF evaluates over one intermediate representation: an "
+"immutable, value-interned RDF 1.2 dataset owned by the ring-fenced [`purrdf-"
+"core`](https://docs.rs/purrdf-core) kernel."
+msgstr ""
+
+#: src/concepts/interned-dataset.md:12
+msgid "Terms are interned once"
+msgstr ""
+
+#: src/concepts/interned-dataset.md:14
+msgid ""
+"Every term — IRI, blank node, literal, triple term — is stored **once** in a "
+"string arena and addressed by a copyable `TermId` (a niche-optimized "
+"`NonZeroU32`). Quads are rows of four `TermId`s. That makes term equality a "
+"single integer compare, keeps quads at a fixed small size, and means a term "
+"that appears in a million quads costs its bytes exactly once."
+msgstr ""
+
+#: src/concepts/interned-dataset.md:20
+msgid ""
+"Hot maps use fixed-key `ahash` — deterministic hashing is part of the [byte-"
+"determinism discipline](codecs.md), not just a speed choice."
+msgstr ""
+
+#: src/concepts/interned-dataset.md:23
+msgid "Builder → freeze"
+msgstr ""
+
+#: src/concepts/interned-dataset.md:25
+msgid "The IR has a strict two-phase life cycle:"
+msgstr ""
+
+#: src/concepts/interned-dataset.md:29
+msgid "// Intern terms once; quads are rows of copyable TermIds.\n"
+msgstr ""
+
+#: src/concepts/interned-dataset.md:33 src/sparql/querying.md:32
+msgid "\"https://example.org/says\""
+msgstr ""
+
+#: src/concepts/interned-dataset.md:34 src/sparql/querying.md:33
+msgid "\"meow\""
+msgstr ""
+
+#: src/concepts/interned-dataset.md:36
+msgid ""
+"// Freeze into the immutable, indexed dataset the engines evaluate over.\n"
+msgstr ""
+
+#: src/concepts/interned-dataset.md:38
+msgid "\"well-formed dataset\""
+msgstr ""
+
+#: src/concepts/interned-dataset.md:42
+msgid ""
+"`RdfDatasetBuilder` is the mutable ingestion phase: intern terms, push "
+"quads, attach reifiers and annotations. `freeze()` validates the structure "
+"and produces an immutable `RdfDataset`: quad rows in `Box<[QuadRow]>` tables "
+"with lazy ordinal permutation indexes (roughly 4 bytes per quad per axis). "
+"The frozen dataset is what SPARQL, SHACL, ShEx, and entailment all read, "
+"through the allocation-free `DatasetView` trait."
+msgstr ""
+
+#: src/concepts/interned-dataset.md:49
+msgid ""
+"Freezing is also what makes concurrency simple: a frozen dataset is "
+"immutable, so it can be shared and read from many threads (the C ABI exposes "
+"exactly this as a `Send + Sync` handle)."
+msgstr ""
+
+#: src/concepts/interned-dataset.md:53
+msgid "Copy-on-write mutation"
+msgstr ""
+
+#: src/concepts/interned-dataset.md:55
+msgid ""
+"\"Immutable\" does not mean \"static\". Mutation happens through a copy-on-"
+"write delta over a frozen base: edits accumulate in a lightweight overlay, "
+"and the result freezes into a new dataset without copying the untouched base "
+"rows or re-interning shared terms. SPARQL UPDATE and the C ABI's mutable "
+"`PurrdfGraph` handle both ride this path."
+msgstr ""
+
+#: src/concepts/interned-dataset.md:61
+msgid "What else lives in the kernel"
+msgstr ""
+
+#: src/concepts/interned-dataset.md:63
+msgid "Beyond the IR itself, `purrdf-core` owns:"
+msgstr ""
+
+#: src/concepts/interned-dataset.md:65
+msgid "**`DatasetView`** — the static read trait every engine evaluates over."
+msgstr ""
+
+#: src/concepts/interned-dataset.md:66
+msgid ""
+"**Structured diagnostics** — typed `RdfDiagnostic`s with source locations "
+"(deliberately SARIF-free; the SARIF boundary is [`purrdf-validate`](https://"
+"docs.rs/purrdf-validate))."
+msgstr ""
+
+#: src/concepts/interned-dataset.md:69
+msgid ""
+"**RDFC-1.0** canonicalization, dataset diff, and isomorphism — see "
+"[Canonicalization & Diff](canonicalization.md)."
+msgstr ""
+
+#: src/concepts/interned-dataset.md:71
+msgid ""
+"**Store and engine seams** — the narrow parser-ingress, serializer-egress, "
+"and `SparqlEngine` traits that adapters implement in sibling crates."
+msgstr ""
+
+#: src/concepts/interned-dataset.md:73
+msgid ""
+"**Provenance and the loss ledger** — a generic provenance sidecar and the "
+"machine-readable RDF↔GTS loss matrix, plus native FnO and SSSOM codecs (see "
+"[Slices, Mappings & Provenance](../slices.md))."
+msgstr ""
+
+#: src/concepts/interned-dataset.md:77
+msgid ""
+"Text codecs are _not_ in the kernel — parsing and serialization live one "
+"layer up in [`purrdf-rdf`](https://docs.rs/purrdf-rdf). The split keeps the "
+"kernel small and its invariants enforceable at the crate boundary: no "
+"oxigraph, no PyO3 (a hygiene gate asserts the dependency tree), `wasm32`\\-"
+"clean, and a file-IO-free IR layer."
+msgstr ""
+
+#: src/concepts/interned-dataset.md:83
+msgid "Why this design"
+msgstr ""
+
+#: src/concepts/interned-dataset.md:85
+msgid ""
+"The layout is chosen by measurement, not assertion: the criterion bench "
+"`crates/rdf-core/benches/ir_layout.rs` compares array-of-structs, struct-of-"
+"arrays, and predicate-adjacency layouts on allocation counts, high-water "
+"memory, and end-to-end latency — the shipped layout is whichever wins. See "
+"[Performance](../project/performance.md)."
+msgstr ""
+
+#: src/concepts/rdf12.md:8
+msgid ""
+"PurRDF is RDF 1.2-first: the features [RDF 1.2 Concepts](https://www.w3.org/"
+"TR/rdf12-concepts/) adds over RDF 1.1 are part of the core data model, "
+"carried through the IR, the codecs, SPARQL, validation, the language "
+"bindings, and the GTS transport."
+msgstr ""
+
+#: src/concepts/rdf12.md:13
+msgid "Triple terms"
+msgstr ""
+
+#: src/concepts/rdf12.md:15
+msgid ""
+"RDF 1.2 lets a triple itself be a term in **object position** — the \"quoted "
+"triple\" of RDF-star, written `<<( s p o )>>` in SPARQL 1.2 syntax. In the "
+"IR a triple term is interned like any other term and gets a `TermId`, so it "
+"composes with everything else (patterns, results, serialization)."
+msgstr ""
+
+#: src/concepts/rdf12.md:20
+msgid ""
+"The star-capable codecs (Turtle, TriG, N-Triples, N-Quads, JSON-LD star) "
+"round-trip triple terms; see [Codecs & Determinism](codecs.md) for what "
+"happens on a star-incapable projection."
+msgstr ""
+
+#: src/concepts/rdf12.md:23
+msgid ""
+"SPARQL 1.2 quoted-triple syntax is parsed by `purrdf-sparql-algebra` and "
+"evaluated natively — the W3C SPARQL 1.2 triple-term surface passes in the "
+"conformance harness ([Conformance & Testing](../project/conformance.md))."
+msgstr ""
+
+#: src/concepts/rdf12.md:26
+msgid ""
+"In JavaScript, `DataFactory.quotedTriple(...)` produces the same term ([RDF/"
+"JS in JavaScript](../interop/rdfjs.md))."
+msgstr ""
+
+#: src/concepts/rdf12.md:29
+msgid "Reifiers and annotations"
+msgstr ""
+
+#: src/concepts/rdf12.md:31
+msgid ""
+"RDF 1.2 replaces old-style reification with **reifiers**: terms that name an "
+"_occurrence_ of a triple (`rdf:reifies`), so you can attach metadata to a "
+"statement without asserting anything odd. In PurRDF, reifier bindings and "
+"annotations live in dedicated **side-tables** on the dataset rather than "
+"being smeared into the quad table."
+msgstr ""
+
+#: src/concepts/rdf12.md:37
+msgid ""
+"Reifier bindings and annotations survive every star-capable codec round-"
+"trip; projections into star-incapable formats drop them _loudly_, with the "
+"realized count handed to the loss ledger (see [Slices, Mappings & Provenance]"
+"(../slices.md)). SHACL support for validating reified statements — the draft "
+"`sh:reifierShape` / `sh:reificationRequired` surface — is covered in [SHACL]"
+"(../validation/shacl.md)."
+msgstr ""
+
+#: src/concepts/rdf12.md:44 src/concepts/rdf12.md:74
+msgid "Base-direction literals"
+msgstr ""
+
+#: src/concepts/rdf12.md:46
+msgid ""
+"RDF 1.2 adds `rdf:dirLangString`: a language-tagged literal that also "
+"carries a base direction (`ltr` or `rtl`) for correct bidirectional-text "
+"handling. These are first-class in the IR and in every binding:"
+msgstr ""
+
+#: src/concepts/rdf12.md:54
+msgid ""
+"Directions survive serialization round-trips through the star-capable codecs "
+"— the [JavaScript quickstart](../getting-started/javascript.md) demonstrates "
+"the N-Quads round-trip."
+msgstr ""
+
+#: src/concepts/rdf12.md:58
+msgid "RDF 1.2 is a complete target, not a draft excuse"
+msgstr ""
+
+#: src/concepts/rdf12.md:60
+msgid ""
+"PurRDF treats the RDF 1.2 / SPARQL 1.2 specifications as a complete, "
+"implementable target. Where a feature is scoped (for example, the SHACL 1.2 "
+"reifier-shape support is a scoped Working Draft feature, not full SHACL 1.2 "
+"conformance), the scope is stated explicitly and gated by tests — never left "
+"as a silent partial implementation. The live per-feature status is the "
+"conformance matrix in [`docs/CONFORMANCE.md`](https://github.com/Blackcat-"
+"Informatics/purrdf/blob/main/docs/CONFORMANCE.md)."
+msgstr ""
+
+#: src/concepts/rdf12.md:68
+msgid "Where each feature shows up"
+msgstr ""
+
+#: src/concepts/rdf12.md:70
+msgid "Feature"
+msgstr ""
+
+#: src/concepts/rdf12.md:70
+msgid "IR"
+msgstr ""
+
+#: src/concepts/rdf12.md:70
+msgid "Codecs"
+msgstr ""
+
+#: src/concepts/rdf12.md:70
+msgid "RDF/JS"
+msgstr ""
+
+#: src/concepts/rdf12.md:70 src/project/conformance.md:46
+msgid "GTS"
+msgstr ""
+
+#: src/concepts/rdf12.md:72
+msgid "Triple terms (object position)"
+msgstr ""
+
+#: src/concepts/rdf12.md:72
+msgid "interned term"
+msgstr ""
+
+#: src/concepts/rdf12.md:72 src/concepts/rdf12.md:73
+msgid "star-capable formats"
+msgstr ""
+
+#: src/concepts/rdf12.md:72
+msgid "`<<( s p o )>>`"
+msgstr ""
+
+#: src/concepts/rdf12.md:72
+msgid "via paths/values"
+msgstr ""
+
+#: src/concepts/rdf12.md:72
+msgid "`quotedTriple`"
+msgstr ""
+
+#: src/concepts/rdf12.md:72
+msgid "mapped per spec"
+msgstr ""
+
+#: src/concepts/rdf12.md:73
+msgid "Reifiers / annotations"
+msgstr ""
+
+#: src/concepts/rdf12.md:73
+msgid "side-tables"
+msgstr ""
+
+#: src/concepts/rdf12.md:73
+msgid "reifier surface"
+msgstr ""
+
+#: src/concepts/rdf12.md:73
+msgid "`sh:reifierShape` (draft)"
+msgstr ""
+
+#: src/concepts/rdf12.md:73 src/concepts/projections.md:450
+#: src/concepts/projections.md:452 src/concepts/projections.md:453
+#: src/entailment.md:23 src/entailment.md:24 src/entailment.md:25
+#: src/entailment.md:50
+msgid "—"
+msgstr ""
+
+#: src/concepts/rdf12.md:73
+msgid "`rdf:reifies` mapping"
+msgstr ""
+
+#: src/concepts/rdf12.md:74
+msgid "literal kind"
+msgstr ""
+
+#: src/concepts/rdf12.md:74
+msgid "round-trips"
+msgstr ""
+
+#: src/concepts/rdf12.md:74
+msgid "matched/produced"
+msgstr ""
+
+#: src/concepts/rdf12.md:74
+msgid "value nodes"
+msgstr ""
+
+#: src/concepts/rdf12.md:74
+msgid "`directionalLiteral`"
+msgstr ""
+
+#: src/concepts/rdf12.md:74
+msgid "carried"
+msgstr ""
+
+#: src/concepts/rdf12.md:76
+msgid ""
+"The GTS mapping of triple terms and `rdf:reifies` is formalized in the [GTS "
+"specification](https://github.com/Blackcat-Informatics/purrdf/blob/main/docs/"
+"GTS-SPEC.md), which pins its RDF 1.2 substrate to the 07 April 2026 W3C "
+"Candidate Recommendation Snapshot."
+msgstr ""
+
+#: src/concepts/visualization.md:8
+msgid ""
+"PurRDF projects RDF into a renderer-neutral statement model before producing "
+"a layout or SVG. The projection keeps structural triple terms, assertion "
+"occurrences, reifier identity, annotations, graph context, nesting, and RDF "
+"dialect diagnostics distinct. The SVG carries that model as embedded JSON "
+"metadata, so it is both a visual document and a lossless machine-readable "
+"export."
+msgstr ""
+
+#: src/concepts/visualization.md:15
+msgid ""
+"The examples below are generated directly by the Rust visualization surface. "
+"Line colour varies subtly within each semantic relation class to make dense "
+"routes easier to follow; line width, dash pattern, labels, and arrow grammar "
+"continue to carry the RDF meaning without relying on colour."
+msgstr ""
+
+#: src/concepts/visualization.md:20
+msgid "Ordinary shared resources"
+msgstr ""
+
+#: src/concepts/visualization.md:22
+msgid ""
+"The compact view preserves the familiar RDF resource graph while separating "
+"routes that share nodes."
+msgstr ""
+
+#: src/concepts/visualization.md:25
+msgid ""
+"[Open compact SVG](../assets/visualization/purrdf-viz2-ordinary-shared-"
+"compact.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:27
+msgid ""
+"![Ordinary RDF graph with shared resources](../assets/visualization/purrdf-"
+"viz2-ordinary-shared-compact.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:32
+msgid ""
+"[Open exact SVG](../assets/visualization/purrdf-viz2-ordinary-shared-"
+"incidence.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:34
+msgid ""
+"![Ordinary RDF exact statement incidence graph](../assets/visualization/"
+"purrdf-viz2-ordinary-shared-incidence.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:41
+msgid ""
+"[Open table SVG](../assets/visualization/purrdf-viz2-ordinary-shared-"
+"table.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:43
+msgid ""
+"![Ordinary RDF statement table](../assets/visualization/purrdf-viz2-ordinary-"
+"shared-table.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:47
+msgid "Asserted, reified, and annotated statements"
+msgstr ""
+
+#: src/concepts/visualization.md:49
+msgid ""
+"Solid arrows remain assertions. Addressable statement anchors connect those "
+"assertions to reifier resources, whose ordinary RDF properties carry "
+"provenance, confidence, timestamps, and directional language literals."
+msgstr ""
+
+#: src/concepts/visualization.md:53
+msgid ""
+"[Open compact SVG](../assets/visualization/purrdf-viz2-asserted-reified-"
+"compact.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:55
+msgid ""
+"![Asserted RDF statements with reifiers and annotations](../assets/"
+"visualization/purrdf-viz2-asserted-reified-compact.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:60
+msgid ""
+"[Open exact SVG](../assets/visualization/purrdf-viz2-asserted-reified-"
+"incidence.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:62
+msgid ""
+"![Exact incidence graph for asserted and reified statements](../assets/"
+"visualization/purrdf-viz2-asserted-reified-incidence.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:69
+msgid ""
+"[Open table SVG](../assets/visualization/purrdf-viz2-asserted-reified-"
+"table.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:71
+msgid ""
+"![Statement table for asserted and reified RDF](../assets/visualization/"
+"purrdf-viz2-asserted-reified-table.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:75
+msgid "Quoted-only and nested triple terms"
+msgstr ""
+
+#: src/concepts/visualization.md:77
+msgid ""
+"A quoted-only triple is a bounded statement glyph, never a solid assertion "
+"arrow. Reifier resources stay distinct from the structural statement they "
+"reify."
+msgstr ""
+
+#: src/concepts/visualization.md:81
+msgid ""
+"[Open quoted-only compact SVG](../assets/visualization/purrdf-viz2-quoted-"
+"only-compact.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:83
+msgid ""
+"![Quoted-only RDF triple terms and their reifiers](../assets/visualization/"
+"purrdf-viz2-quoted-only-compact.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:88
+msgid ""
+"[Open exact SVG](../assets/visualization/purrdf-viz2-quoted-only-"
+"incidence.svg) · [Open table SVG](../assets/visualization/purrdf-viz2-quoted-"
+"only-table.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:91
+msgid ""
+"![Quoted-only exact incidence graph](../assets/visualization/purrdf-viz2-"
+"quoted-only-incidence.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:93
+msgid ""
+"![Quoted-only statement table](../assets/visualization/purrdf-viz2-quoted-"
+"only-table.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:97
+msgid ""
+"Nested triple terms retain recursive statement identity. Dialect badges make "
+"symmetric or generalized RDF positions explicit rather than silently "
+"rendering them as ordinary RDF 1.2."
+msgstr ""
+
+#: src/concepts/visualization.md:101
+msgid ""
+"[Open nested compact SVG](../assets/visualization/purrdf-viz2-nested-dialect-"
+"compact.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:103
+msgid ""
+"![Nested triple terms with RDF dialect diagnostics](../assets/visualization/"
+"purrdf-viz2-nested-dialect-compact.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:108
+msgid ""
+"[Open exact SVG](../assets/visualization/purrdf-viz2-nested-dialect-"
+"incidence.svg) · [Open table SVG](../assets/visualization/purrdf-viz2-nested-"
+"dialect-table.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:111
+msgid ""
+"![Nested exact statement incidence graph](../assets/visualization/purrdf-"
+"viz2-nested-dialect-incidence.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:113
+msgid ""
+"![Nested statement table](../assets/visualization/purrdf-viz2-nested-dialect-"
+"table.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:117
+msgid "Dense connected data"
+msgstr ""
+
+#: src/concepts/visualization.md:119
+msgid ""
+"The exact view uses separated vertical channels and rounded orthogonal turns "
+"so individual subject, predicate, object, reification, and annotation routes "
+"remain traceable through a dense connected dataset."
+msgstr ""
+
+#: src/concepts/visualization.md:123
+msgid ""
+"[Open dense exact SVG](../assets/visualization/purrdf-viz2-dense-connected-"
+"incidence.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:125
+msgid ""
+"![Dense RDF exact statement incidence graph](../assets/visualization/purrdf-"
+"viz2-dense-connected-incidence.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:130
+msgid ""
+"[Open compact SVG](../assets/visualization/purrdf-viz2-dense-connected-"
+"compact.svg) · [Open table SVG](../assets/visualization/purrdf-viz2-dense-"
+"connected-table.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:133
+msgid ""
+"![Dense compact RDF resource graph](../assets/visualization/purrdf-viz2-"
+"dense-connected-compact.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:135
+msgid ""
+"![Dense RDF statement table](../assets/visualization/purrdf-viz2-dense-"
+"connected-table.svg)"
+msgstr ""
+
+#: src/concepts/visualization.md:139
+msgid "Regenerating the samples"
+msgstr ""
+
+#: src/concepts/visualization.md:141
+msgid ""
+"The committed SVGs are projections of the Rust fixtures, not hand-edited "
+"book artwork:"
+msgstr ""
+
+#: src/concepts/visualization.md:149
+msgid ""
+"`make check` regenerates the same artifacts in a temporary directory and "
+"rejects any drift between the renderer and the book."
+msgstr ""
+
+#: src/concepts/projections.md:6
+msgid "Graph, Tabular, Dataset-Description & Research-Object Projections"
+msgstr ""
+
+#: src/concepts/projections.md:8
+msgid ""
+"PurRDF projects an RDF 1.2 dataset into graph, tabular, dataset-description, "
+"and research-object formats without making any of those formats the semantic "
+"authority. One Rust engine implements the mapping, packages its artifacts as "
+"canonical USTAR, and is exposed unchanged through Rust, the CLI, Python, "
+"WebAssembly, and C."
+msgstr ""
+
+#: src/concepts/projections.md:14
+msgid "Every operation has four non-negotiable properties:"
+msgstr ""
+
+#: src/concepts/projections.md:16
+msgid ""
+"configuration supplies every vocabulary role, identity IRI, processing "
+"policy, and resource limit; the library fabricates none;"
+msgstr ""
+
+#: src/concepts/projections.md:18
+msgid "output bytes are deterministic for the same dataset and configuration;"
+msgstr ""
+
+#: src/concepts/projections.md:19
+msgid ""
+"loss is always computed as a closed, located ledger, even when a host "
+"chooses not to display it;"
+msgstr ""
+
+#: src/concepts/projections.md:21
+msgid ""
+"malformed, ambiguous, non-canonical, or out-of-bounds input is a hard error."
+msgstr ""
+
+#: src/concepts/projections.md:23
+msgid "Profiles"
+msgstr ""
+
+#: src/concepts/projections.md:25
+msgid "Profile"
+msgstr ""
+
+#: src/concepts/projections.md:25
+msgid "Native artifacts"
+msgstr ""
+
+#: src/concepts/projections.md:25
+msgid "Direction"
+msgstr ""
+
+#: src/concepts/projections.md:25
+msgid "RDF fidelity"
+msgstr ""
+
+#: src/concepts/projections.md:27
+msgid "`lpg-csv`"
+msgstr ""
+
+#: src/concepts/projections.md:27
+msgid "generic nodes/edges CSV"
+msgstr ""
+
+#: src/concepts/projections.md:27 src/concepts/projections.md:28
+#: src/concepts/projections.md:29 src/concepts/projections.md:30
+#: src/concepts/projections.md:31 src/concepts/projections.md:36
+#: src/concepts/projections.md:37 src/concepts/projections.md:38
+#: src/concepts/projections.md:39 src/concepts/projections.md:42
+msgid "RDF ↔ carrier"
+msgstr ""
+
+#: src/concepts/projections.md:27
+msgid "exact RDF sideband; property-graph lowering ledgered"
+msgstr ""
+
+#: src/concepts/projections.md:28
+msgid "`neo4j-csv`"
+msgstr ""
+
+#: src/concepts/projections.md:28
+msgid "Neo4j Admin Import CSV"
+msgstr ""
+
+#: src/concepts/projections.md:28
+msgid "same canonical LPG authority and ledger"
+msgstr ""
+
+#: src/concepts/projections.md:29
+msgid "`open-cypher`"
+msgstr ""
+
+#: src/concepts/projections.md:29
+msgid "deterministic `CREATE` program"
+msgstr ""
+
+#: src/concepts/projections.md:29
+msgid "strict reader accepts exactly the emitted grammar"
+msgstr ""
+
+#: src/concepts/projections.md:30
+msgid "`graphml`"
+msgstr ""
+
+#: src/concepts/projections.md:30
+msgid "GraphML 1.0 XML"
+msgstr ""
+
+#: src/concepts/projections.md:30
+msgid "exact RDF sideband; strict namespace/key validation"
+msgstr ""
+
+#: src/concepts/projections.md:31
+msgid "`csvw-exact`"
+msgstr ""
+
+#: src/concepts/projections.md:31
+msgid "CSVW metadata plus RDF 1.2 tables"
+msgstr ""
+
+#: src/concepts/projections.md:31
+msgid "lossless"
+msgstr ""
+
+#: src/concepts/projections.md:32
+msgid "`csvw-terms`"
+msgstr ""
+
+#: src/concepts/projections.md:32
+msgid "CSVW metadata plus caller-declared entity tables"
+msgstr ""
+
+#: src/concepts/projections.md:32 src/concepts/projections.md:33
+#: src/concepts/projections.md:34 src/concepts/projections.md:35
+#: src/concepts/projections.md:40 src/concepts/projections.md:41
+msgid "RDF → view"
+msgstr ""
+
+#: src/concepts/projections.md:32 src/concepts/projections.md:33
+#: src/concepts/projections.md:34 src/concepts/projections.md:35
+msgid "located, closed loss ledger"
+msgstr ""
+
+#: src/concepts/projections.md:33
+msgid "`okf-terms`"
+msgstr ""
+
+#: src/concepts/projections.md:33
+msgid "OKF v0.1 concept documents and indexes"
+msgstr ""
+
+#: src/concepts/projections.md:34
+msgid "`obo-graphs`"
+msgstr ""
+
+#: src/concepts/projections.md:34
+msgid "OBO Graphs 0.3.2 JSON"
+msgstr ""
+
+#: src/concepts/projections.md:35
+msgid "`skos`"
+msgstr ""
+
+#: src/concepts/projections.md:35
+msgid "SKOS Turtle"
+msgstr ""
+
+#: src/concepts/projections.md:36
+msgid "`croissant-1.1`"
+msgstr ""
+
+#: src/concepts/projections.md:36
+msgid "`croissant.json`"
+msgstr ""
+
+#: src/concepts/projections.md:36 src/concepts/projections.md:37
+#: src/concepts/projections.md:38 src/concepts/projections.md:39
+#: src/concepts/projections.md:42
+msgid "shared model; profile loss is located"
+msgstr ""
+
+#: src/concepts/projections.md:37
+msgid "`ro-crate-1.3`"
+msgstr ""
+
+#: src/concepts/projections.md:37
+msgid "`ro-crate-metadata.json`"
+msgstr ""
+
+#: src/concepts/projections.md:38
+msgid "`datacite-4.6`"
+msgstr ""
+
+#: src/concepts/projections.md:38
+msgid "`datacite.xml`"
+msgstr ""
+
+#: src/concepts/projections.md:39
+msgid "`dcat-3`"
+msgstr ""
+
+#: src/concepts/projections.md:39
+msgid "`dcat.jsonld`"
+msgstr ""
+
+#: src/concepts/projections.md:40
+msgid "`dcat-rdf`"
+msgstr ""
+
+#: src/concepts/projections.md:40
+msgid "`dcat.<native extension>`"
+msgstr ""
+
+#: src/concepts/projections.md:40
+msgid "mapped or caller-CONSTRUCTed; blank-free RDF"
+msgstr ""
+
+#: src/concepts/projections.md:41
+msgid "`void`"
+msgstr ""
+
+#: src/concepts/projections.md:41
+msgid "`void.<native extension>`"
+msgstr ""
+
+#: src/concepts/projections.md:41
+msgid "selected-graph statistics, partitions, and linksets"
+msgstr ""
+
+#: src/concepts/projections.md:42
+msgid "`frictionless-data-package-1`"
+msgstr ""
+
+#: src/concepts/projections.md:42
+msgid "`datapackage.json`"
+msgstr ""
+
+#: src/concepts/projections.md:44
+msgid ""
+"The type distinction between `ProjectionProfile` and `LiftProfile` matters: "
+"curated CSVW/OKF terms, OBO Graphs, SKOS, native DCAT RDF, and VoID cannot "
+"even be named as lift profiles. They are useful views, not pretend "
+"interchange formats."
+msgstr ""
+
+#: src/concepts/projections.md:49
+msgid "One canonical LPG model"
+msgstr ""
+
+#: src/concepts/projections.md:51
+msgid ""
+"The four labeled-property-graph syntaxes are adapters over one typed LPG "
+"model, not independent RDF mappings. Nodes, edges, labels, typed property "
+"atoms, graph context, reifiers, annotations, and exact RDF statements are "
+"ordered and validated once. This gives all four carriers the same identity "
+"and reverse mapping."
+msgstr ""
+
+#: src/concepts/projections.md:57
+msgid ""
+"Property graphs do not define RDF semantics. PurRDF therefore records each "
+"semantic lowering in the RDF-to-LPG ledger even though the canonical package "
+"also retains exact RDF sideband for reconstruction. A carrier consumer may "
+"use the native LPG view; the sideband remains the authority for an RDF lift."
+msgstr ""
+
+#: src/concepts/projections.md:62
+msgid ""
+"Readers accept the complete form PurRDF emits and reject drift: wrong "
+"headers, duplicate rows or keys, dangling endpoints, token-map "
+"inconsistencies, unknown Cypher statements, unsafe XML, unexpected package "
+"members, and non-canonical encodings all fail."
+msgstr ""
+
+#: src/concepts/projections.md:67
+msgid "LPG scope, limits, progress, and memory"
+msgstr ""
+
+#: src/concepts/projections.md:69
+msgid ""
+"Every LPG configuration contains a mandatory `scope`. `{\"mode\":\"all\"}` "
+"is the only way to request every graph and predicate; omission never means "
+"“all.” A selective scope independently controls the default graph, exact "
+"named-graph terms, predicate allow/deny sets, node RDF types, and native "
+"edge predicates. Named blank graphs retain their scope ordinal, and every "
+"selector IRI must be absolute."
+msgstr ""
+
+#: src/concepts/projections.md:76
+msgid ""
+"Selection is one closed RDF 1.2 operation. Node types are indexed from graph-"
+"selected `rdf_type` statements even when that predicate is omitted from the "
+"output. A retained edge retains its endpoints. Reifiers and annotations are "
+"retained only when their source statement survives, and annotation "
+"predicates obey the same predicate selector. These rules prevent a selected "
+"property graph from containing dangling sideband."
+msgstr ""
+
+#: src/concepts/projections.md:83
+msgid ""
+"`LpgExecutionLimits` independently bounds input records scanned, model "
+"records, nodes, and edges. `ProjectionLimits` bounds artifact count, one-"
+"artifact bytes, total artifact-body bytes, canonical USTAR bytes, and "
+"recursive RDF-term depth. Each bound is consumed before the corresponding "
+"model mutation or sink write; the first excess is a typed hard error. The "
+"engine does not paginate. Splitting one canonically ordered, exactly "
+"reversible carrier would make page identity and cross-page endpoints order-"
+"sensitive; callers instead choose a narrower scope or a larger explicit "
+"bound."
+msgstr ""
+
+#: src/concepts/projections.md:92
+msgid ""
+"The direct sink path retains the selected canonical LPG model because stable "
+"backend-independent ordering, type selection, endpoint closure, and exact "
+"RDF sideband require that bounded sort/index. It then emits each artifact in "
+"lexical path order in chunks no larger than 16 KiB, retaining neither "
+"complete artifact bodies nor a USTAR buffer. The archive convenience path "
+"additionally retains materialized artifacts and the final archive. Thus the "
+"sink path is bounded by the selected model plus encoder scratch and one "
+"chunk; it is not a constant-memory RDF-to-LPG mapper."
+msgstr ""
+
+#: src/concepts/projections.md:101
+msgid ""
+"Progress observers receive monotonic `scanning`, `building`, `writing`, "
+"`complete`, or `aborted` snapshots with input/model/node/edge, finished-"
+"artifact, body-byte, and active-path counters. A sink or observer failure "
+"aborts the active transaction. A sink must stage partial state, publish only "
+"on `commit_package`, and discard it on `abort_package`."
+msgstr ""
+
+#: src/concepts/projections.md:107 src/project/conformance.md:36
+msgid "CSVW"
+msgstr ""
+
+#: src/concepts/projections.md:109
+msgid ""
+"The lower-level CSVW API models annotated table groups, schemas, dialects, "
+"columns, rows, inherited properties, datatypes and formats, language and "
+"text direction, null/default/separator handling, virtual or suppressed "
+"columns, primary and foreign keys, row titles, annotations, and URI "
+"templates. It supports the standard CSVW CSV-to-RDF processing modes over a "
+"complete in-memory package; filesystem and network discovery remain caller "
+"responsibilities."
+msgstr ""
+
+#: src/concepts/projections.md:116
+msgid ""
+"The `csvw-exact` archive profile uses that machinery to carry RDF 1.2 "
+"without loss. Its canonical tables preserve terms, quads, named graph "
+"placement, recursive triple terms, reifier bindings, annotations, datatypes, "
+"language, direction, and blank-node scope. A valid exact round trip has an "
+"empty ledger."
+msgstr ""
+
+#: src/concepts/projections.md:121
+msgid ""
+"The separate `csvw-terms` profile is a deliberately curated wide-table view. "
+"It is for compact catalogs such as classes, properties, individuals, "
+"business entities, or release inventories. Those names have no built-in "
+"meaning: every table, selector, predicate, datatype, and identity rule is "
+"supplied by the caller. The profile never imports an ontology model or "
+"assumes RDF, RDFS, OWL, or any application vocabulary."
+msgstr ""
+
+#: src/concepts/projections.md:128
+msgid "A `CsvwTermsConfig` contains only mandatory policy:"
+msgstr ""
+
+#: src/concepts/projections.md:130
+msgid ""
+"`csvw` is the complete normative CSVW context, vocabulary, processing mode, "
+"record bound, and package limits;"
+msgstr ""
+
+#: src/concepts/projections.md:132
+msgid "`metadata_path` is the safe package-relative metadata member;"
+msgstr ""
+
+#: src/concepts/projections.md:133
+msgid ""
+"`graph_selection` is either explicit `all` or an exact default-graph flag "
+"and set of named-graph IRIs;"
+msgstr ""
+
+#: src/concepts/projections.md:135
+msgid ""
+"each ordered table declaration supplies a stable name, absolute table URL, "
+"artifact path, row selector, visible subject-IRI column, and one or more "
+"ordered predicate columns;"
+msgstr ""
+
+#: src/concepts/projections.md:138
+msgid ""
+"a selector may constrain any/all/none RDF types through an explicitly named "
+"type predicate and may constrain subject IRI prefixes; the type predicate is "
+"present exactly when a type set is non-empty, while an empty prefix set "
+"means no subject-namespace constraint;"
+msgstr ""
+
+#: src/concepts/projections.md:142
+msgid ""
+"a predicate column accepts either exact IRI objects or literals with exact "
+"datatype, language, and RDF 1.2 direction facets, plus requiredness and an "
+"explicit one-or-many cardinality;"
+msgstr ""
+
+#: src/concepts/projections.md:145
+msgid ""
+"`execution_limits` bounds total output rows, represented values, and values "
+"in one cell independently of the package and input-record bounds."
+msgstr ""
+
+#: src/concepts/projections.md:148
+msgid ""
+"Table overlap is intentional. A subject may appear in several views when it "
+"matches several selectors. Duplicate table identities, paths, column names, "
+"or mapped predicates are rejected. `One` fails on a second matching value. "
+"`Many` sorts RDF terms canonically and joins them with the caller's "
+"separator; an actual value containing that separator fails instead of "
+"creating an ambiguous cell. RDF direct-value statements do not carry a "
+"source sequence, so the profile does not fabricate CSVW ordered-list "
+"semantics."
+msgstr ""
+
+#: src/concepts/projections.md:156
+msgid ""
+"Rows are ordered by subject IRI, values by canonical RDF term order, columns "
+"and tables by their declaration order, and archive members by lexical path. "
+"The same dataset and configuration therefore produce the same CSV, metadata, "
+"and USTAR bytes regardless of source interning or statement insertion order."
+msgstr ""
+
+#: src/concepts/projections.md:161
+msgid ""
+"Every source row is accounted for. Unselected graphs or subjects, blank or "
+"triple-term subjects, unmapped predicates, facet-mismatched objects, "
+"selected named-graph placement, empty named graphs, reifier bindings, and "
+"annotations produce stable source-located ledger entries. The generated "
+"tables themselves can be read with the normative `read_csvw` API, but they "
+"cannot reconstruct omitted source RDF. RDF 1.2 direction remains exact in "
+"the annotated CSVW value and `textDirection` metadata; the W3C CSVW-to-RDF "
+"algorithm itself targets RDF 1.1 and therefore returns the language literal "
+"without direction. `csvw-terms` consequently has no `LiftProfile` variant "
+"and contains no hidden exact sideband; use `csvw-exact` whenever archival "
+"fidelity or an RDF round trip is required."
+msgstr ""
+
+#: src/concepts/projections.md:172 src/project/conformance.md:38
+msgid "Research-object carriers"
+msgstr ""
+
+#: src/concepts/projections.md:174
+msgid ""
+"Croissant 1.1, RO-Crate 1.3, DataCite Metadata Schema 4.6, DCAT 3, and "
+"Frictionless Data Package v1 are adapters over one typed "
+"`ResearchObjectModel`. The model covers dataset identity and description, "
+"identifiers and dates, agents, licenses, resources and checksums, "
+"activities, record sets, and fields. It is the N-to-N semantic pivot: a "
+"document can be lifted to caller-vocabulary RDF and projected into any other "
+"profile without a format-pair implementation."
+msgstr ""
+
+#: src/concepts/projections.md:181
+msgid ""
+"The three JSON-LD profiles are completely offline. Croissant, RO-Crate, and "
+"DCAT configuration supplies both the exact accepted/emitted `@context` JSON "
+"and the complete term-to-absolute-IRI definition map. PurRDF never "
+"dereferences a context URL, follows `@import`, or supplies a vocabulary. "
+"Expanded graphs are validated through the same native RDF 1.2 JSON-LD engine "
+"used elsewhere."
+msgstr ""
+
+#: src/concepts/projections.md:187
+msgid ""
+"RO-Crate also requires an explicit `packaging` value. `metadata-only` is the "
+"single-descriptor form. `attached` accepts a bounded `RoCrateAssets` payload "
+"carrier and produces `ro-crate-metadata.json`, a self-contained "
+"deterministic `ro-crate-preview.html`, and the referenced payload members. "
+"The engine owns no filesystem access: Rust receives `RoCrateAssets`, the CLI "
+"receives a canonical payload-only USTAR via `--assets`, and the language "
+"bindings receive the same archive bytes. Local File identities and payload "
+"paths must match one-to-one; missing/extra assets, reserved paths, duplicate "
+"ownership, declared-size drift, or a nonstandard attached crate root are "
+"integrity errors. The reader validates the same contract and exact preview "
+"rendering. Preview files are not added to `hasPart`; only payload File "
+"entities are root data entities."
+msgstr ""
+
+#: src/concepts/projections.md:199
+msgid ""
+"DataCite configuration supplies the namespace, schema location, XML-Schema-"
+"instance IRI, controlled values, and common RDF roles. Its reader is "
+"namespace-aware and rejects DTD/entity input. A separate identifier is used "
+"when present; otherwise the mandatory caller/document dataset identity is "
+"the primary identifier, so no DOI is synthesized. Frictionless configuration "
+"supplies the exact package profile and package name. A resource without a "
+"separate locator uses its caller-bounded relative entity identity as the "
+"safe Data Package path; no new IRI is created."
+msgstr ""
+
+#: src/concepts/projections.md:208
+msgid ""
+"Each native reader accepts the complete profile form emitted by PurRDF and "
+"rejects duplicate members, dangling references, unsafe relative paths, "
+"incorrect context/profile identity, ambiguous cardinality, and resource-"
+"limit excesses. Format-specific constructs outside the shared model are "
+"represented by stable, location-bearing ledger entries. The committed "
+"adversarial fixtures exercise a non-empty reverse ledger for every profile; "
+"a 5×5 metamorphic matrix proves the shared semantic intersection stabilizes "
+"through every source/target pair."
+msgstr ""
+
+#: src/concepts/projections.md:217
+msgid "Native RDF dataset descriptions"
+msgstr ""
+
+#: src/concepts/projections.md:219
+msgid ""
+"`dcat-3` remains the bidirectional JSON-LD research-object carrier described "
+"above. The separate `dcat-rdf` profile emits a blank-free default graph in "
+"any registered native RDF syntax. Its tagged `source` is mandatory and has "
+"two explicit modes:"
+msgstr ""
+
+#: src/concepts/projections.md:224
+msgid ""
+"`mapped` reuses the caller-configured research-object interpretation, then "
+"emits direct RDF IR with the caller's complete DCAT context/role map plus "
+"explicit `rdf:type` and XSD-string IRIs. The semantic lowering ledger from "
+"the shared model is preserved."
+msgstr ""
+
+#: src/concepts/projections.md:228
+msgid ""
+"`construct` treats one caller-supplied SPARQL CONSTRUCT as the complete "
+"view. Query bytes, input records, output records, term depth, artifacts, "
+"bodies, and archive bytes are all bounded. The query is parsed at "
+"configuration time, runs over the complete dataset including RDF 1.2 "
+"statement layers, and must produce a graph."
+msgstr ""
+
+#: src/concepts/projections.md:234
+msgid ""
+"Both modes use the same deterministic native serializer. The selected syntax "
+"controls the single `dcat.<extension>` member; configuration never infers a "
+"vocabulary, query, syntax, or base IRI. Because the result is a description "
+"view rather than an exact carrier, `dcat-rdf` has no lift profile."
+msgstr ""
+
+#: src/concepts/projections.md:239
+msgid ""
+"The `void` profile generates a deterministic, blank-free dataset description "
+"directly in caller-vocabulary RDF. Its configuration names the described "
+"dataset, the base for stable generated resource IRIs, the source header "
+"subject and predicates, three distinct header/alignment/metadata graph "
+"selectors, a non-empty exact set of data graphs, all 22 target roles, local "
+"and external dataset-prefix registries, optional metadata-link mappings and "
+"static dataset statements, and every package/execution limit."
+msgstr ""
+
+#: src/concepts/projections.md:247
+msgid ""
+"Statistics are computed only from the selected data graphs. `triples` counts "
+"selected statements, `entities` and `distinctSubjects` count distinct "
+"subjects, `distinctObjects` counts distinct objects, `classes` counts IRI "
+"objects of the configured type predicate, and `properties` counts "
+"predicates. A class partition includes every selected statement whose "
+"subject has that class; a property partition includes statements with "
+"exactly that predicate. Partition and linkset IRIs use full deterministic "
+"identifiers beneath the caller's base."
+msgstr ""
+
+#: src/concepts/projections.md:255
+msgid ""
+"Alignment rows must have IRI endpoints. Longest-prefix matching classifies "
+"each endpoint, equal-length ambiguity or no match is an error, and every "
+"alignment must have at least one local endpoint. Linksets retain source/"
+"object orientation and are grouped by subject dataset, object dataset, and "
+"predicate. The generator never guesses ownership, swaps direction, fetches "
+"metadata, or supplies a VoID/RDF/XSD namespace."
+msgstr ""
+
+#: src/concepts/projections.md:262
+msgid ""
+"Complete portable `example.org` configurations and an executable TriG source "
+"are under `crates/rdf/tests/fixtures/dataset-description/`. They run "
+"unchanged through every host, for example:"
+msgstr ""
+
+#: src/concepts/projections.md:276
+msgid "OBO Graphs and SKOS views"
+msgstr ""
+
+#: src/concepts/projections.md:278
+msgid ""
+"The OBO Graphs writer emits version 0.3.2 nodes, edges and metadata plus "
+"directly representable equivalent-node sets, logical definitions, "
+"restrictions, domain/range axioms, and property chains. The caller supplies "
+"the graph identity and every RDF/RDFS/OWL/OBO role. Output is checked "
+"against the pinned official 0.3.2 JSON Schema."
+msgstr ""
+
+#: src/concepts/projections.md:284
+msgid ""
+"The SKOS writer maps a caller-selected RDF graph into a caller-identified "
+"concept scheme. It supports concepts, labels, notation, documentation, "
+"hierarchy, mapping relations, membership, and top concepts, while enforcing "
+"the relevant SKOS integrity conditions. Target SKOS role IRIs are supplied "
+"just like source roles; PurRDF is a carrier and does not mint even standard "
+"vocabulary defaults."
+msgstr ""
+
+#: src/concepts/projections.md:290
+msgid ""
+"Both views record every omitted or widened source construct, named-graph "
+"placement, and RDF 1.2 statement-layer row with a stable source location."
+msgstr ""
+
+#: src/concepts/projections.md:293
+msgid "Configuration"
+msgstr ""
+
+#: src/concepts/projections.md:295
+msgid ""
+"The production archive API accepts strict tagged JSON of the form "
+"`{\"profile\":\"…\",\"config\":{…}}`. Unknown fields and a profile/config "
+"mismatch fail. There is no default configuration. A minimal generic LPG "
+"example is:"
+msgstr ""
+
+#: src/concepts/projections.md:301
+msgid "\"profile\""
+msgstr ""
+
+#: src/concepts/projections.md:301
+msgid "\"lpg-csv\""
+msgstr ""
+
+#: src/concepts/projections.md:302
+msgid "\"config\""
+msgstr ""
+
+#: src/concepts/projections.md:303
+msgid "\"rdf_type\""
+msgstr ""
+
+#: src/concepts/projections.md:303 src/concepts/projections.md:369
+#: src/concepts/projections.md:424
+msgid "\"https://example.org/type\""
+msgstr ""
+
+#: src/concepts/projections.md:304
+msgid "\"scope\""
+msgstr ""
+
+#: src/concepts/projections.md:304 src/concepts/projections.md:327
+#: src/concepts/projections.md:330 src/concepts/projections.md:334
+#: src/concepts/projections.md:335 src/concepts/projections.md:336
+#: src/concepts/jsonld.md:27 src/concepts/jsonld.md:82
+msgid "\"mode\""
+msgstr ""
+
+#: src/concepts/projections.md:304 src/concepts/projections.md:334
+#: src/concepts/projections.md:335 src/concepts/projections.md:336
+msgid "\"all\""
+msgstr ""
+
+#: src/concepts/projections.md:305
+msgid "\"limits\""
+msgstr ""
+
+#: src/concepts/projections.md:306
+msgid "\"max_artifacts\""
+msgstr ""
+
+#: src/concepts/projections.md:307
+msgid "\"max_artifact_bytes\""
+msgstr ""
+
+#: src/concepts/projections.md:308
+msgid "\"max_total_bytes\""
+msgstr ""
+
+#: src/concepts/projections.md:309
+msgid "\"max_archive_bytes\""
+msgstr ""
+
+#: src/concepts/projections.md:310
+msgid "\"max_term_depth\""
+msgstr ""
+
+#: src/concepts/projections.md:312
+msgid "\"execution_limits\""
+msgstr ""
+
+#: src/concepts/projections.md:313
+msgid "\"max_input_records\""
+msgstr ""
+
+#: src/concepts/projections.md:314
+msgid "\"max_model_records\""
+msgstr ""
+
+#: src/concepts/projections.md:315
+msgid "\"max_nodes\""
+msgstr ""
+
+#: src/concepts/projections.md:316
+msgid "\"max_edges\""
+msgstr ""
+
+#: src/concepts/projections.md:322
+msgid ""
+"To retain one named graph while admitting every predicate and type, replace "
+"the scope object with:"
+msgstr ""
+
+#: src/concepts/projections.md:327
+msgid "\"select\""
+msgstr ""
+
+#: src/concepts/projections.md:328
+msgid "\"include_default_graph\""
+msgstr ""
+
+#: src/concepts/projections.md:329 src/concepts/projections.md:361
+msgid "\"named_graphs\""
+msgstr ""
+
+#: src/concepts/projections.md:330
+msgid "\"only\""
+msgstr ""
+
+#: src/concepts/projections.md:331 src/concepts/projections.md:359
+msgid "\"include\""
+msgstr ""
+
+#: src/concepts/projections.md:331 src/concepts/projections.md:359
+msgid "\"kind\""
+msgstr ""
+
+#: src/concepts/projections.md:331
+msgid "\"iri\""
+msgstr ""
+
+#: src/concepts/projections.md:331
+msgid "\"value\""
+msgstr ""
+
+#: src/concepts/projections.md:331 src/concepts/projections.md:361
+msgid "\"https://example.org/business\""
+msgstr ""
+
+#: src/concepts/projections.md:332
+msgid "\"exclude\""
+msgstr ""
+
+#: src/concepts/projections.md:334
+msgid "\"predicates\""
+msgstr ""
+
+#: src/concepts/projections.md:334 src/concepts/projections.md:335
+#: src/concepts/projections.md:336
+msgid "\"deny\""
+msgstr ""
+
+#: src/concepts/projections.md:335
+msgid "\"node_types\""
+msgstr ""
+
+#: src/concepts/projections.md:336
+msgid "\"edge_types\""
+msgstr ""
+
+#: src/concepts/projections.md:340
+msgid ""
+"The package and canonical-model bounds apply on write and read as relevant; "
+"the input-record bound governs RDF projection scans. Together they cover "
+"member count, one-member bytes, total body bytes, encoded archive bytes, "
+"input/model records, nodes, edges, and recursive RDF term depth. They are "
+"trust-boundary policy and must be chosen by the application."
+msgstr ""
+
+#: src/concepts/projections.md:346
+msgid ""
+"Research-object configurations add a mandatory `common` object containing "
+"the complete `roles`, `identity`, and bounded `policy` maps. Profile-"
+"specific vocabulary roles, context data, schema identity, controlled values, "
+"and native profile identity are also mandatory. Complete runnable "
+"`example.org` configurations for all five profiles are under `crates/rdf/"
+"tests/fixtures/research-objects/carrier/`; they are examples, never library "
+"defaults."
+msgstr ""
+
+#: src/concepts/projections.md:354
+msgid ""
+"The complete strict tagged-JSON shape for curated CSVW is exercised by "
+"`crates/rdf/tests/fixtures/csvw-terms.json`. Its graph selector is explicit:"
+msgstr ""
+
+#: src/concepts/projections.md:360
+msgid "\"default_graph\""
+msgstr ""
+
+#: src/concepts/projections.md:365
+msgid ""
+"Each table selector then names its own caller vocabulary and row population:"
+msgstr ""
+
+#: src/concepts/projections.md:369
+msgid "\"type_predicate\""
+msgstr ""
+
+#: src/concepts/projections.md:370
+msgid "\"any_types\""
+msgstr ""
+
+#: src/concepts/projections.md:370
+msgid "\"https://example.org/Class\""
+msgstr ""
+
+#: src/concepts/projections.md:371
+msgid "\"all_types\""
+msgstr ""
+
+#: src/concepts/projections.md:372
+msgid "\"none_types\""
+msgstr ""
+
+#: src/concepts/projections.md:372
+msgid "\"https://example.org/Retired\""
+msgstr ""
+
+#: src/concepts/projections.md:373
+msgid "\"iri_prefixes\""
+msgstr ""
+
+#: src/concepts/projections.md:373 src/slices.md:42
+msgid "\"https://example.org/vocab/\""
+msgstr ""
+
+#: src/concepts/projections.md:377
+msgid ""
+"The runnable `csvw_terms` Rust example constructs the complete configuration "
+"with three ordinary table declarations—classes, properties, and individuals— "
+"and writes the canonical archive:"
+msgstr ""
+
+#: src/concepts/projections.md:385
+msgid ""
+"The separate `okf-terms` profile projects caller-classified RDF resources "
+"into OKF v0.1 concept documents and navigation indexes. Configuration is the "
+"entire projection algebra: graph scope, category selectors, safe path "
+"identity, fixed standard-field roles, producer extensions, body/link "
+"sections, index prose, the in-band fidelity declaration, and resource "
+"ceilings. No vocabulary or category has library-owned meaning. Concept "
+"frontmatter uses the OKF standard key order followed by lexical extension "
+"keys; reserved `index.md` files contain navigation Markdown without concept "
+"frontmatter."
+msgstr ""
+
+#: src/concepts/projections.md:394
+msgid ""
+"The complete strict portable configuration is `crates/rdf/tests/fixtures/okf-"
+"terms.json`. It is accepted unchanged by Rust, the CLI, Python, WebAssembly/"
+"TypeScript, and C:"
+msgstr ""
+
+#: src/concepts/projections.md:403
+msgid ""
+"The profile is deliberately absent from `LiftProfile`. Bundle-to-RDF import "
+"remains the responsibility of the existing caller-profiled OKF codec; the "
+"curated generator records every source row it does not carry instead of "
+"claiming an inverse."
+msgstr ""
+
+#: src/concepts/projections.md:408
+msgid "Rust archive API"
+msgstr ""
+
+#: src/concepts/projections.md:418
+msgid ""
+"b\"<https://example.org/alice> <https://example.org/knows> <https://"
+"example.org/bob> .\""
+msgstr ""
+
+#: src/concepts/projections.md:435
+msgid ""
+"`ProjectionArchive` contains the profile, USTAR bytes, and loss ledger. "
+"`ProjectionLift` contains the reconstructed immutable dataset and its lift "
+"ledger. `project_lpg_artifacts_to_sink` dispatches the four LPG profiles "
+"into a caller-owned `ProjectionArtifactSink` through the same configuration "
+"and mapping engine; `LpgProgressObserver` supplies structured progress. "
+"Lower-level APIs also expose the typed LPG, CSVW, OBO, SKOS, DCAT RDF, VoID, "
+"and in-memory research-object/artifact models."
+msgstr ""
+
+#: src/concepts/projections.md:443
+msgid "Other production surfaces"
+msgstr ""
+
+#: src/concepts/projections.md:445
+msgid "The surface names follow the same profile/config/archive contract:"
+msgstr ""
+
+#: src/concepts/projections.md:447 src/entailment.md:47 src/entailment.md:92
+msgid "Host"
+msgstr ""
+
+#: src/concepts/projections.md:447
+msgid "Materialized project"
+msgstr ""
+
+#: src/concepts/projections.md:447
+msgid "Attached RO-Crate"
+msgstr ""
+
+#: src/concepts/projections.md:447
+msgid "Direct LPG artifacts"
+msgstr ""
+
+#: src/concepts/projections.md:447
+msgid "Lift"
+msgstr ""
+
+#: src/concepts/projections.md:449
+msgid "`project_archive`"
+msgstr ""
+
+#: src/concepts/projections.md:449
+msgid "`project_archive_with_assets`"
+msgstr ""
+
+#: src/concepts/projections.md:449
+msgid "`project_lpg_artifacts_to_sink`"
+msgstr ""
+
+#: src/concepts/projections.md:449
+msgid "`lift_archive`"
+msgstr ""
+
+#: src/concepts/projections.md:450 src/concepts/jsonld.md:62
+#: src/entailment.md:50 src/entailment.md:95
+msgid "CLI"
+msgstr ""
+
+#: src/concepts/projections.md:450
+msgid "`purrdf project`"
+msgstr ""
+
+#: src/concepts/projections.md:450
+msgid "`purrdf project --assets PAYLOADS.tar`"
+msgstr ""
+
+#: src/concepts/projections.md:450
+msgid "`purrdf lift`"
+msgstr ""
+
+#: src/concepts/projections.md:451
+msgid "`purrdf.project(...)`"
+msgstr ""
+
+#: src/concepts/projections.md:451
+msgid "`purrdf.project(..., assets=archive)`"
+msgstr ""
+
+#: src/concepts/projections.md:451
+msgid "`purrdf.project_artifacts(...)`"
+msgstr ""
+
+#: src/concepts/projections.md:451
+msgid "`purrdf.lift(...)`"
+msgstr ""
+
+#: src/concepts/projections.md:452
+msgid "JavaScript"
+msgstr ""
+
+#: src/concepts/projections.md:452
+msgid "`dataset.project(...)`"
+msgstr ""
+
+#: src/concepts/projections.md:452
+msgid "`dataset.projectWithAssets(...)`"
+msgstr ""
+
+#: src/concepts/projections.md:452
+msgid "`liftProjection(...)`"
+msgstr ""
+
+#: src/concepts/projections.md:453
+msgid "`purrdf_project(...)`"
+msgstr ""
+
+#: src/concepts/projections.md:453
+msgid "`purrdf_project_with_assets(...)`"
+msgstr ""
+
+#: src/concepts/projections.md:453
+msgid "`purrdf_lift(...)`"
+msgstr ""
+
+#: src/concepts/projections.md:455
+msgid "Runnable examples live at:"
+msgstr ""
+
+#: src/concepts/projections.md:457
+msgid "`crates/rdf/examples/projection_archive.rs`"
+msgstr ""
+
+#: src/concepts/projections.md:458
+msgid "`crates/rdf/examples/csvw_terms.rs`"
+msgstr ""
+
+#: src/concepts/projections.md:459
+msgid "`crates/rdf/examples/okf_terms.rs`"
+msgstr ""
+
+#: src/concepts/projections.md:460
+msgid "`crates/rdf/examples/research_object_roundtrip.rs`"
+msgstr ""
+
+#: src/concepts/projections.md:461
+msgid "`crates/rdf/examples/attached_ro_crate.rs`"
+msgstr ""
+
+#: src/concepts/projections.md:462
+msgid "`crates/cli/examples/projection-roundtrip.sh`"
+msgstr ""
+
+#: src/concepts/projections.md:463
+msgid "`crates/cli/examples/dataset-descriptions.sh`"
+msgstr ""
+
+#: src/concepts/projections.md:464
+msgid "`bindings/python/examples/projection_roundtrip.py`"
+msgstr ""
+
+#: src/concepts/projections.md:465
+msgid "`bindings/python/examples/projection_stream.py`"
+msgstr ""
+
+#: src/concepts/projections.md:466
+msgid "`crates/rdf-wasm/js/examples/projection-roundtrip.mjs`"
+msgstr ""
+
+#: src/concepts/projections.md:467
+msgid "`crates/rdf-capi/examples/projection_roundtrip.c`"
+msgstr ""
+
+#: src/concepts/projections.md:469
+msgid "Determinism and verification"
+msgstr ""
+
+#: src/concepts/projections.md:471
+msgid ""
+"Archive members use safe POSIX-relative paths in lexical order. USTAR "
+"headers, metadata, checksums, padding, and trailer are fixed. A reader "
+"validates the archive and requires its canonical re-encoding to match the "
+"input bytes, so it does not silently normalize attacker-controlled "
+"alternatives."
+msgstr ""
+
+#: src/concepts/projections.md:476
+msgid ""
+"The pinned W3C CSVW manifests exercise 270 RDF cases and 282 validation "
+"cases. A locked independent `csvw` implementation validates production "
+"output and rejects deliberate metadata/data corruption. The OBO writer is "
+"independently validated against the pinned official schema with corruption "
+"probes. Run the whole projection verification slice with:"
+msgstr ""
+
+#: src/concepts/projections.md:487
+msgid ""
+"The benchmark is report-only. It measures RDF-to-LPG mapping, scoped versus "
+"explicit-all mapping over a 20-graph carrier, materialized package versus "
+"direct sink output for every LPG syntax, every LPG read path, exact CSVW "
+"write/read, exact-versus-curated CSVW over the same 12,000-quad carrier, one-"
+"graph versus all-graph curated scope, OBO Graphs and SKOS projection, mapped "
+"and CONSTRUCT DCAT RDF, VoID generation, the shared research-object model, "
+"and all five research-object write/read paths. It also reports allocation "
+"and artifact-body-size observations over deterministic fixtures."
+msgstr ""
+
+#: src/concepts/codecs.md:8
+msgid ""
+"PurRDF ships **first-party** parsers and serializers — no wrapped third-"
+"party codec — for nine formats:"
+msgstr ""
+
+#: src/concepts/codecs.md:11 src/sparql/results.md:56
+msgid "Format"
+msgstr ""
+
+#: src/concepts/codecs.md:11
+msgid "Media type"
+msgstr ""
+
+#: src/concepts/codecs.md:11
+msgid "Star-capable"
+msgstr ""
+
+#: src/concepts/codecs.md:13
+msgid "Turtle"
+msgstr ""
+
+#: src/concepts/codecs.md:13
+msgid "`text/turtle`"
+msgstr ""
+
+#: src/concepts/codecs.md:13 src/concepts/codecs.md:14
+#: src/concepts/codecs.md:15 src/concepts/codecs.md:16
+#: src/concepts/codecs.md:20 src/concepts/codecs.md:21 src/sparql/results.md:58
+#: src/sparql/results.md:59 src/sparql/results.md:60 src/sparql/results.md:61
+#: src/entailment-rules.md:94 src/entailment-rules.md:95
+#: src/entailment-rules.md:96 src/entailment-rules.md:102
+#: src/entailment-rules.md:103 src/entailment-rules.md:104
+#: src/entailment-rules.md:105 src/entailment-rules.md:106
+#: src/entailment-rules.md:107 src/entailment-rules.md:108
+#: src/entailment-rules.md:109 src/entailment-rules.md:110
+#: src/entailment-rules.md:111 src/entailment-rules.md:112
+#: src/entailment-rules.md:113 src/entailment-rules.md:114
+#: src/entailment-rules.md:115 src/entailment-rules.md:116
+#: src/entailment-rules.md:117 src/entailment-rules.md:118
+#: src/entailment-rules.md:119 src/entailment-rules.md:125
+#: src/entailment-rules.md:126 src/entailment-rules.md:127
+#: src/entailment-rules.md:128 src/entailment-rules.md:129
+#: src/entailment-rules.md:130 src/entailment-rules.md:131
+#: src/entailment-rules.md:132 src/entailment-rules.md:133
+#: src/entailment-rules.md:134 src/entailment-rules.md:135
+#: src/entailment-rules.md:136 src/entailment-rules.md:137
+#: src/entailment-rules.md:138 src/entailment-rules.md:139
+#: src/entailment-rules.md:140 src/entailment-rules.md:141
+#: src/entailment-rules.md:142 src/entailment-rules.md:143
+#: src/entailment-rules.md:144 src/entailment-rules.md:145
+#: src/entailment-rules.md:146 src/entailment-rules.md:147
+#: src/entailment-rules.md:148 src/entailment-rules.md:149
+#: src/entailment-rules.md:150 src/entailment-rules.md:151
+#: src/entailment-rules.md:152 src/entailment-rules.md:153
+#: src/entailment-rules.md:154 src/entailment-rules.md:155
+#: src/entailment-rules.md:156 src/entailment-rules.md:157
+#: src/entailment-rules.md:158 src/entailment-rules.md:159
+#: src/entailment-rules.md:160 src/entailment-rules.md:161
+#: src/entailment-rules.md:162 src/entailment-rules.md:163
+#: src/entailment-rules.md:164 src/entailment-rules.md:165
+#: src/entailment-rules.md:166 src/entailment-rules.md:167
+#: src/entailment-rules.md:168 src/entailment-rules.md:169
+#: src/entailment-rules.md:170 src/entailment-rules.md:171
+#: src/entailment-rules.md:172 src/entailment-rules.md:173
+#: src/entailment-rules.md:174 src/entailment-rules.md:175
+#: src/entailment-rules.md:176 src/entailment-rules.md:177
+#: src/entailment-rules.md:178 src/entailment-rules.md:179
+#: src/entailment-rules.md:180 src/entailment-rules.md:181
+#: src/entailment-rules.md:182 src/entailment-rules.md:183
+#: src/entailment-rules.md:184 src/entailment-rules.md:185
+#: src/entailment-rules.md:186 src/entailment-rules.md:187
+#: src/entailment-rules.md:188 src/entailment-rules.md:189
+#: src/entailment-rules.md:190 src/entailment-rules.md:191
+#: src/entailment-rules.md:192 src/entailment-rules.md:193
+#: src/entailment-rules.md:194 src/entailment-rules.md:195
+#: src/entailment-rules.md:196 src/entailment-rules.md:197
+#: src/entailment-rules.md:198 src/entailment-rules.md:199
+#: src/entailment-rules.md:200 src/entailment-rules.md:201
+#: src/entailment-rules.md:202 src/entailment-rules.md:208
+#: src/entailment-rules.md:209 src/entailment-rules.md:210
+#: src/entailment-rules.md:211 src/entailment-rules.md:212
+msgid "yes"
+msgstr ""
+
+#: src/concepts/codecs.md:14
+msgid "TriG"
+msgstr ""
+
+#: src/concepts/codecs.md:14
+msgid "`application/trig`"
+msgstr ""
+
+#: src/concepts/codecs.md:15
+msgid "N-Triples"
+msgstr ""
+
+#: src/concepts/codecs.md:15
+msgid "`application/n-triples`"
+msgstr ""
+
+#: src/concepts/codecs.md:16
+msgid "N-Quads"
+msgstr ""
+
+#: src/concepts/codecs.md:16
+msgid "`application/n-quads`"
+msgstr ""
+
+#: src/concepts/codecs.md:17 src/concepts/base-iris.md:188
+msgid "RDF/XML"
+msgstr ""
+
+#: src/concepts/codecs.md:17
+msgid "`application/rdf+xml`"
+msgstr ""
+
+#: src/concepts/codecs.md:17 src/concepts/codecs.md:18
+#: src/concepts/codecs.md:19 src/concepts/base-iris.md:51
+#: src/concepts/base-iris.md:52 src/concepts/base-iris.md:53
+#: src/concepts/base-iris.md:54 src/concepts/base-iris.md:55
+#: src/concepts/base-iris.md:190
+msgid "no"
+msgstr ""
+
+#: src/concepts/codecs.md:18
+msgid "TriX"
+msgstr ""
+
+#: src/concepts/codecs.md:18
+msgid "`application/trix`"
+msgstr ""
+
+#: src/concepts/codecs.md:19
+msgid "HexTuples"
+msgstr ""
+
+#: src/concepts/codecs.md:19
+msgid "`application/x-hextuples`"
+msgstr ""
+
+#: src/concepts/codecs.md:20
+msgid "JSON-LD (star)"
+msgstr ""
+
+#: src/concepts/codecs.md:20
+msgid "`application/ld+json`"
+msgstr ""
+
+#: src/concepts/codecs.md:21
+msgid "YAML-LD"
+msgstr ""
+
+#: src/concepts/codecs.md:21
+msgid "`application/ld+yaml`"
+msgstr ""
+
+#: src/concepts/codecs.md:23
+msgid ""
+"They live in [`purrdf-rdf`](https://docs.rs/purrdf-rdf), one layer above the "
+"kernel, and are reachable through the umbrella crate:"
+msgstr ""
+
+#: src/concepts/codecs.md:29
+msgid ""
+"br#\"\n"
+"    @prefix ex: <https://example.org/> .\n"
+"    ex:cat ex:says \"meow\" .\n"
+"\"#"
+msgstr ""
+
+#: src/concepts/codecs.md:33
+msgid "// Parse into the frozen, value-interned RDF 1.2 dataset IR.\n"
+msgstr ""
+
+#: src/concepts/codecs.md:37
+msgid ""
+"// Serialize back out through any native codec — byte-deterministic output.\n"
+msgstr ""
+
+#: src/concepts/codecs.md:39
+msgid "\"application/n-quads\""
+msgstr ""
+
+#: src/concepts/codecs.md:40
+msgid "\"serializes\""
+msgstr ""
+
+#: src/concepts/codecs.md:43
+msgid "Open Knowledge Format bundles"
+msgstr ""
+
+#: src/concepts/codecs.md:45
+msgid ""
+"The native OKF codec maps caller-profiled RDF 1.2 datasets to agent-facing "
+"Markdown files with YAML frontmatter and lifts them back through the RDF "
+"event seam. OKF is an in-memory bundle API rather than another media type: "
+"callers choose how to store the files, so the same code remains "
+"deterministic and wasm-clean."
+msgstr ""
+
+#: src/concepts/codecs.md:51
+msgid ""
+"`OkfConfig::new` requires the vocabulary namespace, document base IRI, and "
+"recognized frontmatter keys. There is no built-in ontology or namespace. Use "
+"`lift_okf_bundle` to drive an `RdfEventSink`, or `write_okf_bundle` (backed "
+"by `OkfWriter`, an `RdfDatasetVisitor`) to project a frozen dataset. Both "
+"directions always return a loss ledger. A lossless profile yields an empty "
+"ledger; named graphs, non-profile/OWL rows, and unrelated reifier or "
+"annotation rows are pinpointed explicitly when writing."
+msgstr ""
+
+#: src/concepts/codecs.md:59 src/project/design-rules.md:39
+msgid "Byte determinism"
+msgstr ""
+
+#: src/concepts/codecs.md:61
+msgid ""
+"Every serializer is **byte-deterministic**: the same dataset always produces "
+"the same bytes, on every platform and in every language binding. This is a "
+"hard workspace invariant, not a best effort — no iteration-order, time, or "
+"RNG dependence is allowed in any output path (hashers are fixed-key `ahash` "
+"for exactly this reason), and golden-file tests pin the emitted bytes."
+msgstr ""
+
+#: src/concepts/codecs.md:67
+msgid ""
+"Determinism is what makes the rest of the toolkit composable: content "
+"addressing in [GTS](../gts.md) and the [slice catalog](../slices.md), "
+"diffable serializations in review, and cross-language conformance vectors "
+"that can be compared byte-for-byte."
+msgstr ""
+
+#: src/concepts/codecs.md:72
+msgid "Diagnostics, not partial parses"
+msgstr ""
+
+#: src/concepts/codecs.md:74
+msgid ""
+"Malformed input is a typed `RdfDiagnostic` with a source location where the "
+"codec can provide one — never a silent partial parse. Parsing can optionally "
+"record a source-position span table for richer diagnostics. Diagnostics stay "
+"structured (SARIF-free) in the core; render them as byte-deterministic SARIF "
+"2.1.0 for editors and CI with [`purrdf-validate`](https://docs.rs/purrdf-"
+"validate) (see [SHACL](../validation/shacl.md#sarif-output))."
+msgstr ""
+
+#: src/concepts/codecs.md:82
+msgid "Lossy projections are loud"
+msgstr ""
+
+#: src/concepts/codecs.md:84
+msgid ""
+"RDF 1.2 statement-level data (triple terms, reifier bindings, annotations) "
+"survives every star-capable round-trip. Serializing into a star-incapable "
+"projection drops that layer _loudly_: the realized drop count is handed to "
+"the machine-readable loss ledger ([`generated/rdf-loss-matrix.json`](https://"
+"github.com/Blackcat-Informatics/purrdf/blob/main/generated/rdf-loss-"
+"matrix.json)) rather than disappearing. The same discipline applies at the "
+"SPARQL results boundary ([Result Formats](../sparql/results.md)) and the "
+"RDF↔GTS boundary."
+msgstr ""
+
+#: src/concepts/codecs.md:92
+msgid "The succinct pack codec"
+msgstr ""
+
+#: src/concepts/codecs.md:94
+msgid ""
+"Alongside the text codecs above, `purrdf-core` ships a **binary** codec for "
+"a different job: a read-only, query-the-compressed-form encoding of a whole "
+"dataset for large-scale reference bundles, not an interchange format with a "
+"media type. `PackBuilder::build_bytes(&dataset)` writes a self-contained, "
+"byte-deterministic pack — a value dictionary, graph-partitioned succinct "
+"bitmap-triples, and RDF 1.2 side-tables (reifier bindings, statement "
+"annotations) — into one `Vec<u8>`. `PackView::from_bytes(&[u8])` opens it "
+"zero-copy over a borrowed slice and answers pattern queries directly against "
+"the packed bytes, with no decompression or materialization step first."
+msgstr ""
+
+#: src/concepts/codecs.md:104
+msgid ""
+"Reach for a pack when a dataset is done changing and needs to be "
+"distributed, archived, or served at a scale where re-parsing text on every "
+"load is too slow: RDF 1.2 (named graphs, quoted triples, reifiers, "
+"annotations) is fully supported, and `verify_pack` independently recomputes "
+"the dataset's RDFC-1.0 digest from the pack's own decoded contents — a "
+"**certified read-only projection**, not merely a compressed file. The "
+"library never memory-maps a pack itself (every published crate stays `wasm32-"
+"unknown-unknown`\\-clean); a native consumer that wants a durable, larger-"
+"than-heap tier `mmap`s the file and hands `PackView::from_bytes` the "
+"resulting borrowed slice. See the \"Pack backend\" section of [the backend "
+"contract](https://github.com/Blackcat-Informatics/purrdf/blob/main/docs/"
+"design/purrdf-backend-contract.md) for the full contract."
+msgstr ""
+
+#: src/concepts/codecs.md:117
+msgid "Deterministic embedding companions"
+msgstr ""
+
+#: src/concepts/codecs.md:119
+msgid ""
+"`.purremb` is the mmap-native companion for embedding projections over one "
+"exact `.purrpck`. It does not modify the pack or RDF canonical identity. Its "
+"sorted section directory binds finite dense `f32` or `f64` matrices to the "
+"source pack's exact SHA-256, an independently verified RDFC digest, complete "
+"model and processing contracts, stable target sets, and per-section plus "
+"whole-artifact integrity evidence. `EmbeddingBuilder` accepts unordered "
+"rows; `EmbeddingStreamWriter` accepts canonical rows with bounded matrix "
+"working memory; both produce the same canonical bytes."
+msgstr ""
+
+#: src/concepts/codecs.md:128
+msgid ""
+"Two subject families are first class. Large text collections use a corpus–"
+"document–chunk hierarchy: UTF-8 text remains external while target records "
+"retain content digests, logical identities, byte and Unicode-scalar "
+"coordinates, chunking contracts, and family-scoped token spans. RDF data "
+"uses one RDF 1.2 model for datasets, default and named graphs, statements, "
+"reifier bindings, annotations, directional literals, blank nodes, and "
+"recursive triple terms. Source-local pack ordinals are verified lookup "
+"hints, never identity."
+msgstr ""
+
+#: src/concepts/codecs.md:136
+msgid ""
+"Matryoshka families store only their widest dense matrix. Each declared "
+"leading prefix is a distinct `VectorSpaceId` and `ProjectionId`, so a coarse "
+"prefix cannot be silently compared with or substituted for the full space. "
+"Raw prefix rows are zero-copy strided views; deterministic L2 prefixes are "
+"calculated on demand. Approximate indexes remain opaque, rebuildable derived "
+"artifacts bound to one exact prefix projection. They never replace the "
+"authoritative matrix."
+msgstr ""
+
+#: src/concepts/codecs.md:143
+msgid ""
+"Construction follows one evidence path. First obtain a "
+"`CertifiedPurrpckSource` by building or independently verifying the exact "
+"source pack; arbitrary digest claims cannot construct this type. For a "
+"corpus, derive `CorpusTarget`, `DocumentTarget::from_content`, and "
+"`TextChunkTarget::from_document` records, add the required hierarchy "
+"relations, and add a `TokenSpan` for every document or chunk placed in a "
+"family matrix. For RDF, derive dataset, graph, statement, reifier, "
+"annotation, and term targets from that verified RDF 1.2 dataset. RDF-star "
+"triple terms use `RdfTermTarget::Triple`; they do not enter a separate "
+"identity system."
+msgstr ""
+
+#: src/concepts/codecs.md:153
+msgid ""
+"An `EmbeddingFamilyContract` defines the complete generation pipeline. A "
+"Matryoshka contract lists its allowed leading dimensions, while its "
+"`MatrixInput` carries rows only at the widest dimension and one "
+"`ProjectionSpec` per declared space. Consumers resolve an exact "
+"`(TargetSetId, VectorSpaceId)` through `effective_matrix` and must call "
+"`require_compatible_vector_spaces` before comparing rows from independent "
+"inputs."
+msgstr ""
+
+#: src/concepts/codecs.md:161
+msgid ""
+"Large collections shard at artifact boundaries: each `.purremb` names its "
+"own exact source pack and local target set, while equal family contracts "
+"retain the same `FamilyId` and `VectorSpaceId`. Corpus manifests and "
+"`ExternalBinding::from_bytes` bind external text or other exact artifacts; "
+"`ExternalBinding::from_purrpck` adds independently certified RDF evidence. "
+"Bindings carry caller-supplied roles and media types. PurRDF does not invent "
+"a policy or ontology vocabulary for them."
+msgstr ""
+
+#: src/concepts/codecs.md:169
+msgid ""
+"`EmbeddingView::from_bytes` borrows any stable byte slice, whether heap-"
+"owned, memory-mapped by the caller, or WebAssembly linear memory. Structural "
+"opening, full artifact verification, exact source verification, and "
+"certified source verification are explicit states of evidence rather than "
+"access gates. Callers that mmap files must keep the backing bytes immutable "
+"while a view or resident verification certificate exists."
+msgstr ""
+
+#: src/concepts/codecs.md:176
+msgid ""
+"Embeddings and ANN structures are sensitive derived content: model "
+"inversion, membership inference, similarity probing, digest dictionary "
+"attacks, and index structure can disclose source properties. Container "
+"hashes detect corruption and stale attachment; they do not authenticate an "
+"author, encrypt content, or grant access. See the byte-exact [PURREMB v1 "
+"specification](https://github.com/Blackcat-Informatics/purrdf/blob/main/docs/"
+"PURREMB.md)."
+msgstr ""
+
+#: src/concepts/codecs.md:183
+msgid "The columnar Parquet codec"
+msgstr ""
+
+#: src/concepts/codecs.md:185
+msgid ""
+"`purrdf::columnar` exposes the bidirectional SQL/DataFrame interchange path. "
+"It maps any `DatasetView` plus a content-addressed blob store to five "
+"standard Parquet files (`terms`, `quads`, `reifiers`, `annotations`, and "
+"`blobs`) and reads that exact profile back without Arrow or a general "
+"Parquet runtime. The mapping retains RDF 1.2 triple terms, reifiers, "
+"annotations, graph scope, directional literals, blank-node scope, and "
+"explicitly empty named graphs."
+msgstr ""
+
+#: src/concepts/codecs.md:192
+msgid ""
+"The files are byte-deterministic and readable by engines such as DuckDB. See "
+"the [normative columnar schema](https://github.com/Blackcat-Informatics/"
+"purrdf/blob/main/docs/COLUMNAR.md) for every field and the deliberately "
+"narrow Parquet profile."
+msgstr ""
+
+#: src/concepts/codecs.md:196 src/concepts/base-iris.md:258
+#: src/sparql/querying.md:1881 src/validation/shacl.md:378
+#: src/validation/shex.md:64 src/entailment.md:289
+msgid "Conformance"
+msgstr ""
+
+#: src/concepts/codecs.md:198
+msgid ""
+"The codecs are gated by the W3C `rdf-tests` syntax corpus, vendored and "
+"frozen in-repo — 250/250 round-trip cases across N-Quads, N-Triples, RDF/"
+"XML, TriG, and Turtle at the time of writing. The live scoreboard is [`docs/"
+"CONFORMANCE.md`](https://github.com/Blackcat-Informatics/purrdf/blob/main/"
+"docs/CONFORMANCE.md)."
+msgstr ""
+
+#: src/concepts/codecs.md:203 src/sparql/results.md:103 src/gts.md:91
+#: src/slices.md:95 src/interop/rdflib.md:76 src/interop/rdfjs.md:112
+msgid "Related"
+msgstr ""
+
+#: src/concepts/codecs.md:205
+msgid ""
+"[Canonicalization & Diff](canonicalization.md) — when you need a _canonical_ "
+"serialization rather than just a deterministic one."
+msgstr ""
+
+#: src/concepts/codecs.md:207
+msgid ""
+"[The Interned Dataset IR](interned-dataset.md) — what the text codecs parse "
+"into, and the `DatasetView` read seam the pack codec implements alongside "
+"`RdfDataset`."
+msgstr ""
+
+#: src/concepts/base-iris.md:8
+msgid ""
+"An RDF document may spell an IRI _relatively_ — `<other.ttl>`, `<#me>`, `<>` "
+"— and the reader must turn it into an absolute IRI before it can be a term. "
+"That turning needs a **base IRI**. PurRDF resolves every relative reference, "
+"in every syntax and on every surface, through one layer: `purrdf-iri`."
+msgstr ""
+
+#: src/concepts/base-iris.md:13
+msgid ""
+"**This is a hard failure, and it used to be silent.** A relative IRI with no "
+"base in scope is now an error. Documents that previously \"worked\" this way "
+"did not: they interned a relative string as if it were an IRI, and emitted N-"
+"Triples that no conformant parser accepts. If a document of yours starts "
+"failing with `iri-relative-no-base`, it was already producing invalid RDF — "
+"give it a base (below) rather than working around the error."
+msgstr ""
+
+#: src/concepts/base-iris.md:20
+msgid "Where the base comes from"
+msgstr ""
+
+#: src/concepts/base-iris.md:22
+msgid ""
+"The precedence chain is RFC 3986 §5.1's, in its order. The first step that "
+"yields a base wins:"
+msgstr ""
+
+#: src/concepts/base-iris.md:25
+msgid "Source"
+msgstr ""
+
+#: src/concepts/base-iris.md:25
+msgid "RFC 3986"
+msgstr ""
+
+#: src/concepts/base-iris.md:25
+msgid "Example"
+msgstr ""
+
+#: src/concepts/base-iris.md:27 src/sparql/querying.md:935
+#: src/sparql/querying.md:936 src/sparql/querying.md:937
+#: src/sparql/querying.md:938 src/sparql/querying.md:941
+#: src/sparql/embedding-knn.md:34
+msgid "1"
+msgstr ""
+
+#: src/concepts/base-iris.md:27
+msgid "An in-document base directive"
+msgstr ""
+
+#: src/concepts/base-iris.md:27
+msgid "§5.1.1"
+msgstr ""
+
+#: src/concepts/base-iris.md:27
+msgid ""
+"Turtle/TriG `@base` or `BASE`, SPARQL `BASE`, RDF/XML `xml:base`, JSON-LD/"
+"YAML-LD `@context.@base`"
+msgstr ""
+
+#: src/concepts/base-iris.md:28 src/sparql/querying.md:933
+#: src/sparql/querying.md:934 src/sparql/querying.md:940
+#: src/sparql/querying.md:944 src/sparql/embedding-knn.md:35
+msgid "2"
+msgstr ""
+
+#: src/concepts/base-iris.md:28
+msgid "A base the caller supplied"
+msgstr ""
+
+#: src/concepts/base-iris.md:28
+msgid "§5.1.2"
+msgstr ""
+
+#: src/concepts/base-iris.md:28
+msgid "the `base` argument to `parse_dataset`, the CLI's `--base`"
+msgstr ""
+
+#: src/concepts/base-iris.md:29 src/sparql/embedding-knn.md:36
+#: src/entailment.md:144 src/entailment-rules.md:61
+msgid "3"
+msgstr ""
+
+#: src/concepts/base-iris.md:29
+msgid "The document's **retrieval IRI**"
+msgstr ""
+
+#: src/concepts/base-iris.md:29
+msgid "§5.1.3"
+msgstr ""
+
+#: src/concepts/base-iris.md:29
+msgid "the `file://` IRI of the file the CLI read"
+msgstr ""
+
+#: src/concepts/base-iris.md:30
+msgid "4"
+msgstr ""
+
+#: src/concepts/base-iris.md:30
+msgid "_(none)_ — hard failure"
+msgstr ""
+
+#: src/concepts/base-iris.md:30
+msgid "§5.1.4"
+msgstr ""
+
+#: src/concepts/base-iris.md:30 src/concepts/base-iris.md:151
+msgid "`iri-relative-no-base`"
+msgstr ""
+
+#: src/concepts/base-iris.md:32
+msgid ""
+"Step 1 nests: a `@base` inside a document rebinds relative to the base "
+"already in force, so `@base <sub/>` under `http://example.org/dir/` yields "
+"`http://example.org/dir/sub/`."
+msgstr ""
+
+#: src/concepts/base-iris.md:36
+msgid ""
+"Nothing is ever invented. There is no default base, no fabricated `urn:` "
+"placeholder, and no fall back to the current working directory. Step 4 is a "
+"real, specified outcome, not a gap."
+msgstr ""
+
+#: src/concepts/base-iris.md:40
+msgid "Which surfaces have a retrieval IRI"
+msgstr ""
+
+#: src/concepts/base-iris.md:42
+msgid ""
+"Step 3 needs a retrieval IRI, and only a surface that opened the file itself "
+"has one. **Three** do. The derivation lives in exactly one of them, and the "
+"other two consume it rather than re-deriving one."
+msgstr ""
+
+#: src/concepts/base-iris.md:46
+msgid "Surface"
+msgstr ""
+
+#: src/concepts/base-iris.md:46
+msgid "Retrieval IRI?"
+msgstr ""
+
+#: src/concepts/base-iris.md:46
+msgid "Consequence"
+msgstr ""
+
+#: src/concepts/base-iris.md:48
+msgid "`purrdf-slice` (slice tree, catalog, dependency fixes)"
+msgstr ""
+
+#: src/concepts/base-iris.md:48
+msgid "yes — **derives** it; the workspace's one implementation of §5.1.3"
+msgstr ""
+
+#: src/concepts/base-iris.md:48
+msgid "a relative IRI in an on-disk slice document resolves with no flags"
+msgstr ""
+
+#: src/concepts/base-iris.md:49
+msgid "`purrdf-shapes` shape-union loader"
+msgstr ""
+
+#: src/concepts/base-iris.md:49 src/concepts/base-iris.md:50
+msgid "yes — **consumes** `purrdf-slice`'s"
+msgstr ""
+
+#: src/concepts/base-iris.md:49
+msgid "each shape file parses under its own `file://` IRI"
+msgstr ""
+
+#: src/concepts/base-iris.md:50
+msgid "`purrdf` CLI, per input **file**"
+msgstr ""
+
+#: src/concepts/base-iris.md:50
+msgid "a relative IRI resolves with no flags"
+msgstr ""
+
+#: src/concepts/base-iris.md:51
+msgid "`purrdf` CLI, stdin (`-`)"
+msgstr ""
+
+#: src/concepts/base-iris.md:51
+msgid "a relative IRI is `iri-relative-no-base`; pass `--base`"
+msgstr ""
+
+#: src/concepts/base-iris.md:52
+msgid "Rust byte APIs (`parse_dataset`, `purrdf-rdf`, `purrdf-iri`)"
+msgstr ""
+
+#: src/concepts/base-iris.md:52
+msgid "pass a base, or the document must carry one"
+msgstr ""
+
+#: src/concepts/base-iris.md:53
+msgid "WebAssembly"
+msgstr ""
+
+#: src/concepts/base-iris.md:53 src/concepts/base-iris.md:54
+#: src/concepts/base-iris.md:55
+msgid "as above"
+msgstr ""
+
+#: src/concepts/base-iris.md:54
+msgid "C ABI"
+msgstr ""
+
+#: src/concepts/base-iris.md:57
+msgid ""
+"Every surface that is handed **bytes** rather than a path is in the second "
+"group. Bytes have no retrieval IRI, so §5.1.3 is vacuous there and §5.1.4 — "
+"the hard failure — is the specified answer. This is deliberate rather than "
+"an omission: a base invented from the local filesystem would differ per "
+"machine and leak local paths into published RDF, which would break the byte "
+"determinism the whole toolkit rests on. It is also why `purrdf-iri` and "
+"`purrdf-rdf` never touch the filesystem at all — that is what keeps them "
+"wasm32-clean."
+msgstr ""
+
+#: src/concepts/base-iris.md:65
+msgid ""
+"`purrdf-slice` derives the retrieval IRI from the **canonicalized** path, "
+"translating Windows paths (including UNC hosts and the extended-length `\\\\?"
+"\\` prefix) into RFC 8089 form and percent-encoding each component. Its "
+"consumers apply it only when nothing of higher precedence was given, and a "
+"path with no usable `file://` IRI is a hard error naming `--base`, never a "
+"silent fall back to \"no base\"."
+msgstr ""
+
+#: src/concepts/base-iris.md:72
+msgid "Two grammar families"
+msgstr ""
+
+#: src/concepts/base-iris.md:74
+msgid "Whether a base can help at all depends on the syntax, not on the base:"
+msgstr ""
+
+#: src/concepts/base-iris.md:76
+msgid "Family"
+msgstr ""
+
+#: src/concepts/base-iris.md:76
+msgid "Syntaxes"
+msgstr ""
+
+#: src/concepts/base-iris.md:76
+msgid "Relative reference"
+msgstr ""
+
+#: src/concepts/base-iris.md:78
+msgid "Admits relative references"
+msgstr ""
+
+#: src/concepts/base-iris.md:78
+msgid "Turtle, TriG, RDF/XML, JSON-LD, YAML-LD, SPARQL"
+msgstr ""
+
+#: src/concepts/base-iris.md:78
+msgid "resolved against the base in force"
+msgstr ""
+
+#: src/concepts/base-iris.md:79
+msgid "Absolute-only by grammar"
+msgstr ""
+
+#: src/concepts/base-iris.md:79 src/concepts/base-iris.md:190
+msgid "N-Triples, N-Quads, TriX, HexTuples"
+msgstr ""
+
+#: src/concepts/base-iris.md:79
+msgid "**rejected** — no base is ever applied"
+msgstr ""
+
+#: src/concepts/base-iris.md:81
+msgid ""
+"The second family's grammars have no base directive and no relative-IRI "
+"production. A relative reference there makes the document invalid for its "
+"own syntax, so PurRDF reports a _different_ code and **supplying a base will "
+"not rescue it**: convert the source to Turtle or N-Triples-with-absolute-"
+"IRIs instead."
+msgstr ""
+
+#: src/concepts/base-iris.md:87
+msgid ""
+"Absolute references are never touched. In both families an IRI a document "
+"spelled absolutely is taken lexically verbatim — `<http://a/bb/ccc/../d;p?"
+"q>` survives intact, with or without a base in scope. Putting it through "
+"resolution anyway would apply RFC 3986 §5.2.4 dot-segment removal, which is "
+"§6.2.2.3 _syntax-based normalization_, forbidden by RDF Concepts §3.2. "
+"Identical document bytes must denote one graph with one canonical digest."
+msgstr ""
+
+#: src/concepts/base-iris.md:94
+msgid "Beyond documents: the IR boundary"
+msgstr ""
+
+#: src/concepts/base-iris.md:96
+msgid ""
+"Everything above is about _reading a document_, but a document is not the "
+"only way a term reaches the store. You can also build a dataset directly — "
+"from Python quad objects, from a GTS container, by reopening a `.pack` file, "
+"with SPARQL `INSERT DATA`, or through a projection — and none of those pass "
+"a parser that could resolve a base for you."
+msgstr ""
+
+#: src/concepts/base-iris.md:102
+msgid ""
+"The absoluteness rule therefore does not live in the codecs. It lives at the "
+"**interned term table** every one of those paths necessarily arrives at, so "
+"a relative IRI is not merely rejected on the way in: it is unrepresentable. "
+"A frozen dataset carrying one cannot be constructed, and the refusal reports "
+"the same `iri-relative-no-base` code a parser would."
+msgstr ""
+
+#: src/concepts/base-iris.md:108
+msgid ""
+"There is no base in scope at that boundary and there cannot be: a frozen "
+"dataset is a set of _resolved_ identities, with no document and no `@base` "
+"alongside it to resolve against later. So a relative reference there is not "
+"a term awaiting resolution — it is a term whose identity is unknowable. "
+"Resolve it against whatever base your application means _before_ it becomes "
+"a term."
+msgstr ""
+
+#: src/concepts/base-iris.md:114
+msgid "When you see the error"
+msgstr ""
+
+#: src/concepts/base-iris.md:116
+msgid ""
+"At the mutation that introduced it. `Store.add`, `MutableDataset.add`, the "
+"RDF/JS `dataset.add`, and `purrdf_graph_insert` all refuse a relative IRI at "
+"the call, naming the offending term:"
+msgstr ""
+
+#: src/concepts/base-iris.md:121 src/concepts/base-iris.md:122
+msgid "\"rel\""
+msgstr ""
+
+#: src/concepts/base-iris.md:127
+msgid ""
+"The refused quad does not land — the store is unchanged and still usable."
+msgstr ""
+
+#: src/concepts/base-iris.md:129
+msgid ""
+"The check is repeated at every point where a working set becomes a dataset: "
+"freezing a builder or a store's pending edits, serializing, canonicalizing "
+"or digesting the result, and reopening a `.pack` file (whose bytes may have "
+"been written by another engine, an older version, or corrupted on disk). "
+"That repetition is deliberate. The freeze-time check is the _invariant_ — it "
+"is what makes a relative IRI unrepresentable in the IR from any ingress, "
+"including ones that do not go through a mutation call at all. The insert-"
+"time check is the _diagnosis_: it exists so the error can name the line that "
+"caused it. Neither subsumes the other."
+msgstr ""
+
+#: src/concepts/base-iris.md:139
+msgid "One exception you may rely on"
+msgstr ""
+
+#: src/concepts/base-iris.md:141
+msgid ""
+"Blank node labels and literal lexical forms are arbitrary strings and are "
+"not touched by any of this. Only IRIs are IRIs."
+msgstr ""
+
+#: src/concepts/base-iris.md:144
+msgid "The diagnostic codes"
+msgstr ""
+
+#: src/concepts/base-iris.md:146
+msgid ""
+"These codes are stable and machine-readable. Every codec, the CLI, the C "
+"ABI, Python and wasm report the same code for the same condition."
+msgstr ""
+
+#: src/concepts/base-iris.md:149
+msgid "Code"
+msgstr ""
+
+#: src/concepts/base-iris.md:149
+msgid "Condition"
+msgstr ""
+
+#: src/concepts/base-iris.md:149
+msgid "What to do"
+msgstr ""
+
+#: src/concepts/base-iris.md:151
+msgid "a relative reference in a syntax that admits one, with no base in scope"
+msgstr ""
+
+#: src/concepts/base-iris.md:151
+msgid ""
+"add `@base`/`BASE`/`xml:base`/`@context.@base` to the document, or pass a "
+"base to the API (`--base` on the CLI)"
+msgstr ""
+
+#: src/concepts/base-iris.md:152
+msgid "`iri-not-absolute-by-grammar`"
+msgstr ""
+
+#: src/concepts/base-iris.md:152
+msgid ""
+"a relative reference — including the empty reference `<>` — in N-Triples, N-"
+"Quads, TriX or HexTuples; **or** an RDF/XML element or attribute QName whose "
+"`xmlns:` namespace is itself relative"
+msgstr ""
+
+#: src/concepts/base-iris.md:152
+msgid ""
+"write the IRI in absolute form; **a base cannot help** — this position "
+"admits no relative reference"
+msgstr ""
+
+#: src/concepts/base-iris.md:153
+msgid "`iri-non-absolute-base`"
+msgstr ""
+
+#: src/concepts/base-iris.md:153
+msgid ""
+"the base _itself_ has no scheme (RFC 3986 §5.1 requires an absolute base)"
+msgstr ""
+
+#: src/concepts/base-iris.md:153
+msgid ""
+"supply a base with a scheme, e.g. `http://example.org/dir/`. A filesystem "
+"path is a relative reference, not a base IRI — the CLI rejects one at the "
+"argument boundary and suggests the `file://` IRI you meant"
+msgstr ""
+
+#: src/concepts/base-iris.md:155
+msgid ""
+"RDF/XML appears in both grammar families for a reason, and the row above is "
+"the narrow half. Its `rdf:about` / `rdf:resource` / `rdf:ID` values _are_ "
+"references and do resolve against `xml:base`, which is why the table further "
+"up lists it as admitting relative references. But an element or attribute "
+"_name_ is composed from an `xmlns:` declaration plus a local name; it is not "
+"a reference, so nothing resolves it, and a relative `xmlns:ex=\"rel/\"` "
+"composes to a relative IRI no base may rescue:"
+msgstr ""
+
+#: src/concepts/base-iris.md:163
+msgid ""
+"```console\n"
+"$ purrdf convert data.rdf --from rdfxml --to ntriples\n"
+"purrdf: error iri-not-absolute-by-grammar: invalid IRI from an XML qualified "
+"name:\n"
+"relative IRI reference \"rel/p\" is not permitted by this syntax (the caller-"
+"supplied\n"
+"base, <file:///tmp/data.rdf>, is in scope but is never applied here); write "
+"the IRI\n"
+"in absolute form; this syntax admits no relative IRI reference, so supplying "
+"a base\n"
+"will not help\n"
+"```"
+msgstr ""
+
+#: src/concepts/base-iris.md:172
+msgid ""
+"Note that the message names the base that _is_ in scope and says it is "
+"deliberately not applied there, so a caller who passed one is not sent "
+"hunting for a dropped parameter."
+msgstr ""
+
+#: src/concepts/base-iris.md:176
+msgid ""
+"The message rendered for each already carries its remedy, so a consumer that "
+"prints the error alone still tells its user what to do."
+msgstr ""
+
+#: src/concepts/base-iris.md:179
+msgid "Writing a base out"
+msgstr ""
+
+#: src/concepts/base-iris.md:181
+msgid ""
+"Resolution has a mirror on the serialize leg. A syntax that can express a "
+"document base emits one when a base is supplied, and relativizes its IRIs "
+"against it:"
+msgstr ""
+
+#: src/concepts/base-iris.md:185
+msgid "Syntax"
+msgstr ""
+
+#: src/concepts/base-iris.md:185
+msgid "Reads a base"
+msgstr ""
+
+#: src/concepts/base-iris.md:185
+msgid "Writes a base"
+msgstr ""
+
+#: src/concepts/base-iris.md:187
+msgid "Turtle, TriG"
+msgstr ""
+
+#: src/concepts/base-iris.md:187
+msgid "`@base` / `BASE`"
+msgstr ""
+
+#: src/concepts/base-iris.md:187
+msgid "`@base`"
+msgstr ""
+
+#: src/concepts/base-iris.md:188
+msgid "`xml:base`"
+msgstr ""
+
+#: src/concepts/base-iris.md:189
+msgid "JSON-LD, YAML-LD"
+msgstr ""
+
+#: src/concepts/base-iris.md:189
+msgid "`@context.@base`"
+msgstr ""
+
+#: src/concepts/base-iris.md:190
+msgid "no — absolute IRIs only"
+msgstr ""
+
+#: src/concepts/base-iris.md:192
+msgid ""
+"A format in the last row reaches its writer with no base and emits absolute "
+"IRIs. That is not a silent drop: the format simply has no base surface, so "
+"there is nothing to write, and the output stays valid for its grammar. On "
+"the CLI there is one more step — if a `--base` was given and _neither_ leg "
+"of the run can spend it, the command is refused outright rather than "
+"accepting an inert flag. See below."
+msgstr ""
+
+#: src/concepts/base-iris.md:199
+msgid "`--base` on the command line"
+msgstr ""
+
+#: src/concepts/base-iris.md:201
+msgid ""
+"`purrdf convert`, `query`, `update` and the other RDF-producing subcommands "
+"take `--base <IRI>`, and it acts on **both legs**:"
+msgstr ""
+
+#: src/concepts/base-iris.md:204
+msgid ""
+"**Parsing** — it is the caller-supplied base (§5.1.2), so it outranks the "
+"input's retrieval IRI but not an in-document directive. A parse leg can "
+"spend the base only if the source syntax admits a relative reference."
+msgstr ""
+
+#: src/concepts/base-iris.md:207
+msgid ""
+"**Serializing** — if the target syntax can write a base, it is emitted as "
+"the output document's base and the IRIs are relativized against it. A "
+"serialize leg can spend the base only if the target syntax emits a base "
+"directive."
+msgstr ""
+
+#: src/concepts/base-iris.md:210
+msgid ""
+"**Neither leg can spend it — a usage error, exit 2.** A base spent by _any "
+"one_ leg is honoured, so `--from turtle --to ntriples --base …` is fine (the "
+"parse leg spends it) and so is `--from ntriples --to turtle --base …` (the "
+"serialize leg does). But `--from ntriples --to ntriples --base …` has "
+"nowhere to put it. Rather than exit 0 having silently ignored the flag, the "
+"CLI names both legs and refuses:"
+msgstr ""
+
+#: src/concepts/base-iris.md:217
+msgid ""
+"```console\n"
+"$ purrdf convert data.nt --from ntriples --to ntriples --base http://"
+"example.org/dir/\n"
+"purrdf: --base has no effect on this run: on the source `data.nt`, "
+"ntriples's\n"
+"grammar admits no relative IRI reference, so nothing in the document "
+"resolves\n"
+"against a base; and on the --to target, ntriples can express no base "
+"directive,\n"
+"so nothing is written under one or relativized against it. Drop --base, or "
+"name\n"
+"a syntax that carries one (turtle, trig, rdfxml, jsonld, yamlld)\n"
+"$ echo $?\n"
+"2\n"
+"```"
+msgstr ""
+
+#: src/concepts/base-iris.md:228
+msgid ""
+"The verdict is read off the format registry's `admits_relative_iri` and "
+"`emits_base` columns, so a newly registered syntax is classified by its own "
+"row rather than by a hand list. It applies to `convert`, `validate`, "
+"`reason`, `entails`, `consistency` and `project`. `query`, `update`, "
+"`shex`'s shape map and `describe --iri` are deliberately exempt: each has a "
+"command-line-text IRI surface with no document of its own, so `--base` is "
+"never inert there whatever the format rows say."
+msgstr ""
+
+#: src/concepts/base-iris.md:237
+msgid ""
+"# A file input needs no flag: its own file:// retrieval IRI is the base.\n"
+msgstr ""
+
+#: src/concepts/base-iris.md:239
+msgid ""
+"# stdin has no retrieval IRI, so a relative IRI in it needs an explicit "
+"base.\n"
+msgstr ""
+
+#: src/concepts/base-iris.md:248
+msgid ""
+"`--base` is validated where it is typed. A value that is not an absolute IRI "
+"is a usage error, and a path-shaped value gets a derived suggestion — `./"
+"vocab/` is answered with the `file://` IRI it actually denotes, resolved "
+"rather than spliced."
+msgstr ""
+
+#: src/concepts/base-iris.md:253
+msgid ""
+"A shape map given to `purrdf shex` is command-line text with no document of "
+"its own, so `--base` is the only base it can ever have. A `--schema` file, "
+"by contrast, is an independent document and resolves against its own "
+"retrieval IRI or its own `BASE` directive."
+msgstr ""
+
+#: src/concepts/base-iris.md:260
+msgid ""
+"The RFC 3986 §5.4 normative resolution table is asserted directly against "
+"the resolver in `crates/iri/tests/`. End-to-end, the W3C `rdf-tests` `IRI-"
+"resolution-01/02/07/08` cases — the same table driven through `@base` in a "
+"real document, plus bases with trailing slashes, file paths, empty segments "
+"and colon-bearing segments — are vendored under `crates/rdf/tests/corpus/w3c/"
+"{turtle,trig}/iri/` and graded on every run."
+msgstr ""
+
+#: src/concepts/jsonld.md:8
+msgid "PurRDF has three explicit JSON-LD/YAML-LD serialization modes:"
+msgstr ""
+
+#: src/concepts/jsonld.md:10
+msgid "`expanded` preserves the byte-frozen empty-`@context` representation;"
+msgstr ""
+
+#: src/concepts/jsonld.md:11
+msgid ""
+"`context` compiles a caller prefix map or local JSON-LD 1.1 context once and "
+"applies normative compaction;"
+msgstr ""
+
+#: src/concepts/jsonld.md:13
+msgid ""
+"`derived` deterministically assigns neutral `ns0`, `ns1`, ... aliases solely "
+"from absolute IRIs in the dataset. It never invents a vocabulary or infers "
+"`@vocab`."
+msgstr ""
+
+#: src/concepts/jsonld.md:17
+msgid ""
+"An RDF dataset does not retain prefix declarations from Turtle, JSON-LD, or "
+"another source syntax. Supply them explicitly when those declarations are "
+"application policy. All configured surfaces consume the same closed "
+"version-1 JSON document and reject duplicate members, unknown fields, "
+"invalid contexts, network-only context references, cycles, and resource-"
+"limit excesses before emitting output."
+msgstr ""
+
+#: src/concepts/jsonld.md:26 src/concepts/jsonld.md:81
+msgid "\"version\""
+msgstr ""
+
+#: src/concepts/jsonld.md:27 src/concepts/jsonld.md:82
+#: src/concepts/jsonld.md:103
+msgid "\"context\""
+msgstr ""
+
+#: src/concepts/jsonld.md:28 src/concepts/jsonld.md:83
+msgid "\"prefixes\""
+msgstr ""
+
+#: src/concepts/jsonld.md:29 src/concepts/jsonld.md:50
+#: src/concepts/jsonld.md:83
+msgid "\"ex\""
+msgstr ""
+
+#: src/concepts/jsonld.md:29 src/concepts/jsonld.md:50
+#: src/concepts/jsonld.md:83 src/concepts/jsonld.md:104
+msgid "\"https://example.org/\""
+msgstr ""
+
+#: src/concepts/jsonld.md:30 src/concepts/jsonld.md:51
+msgid "\"schema\""
+msgstr ""
+
+#: src/concepts/jsonld.md:30 src/concepts/jsonld.md:51
+msgid "\"https://schema.org/\""
+msgstr ""
+
+#: src/concepts/jsonld.md:32
+msgid "\"yaml_schema_url\""
+msgstr ""
+
+#: src/concepts/jsonld.md:32
+msgid "\"https://example.org/purrdf.schema.json\""
+msgstr ""
+
+#: src/concepts/jsonld.md:45
+msgid ""
+"b\"<https://example.org/alice> <https://schema.org/name> \\\"Alice\\\" .\""
+msgstr ""
+
+#: src/concepts/jsonld.md:46
+msgid "\"application/n-triples\""
+msgstr ""
+
+#: src/concepts/jsonld.md:57
+msgid ""
+"Keep a `CompiledJsonLdContext` (or `JsonLdSerializeOptions::compiled`) when "
+"the same application context is used for many datasets. "
+"`JsonLdContextRegistry` resolves context IRIs and `@import` only from caller-"
+"supplied immutable local documents; PurRDF never performs network context "
+"loading."
+msgstr ""
+
+#: src/concepts/jsonld.md:64
+msgid ""
+"Write the versioned document to a file, then pass it to any RDF-producing "
+"CLI path:"
+msgstr ""
+
+#: src/concepts/jsonld.md:71
+msgid ""
+"The option is rejected for non-JSON-LD/YAML-LD output, canonical output, non-"
+"graph SPARQL results, and carrier projections rather than being ignored."
+msgstr ""
+
+#: src/concepts/jsonld.md:89 src/concepts/jsonld.md:107
+msgid "\"jsonld\""
+msgstr ""
+
+#: src/concepts/jsonld.md:94
+msgid ""
+"`Store.dump`, `MutableDataset.dump`, immutable `RdfDataset`, and the RDFLib "
+"compatibility `Graph.serialize` surface accept the same configuration. "
+"Prefixes explicitly bound on a compatibility graph become its caller context."
+msgstr ""
+
+#: src/concepts/jsonld.md:98
+msgid "JavaScript and WebAssembly"
+msgstr ""
+
+#: src/concepts/jsonld.md:110
+msgid ""
+"Use `serializeConfigured` for one-shot requests. `QueryEngine` exposes "
+"matching configured methods for CONSTRUCT and DESCRIBE graph results, and "
+"the playground worker accepts the same options document on its serialization "
+"path."
+msgstr ""
+
+#: src/concepts/jsonld.md:116
+msgid ""
+"Compile options with `purrdf_jsonld_context_compile`, reuse the returned "
+"`PurrdfJsonLdContext` with `purrdf_serialize_jsonld_configured`, then "
+"release it with `purrdf_jsonld_context_free`. The serializer accepts exactly "
+"one options byte slice or compiled handle. Buffers and errors retain the "
+"normal libpurrdf ownership rules."
+msgstr ""
+
+#: src/concepts/jsonld.md:122
+msgid ""
+"YAML-LD uses the same context lens. Its optional schema URL changes only the "
+"deterministic YAML language-server header; it does not change RDF semantics."
+msgstr ""
+
+#: src/concepts/canonicalization.md:8
+msgid ""
+"Byte-deterministic serialization ([Codecs & Determinism](codecs.md)) means "
+"the _same dataset_ always emits the same bytes. Canonicalization is the "
+"stronger property: two _different in-memory datasets that are isomorphic_ — "
+"the same graph up to blank-node relabeling — canonicalize to the same bytes."
+msgstr ""
+
+#: src/concepts/canonicalization.md:13 src/project/conformance.md:39
+msgid "RDFC-1.0"
+msgstr ""
+
+#: src/concepts/canonicalization.md:15
+msgid ""
+"PurRDF implements W3C [RDF Dataset Canonicalization (RDFC-1.0)](https://"
+"www.w3.org/TR/rdf-canon/) natively in the kernel, tested against the W3C "
+"`rdf-canon` fixture suite (65 vectors — 64 eval plus 1 negative — all green; "
+"see [`docs/CONFORMANCE.md`](https://github.com/Blackcat-Informatics/purrdf/"
+"blob/main/docs/CONFORMANCE.md))."
+msgstr ""
+
+#: src/concepts/canonicalization.md:21
+msgid ""
+"The entry point is `canonicalize` (with a `canonicalize_with` variant for "
+"choosing the hash), producing canonical blank-node labels and, one layer up "
+"in `purrdf-rdf`, canonical flat N-Quads over the frozen IR:"
+msgstr ""
+
+#: src/concepts/canonicalization.md:28
+msgid ""
+"// Canonical labels are stable across runs, hosts, and language bindings.\n"
+msgstr ""
+
+#: src/concepts/canonicalization.md:32
+msgid ""
+"Use canonicalization when you need a content identity for a graph: hashing, "
+"signing, deduplication, or comparing datasets produced by different writers."
+msgstr ""
+
+#: src/concepts/canonicalization.md:35
+msgid "Isomorphism"
+msgstr ""
+
+#: src/concepts/canonicalization.md:37
+msgid ""
+"`datasets_isomorphic(a, b)` decides whether two frozen datasets are RDF-"
+"structurally isomorphic: the same quads under a blank-node bijection. "
+"Canonicalization gives the equivalent verdict — two datasets are isomorphic "
+"iff their canonicalizations are equal — but the direct check is the "
+"convenient form for tests and harnesses. PurRDF's own conformance harnesses "
+"use RDFC-1.0 isomorphism to compare, for example, SHACL Rules output graphs "
+"against expected inferred graphs."
+msgstr ""
+
+#: src/concepts/canonicalization.md:45
+msgid "Diff"
+msgstr ""
+
+#: src/concepts/canonicalization.md:47
+msgid ""
+"`dataset_diff(a, b)` produces a structural diff between two frozen datasets, "
+"including an `isomorphic` verdict. For a human-facing review flow, `purrdf-"
+"rdf` additionally provides per-subject Symmetric-CBD extraction "
+"(\"describe\") and a review-friendly Turtle normalizer, so a graph change "
+"reads like a code change."
+msgstr ""
+
+#: src/concepts/canonicalization.md:53
+msgid "Choosing the right tool"
+msgstr ""
+
+#: src/concepts/canonicalization.md:55
+msgid "Need"
+msgstr ""
+
+#: src/concepts/canonicalization.md:55
+msgid "Use"
+msgstr ""
+
+#: src/concepts/canonicalization.md:57
+msgid "Same dataset → same bytes"
+msgstr ""
+
+#: src/concepts/canonicalization.md:57
+msgid "any native serializer (always true)"
+msgstr ""
+
+#: src/concepts/canonicalization.md:58
+msgid "Same _graph_ (up to blank nodes) → same bytes"
+msgstr ""
+
+#: src/concepts/canonicalization.md:58
+msgid "RDFC-1.0 `canonicalize`"
+msgstr ""
+
+#: src/concepts/canonicalization.md:59
+msgid "\"Are these two datasets the same graph?\""
+msgstr ""
+
+#: src/concepts/canonicalization.md:59
+msgid "`datasets_isomorphic`"
+msgstr ""
+
+#: src/concepts/canonicalization.md:60
+msgid "\"What changed between these datasets?\""
+msgstr ""
+
+#: src/concepts/canonicalization.md:60
+msgid "`dataset_diff` + describe/normalize"
+msgstr ""
+
+#: src/concepts/canonicalization.md:61
+msgid "Content-addressed transport of a graph"
+msgstr ""
+
+#: src/concepts/canonicalization.md:61
+msgid "[GTS](../gts.md) (BLAKE3 content ids)"
+msgstr ""
+
+#: src/concepts/canonicalization.md:63
+msgid ""
+"API details are on [docs.rs/purrdf-core](https://docs.rs/purrdf-core) (the "
+"`canonicalize`, `datasets_isomorphic`, and `dataset_diff` items) and "
+"[docs.rs/purrdf-rdf](https://docs.rs/purrdf-rdf) (describe and "
+"normalization)."
+msgstr ""
+
+#: src/sparql/querying.md:6
+msgid "SPARQL: Querying"
+msgstr ""
+
+#: src/sparql/querying.md:8
+msgid ""
+"PurRDF's SPARQL stack is native and three-layered, gated by the W3C SPARQL "
+"1.1 and 1.2 conformance suites:"
+msgstr ""
+
+#: src/sparql/querying.md:11
+msgid ""
+"**[`purrdf-sparql-algebra`](https://docs.rs/purrdf-sparql-algebra)** — "
+"parses query and update text into a PurRDF-owned, RDF 1.2-native query "
+"algebra (`Query`/`GraphPattern`, `Update`/`GraphUpdateOperation`). Parse and "
+"algebra only."
+msgstr ""
+
+#: src/sparql/querying.md:15
+msgid ""
+"**[`purrdf-sparql-eval`](https://docs.rs/purrdf-sparql-eval)** — the "
+"multiset evaluator over the frozen IR's `DatasetView`, entirely in interned "
+"`TermId` space."
+msgstr ""
+
+#: src/sparql/querying.md:18
+msgid ""
+"**[`purrdf-sparql-results`](https://docs.rs/purrdf-sparql-results)** — the "
+"results boundary ([next chapter](results.md))."
+msgstr ""
+
+#: src/sparql/querying.md:21
+msgid "All three are re-exported under `purrdf::sparql`."
+msgstr ""
+
+#: src/sparql/querying.md:23
+msgid "A first query"
+msgstr ""
+
+#: src/sparql/querying.md:28
+msgid "// A tiny dataset in interned TermId space.\n"
+msgstr ""
+
+#: src/sparql/querying.md:36
+msgid "// Evaluate through the SparqlEngine seam; parsed plans are memoized.\n"
+msgstr ""
+
+#: src/sparql/querying.md:40
+msgid ""
+"\"SELECT ?what WHERE { <https://example.org/cat> <https://example.org/says> ?"
+"what }\""
+msgstr ""
+
+#: src/sparql/querying.md:43
+msgid "\"evaluates\""
+msgstr ""
+
+#: src/sparql/querying.md:50
+msgid ""
+"The `SparqlEngine` trait itself lives in `purrdf-core`, so hosts can swap "
+"engines behind one seam; `NativeSparqlEngine` is the shipped implementation."
+msgstr ""
+
+#: src/sparql/querying.md:53
+msgid "What the front-end covers"
+msgstr ""
+
+#: src/sparql/querying.md:55
+msgid ""
+"**Query** — all four query forms (SELECT/ASK/CONSTRUCT/DESCRIBE), basic "
+"graph patterns, `OPTIONAL`, `UNION`, `MINUS`, `GRAPH`, `FILTER`/`BIND`/"
+"`VALUES`, property paths, `GROUP BY`/aggregates, `EXISTS`/`NOT EXISTS`, "
+"solution modifiers, RDF 1.2 quoted triple terms (`<<( s p o )>>`), `LATERAL` "
+"(a SEP-0006 extension — see [below](#lateral-sep-0006)), and the SEP-0009 "
+"composite datatypes with their `FOLD` aggregate and `UNFOLD` graph pattern "
+"(see [below](#composite-datatypes-sep-0009))."
+msgstr ""
+
+#: src/sparql/querying.md:63
+msgid ""
+"**Update** — `INSERT DATA`/`DELETE DATA`, the `DELETE`/`INSERT … WHERE` "
+"family (`WITH`/`USING`, `DELETE WHERE`), `LOAD`, and `CLEAR`/`DROP`/`CREATE`/"
+"`ADD`/`MOVE`/`COPY`."
+msgstr ""
+
+#: src/sparql/querying.md:66
+msgid ""
+"**Beyond the grammar** — everything else arrives through the caller-keyed "
+"extension seams described further down this page, never as new syntax: [path "
+"witnesses](#path-witnesses-binding-the-derivation-not-the-endpoints), [full-"
+"text search](full-text.md), [GeoSPARQL](geosparql.md) and [embedding nearest "
+"neighbours](embedding-knn.md) are each a property function (or, for the "
+"`geof:` family, a scalar function) registered under an IRI the caller "
+"supplies."
+msgstr ""
+
+#: src/sparql/querying.md:74
+msgid ""
+"Anything outside this surface — and every malformed query — is a typed "
+"`ParseError`, never a silently degraded parse."
+msgstr ""
+
+#: src/sparql/querying.md:77
+msgid "How the evaluator works"
+msgstr ""
+
+#: src/sparql/querying.md:79
+msgid ""
+"**Multiset (bag) semantics** — solutions are a bag, preserved until "
+"`DISTINCT`/`REDUCED`, per the SPARQL algebra."
+msgstr ""
+
+#: src/sparql/querying.md:81
+msgid ""
+"**Interned evaluation** — constants resolve to a dataset `TermId` once; "
+"solution comparison is an integer compare; computed FILTER/BIND values that "
+"already exist in the dataset are promoted to the interned id at mint time."
+msgstr ""
+
+#: src/sparql/querying.md:84
+msgid ""
+"**Property paths in-engine** — the full path algebra (`* + ? / | ^ !()`) "
+"evaluated over the same indexed surface, wasm-safe."
+msgstr ""
+
+#: src/sparql/querying.md:86
+msgid ""
+"**Cost-based BGP planning** — join order is chosen by a cost model; "
+"`NativeSparqlEngine::explain_query` exposes the chosen order as an ordered "
+"list of triple-pattern strings so you can audit planner decisions without "
+"running the query."
+msgstr ""
+
+#: src/sparql/querying.md:90
+msgid ""
+"**`EXISTS`/`NOT EXISTS`, defensibly** — one substitution-based definition "
+"(SEP-0007), answered either by a memoized existence probe or by the per-row "
+"definition itself, chosen per site by a prepare-time admissibility proof — "
+"see [below](#exists-under-sep-0007)."
+msgstr ""
+
+#: src/sparql/querying.md:94
+msgid ""
+"**The SERVICE seam** — `SERVICE` federation is evaluated through a **host-"
+"injectable `ServiceResolver`**: the engine itself performs no I/O, so "
+"federation stays wasm-portable and the host decides how (and whether) remote "
+"endpoints are reached — down to per-service headers, credentials and "
+"capabilities (see [below](#per-service-context-the-serviceresolver-seam)). "
+"All seven W3C `service` federation cases pass through this seam. The "
+"forwarded body is re-emitted through the deterministic serializer — the "
+"federation wire format — whose parse → serialize → re-parse fidelity is "
+"swept over the 823-item corpus (every vendored W3C and first-party query and "
+"update text, plus this book's own examples) with an empty exception ledger."
+msgstr ""
+
+#: src/sparql/querying.md:106
+msgid ""
+"**Governed twins and explain receipts** — every query/update entry point has "
+"a governed counterpart running under caller-set ceilings (fuel, answer rows, "
+"intermediate cells, scratch bytes, remote requests, deadline) that trips "
+"with certified rows rather than a wrong answer, and `explain_query` returns "
+"a `QueryExplanation` whose ledger decomposes the fuel spent per algebra node "
+"and per charge point, beside the cost planner's estimate for each basic "
+"graph pattern. The normative charge schedule and the frozen 49-case governor "
+"corpus are documented in [`docs/SPARQL-GOVERNOR-PROFILE.md`](https://"
+"github.com/Blackcat-Informatics/purrdf/blob/main/docs/SPARQL-GOVERNOR-"
+"PROFILE.md)."
+msgstr ""
+
+#: src/sparql/querying.md:115
+msgid ""
+"**Hard-fail** — an out-of-scope algebra node or unimplemented builtin is a "
+"typed `EvalError::Unsupported`, never a partial or wrong answer."
+msgstr ""
+
+#: src/sparql/querying.md:118
+msgid "SPARQL 1.2 temporal arithmetic and adjustment"
+msgstr ""
+
+#: src/sparql/querying.md:120
+msgid ""
+"`+`, `-`, `*`, `/`, and unary `-` extend past the numeric tower to "
+"`xsd:dateTime`/`xsd:date`/`xsd:time` (instants), `xsd:duration` and its two "
+"subtypes `xsd:dayTimeDuration`/`xsd:yearMonthDuration`, and the five "
+"Gregorian partial-date types (`xsd:gYearMonth`, `xsd:gYear`, `xsd:gMonth`, "
+"`xsd:gMonthDay`, `xsd:gDay`). The SPARQL 1.2 Query specification's own text "
+"defines no arithmetic beyond the numeric tower; the one documented table is "
+"[SEP-0002](https://github.com/w3c/sparql-dev/blob/main/SEP/SEP-0002/"
+"sep-0002.md)'s, which this section follows for coverage. `ADJUST` (below) is "
+"SEP-0002's remaining, non-arithmetic addition."
+msgstr ""
+
+#: src/sparql/querying.md:130
+msgid "The operator table"
+msgstr ""
+
+#: src/sparql/querying.md:132
+msgid ""
+"SEP-0002's table has 24 rows: 11 are comparisons (`<`/`>` between two "
+"`yearMonthDuration`s or two `dayTimeDuration`s, `=` between two `duration`s, "
+"and `=`/`<`/`>` between two `date`s or two `time`s), already covered by "
+"ordinary value comparison. The remaining 13 are arithmetic:"
+msgstr ""
+
+#: src/sparql/querying.md:137
+msgid "Operands"
+msgstr ""
+
+#: src/sparql/querying.md:137 src/sparql/querying.md:928
+msgid "Result"
+msgstr ""
+
+#: src/sparql/querying.md:139
+msgid "`date - date`"
+msgstr ""
+
+#: src/sparql/querying.md:139 src/sparql/querying.md:144
+#: src/sparql/querying.md:147
+msgid "`dayTimeDuration`"
+msgstr ""
+
+#: src/sparql/querying.md:140
+msgid "`date + yearMonthDuration`"
+msgstr ""
+
+#: src/sparql/querying.md:140 src/sparql/querying.md:141
+#: src/sparql/querying.md:142 src/sparql/querying.md:143
+msgid "`date`"
+msgstr ""
+
+#: src/sparql/querying.md:141
+msgid "`date - yearMonthDuration`"
+msgstr ""
+
+#: src/sparql/querying.md:142
+msgid "`date + dayTimeDuration`"
+msgstr ""
+
+#: src/sparql/querying.md:143
+msgid "`date - dayTimeDuration`"
+msgstr ""
+
+#: src/sparql/querying.md:144
+msgid "`time - time`"
+msgstr ""
+
+#: src/sparql/querying.md:145
+msgid "`time + dayTimeDuration`"
+msgstr ""
+
+#: src/sparql/querying.md:145 src/sparql/querying.md:146
+msgid "`time`"
+msgstr ""
+
+#: src/sparql/querying.md:146
+msgid "`time - dayTimeDuration`"
+msgstr ""
+
+#: src/sparql/querying.md:147
+msgid "`dateTime - dateTime`"
+msgstr ""
+
+#: src/sparql/querying.md:148
+msgid "`dateTime + yearMonthDuration`"
+msgstr ""
+
+#: src/sparql/querying.md:148 src/sparql/querying.md:149
+#: src/sparql/querying.md:150 src/sparql/querying.md:151
+msgid "`dateTime`"
+msgstr ""
+
+#: src/sparql/querying.md:149
+msgid "`dateTime - yearMonthDuration`"
+msgstr ""
+
+#: src/sparql/querying.md:150
+msgid "`dateTime + dayTimeDuration`"
+msgstr ""
+
+#: src/sparql/querying.md:151
+msgid "`dateTime - dayTimeDuration`"
+msgstr ""
+
+#: src/sparql/querying.md:153
+msgid ""
+"```sparql\n"
+"PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
+"SELECT ?diff WHERE {\n"
+"  BIND(\"2002-01-02T10:00:00\"^^xsd:dateTime - "
+"\"2001-01-01T10:00:00\"^^xsd:dateTime AS ?diff)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:160
+msgid ""
+"Beyond this table, `purrdf` also accepts the general `xsd:duration` on every "
+"row above (SEP-0002 lists `xsd:duration` among the operand types the "
+"operator table covers, and the general type's own value space subsumes both "
+"subtypes), duration `±` duration, duration `×`/`÷` an exact number, and "
+"Gregorian `±` duration for all five Gregorian types where the result does "
+"not require fabricating an absent field (see [Divergence](#divergence-from-"
+"other-implementations) below):"
+msgstr ""
+
+#: src/sparql/querying.md:168
+msgid ""
+"```sparql\n"
+"PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
+"SELECT ?next WHERE {\n"
+"  BIND(\"2012-10\"^^xsd:gYearMonth + \"P1Y1M\"^^xsd:yearMonthDuration AS ?"
+"next)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:175
+msgid "Result datatype"
+msgstr ""
+
+#: src/sparql/querying.md:177
+msgid ""
+"A `+`/`-` between two durations, or between a duration and an instant/"
+"Gregorian value, resolves its result's datatype from the operands' "
+"**declared tags**, never from the computed component values: the result is "
+"`dayTimeDuration` iff every duration operand declares `dayTimeDuration`, "
+"`yearMonthDuration` iff every duration operand declares `yearMonthDuration`, "
+"and the general `xsd:duration` otherwise. Two cases make this rule concrete, "
+"because either one alone is satisfied just as well by a components-based "
+"rule that happens to agree at that one point:"
+msgstr ""
+
+#: src/sparql/querying.md:186
+msgid ""
+"A zero-valued result keeps its operands' declared subtype rather than "
+"collapsing to a generic zero:"
+msgstr ""
+
+#: src/sparql/querying.md:189
+msgid ""
+"```sparql\n"
+"PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
+"SELECT ?zero WHERE {\n"
+"  BIND(\"P1Y\"^^xsd:yearMonthDuration - \"P1Y\"^^xsd:yearMonthDuration AS ?"
+"zero)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:196
+msgid ""
+"`?zero` is `\"P0M\"^^xsd:yearMonthDuration` — a components-only rule that "
+"inspects the (zero) result rather than the (matching) declared tags would "
+"reach the same answer here, which is exactly why the second case is needed. "
+"Conversely, a sum whose _components_ look exactly like a pure "
+"`yearMonthDuration` still widens to the general type the moment either "
+"operand's declared tag is the general one:"
+msgstr ""
+
+#: src/sparql/querying.md:203
+msgid ""
+"```sparql\n"
+"PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
+"SELECT ?mixed WHERE {\n"
+"  BIND(\"P1M\"^^xsd:yearMonthDuration + \"PT0S\"^^xsd:dayTimeDuration AS ?"
+"mixed)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:210
+msgid ""
+"`?mixed` is `\"P1M\"^^xsd:duration`, not `\"P1M\"^^xsd:yearMonthDuration` — "
+"the zero `dayTimeDuration` operand contributes nothing to the components but "
+"still widens the result's declared type, because the rule reads tags, not "
+"values."
+msgstr ""
+
+#: src/sparql/querying.md:214
+msgid "Divergence from other implementations"
+msgstr ""
+
+#: src/sparql/querying.md:216
+msgid ""
+"Gregorian `±` duration can ask for a field the operand's type does not carry "
+"— adding a duration with a months component to an `xsd:gDay` needs a month "
+"to apply it to, and `xsd:gDay` has none. `xsd:gMonthDay` clamps a day that "
+"does not exist in the shifted month down to that month's actual length, the "
+"same rule `date`/`dateTime` already follow (XML Schema Appendix E) — but "
+"`xsd:gMonthDay` carries no year for that clamp to run against, so `purrdf` "
+"decides whether one would need to be fabricated by anchoring the _complete_ "
+"months-then-days computation at every year in one full 400-year Gregorian "
+"period (the calendar's leap rule is exactly periodic at that length, so one "
+"period is every anchor that could ever matter) and checking whether every "
+"anchor agrees on the answer. `purrdf` answers exactly when they do, and "
+"returns a typed error exactly when they don't — for a duration of any "
+"magnitude, not only a bounded/ordinary one: the months and days carries are "
+"reduced by the calendar's exact periodicity (400 years, 146,097 days) before "
+"any anchor's arithmetic runs, so an astronomically large `yearMonthDuration` "
+"or `dayTimeDuration` component decides the same way, in the same bounded "
+"work, as a small one. The computation is judged as a whole, not component by "
+"component: a duration's months half can land on an intermediate day whose "
+"clamp is itself year-dependent even though the _finished_ answer, after the "
+"days half also runs, is not — \\`\"--01-31\"^^xsd:gMonthDay"
+msgstr ""
+
+#: src/sparql/querying.md:236
+msgid ""
+"\"P1M1D\"^^xsd:duration`is`\"--03-01\"`from every anchor (the day after "
+"either Feb 28 or Feb 29 is always Mar 1), even "
+"though`\"--01-31\"^^xsd:gMonthDay"
+msgstr ""
+
+#: src/sparql/querying.md:238
+msgid ""
+"\"P1M\"^^xsd:yearMonthDuration`alone is genuinely ambiguous. The one "
+"recurring example of a refused class is February: every other month has the "
+"same length in every year, so a shift landing there is always safe, while a "
+"shift landing on February with the day being clamped the 29th or later is "
+"the case whose answer can turn on a year`xsd:gMonthDay\\` does not carry — "
+"that is an example of the refused class, not the rule itself. RDF4J answers "
+"these by fabricating the missing field (year 0, January, or day"
+msgstr ""
+
+#: src/sparql/querying.md:245
+msgid ""
+"through its underlying JAXP calendar and returning a value built on that "
+"fabrication — for example `\"---31\"^^xsd:gDay + "
+"\"P1M\"^^xsd:yearMonthDuration` answers `\"---29\"`, clamped against a "
+"fabricated leap year. `purrdf` matches RDF4J on every case whose answer does "
+"not depend on the fabricated field — including `\"2012-10\"^^xsd:gYearMonth "
+"+ P1Y1M = \"2013-11\"`, the one Gregorian case RDF4J's own test suite pins — "
+"and returns a typed error exactly where the answer would depend on which "
+"fabricated value RDF4J's calendar happened to pick:"
+msgstr ""
+
+#: src/sparql/querying.md:254
+msgid ""
+"```sparql\n"
+"PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
+"SELECT ?bound WHERE {\n"
+"  BIND(\"---31\"^^xsd:gDay + \"P1M\"^^xsd:yearMonthDuration AS ?maybe)\n"
+"  BIND(BOUND(?maybe) AS ?bound)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:262
+msgid ""
+"`?bound` is `false`: the typed error `?maybe`'s `BIND` raises poisons to "
+"unbound, the engine's ordinary type-error discipline. That poisoning is also "
+"this divergence's limit: at the SPARQL surface, a typed error and a "
+"reference implementation that instead _discarded_ its own fabricated answer "
+"(rather than returning it) would both leave the same variable unbound — "
+"identically. The visible difference between \"refuses to fabricate\" and "
+"\"fabricates and returns a value\" is real, but it lives at the value-space "
+"API boundary (an `Err` versus an `Ok` carrying a specific answer), not in a "
+"SPARQL query's own results, where both a refusal and a hypothetical discard "
+"render the same way."
+msgstr ""
+
+#: src/sparql/querying.md:273
+msgid "Extensions beyond SEP-0002 and F&O"
+msgstr ""
+
+#: src/sparql/querying.md:275
+msgid ""
+"`purrdf` adds three operators SEP-0002 and XPath and XQuery Functions and "
+"Operators (F&O) do not define, each grounded in an existing rule extended to "
+"a type F&O left out:"
+msgstr ""
+
+#: src/sparql/querying.md:279
+msgid ""
+"**`SUM`/`AVG` over durations.** SPARQL 1.1 §18.5.1.3 defines `SUM` by "
+"repeated `op:numeric-add`, whose domain is the numeric tower only; `purrdf` "
+"extends the same fold to the duration group, which is exact and associative "
+"under componentwise addition."
+msgstr ""
+
+#: src/sparql/querying.md:284
+msgid ""
+"```sparql\n"
+"PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
+"SELECT (SUM(?d) AS ?total) WHERE {\n"
+"  VALUES ?d { \"P1M\"^^xsd:yearMonthDuration "
+"\"P2M\"^^xsd:yearMonthDuration }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:291
+msgid ""
+"`?total` is `\"P3M\"^^xsd:yearMonthDuration`. A group mixing numeric and "
+"duration values stays unbound — the extension does not widen `SUM`'s "
+"existing numeric-only acceptance, it only adds a second, disjoint one."
+msgstr ""
+
+#: src/sparql/querying.md:295
+msgid ""
+"**Unary minus on durations.** F&O's unary minus (§4.2.8) is numeric-only and "
+"defines no duration form. `purrdf` negates a duration's two components "
+"together, so `-(?duration)` never produces the mixed-sign value the type "
+"cannot represent. Unary plus deliberately stays numeric-only, so `+(?"
+"duration)` is a type error while `-(?duration)` is not:"
+msgstr ""
+
+#: src/sparql/querying.md:301
+msgid ""
+"```sparql\n"
+"PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
+"SELECT ?neg WHERE {\n"
+"  BIND(-(\"P1Y2M\"^^xsd:yearMonthDuration) AS ?neg)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:308
+msgid "`?neg` is `\"-P1Y2M\"^^xsd:yearMonthDuration`."
+msgstr ""
+
+#: src/sparql/querying.md:310
+msgid ""
+"**`duration ÷ duration` by value commensurability.** F&O defines only the "
+"two same-subtype forms (`op:divide-yearMonthDuration-by-yearMonthDuration`, "
+"`op:divide-dayTimeDuration-by-dayTimeDuration`). `purrdf` also accepts the "
+"general `xsd:duration`, dispatching on whether the two operands' _values_ "
+"are commensurable (both purely months, or both purely seconds) rather than "
+"on their declared tags, so a `dayTimeDuration` and a general `xsd:duration` "
+"that happens to be purely day-shaped still divide:"
+msgstr ""
+
+#: src/sparql/querying.md:318
+msgid ""
+"```sparql\n"
+"PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
+"SELECT ?ratio WHERE {\n"
+"  BIND(\"P30D\"^^xsd:duration / \"P1D\"^^xsd:dayTimeDuration AS ?ratio)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:325
+msgid ""
+"`?ratio` is `30`, typed `xsd:decimal`. Two operands whose values are not "
+"commensurable (a purely-months value against a purely-seconds one, even "
+"under matching declared tags) are a typed error, not an arbitrary answer."
+msgstr ""
+
+#: src/sparql/querying.md:329
+msgid "`ADJUST`"
+msgstr ""
+
+#: src/sparql/querying.md:331
+msgid ""
+"`ADJUST(value, timezone)` shifts an `xsd:dateTime`/`xsd:date`/`xsd:time` "
+"value to a given timezone offset, or attaches one to an untimezoned value. "
+"The SPARQL 1.2 Query specification's own text carries no `ADJUST` section; "
+"the function's one documented definition is SEP-0002's two-argument "
+"signature, which maps onto XPath and XQuery Functions and Operators §9.6's "
+"`fn:adjust-*-to-timezone` family (the same table `purrdf-xsd` implements for "
+"every other SPARQL 1.2 temporal builtin)."
+msgstr ""
+
+#: src/sparql/querying.md:339
+msgid ""
+"```sparql\n"
+"PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
+"SELECT ?adjusted WHERE {\n"
+"  BIND(ADJUST(\"2011-01-10T14:45:13Z\"^^xsd:dateTime,\n"
+"              \"-PT05H\"^^xsd:dayTimeDuration) AS ?adjusted)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:347
+msgid ""
+"`timezone` is an `xsd:dayTimeDuration` in `[-PT14H, PT14H]` (whole minutes "
+"only), or the empty simple literal `\"\"` — SPARQL's stand-in for XPath's "
+"empty-sequence \"remove the timezone\" argument, since SPARQL itself has no "
+"empty sequence; this is the same resolution every other known SEP-0002 "
+"implementation (e.g. Apache Jena's `E_AdjustToTimezone`) reaches. Arity is "
+"fixed at two and enforced at parse time — `ADJUST(?x)` and `ADJUST(?x, ?tz, ?"
+"extra)` are both refused before evaluation. Every domain or type violation "
+"(a non-whole-minute offset, an out-of-range offset, a non-temporal first "
+"argument) is a SPARQL type error, which — inside `BIND`, `FILTER`, or an "
+"aggregate argument — poisons to unbound rather than aborting the query, per "
+"the engine's ordinary type-error discipline."
+msgstr ""
+
+#: src/sparql/querying.md:358
+msgid "LATERAL (SEP-0006)"
+msgstr ""
+
+#: src/sparql/querying.md:360
+msgid ""
+"The SPARQL 1.2 Query specification's own text carries no `LATERAL` "
+"production; the one documented definition is [SEP-0006](https://github.com/"
+"w3c/sparql-dev/blob/main/SEP/SEP-0006/sep-0006.md)'s, implemented in Apache "
+"Jena 4.7.0, which this section follows. `LATERAL` adds one production to "
+"`GroupGraphPatternSub`, positioned alongside `OPTIONAL`/`MINUS`/ `GRAPH` and "
+"left-associative the same way:"
+msgstr ""
+
+#: src/sparql/querying.md:371
+msgid ""
+"Unlike an ordinary join, `LATERAL`'s right-hand side is evaluated ONCE PER "
+"SOLUTION of its left-hand side, with that solution's bindings visible inside "
+"— the same relationship a SQL `LATERAL`/`CROSS APPLY` subquery has to its "
+"outer query. This makes a per-group \"top N\" query expressible in plain "
+"SPARQL: each subject on the left picks its own smallest label on the right, "
+"rather than one globally-smallest label being computed once and joined "
+"against every row."
+msgstr ""
+
+#: src/sparql/querying.md:378
+msgid ""
+"```sparql\n"
+"PREFIX : <https://example.org/>\n"
+"PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n"
+"SELECT * WHERE {\n"
+"  ?s :p ?o\n"
+"  LATERAL {\n"
+"    SELECT * WHERE { ?s rdfs:label ?label }\n"
+"    ORDER BY ?label LIMIT 1\n"
+"  }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:390
+msgid ""
+"Correlation carries a left-hand binding of ANY RDF 1.2 term kind — including "
+"a blank node or a quoted triple — into the right-hand side, even when the "
+"only occurrence of that variable there is inside an expression (a `FILTER`, "
+"a `BIND`, a `BOUND(?s)` call) rather than as a triple-pattern leaf: `BOUND(?"
+"s)` answers correctly for a left-bound blank node or quoted triple the same "
+"as it does for an IRI or a literal, and such a row is not silently dropped "
+"for lacking a leaf occurrence to carry it."
+msgstr ""
+
+#: src/sparql/querying.md:398
+msgid "The scope restriction"
+msgstr ""
+
+#: src/sparql/querying.md:400
+msgid ""
+"`LATERAL`'s right-hand side may freely REUSE a variable already bound on the "
+"left (that is the whole point — it is how correlation happens), but it may "
+"not INTRODUCE a fresh binding for one: no variable target of a `BIND`, of a "
+"sub-`SELECT`'s `(expr AS ?v)` projection, of a `GROUP BY` aggregate's "
+"output, of an expression-valued `GROUP BY (expr AS ?v)` grouping condition, "
+"or a `VALUES` column, at the right-hand side's own scope level, may collide "
+"with a variable already visible on the left. A bare `GROUP BY ?v` grouping "
+"key that just names an already-bound variable is a USE, not an introduction, "
+"and never collides. The one construct that opens a fresh scope level is a "
+"sub-`SELECT`'s own projection — `OPTIONAL`/`UNION`/`GRAPH`/a nested group/a "
+"nested `LATERAL` are all transparent to it. The SEP's own legal and illegal "
+"pair:"
+msgstr ""
+
+#: src/sparql/querying.md:412
+msgid ""
+"```sparql\n"
+"PREFIX : <https://example.org/>\n"
+"PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n"
+"# Legal: the sub-SELECT projects only ?label, so its own (unprojected) "
+"reuse\n"
+"# of ?s is correlation, not an introduction, and cannot collide.\n"
+"SELECT * WHERE {\n"
+"  ?s a :T\n"
+"  LATERAL { SELECT ?label WHERE { ?s rdfs:label ?label } LIMIT 1 }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:433
+msgid "Points of disagreement with Jena"
+msgstr ""
+
+#: src/sparql/querying.md:435
+msgid ""
+"Two corners of the restriction disagree with Jena's own `SyntaxVarScope` "
+"check, each pinned by a named test rather than left to drift:"
+msgstr ""
+
+#: src/sparql/querying.md:438
+msgid ""
+"**Laxer.** A `BIND`/`VALUES`/aggregate introduction confined to a `MINUS` "
+"right operand is ACCEPTED here at any depth — directly under the `LATERAL` "
+"keyword or nested under a `SELECT *` sub-select — while Jena rejects it. "
+"SPARQL §18.2.1 puts `MINUS`\\-right variables out of scope, and §18.5's "
+"evaluation explains why: the right operand is used only to build the "
+"compatibility test against the left operand's rows, then its bindings are "
+"discarded, so nothing built on top of a `MINUS` — a `SELECT *` projection or "
+"anything else — can ever observe a value that operand introduced. There is "
+"nothing observable for the rule to reject. (`SELECT *` over such a right-"
+"hand side is one route to this same shape, not a separate one.)"
+msgstr ""
+
+#: src/sparql/querying.md:448
+msgid ""
+"**Stricter.** A `SERVICE ?g { ... }` endpoint variable counts as left-hand "
+"scope here; Jena omits it. `SERVICE ?g { ... }` with a variable endpoint "
+"requires `?g` to already be bound in the incoming solution — the endpoint "
+"IRI is resolved from that binding before the remote call is made — so by the "
+"time a `LATERAL` right-hand side runs, `?g` already holds an observable, per-"
+"row value from the left, the same as any other left-bound variable. A `BIND`/"
+"`VALUES` on the right giving it a NEW value is therefore exactly the kind of "
+"observable rebinding this rule exists to reject."
+msgstr ""
+
+#: src/sparql/querying.md:457
+msgid "In `UPDATE`"
+msgstr ""
+
+#: src/sparql/querying.md:459
+msgid ""
+"`INSERT`/`DELETE ... WHERE` and `WITH ... WHERE` route through the same "
+"group-graph-pattern grammar a `SELECT`'s `WHERE` clause uses, so `LATERAL` — "
+"scope-checked exactly the same way — is legal there too. A `DELETE WHERE` "
+"quad template is a different grammar production (`TriplesTemplate`, not a "
+"`GroupGraphPattern`) with no group-pattern operators of any kind, so "
+"`LATERAL` there is refused by name rather than misparsed as a subject term."
+msgstr ""
+
+#: src/sparql/querying.md:466
+msgid "`SERVICE` forwarding"
+msgstr ""
+
+#: src/sparql/querying.md:468
+msgid ""
+"A pattern containing a written `LATERAL` clause — anywhere in the forwarded "
+"body, including nested inside another `SERVICE` — is refused only under "
+"`SERVICE SILENT`: there, a remote's rejection of the `LATERAL` extension "
+"would otherwise be swallowed into the identity table, a silent wrong answer "
+"rather than a typed refusal. A plain, non-silent `SERVICE` with a fixed IRI "
+"forwards the body with its `LATERAL { … }` text intact, so the endpoint's "
+"actual verdict — an answer from a `LATERAL`\\-capable endpoint (`LATERAL` is "
+"Jena's own extension, so a Jena-backed endpoint answers it), or an honest "
+"failure from one that does not implement it — surfaces the same way any "
+"other unsupported forwarded construct's rejection would. A variable-endpoint "
+"`SERVICE ?g` is refused only when nothing supplies `?g`'s binding — nothing "
+"in the incoming solution names an IRI for the remote evaluator to resolve. "
+"When an enclosing pattern binds `?g` — a preceding triple pattern in the "
+"same group, or a `LATERAL` left-hand side's per-row correlation — the "
+"endpoint resolves to that IRI before the remote call is made (the same per-"
+"row substitution described under \"Points of disagreement with Jena\" above) "
+"and the query dispatches normally, the same as a `SERVICE` with a fixed IRI."
+msgstr ""
+
+#: src/sparql/querying.md:486
+msgid "Per-service context: the `ServiceResolver` seam"
+msgstr ""
+
+#: src/sparql/querying.md:488
+msgid ""
+"`SERVICE` is answered through one trait, `ServiceResolver`, which receives "
+"the whole request as a `ServiceRequest` — endpoint, forwarded query text, "
+"the `SILENT` flag, the executing query's stop signal, and the intermediate-"
+"cell ceiling. Two implementations ship: `HttpRemoteQuerySource`, which "
+"builds and decodes SPARQL Protocol requests over a host-injected "
+"`HttpTransport`, and `InProcessServiceResolver`, which answers from datasets "
+"already in memory."
+msgstr ""
+
+#: src/sparql/querying.md:495
+msgid ""
+"Everything a resolver needs to know about an _individual_ service — extra "
+"headers, a credential, a timeout, and what it is permitted to do — lives on "
+"the resolver in a `ServiceCatalog`, keyed by the service IRI. Deliberately "
+"not in the IRI itself: a service IRI is a name, not a credential store, and "
+"encoding context there would put it into the query text, where it is visible "
+"to whoever wrote the query, is serialized into plans and receipts, and "
+"travels along with a nested `SERVICE` body."
+msgstr ""
+
+#: src/sparql/querying.md:503
+msgid ""
+"A `ServiceCatalog` maps each service IRI to a `ServiceProfile`, and each "
+"profile grants an explicit set of capabilities:"
+msgstr ""
+
+#: src/sparql/querying.md:506
+msgid "Capability"
+msgstr ""
+
+#: src/sparql/querying.md:506
+msgid "Grants"
+msgstr ""
+
+#: src/sparql/querying.md:508
+msgid "`Query`"
+msgstr ""
+
+#: src/sparql/querying.md:508
+msgid "resolving this service at all"
+msgstr ""
+
+#: src/sparql/querying.md:509
+msgid "`Network`"
+msgstr ""
+
+#: src/sparql/querying.md:509
+msgid "performing network I/O to resolve it"
+msgstr ""
+
+#: src/sparql/querying.md:510
+msgid "`Credentials`"
+msgstr ""
+
+#: src/sparql/querying.md:510
+msgid "attaching the profile's credential to the request"
+msgstr ""
+
+#: src/sparql/querying.md:512
+msgid ""
+"A catalog denies by default: a service with no entry and no explicitly "
+"configured fallback profile is refused. Gating is opt-in — a resolver with "
+"no catalog behaves exactly as it did before catalogs existed, contacting "
+"whatever endpoint it is handed and adding no headers — and configuring a "
+"catalog changes no byte of a request whose profile adds nothing."
+msgstr ""
+
+#: src/sparql/querying.md:518
+msgid ""
+"Withholding `Network` is what makes an in-process façade _provable_ rather "
+"than promised: `InProcessServiceResolver` owns a dataset map and nothing "
+"else — no transport, no socket, no injected callback — so there is no code "
+"path through it that performs I/O. A host can therefore offer `SERVICE`\\-"
+"shaped composition without `SERVICE`\\-shaped risk. `ServiceRouter` composes "
+"the two, sending some services in process and the rest to the network, with "
+"the routing table rather than the query text deciding which is which. The "
+"catalog is consulted on _every_ resolution, nested ones included, so a "
+"`SERVICE` buried inside a forwarded body cannot reach an endpoint the "
+"catalog refuses at the top level."
+msgstr ""
+
+#: src/sparql/querying.md:528
+msgid ""
+"The policy is applied _before_ the transport is called, which is the whole "
+"difference between a gate and an audit log: a denied service never has its "
+"socket opened and then discarded."
+msgstr ""
+
+#: src/sparql/querying.md:532
+msgid ""
+"A service IRI is an IRI like any other, so it is resolved by the workspace's "
+"single RFC 3986 base layer (see [Base IRIs](../concepts/base-iris.md)) and "
+"not by a rule this seam invented. `SERVICE <sparql>` with no `BASE` in the "
+"prologue and no base passed to the API is the shared `iri-relative-no-base` "
+"hard error, raised while the query is parsed — before any resolver is "
+"consulted, and not softened by `SILENT`, which is a promise about an "
+"endpoint that does not answer rather than about an endpoint IRI that cannot "
+"be formed. With a base in scope the resolver is handed the **absolute** IRI, "
+"which is the form a `ServiceCatalog` is keyed on."
+msgstr ""
+
+#: src/sparql/querying.md:541
+msgid "The `SILENT` contract"
+msgstr ""
+
+#: src/sparql/querying.md:543
+msgid ""
+"SPARQL 1.1 §10 says a `SERVICE SILENT` clause whose endpoint cannot be "
+"reached \"will be considered to have matched with a single, empty, "
+"solution\" — the join identity, so the surrounding query proceeds unchanged. "
+"PurRDF keeps that promise exactly, and confines it to what it is a promise "
+"_about_:"
+msgstr ""
+
+#: src/sparql/querying.md:548
+msgid "Outcome"
+msgstr ""
+
+#: src/sparql/querying.md:548
+msgid "`SERVICE`"
+msgstr ""
+
+#: src/sparql/querying.md:548
+msgid "`SERVICE SILENT`"
+msgstr ""
+
+#: src/sparql/querying.md:550
+msgid "The endpoint is unreachable, or its response undecodable"
+msgstr ""
+
+#: src/sparql/querying.md:550 src/sparql/querying.md:551
+msgid "query error"
+msgstr ""
+
+#: src/sparql/querying.md:550
+msgid "join identity"
+msgstr ""
+
+#: src/sparql/querying.md:551
+msgid "A capability was denied"
+msgstr ""
+
+#: src/sparql/querying.md:552
+msgid "This engine's own governor tripped"
+msgstr ""
+
+#: src/sparql/querying.md:552
+msgid "truncation"
+msgstr ""
+
+#: src/sparql/querying.md:554
+msgid ""
+"The first and last rows are long-standing behaviour: `SILENT` is a statement "
+"about an endpoint the caller does not control, never about the caller's own "
+"budget, so a governor trip reached through a `SERVICE` clause propagates as "
+"a truncation whether or not `SILENT` is written."
+msgstr ""
+
+#: src/sparql/querying.md:559
+msgid ""
+"The middle row follows from that same principle. A capability denial is a "
+"decision taken on _this_ side of the seam — by the host running the engine, "
+"deterministically, before any endpoint was consulted — so it is exactly like "
+"a governor trip and nothing like an unreachable endpoint. Swallowing one "
+"would put the join identity into the surrounding join, making it a no-op, "
+"and hand back an answer that looks complete and is wrong; and because a "
+"denial is permanent rather than transient, it would be wrong identically on "
+"every run, so nothing would ever surface a symptom."
+msgstr ""
+
+#: src/sparql/querying.md:568
+msgid ""
+"That row holds at every nesting depth. `InProcessServiceResolver` evaluates "
+"a forwarded body itself, so a denial raised by a `SERVICE` nested inside one "
+"travels back out through that inner evaluation — as a structured denial, "
+"never flattened into a message. Flattening it would make a nested denial "
+"silenceable by an enclosing `SERVICE SILENT` while the identical denial one "
+"level up is not, which is the same look-complete-and-be-wrong outcome the "
+"row exists to prevent."
+msgstr ""
+
+#: src/sparql/querying.md:575
+msgid ""
+"There is deliberately no knob that softens this. A host that genuinely wants "
+"a blocked service to behave like an unreachable one already has an exact way "
+"to say so: return a transport error from its own resolver. That is an honest "
+"claim that the endpoint did not answer, and `SILENT` swallows it under the "
+"first row. Adding a visibility flag would have bought no expressive power, "
+"only a second spelling of an existing one — and with it the possibility of "
+"two callers running the same query over the same data through the same "
+"resolver and getting different answers."
+msgstr ""
+
+#: src/sparql/querying.md:584
+msgid "EXISTS under SEP-0007"
+msgstr ""
+
+#: src/sparql/querying.md:586
+msgid ""
+"SPARQL 1.1/1.2 §18.6 defines `EXISTS`/`NOT EXISTS` through two functions: "
+"`substitute`, which rewrites a pattern's variables against the row being "
+"filtered, and `evalExists`, which asks whether the substituted pattern's "
+"evaluation is non-empty. Read as literal term-rewriting, `substitute` has "
+"defects at several precise points:"
+msgstr ""
+
+#: src/sparql/querying.md:592
+msgid ""
+"**Variable-only positions.** `substitute` is stated over variable POSITIONS "
+"in a pattern, with no defined action on a `Bgp`/`Path` leaf term or a "
+"`GRAPH ?g` name treated as anything other than an expression — so a "
+"correlated variable occurring only in a triple or graph-name position has no "
+"substitution to apply."
+msgstr ""
+
+#: src/sparql/querying.md:597
+msgid ""
+"**The `MINUS` domain flip.** Rewriting a `MINUS`'s shared variables away as "
+"constants erases the very columns its domain-join compares the two operands "
+"on, turning a correlated `MINUS` into an unconditionally disjoint one — the "
+"opposite of what substituting the row in was supposed to preserve."
+msgstr ""
+
+#: src/sparql/querying.md:601
+msgid ""
+"**Blank nodes as variables.** No SPARQL surface syntax can spell a blank "
+"node or a quoted triple as a rewritten constant, so a correlated blank-node "
+"or quoted-triple binding has no legal substituted form under literal term-"
+"rewriting."
+msgstr ""
+
+#: src/sparql/querying.md:605
+msgid ""
+"**Disconnected variables.** A correlated variable reachable ONLY through an "
+"expression position inside a nested `EXISTS` — never through that inner's "
+"own triple-pattern leaves — has nothing in `substitute`'s pattern-rewriting "
+"reading to carry it there."
+msgstr ""
+
+#: src/sparql/querying.md:609
+msgid ""
+"**The assignment restriction.** §18.6's own text states no rule at all about "
+"an `EXISTS` body rebinding a variable already in scope on the row it filters."
+msgstr ""
+
+#: src/sparql/querying.md:613
+msgid ""
+"SEP-0007 — a SPARQL-dev proposal, not yet folded into the SPARQL 1.1/1.2 REC "
+"text — repairs the first four by restating `substitute` as `Replace`, a JOIN "
+"rather than a rewrite, and adds the fifth as Part 3, a new restriction. "
+"`purrdf` implements SEP-0007's repairs in full, including Part 3."
+msgstr ""
+
+#: src/sparql/querying.md:618
+msgid "The one definition"
+msgstr ""
+
+#: src/sparql/querying.md:624
+msgid ""
+"`Replace` is **Values Insertion**: the current row `μ` joins into `X` as a "
+"one-row `VALUES` table at each `Bgp`/`Path`/`Graph(Var, ·)` site, rather "
+"than being spliced in as syntactic constants — total over every RDF 1.2 term "
+"kind, including blank nodes and quoted triples, because it reaches the "
+"dataset through the same evaluation path real `VALUES` data uses, and it "
+"needs no special case for a variable reachable only through an expression, "
+"because the join reaches every leaf regardless of which position introduced "
+"the correlation. `PrjMap` is **`Project`\\-boundary narrowing**: `μ` is "
+"restricted to a `Project` node's own variable list before it is joined in "
+"below that node — the one scope boundary the surface language has, and the "
+"reason a sub-`SELECT`'s own projection can legitimately shadow an outer "
+"variable."
+msgstr ""
+
+#: src/sparql/querying.md:636
+msgid ""
+"SEP-0007 states `Replace` in terms of `toMultiSet(μ)` — converting the row "
+"to the multiset unit the join needs. `purrdf`'s algebra has no pattern/query "
+"type split for that conversion to bridge: a solution row already IS that "
+"multiset unit, so `Replace` lands directly below whatever solution modifiers "
+"wrap the leaf it targets, structurally, with nothing extra to construct or "
+"adjudicate."
+msgstr ""
+
+#: src/sparql/querying.md:643
+msgid ""
+"**The `HAVING` position** is outside SEP-0007's stated coverage — SEP-0007 "
+"only specifies `Replace` for `Bgp`/`Path`/`Graph` Values-Insertion sites and "
+"ordinary expression positions, not for a sub-`SELECT`'s `HAVING` clause. "
+"`purrdf` follows the literal `PrjMap` reading: a sub-`SELECT`'s `HAVING` "
+"filters that sub-`SELECT`'s own scope only, exactly like every other "
+"expression inside it — no special correlation channel is invented for it."
+msgstr ""
+
+#: src/sparql/querying.md:650
+msgid "Existential Normal Form"
+msgstr ""
+
+#: src/sparql/querying.md:652
+msgid ""
+"Exactly one bit per row is observed under `EXISTS`: whether the inner "
+"pattern's evaluation is empty. Four rewrite laws replace a node with "
+"something provably emptiness-equivalent but cheaper, applied wherever they "
+"appear at the top of the inner (never inside a `Join`/`Filter`/`Extend`/ "
+"`Graph`/`Minus` operand, which read more than emptiness from their child):"
+msgstr ""
+
+#: src/sparql/querying.md:658
+msgid ""
+"**`LeftJoin(A, B, c) → A`.** `OPTIONAL` emits at least one row per left row "
+"unconditionally — a padded left row, or one row per compatible match — and "
+"never removes one, so `LeftJoin(A, B, c)` is empty iff `A` is, regardless of "
+"`B` or its join condition."
+msgstr ""
+
+#: src/sparql/querying.md:662
+msgid ""
+"**`OrderBy(P) → P`.** Sorting is a permutation, never a filter: the sort "
+"keys are never even evaluated once emptiness is the only question asked."
+msgstr ""
+
+#: src/sparql/querying.md:664
+msgid ""
+"**`Distinct(P) → P`, `Reduced(P) → P`.** De-duplication only ever removes "
+"rows, and only when an earlier row already carried the same value, so `P` "
+"non-empty always leaves the first row's value present."
+msgstr ""
+
+#: src/sparql/querying.md:667
+msgid ""
+"**`Slice(0, len ≥ 1)(P) → P`.** An offset-zero `LIMIT` with room for at "
+"least one row drops rows only from the end of `P`'s bag, so `P` non-empty "
+"always leaves row zero inside the window."
+msgstr ""
+
+#: src/sparql/querying.md:670
+msgid ""
+"**`Slice(_, Some(0))(P) → false`.** A zero-length `LIMIT` is empty for every "
+"`P` and every row — the whole `EXISTS` folds to constant `false` (`NOT "
+"EXISTS` to `true`) without touching the dataset at all."
+msgstr ""
+
+#: src/sparql/querying.md:674
+msgid ""
+"Every law above is proved emptiness-equivalent over row SETS, never over "
+"side effects, so each fires only when the portion it erases (`B` and the "
+"join condition for `LeftJoin`, the sort keys for `OrderBy`, the whole inner "
+"for the zero-length `Slice` fold) is effect-free — no `SERVICE` call, "
+"property function, or custom/`heldIn`/`rdf:List` function reachable within "
+"it — so a hard error or a remote effect that would have propagated outside "
+"the `EXISTS` still does, rather than vanishing merely for having been "
+"written inside one."
+msgstr ""
+
+#: src/sparql/querying.md:682
+msgid "Two strategies, one answer"
+msgstr ""
+
+#: src/sparql/querying.md:684
+msgid ""
+"`purrdf` carries exactly two implementations of the one definition above:"
+msgstr ""
+
+#: src/sparql/querying.md:686
+msgid ""
+"**The definition itself** — per-row substitution via `Replace`, wrapped in a "
+"`Slice{0, Some(1)}` first-witness stop (sound because \"does this bag have a "
+"first row\" is exactly what `EXISTS` asks) and backed by a **restriction-"
+"keyed memo**: the memo key is the outer row restricted to the inner's own "
+"correlated-variable columns, so `k` distinct restrictions across `N` outer "
+"rows evaluate the inner exactly `k` times, never `N`. Always correct, for "
+"any inner pattern."
+msgstr ""
+
+#: src/sparql/querying.md:693
+msgid ""
+"**The memoized probe** — evaluate the inner exactly once, unconstrained, "
+"index it on the columns it shares with the outer schema, and existence-probe "
+"each row's `μ` against that index. Correct only where a prepare-time "
+"admissibility proof shows it equivalent to the definition for every row the "
+"site can see."
+msgstr ""
+
+#: src/sparql/querying.md:699
+msgid ""
+"A prepare-time analysis decides, once per site per evaluation, which "
+"strategy answers each `EXISTS`/`NOT EXISTS`. `--explain`'s per-algebra-node "
+"charge ledger reports the decision through three evidence counters: `exists-"
+"probe-answered` (one memoized-probe evaluation), `exists-definition-"
+"answered` (one per-row-definition evaluation), and `exists-inner-solutions-"
+"consumed` (one row the definition path's inner actually materialized — "
+"bounded at 1 per evaluation by the first-witness stop). An `EXISTS`/`NOT "
+"EXISTS` inner's own plan nodes — a `MINUS`, a `Bgp`, a nested `EXISTS` "
+"(however deeply nested), whatever the body contains — carry their own ledger "
+"lines too, decomposed exactly like an ordinary node's rather than folded "
+"into the enclosing `FILTER`/`BIND`, under EITHER strategy: the memoized "
+"probe's one once-per-site evaluation attributes exactly like the per-row "
+"definition's, just charged once rather than once per distinct restriction. A "
+"node that legitimately reads `fuel=0 rows=0` is one Existential Normal Form "
+"erased from the evaluated tree entirely (an `OPTIONAL`/`ORDER BY`/`DISTINCT`/"
+"`LIMIT` wrapper the emptiness-preserving laws proved transparent — see "
+"\"Existential Normal Form\" above) and therefore never ran, not a charge "
+"that went missing."
+msgstr ""
+
+#: src/sparql/querying.md:718
+msgid ""
+"**The one named exception**: an `EXISTS`/`NOT EXISTS` inner whose OWN ENF-"
+"normalized top-level shape is a `Project` (a sub-`SELECT`) or a `Union` (a "
+"top-level `{ A } UNION { B }`, not one nested further down) does NOT "
+"attribute — every node inside it, however deep, folds into the enclosing "
+"`FILTER`/`BIND` as `fuel=0 rows=0`, under either strategy, regardless of "
+"what the body itself contains. `Project`/`Union` synthesize their output "
+"from more than one child rather than being a 1:1 structural clone of "
+"anything in the original tree, and reconstructing the same original-address "
+"correspondence for them would need the same wrapper/wrapped `counts_rows` "
+"arbitration the `LATERAL` Values-Insertion machinery already does — "
+"deliberately not attempted, so the correspondence is simply absent for that "
+"one site rather than guessed at. This is not a regression: it is exactly the "
+"behavior every `EXISTS`/`NOT EXISTS` inner had before per-node attribution "
+"existed at all, now confined to this one shape instead of the whole feature."
+msgstr ""
+
+#: src/sparql/querying.md:733
+msgid ""
+"**The performance characteristic, stated plainly**: an uncorrelated inner, "
+"or a correlated one built only from `Bgp`/`Path`/`Values`/`Graph`/`Join`/ "
+"`Union`/`OrderBy`/`Project`/`Distinct`/`Reduced` and `Filter`/`Extend` "
+"expressions that read only certainly-bound columns of the inner, is served "
+"by the probe — one evaluation total, however many outer rows filter through "
+"it. A shape the probe cannot serve — `MINUS`, a restricting `Slice` (any "
+"offset or limit, not only one past the first row), `GROUP BY`, `LATERAL`, a "
+"property-function call, a `SERVICE` call, or a `FILTER`/`BIND` expression "
+"that reads a correlated variable the inner does not certainly bind (for "
+"example, one visible only down an `OPTIONAL` branch) — evaluates per row "
+"through the definition, with the restriction-keyed memo and first-witness "
+"stop above bounding the cost."
+msgstr ""
+
+#: src/sparql/querying.md:746
+msgid "The Part 3 assignment restriction"
+msgstr ""
+
+#: src/sparql/querying.md:748
+msgid ""
+"Neither a `BIND`/a sub-`SELECT`'s `(expr AS ?v)` projection target/a `GROUP "
+"BY (expr AS ?v)` grouping target, nor a `VALUES` column, inside an `EXISTS`/"
+"`NOT EXISTS` body may rebind a variable already in scope on the row being "
+"filtered. `NOT EXISTS` shares the exact same grammar production as `EXISTS` "
+"— there is no separate \"`NOT EXISTS`\" wording — so the restriction applies "
+"identically to both, and to a nested `EXISTS`'s own body against whatever "
+"its immediately enclosing `EXISTS` already has in scope. A rebinding "
+"confined to a `MINUS` right operand inside the body is exempt at any depth, "
+"the same reasoning `LATERAL`'s own scope restriction applies (§18.2.1: a "
+"`MINUS`\\-right introduction never escapes it, so it can never observably "
+"rebind the row)."
+msgstr ""
+
+#: src/sparql/querying.md:760
+msgid ""
+"```sparql\n"
+"PREFIX : <https://example.org/>\n"
+"# Legal: ?fresh is not in scope on the row FILTER EXISTS is testing, so "
+"BIND\n"
+"# giving it a value is an ordinary fresh binding, not a rebinding.\n"
+"SELECT ?s WHERE {\n"
+"  ?s :p ?o .\n"
+"  FILTER EXISTS { BIND(1 AS ?fresh) }\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:780
+msgid ""
+"The restriction is SEP-0007's own addition, adopted here because it is what "
+"makes `EXISTS`'s substitution semantics defensible at every site — SPARQL "
+"1.1/1.2's own §18.6 text requires no such rule."
+msgstr ""
+
+#: src/sparql/querying.md:784
+msgid "SHA-3 hashing (SEP-0008)"
+msgstr ""
+
+#: src/sparql/querying.md:786
+msgid ""
+"SPARQL 1.1 §17.4.4 ships five hash built-ins — `MD5`, `SHA1`, `SHA256`, "
+"`SHA384`, `SHA512`. `purrdf` adds the four SHA-3 (FIPS 202 Keccak) functions "
+"[SEP-0008](https://github.com/w3c/sparql-dev/blob/main/SEP/SEP-0008/"
+"sep-0008.md) proposes, on exactly the same call convention. SEP-0008 is a "
+"proposal, **not part of the SPARQL 1.1 or 1.2 recommendation** — these four "
+"are a first-party extension, and [they do not travel](#taking-a-sha-3-query-"
+"to-another-engine):"
+msgstr ""
+
+#: src/sparql/querying.md:793 src/sparql/querying.md:928
+msgid "Call"
+msgstr ""
+
+#: src/sparql/querying.md:793
+msgid "Digest"
+msgstr ""
+
+#: src/sparql/querying.md:793
+msgid "Hex characters"
+msgstr ""
+
+#: src/sparql/querying.md:795
+msgid "`SHA3-224(string)`"
+msgstr ""
+
+#: src/sparql/querying.md:795
+msgid "SHA3-224"
+msgstr ""
+
+#: src/sparql/querying.md:795
+msgid "56"
+msgstr ""
+
+#: src/sparql/querying.md:796
+msgid "`SHA3-256(string)`"
+msgstr ""
+
+#: src/sparql/querying.md:796
+msgid "SHA3-256"
+msgstr ""
+
+#: src/sparql/querying.md:796 src/sparql/querying.md:1099
+msgid "64"
+msgstr ""
+
+#: src/sparql/querying.md:797
+msgid "`SHA3-384(string)`"
+msgstr ""
+
+#: src/sparql/querying.md:797
+msgid "SHA3-384"
+msgstr ""
+
+#: src/sparql/querying.md:797
+msgid "96"
+msgstr ""
+
+#: src/sparql/querying.md:798
+msgid "`SHA3-512(string)`"
+msgstr ""
+
+#: src/sparql/querying.md:798
+msgid "SHA3-512"
+msgstr ""
+
+#: src/sparql/querying.md:798
+msgid "128"
+msgstr ""
+
+#: src/sparql/querying.md:800
+msgid ""
+"```sparql\n"
+"SELECT ?s (SHA3-256(?label) AS ?fingerprint)\n"
+"WHERE { ?s <http://example.org/label> ?label }\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:805
+msgid "The argument contract"
+msgstr ""
+
+#: src/sparql/querying.md:807
+msgid ""
+"Each function takes **one** argument and hashes the UTF-8 bytes of its "
+"**lexical form**, returning the digest as a lowercase hex `xsd:string` — the "
+"same contract `SHA256` has, so a query can swap one for the other without "
+"changing anything else about the row."
+msgstr ""
+
+#: src/sparql/querying.md:812
+msgid ""
+"The accepted arguments are a simple literal, an explicitly `xsd:string`\\-"
+"typed literal, an `rdf:langString`, and an RDF 1.2 `rdf:dirLangString`. A "
+"tagged literal is hashed on its **text only**: `SHA3-256(\"abc\"@en)` and "
+"`SHA3-256(\"abc\")` are the same digest, because the tag is not part of the "
+"lexical form."
+msgstr ""
+
+#: src/sparql/querying.md:818
+msgid ""
+"Anything else is an expression error, which is SPARQL's ordinary \"this row "
+"produces no value\" outcome rather than a query failure:"
+msgstr ""
+
+#: src/sparql/querying.md:821
+msgid "an **unbound** variable (`SHA3-256(?missing)`),"
+msgstr ""
+
+#: src/sparql/querying.md:822
+msgid "an IRI or a blank node,"
+msgstr ""
+
+#: src/sparql/querying.md:823
+msgid "a non-string literal (`SHA3-256(7)`)."
+msgstr ""
+
+#: src/sparql/querying.md:825
+msgid ""
+"In a `SELECT` projection an errored call leaves the projected variable "
+"**unbound** on that row; under `FILTER` it makes the constraint false; a "
+"`BIND` of it binds nothing. Wrap the argument in `STR(…)` when you mean "
+"\"hash whatever this term looks like\" — `SHA3-256(STR(?anything))` — "
+"because `STR` is the function that turns a term into a string, and these do "
+"not do it implicitly."
+msgstr ""
+
+#: src/sparql/querying.md:832
+msgid "The hyphen is part of the name"
+msgstr ""
+
+#: src/sparql/querying.md:834
+msgid ""
+"These are the only built-in names in the language containing a `-`, so the "
+"spacing rule is worth stating outright:"
+msgstr ""
+
+#: src/sparql/querying.md:837
+msgid "Text"
+msgstr ""
+
+#: src/sparql/querying.md:837
+msgid "Reading"
+msgstr ""
+
+#: src/sparql/querying.md:839
+msgid "`SHA3-256(?o)`"
+msgstr ""
+
+#: src/sparql/querying.md:839
+msgid "the built-in call — one token, hyphen included"
+msgstr ""
+
+#: src/sparql/querying.md:840
+msgid "`SHA3 - 256`"
+msgstr ""
+
+#: src/sparql/querying.md:840
+msgid "**a parse error**: `SHA3` alone is no function or keyword"
+msgstr ""
+
+#: src/sparql/querying.md:841
+msgid "`STRLEN(SHA3-256(?o)) - 4`"
+msgstr ""
+
+#: src/sparql/querying.md:841
+msgid "subtraction — the `-` follows `)`, not a word character"
+msgstr ""
+
+#: src/sparql/querying.md:843
+msgid ""
+"The lexer's `PN_PREFIX` scan admits `-` as a name character, so `SHA3-256` "
+"arrives at the parser as a single word. Whitespace around the hyphen makes "
+"it the subtraction operator again, and because `SHA3` is not itself a "
+"function, the spaced form fails loudly rather than meaning something else. "
+"Names are case-insensitive like every other built-in (`sha3-256` is the same "
+"call)."
+msgstr ""
+
+#: src/sparql/querying.md:849
+msgid ""
+"SEP-0008's own text spells the four functions with an **underscore** "
+"(`sha3_256`), so `SHA3_256(?o)` is accepted as an alias for `SHA3-256(?o)`: "
+"a query copied out of the proposal parses. The alias is an input spelling "
+"only — the algebra has one function per digest size, so a serialized query "
+"always carries the canonical hyphenated name and stays byte-deterministic "
+"whichever spelling was typed."
+msgstr ""
+
+#: src/sparql/querying.md:856
+msgid "Taking a SHA-3 query to another engine"
+msgstr ""
+
+#: src/sparql/querying.md:858
+msgid ""
+"Expect a **parse error**. `SHA3-256` is a built-in name here, but the SPARQL "
+"1.1/1.2 grammar offers exactly two ways to name a function — a keyword from "
+"its own built-in list, or a `FunctionCall ::= iri ArgList` whose `iri` is an "
+"`IRIREF` or a prefixed name. On an engine that has not adopted SEP-0008, "
+"`SHA3-256` is not in the built-in list, and a bare word with no colon is not "
+"an `iri` either, so `SHA3-256(?o)` has no parse at all. The underscored "
+"`SHA3_256(?o)` spelling fails for the same reason. The failure is therefore "
+"loud and immediate rather than a quietly unbound column."
+msgstr ""
+
+#: src/sparql/querying.md:867
+msgid ""
+"The portable substitute is one of the SPARQL 1.1 §17.4.4 hashes. `SHA256` "
+"takes the same single argument and returns the same lowercase-hex "
+"`xsd:string`, so swapping the name is the whole edit — it changes the "
+"digest, and nothing else about the query. Reach for the SHA-3 names when you "
+"control the engine and want the Keccak construction specifically; reach for "
+"`SHA256` when the query text has to run anywhere."
+msgstr ""
+
+#: src/sparql/querying.md:874
+msgid "Reaching it from other hosts"
+msgstr ""
+
+#: src/sparql/querying.md:876
+msgid ""
+"There is nothing to configure: unlike the extension-function and custom-"
+"aggregate seams, these are built-ins, so every surface that takes query text "
+"has them — `purrdf query`, `Store.query` / `MutableDataset.query` in Python, "
+"`Dataset.query` / `QueryEngine.select` in WebAssembly, and `purrdf_query` / "
+"`purrdf_query_json` over the C ABI."
+msgstr ""
+
+#: src/sparql/querying.md:882
+msgid "Composite datatypes (SEP-0009)"
+msgstr ""
+
+#: src/sparql/querying.md:884
+msgid ""
+"SPARQL 1.1 and 1.2 have no term that holds several other terms. `purrdf` "
+"implements [SEP-0009](https://github.com/w3c/sparql-dev/blob/main/SEP/"
+"SEP-0009/sep-0009.md)'s two composite datatypes, `cdt:List` and `cdt:Map`, "
+"together with the fifteen functions the SEP defines, the `FOLD` aggregate "
+"that builds one from a group, and the `UNFOLD` graph pattern that takes one "
+"apart. SEP-0009 is a proposal, **not part of the SPARQL 1.1 or 1.2 "
+"recommendation** — everything in this section is an extension, and a query "
+"using it [does not travel unchanged](#taking-a-composite-query-to-another-"
+"engine)."
+msgstr ""
+
+#: src/sparql/querying.md:894
+msgid ""
+"The namespace is the SEP's own, recognized and never invented — every "
+"example below is written under this prologue:"
+msgstr ""
+
+#: src/sparql/querying.md:897
+msgid ""
+"```text\n"
+"PREFIX cdt: <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:901
+msgid ""
+"A composite is an ordinary RDF literal whose datatype is `cdt:List` or "
+"`cdt:Map` and whose lexical form spells the contents out. These are terms, "
+"not queries:"
+msgstr ""
+
+#: src/sparql/querying.md:905
+msgid ""
+"```text\n"
+"\"[1,2,3]\"^^cdt:List\n"
+"\"[1,null,<http://example.org/s>]\"^^cdt:List\n"
+"\"[[1,2],[3]]\"^^cdt:List\n"
+"\"{1:'a', 2:'b'}\"^^cdt:Map\n"
+"\"[]\"^^cdt:List        \"{}\"^^cdt:Map\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:913
+msgid ""
+"List elements may be IRIs, blank nodes, literals, `null`, or nested "
+"composites. Map **keys** may be IRIs or literals — never blank nodes, never "
+"`null`, never a nested composite — and must be pairwise distinct **by "
+"term**, so `{1: \"a\", \"1\"^^xsd:integer: \"b\"}` is one key written twice "
+"and is refused. Map **values** carry no such restriction. Every IRI inside a "
+"composite lexical form must be **absolute**: a composite's contents are its "
+"own, and are not resolved against whatever base the surrounding document "
+"happens to declare."
+msgstr ""
+
+#: src/sparql/querying.md:921
+msgid "The function library"
+msgstr ""
+
+#: src/sparql/querying.md:923
+msgid ""
+"The set is **closed**. There is no registry to configure and no way for a "
+"caller to shadow one of these names, so the same query means the same thing "
+"on every host, and a configured extension namespace cannot capture a CDT "
+"name. Arity is enforced at **parse** time, before any evaluation."
+msgstr ""
+
+#: src/sparql/querying.md:928
+msgid "Arity"
+msgstr ""
+
+#: src/sparql/querying.md:930
+msgid "`cdt:List(…)`"
+msgstr ""
+
+#: src/sparql/querying.md:930 src/sparql/querying.md:932
+msgid "any"
+msgstr ""
+
+#: src/sparql/querying.md:930
+msgid "a `cdt:List` of the argument terms"
+msgstr ""
+
+#: src/sparql/querying.md:931
+msgid "`cdt:Map(…)`"
+msgstr ""
+
+#: src/sparql/querying.md:931
+msgid "even"
+msgstr ""
+
+#: src/sparql/querying.md:931
+msgid "a `cdt:Map` from alternating key/value arguments"
+msgstr ""
+
+#: src/sparql/querying.md:932
+msgid "`cdt:concat(…)`"
+msgstr ""
+
+#: src/sparql/querying.md:932
+msgid "the argument lists joined end to end"
+msgstr ""
+
+#: src/sparql/querying.md:933
+msgid "`cdt:contains(list, term)`"
+msgstr ""
+
+#: src/sparql/querying.md:933
+msgid "`xsd:boolean` — does the list hold an equal term"
+msgstr ""
+
+#: src/sparql/querying.md:934
+msgid "`cdt:get(coll, n_or_key)`"
+msgstr ""
+
+#: src/sparql/querying.md:934
+msgid "one element by **1-based** position, or one map value by key"
+msgstr ""
+
+#: src/sparql/querying.md:935
+msgid "`cdt:head(list)`"
+msgstr ""
+
+#: src/sparql/querying.md:935
+msgid "the first element"
+msgstr ""
+
+#: src/sparql/querying.md:936
+msgid "`cdt:tail(list)`"
+msgstr ""
+
+#: src/sparql/querying.md:936
+msgid "everything but the first element"
+msgstr ""
+
+#: src/sparql/querying.md:937
+msgid "`cdt:reverse(list)`"
+msgstr ""
+
+#: src/sparql/querying.md:937
+msgid "the elements in opposite order"
+msgstr ""
+
+#: src/sparql/querying.md:938
+msgid "`cdt:size(coll)`"
+msgstr ""
+
+#: src/sparql/querying.md:938
+msgid ""
+"`xsd:integer` element or entry count — the one function that takes either "
+"datatype"
+msgstr ""
+
+#: src/sparql/querying.md:939
+msgid "`cdt:subseq(list, start[, len])`"
+msgstr ""
+
+#: src/sparql/querying.md:939 src/sparql/querying.md:943
+msgid "2–3"
+msgstr ""
+
+#: src/sparql/querying.md:939
+msgid "a contiguous run, `start` **1-based**"
+msgstr ""
+
+#: src/sparql/querying.md:940
+msgid "`cdt:containsKey(map, key)`"
+msgstr ""
+
+#: src/sparql/querying.md:940
+msgid "`xsd:boolean` — is this a key of the map"
+msgstr ""
+
+#: src/sparql/querying.md:941
+msgid "`cdt:keys(map)`"
+msgstr ""
+
+#: src/sparql/querying.md:941
+msgid "the map's keys, as a `cdt:List`"
+msgstr ""
+
+#: src/sparql/querying.md:942
+msgid "`cdt:merge(…)`"
+msgstr ""
+
+#: src/sparql/querying.md:942
+msgid "≥ 2"
+msgstr ""
+
+#: src/sparql/querying.md:942
+msgid ""
+"the union of the argument maps; a key held by more than one is resolved by "
+"the **first** map that carries it"
+msgstr ""
+
+#: src/sparql/querying.md:943
+msgid "`cdt:put(map, key[, value])`"
+msgstr ""
+
+#: src/sparql/querying.md:943
+msgid ""
+"the map with one entry set; an omitted or erroring value stores the `null` "
+"entry"
+msgstr ""
+
+#: src/sparql/querying.md:944
+msgid "`cdt:remove(map, key)`"
+msgstr ""
+
+#: src/sparql/querying.md:944
+msgid "the map without that entry; an absent key leaves it unchanged"
+msgstr ""
+
+#: src/sparql/querying.md:946
+msgid ""
+"Handing a list function a map (or the reverse) **raises** — it is a type "
+"error, not an unbound column. The indices are 1-based throughout, per the "
+"SEP."
+msgstr ""
+
+#: src/sparql/querying.md:949
+msgid ""
+"```sparql\n"
+"PREFIX cdt: <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>\n"
+"SELECT ?s ?first\n"
+"WHERE {\n"
+"  ?s <http://example.org/tags> ?tags\n"
+"  FILTER(cdt:size(?tags) > 1)\n"
+"  BIND(cdt:head(?tags) AS ?first)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:959
+msgid "`FOLD`: a group becomes one term"
+msgstr ""
+
+#: src/sparql/querying.md:961
+msgid ""
+"`FOLD` is an aggregate, so it sits wherever `SUM` or `GROUP_CONCAT` sits — "
+"in the `SELECT` list, in `HAVING`, beside other aggregates, under `GROUP BY`."
+msgstr ""
+
+#: src/sparql/querying.md:969
+msgid ""
+"One expression builds a `cdt:List`; two build a `cdt:Map`, the first being "
+"the key. The optional `ORDER BY` belongs to the aggregate itself and follows "
+"the last expression with **no comma** — this is the seam that makes `FOLD` "
+"the first order-dependent aggregate in the engine, and it is why `FOLD` "
+"carries an `ORDER BY` where every other aggregate rejects one."
+msgstr ""
+
+#: src/sparql/querying.md:975
+msgid "Accepted spellings, as a catalogue:"
+msgstr ""
+
+#: src/sparql/querying.md:983
+msgid "and one whole query:"
+msgstr ""
+
+#: src/sparql/querying.md:985
+msgid ""
+"```sparql\n"
+"PREFIX cdt: <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>\n"
+"SELECT ?s (FOLD(?tag ORDER BY ?tag) AS ?tags)\n"
+"WHERE { ?s <http://example.org/tag> ?tag }\n"
+"GROUP BY ?s\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:992
+msgid "Four behaviours are worth knowing before you rely on one:"
+msgstr ""
+
+#: src/sparql/querying.md:994
+msgid ""
+"An **empty group folds to a bound empty composite** — `\"[]\"^^cdt:List` or "
+"`\"{}\"^^cdt:Map` — never to an unbound column. `SUM` over nothing is `0` "
+"and `GROUP_CONCAT` over nothing is `\"\"`; `FOLD` follows that shape rather "
+"than `MIN`'s."
+msgstr ""
+
+#: src/sparql/querying.md:998
+msgid ""
+"A row whose element expression is **unbound or erroring contributes a `null` "
+"element**, which is the opposite of every other aggregate, all of which skip "
+"such a row. The SEP wants the arity of the list to match the arity of the "
+"group. A map **key** that is unbound or erroring drops the entry entirely, "
+"because there is nothing to file the value under."
+msgstr ""
+
+#: src/sparql/querying.md:1003
+msgid "A repeated map key resolves to the **last** binding."
+msgstr ""
+
+#: src/sparql/querying.md:1004
+msgid ""
+"`DISTINCT` is RDF-term identity, not value equality, so `\"1\"^^xsd:integer` "
+"and `\"01\"^^xsd:integer` survive as two elements."
+msgstr ""
+
+#: src/sparql/querying.md:1007
+msgid ""
+"There is no `; SEPARATOR=` on `FOLD` — that scalar parameter is "
+"`GROUP_CONCAT`'s alone — and `FOLD(*)` is not grammar."
+msgstr ""
+
+#: src/sparql/querying.md:1010
+msgid "`UNFOLD`: one term becomes rows"
+msgstr ""
+
+#: src/sparql/querying.md:1012
+msgid ""
+"`UNFOLD` is a **graph pattern**, not a function. It is its own "
+"`GraphPatternNotTriples` alternative — structurally where `LATERAL` sits — "
+"and it stacks above the pattern parsed so far:"
+msgstr ""
+
+#: src/sparql/querying.md:1020
+msgid "Operand"
+msgstr ""
+
+#: src/sparql/querying.md:1020
+msgid "first variable"
+msgstr ""
+
+#: src/sparql/querying.md:1020
+msgid "second variable"
+msgstr ""
+
+#: src/sparql/querying.md:1022
+msgid "`cdt:List`"
+msgstr ""
+
+#: src/sparql/querying.md:1022
+msgid "each element, in list order, duplicates preserved"
+msgstr ""
+
+#: src/sparql/querying.md:1022
+msgid "the **1-based** `xsd:integer` index"
+msgstr ""
+
+#: src/sparql/querying.md:1023
+msgid "`cdt:Map`"
+msgstr ""
+
+#: src/sparql/querying.md:1023
+msgid "each entry's key"
+msgstr ""
+
+#: src/sparql/querying.md:1023
+msgid "that entry's value"
+msgstr ""
+
+#: src/sparql/querying.md:1025
+msgid ""
+"```sparql\n"
+"SELECT ?elem ?i\n"
+"WHERE {\n"
+"  ?s <http://example.org/tags> ?tags\n"
+"  UNFOLD(?tags AS ?elem, ?i)\n"
+"  FILTER(?i < 4)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:1034
+msgid ""
+"Both targets obey `BIND`'s §19.6 scope rule: a variable already in scope in "
+"the group graph pattern is a **syntax error**, not a join, and naming the "
+"same variable twice is likewise refused."
+msgstr ""
+
+#: src/sparql/querying.md:1038
+msgid ""
+"The two edges that decide whether an `OPTIONAL` around an `UNFOLD` is doing "
+"what you think:"
+msgstr ""
+
+#: src/sparql/querying.md:1041
+msgid ""
+"A **well-formed but empty** composite (`\"[]\"^^cdt:List`, `cdt:Map()`) "
+"yields **zero rows**. The row is gone."
+msgstr ""
+
+#: src/sparql/querying.md:1043
+msgid ""
+"An operand that is **not a composite at all** — unbound, erroring, an "
+"`xsd:integer`, a plain string, or a `cdt:`\\-typed literal whose lexical "
+"form does not parse — passes **the row through unchanged** with both targets "
+"unbound. This is SEP-0009 §12.3 verbatim, and it is deliberately not a no-"
+"rows outcome, so `UNFOLD` never silently deletes a row it merely failed to "
+"understand."
+msgstr ""
+
+#: src/sparql/querying.md:1050
+msgid ""
+"`FOLD` and `UNFOLD` compose, which is how a query re-orders a list without "
+"leaving the query language:"
+msgstr ""
+
+#: src/sparql/querying.md:1053
+msgid ""
+"```sparql\n"
+"PREFIX cdt: <http://w3id.org/awslabs/neptune/SPARQL-CDTs/>\n"
+"SELECT (FOLD(?e ORDER BY ?e) AS ?sorted)\n"
+"WHERE { BIND(\"[3,1,2]\"^^cdt:List AS ?l) UNFOLD(?l AS ?e) }\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:1059
+msgid "Ordering, `MIN` and `MAX`"
+msgstr ""
+
+#: src/sparql/querying.md:1061
+msgid ""
+"`ORDER BY`, `MIN`, `MAX` and `FOLD`'s own `ORDER BY` all order composite "
+"literals **by the value they denote**, not by their lexical form, through "
+"one shared projection of SPARQL §15.1. Composites rank between plain "
+"literals and RDF 1.2 triple terms: `unbound < blank < IRI < literal < "
+"composite < triple term`. SEP-0009 does not pin that placement; it is "
+"`purrdf`'s documented choice."
+msgstr ""
+
+#: src/sparql/querying.md:1068
+msgid ""
+"The order `purrdf` exports for composites is **syntactic**, and that is not "
+"an oversight. SEP-0009's value relations are partial and raise on "
+"incomparable operands, and the obvious repair — order by value, break ties "
+"syntactically — is **intransitive** on SPARQL's own type lattice "
+"(`\"9\"^^xsd:double` \\< `\"P1D\"^^xsd:duration` \\< `\"8\"^^xsd:float` \\< "
+"`\"9\"^^xsd:double`). Rust's sorts may **panic** on a comparator like that, "
+"so a total order is a correctness requirement here, not a nicety."
+msgstr ""
+
+#: src/sparql/querying.md:1076
+msgid ""
+"`MEDIAN` and `PERCENTILE` are numeric folds and are **not** composite-aware: "
+"a composite is outside their domain and the aggregate comes back unbound."
+msgstr ""
+
+#: src/sparql/querying.md:1079
+msgid "Blank nodes inside a composite"
+msgstr ""
+
+#: src/sparql/querying.md:1081
+msgid ""
+"A `_:b` written inside a composite lexical form binds through the **same** "
+"ingress rule as a bare `_:b` token, on every codec — Turtle, TriG, N-"
+"Triples, N-Quads, RDF/XML, TriX, HexTuples, JSON-LD, and both GTS import "
+"paths. So `_:b` written as a subject and `_:b` written inside a `cdt:List` "
+"**in the same document** are one node, while the same label in two different "
+"documents stays two nodes, exactly as RDF 1.1 §4.1 requires. Composite-"
+"embedded blank nodes also participate in canonicalization and in "
+"skolemization."
+msgstr ""
+
+#: src/sparql/querying.md:1089
+msgid ""
+"Query text gets its own blank scope for the same reason, so a `_:b` you "
+"write inside a composite literal in a query is never the `_:b` in the data."
+msgstr ""
+
+#: src/sparql/querying.md:1092
+msgid "Limits, and what a composite refuses"
+msgstr ""
+
+#: src/sparql/querying.md:1094
+msgid ""
+"Nesting is bounded, and the bounds are an invariant of the value — the "
+"programmatic constructors enforce them exactly as the parser does:"
+msgstr ""
+
+#: src/sparql/querying.md:1097
+msgid "Bound"
+msgstr ""
+
+#: src/sparql/querying.md:1097
+msgid "Value"
+msgstr ""
+
+#: src/sparql/querying.md:1099
+msgid "Nesting depth"
+msgstr ""
+
+#: src/sparql/querying.md:1100
+msgid "Total elements, all levels"
+msgstr ""
+
+#: src/sparql/querying.md:1100
+msgid "2²⁰ (1 048 576)"
+msgstr ""
+
+#: src/sparql/querying.md:1101
+msgid "Lexical bytes"
+msgstr ""
+
+#: src/sparql/querying.md:1101
+msgid "64 MiB"
+msgstr ""
+
+#: src/sparql/querying.md:1103
+msgid ""
+"Crossing one at evaluation is a **hard query failure** naming the bound "
+"crossed, never a quietly unbound answer."
+msgstr ""
+
+#: src/sparql/querying.md:1106
+msgid ""
+"An **ill-formed composite literal in a document refuses the whole document** "
+"(`cdt-literal-malformed`), where an ill-formed `\"abc\"^^xsd:integer` does "
+"not. That asymmetry is deliberate and is [written down in full](https://"
+"github.com/Blackcat-Informatics/purrdf/blob/main/docs/CONFORMANCE.md): the "
+"embedded-blank scanner is lexical, so admitting an unparseable form opaquely "
+"would leave half a blank-node scope bound and half of it raw. In **query "
+"text** the same literal parses — ill-typedness is an evaluation-time "
+"question there, a function over it is unbound, and a comparison with it "
+"raises."
+msgstr ""
+
+#: src/sparql/querying.md:1115
+msgid "Taking a composite query to another engine"
+msgstr ""
+
+#: src/sparql/querying.md:1117
+msgid ""
+"Expect a **parse error** for `FOLD` and `UNFOLD`, which are keywords no "
+"unextended grammar admits, and quietly **different answers** for the "
+"function calls, which are ordinary `iri ArgList` calls that an engine "
+"without SEP-0009 will report as unknown functions. There is nothing to "
+"configure to reach any of it from a host: like the SHA-3 built-ins, "
+"composites are unconditional, so `purrdf query`, Python's `Store.query` / "
+"`MutableDataset.query`, WebAssembly's `Dataset.query` / "
+"`QueryEngine.select`, and the C ABI's `purrdf_query` / `purrdf_query_json` "
+"all have them."
+msgstr ""
+
+#: src/sparql/querying.md:1126
+msgid ""
+"One divergence runs the other way, and it is stated rather than argued. "
+"`purrdf`'s reader admits two element forms the published SEP-0009 lexical "
+"space does not — an RDF 1.2 triple term `<<( s p o )>>`, and a directional "
+"language-tagged literal (`\"x\"@en--ltr`) — as list elements and map values, "
+"because refusing a term type the RDF 1.2 data model defines, inside a "
+"container the data model also defines, is not an admissible outcome for this "
+"toolkit. They are emitted only for values the published grammar cannot "
+"express at all. **A conformant SEP-0009 reader handed one of those literals "
+"will call it ill-formed.** See [`docs/CONFORMANCE.md`](https://github.com/"
+"Blackcat-Informatics/purrdf/blob/main/docs/CONFORMANCE.md) for the "
+"divergence and the scan that bounds its blast radius."
+msgstr ""
+
+#: src/sparql/querying.md:1138
+msgid "Quad templates: `CONSTRUCT` into named graphs"
+msgstr ""
+
+#: src/sparql/querying.md:1140
+msgid ""
+"A SPARQL 1.1 `CONSTRUCT` template is a set of triples, and the result is one "
+"graph. `purrdf` also accepts a **quad template**, so a template may name the "
+"graph each statement lands in, and a single result may span several named "
+"graphs."
+msgstr ""
+
+#: src/sparql/querying.md:1145
+msgid "Provenance: a `purrdf` extension, not a SPARQL 1.2 feature"
+msgstr ""
+
+#: src/sparql/querying.md:1147
+msgid ""
+"**SPARQL 1.2 does not define the quad template.** Neither the 1.1 nor the "
+"1.2 grammar admits a `GRAPH` block inside a `CONSTRUCT` template "
+"(`ConstructTemplate ::= '{' ConstructTriples? '}'`, and `ConstructTriples` "
+"is triples only), and neither defines the `CONSTRUCT GRAPH …` shorthand. "
+"Both spellings documented below are first-party extensions this engine "
+"ships. Producing quads from a `CONSTRUCT` is a long-running request in the "
+"SPARQL community's proposal process, and other engines — Jena and Stardog "
+"among them — already ship a form of it, but no standardized spelling exists, "
+"so the one described here is `purrdf`'s."
+msgstr ""
+
+#: src/sparql/querying.md:1157
+msgid ""
+"Declaring `VERSION \"1.2\"` does not subtract the extension: a version "
+"declaration selects semantics, not a feature whitelist. See [The `VERSION` "
+"declaration](#the-version-declaration)."
+msgstr ""
+
+#: src/sparql/querying.md:1161
+msgid "Taking one of these queries to another engine"
+msgstr ""
+
+#: src/sparql/querying.md:1163
+msgid ""
+"Expect a **parse error**, not a different answer. An engine without the "
+"extension rejects the `GRAPH` keyword as soon as it meets it inside a "
+"`CONSTRUCT` template, because its grammar has no production that admits one "
+"there — the query fails before evaluation, so there is no risk of silently "
+"getting the wrong graphs. An engine that ships its own form of the feature "
+"may accept only one of the two spellings, since neither is standardized."
+msgstr ""
+
+#: src/sparql/querying.md:1170
+msgid "Two portable rewrites:"
+msgstr ""
+
+#: src/sparql/querying.md:1172
+msgid ""
+"**If the result is going into a store**, use SPARQL 1.1 Update rather than "
+"`CONSTRUCT`. Update's template has always been a quad template, so `INSERT "
+"{ GRAPH … { … } } WHERE { … }` is standard, universally implemented, and "
+"gives the same per-solution graph targeting — including a graph name bound "
+"per row:"
+msgstr ""
+
+#: src/sparql/querying.md:1178
+msgid ""
+"```sparql\n"
+"PREFIX ex: <http://example.org/>\n"
+"INSERT { GRAPH ?g { ?s ex:friend ?o } }\n"
+"WHERE  { GRAPH ?g { ?s ex:knows ?o } }\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:1184
+msgid ""
+"**If the result must come back as a document**, issue one ordinary triple-"
+"producing `CONSTRUCT` per target graph and assemble the dataset on the "
+"client. This costs a round trip per graph and cannot express a graph name "
+"computed per solution row, which is the gap the quad template closes."
+msgstr ""
+
+#: src/sparql/querying.md:1189
+msgid ""
+"Queries that stay inside the triple form are unaffected in either direction: "
+"a template with no `GRAPH` slot is an ordinary SPARQL 1.1 `CONSTRUCT` here "
+"and emits byte-identically, so only the templates that actually name a graph "
+"are the ones that will not travel."
+msgstr ""
+
+#: src/sparql/querying.md:1194
+msgid "`GRAPH` blocks inside the template"
+msgstr ""
+
+#: src/sparql/querying.md:1196
+msgid ""
+"```sparql\n"
+"PREFIX ex: <http://example.org/>\n"
+"CONSTRUCT { GRAPH ex:derived { ?s ex:friend ?o } }\n"
+"WHERE { ?s ex:knows ?o }\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:1202
+msgid "A variable graph name"
+msgstr ""
+
+#: src/sparql/querying.md:1204
+msgid ""
+"The graph slot takes a variable as well as an IRI, so the graph a statement "
+"lands in can be decided per solution row:"
+msgstr ""
+
+#: src/sparql/querying.md:1207
+msgid ""
+"```sparql\n"
+"PREFIX ex: <http://example.org/>\n"
+"CONSTRUCT { GRAPH ?g { ?s ex:friend ?o } }\n"
+"WHERE { GRAPH ?g { ?s ex:knows ?o } }\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:1213
+msgid "Several graphs, and mixed default-graph triples"
+msgstr ""
+
+#: src/sparql/querying.md:1215
+msgid ""
+"One template may write into more than one graph, and may mix graph-scoped "
+"quads with unscoped triples that land in the default graph:"
+msgstr ""
+
+#: src/sparql/querying.md:1218
+msgid ""
+"```sparql\n"
+"PREFIX ex: <http://example.org/>\n"
+"CONSTRUCT {\n"
+"  ?s ex:seen true .\n"
+"  GRAPH ex:people  { ?s ex:friend ?o }\n"
+"  GRAPH ex:reverse { ?o ex:friend ?s }\n"
+"}\n"
+"WHERE { ?s ex:knows ?o }\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:1228
+msgid "The whole-template shorthand"
+msgstr ""
+
+#: src/sparql/querying.md:1230
+msgid ""
+"`CONSTRUCT GRAPH <iri> { … }` scopes the entire template to one graph "
+"without a `GRAPH` block around it. It also works with the short form "
+"(`CONSTRUCT GRAPH <iri> WHERE { … }`), and it takes a variable (`CONSTRUCT "
+"GRAPH ?g { … }`), a prefixed name, or a `BASE`\\-relative IRI:"
+msgstr ""
+
+#: src/sparql/querying.md:1235
+msgid ""
+"```sparql\n"
+"PREFIX ex: <http://example.org/>\n"
+"CONSTRUCT GRAPH ex:derived { ?s ex:friend ?o }\n"
+"WHERE { ?s ex:knows ?o }\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:1241
+msgid ""
+"The shorthand is a **default, not an override**: it supplies the graph for "
+"every template slot that did not name one itself, so an inner `GRAPH` block "
+"still wins over it. `CONSTRUCT GRAPH { … }` with no name is a syntax error "
+"rather than a silently unscoped template."
+msgstr ""
+
+#: src/sparql/querying.md:1246
+msgid "Skip semantics"
+msgstr ""
+
+#: src/sparql/querying.md:1248
+msgid ""
+"SPARQL §16.2 already skips a template statement whose variables are unbound "
+"or whose instantiation is ill-formed. Ill-formed means \"not a legal RDF 1.2 "
+"statement\", position by position:"
+msgstr ""
+
+#: src/sparql/querying.md:1252
+msgid ""
+"the **subject** is an IRI or a blank node — a literal is illegal there, and "
+"so is a triple term (a quoted triple is a value; an asserted statement is "
+"made about a reifier, not about the quoted triple itself). Both are "
+"reachable from ordinary data: over RDF 1.2 input, `CONSTRUCT { ?o ?p ?s } "
+"WHERE { ?s ?p ?o }` binds `?o` to a triple term as readily as to a literal;"
+msgstr ""
+
+#: src/sparql/querying.md:1257
+msgid "the **predicate** is an IRI, and nothing else;"
+msgstr ""
+
+#: src/sparql/querying.md:1258
+msgid ""
+"the **object** may be any term, but when it is a triple term that triple "
+"term's own components carry the same rules recursively (its subject must not "
+"be a literal, its predicate must be an IRI)."
+msgstr ""
+
+#: src/sparql/querying.md:1262
+msgid ""
+"The graph slot follows the same rule, and this is worth being explicit about:"
+msgstr ""
+
+#: src/sparql/querying.md:1264
+msgid ""
+"**An unresolvable graph name skips its statement.** It is not an error, and "
+"it is _not_ a fallback to the default graph. The graph slot is resolved "
+"first, so a statement whose graph name is an unbound variable, or is bound "
+"to anything that is not an IRI (a literal, a blank node, a triple term), is "
+"not instantiated at all — it mints no blank-node labels either, so the rest "
+"of the result is exactly what it would be if that quad were absent from the "
+"template."
+msgstr ""
+
+#: src/sparql/querying.md:1271
+msgid ""
+"The skip is **per statement**, not per row: a sibling template quad whose "
+"own graph slot resolves is still emitted for the same solution."
+msgstr ""
+
+#: src/sparql/querying.md:1274
+msgid "Which output formats can carry the result"
+msgstr ""
+
+#: src/sparql/querying.md:1276
+msgid ""
+"A named graph needs a syntax with somewhere to put a graph name. Six of the "
+"nine RDF syntaxes have one:"
+msgstr ""
+
+#: src/sparql/querying.md:1279
+msgid "Carries named graphs"
+msgstr ""
+
+#: src/sparql/querying.md:1279
+msgid "Does not"
+msgstr ""
+
+#: src/sparql/querying.md:1281
+msgid "TriG, N-Quads, TriX, HexTuples, JSON-LD, YAML-LD"
+msgstr ""
+
+#: src/sparql/querying.md:1281
+msgid "Turtle, N-Triples, RDF/XML"
+msgstr ""
+
+#: src/sparql/querying.md:1283
+msgid ""
+"The single-graph serializers **drop** graph-scoped statements — they do not "
+"fold them into the default graph — so writing a graph-carrying result to one "
+"of them would produce a well-formed document silently missing exactly what "
+"the query asked for. No host lets that pass unsignalled. The three hosts "
+"whose egress is a _document_ refuse outright, each naming the graphs it "
+"would have dropped, the format it was asked for, and the quad-capable "
+"alternatives; the C ABI, whose egress is the dataset itself, reports the "
+"loss as a count instead:"
+msgstr ""
+
+#: src/sparql/querying.md:1291
+msgid ""
+"**CLI** — `purrdf query … --results-format turtle` exits **2** (a usage "
+"refusal, distinct from an evaluation error) and prints the refusal on "
+"stderr, pointing at `--results-format trig/nquads/trix/hextuples/jsonld/"
+"yamlld`."
+msgstr ""
+
+#: src/sparql/querying.md:1295
+msgid ""
+"**Python** — the result of a graph-carrying `CONSTRUCT` is a `QueryQuads` "
+"(whose members are `Quad`s with a live `graph_name`) rather than a "
+"`QueryTriples`. `QueryQuads.serialize(RdfFormat.TURTLE)` raises "
+"`ValueError`, naming `RdfFormat.N_QUADS/TRIG/TRIX/HEXTUPLES/JSON_LD/YAML_LD`."
+msgstr ""
+
+#: src/sparql/querying.md:1299
+msgid ""
+"**WebAssembly** — an explicit `serialize(\"turtle\")` / `queryRaw(…, "
+"{format: \"turtle\"})` **throws**, with the same sentence and the same "
+"alternatives. When the caller names NO format the default widens from "
+"`turtle` to `trig` instead of throwing, because there was no request to "
+"contradict and an empty document would be the wrong answer; a result with no "
+"named graph still gets `turtle`, byte for byte."
+msgstr ""
+
+#: src/sparql/querying.md:1305
+msgid ""
+"**C ABI** — the shape is different, and deliberately so. `purrdf_query` "
+"hands back a `PurrdfDataset` handle, which is the frozen IR itself and has "
+"somewhere to put a graph name, so the graphs are never lost at the query "
+"boundary. Serializing that handle is a separate call, and `purrdf_serialize` "
+"to a single-graph media type succeeds while reporting what it discarded "
+"through the `out_named_graph_rows_dropped` out-parameter — a count rather "
+"than an exception, because that is the signal C has. The parameter is "
+"independently nullable; a caller that passes null for it has asked not to be "
+"told, so read it — or serialize to a quad-capable media type — whenever the "
+"result may carry graphs."
+msgstr ""
+
+#: src/sparql/querying.md:1316
+msgid ""
+"The convenience path, `purrdf_query_json`, needs neither: it renders a "
+"`CONSTRUCT`/`DESCRIBE` result as **N-Quads** inside its `{\"graph\": \"...\"}"
+"` envelope, so the graph names, the base quads and the RDF 1.2 statement "
+"layer all survive and there is no loss to report. That member is `purrdf`'s "
+"own envelope rather than a caller-selected RDF syntax, which is why it "
+"widens the way the WebAssembly no-format default does instead of refusing "
+"the way an explicit `serialize(\"turtle\")` does. A default-graph-only "
+"result is byte-identical to the N-Triples the member used to hold — an N-"
+"Quads line with no graph term is the N-Triples line."
+msgstr ""
+
+#: src/sparql/querying.md:1326
+msgid ""
+"A result carrying only default-graph statements is untouched everywhere: "
+"every SPARQL 1.1 `CONSTRUCT` and every `DESCRIBE` serializes to Turtle "
+"exactly as before. A **mixed** result is refused as a whole rather than half-"
+"emitted, because emitting the default-graph half would report a partial "
+"answer as a complete one."
+msgstr ""
+
+#: src/sparql/querying.md:1332
+msgid "The `VERSION` declaration"
+msgstr ""
+
+#: src/sparql/querying.md:1334
+msgid ""
+"A query or update prologue may declare `VERSION \"<string>\"` (SPARQL 1.2 "
+"Query specification §4.4). Parsing is syntax-only — any string is accepted, "
+"and when the prologue repeats the declaration the last one wins — but the "
+"declared value is no longer discarded: `Query::version()` / "
+"`Update::version()` expose it as a typed `SparqlVersion`, alongside the "
+"existing `dataset()`/`base_iri()` accessors."
+msgstr ""
+
+#: src/sparql/querying.md:1340
+msgid ""
+"Evaluation is the admission boundary. `VERSION \"1.2\"` and `VERSION \"1.2-"
+"basic\"` are recognized; any other declared string — `VERSION \"1.1\"`, a "
+"typo, a future version this build predates — is refused at evaluation "
+"admission with a typed error naming the declared string, before any work is "
+"spent."
+msgstr ""
+
+#: src/sparql/querying.md:1345
+msgid ""
+"`VERSION \"1.2\"` evaluates normally on the full engine. `VERSION \"1.2-"
+"basic\"` is enforced as a narrower profile: the SPARQL 1.2 Query "
+"specification's §4.3.1 \"Version Labels\" table defines `1.2-basic` as full "
+"`1.2` syntax \"without triple terms and without triple patterns that have a "
+"triple pattern in their subject or object position\" — the RDF 1.2 triple-"
+"term/reification feature area. A `1.2-basic` query or update that uses a "
+"quoted triple term (`<<( s p o )>>`), a reifying triple or annotation (`<< s "
+"p o >>`, `{| ... |}`), a ground triple term in `VALUES`, or one of the "
+"\"Functions on Triple Terms\" (`TRIPLE`, `isTRIPLE`, `SUBJECT`, `PREDICATE`, "
+"`OBJECT`, §17.4.6) is refused at evaluation admission with a typed error "
+"naming the offending construct — for an update, with no mutation applied. A "
+"`1.2-basic` request that uses none of those constructs evaluates exactly as "
+"a `1.2` one would."
+msgstr ""
+
+#: src/sparql/querying.md:1358
+msgid "Aggregate determinism: row order, `DISTINCT`, and `GROUP_CONCAT`"
+msgstr ""
+
+#: src/sparql/querying.md:1360
+msgid ""
+"SPARQL 1.1/1.2 leave several corners of `GROUP BY`/aggregate evaluation "
+"intentionally underspecified — a conforming engine may pick any answer "
+"within the spec's envelope. `purrdf-sparql-eval` picks ONE deterministic "
+"answer for each and documents it here (mirrored in "
+"`purrdf_sparql_eval::modifier`'s crate docs), so \"what does `GROUP_CONCAT` "
+"return\" has a single, testable meaning rather than \"any order the engine "
+"happened to produce.\""
+msgstr ""
+
+#: src/sparql/querying.md:1367
+msgid ""
+"**Row and group order (§18.6.1 \"Aggregate Algebra\").** `GROUP BY` "
+"partitions the inner solution sequence into groups; this crate keeps groups "
+"in **first-seen order** (the order each group's key first appears in the "
+"inner solution sequence) and keeps each group's own rows in **inner-operator "
+"order** (the order the ungrouped input produced them). Every order-sensitive "
+"fold — `GROUP_CONCAT`'s concatenation, `SAMPLE`'s \"first value wins\", a "
+"custom aggregate's `OrderDependent` fold — folds over rows in exactly that "
+"order."
+msgstr ""
+
+#: src/sparql/querying.md:1376
+msgid ""
+"\"Inner-operator order\" is REPRODUCIBLE (the same query against the same "
+"dataset yields the same order every time) but is not, by itself, a "
+"documented invariant a query text can rely on for a plain triple-pattern "
+"scan: a bare BGP's solution order follows this store's internal index layout "
+"(currently sorted by interned term id along the index the planner picks), "
+"which is an implementation detail, not a promise. The one row order a query "
+"CAN rely on is an explicit `ORDER BY`: when the aggregate's immediate input "
+"is (or is fed by) an `ORDER BY`\\-sorted solution sequence — for example a "
+"subquery `{ SELECT ?v WHERE { ... } ORDER BY ?key }` feeding an outer "
+"aggregate — \"inner-operator order\" is exactly that `ORDER BY`'s SPARQL "
+"total order (§15.1), which the specification itself fixes."
+msgstr ""
+
+#: src/sparql/querying.md:1388
+msgid ""
+"**`DISTINCT` (inside an aggregate call).** Per §18.6.1's `Aggregation` "
+"definition, `DISTINCT` folds `Dedup(M(Ψ))` rather than `M(Ψ)` — an order-"
+"preserving, duplicate-free view whose relative order of first occurrences is "
+"preserved. This crate's dedup keeps the FIRST occurrence (in the row order "
+"above) of an equal-by-value tuple; every later occurrence never reaches the "
+"fold's `step`."
+msgstr ""
+
+#: src/sparql/querying.md:1395
+msgid "`GROUP_CONCAT` ordering"
+msgstr ""
+
+#: src/sparql/querying.md:1397
+msgid ""
+"§18.6.1.7 defines `GroupConcat` as concatenating the sequence's elements "
+"with `sep` between them, but explicitly leaves the sequence's own order "
+"unspecified (\"The order of the strings is not specified\") — exactly the "
+"freedom the paragraphs above pin down. This crate concatenates in the row "
+"order stated above: **groups first-seen, rows in inner-operator order, "
+"`DISTINCT` keeping the first occurrence** — producing a plain `xsd:string` "
+"of the lexical forms joined by `sep` (default `\" \"` per §18.6.1.7, absent "
+"an explicit `SEPARATOR`). A term with no lexical form (a blank node or a "
+"triple term) poisons the fold to unbound, the same reading `SUM`/`AVG` use "
+"for a non-numeric running total."
+msgstr ""
+
+#: src/sparql/querying.md:1408
+msgid ""
+"Because a plain BGP's own scan order is an implementation detail rather than "
+"a documented guarantee (see above), a `GROUP_CONCAT` fixture that wants to "
+"demonstrate the determinism reading with an exact-string pin cannot rest the "
+"proof on scanning a triple pattern directly — that would pin an incidental "
+"property of the current index layout, not the specification-backed ordering "
+"this section documents. This project's own conformance fixture, `crates/"
+"sparql-conformance/suite/purrdf-extend/group-concat-order.rq`, drives its "
+"row order from an `ORDER BY DESC(?s)` subquery feeding the outer "
+"`GROUP_CONCAT` — anchoring the pin to SPARQL's own `ORDER BY` total order "
+"(§15.1) over distinct IRIs, and using `DESC` rather than `ASC` so a "
+"regression that silently ignored the subquery's `ORDER BY` (and fell back to "
+"the store's incidental scan order) would produce a detectably different, "
+"wrong string instead of coincidentally passing."
+msgstr ""
+
+#: src/sparql/querying.md:1422
+msgid "Extending the evaluator: custom aggregates"
+msgstr ""
+
+#: src/sparql/querying.md:1424
+msgid ""
+"Beyond the SPARQL 1.1 built-in aggregates (`COUNT`/`SUM`/`AVG`/`MIN`/`MAX`/ "
+"`SAMPLE`/`GROUP_CONCAT`), a Rust host may register additional `GROUP BY` "
+"reductions and reach them from query text as `AGG(<iri>, [DISTINCT] arg, "
+"arg, …)` — the normative positional spelling (a deliberate divergence from "
+"Jena ARQ's `AGG <iri>(args)`). Where `purrdf_sparql_eval::property_fn` "
+"injects a _relation_ (a row source in graph-pattern position) and `user_fn` "
+"injects a _scalar function_ (one value per call), `agg_fn` injects a "
+"**fold**: a group's rows reduce to one value through a caller-supplied "
+"accumulator, exactly as a built-in aggregate does."
+msgstr ""
+
+#: src/sparql/querying.md:1434
+msgid ""
+"A registered aggregate implements two traits — `CustomAggregate` (the per-"
+"IRI factory: declared arity, `Volatility`, `AlgebraicClass`, and a declared "
+"state bound) and `AggregateAccumulator` (the per-invocation fold: `step` one "
+"already-evaluated argument tuple at a time, `combine` two partial folds in "
+"source order, `finish` to the group's answer) — and is registered into an "
+"`AggregateRegistry` under an IRI of the caller's choosing:"
+msgstr ""
+
+#: src/sparql/querying.md:1448
+msgid ""
+"/// A running total over one numeric argument — `example.org`'s own\n"
+"/// `AGG(<https://example.org/agg#total>, ?x)`.\n"
+msgstr ""
+
+#: src/sparql/querying.md:1466
+msgid ""
+"// Recover `other`'s real state through `into_any` rather than\n"
+"        // re-deriving it from `finish()`'s lexical form: `finish()` is a\n"
+"        // lossy, string-typed answer, and re-parsing it is exactly the\n"
+"        // pattern this crate's own `agg_fn`/`stat_agg` merges avoid (see\n"
+"        // their \"Real merges via `into_any`\" docs). A running total "
+"happens\n"
+"        // to survive that round trip losslessly, but the type-recovered\n"
+"        // merge below is the pattern to copy for a fold whose finished\n"
+"        // answer is NOT itself sufficient mergeable state.\n"
+msgstr ""
+
+#: src/sparql/querying.md:1476
+msgid "\"combine received a partial accumulator of a different concrete type\""
+msgstr ""
+
+#: src/sparql/querying.md:1484
+msgid "// a running total IS its own sufficient merge state\n"
+msgstr ""
+
+#: src/sparql/querying.md:1490
+msgid "\"http://www.w3.org/2001/XMLSchema#integer\""
+msgstr ""
+
+#: src/sparql/querying.md:1502
+msgid "// eligible for the within-group parallel fold\n"
+msgstr ""
+
+#: src/sparql/querying.md:1508
+msgid "// stateless besides the running total\n"
+msgstr ""
+
+#: src/sparql/querying.md:1517
+msgid "\"https://example.org/agg#total\""
+msgstr ""
+
+#: src/sparql/querying.md:1525
+msgid ""
+"\"SELECT (AGG(<https://example.org/agg#total>, ?x) AS ?t) WHERE { ?s "
+"<https://example.org/n> ?x }\""
+msgstr ""
+
+#: src/sparql/querying.md:1536
+msgid ""
+"An `AGG(<iri>, …)` call to an unregistered IRI, with the wrong argument "
+"count, or with an invalid `; NAME=value` scalarval clause (an unrecognized "
+"name, a duplicate name, a missing required name, or a wrong-typed value — "
+"see below), is refused when the query is **prepared** — before any budget "
+"unit is spent — and the prepared plan carries the registry's fingerprint, so "
+"a plan admitted under one registry can never silently run under another (see "
+"`purrdf-sparql-eval`'s `agg_fn` module docs for the full trust-boundary and "
+"determinism contract, including `into_any`'s role in merging structural "
+"state a fold's finished answer alone cannot reconstruct)."
+msgstr ""
+
+#: src/sparql/querying.md:1546
+msgid "Named scalar-value parameters"
+msgstr ""
+
+#: src/sparql/querying.md:1548
+msgid ""
+"Beyond its positional `args`, `AGG(<iri>, …)` admits zero or more trailing "
+"`; NAME=value` clauses — a named, per-aggregation scalar parameter, "
+"generalizing `GROUP_CONCAT`'s own `; SEPARATOR=\"…\"` (SPARQL's existing "
+"precedent for a named scalar aggregate parameter) to any custom aggregate: "
+"`AGG(<{NS}PERCENTILE>, ?x; P=0.95)`, `AGG(<{NS}TOPK>, ?x; K=3)`. `NAME` is "
+"matched case-insensitively and stored upper-cased; `value` is any SPARQL "
+"literal — the full numeric tower including its signed forms (`Q=-1`, "
+"`P=+0.5`), the boolean literals (`B=true`), and strings — so a numeric "
+"scalarval keeps its natural datatype. Unlike a positional argument, a "
+"scalarval is evaluated **once for the whole aggregation**, never per row — "
+"the correct semantics for a parameter like a percentile rank or a \"top k\" "
+"count, which must be one fixed value across the group, not a per-row "
+"expression the query author merely intends to hold constant."
+msgstr ""
+
+#: src/sparql/querying.md:1562
+msgid ""
+"A registered aggregate declares which names it accepts via "
+"`CustomAggregate::scalarvals`, returning a slice of `ScalarvalSpec { name, "
+"kind }` (`kind` is `ScalarvalKind::Numeric` or `ScalarvalKind::String`); "
+"every declared name is required. `CustomAggregate::init` receives the call "
+"site's scalarvals already resolved to `TermValue` and already validated "
+"against that declaration, so an accumulator can read them back by name "
+"(`scalarvals.iter().find(|(k, _)| k == \"P\")`) without re-checking type or "
+"presence."
+msgstr ""
+
+#: src/sparql/querying.md:1571
+msgid ""
+"`AGG(<iri>, …)` execution is governed like any other fold: profile v6 adds "
+"two charge points — `aggregate-invocation` (once per group per aggregate "
+"expression) and `aggregate-accumulation` (once per value inspected) — shared "
+"by built-in and custom aggregates alike, so a registered aggregate over a "
+"given group shape spends identical fuel to a built-in one. See [`docs/SPARQL-"
+"GOVERNOR-PROFILE.md`](https://github.com/Blackcat-Informatics/purrdf/blob/"
+"main/docs/SPARQL-GOVERNOR-PROFILE.md)."
+msgstr ""
+
+#: src/sparql/querying.md:1578
+msgid "The statistical aggregate set"
+msgstr ""
+
+#: src/sparql/querying.md:1580
+msgid ""
+"`purrdf-sparql-eval` ships ten exact statistical aggregates — `MEDIAN`, "
+"`PERCENTILE`, `STDDEV`, `STDDEV_POP`, `VARIANCE`, `VAR_POP`, `MODE`, "
+"`FIRST`, `LAST`, `TOPK` — as first-party `CustomAggregate` instances behind "
+"the same `agg_fn` seam, closed (no caller extension point) and reached "
+"through **one** call: `AggregateRegistry::register_statistical_aggregates`:"
+msgstr ""
+
+#: src/sparql/querying.md:1588
+msgid "\"https://example.org/agg#\""
+msgstr ""
+
+#: src/sparql/querying.md:1588
+msgid ""
+"// Now reachable: AGG(<https://example.org/agg#MEDIAN>, ?x), …STDDEV…, …"
+"TOPK…\n"
+msgstr ""
+
+#: src/sparql/querying.md:1592
+msgid ""
+"As with every vocabulary PurRDF touches, `namespace` is caller-supplied "
+"configuration with no fabricated default — a host that never calls this "
+"method gets none of the ten IRIs registered, exactly as a host that never "
+"configures `ParserOptions::extension_fn_namespaces` gets none of the built-"
+"in scalar extension functions."
+msgstr ""
+
+#: src/sparql/querying.md:1598
+msgid "Per-member semantics:"
+msgstr ""
+
+#: src/sparql/querying.md:1600
+msgid ""
+"**Numeric members** (`STDDEV*`/`VARIANCE*`, `MEDIAN`, `PERCENTILE`) follow "
+"the same `integer ⊂ decimal ⊂ float ⊂ double` promotion tower the built-in "
+"`SUM`/`AVG` fold uses; a non-numeric input **poisons** the fold to unbound "
+"rather than raising a hard error, matching `SUM`'s own discipline. Only "
+"`STDDEV`/`STDDEV_POP`'s final square root leaves the exact decimal tower; "
+"`VARIANCE`/`VAR_POP` never do."
+msgstr ""
+
+#: src/sparql/querying.md:1606
+msgid ""
+"**`STDDEV`/`VARIANCE`** are the sample statistics (`n - 1` denominator, "
+"unbound under two values); **`STDDEV_POP`/`VAR_POP`** are the population "
+"statistics (`n` denominator, defined at one value) — SQL's own naming "
+"convention."
+msgstr ""
+
+#: src/sparql/querying.md:1610
+msgid ""
+"**`MEDIAN`** is `PERCENTILE` at `p = 0.5` under linear interpolation between "
+"the two closest ranks — for an even-sized group this is exactly the mean of "
+"the two middle values."
+msgstr ""
+
+#: src/sparql/querying.md:1613
+msgid ""
+"**`PERCENTILE`** takes a named scalarval, `AGG(<{NS}PERCENTILE>, ?x; "
+"P=0.95)`: `P` is resolved once for the whole aggregation (never per row — "
+"see \"Named scalar-value parameters\" above); a `P` outside `[0, 1]` poisons "
+"to unbound, the same \"poison, don't abort\" discipline every numeric member "
+"uses. A missing or non-numeric `P` is refused at prepare time."
+msgstr ""
+
+#: src/sparql/querying.md:1618
+msgid ""
+"**`MODE`** works over any term kind, counted by RDF term identity (not value "
+"equality — `\"5\"^^xsd:integer` and `\"05\"^^xsd:integer` count as two "
+"different terms). A tie is broken toward the smallest term under the same "
+"total order `MIN`/`ORDER BY` use."
+msgstr ""
+
+#: src/sparql/querying.md:1622
+msgid "**`FIRST`/`LAST`** work over any term kind, in input row order."
+msgstr ""
+
+#: src/sparql/querying.md:1623
+msgid ""
+"**`TOPK`** takes a named scalarval, `AGG(<{NS}TOPK>, ?x; K=3)`: `K` must be "
+"a positive `xsd:integer`, resolved once for the whole aggregation (a `K ≤ 0` "
+"poisons to unbound; a missing or non-integer `K` is refused at prepare "
+"time). Since every SPARQL aggregate yields exactly one RDF term, `TOPK` "
+"answers the same way `GROUP_CONCAT` answers a multi-valued question — the "
+"top `k` values, in descending order, with their lexical forms joined by a "
+"single fixed space separator."
+msgstr ""
+
+#: src/sparql/querying.md:1631
+msgid ""
+"All ten declare `Volatility::Stable` and merge partial folds through real, "
+"type-recovered structural state (`AggregateAccumulator::into_any`) rather "
+"than a lossy re-derivation from a finished answer — so a large single group "
+"folds in parallel chunks (see `crate::modifier::eval_custom_aggregate`) with "
+"a result byte-identical to the sequential fold."
+msgstr ""
+
+#: src/sparql/querying.md:1637
+msgid "Path witnesses: binding the derivation, not the endpoints"
+msgstr ""
+
+#: src/sparql/querying.md:1639
+msgid ""
+"The core grammar's property paths answer a **reachability** question. `?s "
+"ex:p+ ?o` says that some sequence of `ex:p` edges leads from `?s` to `?o`, "
+"and the answer is the endpoint pair; _which_ edges is not expressible, so a "
+"query that needs to explain, weight, filter, or re-join the route has "
+"nowhere to look."
+msgstr ""
+
+#: src/sparql/querying.md:1644
+msgid ""
+"A **path-witness** property function answers the derivation question "
+"instead. A call reads"
+msgstr ""
+
+#: src/sparql/querying.md:1651
+msgid ""
+"and emits **one row per hop**. For a walk of `k` hops, row `i` binds `?len = "
+"k`, `?step = i`, `?node` to the node that hop arrived at, and `?edge` to the "
+"**statement** it traversed — a first-class RDF 1.2 triple term in asserted "
+"orientation, so it joins straight back into the dataset by an ordinary basic "
+"graph pattern. `?step` and `?len` are `xsd:integer` literals precisely so "
+"`ORDER BY ?step` orders numerically rather than putting `\"10\"` before "
+"`\"2\"`."
+msgstr ""
+
+#: src/sparql/querying.md:1658
+msgid ""
+"There is no default relation IRI and no default traversal envelope. PurRDF "
+"mints no vocabulary IRIs, so the name a query spells in predicate position "
+"is caller-supplied; and a zero-hop path has no witness while an unbounded "
+"depth is a stack-overflow abort, so the minimum and maximum hop counts and "
+"the two resource guards are stated every time rather than invented by the "
+"library."
+msgstr ""
+
+#: src/sparql/querying.md:1664
+msgid ""
+"Two relation TYPES, not one with a mode switch: `PathWitnessRelation` "
+"enumerates every simple-prefix walk (exponential in the worst case) and "
+"`ShortestPathWitnessRelation` yields one shortest witness per reachable pair "
+"(polynomial). The planner reads cardinality off the registration, so which "
+"of the two answers an IRI is a property of the registration and not of a "
+"runtime value the planner cannot see."
+msgstr ""
+
+#: src/sparql/querying.md:1671
+msgid "A worked example"
+msgstr ""
+
+#: src/sparql/querying.md:1673
+msgid "Over a three-edge chain `ex:a → ex:b → ex:c → ex:d`:"
+msgstr ""
+
+#: src/sparql/querying.md:1684
+msgid ""
+"```text\n"
+"end,len,step,node\n"
+"http://example.org/b,1,1,http://example.org/b\n"
+"http://example.org/c,2,1,http://example.org/b\n"
+"http://example.org/c,2,2,http://example.org/c\n"
+"http://example.org/d,3,1,http://example.org/b\n"
+"http://example.org/d,3,2,http://example.org/c\n"
+"http://example.org/d,3,3,http://example.org/d\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:1694
+msgid ""
+"`GROUP BY ?pathId` is how the hop rows become walks again. The identifier is "
+"constant across one walk's rows and distinct between walks, so each group IS "
+"one walk; `?start`, `?end` and `?len` are constant within a group, so "
+"grouping by them alongside is free and lets them be projected:"
+msgstr ""
+
+#: src/sparql/querying.md:1708
+msgid ""
+"```text\n"
+"end,len,route\n"
+"http://example.org/b,1,http://example.org/b\n"
+"http://example.org/c,2,http://example.org/b->http://example.org/c\n"
+"http://example.org/d,3,http://example.org/b->http://example.org/c->http://"
+"example.org/d\n"
+"```"
+msgstr ""
+
+#: src/sparql/querying.md:1715
+msgid ""
+"Swap `?node` for `?edge` and the same grouping reconstructs the STATEMENT "
+"sequence, which is where an aggregate over a walk belongs: a `SUM` of a per-"
+"hop weight joined in through `?edge`, a `MIN` of a per-hop confidence, a "
+"`HAVING` that keeps only routes whose every hop is annotated. None of that "
+"is reachable from a relation that returned endpoints, and none of it needed "
+"a list term."
+msgstr ""
+
+#: src/sparql/querying.md:1721
+msgid "The same registration from Python:"
+msgstr ""
+
+#: src/sparql/querying.md:1725
+msgid "\"SELECT ?end ?len ?step ?node WHERE { <http://example.org/a> \""
+msgstr ""
+
+#: src/sparql/querying.md:1726
+msgid ""
+"\"<http://example.org/pf#walk> ( ?end ?pathId ?len ?step ?node ?edge ) } \""
+msgstr ""
+
+#: src/sparql/querying.md:1727
+msgid "\"ORDER BY ?len ?step\""
+msgstr ""
+
+#: src/sparql/querying.md:1729
+msgid "\"http://example.org/pf#walk\""
+msgstr ""
+
+#: src/sparql/querying.md:1730
+msgid "\"http://example.org/p\""
+msgstr ""
+
+#: src/sparql/querying.md:1730
+msgid "\"forward\""
+msgstr ""
+
+#: src/sparql/querying.md:1731
+msgid "\"walk\""
+msgstr ""
+
+#: src/sparql/querying.md:1737
+msgid "Under an entailment regime, the walk reads the closure"
+msgstr ""
+
+#: src/sparql/querying.md:1739
+msgid ""
+"A path relation is a snapshot of the step's edges, and the dataset it must "
+"be snapshotted from is the one the query is _answered over_. Under `--"
+"entailment` (or Python's `query_entailment_governed`) that is the "
+"**closure**, not the source graph — so a regime that derives a quad under "
+"the step's predicate widens the walk exactly as it widens a `p+` written "
+"beside it. Over"
+msgstr ""
+
+#: src/sparql/querying.md:1751
+msgid ""
+"`SELECT ?end WHERE { ex:a ex:p+ ?end }` under `rdfs` answers `ex:b, ex:c`, "
+"and the registered walk seeded at `ex:a` reaches `ex:c` too. Without the "
+"regime both stop at `ex:b`, because the derived `ex:b ex:p ex:c` does not "
+"exist to be walked."
+msgstr ""
+
+#: src/sparql/querying.md:1755
+msgid ""
+"One pairing is refused rather than answered: `--entailment owl-direct` on an "
+"ontology whose restricted chase mints existential witnesses. Those witnesses "
+"are blank nodes that are not terms of the scoping graph, and the regime's "
+"witness filtration cannot reach a property function's output — so a walk "
+"over that closure could hand one back as a binding. The refusal carries the "
+"code `reasoning-closure-relation-witness` and names the regimes that do "
+"accept the pairing. An `owl-direct` run that mints no witness — a TBox "
+"outside the combined approach's Horn fragment, or one whose chase fires no "
+"existential rule — is not refused."
+msgstr ""
+
+#: src/sparql/querying.md:1764
+msgid ""
+"The Rust surface spells the same thing explicitly: `query_with_entailment` "
+"and `query_with_entailment_governed` take a `ClosureRelations` argument, "
+"which is either `ClosureRelations::NONE` (every registered relation is "
+"dataset-independent, so the caller's registry is used unchanged) or "
+"`ClosureRelations::rebuilt_by(&f)`, where `f` is handed the materialized "
+"closure and returns the registry to answer with."
+msgstr ""
+
+#: src/sparql/querying.md:1770
+msgid "Reaching extensions from other hosts"
+msgstr ""
+
+#: src/sparql/querying.md:1772
+msgid ""
+"The SHACL-AF function registry and the GENERAL custom-aggregate registry are "
+"**Rust-closure seams**: a registered function or aggregate is arbitrary host "
+"Rust (`init`/`step`/`combine`/`finish` closures for an aggregate), so "
+"registering one is a Rust-host-only operation. It genuinely cannot cross a "
+"Python, WebAssembly, or C boundary as a string or any other FFI-shaped value "
+"— there is no callback protocol this project is willing to invent for it, "
+"and none of the four host surfaces below expose it."
+msgstr ""
+
+#: src/sparql/querying.md:1780
+msgid ""
+"The property-function registry is a closure seam in the same sense — a "
+"`PropertyFunction` is an arbitrary host implementation — but its DATA-SHAPED "
+"members are not, and those do cross. A frozen table of terms, a table read "
+"out of the store's own dataset as an `rdf:List` of `rdf:List`s, and a path-"
+"witness traversal are each fully described by owned data, so each is "
+"registrable from Python (`relations`, `relations_from_graph`, "
+"`path_relations` on every `Store` / `MutableDataset` query and update entry) "
+"and a path relation is registrable from the CLI (`purrdf query --path-"
+"relation`, `purrdf update --path-relation`). None of them is a callback: "
+"nothing the engine invokes while the GIL is released can re-enter the "
+"interpreter, which is exactly why they are the members that cross. The "
+"WebAssembly and C-ABI surfaces expose no property-function registration at "
+"all."
+msgstr ""
+
+#: src/sparql/querying.md:1793
+msgid ""
+"PurRDF's first-party **statistical set** is different, precisely because it "
+"is NOT an arbitrary closure: "
+"`AggregateRegistry::register_statistical_aggregates` takes only a namespace "
+"**string** and wires ten pre-built Rust instances internally, so it crosses "
+"every host boundary this crate ships exactly the way "
+"`property_fn_namespaces` does — no callback, no per-aggregate marshaling. "
+"Every host surface threads it through as a keyword argument / flag / "
+"parameter named `aggregate_namespace` (`aggregateNamespace` in camelCase-"
+"spelled JavaScript), mirroring however that surface already threads "
+"`property_fn_namespaces` or the nearest equivalent optional-string "
+"configuration:"
+msgstr ""
+
+#: src/sparql/querying.md:1803
+msgid ""
+"**Rust** (embedding the engine directly): `QueryOptions.aggregates`, as "
+"shown throughout this page."
+msgstr ""
+
+#: src/sparql/querying.md:1805
+msgid ""
+"**Python** (`purrdf.Store` / `purrdf.MutableDataset`): the "
+"`aggregate_namespace` keyword on `query` / `query_governed` / `update` / "
+"`update_governed`."
+msgstr ""
+
+#: src/sparql/querying.md:1811
+msgid "\"PREFIX ex: <https://ex.example/> \""
+msgstr ""
+
+#: src/sparql/querying.md:1812
+msgid "\"SELECT (AGG(<https://ex.example/agg#MEDIAN>, ?v) AS ?m) \""
+msgstr ""
+
+#: src/sparql/querying.md:1813
+msgid "\"WHERE { ?s ex:value ?v }\""
+msgstr ""
+
+#: src/sparql/querying.md:1814 src/sparql/querying.md:1831
+#: src/sparql/querying.md:1841
+msgid "\"https://ex.example/agg#\""
+msgstr ""
+
+#: src/sparql/querying.md:1818
+msgid ""
+"**CLI** (`purrdf query` / `purrdf update`): the `--aggregate-namespace IRI` "
+"flag."
+msgstr ""
+
+#: src/sparql/querying.md:1822
+msgid "'https://ex.example/agg#'"
+msgstr ""
+
+#: src/sparql/querying.md:1823
+msgid ""
+"'SELECT (AGG(<https://ex.example/agg#MEDIAN>, ?v) AS ?m) WHERE { ?s ?p ?v }'"
+msgstr ""
+
+#: src/sparql/querying.md:1826
+msgid ""
+"**WebAssembly** (`QueryEngine.queryGoverned` / `updateGoverned`): the "
+"`aggregateNamespace` option, alongside the other governed-call options."
+msgstr ""
+
+#: src/sparql/querying.md:1835
+msgid ""
+"**C ABI** (`purrdf_query_governed` / `purrdf_update_governed`): a nullable "
+"`const char *aggregate_namespace` parameter, the same optional-C-string "
+"convention every other nullable string on this ABI uses."
+msgstr ""
+
+#: src/sparql/querying.md:1840
+msgid "/* base_iri */"
+msgstr ""
+
+#: src/sparql/querying.md:1841
+msgid "/* … */"
+msgstr ""
+
+#: src/sparql/querying.md:1844
+msgid ""
+"`namespace` stays caller-supplied configuration with no fabricated default "
+"on every one of these surfaces: omitting it (`None` / not passing the flag / "
+"`undefined` / a null pointer) leaves every one of the ten names an ordinary "
+"unregistered custom-aggregate IRI, refused exactly as before this parameter "
+"existed."
+msgstr ""
+
+#: src/sparql/querying.md:1850
+msgid ""
+"The **entailment-aware query lane** (`query_with_entailment`/ "
+"`query_with_entailment_governed`, and every Python/CLI/WebAssembly/C wrapper "
+"around the governed entry point) combines with `aggregate_namespace` exactly "
+"as the raw-view lane does: both take the engine's `QueryOptions`, threaded "
+"through the closure query's parse and its evaluation, so `AGG(<{NS}MEDIAN>, "
+"…)` resolves over an entailed closure the same way it resolves over a raw "
+"view."
+msgstr ""
+
+#: src/sparql/querying.md:1864
+msgid ""
+"`purrdf.Store.query_entailment_governed(..., aggregate_namespace=NS)` "
+"answers the same query the same way, and the WebAssembly and C-ABI governed "
+"entailment entry points take the same parameter."
+msgstr ""
+
+#: src/sparql/querying.md:1868
+msgid ""
+"One structural limit applies everywhere the statistical set is reachable: "
+"SPARQL UPDATE's grammar admits an aggregate only inside a nested `SELECT … "
+"GROUP BY` in a `WHERE` clause (an ordinary `DELETE`/`INSERT WHERE` basic "
+"graph pattern has no `GROUP BY` of its own) — every host's `update` entry "
+"reaches the statistical set through exactly that nested-subquery shape."
+msgstr ""
+
+#: src/sparql/querying.md:1875
+msgid "Entailment regimes"
+msgstr ""
+
+#: src/sparql/querying.md:1877
+msgid ""
+"SPARQL queries can be answered under an entailment regime by materializing "
+"the dataset first with [`purrdf-entail`](../entailment.md) — "
+"`Regime::from_iri` maps a `sparql:entailmentRegime` IRI to the matching "
+"engine."
+msgstr ""
+
+#: src/sparql/querying.md:1883
+msgid ""
+"The full W3C SPARQL 1.1 query + update evaluation suites plus the SPARQL 1.2 "
+"suite are vendored verbatim and run by `purrdf-sparql-conformance`; every "
+"non-pass is a typed, ledgered expected-failure. See [Conformance & Testing]"
+"(../project/conformance.md) and [`docs/CONFORMANCE.md`](https://github.com/"
+"Blackcat-Informatics/purrdf/blob/main/docs/CONFORMANCE.md) for the live "
+"matrix."
+msgstr ""
+
+#: src/sparql/results.md:6
+msgid "SPARQL: Result Formats"
+msgstr ""
+
+#: src/sparql/results.md:8
+msgid ""
+"[`purrdf-sparql-results`](https://docs.rs/purrdf-sparql-results) is the "
+"results boundary of the SPARQL stack: the canonical authority for turning a "
+"`SparqlResult` (SELECT solutions, ASK boolean, or CONSTRUCT graph) into the "
+"four W3C SPARQL Results formats — JSON (SRJ), XML, CSV, and TSV — plus an "
+"additive, caller-named provenance extension where the format can carry one. "
+"JSON and XML documents can also be read back (`from_json`, `from_xml`)."
+msgstr ""
+
+#: src/sparql/results.md:17
+msgid ""
+"// `result` is the SparqlResult produced by purrdf-sparql-eval (or any "
+"engine\n"
+"// implementing the purrdf-core SparqlEngine seam). `None` here means "
+"\"carry\n"
+"// no provenance extension\" — see \"The provenance extension\" below.\n"
+msgstr ""
+
+#: src/sparql/results.md:22
+msgid "\"SELECT serializes to SRJ\""
+msgstr ""
+
+#: src/sparql/results.md:28
+msgid ""
+"Per-format writers (`to_json`, `to_xml`, `to_csv`, `to_tsv`) and readers "
+"(`from_json`, `from_json_boolean`, `from_xml`, `from_xml_boolean`) are also "
+"exported directly."
+msgstr ""
+
+#: src/sparql/results.md:32
+msgid "Behavior worth knowing before you pick a format"
+msgstr ""
+
+#: src/sparql/results.md:34
+msgid ""
+"**Byte-deterministic output** — the same result always serializes to the "
+"same bytes, like every other PurRDF output path ([Codecs & Determinism](../"
+"concepts/codecs.md))."
+msgstr ""
+
+#: src/sparql/results.md:37
+msgid ""
+"**The support matrix is enforced, not fudged** — XML rejects CONSTRUCT "
+"graphs, and CSV/TSV reject both ASK booleans and CONSTRUCT graphs, each as a "
+"typed `Error::Format`, rather than emitting something spec-shaped but wrong."
+msgstr ""
+
+#: src/sparql/results.md:41
+msgid ""
+"**Lossy projections are flagged** — CSV/TSV have no extension point, so a "
+"populated provenance is trimmed at the exit gate and "
+"`SerializeOutcome::provenance_dropped` is set; the drop is never silent. The "
+"same flag is set for JSON/XML when a non-empty `ResultProvenance` is "
+"supplied with no `ProvenanceNamespace` to anchor it under — see below."
+msgstr ""
+
+#: src/sparql/results.md:46
+msgid ""
+"**RDF 1.2 base direction uses the spec's own key** — a directional literal's "
+"base direction serializes as `its:dir` (JSON: an additive `\"its:dir\"` "
+"member beside `\"value\"`/`\"xml:lang\"`; XML: `<literal its:dir=\"…\">`), "
+"the same spelling the SPARQL 1.2 Query Results specification's own example "
+"uses and the RDF/XML codec already emits. The XML/JSON readers also accept "
+"two legacy spellings this crate's own writer previously produced (a bare "
+"`dir` attribute, and — XML only — a `purrdf:dir`\\-namespaced one) for "
+"backward compatibility, but `its:dir` wins when more than one is present on "
+"the same literal, and only `its:dir` is ever written."
+msgstr ""
+
+#: src/sparql/results.md:56
+msgid "SELECT"
+msgstr ""
+
+#: src/sparql/results.md:56
+msgid "ASK"
+msgstr ""
+
+#: src/sparql/results.md:56
+msgid "CONSTRUCT"
+msgstr ""
+
+#: src/sparql/results.md:56
+msgid "Provenance extension"
+msgstr ""
+
+#: src/sparql/results.md:58
+msgid "JSON (SRJ)"
+msgstr ""
+
+#: src/sparql/results.md:58 src/sparql/results.md:59
+msgid "yes, with a namespace"
+msgstr ""
+
+#: src/sparql/results.md:59
+msgid "XML"
+msgstr ""
+
+#: src/sparql/results.md:59 src/sparql/results.md:60 src/sparql/results.md:61
+msgid "rejected"
+msgstr ""
+
+#: src/sparql/results.md:60
+msgid "CSV"
+msgstr ""
+
+#: src/sparql/results.md:60 src/sparql/results.md:61
+msgid "dropped, flagged"
+msgstr ""
+
+#: src/sparql/results.md:61
+msgid "TSV"
+msgstr ""
+
+#: src/sparql/results.md:63
+msgid "The provenance extension"
+msgstr ""
+
+#: src/sparql/results.md:65
+msgid ""
+"The provenance extension is **additive** and **caller-named**: a standard "
+"SPARQL results consumer can read the JSON/XML documents unchanged, while a "
+"provenance-aware consumer can recover per-result data carried alongside the "
+"bindings, anchored under an identifier the _caller_ supplies — never a "
+"purrdf-minted one (PurRDF mints no vocabulary IRIs of its own; see "
+"[AGENTS.md](https://github.com/Blackcat-Informatics/purrdf/blob/main/"
+"AGENTS.md)'s \"NOT an ontology\" contract). Supply a `ProvenanceNamespace` — "
+"a `prefix` (the bare top-level JSON member key, and the XML namespace "
+"prefix) plus the XML namespace `iri` — as `serialize`'s fourth argument "
+"(`to_json`/`to_xml` take it as their third: those two have no `format` "
+"parameter to pick). `ProvenanceNamespace::new` validates `prefix` as an XML "
+"Namespaces `NCName` (rejecting, among other things, `:`, whitespace, and the "
+"reserved `xml`/ `xmlns` names) and `iri` as an absolute IRI, since `prefix` "
+"is spliced directly into XML element/attribute names and cannot be escaped "
+"the way text content can:"
+msgstr ""
+
+#: src/sparql/results.md:84
+msgid "\"prov\""
+msgstr ""
+
+#: src/sparql/results.md:84
+msgid "\"https://example.org/provenance#\""
+msgstr ""
+
+#: src/sparql/results.md:85
+msgid "\"valid NCName prefix + absolute IRI\""
+msgstr ""
+
+#: src/sparql/results.md:86
+msgid "// or a populated one\n"
+msgstr ""
+
+#: src/sparql/results.md:90
+msgid ""
+"With `namespace: None`, JSON/XML emit no provenance element/member at all, "
+"however populated a `ResultProvenance` is — the same drop-and-flag contract "
+"CSV/TSV always used. Where the format has no extension point at all (CSV/"
+"TSV), the provenance is dropped loudly regardless of `namespace`, per the "
+"loss discipline described in [Slices, Mappings & Provenance](../slices.md)."
+msgstr ""
+
+#: src/sparql/results.md:96
+msgid "One term-syntax authority"
+msgstr ""
+
+#: src/sparql/results.md:98
+msgid ""
+"The crate depends only on `purrdf-core` and stays wasm-clean; term and N-"
+"Triples syntax come exclusively from the kernel's emit primitives, so there "
+"is exactly one term-syntax authority in the workspace — results, codecs, and "
+"diagnostics can never disagree about how a term is written."
+msgstr ""
+
+#: src/sparql/results.md:105
+msgid ""
+"[SPARQL: Querying](querying.md) — producing the `SparqlResult` in the first "
+"place."
+msgstr ""
+
+#: src/sparql/results.md:107
+msgid ""
+"[docs.rs/purrdf-sparql-results](https://docs.rs/purrdf-sparql-results) — the "
+"full API reference."
+msgstr ""
+
+#: src/sparql/full-text.md:8
+msgid ""
+"`purrdf-text` (`purrdf::text` from the umbrella crate) is PurRDF's "
+"deterministic full-text index. It reads RDF 1.2 literals out of a frozen "
+"dataset, tokenizes them by the Unicode standard's own rules, and answers "
+"ranked retrieval queries with BM25 scores — from SPARQL, through the "
+"evaluator's property-function seam, under IRIs the caller supplies."
+msgstr ""
+
+#: src/sparql/full-text.md:14
+msgid ""
+"It is an **out-of-core sibling crate**, not a kernel change: nothing in "
+"`purrdf-core`, `purrdf-sparql-algebra` or the property-function seam itself "
+"was altered to admit it. That is the shape every extension in this chapter "
+"takes."
+msgstr ""
+
+#: src/sparql/full-text.md:18
+msgid "Two relations, one index"
+msgstr ""
+
+#: src/sparql/full-text.md:20
+msgid ""
+"An index is built once over a dataset and shared by two property functions, "
+"which are two distinct types rather than one type with a mode switch:"
+msgstr ""
+
+#: src/sparql/full-text.md:23
+msgid ""
+"```text\n"
+"?doc <caller-iri>  ( \"needle\" ?score ?rank ?lang ?matched )   # ranked "
+"retrieval\n"
+"?doc <caller-iri2> ( \"term\"   ?lang  ?position )              # one row "
+"per occurrence\n"
+"```"
+msgstr ""
+
+#: src/sparql/full-text.md:28
+msgid ""
+"**Ranked retrieval** (`TextSearchRelation`) emits one row per matching "
+"document. `?score` is an `xsd:decimal` carrying the exact BM25 value, `?"
+"rank` is the document's 1-based position **within its `(graph, language)` "
+"partition**, `?lang` is the partition's language tag, and `?matched` counts "
+"how many distinct needle terms the document holds."
+msgstr ""
+
+#: src/sparql/full-text.md:33
+msgid ""
+"**Term occurrence** (`TermOccurrenceRelation`) emits one row per occurrence "
+"of a single term, with its token `?position`."
+msgstr ""
+
+#: src/sparql/full-text.md:36
+msgid ""
+"Phrase and proximity search are delivered by composition in SPARQL rather "
+"than by an embedded query dialect — an embedded syntax would have minted one "
+"more incompatible vendor language, which is exactly what a carrier must not "
+"do:"
+msgstr ""
+
+#: src/sparql/full-text.md:40
+msgid ""
+"```sparql\n"
+"# \"quick\" immediately followed by \"brown\"\n"
+"SELECT ?doc WHERE {\n"
+"  ?doc <https://example.org/pf/occurs> ( \"quick\" ?l ?p1 ) .\n"
+"  ?doc <https://example.org/pf/occurs> ( \"brown\" ?l ?p2 ) .\n"
+"  FILTER(?p2 = ?p1 + 1)\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/full-text.md:49
+msgid ""
+"`FILTER(ABS(?p2 - ?p1) <= 3)` is proximity; `FILTER(?matched = 2)` on the "
+"ranked relation is conjunctive retrieval."
+msgstr ""
+
+#: src/sparql/full-text.md:52
+msgid "Wiring it from Rust"
+msgstr ""
+
+#: src/sparql/full-text.md:54
+msgid ""
+"The index takes the predicates whose literals it should read and a graph "
+"selector — `GraphSelector::Any`, `Default`, or `Named(iri)` — and PurRDF "
+"supplies no default for either. A configuration naming no predicate is a "
+"typed `TextError::Config`, not a guess."
+msgstr ""
+
+#: src/sparql/full-text.md:66
+msgid "// Which literals to index: the caller names the predicates.\n"
+msgstr ""
+
+#: src/sparql/full-text.md:69
+msgid "\"https://example.org/note\""
+msgstr ""
+
+#: src/sparql/full-text.md:73
+msgid "// Which IRIs a query calls the index by: the caller names those too.\n"
+msgstr ""
+
+#: src/sparql/full-text.md:77
+msgid "\"https://example.org/pf/search\""
+msgstr ""
+
+#: src/sparql/full-text.md:81
+msgid "\"https://example.org/pf/occurs\""
+msgstr ""
+
+#: src/sparql/full-text.md:88
+msgid ""
+"r#\"SELECT ?doc ?score ?rank WHERE {\n"
+"                    ?doc <https://example.org/pf/search> ( \"quick brown\" ?"
+"score ?rank ?lang ?matched )\n"
+"                  } LIMIT 3\"#"
+msgstr ""
+
+#: src/sparql/full-text.md:98
+msgid ""
+"A registered IRI is recognized in predicate position exactly, so no parser "
+"option is needed to reach it. An IRI a query names that is declared through "
+"`ParserOptions` but not registered hard-fails naming the IRI; an IRI in "
+"neither stays an ordinary triple pattern."
+msgstr ""
+
+#: src/sparql/full-text.md:103
+msgid ""
+"This is a Rust-host seam. The index and its relations are host closures, so "
+"they do not cross the Python, WebAssembly or C boundary — only the data-"
+"shaped property functions (frozen tables, graph-backed tables and path "
+"witnesses) do. See [Reaching extensions from other hosts]"
+"(querying.md#reaching-extensions-from-other-hosts)."
+msgstr ""
+
+#: src/sparql/full-text.md:108
+msgid "Every score is exact, and identical on every target"
+msgstr ""
+
+#: src/sparql/full-text.md:110
+msgid ""
+"Ranking is done entirely in base-10 fixed-point integer arithmetic (`i128`, "
+"twelve fractional digits). No floating-point value enters the crate: its "
+"root denies `clippy::float_arithmetic`, so none can."
+msgstr ""
+
+#: src/sparql/full-text.md:114
+msgid ""
+"That is a correctness requirement, not a preference. BM25 needs a natural "
+"logarithm, and a libm `ln` may differ by a unit in the last place between "
+"implementations — enough to reverse the order of two near-tied documents, so "
+"the same query over the same data would return rows in one order from a "
+"native build and another from a `wasm32-unknown-unknown` build of the same "
+"engine. The logarithm here is a fixed-length integer series with a fixed "
+"iteration count, never a convergence test, so its result is a pure function "
+"of its input on every target. The ranking — row order together with every "
+"score's decimal lexical — is pinned by a single test body carrying both "
+"`#[test]` and `#[wasm_bindgen_test]`, so `make wasm-test` executes it on "
+"wasm32 against the same expectations `cargo test` asserts natively."
+msgstr ""
+
+#: src/sparql/full-text.md:126
+msgid ""
+"The BM25 constants `k1 = 1.2` and `b = 0.75` are crate constants rather than "
+"caller parameters. PurRDF is a carrier, and optionality that changes "
+"semantics per consumer is forbidden: two callers must not get different "
+"ranks out of the same index and the same needle."
+msgstr ""
+
+#: src/sparql/full-text.md:131
+msgid "Ordering, and the idioms that reproduce it"
+msgstr ""
+
+#: src/sparql/full-text.md:133
+msgid ""
+"Corpus statistics are computed per `(graph, language)` partition, so a score "
+"is a number relative to one corpus and `?rank` is a position within that "
+"partition, never a global one. Rows are emitted in `(partition key ASC, rank "
+"ASC)` order; within a partition the order is `(score DESC, document id "
+"ASC)`, and document ids are assigned after sorting on `(graph, subject, "
+"language)`, so the tie-break is reproducible across independently built "
+"indexes. A query that wants one ranked list binds `?lang` (and `?graph` "
+"through the selector) or builds a single-partition index."
+msgstr ""
+
+#: src/sparql/full-text.md:142
+msgid "Two consequences worth knowing:"
+msgstr ""
+
+#: src/sparql/full-text.md:144
+msgid ""
+"**Bare `LIMIT k` is top-k.** Emission order _is_ rank order, so the "
+"evaluator's row-ceiling licence applies and the relation stops after `k` "
+"rows. `ORDER BY DESC(?score) LIMIT k` is not pushed down — `ORDER BY` plus "
+"`LIMIT` has no certified lower bound the governor can license — and the "
+"`ORDER BY` is redundant anyway."
+msgstr ""
+
+#: src/sparql/full-text.md:149
+msgid ""
+"**`ORDER BY ?rank` is the reproducing idiom.** A score reaches the consumer "
+"as a decimal of fixed width, so two rows can report the same `?score` while "
+"carrying different `?rank`; `ORDER BY DESC(?score)` can therefore disagree "
+"with the exact internal order, and `?rank` cannot."
+msgstr ""
+
+#: src/sparql/full-text.md:154
+msgid "RDF 1.2 first class"
+msgstr ""
+
+#: src/sparql/full-text.md:156
+msgid ""
+"`RdfDataset::quads()` returns only the asserted triple table; annotations "
+"live in a separate side table. The index reads both layers, so text carried "
+"only by `:s :p :o {| :note \"...\" |}` is searchable, with the reifier as "
+"the document subject. An index reading only the asserted layer would index "
+"zero annotation literals and report nothing — the crate's tests guard "
+"against exactly that."
+msgstr ""
+
+#: src/sparql/full-text.md:162
+msgid "Stated limits"
+msgstr ""
+
+#: src/sparql/full-text.md:164
+msgid ""
+"Document ids are a function of content _except_ through blank-node labels, "
+"which are a parsing artifact: two isomorphic datasets with different labels "
+"produce different index fingerprints."
+msgstr ""
+
+#: src/sparql/full-text.md:167
+msgid ""
+"The index is in-memory and built over a frozen dataset. `verify_binding` "
+"checks that the index a query runs against was built over the dataset in "
+"front of it, closing the silent channel where a stale index emits documents "
+"that join back to zero rows."
+msgstr ""
+
+#: src/sparql/full-text.md:172
+msgid ""
+"The scoring design record — including the fixed-point logarithm and the "
+"Unicode table versions folded into the index fingerprint — is [`docs/design/"
+"purrdf-text-scoring.md`](https://github.com/Blackcat-Informatics/purrdf/blob/"
+"main/docs/design/purrdf-text-scoring.md)."
+msgstr ""
+
+#: src/sparql/geosparql.md:8
+msgid ""
+"`purrdf-geo` (`purrdf::geo` from the umbrella crate) implements GeoSPARQL "
+"1.1 (OGC 22-047r1) for PurRDF: exact, float-free geometry reached from "
+"SPARQL through the evaluator's two existing extension seams. It parses "
+"`geo:wktLiteral` and `geo:geoJSONLiteral` lexical forms into an exact "
+"geometry model, decides the OGC topological relations over that model, "
+"computes the non-topological accessors, measures and constructors, and hands "
+"the `geof:` family to a host as scalar-function registrations and the "
+"spatial relations as property-function registrations. There is no GEOS and "
+"no PROJ behind it — the DE-9IM engine, WKT and GeoJSON are implemented in-"
+"crate, in pure Rust, which is what lets it build for `wasm32-unknown-"
+"unknown`."
+msgstr ""
+
+#: src/sparql/geosparql.md:19
+msgid "It mints no vocabulary"
+msgstr ""
+
+#: src/sparql/geosparql.md:21
+msgid ""
+"GeoSPARQL's IRIs are OGC's, not PurRDF's. Every IRI the crate reads or "
+"writes — the two literal datatypes, the `geof:` function names, the `geo:` "
+"spatial relations, the Simple Features geometry classes, and the coordinate "
+"reference system a WKT literal omits — is supplied by the caller through "
+"`GeoVocab`, which has no `Default` and never will. A term that is absent "
+"makes the feature that needs it a hard error, never a fabricated fallback."
+msgstr ""
+
+#: src/sparql/geosparql.md:31
+msgid "\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\""
+msgstr ""
+
+#: src/sparql/geosparql.md:33
+msgid "\"http://www.opengis.net/ont/geosparql#\""
+msgstr ""
+
+#: src/sparql/geosparql.md:33
+msgid ""
+"// geo:\n"
+"    \"http://www.opengis.net/def/function/geosparql/\""
+msgstr ""
+
+#: src/sparql/geosparql.md:34
+msgid "// geof:\n"
+msgstr ""
+
+#: src/sparql/geosparql.md:35
+msgid "// the CRS a bare WKT literal means\n"
+msgstr ""
+
+#: src/sparql/geosparql.md:36
+msgid "// the CRS GeoJSON is in\n"
+msgstr ""
+
+#: src/sparql/geosparql.md:38 src/sparql/geosparql.md:39
+msgid "\"http://www.opengis.net/def/uom/OGC/1.0/metre\""
+msgstr ""
+
+#: src/sparql/geosparql.md:40
+msgid "\"http://www.opengis.net/ont/sf#\""
+msgstr ""
+
+#: src/sparql/geosparql.md:44
+msgid "The `geof:` family on the scalar seam"
+msgstr ""
+
+#: src/sparql/geosparql.md:46
+msgid ""
+"`functions::register` installs every `geof:` function into a "
+"`UserFunctionRegistry` under the vocabulary's function namespace, and the "
+"registry is handed to the engine through `QueryOptions::functions`:"
+msgstr ""
+
+#: src/sparql/geosparql.md:61
+msgid ""
+"r#\"PREFIX geof: <http://www.opengis.net/def/function/geosparql/>\n"
+"                  PREFIX geo:  <http://www.opengis.net/ont/geosparql#>\n"
+"                  SELECT ?a ?b WHERE {\n"
+"                    ?fa geo:hasGeometry/geo:asWKT ?a .\n"
+"                    ?fb geo:hasGeometry/geo:asWKT ?b .\n"
+"                    FILTER(geof:sfWithin(?a, ?b))\n"
+"                  }\"#"
+msgstr ""
+
+#: src/sparql/geosparql.md:75
+msgid ""
+"A function's refusals travel exactly as far as SPARQL says they should. A "
+"malformed literal or a domain refusal — mixed CRSs, the measure of an empty "
+"geometry, an out-of-range index — is a per-solution **expression error**: "
+"the row is eliminated under `FILTER`, and the variable is left unbound under "
+"`BIND`/`SELECT`, while the query continues. An unimplemented function, an "
+"undeclared vocabulary term or a wrong argument count holds for every "
+"solution alike and stays query-fatal, because answering \"no value\" there "
+"would empty a result set and present that as the answer. A caller that needs "
+"the refusal itself, with its message and kind intact, calls "
+"`functions::compute`."
+msgstr ""
+
+#: src/sparql/geosparql.md:85
+msgid "Spatial relations on the property-function seam"
+msgstr ""
+
+#: src/sparql/geosparql.md:87
+msgid ""
+"GeoSPARQL's Query Rewrite rules let `?a geo:sfWithin ?b` hold between "
+"_features_ whose geometries satisfy the relation, not only where a triple "
+"asserts it. `GeoIndex::from_dataset` projects a dataset's geometry literals "
+"once, and `relation::register` installs one property function per relation "
+"of the families the caller names — Simple Features, Egenhofer, RCC8 — "
+"against a `PropertyFunctionRegistry`. An empty family list is refused: "
+"registering nothing and returning success would surface much later as a "
+"query whose `geo:sfWithin` was parsed as an ordinary triple pattern and "
+"matched nothing."
+msgstr ""
+
+#: src/sparql/geosparql.md:111
+msgid ""
+"// The parser must claim `geo:sfWithin` in predicate position; the "
+"registry's\n"
+"// own descriptors are exactly the IRIs it should claim.\n"
+msgstr ""
+
+#: src/sparql/geosparql.md:121
+msgid ""
+"An asserted `geo:sfWithin` triple matches whether or not the geometries "
+"satisfy it — the rewrite rules are entailments, not definitions — and a "
+"relation the index refutes contributes no row beyond what the data asserts."
+msgstr ""
+
+#: src/sparql/geosparql.md:125
+msgid "Every answer is exact, and identical on every target"
+msgstr ""
+
+#: src/sparql/geosparql.md:127
+msgid ""
+"Geometry is where floating point normally destroys reproducibility: `f64` "
+"addition is not associative, so a different traversal order gives a "
+"different answer, and a native build and a wasm32 build can disagree about a "
+"predicate that sits near a boundary. This crate closes that channel rather "
+"than mitigating it."
+msgstr ""
+
+#: src/sparql/geosparql.md:133
+msgid ""
+"**Coordinates are read as exact rationals.** A lexical decimal is parsed "
+"digit by digit into an exact numerator and denominator; nothing is rounded "
+"on the way in."
+msgstr ""
+
+#: src/sparql/geosparql.md:136
+msgid ""
+"**Every geometric decision is integer arithmetic.** Orientation, segment "
+"intersection, point-in-ring, ring winding and the DE-9IM matrix are "
+"comparisons of exact rationals over arbitrary-precision integers, which Rust "
+"specifies completely and identically on every target."
+msgstr ""
+
+#: src/sparql/geosparql.md:140
+msgid ""
+"**Irrational measures are integer square roots** at a fixed internal scale, "
+"summed as integers — one rounding, at the end, of a value that was exact "
+"until then."
+msgstr ""
+
+#: src/sparql/geosparql.md:143
+msgid ""
+"**The single float boundary is the result literal.** An `xsd:double` result "
+"is the correctly rounded nearest double, computed with integer arithmetic "
+"and assembled with `f64::from_bits`. The crate root denies "
+"`clippy::float_arithmetic`, so there is no second float path to find."
+msgstr ""
+
+#: src/sparql/geosparql.md:148
+msgid ""
+"The cross-target claim is executed, not argued: `make geo-determinism` runs "
+"the same corpus natively and on wasm32 and compares bytes."
+msgstr ""
+
+#: src/sparql/geosparql.md:151
+msgid "What is here, and what is not"
+msgstr ""
+
+#: src/sparql/geosparql.md:153
+msgid ""
+"Implemented: the WKT and GeoJSON codecs (with CRS and coordinate-dimension "
+"support); every topological relation of the Simple Features, Egenhofer and "
+"RCC8 families over an exact DE-9IM; the accessors; and the measures and "
+"constructors that are exactly computable."
+msgstr ""
+
+#: src/sparql/geosparql.md:158
+msgid ""
+"Registered but **hard-erroring by name**: the operations that would require "
+"facilities the crate deliberately does not have — a coordinate-reference-"
+"system database for `geof:transform`, and an ellipsoidal geodesic for the "
+"`metric*` family. They are never silently absent and never answer a default. "
+"A topological predicate that returned `false` because it was unimplemented "
+"would be indistinguishable from one that returned `false` because the "
+"geometries genuinely do not relate, and that is the failure this crate "
+"exists to keep out."
+msgstr ""
+
+#: src/sparql/geosparql.md:166
+msgid ""
+"Like the full-text index, this is a Rust-host seam: the registrations are "
+"host closures and do not cross the Python, WebAssembly or C boundary. The "
+"full exactness accounting is [`docs/design/purrdf-geo-exactness.md`](https://"
+"github.com/Blackcat-Informatics/purrdf/blob/main/docs/design/purrdf-geo-"
+"exactness.md)."
+msgstr ""
+
+#: src/sparql/embedding-knn.md:8
+msgid ""
+"The PURREMB layer in `purrdf-core` (see [Deterministic embedding companions]"
+"(../concepts/codecs.md#deterministic-embedding-companions) and [`docs/"
+"PURREMB.md`](https://github.com/Blackcat-Informatics/purrdf/blob/main/docs/"
+"PURREMB.md)) stores RDF-1.2-addressable vectors, a declared distance metric, "
+"and tamper-evident guards binding third-party index payloads to the exact "
+"matrix they were built over. It deliberately does not rank anything — "
+"ranking is a query operation and PURREMB is an artifact format. The `knn` "
+"module of `purrdf-sparql-eval` is that query operation, exposed through the "
+"property-function seam."
+msgstr ""
+
+#: src/sparql/embedding-knn.md:18
+msgid "The call shape"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:20
+msgid ""
+"```sparql\n"
+"PREFIX knn: <https://example.org/space/>\n"
+"PREFIX d:   <https://example.org/d/>\n"
+"\n"
+"SELECT ?neighbour ?distance WHERE {\n"
+"  ?neighbour knn:points ( d:a 3 ?distance )\n"
+"}\n"
+"```"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:29
+msgid ""
+"Four flattened positions — one on the subject side, three on the object side:"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:31
+msgid "position"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:31
+msgid "name"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:31
+msgid "role"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:33 src/entailment.md:143 src/entailment.md:148
+#: src/entailment.md:149 src/entailment-rules.md:60 src/entailment-rules.md:64
+#: src/entailment-rules.md:65
+msgid "0"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:33
+msgid "`?neighbour`"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:33
+msgid "**out**: the RDF term whose vector was retrieved"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:34
+msgid "`?query`"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:34
+msgid "**in**: the term whose vector seeds the search"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:35
+msgid "`k`"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:35
+msgid "**in**: how many neighbours to retrieve"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:36
+msgid "`?distance`"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:36
+msgid "**out**: the distance, as `xsd:double`"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:38
+msgid ""
+"The one declared mode is `fbbf`: the seed and `k` are inputs the relation "
+"cannot enumerate, while `?neighbour` and `?distance` may each be bound or "
+"free. `k` accepts any integer-derived datatype (`xsd:integer`, `xsd:int`, "
+"`xsd:long`, `xsd:nonNegativeInteger`, …); `k = 0` is a valid request for "
+"zero neighbours. A seed with no vector in the space is an **empty answer**, "
+"not an abort — otherwise every query ranging a seed over partly-embedded "
+"terms would die."
+msgstr ""
+
+#: src/sparql/embedding-knn.md:46
+msgid "PurRDF mints no IRI for this"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:48
+msgid ""
+"The predicate is the caller's, and it is how a query names a space: a host "
+"builds one `EmbeddingSpace` per `(artifact, target set, vector space)` "
+"triple it wants queryable and registers an `EmbeddingKnnRelation` over it "
+"under whatever IRI its own vocabulary uses. There is no default IRI and no "
+"fallback space. Registering one relation per space — rather than one "
+"relation taking a space IRI as an argument — is what lets the planner read "
+"an honest row bound off the space that will actually be searched."
+msgstr ""
+
+#: src/sparql/embedding-knn.md:59
+msgid ""
+"// The guard is caller-supplied configuration with no default: the largest\n"
+"// space one invocation may scan, and the largest `k` it may request.\n"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:62
+msgid "/* max_candidates */"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:62
+msgid "/* max_neighbours */"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:63
+msgid ""
+"// `bindings` names the RDF term each PURREMB row stands for. A row with no\n"
+"// term is a construction-time refusal, not a skipped row — a top-k over a\n"
+"// silently smaller candidate set would be the top-k of a subset.\n"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:73
+msgid "\"https://example.org/space/points\""
+msgstr ""
+
+#: src/sparql/embedding-knn.md:78
+msgid ""
+"The registry then reaches the engine through "
+"`QueryOptions::property_functions` exactly as on the [full-text](full-"
+"text.md) page. This is a Rust-host seam."
+msgstr ""
+
+#: src/sparql/embedding-knn.md:81
+msgid "Exact search, ordered under the declared metric"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:83
+msgid ""
+"The search is **exact**: every candidate row is scored under the metric the "
+"space's family contract declares (`FamilyView::metric()` — cosine or squared "
+"Euclidean disagree on real data, and a surface using one kernel for both "
+"fails the tests that pin them apart), and the `k` returned are the true `k` "
+"nearest. There is no candidate pruning anywhere. That is what lets the "
+"engine's row-ceiling pushdown be sound here — emission order _is_ rank "
+"order, so the first `n` rows are the `n` nearest for every `n ≤ k` — and "
+"what makes \"ordered correctly\" a property the module is tested for rather "
+"than a property of a tuning parameter."
+msgstr ""
+
+#: src/sparql/embedding-knn.md:93
+msgid ""
+"Rank order is `(distance ASC, row ASC)`. Row numbers are distinct, so the "
+"order is strict and total, and the tie-break is meaningful: a PURREMB target "
+"set is sorted and deduplicated by `TargetId`, a digest of canonical "
+"identity, so ascending row number _is_ ascending canonical content order. "
+"Two artifacts built from the same content in opposite insertion orders "
+"answer byte for byte, serialized JSON included."
+msgstr ""
+
+#: src/sparql/embedding-knn.md:100
+msgid "Binary64, in a pinned order"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:102
+msgid ""
+"The workspace's other ranked-retrieval surface forbids floating point "
+"entirely, because BM25 needs a logarithm and IEEE-754 does not require `ln` "
+"to be correctly rounded. That reason does not transfer. A kNN kernel needs "
+"no transcendental — subtraction, multiplication, addition, division and "
+"square root are all correctly rounded — so binary64 gives the _same_ cross-"
+"target guarantee here, and it is the arithmetic `docs/PURREMB.md` states "
+"normatively (\"binary64, round-to-nearest ties-to-even, in the written "
+"order, without a fused multiply-add\"). Fixed point would have introduced a "
+"quantization step the format does not have."
+msgstr ""
+
+#: src/sparql/embedding-knn.md:112
+msgid ""
+"The two residual hazards are closed structurally: every fold runs over "
+"ascending component index in one sequential loop, never split across workers "
+"(a test folds `[1e16, -1e16, 1]`, which sums to `1` one way and `0` the "
+"other, and pins which), and every product is bound to a named local before "
+"it is added so no fused multiply-add can form. Distances are emitted as "
+"`xsd:double`, whose canonical lexical round-trips the exact bits — a rounded "
+"decimal would print two adjacent doubles alike and hide exactly the "
+"divergence this is about."
+msgstr ""
+
+#: src/sparql/embedding-knn.md:120
+msgid ""
+"One limit, stated rather than hidden: cosine self-distance is not exactly "
+"zero (`dot(v, v)` and `|v|·|v|` are two roundings of one real number), so a "
+"seed ranks strictly ahead of every other direction rather than at a zero "
+"that is not there."
+msgstr ""
+
+#: src/sparql/embedding-knn.md:125
+msgid "What a search costs"
+msgstr ""
+
+#: src/sparql/embedding-knn.md:127
+msgid ""
+"The governor's earlier charge points priced a host relation by invocations "
+"driven and rows accepted. For a generator, neither is where the cost is: a "
+"scan over a million vectors returning five rows would have been priced like "
+"a six-row table scan. The relation therefore reports its internal work "
+"through `PfCursor::take_work` after every pull, and the engine spends one "
+"unit of fuel per reported unit — so the search charge follows the space "
+"size, not the rows returned, and a `KnnGuard` is what keeps both the charge "
+"and the planner's row bound honest."
+msgstr ""
+
+#: src/sparql/embedding-knn.md:136
+msgid ""
+"The design record — the four decisions that were not obvious and what fixed "
+"each — is [`docs/design/purrdf-embedding-knn.md`](https://github.com/"
+"Blackcat-Informatics/purrdf/blob/main/docs/design/purrdf-embedding-knn.md)."
+msgstr ""
+
+#: src/validation/shacl.md:8
+msgid ""
+"[`purrdf-shapes`](https://docs.rs/purrdf-shapes) (re-exported as "
+"`purrdf::shapes`) is PurRDF's native SHACL validator: the **complete SHACL "
+"Core feature set** — all constraint components, full property paths, "
+"qualified value shapes, property pairs — plus **SHACL-SPARQL** constraints "
+"and targets and the **SHACL-AF** surface, running entirely on PurRDF's own "
+"interned IR and native SPARQL engine (no oxigraph, no PyO3)."
+msgstr ""
+
+#: src/validation/shacl.md:15
+msgid ""
+"It validates an RDF 1.2 data graph against a SHACL shapes graph with **no "
+"inference** (parity with pySHACL `inference=\"none\"`); combine with "
+"[Entailment](../entailment.md) if you want to validate a materialized "
+"closure."
+msgstr ""
+
+#: src/validation/shacl.md:19
+msgid "What it covers"
+msgstr ""
+
+#: src/validation/shacl.md:21
+msgid ""
+"**SHACL Core** — every constraint component, full property paths, qualified "
+"value shapes, property pairs. The W3C `data-shapes` suite passes clean "
+"(129/129, zero ledgered gaps at the time of writing — the live number is in "
+"[`docs/CONFORMANCE.md`](https://github.com/Blackcat-Informatics/purrdf/blob/"
+"main/docs/CONFORMANCE.md))."
+msgstr ""
+
+#: src/validation/shacl.md:25
+msgid ""
+"**SHACL-SPARQL** — SPARQL-based constraints and targets, custom constraint "
+"components with pre-binding semantics, user-defined `sh:SPARQLFunction` "
+"calls, and `sh:SPARQLTargetType`, evaluated on the native SPARQL engine."
+msgstr ""
+
+#: src/validation/shacl.md:28
+msgid ""
+"**SHACL-AF** — node expressions (including "
+"`sh:ExpressionConstraintComponent`) and **SHACL Rules** (`sh:TripleRule` and "
+"`sh:SPARQLRule`, with `sh:condition`, `sh:order`, `sh:deactivated`): rules "
+"fire in an iterative fixpoint and the derivation is materialized as a new "
+"dataset (`base ⊎ derived`), leaving the input graph untouched. The surface "
+"is aligned with the SHACL 1.2 Working Drafts: the SHACL 1.2 Node Expressions "
+"vocabulary (`shnex:`, `http://www.w3.org/ns/shacl-node-expr#`) and the older "
+"SHACL-AF spelling of a node expression parse to one representation and run "
+"through one evaluator; `sh:nodeByExpression` is validated; SPARQL-based node "
+"expressions and expression-bodied functions ride the native engine; and "
+"rules execute as `sh:order` strata with the `once`/`general` partition of "
+"the SPARQL 1.2 RL draft, each stratum materialized before the next runs, so "
+"swapping two rules' orders can change the closure. `sh:condition` resolves "
+"at shapes-load, so an unresolvable condition is a load error rather than a "
+"rule that silently never fires. Every one of those IRIs is defined by a W3C "
+"document; PurRDF mints none. Some node-expression conveniences (`sh:if`, "
+"aggregations, ordering wrappers) are DASH/TopBraid conventions with no "
+"normative RDF definition; PurRDF documents its adopted reading and pins it "
+"with a frozen corpus — see the [SHACL-AF section of docs/CONFORMANCE.md]"
+"(https://github.com/Blackcat-Informatics/purrdf/blob/main/docs/"
+"CONFORMANCE.md#shacl-af-node-expressions-normative-surface-vs-owned-"
+"extensions)."
+msgstr ""
+
+#: src/validation/shacl.md:49
+msgid "The SHACL 1.2 reifier-shape draft scope"
+msgstr ""
+
+#: src/validation/shacl.md:51
+msgid ""
+"The crate implements a **scoped** SHACL 1.2 Working Draft feature: "
+"`sh:reifierShape` and `sh:reificationRequired` for direct IRI property "
+"paths, so shapes can constrain the RDF 1.2 reifier metadata attached to "
+"statements (see [RDF 1.2 Features](../concepts/rdf12.md)). The relevant "
+"SHACL 1.2 Core draft is dated 2026-06-02. **This is not a claim of full "
+"SHACL 1.2 conformance** — it is one draft feature, explicitly scoped and "
+"tested."
+msgstr ""
+
+#: src/validation/shacl.md:58
+msgid "Ontology-complete developer schemas"
+msgstr ""
+
+#: src/validation/shacl.md:60
+msgid ""
+"The public `compile_schema` boundary accepts a `SchemaCompileRequest` that "
+"binds the parsed shapes, exact ontology dataset, caller-owned `Namespaces`, "
+"and an explicit `SchemaSurfaceMode`. `ShapedOnly` retains the active SHACL "
+"target-class surface. `OntologyComplete` adds existing caller-vocabulary "
+"classes and optional OWL/RDFS-derived properties. The result carries JSON "
+"Schema draft 2020-12, OpenAPI 3.1, the normal forward loss ledger, a "
+"canonical property-coverage report, and a deterministic pre-compilation "
+"cache key. Its `CompiledSchema` feeds the LinkML, TypeScript, GraphQL, and "
+"Pydantic emitters without a second schema-discovery pass."
+msgstr ""
+
+#: src/validation/shacl.md:70
+msgid ""
+"The bounded theory catalogs only schema evidence: direct IRI `sh:path`, RDF/"
+"OWL property declarations, domain/range declarations, and both endpoints of "
+"subproperty, equivalent-property, and inverse-property relations. A "
+"predicate seen only on an instance is not promoted. Class admission is "
+"likewise explicit, and synthesized definitions are limited to namespaces the "
+"caller supplied; PurRDF does not turn builtin compaction prefixes into an "
+"ontology boundary."
+msgstr ""
+
+#: src/validation/shacl.md:77
+msgid ""
+"Subclass/equivalent-class closure determines domain membership. Multiple "
+"domains are conjunctive; OWL union members are alternatives and intersection "
+"members are conjunctive. Subproperties inherit superproperty domains, "
+"ranges, and forward functionality, equivalent properties propagate "
+"bidirectionally, and inverse properties exchange domain and range. Strongly "
+"connected cycles are condensed deterministically. Multiple ranges remain "
+"conjunctive in emitted JSON Schema; union and intersection expressions map "
+"to `anyOf` and `allOf`."
+msgstr ""
+
+#: src/validation/shacl.md:85
+msgid ""
+"Direct SHACL remains authoritative. Ontology-only fields are optional; "
+"`owl:FunctionalProperty` gives a scalar representation with approximation "
+"provenance, while inverse functionality does not. Closed shapes reject "
+"unshaped fields unless they are directly present or ignored. Classes without "
+"a target shape are emitted as open carriers, never as fabricated closed "
+"models. This is not ABox materialization or unrestricted OWL: property "
+"chains and axioms outside the fragment do not create fields."
+msgstr ""
+
+#: src/validation/shacl.md:93
+msgid ""
+"`SchemaCoverageReport` accounts for every catalogued property once, "
+"including exclusions, with sorted per-class outcomes and source-axiom "
+"provenance. `SchemaCompileRequest::coverage_report` can produce it before "
+"emission. The request cache key binds RDFC-1.0 identities for the shapes and "
+"ontology graphs, caller namespaces, mode, value-vocabulary marker, compiler/"
+"policy salts, and the fixed ceilings: 65,536 properties, 65,536 classes, "
+"1,048,576 relation or coverage cells, and expression depth 64. Malformed OWL "
+"lists, contradictory property kinds/ranges, key collisions, and limit "
+"exhaustion are typed failures."
+msgstr ""
+
+#: src/validation/shacl.md:102
+msgid "Run the complete two-mode and four-emitter example with:"
+msgstr ""
+
+#: src/validation/shacl.md:108
+msgid "Schema → SHACL imports"
+msgstr ""
+
+#: src/validation/shacl.md:110
+msgid ""
+"The schema-projection surface is bidirectional. `SchemaImportConfig` "
+"requires the caller's namespace table and the complete RDF datatype mapping "
+"for JSON scalars; there is no default vocabulary. The five production "
+"reverse directions are JSON Schema draft 2020-12 (`import_json_schema`), "
+"native LinkML 1.11 (`import_linkml`), and verified PurRDF-emitted Pydantic "
+"v2, TypeScript 7.0, and GraphQL September 2025 packages "
+"(`import_*_package`). All five lower through one ordered JSON-Schema "
+"semantic model and return typed shapes plus an always-computed, located "
+"reverse `LossLedger`."
+msgstr ""
+
+#: src/validation/shacl.md:119
+msgid ""
+"Malformed values, open or dangling references, identity collisions, "
+"generated artifact/map drift, and resource-limit exhaustion fail closed. "
+"Valid source constructs without an exact SHACL interpretation are ledgered "
+"at their native JSON Pointer. Arbitrary Python, TypeScript, and GraphQL SDL "
+"are intentionally outside the inverse boundary because none defines one "
+"unique runtime JSON acceptance relation. LinkML does have a native reader; "
+"its schema identity and documentation can therefore appear as losses even "
+"when the validation-bearing SHACL recompiles byte-exactly."
+msgstr ""
+
+#: src/validation/shacl.md:128
+msgid ""
+"The executable example constructs caller-owned `example.org` configuration "
+"and exercises all five paths:"
+msgstr ""
+
+#: src/validation/shacl.md:135
+msgid "Pydantic v2 projection"
+msgstr ""
+
+#: src/validation/shacl.md:137
+msgid ""
+"`purrdf-shapes` can transliterate a compiled SHACL-derived JSON Schema into "
+"a deterministic, typed Pydantic v2 package entirely in memory. The public "
+"`emit_pydantic` function consumes `CompiledSchema`; `PydanticConfig` "
+"requires the caller to supply the package name and package/module prose, so "
+"the library does not invent a vocabulary, namespace, or downstream brand."
+msgstr ""
+
+#: src/validation/shacl.md:143
+msgid ""
+"Every `$defs` entry gets a stable import path, JSON property names remain "
+"exact through Pydantic aliases, and generated classes expose the originating "
+"definition through `model_json_schema(by_alias=True)`. Pydantic runtime "
+"annotations enforce the representable portion. A JSON Schema assertion with "
+"no exact runtime annotation remains visible on that schema surface and "
+"produces a located entry in the always-computed `json-schema` → `pydantic-"
+"v2` `LossLedger`; a lossless input yields an empty ledger. The renderer "
+"itself has no Python dependency and stays wasm-clean. A dev-only Python "
+"oracle executes the generated code and checks the live reverse/schema "
+"surface. `import_pydantic_package` separately verifies the retained source "
+"schema, generated files, model map, dialect, and forward ledger before "
+"importing SHACL."
+msgstr ""
+
+#: src/validation/shacl.md:155
+msgid ""
+"The optional caller-owned `PydanticPackageTopology` is a total partition of "
+"`$defs` entries into portable dotted leaf modules. Each route carries the "
+"class docstring and a sorted, vocabulary-neutral `json_schema_extra` map "
+"suitable for documentation URLs, content digests, and other caller-defined "
+"linkage. An optional `PydanticVersionStamp` adds an exact PEP 440 "
+"`__version__` export. Routed packages share schema/runtime support modules, "
+"generate intermediate package initializers, use explicit symbol tables for "
+"one root-level rebuild, and pass the executable runtime oracle plus strict "
+"mypy. Exact route coverage, portable path/symbol uniqueness, and fixed input/"
+"config/output limits all fail closed. When both topology and version "
+"stamping are omitted, the original flat package bytes remain unchanged. A "
+"flat version stamp adds `__about__.py` and updates the `__init__.py` exports."
+msgstr ""
+
+#: src/validation/shacl.md:168
+msgid "LinkML 1.11 projection"
+msgstr ""
+
+#: src/validation/shacl.md:170
+msgid ""
+"The same `CompiledSchema` carrier can be projected to canonical LinkML 1.11 "
+"with `emit_linkml`. `LinkmlConfig` requires the caller's schema IRI, name, "
+"description, default prefix, and complete prefix map, so PurRDF never mints "
+"a consumer vocabulary or identity. The returned `LinkmlPackage` includes the "
+"typed document, deterministic YAML, a reversible `$defs`\\-key mapping, and "
+"a located `json-schema` → `linkml-1.11` loss ledger. It also carries "
+"ordered, integrity-checked slot rename and skip-diagnostic reports."
+msgstr ""
+
+#: src/validation/shacl.md:178
+msgid ""
+"Classes and exact property aliases, types, enums, local references, inline "
+"objects, requiredness, homogeneous arrays, patterns, inclusive bounds, and "
+"LinkML boolean expressions are represented directly. An unsafe LinkML slot "
+"name uses `SanitizePolicy::Rename` by default; `Skip` omits only that slot "
+"with a located diagnostic/loss, and `Fail` returns a contextual error. "
+"Rename preserves declared CURIE and absolute-IRI identity byte-exactly in "
+"`slot_uri`; an unsafe bare token or exact caller re-home receives a reported "
+"identity under the caller-supplied default prefix. All valid IRI schemes "
+"remain absolute unless the caller marks that exact token, so custom schemes "
+"are not guessed from their spelling. Safe names reserve first and hash-plus-"
+"ordinal collision allocation is bounded and deterministic."
+msgstr ""
+
+#: src/validation/shacl.md:190
+msgid ""
+"Every unsupported assertion is classified by a closed capability table; "
+"malformed inputs, external/dynamic/dangling references, stale re-home hints, "
+"semantic identity collisions, and fixed-limit breaches fail closed. "
+"`parse_linkml` and `write_linkml` preserve all JSON-compatible metamodel "
+"fields and provide byte-stable read/write round trips while rejecting YAML-"
+"only tags, duplicate keys, non-string keys, and non-finite numbers."
+msgstr ""
+
+#: src/validation/shacl.md:198
+msgid ""
+"`import_linkml` consumes that validated native document; the emitted-package "
+"variant `import_linkml_package` first verifies canonical YAML and the "
+"reversible element map, slot reports, policy losses, aliases, and emitted "
+"identities. Both use the same caller-owned SHACL import configuration. "
+"Migration adapters should pass `CompiledSchema` unchanged, configure exact "
+"re-homes, and consume `slot_renames`; rewriting shared property/required "
+"keys is unnecessary."
+msgstr ""
+
+#: src/validation/shacl.md:205
+msgid ""
+"The Rust production path has no LinkML-toolkit dependency. CI uses the "
+"locked official LinkML 1.11.1 Python packages only as a differential oracle. "
+"It loads safe, lossy, and renamed fixtures through `SchemaDefinition` and "
+"`SchemaView`, regenerates JSON Schema, and verifies reverse predicates:"
+msgstr ""
+
+#: src/validation/shacl.md:214
+msgid "TypeScript 7.0 projection"
+msgstr ""
+
+#: src/validation/shacl.md:216
+msgid ""
+"`emit_typescript` projects the same `CompiledSchema` into deterministic "
+"TypeScript 7.0 declarations. The caller supplies the package name and all "
+"package/module prose through `TypeScriptConfig`. The returned package "
+"contains one `index.d.ts`, a reversible `$defs`\\-key to exported-type map, "
+"and a located `json-schema` → `typescript-7.0` loss ledger; PurRDF invents "
+"no consumer identity or vocabulary."
+msgstr ""
+
+#: src/validation/shacl.md:223
+msgid ""
+"The fixed declaration dialect uses `strict` plus "
+"`exactOptionalPropertyTypes`. Type aliases preserve JSON primitives and "
+"literals, required versus optional fields, explicit `null`, local recursive "
+"references, unions, intersections, homogeneous arrays, and bounded tuples. "
+"There are no runtime enums, mergeable interfaces, branded pseudo-validators, "
+"or `any` escape hatches. Invalid keywords, open/dangling references, and "
+"name collisions fail before bytes are emitted."
+msgstr ""
+
+#: src/validation/shacl.md:231
+msgid ""
+"Runtime assertions outside TypeScript structural assignability are never "
+"silently erased: integer, numeric/string predicate, closure, pattern-"
+"property, dependency, conditional, negation, contains/unique, evaluation-"
+"state, and bounded-expansion gaps receive stable codes and JSON Pointer "
+"locations. CI classifies instances independently with a draft 2020-12 "
+"validator and compiles the generated declarations with the locked TypeScript "
+"7.0.2 compiler, including fresh-literal and through-variable probes:"
+msgstr ""
+
+#: src/validation/shacl.md:243
+msgid ""
+"The projection intentionally has no arbitrary TypeScript reader. TypeScript "
+"declarations do not define a unique runtime JSON acceptance relation, and "
+"the projection is many-to-one. `import_typescript_package` is the "
+"authoritative reverse surface: it deterministically verifies the retained "
+"source schema, declaration, reversible name map, dialect, and forward "
+"ledger. TypeScript is only a dev-time oracle dependency; the Rust emitter/"
+"importer is filesystem-free and wasm-clean."
+msgstr ""
+
+#: src/validation/shacl.md:251
+msgid "GraphQL September 2025 projection"
+msgstr ""
+
+#: src/validation/shacl.md:253
+msgid ""
+"`emit_graphql` projects `CompiledSchema` into deterministic GraphQL "
+"September 2025 SDL. `GraphqlConfig` has no defaults: the caller supplies the "
+"schema name, package and module prose, and a non-built-in fallback-scalar "
+"name. The returned `GraphqlPackage` contains `schema.graphql`, canonical "
+"`name-map.json`, the same name map as typed Rust data, a located `json-"
+"schema` → `graphql-september-2025` loss ledger, and the production value "
+"codec."
+msgstr ""
+
+#: src/validation/shacl.md:260
+msgid ""
+"The SDL is deliberately a type-system fragment. PurRDF emits paired output "
+"`type` and input `input` objects, but no query, mutation, or subscription "
+"root, resolver, pagination rule, authorization policy, federation directive, "
+"or other application behavior. A caller composes the fragment with its own "
+"executable schema."
+msgstr ""
+
+#: src/validation/shacl.md:266
+msgid ""
+"The exact grammar includes GraphQL booleans, strings, numbers, the signed 32-"
+"bit `Int` domain, explicit nullability, finite JSON `const`/`enum` sets, "
+"closed object fields, requiredness, homogeneous lists, direct local `$defs` "
+"references and aliases, descriptions, and inline object helpers. One global "
+"collision-checked namespace covers types, helpers, and the fallback scalar; "
+"fields and enum symbols are checked in their GraphQL-local namespaces. The "
+"typed/canonical name maps retain the source definition keys, property keys, "
+"and finite JSON values."
+msgstr ""
+
+#: src/validation/shacl.md:275
+msgid ""
+"`GraphqlPackage::encode_input` maps source JSON keys and finite values to "
+"input field names and enum symbols. `decode_output` performs the inverse for "
+"fields present in a GraphQL response, without inventing omitted selections. "
+"Unknown or incompatible values fail. This package codec is the precise value "
+"boundary; `import_graphql_package` is the schema reverse boundary and "
+"verifies the SDL, typed/canonical maps, identity, retained source schema, "
+"and forward ledger. Arbitrary GraphQL SDL has no unique JSON Schema "
+"acceptance relation and is not accepted as an inverse format."
+msgstr ""
+
+#: src/validation/shacl.md:284
+msgid ""
+"GraphQL variable coercion differs from JSON Schema validation at these "
+"closed boundaries:"
+msgstr ""
+
+#: src/validation/shacl.md:287
+msgid "Boundary"
+msgstr ""
+
+#: src/validation/shacl.md:287
+msgid "Located loss families"
+msgstr ""
+
+#: src/validation/shacl.md:289
+msgid "object fields and names"
+msgstr ""
+
+#: src/validation/shacl.md:289
+msgid "additional properties, pattern properties, property names/counts"
+msgstr ""
+
+#: src/validation/shacl.md:290
+msgid "requiredness and recursion"
+msgstr ""
+
+#: src/validation/shacl.md:290
+msgid ""
+"nullable-presence widening, one deterministic recursive-input nullability "
+"relaxation"
+msgstr ""
+
+#: src/validation/shacl.md:291
+msgid "lists"
+msgstr ""
+
+#: src/validation/shacl.md:291
+msgid ""
+"singleton coercion, cardinality, contains, uniqueness, tuples, unevaluated "
+"items"
+msgstr ""
+
+#: src/validation/shacl.md:292
+msgid "scalar assertions"
+msgstr ""
+
+#: src/validation/shacl.md:292
+msgid "integer domain delegation, numeric predicates, string predicates"
+msgstr ""
+
+#: src/validation/shacl.md:293
+msgid "applicators"
+msgstr ""
+
+#: src/validation/shacl.md:293
+msgid "conditionals, dependencies, intersections, unions, `oneOf`, negation"
+msgstr ""
+
+#: src/validation/shacl.md:294
+msgid "runtime boundary"
+msgstr ""
+
+#: src/validation/shacl.md:294
+msgid "custom-scalar and unknown-keyword validation delegation"
+msgstr ""
+
+#: src/validation/shacl.md:296
+msgid ""
+"The caller-named fallback scalar is declared but PurRDF does not invent its "
+"`parseValue`, `parseLiteral`, or serialization semantics. Every delegated "
+"use is therefore ledgered. Loss entries carry stable codes and source JSON "
+"Pointer locations; an exact package has an empty ledger."
+msgstr ""
+
+#: src/validation/shacl.md:301
+msgid ""
+"Emission fails before returning bytes for invalid caller configuration, "
+"malformed schema keywords, `$id` rebasing, external/indirect/dangling "
+"`$ref`, `$dynamicRef`/`$recursiveRef`, alias cycles, unsatisfiable closed "
+"required fields, and generated-name collisions. The fixed limits are 16 MiB "
+"for the input schema, each artifact, and one codec value; 65,536 "
+"definitions, fields per object, or finite values; depth 128; and 255 bytes "
+"per GraphQL name."
+msgstr ""
+
+#: src/validation/shacl.md:308
+msgid ""
+"The independent dev oracle classifies source values with `boon`, builds the "
+"SDL with locked official GraphQL.js 16.14.0, and executes real variable "
+"coercion. It verifies exact agreement, every closed loss family and "
+"location, the name map and production codec, and deliberate corruption "
+"failures:"
+msgstr ""
+
+#: src/validation/shacl.md:317
+msgid ""
+"GraphQL.js is dev-only. Emission and value translation remain filesystem-"
+"free, wasm-clean Rust."
+msgstr ""
+
+#: src/validation/shacl.md:320
+msgid "From Python"
+msgstr ""
+
+#: src/validation/shacl.md:325
+msgid "\"...\""
+msgstr ""
+
+#: src/validation/shacl.md:326
+msgid "# True / False\n"
+msgstr ""
+
+#: src/validation/shacl.md:327
+msgid "\"results\""
+msgstr ""
+
+#: src/validation/shacl.md:327
+msgid "# list of violation dicts\n"
+msgstr ""
+
+#: src/validation/shacl.md:330
+msgid ""
+"Each result dict keeps the stable keys `focus`, `path`, `value`, `severity`, "
+"`component`, `source_shape`, and `message`."
+msgstr ""
+
+#: src/validation/shacl.md:333
+msgid "The report is a dataset"
+msgstr ""
+
+#: src/validation/shacl.md:335
+msgid ""
+"`ValidationReport::to_dataset()` materializes the W3C validation report — "
+"the `sh:ValidationReport` node and its `sh:ValidationResult`s — as a frozen "
+"`RdfDataset`, built straight from the report's own terms rather than through "
+"a `to_ntriples()` → `parse_dataset()` round-trip. The direct path carries "
+"every RDF 1.2 term the report holds (a triple-term focus node included) with "
+"the report's own blank-node labels, and the blank nodes the report _mints_ "
+"(the report node, one per result, the interior nodes of a complex `sh:path`) "
+"are guaranteed distinct from every blank node the data graph _carries_. "
+"Rendering the report in any syntax is then "
+"`serialize_dataset(&report.to_dataset(), …)`, which is exactly what `purrdf "
+"validate --format` does."
+msgstr ""
+
+#: src/validation/shacl.md:346
+msgid "SARIF output"
+msgstr ""
+
+#: src/validation/shacl.md:348
+msgid ""
+"Validation reports stay structured in the engine; the SARIF 2.1.0 boundary "
+"is the separate [`purrdf-validate`](https://docs.rs/purrdf-validate) crate "
+"(`purrdf::validate`), which renders a report — or parser diagnostics — as a "
+"source-traced, byte-deterministic SARIF log for editors, CI, and code-"
+"scanning dashboards:"
+msgstr ""
+
+#: src/validation/shacl.md:357
+msgid ""
+"r#\"\n"
+"    @prefix sh:  <http://www.w3.org/ns/shacl#> .\n"
+"    @prefix ex:  <http://example.org/> .\n"
+"    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
+"    ex:PersonShape a sh:NodeShape ;\n"
+"      sh:targetClass ex:Person ;\n"
+"      sh:property [ sh:path ex:age ; sh:datatype xsd:integer ] .\n"
+"\"#"
+msgstr ""
+
+#: src/validation/shacl.md:365
+msgid ""
+"r#\"<http://example.org/alice> <http://www.w3.org/1999/02/22-rdf-syntax-"
+"ns#type> <http://example.org/Person> .\n"
+"<http://example.org/alice> <http://example.org/age> \"nope\" .\n"
+"\"#"
+msgstr ""
+
+#: src/validation/shacl.md:370
+msgid "\"sarif produced\""
+msgstr ""
+
+#: src/validation/shacl.md:371
+msgid "\"\\\"version\\\": \\\"2.1.0\\\"\""
+msgstr ""
+
+#: src/validation/shacl.md:374
+msgid ""
+"Lower-level entry points (`build_report_sarif`, `build_diagnostics_sarif`) "
+"build a `SarifLog` value instead of a string, so a host can merge runs "
+"before serializing."
+msgstr ""
+
+#: src/validation/shacl.md:380
+msgid ""
+"The validator is gated by the vendored W3C `data-shapes` suite, a vendored "
+"DASH SHACL-AF/rules corpus, and a first-party frozen corpus of 70 cases with "
+"byte-frozen expected reports; SHACL Rules output is compared to expected "
+"inferred graphs by RDFC-1.0 isomorphism. See [Conformance & Testing](../"
+"project/conformance.md)."
+msgstr ""
+
+#: src/validation/shex.md:8
+msgid ""
+"[`purrdf-shex`](https://docs.rs/purrdf-shex) (re-exported as `purrdf::shex`) "
+"is PurRDF's native [Shape Expressions Language 2.1](https://shex.io/shex-"
+"semantics/) engine: the schema layer and the shape-map validator, pure Rust "
+"and wasm-clean."
+msgstr ""
+
+#: src/validation/shex.md:13
+msgid "Schemas: ShExC and ShExJ"
+msgstr ""
+
+#: src/validation/shex.md:15
+msgid ""
+"**ShExC** (the compact syntax, spec §6) — a hand-rolled lexer and recursive-"
+"descent parser covering the full grammar: directives, `start`, the `AND`/"
+"`OR`/`NOT` shape algebra, node constraints and the facet table, value sets "
+"with stems/ranges/exclusions, triple expressions with all cardinality forms, "
+"`$`/`&` labels and inclusions, `^` inverse, annotations and `%…{ … %}` "
+"semantic actions, with relative-IRI resolution against `BASE` via `purrdf-"
+"iri`."
+msgstr ""
+
+#: src/validation/shex.md:22
+msgid ""
+"**ShExJ** (the JSON wire format, spec Appendix A) — strict, round-tripping "
+"serde support matching the shexTest ground truth."
+msgstr ""
+
+#: src/validation/shex.md:24
+msgid ""
+"**Structural checks** (spec §5.7) — dangling references, label collisions, "
+"reference-only cycles, and the negation-stratification requirement."
+msgstr ""
+
+#: src/validation/shex.md:31
+msgid ""
+"\"PREFIX ex: <http://example.org/>\\n\\\n"
+"     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\\n\\\n"
+"     ex:S { ex:p xsd:integer? }\""
+msgstr ""
+
+#: src/validation/shex.md:36
+msgid "\"well-formed\""
+msgstr ""
+
+#: src/validation/shex.md:40
+msgid ""
+"Hard-fail discipline: every malformed schema is a typed `ShexError` — no "
+"lenient mode, no panics on any input."
+msgstr ""
+
+#: src/validation/shex.md:43
+msgid "Validation with shape maps"
+msgstr ""
+
+#: src/validation/shex.md:45
+msgid ""
+"Validation (spec §5.2–§5.5) is **fixed shape-map** validation over the "
+"frozen `purrdf-core` dataset IR, in interned `TermId` space: you supply "
+"`(node, shape)` associations and the validator decides conformance for each. "
+"It covers node constraints (node kind, datatype with lexical-validity "
+"checking, string/numeric facets, value sets with stems and exclusions), "
+"`EXTRA`/`CLOSED` triple-expression matching with `EachOf`/`OneOf` "
+"partitioning and group cardinalities, inverse constraints, typing-based "
+"recursion, and an `EXTERNAL` resolver hook."
+msgstr ""
+
+#: src/validation/shex.md:54
+msgid "From Python:"
+msgstr ""
+
+#: src/validation/shex.md:66
+msgid ""
+"The engine is gated against the vendored official [shexTest](https://"
+"github.com/shexSpec/shexTest) suite, pinned at tag `v2.1.0` (`vectors/"
+"shexTest/`): the full `validation/` manifest, the `schemas/` ShExC/ShExJ "
+"pairs and round-trips, and the negative syntax and negative structure "
+"suites. At the time of writing the validation manifest passes "
+"**1,105/1,105** attempted cases with zero expected-failures and an empty "
+"trait-skip list (imports and semantic actions included); the live scoreboard "
+"is [`docs/CONFORMANCE.md`](https://github.com/Blackcat-Informatics/purrdf/"
+"blob/main/docs/CONFORMANCE.md)."
+msgstr ""
+
+#: src/validation/shex.md:76
+msgid ""
+"Reported conformance is logic-level (pass/fail parity), per suite "
+"convention; result-structure conformance is upstream-experimental."
+msgstr ""
+
+#: src/validation/shex.md:79
+msgid "SHACL or ShEx?"
+msgstr ""
+
+#: src/validation/shex.md:81
+msgid ""
+"PurRDF implements both natively over the same IR, so the choice is yours, "
+"not the toolkit's: SHACL suits constraint reporting (violations with "
+"severities, [SARIF output](shacl.md#sarif-output)) and SHACL-SPARQL escape "
+"hatches; ShEx suits schema-like conformance decisions over explicit shape "
+"maps."
+msgstr ""
+
+#: src/entailment.md:8
+msgid ""
+"[`purrdf-entail`](https://docs.rs/purrdf-entail) (re-exported as "
+"`purrdf::entail`) is native, `wasm32`\\-clean entailment for the PurRDF "
+"`RdfDataset` IR. A family of engines sits behind one facade, each the right "
+"tool for its SPARQL entailment regime — closing a dataset to its inferred "
+"fixpoint entirely in interned `TermId` space, with **no** external reasoner, "
+"no async runtime, and no string round-trip."
+msgstr ""
+
+#: src/entailment.md:15
+msgid "Surface map"
+msgstr ""
+
+#: src/entailment.md:17
+msgid "Entry point"
+msgstr ""
+
+#: src/entailment.md:17
+msgid "Regime(s)"
+msgstr ""
+
+#: src/entailment.md:17 src/project/conformance.md:32
+msgid "Engine"
+msgstr ""
+
+#: src/entailment.md:19
+msgid "`materialize(ds, regime)`"
+msgstr ""
+
+#: src/entailment.md:19
+msgid "`Simple`, `RDF`, `RDFS`, `OWL-RL`, `D`"
+msgstr ""
+
+#: src/entailment.md:19
+msgid ""
+"Forward materialization (\"chase\") of the regime's declared clause program "
+"via a native semi-naive fixpoint. Returns `(closure, ReasoningReport)`; the "
+"report is not optional."
+msgstr ""
+
+#: src/entailment.md:20
+msgid ""
+"`materialize_dl_reported(...)`, or `materialize(ds, "
+"Materialization::OwlDirect(bgp))`"
+msgstr ""
+
+#: src/entailment.md:20 src/entailment.md:148
+msgid "`OWL-Direct`"
+msgstr ""
+
+#: src/entailment.md:20
+msgid ""
+"Open-world OWL DL over a SHOIQ(D) tableau, directed by the query's basic "
+"graph pattern `bgp`; `materialize` delegates to it for this regime rather "
+"than restating it."
+msgstr ""
+
+#: src/entailment.md:21
+msgid "`materialize_rif(...)`"
+msgstr ""
+
+#: src/entailment.md:21 src/entailment.md:22 src/entailment.md:149
+msgid "`RIF`"
+msgstr ""
+
+#: src/entailment.md:21
+msgid "RIF-Core rule entailment over a parsed `RuleSet`."
+msgstr ""
+
+#: src/entailment.md:22
+msgid "`parse_rif_xml(...)` / `resolve_rif_imports(...)`"
+msgstr ""
+
+#: src/entailment.md:22
+msgid "RIF-XML parsing with caller-owned, I/O-free import resolution."
+msgstr ""
+
+#: src/entailment.md:23
+msgid "`rules(regime)` / `implemented(regime)`"
+msgstr ""
+
+#: src/entailment.md:23
+msgid ""
+"The rule table a regime is _defined by_, and the subset this workspace "
+"fires. Their difference is the measurable gap."
+msgstr ""
+
+#: src/entailment.md:24
+msgid "`calculus_program(regime)`"
+msgstr ""
+
+#: src/entailment.md:24
+msgid ""
+"The regime's calculus as DL-clause data — the very program `materialize` "
+"evaluates, so a consumer can recompute its contract hash."
+msgstr ""
+
+#: src/entailment.md:25
+msgid "`Regime::from_iri(iri)`"
+msgstr ""
+
+#: src/entailment.md:25
+msgid "Parse a `sparql:entailmentRegime` IRI to its enum."
+msgstr ""
+
+#: src/entailment.md:29
+msgid ""
+"// Close a frozen dataset to its RDFS fixpoint; the result is a new dataset\n"
+"// AND a report of what the run did.\n"
+msgstr ""
+
+#: src/entailment.md:32
+msgid "\"materializes\""
+msgstr ""
+
+#: src/entailment.md:36
+msgid "The same engine in five hosts"
+msgstr ""
+
+#: src/entailment.md:38
+msgid ""
+"Entailment is not re-implemented per host. The `purrdf` command line, "
+"Python, WebAssembly, and the C ABI all route through one shared string "
+"boundary (`purrdf_validate::regime`) that wraps the Rust engine, and the "
+"surfaces are checked against a single committed golden-vector artifact — so "
+"a divergence shows up as one vector failing rather than as several surfaces "
+"that quietly stopped agreeing. The regime spellings (`simple`, `rdf`, "
+"`rdfs`, `owl-rl`, `owl-direct`, `rif`, `d`) are the same everywhere."
+msgstr ""
+
+#: src/entailment.md:47
+msgid "Materialize"
+msgstr ""
+
+#: src/entailment.md:47
+msgid "Defined rule table"
+msgstr ""
+
+#: src/entailment.md:47
+msgid "Implemented rules"
+msgstr ""
+
+#: src/entailment.md:49
+msgid "`materialize(&ds, Materialization::Rdfs)`"
+msgstr ""
+
+#: src/entailment.md:49
+msgid "`rules(Regime::Rdfs)`"
+msgstr ""
+
+#: src/entailment.md:49
+msgid "`implemented(Regime::Rdfs)`"
+msgstr ""
+
+#: src/entailment.md:50
+msgid ""
+"`purrdf reason --regime rdfs`, `purrdf convert --entailment rdfs`, `purrdf "
+"query --entailment rdfs` (and `purrdf entails` asks the [conclusion-directed "
+"question](#asking-a-question-instead-the-conclusion-directed-services))"
+msgstr ""
+
+#: src/entailment.md:51
+msgid ""
+"`purrdf.entail.materialize(dataset, \"rdfs\", \"\")`, "
+"`purrdf.entail.materialize_nt(text, \"rdfs\", \"\")`"
+msgstr ""
+
+#: src/entailment.md:51
+msgid "`purrdf.entail.rules(\"rdfs\")`"
+msgstr ""
+
+#: src/entailment.md:51
+msgid "`purrdf.entail.implemented_rules(\"rdfs\")`"
+msgstr ""
+
+#: src/entailment.md:52
+msgid "`entailMaterialize(doc, \"rdfs\", \"\")`"
+msgstr ""
+
+#: src/entailment.md:52
+msgid "`entailRules(\"rdfs\")`"
+msgstr ""
+
+#: src/entailment.md:52
+msgid "`entailImplementedRules(\"rdfs\")`"
+msgstr ""
+
+#: src/entailment.md:53
+msgid "`purrdf_entail_materialize_to_nquads(...)`"
+msgstr ""
+
+#: src/entailment.md:53
+msgid "`purrdf_entail_rules(...)`"
+msgstr ""
+
+#: src/entailment.md:53
+msgid "`purrdf_entail_implemented_rules(...)`"
+msgstr ""
+
+#: src/entailment.md:55
+msgid ""
+"Every host materializes every regime; none refuses one. What two regimes "
+"need is an INPUT, and each host has a parameter for it: `--rules <FILE>` on "
+"the CLI, a `program` string on the Python, WebAssembly and C surfaces, and "
+"the `Materialization` value itself in Rust. `rif` takes a normative RIF-in-"
+"XML rule document there; every other regime takes none, and supplying one is "
+"an error rather than a discarded argument. `owl-direct`'s extra input is a "
+"_query's_ class expressions, so a document-in/document-out call runs the "
+"query-independent augmentation and a query surface "
+"(`purrdf::query_with_entailment`, `purrdf query --entailment owl-direct`) is "
+"where the query-directed lane lives."
+msgstr ""
+
+#: src/entailment.md:65
+msgid "One host-specific note:"
+msgstr ""
+
+#: src/entailment.md:67
+msgid ""
+"The **WebAssembly** module also exports `entailCheckGoldenVectors()`, which "
+"replays the committed tri-host vector artifact inside the module a consumer "
+"actually loaded — so agreement with the reference implementation can be "
+"checked without trusting this repository's CI."
+msgstr ""
+
+#: src/entailment.md:72
+msgid "Asking a question instead: the conclusion-directed services"
+msgstr ""
+
+#: src/entailment.md:74
+msgid ""
+"Materializing answers \"what does this premise entail?\". The three services "
+"below answer \"does this premise entail _that_?\", which is a different "
+"question and not the membership test in a closure it looks like: a "
+"conclusion's blank nodes are existentials that have to be _mapped_, an "
+"inconsistent premise entails everything, a failure to find a mapping means "
+"nothing unless the rule set is complete for the premise it ran on — and a "
+"conclusion can be entailed while appearing nowhere in the closure at all, "
+"which is what the five mechanisms beyond the rule table exist for (see "
+"[Conformance](#conformance))."
+msgstr ""
+
+#: src/entailment.md:83
+msgid ""
+"They run over the same shared boundary, on all **five** host shapes, and the "
+"`purrdf` command line is one of them. `scripts/check-entailment-surface.py` "
+"is the gate: it derives the service set from `purrdf-entail`'s own public "
+"entry points and fails until every one of them is reachable from every host "
+"_with the boundary's whole parameter list_, so a service or a parameter "
+"cannot land on four hosts and go dark on the fifth. It also mutation-tests "
+"itself on every run — one edit per check, applied in memory over the "
+"committed tree, each of which must make the gate fail — because a check that "
+"cannot withhold a green light is not a check."
+msgstr ""
+
+#: src/entailment.md:92
+msgid "Does P entail C?"
+msgstr ""
+
+#: src/entailment.md:92
+msgid "Re-decide the warrant"
+msgstr ""
+
+#: src/entailment.md:92
+msgid "Certain answers of a pattern"
+msgstr ""
+
+#: src/entailment.md:94
+msgid "`entails(&p, &c, Regime::OwlRl, &imports)`"
+msgstr ""
+
+#: src/entailment.md:94
+msgid "`verify(warrant, &p, &c)`"
+msgstr ""
+
+#: src/entailment.md:94
+msgid "`certain_answers(&p, &bgp, Regime::OwlRl, &imports)`"
+msgstr ""
+
+#: src/entailment.md:95
+msgid "`purrdf entails --regime owl-rl --premise P --conclusion C`"
+msgstr ""
+
+#: src/entailment.md:95
+msgid "`… --conclusion C --verify`"
+msgstr ""
+
+#: src/entailment.md:95
+msgid "`… --pattern BGP`"
+msgstr ""
+
+#: src/entailment.md:96
+msgid "`purrdf.entail.graph_entails(\"owl-rl\", p, c, imports)`"
+msgstr ""
+
+#: src/entailment.md:96
+msgid "`purrdf.entail.verify_entailment(...)`"
+msgstr ""
+
+#: src/entailment.md:96
+msgid "`purrdf.entail.certain_answers(\"owl-rl\", p, bgp, imports)`"
+msgstr ""
+
+#: src/entailment.md:97
+msgid "`entailGraphEntails(\"owl-rl\", p, c, iris, docs)`"
+msgstr ""
+
+#: src/entailment.md:97
+msgid "`entailVerifyEntailment(...)`"
+msgstr ""
+
+#: src/entailment.md:97
+msgid "`entailCertainAnswers(...)`"
+msgstr ""
+
+#: src/entailment.md:98
+msgid "`purrdf_entail_graph_entails(...)`"
+msgstr ""
+
+#: src/entailment.md:98
+msgid "`purrdf_entail_verify_entailment(...)`"
+msgstr ""
+
+#: src/entailment.md:98
+msgid "`purrdf_entail_certain_answers(...)`"
+msgstr ""
+
+#: src/entailment.md:100
+msgid ""
+"Two things differ from the materializing table above, and both are "
+"consequences of the question rather than of any host:"
+msgstr ""
+
+#: src/entailment.md:103
+msgid ""
+"**Five regimes, not seven.** `owl-direct` is directed by a _query's_ class "
+"expressions and `rif` entails under the _caller's_ rule document, and "
+"\"premise, conclusion, regime\" carries neither. Both are refused by name on "
+"every host — never answered under a weaker regime and labelled with the one "
+"that was asked for — and both still materialize."
+msgstr ""
+
+#: src/entailment.md:108
+msgid ""
+"**The import table is a parameter, on every host.** An ontology's imports "
+"closure _is_ the ontology, so a premise carrying an `owl:imports` the call "
+"was not handed is a different premise. PurRDF fetches nothing, so the "
+"closure arrives as caller-supplied configuration: an ordered list of "
+"`(ontology IRI, document)` pairs, spelled `--import IRI=FILE` on the command "
+"line. An unresolved import is a refusal naming the document, never a "
+"silently truncated premise."
+msgstr ""
+
+#: src/entailment.md:115
+msgid ""
+"A pattern is N-Triples with `?name` (or `$name`) in any position, the "
+"**predicate** included. RDF reserves that position for an IRI, so the "
+"boundary reaches it by rewriting each variable to a term drawn from a "
+"namespace it has swept out of the caller's own text and mapping every "
+"occurrence back afterwards; nothing of that namespace reaches a row, a "
+"binding or a report. The one slot that admits no variable is a literal's "
+"**datatype**: `\"5\"^^?d` asks for a binding in a position that holds an IRI "
+"rather than a term, and it is refused by name — the stand-in must never be "
+"left sitting there, matching the boundary's own namespace instead of the "
+"caller's data. A predicate variable is projected like any other, and under "
+"`owl-rl` it also renders a `limit`: it ranges over the whole predicate "
+"vocabulary, so it ranges over the schema predicates Theorem PR1's conclusion "
+"hypothesis excludes — the table claims no completeness for them, whether or "
+"not `scm-*` derives one — and over the constructs the mechanisms beyond the "
+"table decide, for which the closure the rows are drawn from holds nothing."
+msgstr ""
+
+#: src/entailment.md:130
+msgid ""
+"Every answer arrives with the certificate of the run underneath it — the "
+"same `purrdf-reasoning-report` block a materialization renders, plus a "
+"`mechanism` line naming which of the six reached the verdict."
+msgstr ""
+
+#: src/entailment.md:134
+msgid "Rule coverage"
+msgstr ""
+
+#: src/entailment.md:136
+msgid ""
+"`rules(regime)` is the rule table the specification defines the regime by; "
+"`implemented(regime)` is the subset the evaluator fires. Both are `&'static` "
+"slices in specification table order, so the gap is an executable artifact "
+"instead of a sentence:"
+msgstr ""
+
+#: src/entailment.md:141 src/entailment-rules.md:58 src/entailment-rules.md:86
+msgid "Regime"
+msgstr ""
+
+#: src/entailment.md:141
+msgid "Rule table"
+msgstr ""
+
+#: src/entailment.md:141 src/entailment-rules.md:58
+msgid "Defined"
+msgstr ""
+
+#: src/entailment.md:141 src/entailment-rules.md:58 src/entailment-rules.md:92
+#: src/entailment-rules.md:100 src/entailment-rules.md:123
+#: src/entailment-rules.md:206
+msgid "Implemented"
+msgstr ""
+
+#: src/entailment.md:143
+msgid "`Simple`"
+msgstr ""
+
+#: src/entailment.md:143
+msgid "— (identity closure)"
+msgstr ""
+
+#: src/entailment.md:144
+msgid "`RDF`"
+msgstr ""
+
+#: src/entailment.md:144
+msgid "RDF 1.2 Semantics §8.1.1"
+msgstr ""
+
+#: src/entailment.md:145
+msgid "`RDFS`"
+msgstr ""
+
+#: src/entailment.md:145
+msgid "RDF 1.2 Semantics §8.1.1 + §9.2.1"
+msgstr ""
+
+#: src/entailment.md:145 src/entailment-rules.md:62
+msgid "18"
+msgstr ""
+
+#: src/entailment.md:146
+msgid "`OWL-RL`"
+msgstr ""
+
+#: src/entailment.md:146
+msgid "OWL 2 Profiles §4.3 Tables 4–9"
+msgstr ""
+
+#: src/entailment.md:146 src/entailment-rules.md:63
+msgid "78"
+msgstr ""
+
+#: src/entailment.md:147
+msgid "`D`"
+msgstr ""
+
+#: src/entailment.md:147
+msgid "OWL 2 Profiles §4.3 Table 8"
+msgstr ""
+
+#: src/entailment.md:147 src/entailment-rules.md:66
+msgid "5"
+msgstr ""
+
+#: src/entailment.md:148
+msgid "— (SHOIQ(D) tableau, not a fixed table)"
+msgstr ""
+
+#: src/entailment.md:149
+msgid "— (caller-supplied rule set)"
+msgstr ""
+
+#: src/entailment.md:151
+msgid ""
+"The per-rule breakdown — every rule id, its specification citation, and "
+"whether it is fired — is [generated from that API](entailment-rules.md) and "
+"drift-guarded, so it cannot fall behind the code."
+msgstr ""
+
+#: src/entailment.md:155
+msgid "Where the numbers stop:"
+msgstr ""
+
+#: src/entailment.md:157
+msgid ""
+"**The four existential rules fire, but their conclusions are withheld.** "
+"`rdfD1`, `rdfD1a`, `rdfs14` and `rdfs14a` each conclude about a _fresh_ "
+"blank node. The restricted chase mints each one as a frontier-addressed "
+"Skolem witness and closes under it, so the rules genuinely fire — but every "
+"conclusion mentioning a surrogate is dropped when the closure is "
+"materialized back, because a SPARQL entailment regime draws its answers from "
+"the scoping graph and a surrogate is not in it. The withholding is reported "
+"as `Construct::Surrogate`. Nothing surrogate-free is lost: replacing a term "
+"with a fresh blank node only weakens a triple."
+msgstr ""
+
+#: src/entailment.md:166
+msgid ""
+"**A complete rule table is not a complete closure.** `OWL-RL` fires all 78 "
+"rules, and a run that met a boundary still reports "
+"`Completeness::ExactWithinBoundaries` rather than `Exact`. The two claims "
+"are reported separately on purpose. Nor is a complete rule table entailment "
+"conformance: on this vendored W3C corpus of OWL 2 RL entailment tests "
+"`entails()` reaches 27 of 27 published positive entailments, and agrees with "
+"W3C on 23 of 23 negative ones — 3 of those 23 _refuted_, a decided non-"
+"entailment, and 20 _admitted_, the closure computed and observed not to "
+"contain the non-conclusion. Read `23 of 23` as \"no unsoundness found\", "
+"never as \"23 non-entailments proved\" (see [Conformance](#conformance) "
+"below). 78 / 78 says every rule of Tables 4–9 is implemented — and the one "
+"W3C-published entailment that is reachable only by a sound rule outside "
+"those tables is reached by an **extension**, `ext-eq-diff-sym`, which "
+"`extensions(Regime::OwlRl)` names, neither `rules()` nor `implemented()` "
+"names, and every report renders on its own `extension` line. Eight more are "
+"reached by **refutation** rather than by matching, and those add no rule at "
+"all: see the conformance section below."
+msgstr ""
+
+#: src/entailment.md:183
+msgid ""
+"**Seventeen OWL 2 RL rules conclude `false`.** \"Implemented\" for those "
+"means _decided_: a body match becomes `EntailError::Inconsistent` carrying a "
+"witness that names the rule and the asserted triples that satisfied it. That "
+"is the only thing a rule with no conclusion can do."
+msgstr ""
+
+#: src/entailment.md:188
+msgid "The chase (Simple / RDF / RDFS / OWL-RL / D)"
+msgstr ""
+
+#: src/entailment.md:190
+msgid ""
+"`materialize` runs a forward-materialization chase: a fixed rule set for the "
+"selected regime, applied by a semi-naive fixpoint until no new quads appear. "
+"Because it runs over the frozen IR, it is deterministic — a given input and "
+"regime always yields the same closure — and because it works in `TermId` "
+"space, no term is ever re-parsed or re-serialized along the way."
+msgstr ""
+
+#: src/entailment.md:196
+msgid ""
+"Typical use: materialize first, then query with the plain [SPARQL engine]"
+"(sparql/querying.md) or validate the closure with [SHACL](validation/"
+"shacl.md) (the SHACL validator itself performs no inference)."
+msgstr ""
+
+#: src/entailment.md:201
+msgid ""
+"The rule set is not written twice. `calculus_program(regime)` renders it as "
+"DL clauses and `materialize` evaluates exactly those clauses through "
+"[`purrdf-datalog`](datalog.md)'s semi-naive evaluator, so the contract hash "
+"a report carries identifies the clauses that actually ran."
+msgstr ""
+
+#: src/entailment.md:206
+msgid "Every run says what it did"
+msgstr ""
+
+#: src/entailment.md:208
+msgid ""
+"`materialize` returns `(closure, ReasoningReport)`. There is deliberately no "
+"report-free variant, because the alternative — two entry points, one of "
+"which discards the evidence — is how a partial rule set comes to be "
+"described as a complete one. The report carries:"
+msgstr ""
+
+#: src/entailment.md:213
+msgid ""
+"**`Completeness`** — derived from `rules(regime)` minus "
+"`implemented(regime)`, so it improves by itself as rules are added, and it "
+"names the `missing` rules rather than merely counting them;"
+msgstr ""
+
+#: src/entailment.md:216
+msgid ""
+"**per-rule firing counts** — which rules fired and how many conclusions each "
+"contributed;"
+msgstr ""
+
+#: src/entailment.md:218
+msgid ""
+"**`Boundary`s** — the constructs the run met and could not close over, each "
+"with its reason;"
+msgstr ""
+
+#: src/entailment.md:220
+msgid ""
+"**the evaluation budget** — what the run consumed of the evaluator's fixed "
+"ceilings;"
+msgstr ""
+
+#: src/entailment.md:222
+msgid ""
+"**a contract hash** — `purrdf-datalog`'s digest of the clause program, so a "
+"cached closure minted under a different calculus can be _refused_ rather "
+"than trusted;"
+msgstr ""
+
+#: src/entailment.md:225
+msgid ""
+"**an inconsistency witness**, when a rule that concludes `false` matched: "
+"the rule id, the asserted triples that satisfied its premises in premise "
+"order, and the graph they were read from."
+msgstr ""
+
+#: src/entailment.md:229
+msgid ""
+"A report cannot claim `Exact` while naming a boundary. `ReasoningReport` "
+"stores no completeness field at all: `completeness()` derives the value from "
+"the boundary list itself, so the contradictory state is unrepresentable "
+"rather than merely checked. That is deliberate — an earlier design stored "
+"the field and compared it against a derivation of the same inputs, which is "
+"vacuous by construction and could never fail."
+msgstr ""
+
+#: src/entailment.md:236
+msgid ""
+"The rendering is byte-stable, so the Python, WebAssembly, and C hosts hand "
+"back the same report text as Rust for the same input."
+msgstr ""
+
+#: src/entailment.md:239
+msgid "OWL-Direct: the tableau"
+msgstr ""
+
+#: src/entailment.md:241
+msgid ""
+"`OWL-Direct` semantics is open-world Description Logic, which a forward "
+"chase cannot answer. `materialize_dl_reported` runs an **SHOIQ(D) tableau** "
+"instead — answering instance and subsumption queries via classification, "
+"realization, and query-directed materialization. Because it needs the "
+"query's class expressions, it takes them as its own `query_bgp` parameter; "
+"`materialize` reaches the same tableau by delegating to it for "
+"`Materialization::OwlDirect` rather than restating it."
+msgstr ""
+
+#: src/entailment.md:249 src/entailment-rules.md:65
+msgid "RIF"
+msgstr ""
+
+#: src/entailment.md:251
+msgid ""
+"`materialize_rif` evaluates **RIF-Core** rules over a parsed `RuleSet`, "
+"covering the SPARQL RIF entailment regime."
+msgstr ""
+
+#: src/entailment.md:254
+msgid "D (datatype) entailment"
+msgstr ""
+
+#: src/entailment.md:256
+msgid ""
+"`D` is materialized, not refused. PurRDF realizes it as Simple entailment "
+"plus the five `dt-*` rules of OWL 2 Profiles §4.3 Table 8 — the fixed rule "
+"table a forward chase can enumerate for it — decided over the XSD _value_ "
+"space by `purrdf-xsd` rather than by comparing lexical forms."
+msgstr ""
+
+#: src/entailment.md:261
+msgid ""
+"What Table 8 does not cover is the infinite value spaces themselves, and "
+"that is reported as a `Construct::DatatypeValueSpace` boundary on the run "
+"rather than claimed. So a `D` closure is complete _within its stated "
+"boundary_, and the report is where the boundary is stated."
+msgstr ""
+
+#: src/entailment.md:266
+msgid "Every host materializes `d`, the command-line tool included."
+msgstr ""
+
+#: src/entailment.md:268
+msgid ""
+"There is **no unsupported-regime error**. `materialize` takes a "
+"`Materialization`, which carries each regime's own input — a basic graph "
+"pattern for `OWL-Direct`, a `RuleSet` for `RIF` — so all seven inhabitants "
+"of that type are served and a caller cannot hand the function a value it "
+"accepts and get a refusal instead of an answer. `Regime` stays as the "
+"reporting and identity type that `ReasoningReport::regime()`, `rules()`, "
+"`implemented()` and `Regime::from_iri` speak in."
+msgstr ""
+
+#: src/entailment.md:275
+msgid "Invariants"
+msgstr ""
+
+#: src/entailment.md:277
+msgid ""
+"**No minted vocabulary.** Every constant in the crate's `vocab` module is a "
+"standard `rdf:`/`rdfs:`/`owl:` IRI drawn from the entailment specs "
+"themselves — the crate fabricates none, per the [toolkit-not-ontology rule]"
+"(project/design-rules.md)."
+msgstr ""
+
+#: src/entailment.md:281
+msgid ""
+"**Dependency-lean and wasm-clean.** The dependencies are `purrdf-core`, "
+"[`purrdf-datalog`](datalog.md), `purrdf-xsd`, `roxmltree`, `blake3`, and two "
+"fixed-key hashers (`ahash`, `hashbrown`) — every one of them `wasm32-unknown-"
+"unknown`\\-clean, so the engines carry into Rust, Python, WebAssembly, and C "
+"unchanged, with no threads, filesystem, or RNG dependency."
+msgstr ""
+
+#: src/entailment.md:286
+msgid ""
+"**Deterministic.** Same input + regime → same closure, always — and the same "
+"report, byte for byte."
+msgstr ""
+
+#: src/entailment.md:291
+msgid "Two corpora measure two different things, and the distinction matters:"
+msgstr ""
+
+#: src/entailment.md:293
+msgid ""
+"**W3C SPARQL 1.1 entailment-regime group — 70 of 70 cases pass**, with zero "
+"ledgered residuals: the RDF/RDFS/OWL-RL chase, the OWL-Direct (DL) tableau, "
+"the RIF-Core rule engine, and RDF-axiomatic predicate typing, all run "
+"through the SPARQL conformance harness."
+msgstr ""
+
+#: src/entailment.md:297
+msgid ""
+"**W3C OWL 2 test suite — 258 of 262 cases agree, 4 ledgered**, zero "
+"unledgered. This corpus is _consistency_\\-shaped: all 262 vendored cases "
+"are `otest:ConsistencyTest` (226) or `otest:InconsistencyTest` (36). It "
+"therefore grades the DL/tableau lane's satisfiability verdicts and says "
+"nothing about the OWL 2 RL rule table. Every one of the 4 divergences is "
+"named in a typed ledger; an unledgered divergence, and a ledgered case that "
+"has started agreeing, are both hard failures."
+msgstr ""
+
+#: src/entailment.md:305
+msgid ""
+"Two things this row does **not** say. First, the upstream material is not "
+"free of entailment tests — the W3C manifest holds **206 positive and 23 "
+"negative entailment tests**; this corpus lacks them because the flattening "
+"it was taken from extracted the premise literal and discarded the conclusion "
+"literal, which is exactly the half an entailment grade needs. They are "
+"vendored and graded by the next bullet. Second, the corpus is a **subset**: "
+"262 of the 482 consistency-shaped cases upstream. Of the 220 it leaves out, "
+"**172 the tableau decided when the exclusion was measured** (108 consistent, "
+"64 inconsistent), 0 did not terminate under a 40 s ceiling, 25 were withheld "
+"(20 reasoner, 5 parse), and 23 carry no RDF/XML premise — so the exclusion "
+"was payload triage, not a capability limit, and \"258 of 262\" is a number "
+"over a corpus rather than over what W3C published."
+msgstr ""
+
+#: src/entailment.md:318
+msgid ""
+"Those five figures are a **dated measurement**, recorded in `census.tsv`'s "
+"`dl_probe` column and described in that suite's `PROVENANCE.md`. The harness "
+"reads the column and prints it on every run; it does NOT re-run the reasoner "
+"over the 220 excluded cases, so this row cannot detect a regression among "
+"them. Re-deriving them means re-running the probe, which is a deliberate act "
+"rather than part of the gate."
+msgstr ""
+
+#: src/entailment.md:324
+msgid ""
+"**W3C OWL 2 RL entailment tests — 50 of 50 cases agree, 0 ledgered**, zero "
+"unledgered. This is the independent oracle for the rule table: W3C's own "
+"entailment tests, answered by one call to `purrdf_entail::entails()` per "
+"case under `Regime::OwlRl`. The two lanes prove different things and are "
+"reported separately."
+msgstr ""
+
+#: src/entailment.md:330
+msgid ""
+"**The negative lane is 23 of 23: no unsoundness.** The chase never derived a "
+"triple W3C publishes as _not_ entailed. That is the safety result, and it "
+"holds over _all_ 23 negative cases — soundness is owed on every case, so "
+"none were filtered by profile."
+msgstr ""
+
+#: src/entailment.md:335
+msgid ""
+"**Those 23 agreements are two different results, and the harness prints the "
+"split** on a scoreboard line of its own:"
+msgstr ""
+
+#: src/entailment.md:342
+msgid ""
+"Three are _decided_ non-entailments — both halves of Theorem PR1's "
+"hypothesis hold, so the closure's failure to contain the non-conclusion is a "
+"proof. The other 20 _admit_: the closure was computed and does not contain "
+"the non-conclusion, which is the whole of the soundness observation, and "
+"nothing beyond it is claimed. Both agree, and correctly so; what they differ "
+"in is discriminating power, since a reasoner that derived nothing at all "
+"would score `negative 23 of 23` with `refuted 0`. Read `23 of 23` as \"no "
+"unsoundness found\", never as \"23 non-entailments proved\"."
+msgstr ""
+
+#: src/entailment.md:351
+msgid ""
+"The positive lane is **27 of 27** — the 27 positive entailments W3C itself "
+"places inside the RL profile under RDF-Based semantics — and the typed "
+"divergence ledger `purrdf_sparql_conformance::owl2_rl::LEDGER` is EMPTY — 0 "
+"`schema-conclusion`, 0 `negative-conclusion`, 0 `construct-outside-rl`, 0 "
+"`imports-unresolved`, and **0 are actionable** (0 `missing-rule`)."
+msgstr ""
+
+#: src/entailment.md:358
+msgid ""
+"Every class it used to hold is closed, and the rule table did not change "
+"once to close any of them. `entails()` reaches a conclusion six ways, and "
+"five of the six are not matching:"
+msgstr ""
+
+#: src/entailment.md:362
+msgid ""
+"**refutation.** A negative fact still has no head anywhere in Tables 4–9 — "
+"no rule concludes `owl:differentFrom`, and none concludes membership in an "
+"`owl:complementOf` class. What the table _does_ have is seventeen rules "
+"whose conclusion is `false`, and those seventeen are an inconsistency "
+"calculus: assert the conclusion's negation into the premise, re-run the same "
+"seventy-eight rules over a premise whose consistency the first run already "
+"established, and read the resulting inconsistency as the proof. An "
+"`owl:AllDifferent` collection is, by OWL 2's own definition, the conjunction "
+"of its `n(n−1)/2` pairwise inequalities, so it lowers to the same shape and "
+"is entailed exactly when every pair refutes — which is why two entries left "
+"the `schema-conclusion` class with them."
+msgstr ""
+
+#: src/entailment.md:373
+msgid ""
+"**freeze-and-chase.** `p rdf:type owl:TransitiveProperty` abbreviates a "
+"universally quantified Horn implication, and an implication is decided by "
+"generalisation on constants: freeze its body over constants the premise does "
+"not mention, re-run the table, and look for the head. `chain2trans1`'s "
+"arrives through `prp-spo2`, one of the 78. The axiom's other conjunct — `p` "
+"is an object property — is a lookup in the premise's own closure, and it is "
+"owed: a schema axiom is a conjunction and establishing only the interesting "
+"half would claim conclusions the semantics does not license."
+msgstr ""
+
+#: src/entailment.md:381
+msgid ""
+"**comprehension.** A conclusion may assert that a CLASS EXISTS — an "
+"anonymous `owl:unionOf`, an anonymous `owl:Restriction` — which the RDF-"
+"Based semantics' own comprehension conditions license, subject to a typing "
+"side condition on the operands. Only the scaffolds the conclusion names are "
+"minted, over blank nodes checked absent from both documents."
+msgstr ""
+
+#: src/entailment.md:386
+msgid ""
+"**reflexivity.** `owl:ReflexiveProperty` is outside the RL syntax, so the "
+"profile states no rule for it — and a rule that did would range over every "
+"resource, widening a closure every consumer computes by default. The "
+"conclusion's own self-loops are read off the premise's reflexive typings "
+"instead."
+msgstr ""
+
+#: src/entailment.md:391
+msgid ""
+"**datatype containment.** A property's declared `rdfs:range` datatypes "
+"intersect, and the intersection may be contained in one the premise never "
+"mentions — `xsd:byte ⊑ xsd:short`, and `short ⊓ unsignedInt ⊑ "
+"unsignedShort`, neither of which a join over triples can discover. Decided "
+"over the XSD value spaces, three-valued, with the negative answer gated on "
+"the counterexample range being exactly decided."
+msgstr ""
+
+#: src/entailment.md:398
+msgid ""
+"The last case needed no mechanism at all, only the document its premise "
+"names: `webont-imports-011` `owl:imports` a support ontology the upstream "
+"manifest does not inline, so it is vendored beside the cases from W3C's own "
+"URL and supplied to `entails()` as caller-owned configuration. The library "
+"still fetches nothing."
+msgstr ""
+
+#: src/entailment.md:404
+msgid ""
+"Nothing about the inventory moves: `rules(Regime::OwlRl)` and "
+"`implemented(Regime::OwlRl)` are still exactly the same 78, "
+"`extensions(Regime::OwlRl)` is still the one `ext-eq-diff-sym`, and strict "
+"`Materialization::OwlRl` output is byte-for-byte what it was. The evidence "
+"moves instead — each mechanism arrives with its own `EntailmentWarrant` arm "
+"carrying what it actually used (the `false`\\-concluding rule that fired and "
+"a minimal entailing premise subset; the frozen constants, body and head; the "
+"minted triples and the closure triples that license them) and its own "
+"checker that re-decides the whole thing without running a reasoner."
+msgstr ""
+
+#: src/entailment.md:414
+msgid ""
+"The one case that used to be actionable is closed by an **extension**, and "
+"the extension is labelled rather than absorbed. `a owl:differentFrom b` "
+"entails `b owl:differentFrom a`, which is sound — `owl:differentFrom` "
+"denotes inequality and inequality is symmetric — and shaped exactly like "
+"`prp-symp`, yet is not among the 78 rules, because Table 4's "
+"`owl:differentFrom` rules only ever conclude `false`. PurRDF states it as "
+"`ext-eq-diff-sym`, in a rule family declared to sit _outside_ every "
+"specification table: `extensions(Regime::OwlRl)` returns it, `rules()` and "
+"`implemented()` are still exactly the same 78 and return none of it, "
+"`RuleId::is_extension` decides which is which, and every rendered report "
+"carries an `extension ext-eq-diff-sym` line beside its `missing` lines. So "
+"the closure a caller gets is Tables 4–9 plus a list it can read and reject, "
+"and `OWL-RL 78 / 78` remains a claim about Tables 4–9 and nothing else."
+msgstr ""
+
+#: src/entailment.md:428
+msgid ""
+"The live scoreboard is [`docs/CONFORMANCE.md`](https://github.com/Blackcat-"
+"Informatics/purrdf/blob/main/docs/CONFORMANCE.md)."
+msgstr ""
+
+#: src/entailment-rules.md:8
+msgid ""
+"**This file is generated. Do not edit it by hand.** It is emitted by `cargo "
+"run -p purrdf-entail --example gen_rule_inventory` from "
+"`purrdf_entail::RuleId`, `rules(regime)` and `implemented(regime)`, and "
+"`scripts/check-generated.sh` fails the build when the committed copy and a "
+"fresh run disagree. Regenerate with `make metadata`."
+msgstr ""
+
+#: src/entailment-rules.md:14
+msgid ""
+"**Defined** is the rule table the specification defines the regime by "
+"(`rules(regime)`). **Implemented** is the subset this workspace's evaluator "
+"actually fires (`implemented(regime)`). Their difference is the regime's "
+"gap, and it is the same set a `ReasoningReport` names under `missing`."
+msgstr ""
+
+#: src/entailment-rules.md:19
+msgid ""
+"Neither column counts an **extension** — a rule this workspace fires that no "
+"specification table states. Those are listed in their own section below "
+"(`extensions(regime)`), never folded into a coverage number, so a figure "
+"like `OWL-RL 78 / 78` stays a claim about OWL 2 Profiles §4.3 Tables 4–9 and "
+"about nothing else."
+msgstr ""
+
+#: src/entailment-rules.md:25
+msgid "`78 / 78` and `50 / 50` are two different measurements"
+msgstr ""
+
+#: src/entailment-rules.md:27
+msgid ""
+"This page is the RULE INVENTORY: `78 / 78` says every rule OWL 2 Profiles "
+"§4.3 Tables 4–9 states is one the chase fires. It says nothing about how "
+"many published entailments that reaches, and the two figures are measured "
+"against different things and can move independently."
+msgstr ""
+
+#: src/entailment-rules.md:32
+msgid ""
+"The second measurement is ENTAILMENT CONFORMANCE, over the vendored W3C OWL "
+"2 RL entailment corpus: 50 of 50 cases agree with W3C's published verdict, "
+"27 of 27 positive and 23 of 23 negative, with an empty divergence ledger. "
+"That figure is `crates/sparql-conformance/entailment-suite/w3c-owl2-rl/`'s "
+"and is bounded by what is vendored there — see `docs/CONFORMANCE.md`, which "
+"carries it beside the corpus it was measured on."
+msgstr ""
+
+#: src/entailment-rules.md:39
+msgid ""
+"Fifteen of those 50 are reached by a mechanism that exists because the rule "
+"table DECIDES no conclusion of that shape: refutation, freeze-and-chase, "
+"comprehension, reflexivity and datatype containment, each documented on "
+"`purrdf_entail::EntailmentMechanism`. NONE of them adds a rule, which is why "
+"this inventory is byte-for-byte what it was before they existed — they "
+"change how many times the table is run and what its `false` is read as, not "
+"what the table states."
+msgstr ""
+
+#: src/entailment-rules.md:47
+msgid ""
+"The five COMPOSE. A conclusion graph is a conjunction and entailment is "
+"monotone over one, so a conclusion stating a negative fact beside a schema "
+"axiom is entailed when each half is: `purrdf_entail::entails()` threads the "
+"residual through every lane in turn and matches only what survives, and an "
+"answer that needed two or more of them renders as `composite` rather than as "
+"any single constituent's name. No vendored case needs it — each of the 50 is "
+"reached by one lane or by none — so the corpus does not measure it and the "
+"crate's own tests do."
+msgstr ""
+
+#: src/entailment-rules.md:56
+msgid "Coverage by regime"
+msgstr ""
+
+#: src/entailment-rules.md:58 src/entailment-rules.md:86
+msgid "`--regime`"
+msgstr ""
+
+#: src/entailment-rules.md:60
+msgid "Simple"
+msgstr ""
+
+#: src/entailment-rules.md:60
+msgid "`simple`"
+msgstr ""
+
+#: src/entailment-rules.md:61
+msgid "RDF"
+msgstr ""
+
+#: src/entailment-rules.md:61
+msgid "`rdf`"
+msgstr ""
+
+#: src/entailment-rules.md:62
+msgid "RDFS"
+msgstr ""
+
+#: src/entailment-rules.md:62
+msgid "`rdfs`"
+msgstr ""
+
+#: src/entailment-rules.md:63 src/entailment-rules.md:88
+msgid "OWL-RL"
+msgstr ""
+
+#: src/entailment-rules.md:63 src/entailment-rules.md:88
+msgid "`owl-rl`"
+msgstr ""
+
+#: src/entailment-rules.md:64
+msgid "OWL-Direct"
+msgstr ""
+
+#: src/entailment-rules.md:64
+msgid "`owl-direct`"
+msgstr ""
+
+#: src/entailment-rules.md:65
+msgid "`rif`"
+msgstr ""
+
+#: src/entailment-rules.md:66
+msgid "D"
+msgstr ""
+
+#: src/entailment-rules.md:66
+msgid "`d`"
+msgstr ""
+
+#: src/entailment-rules.md:68
+msgid ""
+"A regime with a zero-length rule table is one this crate does not enumerate "
+"rules for: `Simple` is the identity closure, and `OWL-Direct` and `RIF` are "
+"served by a tableau and by a caller-supplied rule set respectively, neither "
+"of which is a fixed table."
+msgstr ""
+
+#: src/entailment-rules.md:73
+msgid "Extensions"
+msgstr ""
+
+#: src/entailment-rules.md:75
+msgid ""
+"A rule this workspace's evaluator fires that **no specification table "
+"states**. An extension appears in neither column above, for any regime: "
+"`rules(regime)` and `implemented(regime)` name only specification rules, and "
+"`extensions(regime)` names only these. `RuleId::is_extension` decides which "
+"is which, and a `ReasoningReport` renders the list under `extension` beside "
+"the `missing` list — so a caller that must act only on normative conclusions "
+"can tell from the report rather than from prose."
+msgstr ""
+
+#: src/entailment-rules.md:83
+msgid ""
+"Every entry is sound under the semantics of the vocabulary it reads; that is "
+"the only standard a rule with no specification to appeal to can meet."
+msgstr ""
+
+#: src/entailment-rules.md:86 src/entailment-rules.md:92
+#: src/entailment-rules.md:100 src/entailment-rules.md:123
+#: src/entailment-rules.md:206
+msgid "Rule"
+msgstr ""
+
+#: src/entailment-rules.md:88
+msgid "`ext-eq-diff-sym`"
+msgstr ""
+
+#: src/entailment-rules.md:90
+msgid "RDF — 3 of 3 rules implemented"
+msgstr ""
+
+#: src/entailment-rules.md:92 src/entailment-rules.md:100
+#: src/entailment-rules.md:123 src/entailment-rules.md:206
+msgid "Specification"
+msgstr ""
+
+#: src/entailment-rules.md:94 src/entailment-rules.md:102
+msgid "`rdfD1`"
+msgstr ""
+
+#: src/entailment-rules.md:94 src/entailment-rules.md:95
+#: src/entailment-rules.md:96 src/entailment-rules.md:102
+#: src/entailment-rules.md:103 src/entailment-rules.md:104
+msgid "RDF 1.2 Semantics §8.1.1 (RDF patterns)"
+msgstr ""
+
+#: src/entailment-rules.md:95 src/entailment-rules.md:103
+msgid "`rdfD1a`"
+msgstr ""
+
+#: src/entailment-rules.md:96 src/entailment-rules.md:104
+msgid "`rdfD2`"
+msgstr ""
+
+#: src/entailment-rules.md:98
+msgid "RDFS — 18 of 18 rules implemented"
+msgstr ""
+
+#: src/entailment-rules.md:105
+msgid "`rdfs1`"
+msgstr ""
+
+#: src/entailment-rules.md:105 src/entailment-rules.md:106
+#: src/entailment-rules.md:107 src/entailment-rules.md:108
+#: src/entailment-rules.md:109 src/entailment-rules.md:110
+#: src/entailment-rules.md:111 src/entailment-rules.md:112
+#: src/entailment-rules.md:113 src/entailment-rules.md:114
+#: src/entailment-rules.md:115 src/entailment-rules.md:116
+#: src/entailment-rules.md:117 src/entailment-rules.md:118
+#: src/entailment-rules.md:119
+msgid "RDF 1.2 Semantics §9.2.1 (RDFS patterns)"
+msgstr ""
+
+#: src/entailment-rules.md:106
+msgid "`rdfs2`"
+msgstr ""
+
+#: src/entailment-rules.md:107
+msgid "`rdfs3`"
+msgstr ""
+
+#: src/entailment-rules.md:108
+msgid "`rdfs4`"
+msgstr ""
+
+#: src/entailment-rules.md:109
+msgid "`rdfs5`"
+msgstr ""
+
+#: src/entailment-rules.md:110
+msgid "`rdfs6`"
+msgstr ""
+
+#: src/entailment-rules.md:111
+msgid "`rdfs7`"
+msgstr ""
+
+#: src/entailment-rules.md:112
+msgid "`rdfs8`"
+msgstr ""
+
+#: src/entailment-rules.md:113
+msgid "`rdfs9`"
+msgstr ""
+
+#: src/entailment-rules.md:114
+msgid "`rdfs10`"
+msgstr ""
+
+#: src/entailment-rules.md:115
+msgid "`rdfs11`"
+msgstr ""
+
+#: src/entailment-rules.md:116
+msgid "`rdfs12`"
+msgstr ""
+
+#: src/entailment-rules.md:117
+msgid "`rdfs13`"
+msgstr ""
+
+#: src/entailment-rules.md:118
+msgid "`rdfs14`"
+msgstr ""
+
+#: src/entailment-rules.md:119
+msgid "`rdfs14a`"
+msgstr ""
+
+#: src/entailment-rules.md:121
+msgid "OWL-RL — 78 of 78 rules implemented"
+msgstr ""
+
+#: src/entailment-rules.md:125
+msgid "`eq-ref`"
+msgstr ""
+
+#: src/entailment-rules.md:125 src/entailment-rules.md:126
+#: src/entailment-rules.md:127 src/entailment-rules.md:128
+#: src/entailment-rules.md:129 src/entailment-rules.md:130
+#: src/entailment-rules.md:131 src/entailment-rules.md:132
+#: src/entailment-rules.md:133
+msgid "OWL 2 Profiles §4.3 Table 4 (Equality)"
+msgstr ""
+
+#: src/entailment-rules.md:126
+msgid "`eq-sym`"
+msgstr ""
+
+#: src/entailment-rules.md:127
+msgid "`eq-trans`"
+msgstr ""
+
+#: src/entailment-rules.md:128
+msgid "`eq-rep-s`"
+msgstr ""
+
+#: src/entailment-rules.md:129
+msgid "`eq-rep-p`"
+msgstr ""
+
+#: src/entailment-rules.md:130
+msgid "`eq-rep-o`"
+msgstr ""
+
+#: src/entailment-rules.md:131
+msgid "`eq-diff1`"
+msgstr ""
+
+#: src/entailment-rules.md:132
+msgid "`eq-diff2`"
+msgstr ""
+
+#: src/entailment-rules.md:133
+msgid "`eq-diff3`"
+msgstr ""
+
+#: src/entailment-rules.md:134
+msgid "`prp-ap`"
+msgstr ""
+
+#: src/entailment-rules.md:134 src/entailment-rules.md:135
+#: src/entailment-rules.md:136 src/entailment-rules.md:137
+#: src/entailment-rules.md:138 src/entailment-rules.md:139
+#: src/entailment-rules.md:140 src/entailment-rules.md:141
+#: src/entailment-rules.md:142 src/entailment-rules.md:143
+#: src/entailment-rules.md:144 src/entailment-rules.md:145
+#: src/entailment-rules.md:146 src/entailment-rules.md:147
+#: src/entailment-rules.md:148 src/entailment-rules.md:149
+#: src/entailment-rules.md:150 src/entailment-rules.md:151
+#: src/entailment-rules.md:152 src/entailment-rules.md:153
+msgid "OWL 2 Profiles §4.3 Table 5 (Property Axioms)"
+msgstr ""
+
+#: src/entailment-rules.md:135
+msgid "`prp-dom`"
+msgstr ""
+
+#: src/entailment-rules.md:136
+msgid "`prp-rng`"
+msgstr ""
+
+#: src/entailment-rules.md:137
+msgid "`prp-fp`"
+msgstr ""
+
+#: src/entailment-rules.md:138
+msgid "`prp-ifp`"
+msgstr ""
+
+#: src/entailment-rules.md:139
+msgid "`prp-irp`"
+msgstr ""
+
+#: src/entailment-rules.md:140
+msgid "`prp-symp`"
+msgstr ""
+
+#: src/entailment-rules.md:141
+msgid "`prp-asyp`"
+msgstr ""
+
+#: src/entailment-rules.md:142
+msgid "`prp-trp`"
+msgstr ""
+
+#: src/entailment-rules.md:143
+msgid "`prp-spo1`"
+msgstr ""
+
+#: src/entailment-rules.md:144
+msgid "`prp-spo2`"
+msgstr ""
+
+#: src/entailment-rules.md:145
+msgid "`prp-eqp1`"
+msgstr ""
+
+#: src/entailment-rules.md:146
+msgid "`prp-eqp2`"
+msgstr ""
+
+#: src/entailment-rules.md:147
+msgid "`prp-pdw`"
+msgstr ""
+
+#: src/entailment-rules.md:148
+msgid "`prp-adp`"
+msgstr ""
+
+#: src/entailment-rules.md:149
+msgid "`prp-inv1`"
+msgstr ""
+
+#: src/entailment-rules.md:150
+msgid "`prp-inv2`"
+msgstr ""
+
+#: src/entailment-rules.md:151
+msgid "`prp-key`"
+msgstr ""
+
+#: src/entailment-rules.md:152
+msgid "`prp-npa1`"
+msgstr ""
+
+#: src/entailment-rules.md:153
+msgid "`prp-npa2`"
+msgstr ""
+
+#: src/entailment-rules.md:154
+msgid "`cls-thing`"
+msgstr ""
+
+#: src/entailment-rules.md:154 src/entailment-rules.md:155
+#: src/entailment-rules.md:156 src/entailment-rules.md:157
+#: src/entailment-rules.md:158 src/entailment-rules.md:159
+#: src/entailment-rules.md:160 src/entailment-rules.md:161
+#: src/entailment-rules.md:162 src/entailment-rules.md:163
+#: src/entailment-rules.md:164 src/entailment-rules.md:165
+#: src/entailment-rules.md:166 src/entailment-rules.md:167
+#: src/entailment-rules.md:168 src/entailment-rules.md:169
+#: src/entailment-rules.md:170 src/entailment-rules.md:171
+#: src/entailment-rules.md:172
+msgid "OWL 2 Profiles §4.3 Table 6 (Classes)"
+msgstr ""
+
+#: src/entailment-rules.md:155
+msgid "`cls-nothing1`"
+msgstr ""
+
+#: src/entailment-rules.md:156
+msgid "`cls-nothing2`"
+msgstr ""
+
+#: src/entailment-rules.md:157
+msgid "`cls-int1`"
+msgstr ""
+
+#: src/entailment-rules.md:158
+msgid "`cls-int2`"
+msgstr ""
+
+#: src/entailment-rules.md:159
+msgid "`cls-uni`"
+msgstr ""
+
+#: src/entailment-rules.md:160
+msgid "`cls-com`"
+msgstr ""
+
+#: src/entailment-rules.md:161
+msgid "`cls-svf1`"
+msgstr ""
+
+#: src/entailment-rules.md:162
+msgid "`cls-svf2`"
+msgstr ""
+
+#: src/entailment-rules.md:163
+msgid "`cls-avf`"
+msgstr ""
+
+#: src/entailment-rules.md:164
+msgid "`cls-hv1`"
+msgstr ""
+
+#: src/entailment-rules.md:165
+msgid "`cls-hv2`"
+msgstr ""
+
+#: src/entailment-rules.md:166
+msgid "`cls-maxc1`"
+msgstr ""
+
+#: src/entailment-rules.md:167
+msgid "`cls-maxc2`"
+msgstr ""
+
+#: src/entailment-rules.md:168
+msgid "`cls-maxqc1`"
+msgstr ""
+
+#: src/entailment-rules.md:169
+msgid "`cls-maxqc2`"
+msgstr ""
+
+#: src/entailment-rules.md:170
+msgid "`cls-maxqc3`"
+msgstr ""
+
+#: src/entailment-rules.md:171
+msgid "`cls-maxqc4`"
+msgstr ""
+
+#: src/entailment-rules.md:172
+msgid "`cls-oo`"
+msgstr ""
+
+#: src/entailment-rules.md:173
+msgid "`cax-sco`"
+msgstr ""
+
+#: src/entailment-rules.md:173 src/entailment-rules.md:174
+#: src/entailment-rules.md:175 src/entailment-rules.md:176
+#: src/entailment-rules.md:177
+msgid "OWL 2 Profiles §4.3 Table 7 (Class Axioms)"
+msgstr ""
+
+#: src/entailment-rules.md:174
+msgid "`cax-eqc1`"
+msgstr ""
+
+#: src/entailment-rules.md:175
+msgid "`cax-eqc2`"
+msgstr ""
+
+#: src/entailment-rules.md:176
+msgid "`cax-dw`"
+msgstr ""
+
+#: src/entailment-rules.md:177
+msgid "`cax-adc`"
+msgstr ""
+
+#: src/entailment-rules.md:178 src/entailment-rules.md:208
+msgid "`dt-type1`"
+msgstr ""
+
+#: src/entailment-rules.md:178 src/entailment-rules.md:179
+#: src/entailment-rules.md:180 src/entailment-rules.md:181
+#: src/entailment-rules.md:182 src/entailment-rules.md:208
+#: src/entailment-rules.md:209 src/entailment-rules.md:210
+#: src/entailment-rules.md:211 src/entailment-rules.md:212
+msgid "OWL 2 Profiles §4.3 Table 8 (Datatypes)"
+msgstr ""
+
+#: src/entailment-rules.md:179 src/entailment-rules.md:209
+msgid "`dt-type2`"
+msgstr ""
+
+#: src/entailment-rules.md:180 src/entailment-rules.md:210
+msgid "`dt-eq`"
+msgstr ""
+
+#: src/entailment-rules.md:181 src/entailment-rules.md:211
+msgid "`dt-diff`"
+msgstr ""
+
+#: src/entailment-rules.md:182 src/entailment-rules.md:212
+msgid "`dt-not-type`"
+msgstr ""
+
+#: src/entailment-rules.md:183
+msgid "`scm-cls`"
+msgstr ""
+
+#: src/entailment-rules.md:183 src/entailment-rules.md:184
+#: src/entailment-rules.md:185 src/entailment-rules.md:186
+#: src/entailment-rules.md:187 src/entailment-rules.md:188
+#: src/entailment-rules.md:189 src/entailment-rules.md:190
+#: src/entailment-rules.md:191 src/entailment-rules.md:192
+#: src/entailment-rules.md:193 src/entailment-rules.md:194
+#: src/entailment-rules.md:195 src/entailment-rules.md:196
+#: src/entailment-rules.md:197 src/entailment-rules.md:198
+#: src/entailment-rules.md:199 src/entailment-rules.md:200
+#: src/entailment-rules.md:201 src/entailment-rules.md:202
+msgid "OWL 2 Profiles §4.3 Table 9 (Schema Vocabulary)"
+msgstr ""
+
+#: src/entailment-rules.md:184
+msgid "`scm-sco`"
+msgstr ""
+
+#: src/entailment-rules.md:185
+msgid "`scm-eqc1`"
+msgstr ""
+
+#: src/entailment-rules.md:186
+msgid "`scm-eqc2`"
+msgstr ""
+
+#: src/entailment-rules.md:187
+msgid "`scm-op`"
+msgstr ""
+
+#: src/entailment-rules.md:188
+msgid "`scm-dp`"
+msgstr ""
+
+#: src/entailment-rules.md:189
+msgid "`scm-spo`"
+msgstr ""
+
+#: src/entailment-rules.md:190
+msgid "`scm-eqp1`"
+msgstr ""
+
+#: src/entailment-rules.md:191
+msgid "`scm-eqp2`"
+msgstr ""
+
+#: src/entailment-rules.md:192
+msgid "`scm-dom1`"
+msgstr ""
+
+#: src/entailment-rules.md:193
+msgid "`scm-dom2`"
+msgstr ""
+
+#: src/entailment-rules.md:194
+msgid "`scm-rng1`"
+msgstr ""
+
+#: src/entailment-rules.md:195
+msgid "`scm-rng2`"
+msgstr ""
+
+#: src/entailment-rules.md:196
+msgid "`scm-hv`"
+msgstr ""
+
+#: src/entailment-rules.md:197
+msgid "`scm-svf1`"
+msgstr ""
+
+#: src/entailment-rules.md:198
+msgid "`scm-svf2`"
+msgstr ""
+
+#: src/entailment-rules.md:199
+msgid "`scm-avf1`"
+msgstr ""
+
+#: src/entailment-rules.md:200
+msgid "`scm-avf2`"
+msgstr ""
+
+#: src/entailment-rules.md:201
+msgid "`scm-int`"
+msgstr ""
+
+#: src/entailment-rules.md:202
+msgid "`scm-uni`"
+msgstr ""
+
+#: src/entailment-rules.md:204
+msgid "D — 5 of 5 rules implemented"
+msgstr ""
+
+#: src/datalog.md:8
+msgid ""
+"[`purrdf-datalog`](https://docs.rs/purrdf-datalog) is deterministic, "
+"`wasm32`\\-clean Datalog evaluation: a columnar relation store, an index-"
+"selecting planner, and a semi-naive fixpoint, carrying no ambient I/O, no "
+"wall clock, and no RNG."
+msgstr ""
+
+#: src/datalog.md:12
+msgid ""
+"It exists so that a rule set is _data_ rather than a hand-written loop. "
+"[`purrdf-entail`](entailment.md) declares the RDF, RDFS, OWL 2 RL, and D "
+"calculi as DL-clause programs and evaluates them here, which is what lets a "
+"reasoning report carry a **contract hash** of the exact program that ran "
+"instead of a claim about which rules were meant to run."
+msgstr ""
+
+#: src/datalog.md:18
+msgid ""
+"`purrdf-datalog` is re-exported by the umbrella `purrdf` crate as the "
+"`purrdf::datalog` module — the entailment surface CARRIES its types (a "
+"[`ReasoningReport`](entailment.md) hands out a "
+"`datalog::cache::ContractHash` and a `datalog::seminaive::BudgetReport`), so "
+"a consumer that matches on them needs no second dependency on `purrdf-"
+"datalog`. Depend on the crate directly (`purrdf-datalog = \"…\"`) only when "
+"you want the fixpoint alone, with no other `purrdf` surface in the build."
+msgstr ""
+
+#: src/datalog.md:26
+msgid "One rule IR: the DL-clause"
+msgstr ""
+
+#: src/datalog.md:28
+msgid "Every rule has the shape"
+msgstr ""
+
+#: src/datalog.md:34
+msgid ""
+"where each disjunct `Cᵢ` is itself a conjunction of head atoms. That single "
+"shape holds all five head forms — atomic (an ordinary Datalog rule), "
+"existential, disjunctive, conjunctive, and empty (`false`) — so an axiom "
+"like `A ⊑ ∃r.C`, which lowers to `∃y. (r(x, y) ∧ C(y))` with one _shared_ "
+"witness, is one rule rather than two unrelated ones."
+msgstr ""
+
+#: src/datalog.md:40
+msgid ""
+"The semi-naive evaluator runs the atomic form and refuses the other four "
+"**by name**. The existential form is not lost by that refusal: the "
+"restricted chase consumes it, minting frontier-addressed Skolem witnesses, "
+"which is how the four existential RDF/RDFS patterns fire and the rule "
+"inventory reads complete. What never happens is a surrogate leaking into an "
+"answer — the entailment layer above withholds every conclusion that mentions "
+"a witness at the materialization boundary and reports the withholding, "
+"rather than inventing an answer the caller did not ask for."
+msgstr ""
+
+#: src/datalog.md:49
+msgid "Determinism"
+msgstr ""
+
+#: src/datalog.md:51
+msgid ""
+"Per-key rows keep insertion order; the arrangement is sorted; no map "
+"iteration order reaches an output path."
+msgstr ""
+
+#: src/datalog.md:53
+msgid ""
+"Plans are content-addressed by a BLAKE3 digest over the planner version, the "
+"caller's contract hash, and a canonical digest of the clause program. The "
+"cache is owned by the caller, never a process global — a global would make "
+"an answer depend on evaluation history."
+msgstr ""
+
+#: src/datalog.md:57
+msgid ""
+"Where work is parallelised it uses indexed `par_iter`/`par_chunks` reduced "
+"in source order, never `par_sort` or `par_bridge`, and degrades to inline-"
+"sequential on `wasm32-unknown-unknown`."
+msgstr ""
+
+#: src/datalog.md:61
+msgid "Identical input yields byte-identical output, on every target."
+msgstr ""
+
+#: src/datalog.md:63
+msgid "Budgets are constants, not knobs"
+msgstr ""
+
+#: src/datalog.md:65
+msgid ""
+"Three ceilings bound every run, and all three are fixed workspace constants "
+"whose consumption is _reported_, never configured — two callers with the "
+"same input always get the same answer:"
+msgstr ""
+
+#: src/datalog.md:69
+msgid "Ceiling"
+msgstr ""
+
+#: src/datalog.md:69
+msgid "Bounds"
+msgstr ""
+
+#: src/datalog.md:71
+msgid "`MAX_JOIN_STEPS`"
+msgstr ""
+
+#: src/datalog.md:71
+msgid "candidate solutions enumerated"
+msgstr ""
+
+#: src/datalog.md:72
+msgid "`MAX_STORED_FACTS`"
+msgstr ""
+
+#: src/datalog.md:72
+msgid "facts seeded or derived"
+msgstr ""
+
+#: src/datalog.md:73
+msgid "`MAX_TERM_ARENA_BYTES`"
+msgstr ""
+
+#: src/datalog.md:73
+msgid "interned term surface bytes"
+msgstr ""
+
+#: src/datalog.md:75
+msgid ""
+"There is deliberately no wall-clock budget: it would break both `wasm32` and "
+"reproducibility."
+msgstr ""
+
+#: src/datalog.md:78
+msgid ""
+"Passing a ceiling is a **total** refusal, not a truncation. There is no "
+"partial fixpoint to hand back with a note attached, and a truncated closure "
+"presented as a complete one is exactly the failure a reasoning report exists "
+"to prevent. The error names which ceiling was hit and what the run had "
+"consumed when it stopped; in `purrdf-entail` that surfaces as "
+"`EntailError::Evaluate`."
+msgstr ""
+
+#: src/gts.md:8
+msgid ""
+"**GTS (Graph Transport Substrate)** is an ontology-independent binary "
+"container and transport format for RDF 1.2 datasets and content-addressed "
+"binary payloads. PurRDF hosts the reference Rust engine, [`purrdf-gts`]"
+"(https://docs.rs/purrdf-gts) (re-exported as `purrdf::gts`)."
+msgstr ""
+
+#: src/gts.md:13
+msgid ""
+"This chapter is a user-level tour. **The wire format itself is specified in "
+"[`docs/GTS-SPEC.md`](https://github.com/Blackcat-Informatics/purrdf/blob/"
+"main/docs/GTS-SPEC.md)** — consult the spec for framing, fold semantics, "
+"registries, and conformance classes; nothing here supersedes it."
+msgstr ""
+
+#: src/gts.md:18
+msgid "The container model, at a high level"
+msgstr ""
+
+#: src/gts.md:20
+msgid ""
+"A GTS file is a **CBOR Sequence of one or more append-only segments**. Each "
+"segment is a deterministic CBOR header followed by deterministic CBOR frames "
+"chained by **BLAKE3 content identifiers**. The logical dataset is obtained "
+"by a **deterministic fold** over the segment sequence: quads, reifiers, "
+"annotations, and binary blobs all become rows of the folded container graph."
+msgstr ""
+
+#: src/gts.md:26
+msgid "Properties that fall out of this design:"
+msgstr ""
+
+#: src/gts.md:28
+msgid ""
+"**Content-addressed and append-only** — history is never rewritten; "
+"suppression is itself an appended record. Multi-segment files compose by "
+"simple concatenation."
+msgstr ""
+
+#: src/gts.md:31
+msgid ""
+"**Partial readability, total reader** — the reader verifies the BLAKE3 chain "
+"and folds what it can; undecodable frames (unknown codec, encrypted without "
+"a key) degrade to _opaque nodes_ plus a diagnostic instead of aborting."
+msgstr ""
+
+#: src/gts.md:35
+msgid ""
+"**Binary payloads ride along** — the blobs a graph references travel in the "
+"same file, content-addressed like everything else."
+msgstr ""
+
+#: src/gts.md:37
+msgid ""
+"**RDF 1.2-native** — the spec formalizes the triple-term and `rdf:reifies` "
+"mapping, blank-node scoping, and multi-segment value union."
+msgstr ""
+
+#: src/gts.md:40
+msgid "Reading and writing from Rust"
+msgstr ""
+
+#: src/gts.md:42
+msgid ""
+"The container engine (`purrdf-gts`) owns the wire-format machinery — reader, "
+"writer, fold, verify, COSE, trust policy:"
+msgstr ""
+
+#: src/gts.md:47
+msgid ""
+"// Fold GTS bytes into the container graph model, verifying the BLAKE3 "
+"chain.\n"
+msgstr ""
+
+#: src/gts.md:49
+msgid "/* allow_segments */"
+msgstr ""
+
+#: src/gts.md:49
+msgid "/* expected_head */"
+msgstr ""
+
+#: src/gts.md:50
+msgid ""
+"// The fold is total: quads, reifiers, annotations, and blobs are all rows,\n"
+"// and anything undecodable is preserved as an opaque node plus a "
+"diagnostic.\n"
+msgstr ""
+
+#: src/gts.md:53
+msgid "\"{} quads, {} blobs\""
+msgstr ""
+
+#: src/gts.md:56
+msgid ""
+"The writer authors frames and produces **byte-deterministic single-segment "
+"snapshots** (`Writer::deterministic`) — the GTS writer is under the same "
+"determinism invariant as every PurRDF serializer."
+msgstr ""
+
+#: src/gts.md:60
+msgid ""
+"The `RdfDataset` import/export path lives one layer up: the umbrella crate's "
+"`gts` module combines the container engine with the RDF-level adapter "
+"(snapshot composition, content-chain verification), so RDF-facing GTS work "
+"goes through `purrdf` directly."
+msgstr ""
+
+#: src/gts.md:65
+msgid "Signing and encryption"
+msgstr ""
+
+#: src/gts.md:67
+msgid ""
+"Frames can be signed and encrypted with **COSE**; OpenPGP-based checks and a "
+"trust-policy layer are also part of the engine. All cryptography is **pure "
+"Rust** — no C toolchain, threads, or syscall dependencies — which is what "
+"keeps the whole engine wasm-friendly. An encrypted frame you cannot decrypt "
+"is simply an opaque node in the fold: the container remains readable."
+msgstr ""
+
+#: src/gts.md:73
+msgid "Conformance vectors"
+msgstr ""
+
+#: src/gts.md:75
+msgid ""
+"GTS conformance is defined against a **frozen, language-neutral vector "
+"corpus** (`vectors/` in the repository), shared **byte-exact** across the "
+"sibling GTS engines in other languages. The vectors are never regenerated or "
+"\"fixed\" in this repository — the format is governed in the [`gmeow-gts`]"
+"(https://github.com/Blackcat-Informatics/gmeow-gts) project, alongside the "
+"specification and the other reference engines."
+msgstr ""
+
+#: src/gts.md:82
+msgid "The C ABI's star-layer round-trip"
+msgstr ""
+
+#: src/gts.md:84
+msgid ""
+"The GTS star-layer round-trip of a dataset containing quoted triples / "
+"reifier bindings succeeds through the kernel `to_gts` → `read_graph` → "
+"`import_gts_graph` path, the same as a star-free round-trip; `crates/rdf-"
+"capi/tests/abi.rs`'s `gts_star_roundtrip_preserves_the_statement_layer` pins "
+"it. See [Getting Started: C](getting-started/c.md#gts-star-layer-round-trip)."
+msgstr ""
+
+#: src/gts.md:93
+msgid ""
+"[`docs/GTS-SPEC.md`](https://github.com/Blackcat-Informatics/purrdf/blob/"
+"main/docs/GTS-SPEC.md) — the normative wire format (version 0.9-draft, wire-"
+"format major 1)."
+msgstr ""
+
+#: src/gts.md:95
+msgid "[Slices, Mappings & Provenance](slices.md) — the RDF↔GTS loss ledger."
+msgstr ""
+
+#: src/gts.md:96
+msgid ""
+"[Getting Started: Python](getting-started/python.md#gts-relational-exports) "
+"— projecting a container into SQLite/DuckDB/Parquet."
+msgstr ""
+
+#: src/slices.md:8
+msgid ""
+"Beyond the engines, PurRDF carries the plumbing a serious vocabulary or data-"
+"pipeline project needs: a slice catalog for organizing authored RDF, an "
+"explicit loss ledger for lossy projections, and native codecs for the SSSOM "
+"and FnO interchange formats."
+msgstr ""
+
+#: src/slices.md:13
+msgid "The slice catalog"
+msgstr ""
+
+#: src/slices.md:15
+msgid ""
+"[`purrdf-slice`](https://docs.rs/purrdf-slice) (re-exported as "
+"`purrdf::slice`) is tooling for ontology/vocabulary repositories organized "
+"as _slices_ — directories of authored RDF (`slices/<group>/<name>/`), each "
+"described by a `manifest.ttl`:"
+msgstr ""
+
+#: src/slices.md:20
+msgid ""
+"**Catalog** — manifest-based discovery (`SliceCatalog::discover`), typed "
+"slice metadata (`SliceRecord`, `SliceTier`), and artifact roles. Slice "
+"identity comes from the manifest, not the directory name."
+msgstr ""
+
+#: src/slices.md:23
+msgid ""
+"**Ownership & dependencies** — term-ownership analysis (every declared term "
+"has exactly one owning slice), dependency edges with evidence, forbidden-"
+"edge rules (extension slices depend only on core), and machine-applicable "
+"fix suggestions."
+msgstr ""
+
+#: src/slices.md:27
+msgid ""
+"**Content addressing** — deterministic artifact digests and cache keys for "
+"incremental pipelines."
+msgstr ""
+
+#: src/slices.md:29
+msgid ""
+"**Emitters** — projection/mapping emitters and lints: prefix maps, JSON-LD "
+"contexts, FnO function catalogs, claim views."
+msgstr ""
+
+#: src/slices.md:32
+msgid ""
+"True to the rule that PurRDF mints no vocabulary IRIs, every term the slice "
+"framework reads or emits belongs to the **caller's** vocabulary: a "
+"`SliceVocab` is caller-constructed (it has no `Default`) and threaded "
+"through every public entry point."
+msgstr ""
+
+#: src/slices.md:40
+msgid "// Your vocabulary namespace — PurRDF fabricates none.\n"
+msgstr ""
+
+#: src/slices.md:43
+msgid "\"https://example.org/vocab/Slice\""
+msgstr ""
+
+#: src/slices.md:44
+msgid ""
+"// Discover every slice under the repository root from its manifest.ttl.\n"
+msgstr ""
+
+#: src/slices.md:46
+msgid "\"slices\""
+msgstr ""
+
+#: src/slices.md:47
+msgid "\"slices discovered\""
+msgstr ""
+
+#: src/slices.md:49
+msgid "\"{} ({:?})\""
+msgstr ""
+
+#: src/slices.md:53
+msgid "The loss ledger"
+msgstr ""
+
+#: src/slices.md:55
+msgid ""
+"PurRDF's projections are allowed to be lossy — but never silently. The "
+"kernel carries a machine-readable **RDF↔GTS loss matrix** ([`generated/rdf-"
+"loss-matrix.json`](https://github.com/Blackcat-Informatics/purrdf/blob/main/"
+"generated/rdf-loss-matrix.json), a generated artifact) and a `LossLedger` "
+"API: when a star-incapable codec drops reifier bindings, or CSV results drop "
+"provenance, the realized count is recorded and surfaced to the caller. See "
+"[Codecs & Determinism](concepts/codecs.md#lossy-projections-are-loud) and "
+"[Result Formats](sparql/results.md)."
+msgstr ""
+
+#: src/slices.md:64
+msgid "Provenance"
+msgstr ""
+
+#: src/slices.md:66
+msgid ""
+"`purrdf-core` includes a generic **provenance sidecar** for the frozen IR — "
+"attribution, origin sets, and per-quad provenance that engines can carry "
+"without polluting the data graph. The SPARQL results extension ([Result "
+"Formats](sparql/results.md#the-provenance-extension)) and the SARIF boundary "
+"both resolve these runtime-only provenance ids to public IRIs at their "
+"serialization edges."
+msgstr ""
+
+#: src/slices.md:73
+msgid "SSSOM and FnO"
+msgstr ""
+
+#: src/slices.md:75
+msgid "Two native interchange codecs live in the kernel:"
+msgstr ""
+
+#: src/slices.md:77
+msgid ""
+"**SSSOM** — [Simple Standard for Sharing Ontological Mappings](https://"
+"mapping-commons.github.io/sssom/) mapping-set TSV support "
+"(`SssomMappingSet`, `SssomMapping`, with typed diagnostics), for carrying "
+"cross-vocabulary mappings alongside your data. `SssomSetComment` models set-"
+"level ordinary comments and provenance as a lossless document envelope, "
+"independently of YAML-like header metadata. Newly appended provenance uses "
+"the interoperable metadata-to-table position; parsed after-table comments "
+"are retained as an explicit extension. Raw Unicode comment lines and their "
+"order are preserved, while physical line endings serialize deterministically "
+"as LF."
+msgstr ""
+
+#: src/slices.md:86
+msgid ""
+"**FnO** — a [Function Ontology](https://fno.io/) function-catalog codec "
+"(`FnoCatalog`, `fno_to_quads`, `fno_to_ntriples`), used by the slice "
+"emitters to describe function catalogs as RDF."
+msgstr ""
+
+#: src/slices.md:90
+msgid ""
+"As with everything else in the toolkit, these are codecs for _caller_ data — "
+"PurRDF does not define mappings or functions of its own. SSSOM envelope "
+"comments also remain caller-neutral projection data: they do not mint RDF "
+"predicates, change mapping validation, or alter the RDF projection."
+msgstr ""
+
+#: src/slices.md:97
+msgid "[GTS Graph Transport](gts.md) — the other side of the RDF↔GTS ledger."
+msgstr ""
+
+#: src/slices.md:98
+msgid ""
+"[Design Rules & Invariants](project/design-rules.md) — the mints-no-IRIs "
+"rule in full."
+msgstr ""
+
+#: src/interop/rdflib.md:8
+msgid ""
+"Python's [rdflib](https://rdflib.readthedocs.io/) is the incumbent RDF "
+"library of the ecosystem, and PurRDF meets it in two tiers: an explicit "
+"compat module, and an opt-in drop-in shadow."
+msgstr ""
+
+#: src/interop/rdflib.md:12
+msgid "Tier 1: the explicit compat layer"
+msgstr ""
+
+#: src/interop/rdflib.md:14
+msgid ""
+"The main `purrdf` wheel ships an rdflib compatibility layer backed by the "
+"native engine:"
+msgstr ""
+
+#: src/interop/rdflib.md:21
+msgid ""
+"\"<https://example.org/a> <https://example.org/b> <https://example.org/c> .\""
+msgstr ""
+
+#: src/interop/rdflib.md:22
+msgid "\"turtle\""
+msgstr ""
+
+#: src/interop/rdflib.md:25
+msgid ""
+"This is the recommended path for new code that wants an rdflib-shaped API on "
+"the PurRDF engine: the import name is honest, and it coexists with a genuine "
+"`rdflib` installation."
+msgstr ""
+
+#: src/interop/rdflib.md:29
+msgid "Tier 2: the `purrdf[rdflib]` shadow distribution"
+msgstr ""
+
+#: src/interop/rdflib.md:31
+msgid "For a literal, zero-change `import rdflib`, install the opt-in extra:"
+msgstr ""
+
+#: src/interop/rdflib.md:47
+msgid "How compatibility is kept honest"
+msgstr ""
+
+#: src/interop/rdflib.md:49
+msgid ""
+"The compat layer is not \"best effort\" — it is gated in CI as part of the "
+"single conformance matrix ([`docs/CONFORMANCE.md`](https://github.com/"
+"Blackcat-Informatics/purrdf/blob/main/docs/CONFORMANCE.md)):"
+msgstr ""
+
+#: src/interop/rdflib.md:53
+msgid ""
+"**The rdflib drop-in (LSP) gate** runs rdflib 7.6's **own vendored test "
+"suite** against the purrdf drop-in."
+msgstr ""
+
+#: src/interop/rdflib.md:55
+msgid ""
+"**The parity suite** runs first-party differential tests of `purrdf.compat` "
+"against the real rdflib 7.6."
+msgstr ""
+
+#: src/interop/rdflib.md:58
+msgid ""
+"Both use strict expected-failure ledgers: every known divergence is listed "
+"with a per-test reason, an unexpected failure breaks the build, and a "
+"silently fixed divergence also breaks the build until the ledger shrinks. "
+"The ledgered residuals cover corners like Graph-subclass identity through "
+"set operators, `rdf:List`/Collection mutation, `Result.bindings` / `SELECT "
+"*` subselect projection, graph-prefix forwarding, and legacy "
+"`ConjunctiveGraph` semantics — consult the ledgers for the current, exact "
+"list."
+msgstr ""
+
+#: src/interop/rdflib.md:68
+msgid ""
+"A report-only benchmark harness times the native-backed "
+"`purrdf.compat.rdflib` drop-in against the real rdflib on parse, serialize, "
+"SPARQL, and triple-pattern iteration (`make bench-python`). Methodology and "
+"a representative (host-dependent) results table live in [`docs/"
+"BENCHMARKS.md`](https://github.com/Blackcat-Informatics/purrdf/blob/main/"
+"docs/BENCHMARKS.md) — numbers vary by host, so reproduce locally rather than "
+"trusting a fixed multiplier. See [Performance](../project/performance.md) "
+"for the philosophy."
+msgstr ""
+
+#: src/interop/rdflib.md:78
+msgid "[Getting Started: Python](../getting-started/python.md)"
+msgstr ""
+
+#: src/interop/rdflib.md:79
+msgid ""
+"[Conformance & Testing](../project/conformance.md) — how the ledger "
+"discipline works."
+msgstr ""
+
+#: src/interop/rdfjs.md:8
+msgid ""
+"In JavaScript, PurRDF does not invent its own API shape: the npm package "
+"[`@blackcatinformatics/purrdf`](https://www.npmjs.com/package/"
+"@blackcatinformatics/purrdf) implements the [RDF/JS](https://rdf.js.org/) "
+"community specifications — `DataFactory`, `DatasetCore`, and `Stream`/`Sink` "
+"— over the wasm-compiled native engine. Code written against RDF/JS "
+"interfaces works with PurRDF terms and datasets."
+msgstr ""
+
+#: src/interop/rdfjs.md:15
+msgid "The data factory"
+msgstr ""
+
+#: src/interop/rdfjs.md:17
+msgid ""
+"`DataFactory` covers the standard RDF/JS term constructors — `namedNode`, "
+"`blankNode`, `literal(value, languageOrDatatype?)`, `variable`, "
+"`defaultGraph`, `quad`, `fromTerm`, `fromQuad` — plus the deliberate RDF 1.2 "
+"extensions no incumbent RDF/JS library carries:"
+msgstr ""
+
+#: src/interop/rdfjs.md:26
+msgid "// RDF/JS standard surface.\n"
+msgstr ""
+
+#: src/interop/rdfjs.md:33
+msgid ""
+"// RDF 1.2 extensions: quoted triple terms and base-direction literals.\n"
+msgstr ""
+
+#: src/interop/rdfjs.md:39
+msgid ""
+"`typedLiteral` is a convenience alongside the spec's overloaded `literal`."
+msgstr ""
+
+#: src/interop/rdfjs.md:41
+msgid "Datasets"
+msgstr ""
+
+#: src/interop/rdfjs.md:43
+msgid ""
+"`Dataset` implements RDF/JS `DatasetCore`: `add`, `delete`, `has`, `match`, "
+"`size`, and iteration (`for (const quad of dataset)`), plus parsing and "
+"serialization through the native codecs:"
+msgstr ""
+
+#: src/interop/rdfjs.md:48
+msgid "\"<https://ex/s> <https://ex/p> <https://ex/o> .\""
+msgstr ""
+
+#: src/interop/rdfjs.md:48
+msgid "\"ntriples\""
+msgstr ""
+
+#: src/interop/rdfjs.md:49
+msgid "\"https://ex/p\""
+msgstr ""
+
+#: src/interop/rdfjs.md:52
+msgid "\"trig\""
+msgstr ""
+
+#: src/interop/rdfjs.md:55
+msgid ""
+"Accepted format names: `turtle`, `ntriples`, `nquads`, `trig`, `rdfxml`, or "
+"their media types. Because these are the native codecs, output is byte-"
+"deterministic and identical to what the Rust, Python, and C surfaces emit "
+"([Codecs & Determinism](../concepts/codecs.md))."
+msgstr ""
+
+#: src/interop/rdfjs.md:62
+msgid ""
+"Use `QueryEngine` when running more than one query or when the caller wants "
+"typed results instead of raw strings. The engine owns the native SPARQL plan "
+"cache and returns package-root terms and datasets:"
+msgstr ""
+
+#: src/interop/rdfjs.md:72
+msgid "\"PREFIX ex: <https://ex/> SELECT ?o WHERE { ex:s ex:p ?o }\""
+msgstr ""
+
+#: src/interop/rdfjs.md:78
+msgid ""
+"\"PREFIX ex: <https://ex/> CONSTRUCT { ex:copy ex:p ?o } WHERE { ex:s ex:p ?"
+"o }\""
+msgstr ""
+
+#: src/interop/rdfjs.md:82
+msgid ""
+"SELECT rows are single-owner and lazy across the wasm boundary. Iterate "
+"`result.rows`, call `result.rows.take(index)` for indexed consumption, or "
+"call `result.rows.toArray()` to materialize the remaining rows. A row can be "
+"consumed once; call `result.free()` when abandoning a result before "
+"exhaustion."
+msgstr ""
+
+#: src/interop/rdfjs.md:87
+msgid ""
+"`QueryEngine.queryRaw(...)` serializes SELECT/ASK results as SPARQL Results "
+"JSON/XML/CSV/TSV and graph results through the same graph formats accepted "
+"by `Dataset.serialize`. `QueryEngine.update(...)` applies SPARQL UPDATE "
+"atomically: the dataset changes only after the whole update succeeds."
+msgstr ""
+
+#: src/interop/rdfjs.md:92
+msgid "Streams and sinks"
+msgstr ""
+
+#: src/interop/rdfjs.md:94
+msgid ""
+"The package speaks the async RDF/JS Stream/Sink protocol over the `purrdf-"
+"events` ingestion seam:"
+msgstr ""
+
+#: src/interop/rdfjs.md:97
+msgid ""
+"**`Sink`** — a streaming consumer: `push(quad)` per quad, `finish()` returns "
+"the accumulated `Dataset`."
+msgstr ""
+
+#: src/interop/rdfjs.md:99
+msgid ""
+"**`datasetToStream(dataset)`** / **`streamToDataset(stream)`** — bridge "
+"between a `Dataset` and RDF/JS streams, for piping into or out of other RDF/"
+"JS tooling."
+msgstr ""
+
+#: src/interop/rdfjs.md:103
+msgid "Scope notes"
+msgstr ""
+
+#: src/interop/rdfjs.md:105
+msgid ""
+"The engine is **in-memory**; there is no persistent store in the wasm build. "
+"SPARQL runs over the in-memory dataset; this package provides no network "
+"resolver, so remote `SERVICE` and `LOAD` fail explicitly."
+msgstr ""
+
+#: src/interop/rdfjs.md:114
+msgid ""
+"[Getting Started: JavaScript / WebAssembly](../getting-started/javascript.md)"
+msgstr ""
+
+#: src/interop/rdfjs.md:115
+msgid "[RDF 1.2 Features](../concepts/rdf12.md) — what the extensions mean."
+msgstr ""
+
+#: src/interop/rdfjs.md:116
+msgid ""
+"[`crates/rdf-wasm`](https://github.com/Blackcat-Informatics/purrdf/tree/main/"
+"crates/rdf-wasm) — the Rust cdylib behind the package."
+msgstr ""
+
+#: src/project/design-rules.md:8
+msgid ""
+"PurRDF must stay fast, deterministic, and boring: **one engine, one "
+"behavior, carried verbatim into Rust, Python, WebAssembly, and C**. That "
+"promise is kept by a small set of hard invariants, each enforced by CI "
+"rather than by convention. The canonical statement is [AGENTS.md](https://"
+"github.com/Blackcat-Informatics/purrdf/blob/main/AGENTS.md) in the "
+"repository; this chapter explains the _why_."
+msgstr ""
+
+#: src/project/design-rules.md:15
+msgid "No semantic Cargo features, ever"
+msgstr ""
+
+#: src/project/design-rules.md:17
+msgid ""
+"The workspace has **zero semantic feature flags**. Its sole feature "
+"declaration is the empty `purrdf-capi:capi = []` compatibility marker that "
+"`cargo-c` unconditionally enables when building the C ABI. The marker gates "
+"no code and must never appear in `cfg(feature = ...)`; CI verifies its exact "
+"empty shape and scans Rust sources for feature-gated behavior. PurRDF is a "
+"data carrier, and optionality changes semantics per consumer — two builds of "
+"\"the same version\" that parse or serialize differently would defeat the "
+"whole point. No other `[features]`, no optional dependencies, and no feature-"
+"gated behavior. Every consumer gets the same byte-identical semantics."
+msgstr ""
+
+#: src/project/design-rules.md:27
+msgid "PurRDF is NOT an ontology — it mints no vocabulary IRIs"
+msgstr ""
+
+#: src/project/design-rules.md:29
+msgid ""
+"Every vocabulary the library reads or writes — slice manifests, statement-"
+"metadata downcast, box roles, SPARQL extension-function namespaces, JSON-"
+"Schema namespaces — is **caller-supplied configuration with no fabricated "
+"default**. A feature exercised without its vocabulary hard-errors or stays "
+"inactive. The library never hardcodes a vendor namespace (the GMEOW ontology "
+"is a _consumer_; the dependency arrow never points from purrdf to it), and "
+"test fixtures use `example.org`. Consumer-config types (`SliceVocab`, "
+"`Namespaces`, `StatementMetadataVocab`) are unified behind an "
+"`OntologyProfile` a downstream builds once."
+msgstr ""
+
+#: src/project/design-rules.md:41
+msgid ""
+"Serializers and the GTS writer are byte-deterministic. No iteration-order, "
+"time, or RNG dependence is permitted in any output path; hot maps use fixed-"
+"key `ahash` for this reason. Changes that alter emitted bytes must update "
+"the affected golden files, visibly."
+msgstr ""
+
+#: src/project/design-rules.md:46
+msgid "The kernel ring-fence"
+msgstr ""
+
+#: src/project/design-rules.md:48
+msgid ""
+"`purrdf-core` must never depend on oxigraph or PyO3 — the whole workspace is "
+"oxigraph-free, and a hygiene gate asserts the dependency tree. The three "
+"foundation leaves (`purrdf-iri`, `purrdf-xsd`, `purrdf-events`) keep **zero "
+"runtime dependencies**. Diagnostics stay structured and SARIF-free in the "
+"kernel; the SARIF boundary is the `purrdf-validate` leaf."
+msgstr ""
+
+#: src/project/design-rules.md:54
+msgid "Everything is wasm-able"
+msgstr ""
+
+#: src/project/design-rules.md:56
+msgid ""
+"Every release crate must build for `wasm32-unknown-unknown`, and CI hard-"
+"fails otherwise. No dependency may drag in threads, the filesystem, C "
+"toolchains, or wall-clock/RNG syscalls on the wasm path — cryptography stays "
+"pure Rust for exactly this reason. This is what makes the JavaScript package "
+"the _same engine_ rather than a port."
+msgstr ""
+
+#: src/project/design-rules.md:62
+msgid "Hard-fail, never wrong"
+msgstr ""
+
+#: src/project/design-rules.md:64
+msgid ""
+"Across the toolkit, out-of-scope input is a **typed error**, never a partial "
+"answer: malformed RDF is an `RdfDiagnostic`, an unsupported SPARQL builtin "
+"is `EvalError::Unsupported`, a malformed ShEx schema is a `ShexError`, an "
+"exhausted evaluation ceiling is `EntailError::Evaluate` rather than a "
+"truncated closure, and an unsupported results projection is a typed format "
+"error. Lossy-by-design projections are permitted but _loud_, via the [loss "
+"ledger](../slices.md#the-loss-ledger)."
+msgstr ""
+
+#: src/project/design-rules.md:72
+msgid ""
+"A hard-fail is owed to input the toolkit cannot handle — never to a value "
+"its own signature accepts. `purrdf-entail::materialize` used to refuse `OWL-"
+"Direct` and `RIF` because a `Regime` value carries neither the query's class "
+"expressions nor a rule set; that was a partial function wearing a total "
+"signature, and the fix was to change the parameter rather than to document "
+"the hole. It takes a `Materialization` now, which carries each regime's own "
+"input, and there is no unsupported-regime error left to name."
+msgstr ""
+
+#: src/project/design-rules.md:80
+msgid ""
+"The reasoning side adds a second discipline on top of hard-fail: where a run "
+"_succeeds_ but is bounded, it says so. `materialize` returns a "
+"`ReasoningReport` with every closure — never a bare dataset — carrying the "
+"regime's completeness, the rules that did and did not fire, the boundaries "
+"met, and a contract hash of the calculus that ran. A correct-but-incomplete "
+"answer delivered silently is the same failure mode as a wrong one."
+msgstr ""
+
+#: src/project/design-rules.md:87
+msgid "Conformance corpora are the contract"
+msgstr ""
+
+#: src/project/design-rules.md:89
+msgid ""
+"The W3C and community test suites are vendored, **byte-frozen**, and SHA-256-"
+"verified; harnesses assert exact counts and enforce XPASS discipline on "
+"their expected-failure ledgers. See [Conformance & Testing](conformance.md)."
+msgstr ""
+
+#: src/project/design-rules.md:94
+msgid "Supporting rules"
+msgstr ""
+
+#: src/project/design-rules.md:96
+msgid ""
+"**Measured performance** — perf claims require a criterion bench, not an "
+"adjective ([Performance](performance.md))."
+msgstr ""
+
+#: src/project/design-rules.md:98
+msgid ""
+"**One version, lockstep releases** — crates.io, PyPI, and npm ship one "
+"workspace version ([Versioning & Releases](releases.md))."
+msgstr ""
+
+#: src/project/design-rules.md:100
+msgid ""
+"**Nightly-free source, stable MSRV** — there are no `#![feature(...)]` "
+"attributes anywhere in the workspace and the MSRV floor (currently 1.96, on "
+"the stable channel) is enforced by a dedicated CI job that builds on exactly "
+"that compiler. Contributors and the CI gates run a _dated_ nightly pinned in "
+"`rust-toolchain.toml` for its sharper clippy and rustdoc lints; release "
+"artifacts are built on stable."
+msgstr ""
+
+#: src/project/design-rules.md:106
+msgid ""
+"**Brand** — the project is **PurRDF** in prose and `purrdf` in identifiers "
+"([`docs/BRAND.md`](https://github.com/Blackcat-Informatics/purrdf/blob/main/"
+"docs/BRAND.md))."
+msgstr ""
+
+#: src/project/conformance.md:8
+msgid ""
+"Every PurRDF engine is gated by its official test suite. The suites are "
+"vendored and **byte-frozen** in-repo — never hand-edited, SHA-256-verified "
+"on every `make check` so a silent content edit fails the build. The full, "
+"live scoreboard is [`docs/CONFORMANCE.md`](https://github.com/Blackcat-"
+"Informatics/purrdf/blob/main/docs/CONFORMANCE.md); this chapter explains how "
+"the machine works."
+msgstr ""
+
+#: src/project/conformance.md:15
+msgid "The single conformance matrix"
+msgstr ""
+
+#: src/project/conformance.md:17
+msgid ""
+"The native Rust W3C harnesses **and** the Python rdflib drop-in gate are "
+"reported together as one scoreboard:"
+msgstr ""
+
+#: src/project/conformance.md:21
+msgid "# aggregates every suite into one table\n"
+msgstr ""
+
+#: src/project/conformance.md:24
+msgid ""
+"The aggregator runs each suite in a fixed order and prints per-suite "
+"**pass / xfail-or-skip / fail** counts with an overall RED/GREEN verdict. It "
+"exits non-zero on any unexpected failure, and the rendered matrix in `docs/"
+"CONFORMANCE.md` is itself drift-guarded in CI (the gate fails if the "
+"committed block is stale)."
+msgstr ""
+
+#: src/project/conformance.md:30
+msgid "What is gated"
+msgstr ""
+
+#: src/project/conformance.md:32
+msgid "Suite"
+msgstr ""
+
+#: src/project/conformance.md:34
+msgid "IRI (RFC 3987)"
+msgstr ""
+
+#: src/project/conformance.md:34
+msgid "W3C IRI + RFC 3986 §5.4 resolution vectors"
+msgstr ""
+
+#: src/project/conformance.md:35
+msgid "Syntax codecs"
+msgstr ""
+
+#: src/project/conformance.md:35
+msgid "W3C rdf-tests (Turtle/TriG/N-Triples/N-Quads/RDF-XML)"
+msgstr ""
+
+#: src/project/conformance.md:36
+msgid ""
+"W3C RDF-conversion and metadata-validation manifests plus a locked "
+"independent implementation"
+msgstr ""
+
+#: src/project/conformance.md:37
+msgid "OBO Graphs"
+msgstr ""
+
+#: src/project/conformance.md:37
+msgid "official OBO Graphs 0.3.2 JSON Schema plus corruption probes"
+msgstr ""
+
+#: src/project/conformance.md:38
+msgid ""
+"five adversarial native fixtures, a 5×5 stable semantic-transcode matrix, "
+"and the vendored Frictionless Data Package v1 schema"
+msgstr ""
+
+#: src/project/conformance.md:39
+msgid "W3C rdf-canon fixtures"
+msgstr ""
+
+#: src/project/conformance.md:40
+msgid "SPARQL 1.1/1.2"
+msgstr ""
+
+#: src/project/conformance.md:40
+msgid ""
+"full W3C sparql11 + sparql12 + entailment suites, plus first-party CONSTRUCT "
+"and DESCRIBE corpora"
+msgstr ""
+
+#: src/project/conformance.md:41
+msgid "SPARQL CDT (SEP-0009)"
+msgstr ""
+
+#: src/project/conformance.md:41
+msgid ""
+"the vendored `awslabs/SPARQL-CDTs` corpus — read with the lexical-space "
+"divergence recorded in `docs/CONFORMANCE.md`, which no upstream vector can "
+"express"
+msgstr ""
+
+#: src/project/conformance.md:42
+msgid "SPARQL execution governors"
+msgstr ""
+
+#: src/project/conformance.md:42
+msgid "a first-party frozen corpus of ceiling band cases and seam cases"
+msgstr ""
+
+#: src/project/conformance.md:43
+msgid "W3C data-shapes + DASH SHACL-AF/rules + a first-party frozen corpus"
+msgstr ""
+
+#: src/project/conformance.md:44
+msgid "ShEx 2.1"
+msgstr ""
+
+#: src/project/conformance.md:44
+msgid "shexTest v2.1.0 (validation, schemas, negative syntax/structure)"
+msgstr ""
+
+#: src/project/conformance.md:45
+msgid ""
+"the W3C SPARQL entailment-regime cases (via the SPARQL harness), the "
+"vendored W3C OWL 2 suite (DL consistency, ledgered), and W3C's own OWL 2 RL "
+"entailment tests (the independent oracle for the rule table, ledgered)"
+msgstr ""
+
+#: src/project/conformance.md:46
+msgid ""
+"frozen cross-language vectors — 38 of the 39 fold byte-exactly into their "
+"committed expectation, with the 39th a ledgered divergence from an upstream "
+"expectation this reader contradicts"
+msgstr ""
+
+#: src/project/conformance.md:47
+msgid "rdflib drop-in"
+msgstr ""
+
+#: src/project/conformance.md:47
+msgid "rdflib 7.6's own vendored tests + first-party parity"
+msgstr ""
+
+#: src/project/conformance.md:49
+msgid ""
+"At the time of writing every suite is green — for example 1,105/1,105 "
+"attempted shexTest validation cases, 129/129 W3C SHACL, 264/264 codec round-"
+"trips, 70/70 W3C SPARQL entailment-regime cases, and 258/262 agreeing "
+"verdicts on the vendored W3C OWL 2 DL-consistency corpus — with the "
+"remaining non-passes strictly ledgered (five SPARQL fixtures with upstream-"
+"errata non-canonical XSD lexicals; 4 typed OWL 2 divergences). Two of those "
+"numbers need their scope stated: the OWL 2 DL corpus is a _subset_, 262 of "
+"the 482 consistency-shaped cases W3C published, and rule-table coverage is "
+"not entailment conformance — on this vendored W3C corpus of OWL 2 RL "
+"entailment tests the chase scores 50/50, being 27 of 27 positive and 23 of "
+"23 negative, the latter meaning no unsoundness was found. Always read the "
+"current numbers from [`docs/CONFORMANCE.md`](https://github.com/Blackcat-"
+"Informatics/purrdf/blob/main/docs/CONFORMANCE.md) rather than this snapshot."
+msgstr ""
+
+#: src/project/conformance.md:64
+msgid "Ledger discipline"
+msgstr ""
+
+#: src/project/conformance.md:66
+msgid ""
+"A harness never skips silently. Four mechanisms keep the scoreboard honest:"
+msgstr ""
+
+#: src/project/conformance.md:68
+msgid ""
+"**Exact totals** — each harness asserts the number of discovered tests, so "
+"corpus drift fails loudly."
+msgstr ""
+
+#: src/project/conformance.md:70
+msgid ""
+"**XFAIL ledgers** — every known gap is listed with a reason string, and the "
+"harness asserts it _still fails_. Fixing a gap without removing its ledger "
+"entry breaks the build (XPASS discipline), so the ledgers double as roadmaps."
+msgstr ""
+
+#: src/project/conformance.md:74
+msgid ""
+"**Trait skips (ShEx only)** — whole spec features can be skipped by manifest "
+"trait tags, counted exactly. The list is currently **empty**."
+msgstr ""
+
+#: src/project/conformance.md:76
+msgid ""
+"**A monotone budget (ratchet)** — a committed baseline records the exact "
+"allowed count of ledgered gaps per suite. A larger live count fails RED "
+"(regression), and a _smaller_ one also fails RED until the budget is lowered "
+"to lock the gain in. The budget may only ever be edited downward, which "
+"makes \"the skip list only shrinks\" a mechanical guarantee rather than a "
+"convention."
+msgstr ""
+
+#: src/project/conformance.md:83
+msgid "Running the suites locally"
+msgstr ""
+
+#: src/project/conformance.md:86
+msgid "# the single matrix\n"
+msgstr ""
+
+#: src/project/conformance.md:87
+msgid "# all four ShEx suites\n"
+msgstr ""
+
+#: src/project/conformance.md:88
+msgid "# W3C SHACL scoreboard\n"
+msgstr ""
+
+#: src/project/conformance.md:89
+msgid "# W3C SPARQL\n"
+msgstr ""
+
+#: src/project/conformance.md:90
+msgid "# RDFC-1.0 + codec goldens\n"
+msgstr ""
+
+#: src/project/conformance.md:91
+msgid "# W3C CSVW + independent CSVW/OBO checks\n"
+msgstr ""
+
+#: src/project/conformance.md:92
+msgid "# GTS vectors\n"
+msgstr ""
+
+#: src/project/conformance.md:95
+msgid ""
+"`make check` — the full local gate (fmt, clippy, build, tests, hygiene) — "
+"runs the Rust suites as part of the workspace gate."
+msgstr ""
+
+#: src/project/conformance.md:98
+msgid "Frozen means frozen"
+msgstr ""
+
+#: src/project/conformance.md:100
+msgid ""
+"The GTS vectors in `vectors/` are shared byte-exact with the sibling GTS "
+"engines in other languages and are **never** regenerated in this repository; "
+"the wire format is governed in [`gmeow-gts`](https://github.com/Blackcat-"
+"Informatics/gmeow-gts). The same never-hand-edit rule applies to every "
+"vendored corpus and everything under `generated/`."
+msgstr ""
+
+#: src/project/performance.md:8
+msgid ""
+"PurRDF's performance is **measured, never asserted**. No number in the "
+"project's documentation is a guarantee: benchmarks are report-only, timing-"
+"sensitive, and vary by host, CPU, allocator, and build flags. Treat every "
+"figure as a host-dependent illustration you reproduce locally — not a "
+"promise of \"N× faster.\" The methodology and a representative results table "
+"live in [`docs/BENCHMARKS.md`](https://github.com/Blackcat-Informatics/"
+"purrdf/blob/main/docs/BENCHMARKS.md)."
+msgstr ""
+
+#: src/project/performance.md:16
+msgid "Fast by construction"
+msgstr ""
+
+#: src/project/performance.md:18
+msgid ""
+"The engine-level speed comes from the IR design ([The Interned Dataset IR]"
+"(../concepts/interned-dataset.md)): every term stored once in a string arena "
+"addressed by copyable `NonZeroU32` ids, fixed-key `ahash` everywhere hot, "
+"frozen `Box<[QuadRow]>` quad tables with lazy ordinal permutation indexes "
+"(~4 bytes/quad per axis), and evaluation in `TermId` space so solution "
+"comparison is an integer compare."
+msgstr ""
+
+#: src/project/performance.md:25
+msgid ""
+"Crucially, the _layout itself_ was chosen by benchmark: the `crates/rdf-core/"
+"benches/ir_layout.rs` criterion suite measures array-of-structs vs. struct-"
+"of-arrays vs. predicate-adjacency layouts on allocation counts, high-water "
+"memory, and end-to-end latency — and the shipped layout is whichever wins."
+msgstr ""
+
+#: src/project/performance.md:31
+msgid "The two benchmark layers"
+msgstr ""
+
+#: src/project/performance.md:33
+msgid "Layer"
+msgstr ""
+
+#: src/project/performance.md:33
+msgid "What it measures"
+msgstr ""
+
+#: src/project/performance.md:33
+msgid "How to run"
+msgstr ""
+
+#: src/project/performance.md:35
+msgid "**Rust criterion suites**"
+msgstr ""
+
+#: src/project/performance.md:35
+msgid ""
+"Native engine hot paths — IR layout, copy-on-write mutation, pack index "
+"alternatives, codecs, graph/tabular/research-object projections, SPARQL "
+"lexing/evaluation/planning, SHACL validation, entailment chase, GTS "
+"authoring, IRI parsing."
+msgstr ""
+
+#: src/project/performance.md:35
+msgid "`make bench`"
+msgstr ""
+
+#: src/project/performance.md:36
+msgid "**Python compat harness**"
+msgstr ""
+
+#: src/project/performance.md:36
+msgid ""
+"`purrdf.compat.rdflib` (the native-backed drop-in) vs. the real rdflib 7.x "
+"on parse, serialize, SPARQL, and triple-pattern iteration, over a "
+"deterministic `example.org` corpus."
+msgstr ""
+
+#: src/project/performance.md:36
+msgid "`make bench-python`"
+msgstr ""
+
+#: src/project/performance.md:38
+msgid ""
+"Both layers are report-only: they are never part of `make check`, and no "
+"test gate asserts a speedup."
+msgstr ""
+
+#: src/project/performance.md:41
+msgid "The discipline for changes"
+msgstr ""
+
+#: src/project/performance.md:43
+msgid ""
+"Any change claiming a performance win must **extend the criterion benches** "
+"rather than asserting the speedup in prose. Where a planner or algorithm "
+"choice matters for correctness-adjacent behavior, it is gated by "
+"_deterministic_ tests instead of timings — for example, the cost-based BGP "
+"planner's win over the retired structural heuristic is asserted by unit "
+"tests that count real intermediate rows, and by a differential corpus test, "
+"while the criterion bench merely watches for regressions."
+msgstr ""
+
+#: src/project/performance.md:51
+msgid ""
+"`NativeSparqlEngine::explain_query` exposes the chosen BGP join order so "
+"planner decisions can be audited without running the query ([SPARQL: "
+"Querying](../sparql/querying.md))."
+msgstr ""
+
+#: src/project/performance.md:55
+msgid "Reproducing locally"
+msgstr ""
+
+#: src/project/performance.md:58
+msgid "# the default criterion set\n"
+msgstr ""
+
+#: src/project/performance.md:59
+msgid "# a single package's bench\n"
+msgstr ""
+
+#: src/project/performance.md:60
+msgid "# pack index experiment\n"
+msgstr ""
+
+#: src/project/performance.md:61
+msgid "# projection/carrier sample\n"
+msgstr ""
+
+#: src/project/performance.md:62
+msgid "# the rdflib comparison harness\n"
+msgstr ""
+
+#: src/project/performance.md:65
+msgid ""
+"Benchmark on a quiet machine, and compare like with like: allocator, CPU "
+"scaling, and build flags all move the numbers."
+msgstr ""
+
+#: src/project/releases.md:8
+msgid ""
+"PurRDF ships to three registries — the crates.io crate suite, the PyPI "
+"`purrdf` package, and the npm `@blackcatinformatics/purrdf` package — from "
+"**one** workspace version, in lockstep. The full process is [`docs/"
+"RELEASE.md`](https://github.com/Blackcat-Informatics/purrdf/blob/main/docs/"
+"RELEASE.md)."
+msgstr ""
+
+#: src/project/releases.md:13
+msgid "Pre-1.0 semver policy"
+msgstr ""
+
+#: src/project/releases.md:15
+msgid "While the version is `0.x`:"
+msgstr ""
+
+#: src/project/releases.md:17
+msgid "a **minor** bump (`0.x` → `0.(x+1)`) may include breaking API changes;"
+msgstr ""
+
+#: src/project/releases.md:18
+msgid ""
+"a **patch** bump (`0.x.y` → `0.x.(y+1)`) is bugfix-only and API-compatible."
+msgstr ""
+
+#: src/project/releases.md:20
+msgid ""
+"All three published surfaces share one workspace version and are released "
+"together. That coherence is enforced in CI: a version-coherence check fails "
+"the build if the three version sources disagree."
+msgstr ""
+
+#: src/project/releases.md:24
+msgid "MSRV policy"
+msgstr ""
+
+#: src/project/releases.md:26
+msgid ""
+"The supported minimum Rust is `rust-version` in the root `Cargo.toml` — "
+"currently **1.96** — on the **stable** channel, enforced by a dedicated CI "
+"MSRV job that sets `RUSTUP_TOOLCHAIN` explicitly and asserts the compiler it "
+"measured really is 1.96. Raising the MSRV is a notable change recorded in "
+"the changelog and, pre-1.0, rides a minor bump."
+msgstr ""
+
+#: src/project/releases.md:32
+msgid ""
+"The MSRV is a promise to consumers; the development toolchain is a tool "
+"choice, and the two are orthogonal. `rust-toolchain.toml` pins a **dated "
+"nightly** for local work and the CI gates, because nightly clippy and "
+"rustdoc carry lints stable lacks — but the source is nightly-free by policy "
+"(zero `#![feature(...)]` attributes, which the MSRV job proves on every "
+"change), and the release lanes build every published artifact on stable."
+msgstr ""
+
+#: src/project/releases.md:39
+msgid "Tag-driven trusted publishing"
+msgstr ""
+
+#: src/project/releases.md:41
+msgid ""
+"Releases are tag-driven: `rust-v<version>` publishes the crate suite to "
+"crates.io, `py-v<version>` publishes to PyPI, and `npm-v<version>` publishes "
+"the wasm package to npm. The lanes share the supply-chain posture of the "
+"cargo lane:"
+msgstr ""
+
+#: src/project/releases.md:46
+msgid ""
+"publication uses **Trusted Publishing** through GitHub Actions OIDC — no "
+"long-lived registry secret;"
+msgstr ""
+
+#: src/project/releases.md:48
+msgid "the privileged publish jobs use pinned actions and no dependency cache;"
+msgstr ""
+
+#: src/project/releases.md:49
+msgid ""
+"every `.crate` package receives a GitHub **build-provenance attestation**;"
+msgstr ""
+
+#: src/project/releases.md:50
+msgid "the package set receives an **SPDX SBOM** and SBOM attestation;"
+msgstr ""
+
+#: src/project/releases.md:51
+msgid ""
+"the release crate set is checked on `wasm32-unknown-unknown` before "
+"publishing;"
+msgstr ""
+
+#: src/project/releases.md:53
+msgid "every workspace crate version must match the tag version."
+msgstr ""
+
+#: src/project/releases.md:55
+msgid ""
+"Four workspace members are deliberately never published to crates.io: "
+"`purrdf-capi` (built via cargo-c, distributed as `libpurrdf`), `purrdf-"
+"sparql-conformance` (the test harness), `purrdf-cli` (the `purrdf` binary), "
+"and `purrdf-python` (the extension crate, which ships to PyPI via maturin "
+"instead)."
+msgstr ""
+
+#: src/project/releases.md:61
+msgid "Cutting a release"
+msgstr ""
+
+#: src/project/releases.md:63
+msgid ""
+"The coherent flow from `main` uses the `make` helpers so the three lanes can "
+"never drift:"
+msgstr ""
+
+#: src/project/releases.md:67
+msgid ""
+"# 1. Bump all three version sources in lockstep (fails unless they end up "
+"equal).\n"
+msgstr ""
+
+#: src/project/releases.md:69
+msgid ""
+"# 2. Regenerate the committed C-ABI header from the bumped crate version.\n"
+msgstr ""
+
+#: src/project/releases.md:72
+msgid "# 3. Regenerate the changelog from the conventional-commit history.\n"
+msgstr ""
+
+#: src/project/releases.md:75
+msgid ""
+"# 4. Review, then commit the release bump, generated header, and changelog.\n"
+msgstr ""
+
+#: src/project/releases.md:77
+msgid "\"chore(release): 0.2.2\""
+msgstr ""
+
+#: src/project/releases.md:78
+msgid ""
+"# 5. From an up-to-date main, run every release gate, then push all three "
+"tags.\n"
+msgstr ""
+
+#: src/project/releases.md:83
+msgid ""
+"`make release-tags` refuses to run unless the working tree is clean, the "
+"branch is `main` and synchronized with `origin/main`, the version check "
+"passes, `VERSION` matches the tree, the release-notes section exists, and "
+"none of the three tags already exists locally or remotely. It then runs the "
+"Rust and wasm workspace gate, the generated C-ABI/header check, the native "
+"Python binding suite, and the optimized size-gated npm/wasm package tests. "
+"Only after every surface passes does it recheck the clean synchronized state "
+"and atomically push the `rust-v`, `py-v`, and `npm-v` tags together. No tag "
+"is created before the complete cross-surface preflight passes. Each tag "
+"triggers its own lane, and the cargo lane additionally publishes a GitHub "
+"Release built from the committed `CHANGELOG.md`."
+msgstr ""
+
+#: src/project/releases.md:95
+msgid "Citing PurRDF"
+msgstr ""
+
+#: src/project/releases.md:97
+msgid ""
+"Releases carry a DOI; if you use PurRDF in research, please cite it — see "
+"[`CITATION.cff`](https://github.com/Blackcat-Informatics/purrdf/blob/main/"
+"CITATION.cff) in the repository."
+msgstr ""

--- a/scripts/check-brand-casing.py
+++ b/scripts/check-brand-casing.py
@@ -16,9 +16,15 @@ adjacent characters marks the word as part of a longer identifier instead of
 prose: ``purrdf-xsd``/``purrdf_xsd`` are crate/module names, ``purrdf::`` is a
 Rust path, ``purrdf/`` and ``purrdf.h`` are filesystem/header paths, a
 backtick-wrapped `` `purrdf` `` is a code span naming the crate, and an
-alphanumeric neighbour makes it a fragment of a longer identifier or plural —
-``libpurrdf``, ``purrdfs`` — not the bare word. None of those are prose and
-none are rewritten. A bare match IS prose, and the fix depends on what it
+ASCII-alphanumeric neighbour makes it a fragment of a longer identifier or
+plural — ``libpurrdf``, ``purrdfs`` — not the bare word. None of those are
+prose and none are rewritten. The neighbour test is ASCII on purpose:
+``str.isalnum`` is Unicode-aware (``'本'.isalnum()`` is ``True``), and with it a
+bare ``purrdf`` glued to CJK prose — ``本purrdf项目`` — was classified as an
+identifier fragment and never flagged, while the same word one half-width
+space away (``本 PurRDF 项目``, the house typography) was. Every identifier
+this repository mints is ASCII, so a non-ASCII neighbour is prose by
+construction. A bare match IS prose, and the fix depends on what it
 names: if it names the PROJECT/BRAND, capitalize it to ``PurRDF``; if it names
 the ``purrdf`` FACADE CRATE specifically (a legitimate but unmarked mention),
 wrap it in backticks instead of capitalizing it — the crate's own name does
@@ -44,6 +50,25 @@ fields are covered by their own convention (checked by hand — every
 and ``.py``/``.yaml`` comments in this repository do not carry brand-name
 prose today. Widen this list the day one does.
 
+    python3 scripts/check-brand-casing.py                       # verify (exit 1 on a hit)
+    python3 scripts/check-brand-casing.py --self-test           # prove the rule bites both ways
+    python3 scripts/check-brand-casing.py --rendered-tree DIR   # scan a rendered book tree
+
+The self-test replays glued-CJK, spaced-CJK, code-span and identifier shapes
+against the same scanners the tree scan uses, and runs before every scan: a
+shape this gate cannot see is a shape that ships with the gate green.
+
+``--rendered-tree DIR`` scans every ``.md`` under DIR — a rendering of
+``docs/book/src/`` produced by ``mdbook build`` with the ``markdown`` renderer
+and a translation applied (see ``scripts/check-i18n-render.py``). The register
+below is consulted through that mapping (``DIR/x.md`` is
+``docs/book/src/x.md``), and in that mode it is a CEILING rather than an exact
+count: a translation that carries fewer bare mentions than its English source
+is an improvement, not stale debt, and the English source's own scan is what
+keeps the register exact. Nothing under ``docs/book/book`` or any other build
+output is ever scanned by the default mode, so this flag is the only way a
+translation reaches this gate at all.
+
 Like ``check-issue-refs.py``'s ``PRE_EXISTING_PROCESS_REFERENCES``, the debt
 that predates this rule is carried in a single frozen register,
 ``PRE_EXISTING_BRAND_CASING``, which may only SHRINK. It differs from that
@@ -67,6 +92,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+import sys
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -171,10 +197,14 @@ SCAN_DIRS = ("crates", "bindings", "docs")
 
 # A bare-word match may not touch one of these characters on either side —
 # each one marks the word as part of an identifier rather than prose. An
-# alphanumeric neighbour is checked separately in ``is_bare`` (it marks a
-# longer identifier or plural, e.g. ``libpurrdf``/``purrdfs``, and cannot be
+# ASCII-alphanumeric neighbour is checked separately in ``is_bare`` (it marks
+# a longer identifier or plural, e.g. ``libpurrdf``/``purrdfs``, and cannot be
 # enumerated as a fixed character set).
 _ADJACENT_IDENTIFIER_CHARS = frozenset("-_:/.`")
+
+# Where a rendered book tree's files live in the source tree, for register
+# lookups in ``--rendered-tree`` mode.
+RENDERED_SOURCE_PREFIX = "docs/book/src/"
 
 BRAND_RE = re.compile(r"purrdf")
 
@@ -378,26 +408,46 @@ def find_inline_code_spans(line: str) -> list[tuple[int, int]]:
     return spans
 
 
+def is_identifier_char(c: str) -> bool:
+    """Whether ``c`` can continue an identifier: ASCII letters and digits only.
+
+    Not ``str.isalnum``. That predicate is Unicode-aware — ``'本'.isalnum()`` is
+    ``True`` — so a bare ``purrdf`` glued to CJK prose (``本purrdf项目``) read
+    as an identifier fragment and passed silently, while ``本 PurRDF 项目``
+    one space away was scanned. Every identifier this repository mints (crate
+    names, module paths, the binary, package names) is ASCII, so ASCII is the
+    exact boundary: a non-ASCII neighbour is prose.
+    """
+    return c.isascii() and c.isalnum()
+
+
 def is_bare(text: str, start: int, end: int) -> bool:
     """Whether ``text[start:end]`` (a ``purrdf`` match) is a bare prose word.
 
     Not bare — i.e. an identifier fragment, not prose — if a ``-``, ``_``,
     ``:``, ``/``, ``.``, or backtick sits immediately before or after it, or if
-    an alphanumeric character does: that shape is a longer identifier
-    (``libpurrdf``) or a plural/suffixed form (``purrdfs``), not the bare word.
+    an ASCII-alphanumeric character does (see ``is_identifier_char``): that
+    shape is a longer identifier (``libpurrdf``) or a plural/suffixed form
+    (``purrdfs``), not the bare word. A CJK neighbour is prose, so
+    ``本purrdf项目`` IS bare.
     """
     before = text[start - 1] if start > 0 else " "
     after = text[end] if end < len(text) else " "
-    if before in _ADJACENT_IDENTIFIER_CHARS or before.isalnum():
+    if before in _ADJACENT_IDENTIFIER_CHARS or is_identifier_char(before):
         return False
-    if after in _ADJACENT_IDENTIFIER_CHARS or after.isalnum():
+    if after in _ADJACENT_IDENTIFIER_CHARS or is_identifier_char(after):
         return False
     return True
 
 
 def scan_rust(path: Path) -> list[tuple[int, int, str]]:
     """Return ``(line, col, snippet)`` bare-``purrdf`` hits in a Rust file."""
-    src = path.read_text(encoding="utf-8")
+    return scan_rust_text(path.read_text(encoding="utf-8"))
+
+
+def scan_rust_text(src: str) -> list[tuple[int, int, str]]:
+    """[`scan_rust`] over TEXT — what the self-test calls, so a case is
+    measured against the scanner that ships rather than a copy of it."""
     hits: list[tuple[int, int, str]] = []
     for start_line, start_col, text in rust_comments(src):
         for m in BRAND_RE.finditer(text):
@@ -416,7 +466,11 @@ def scan_rust(path: Path) -> list[tuple[int, int, str]]:
 
 def scan_markdown(path: Path) -> list[tuple[int, int, str]]:
     """Return ``(line, col, snippet)`` bare-``purrdf`` hits in a Markdown file."""
-    src = path.read_text(encoding="utf-8")
+    return scan_markdown_text(path.read_text(encoding="utf-8"))
+
+
+def scan_markdown_text(src: str) -> list[tuple[int, int, str]]:
+    """[`scan_markdown`] over TEXT — see [`scan_rust_text`]."""
     hits: list[tuple[int, int, str]] = []
 
     in_fence = False
@@ -440,7 +494,151 @@ def scan_markdown(path: Path) -> list[tuple[int, int, str]]:
     return hits
 
 
-def main() -> int:
+# ── This gate's own falsifiability ────────────────────────────────────────────
+#
+# ``(what, suffix, text, expected hit count)``. Every case is scanned by the
+# same function the tree scan uses. The CJK pairs are the point: a tightening
+# is a refusal, and a refusal is a claim — so the glued shape that must now be
+# FLAGGED sits beside the spaced, code-span and identifier neighbours that
+# must still PASS, and both halves are asserted on every run.
+_CASES: tuple[tuple[str, str, str, int], ...] = (
+    # Must be flagged: bare prose, with and without CJK neighbours.
+    ("bare 'purrdf' glued to CJK on both sides", ".md", "本purrdf项目\n", 1),
+    (
+        "bare 'purrdf' glued to CJK, full-width comma after",
+        ".md",
+        "本工具包名为purrdf，用于处理RDF。\n",
+        1,
+    ),
+    ("bare 'purrdf' before full-width punctuation", ".md", "purrdf。它是一个工具包。\n", 1),
+    ("bare 'purrdf' in English prose", ".md", "the purrdf toolkit\n", 1),
+    ("bare 'purrdf' glued to CJK in a Rust comment", ".rs", "// 本purrdf项目\nfn f() {}\n", 1),
+    ("bare 'purrdf' glued to CJK in a Rust doc comment", ".rs", "/// 本purrdf项目\nfn f() {}\n", 1),
+    # Must pass: the capitalised brand, code spans, identifiers, fences.
+    ("the brand, house typography (half-width spaces)", ".md", "本 PurRDF 项目\n", 0),
+    ("the brand glued to CJK", ".md", "PurRDF工具包支持SPARQL。\n", 0),
+    ("the facade crate in a code span beside CJK", ".md", "`purrdf` 门面 crate\n", 0),
+    ("a crate name beside CJK", ".md", "purrdf-core 是内核\n", 0),
+    ("a longer identifier and a plural", ".md", "libpurrdf and purrdfs\n", 0),
+    ("a Rust path and a module path", ".md", "purrdf::Dataset and purrdf_core\n", 0),
+    ("the crate name inside a fenced block", ".md", "```\npurrdf\n```\n", 0),
+    ("a string literal in Rust is not a comment", ".rs", 'const N: &str = "purrdf";\n', 0),
+)
+
+
+def self_test(report: bool) -> list[str]:
+    """Every case the scanners answer wrongly. An empty list is the only pass."""
+    problems: list[str] = []
+    for what, suffix, text, expected in _CASES:
+        hits = scan_rust_text(text) if suffix == ".rs" else scan_markdown_text(text)
+        ok = len(hits) == expected
+        if report:
+            verdict = "flagged" if hits else "passes "
+            print(f"  {'ok' if ok else 'WRONG':5}  {verdict}  {suffix}: {what}")
+        if ok:
+            continue
+        if expected:
+            problems.append(
+                f"  • {suffix}: {what} is NOT flagged — exactly the bare prose this "
+                "gate exists to reject"
+            )
+        else:
+            problems.append(
+                f"  • {suffix}: {what} is FLAGGED ({hits}) — a lint that fires on an "
+                "identifier or the brand itself is a lint that gets switched off"
+            )
+    return problems
+
+
+def iter_rendered_paths(tree: Path) -> Iterator[Path]:
+    """Every ``.md`` under a rendered book tree, in a deterministic order."""
+    yield from sorted(p for p in tree.rglob("*.md") if p.is_file())
+
+
+def scan_rendered_tree(tree: Path) -> int:
+    """Scan a rendered book tree (see the module doc). Returns the exit code.
+
+    Every hit is reported. A file is spared only up to the count its SOURCE
+    page carries in ``PRE_EXISTING_BRAND_CASING`` — a ceiling, since a
+    translation that drops a bare mention improved on its source.
+    """
+    registered_counts = dict(PRE_EXISTING_BRAND_CASING)
+    offenders: list[tuple[str, int, int, str]] = []
+    scanned = 0
+    for path in iter_rendered_paths(tree):
+        scanned += 1
+        rel = path.relative_to(tree).as_posix()
+        found = scan_markdown(path)
+        if not found:
+            continue
+        ceiling = registered_counts.get(RENDERED_SOURCE_PREFIX + rel, 0)
+        if len(found) <= ceiling:
+            continue
+        for line, col, snippet in found:
+            offenders.append((rel, line, col, snippet))
+    if scanned == 0:
+        print(
+            f"check-brand-casing: no .md file under {tree} — a rendered tree "
+            "with nothing in it is a vacuous pass, not a clean one",
+            file=sys.stderr,
+        )
+        return 1
+    for rel, line, col, snippet in offenders:
+        print(
+            f"{tree / rel}:{line}:{col}: bare 'purrdf' in prose — use 'PurRDF' "
+            f"for the project/brand, or wrap `purrdf` in backticks if it names "
+            f"the facade crate"
+        )
+        print(f"    {snippet}")
+    if offenders:
+        return 1
+    print(
+        f"OK: no bare 'purrdf' prose in the rendered tree ({scanned} page(s) "
+        f"scanned under {tree})."
+    )
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    rendered: Path | None = None
+    alone = False
+    args = list(argv[1:])
+    while args:
+        arg = args.pop(0)
+        if arg == "--self-test":
+            alone = True
+        elif arg == "--rendered-tree" and args:
+            rendered = Path(args.pop(0))
+        else:
+            print(
+                f"usage: {Path(argv[0]).name} [--self-test] [--rendered-tree DIR]",
+                file=sys.stderr,
+            )
+            return 2
+
+    if alone:
+        print("check-brand-casing: proving the bare-word rule bites, and only bites —")
+    # BEFORE the scan, on every run (pure text over a dozen strings): a gate
+    # that cannot see the shape it rejects prints OK over exactly that shape.
+    blind = self_test(report=alone)
+    if blind:
+        print(
+            "check-brand-casing: this gate answers its own cases wrongly:\n"
+            + "\n".join(blind)
+            + "\n\nFix the scan, not the case.",
+            file=sys.stderr,
+        )
+        return 1
+    if alone:
+        print(f"OK: all {len(_CASES)} shapes are flagged or spared as written.")
+        return 0
+
+    if rendered is not None:
+        if not rendered.is_dir():
+            print(f"check-brand-casing: {rendered} is not a directory", file=sys.stderr)
+            return 2
+        return scan_rendered_tree(rendered)
+
     root = repo_root()
     registered_counts = dict(PRE_EXISTING_BRAND_CASING)
 
@@ -499,4 +697,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main(sys.argv))

--- a/scripts/check-doc-claims.py
+++ b/scripts/check-doc-claims.py
@@ -1262,8 +1262,12 @@ def _entailment_claim_units(surface: list[Path]) -> list[tuple[str, str]]:
 _BLOCK_OPENER = re.compile(r"^\s*(?:#{1,6}\s|[-*+]\s|\d+[.)]\s|\|)")
 _FENCE = re.compile(r"^\s*(?:```|~~~)")
 # The sentence terminator, and the whitespace after it that a paragraph join has already
-# normalized to one space.
-_TERMINATOR = re.compile(r"(?<=[.!?])\s+")
+# normalized to one space. Two alphabets of terminator: the ASCII three, which are followed
+# by whitespace, and the full-width CJK three (。！？), which are not — Chinese prose runs
+# its sentences together with no space, so the split there is zero-width. Without the
+# second alternation a Chinese paragraph was ONE sentence to the ban, and a scope phrase
+# anywhere in it exempted every claim in it.
+_TERMINATOR = re.compile(r"(?<=[.!?])\s+|(?<=[。！？])\s*")
 
 
 def _paragraph_sentences(lines: list[tuple[int, str]]) -> list[tuple[int, str]]:
@@ -1749,6 +1753,45 @@ def _check_separators() -> None:
         )
 
 
+# A Chinese paragraph of four sentences, terminated by the three full-width marks and the
+# full stop again. `_sentences` must return four units from it; it returned one.
+_CJK_PARAGRAPH = "第一句。第二句！第三句？第四句。"
+
+
+def _check_cjk_terminators() -> None:
+    """Full-width terminators split sentences, so a Chinese scope phrase scopes ONE claim.
+
+    Two directions, like every other pair here. The claim in the SECOND sentence of a
+    Chinese paragraph must be caught although the FIRST sentence carries the scope phrase —
+    that is the weakening the one-sentence paragraph produced. And the claim that carries
+    the scope phrase in its OWN sentence must stay exempt when a Chinese sentence follows
+    it — the neighbouring valid case, so the split does not refuse a scoped claim by
+    cutting its scope off.
+    """
+    units = _sentences(_CJK_PARAGRAPH)
+    if len(units) != 4:
+        raise SystemExit(
+            f"check-doc-claims: `_sentences` splits {_CJK_PARAGRAPH!r} into {len(units)} "
+            f"unit(s), not 4 — full-width terminators (。！？) are not sentence boundaries "
+            f"to it, so a Chinese paragraph is one sentence and one scope phrase exempts "
+            f"every claim in it"
+        )
+    specimen, _wrapped = _OVERCLAIM_SPECIMENS[2]
+    claim = specimen.rstrip(".")
+    leaked = f"{_CORPUS_SCOPE} 限定了第一句。{claim}。第三句。"
+    if not _overclaims_in("cjk-probe", f"{leaked}\n"):
+        raise SystemExit(
+            f"check-doc-claims: the banned claim in the second sentence of {leaked!r} is "
+            f"NOT caught — the scope phrase in the first Chinese sentence exempted it"
+        )
+    scoped = f"第一句。{claim} {_CORPUS_SCOPE}。第三句。"
+    if _overclaims_in("cjk-probe", f"{scoped}\n"):
+        raise SystemExit(
+            f"check-doc-claims: the scoped claim in {scoped!r} is REFUSED — the full-width "
+            f"split cut a sentence off from the scope phrase it carries"
+        )
+
+
 def _check_reflow_agreement(form: str, text: str) -> None:
     """The two spellings of the normalization must produce the same string."""
     if _reflowed_stripped(text) != _reflowed(text).strip():
@@ -1984,6 +2027,7 @@ def overclaim_self_test(surface: list[Path], report: bool) -> list[str]:
     """
     _check_ban_table()
     _check_specimens()
+    _check_cjk_terminators()
     units = _entailment_claim_units(surface)
     wrong: list[str] = []
     checked = 0
@@ -5134,12 +5178,84 @@ def build_claims(
     ]
 
 
+def scan_rendered_tree(tree: Path) -> int:
+    """The two prose bans over a rendered book tree. Returns the exit code.
+
+    A rendering of ``docs/book/src/`` with a translation applied (``mdbook build`` with
+    the ``markdown`` renderer; see ``scripts/check-i18n-render.py``) is build output, so
+    :func:`_documented_surface` never reaches it — and a gettext ``.po`` file is reached
+    by nothing at all. The 105 numeric claims are located by English sentence in named
+    files and are not re-located here: the scoreboards stay English and the translation
+    links to them. What DOES transfer is the two bans that judge prose by rule — the
+    entailment-overclaim ban, sentence by sentence (now including full-width
+    terminators), and the superseded-fragment-name ban — so those run over every page.
+
+    The overclaim ban's MEMBERSHIP rule transfers with it: a page is swept only when its
+    reflowed text carries a subject marker (:func:`_markers_in`), exactly as
+    :func:`_entailment_claim_units` derives the swept set from the source. The first
+    version of this mode swept every page and refused ``project/performance.md`` for the
+    word ``faster`` — a page the source gate does not sweep, and one whose own sentence
+    disclaims the comparative claim — which is the over-refusal a widened sweep produces
+    when it stops reading the rule it widens.
+    """
+    _check_cjk_terminators()
+    problems: list[str] = []
+    scanned = 0
+    swept = 0
+    for path in sorted(p for p in tree.rglob("*.md") if p.is_file()):
+        scanned += 1
+        text = path.read_text(encoding="utf-8")
+        label = str(path)
+        if _markers_in(text):
+            swept += 1
+            problems.extend(_overclaims_in(label, text))
+        for match in re.finditer(r"\bALCH?OIQ\b", text):
+            line = text.count("\n", 0, match.start()) + 1
+            problems.append(
+                f"{label}:{line}: superseded fragment spelling `{match.group(0)}` — the "
+                f"decision core's one published name is SHOIQ(D)"
+            )
+    if scanned == 0:
+        print(
+            f"check-doc-claims: no .md file under {tree} — a rendered tree with nothing "
+            "in it is a vacuous pass, not a clean one",
+            file=sys.stderr,
+        )
+        return 1
+    if problems:
+        print("Rendered pages make a banned claim:\n", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+    print(
+        f"OK: the stale-name ban swept {scanned} rendered page(s) under {tree}, and the "
+        f"entailment-overclaim ban swept the {swept} marker-bearing page(s) among them, "
+        f"sentence by sentence."
+    )
+    return 0
+
+
 def main(argv: list[str]) -> int:
-    unknown = [argument for argument in argv[1:] if argument != "--self-test"]
-    if unknown:
-        print(f"usage: {Path(argv[0]).name} [--self-test]", file=sys.stderr)
-        return 2
-    alone = "--self-test" in argv[1:]
+    rendered: Path | None = None
+    alone = False
+    args = list(argv[1:])
+    while args:
+        argument = args.pop(0)
+        if argument == "--self-test":
+            alone = True
+        elif argument == "--rendered-tree" and args:
+            rendered = Path(args.pop(0))
+        else:
+            print(
+                f"usage: {Path(argv[0]).name} [--self-test] [--rendered-tree DIR]",
+                file=sys.stderr,
+            )
+            return 2
+    if rendered is not None:
+        if not rendered.is_dir():
+            print(f"check-doc-claims: {rendered} is not a directory", file=sys.stderr)
+            return 2
+        return scan_rendered_tree(rendered)
 
     # ONE traversal of the documented surface, shared by both bans, so neither can be
     # narrowed without narrowing the other.

--- a/scripts/check-doc-claims.py
+++ b/scripts/check-doc-claims.py
@@ -101,6 +101,7 @@ import json
 import re
 import string
 import sys
+import subprocess
 import tomllib
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -613,6 +614,24 @@ def _check_surface_landmarks(found: set[Path]) -> None:
             )
 
 
+@lru_cache(maxsize=1)
+def _tracked_paths() -> tuple[Path, ...]:
+    """Every path ``git ls-files`` reports, absolute, in path order.
+
+    ONE enumeration for every walk in this script, so the documented surface, the
+    registry manifests and the coverage-table candidates agree about what "the tree"
+    is, and all three agree with the other prose gates: committed first-party source,
+    never a build output, never an untracked file.
+    """
+    out = subprocess.run(
+        ["git", "-C", str(_REPO), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return tuple(sorted(_REPO / rel for rel in out.split("\0") if rel))
+
+
 def _documented_surface() -> list[Path]:
     """Every file in this repository's own documented surface, in path order.
 
@@ -636,11 +655,14 @@ def _documented_surface() -> list[Path]:
         only one of its fields is published. See :func:`_registry_prose`, which the
         entailment-overclaim ban sweeps alongside this walk's Markdown.
       * ``.html`` is deliberately out. Two HTML files are tracked (one vendored RO-Crate
-        fixture and the playground shell), and ``docs/book/book`` holds hundreds more that
-        are mdBook OUTPUT — a re-rendering of Markdown this walk already reads. Including
-        the suffix would sweep the same prose twice and make the gate's answer depend on
-        whether ``make book`` had been run on the machine. The suffix set is what keeps
-        this walk independent of the build.
+        fixture and the playground shell); a re-rendering of Markdown this walk already
+        reads would sweep the same prose twice.
+      * UNTRACKED files are out, whatever their suffix: the walk enumerates ``git
+        ls-files`` — the convention the three sibling prose gates follow — so a build
+        output under ``docs/book/book`` or a developer's scratch notes under ``docs/``
+        never reach it. The first version walked the filesystem, and a stray untracked
+        ``.md`` reddened this gate while the other three could not see it. ``git add``
+        before running the gates.
       * ``.sh``, ``.yml`` and the ``Makefile`` are deliberately out: their comments are build
         mechanics addressed to whoever edits the build, published to no reader. The
         ``scripts`` arm takes ``.py``/``.json`` because those two carry the conformance
@@ -649,17 +671,18 @@ def _documented_surface() -> list[Path]:
         statements this project makes.
     """
     found: list[Path] = []
-    for root in ("crates", "bindings", "docs"):
-        for path in sorted((_REPO / root).rglob("*")):
+    for path in _tracked_paths():
+        parts = path.relative_to(_REPO).parts
+        if parts[0] in ("crates", "bindings", "docs"):
             if path.suffix not in {".rs", ".md", ".pyi", ".mjs", ".ts"}:
                 continue
-            if _UNDOCUMENTED_SEGMENTS.intersection(path.parts):
+            if _UNDOCUMENTED_SEGMENTS.intersection(parts):
                 continue
             found.append(path)
-    for path in sorted((_REPO / "scripts").rglob("*")):
-        if path.suffix in {".py", ".json"}:
+        elif parts[0] == "scripts" and path.suffix in {".py", ".json"}:
             found.append(path)
-    found.extend(sorted(_REPO.glob("*.md")))
+        elif len(parts) == 1 and path.suffix == ".md":
+            found.append(path)
     # Subsumes "the walk returned nothing": every arm must reach its landmark, so a walk
     # that returns nothing fails by naming the first arm that stopped running rather than
     # by reporting a zero that says nothing about which arm produced it.
@@ -720,12 +743,14 @@ def _registry_manifest_paths() -> tuple[Path, ...]:
         )
     names = sorted({name for name, _ in _REGISTRY_DESCRIPTION})
     found: list[Path] = []
-    for root in ("crates", "bindings"):
-        for name in names:
-            for path in (_REPO / root).rglob(name):
-                if not _UNDOCUMENTED_SEGMENTS.intersection(path.parts):
-                    found.append(path)
-    found.extend(_REPO / name for name in names if (_REPO / name).is_file())
+    for path in _tracked_paths():
+        parts = path.relative_to(_REPO).parts
+        if path.name not in names:
+            continue
+        if parts[0] in ("crates", "bindings") and not _UNDOCUMENTED_SEGMENTS.intersection(parts):
+            found.append(path)
+        elif len(parts) == 1:
+            found.append(path)
     reached = set(found)
     members = (
         tomllib.loads(_read(_REPO / "Cargo.toml")).get("workspace", {}).get("members", [])
@@ -3841,14 +3866,16 @@ _COVERAGE_HEADER = "| Regime | Rule table | Defined | Implemented |"
 # binding READMEs, and the repository front page. Every `.md` under `docs/` is
 # swept, so a new chapter is covered without an edit here.
 def _coverage_candidates() -> list[Path]:
-    return sorted(
-        {
-            _REPO / "README.md",
-            *(_REPO / "crates").glob("*/README.md"),
-            *(_REPO / "bindings").glob("*/README.md"),
-            *(_REPO / "docs").rglob("*.md"),
-        }
-    )
+    found = {_REPO / "README.md"}
+    for path in _tracked_paths():
+        parts = path.relative_to(_REPO).parts
+        if path.suffix != ".md":
+            continue
+        if parts[0] == "docs" or (
+            parts[0] in ("crates", "bindings") and len(parts) == 3 and path.name == "README.md"
+        ):
+            found.add(path)
+    return sorted(found)
 
 
 def rule_coverage_documents() -> list[Path]:

--- a/scripts/check-i18n-glossary.py
+++ b/scripts/check-i18n-glossary.py
@@ -172,10 +172,44 @@ def parse_glossary(text: str) -> list[Row]:
     return rows
 
 
+# How a self-test specimen is derived from a ``/regex/`` rejection: the
+# lookarounds are removed and the two quantified classes the glossary uses are
+# given a concrete value. ``check_consistency`` asserts the derived specimen
+# really matches its regex, so a regex this table cannot derive a specimen for
+# is a hard error rather than a rejection the self-test never exercises.
+_SPECIMEN_SUBSTITUTIONS = (
+    (re.compile(r"\(\?<?[!=].*?\)"), ""),
+    (re.compile(r"\\d\+"), "0"),
+    (re.compile(r"\\d"), "0"),
+    (re.compile(r"\\s\*"), " "),
+    (re.compile(r"\\s\+"), " "),
+)
+
+
+def specimen(rule: Rejection) -> str:
+    """Text the self-test injects to prove ``rule`` is refused."""
+    spelled = rule.spelled
+    if not (len(spelled) >= 2 and spelled[0] == "/" and spelled[-1] == "/"):
+        return spelled
+    text = spelled[1:-1]
+    for pattern, replacement in _SPECIMEN_SUBSTITUTIONS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
 def check_consistency(rows: list[Row]) -> None:
-    """A rejected rendering may not appear inside ANY row's rendering."""
+    """A rejected rendering may not appear inside ANY row's rendering, and every
+    ``/regex/`` rejection must match the specimen derived for it."""
     for row in rows:
         for rejection in row.rejected:
+            probe = specimen(rejection)
+            if rejection.find(probe) is None:
+                raise SystemExit(
+                    f"check-i18n-glossary: row {row.term!r} rejects {rejection.spelled!r}, "
+                    f"but the specimen derived for it ({probe!r}) does not match it, so "
+                    f"the self-test could never prove it bites. Spell the regex with the "
+                    f"constructs the specimen derivation knows (lookarounds, \\d, \\s)"
+                )
             for other in rows:
                 hit = rejection.find(_strip_code(other.rendering))
                 if hit:
@@ -278,12 +312,10 @@ def self_test(rows: list[Row], report: bool) -> list[str]:
 
     for row in rows:
         for rule in row.rejected:
-            # A literal rejection is injected as itself; a /regex/ one needs a
-            # specimen, which is the rejection with its lookaround stripped.
-            specimen = re.sub(r"\(\?<?!.*?\)", "", rule.spelled.strip("/"))
+            probe = specimen(rule)
             verdict(
-                f"{rule.term}: the rejected rendering {specimen!r} in a msgstr",
-                _po_with(f"本页使用{specimen}一词。"),
+                f"{rule.term}: the rejected rendering {probe!r} in a msgstr",
+                _po_with(f"本页使用{probe}一词。"),
                 True,
             )
         rendering = _strip_code(row.rendering)
@@ -292,18 +324,17 @@ def self_test(rows: list[Row], report: bool) -> list[str]:
             _po_with(f"本页使用 {rendering} 一词。"),
             False,
         )
-    first = rules[0]
-    specimen = re.sub(r"\(\?<?!.*?\)", "", first.spelled.strip("/"))
+    probe = specimen(rules[0])
     verdict("an untranslated entry (empty msgstr)", _po_with(""), False)
     verdict("an English msgstr", _po_with("Entailment regimes"), False)
     verdict(
-        f"a FUZZY entry carrying {specimen!r} (not rendered, so not refused)",
-        _po_with(f"本页使用{specimen}一词。", fuzzy=True),
+        f"a FUZZY entry carrying {probe!r} (not rendered, so not refused)",
+        _po_with(f"本页使用{probe}一词。", fuzzy=True),
         False,
     )
     verdict(
-        f"an OBSOLETE entry carrying {specimen!r} (not rendered, so not refused)",
-        _po_with(f"本页使用{specimen}一词。", obsolete=True),
+        f"an OBSOLETE entry carrying {probe!r} (not rendered, so not refused)",
+        _po_with(f"本页使用{probe}一词。", obsolete=True),
         False,
     )
     return problems

--- a/scripts/check-i18n-glossary.py
+++ b/scripts/check-i18n-glossary.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""Reject a translated unit that renders a glossary term the way the glossary says not to.
+
+The zh-Hans glossary (``docs/book/po/glossary-zh-Hans.md``) is a gate input, not a page.
+Roughly a third of the terms PurRDF's documentation turns on have no established mainland
+rendering, and for several of the rest two renderings circulate (蕴涵 and 蕴含 for
+*entailment*, 规范化 and 标准化 for *canonicalization*). A reader who meets both concludes
+they are two concepts. The glossary settles one rendering per term and lists, per term,
+the renderings that are WRONG wherever they appear; this gate refuses any translated unit
+that uses one.
+
+Translated units are:
+
+* every ``msgstr`` in ``docs/book/po/zh-Hans.po`` that ``mdbook-gettext`` would render —
+  non-empty, not fuzzy, not obsolete (a fuzzy or obsolete entry renders as English, so a
+  rejected rendering in it is not published and is not refused);
+* every line of every tracked Markdown file with ``zh-Hans`` in its path — a
+  ``README.zh-Hans.md`` sibling, a paragraph-aligned draft under
+  ``docs/book/po/zh-Hans/`` awaiting its pour into the catalogue — enumerated by
+  ``git ls-files`` like the other prose gates; the glossary itself excepted, since it
+  lists the rejected renderings by design.
+
+The glossary is read by its header row. A **Rejected** entry is a plain substring, or a
+``/…/`` regular expression where the wrong rendering is a substring of a right one (bare
+闭包 inside 推理闭包). The table is checked for self-consistency before it is applied: a
+rejected entry that appears inside any row's own rendering would make the glossary refuse
+itself, and is a hard error naming the two rows.
+
+    python3 scripts/check-i18n-glossary.py               # verify (exit 1 on a hit)
+    python3 scripts/check-i18n-glossary.py --self-test   # prove the rule bites both ways
+    python3 scripts/check-i18n-glossary.py --po PATH     # a different catalogue
+
+The self-test runs before every scan: each rejected rendering the glossary lists is
+injected into a ``msgstr`` and must be refused, and the glossary's own rendering for the
+same term, an untranslated entry, an English ``msgstr`` and a fuzzy entry carrying the
+rejected rendering must all pass. A glossary with no rejected entries at all is a
+self-test failure — the gate would then be proving nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+PO_PATH = _REPO / "docs" / "book" / "po" / "zh-Hans.po"
+GLOSSARY_PATH = _REPO / "docs" / "book" / "po" / "glossary-zh-Hans.md"
+TRANSLATED_PATH_MARK = "zh-Hans"
+
+_HEADER_CELLS = ("#", "Term", "Rendering", "Basis", "Rejected", "Note")
+_NONE_MARKERS = {"", "—", "-", "–"}
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import po_catalog  # noqa: E402 — the sibling module, found via the line above
+
+
+@dataclass(frozen=True)
+class Rejection:
+    """One rendering the glossary refuses, and the row that refuses it."""
+
+    term: str
+    rendering: str
+    spelled: str
+    pattern: re.Pattern[str]
+
+    def find(self, text: str) -> str | None:
+        match = self.pattern.search(text)
+        return match.group(0) if match else None
+
+
+@dataclass(frozen=True)
+class Row:
+    term: str
+    rendering: str
+    rejected: tuple[Rejection, ...]
+
+
+def split_cells(line: str) -> list[str]:
+    """The cells of a Markdown table row, honouring backtick spans.
+
+    ``|`` inside a code span is content (the annotation syntax ``{| |}`` sits in
+    one cell of the glossary), so the split tracks backtick state.
+    """
+    cells: list[str] = []
+    buf: list[str] = []
+    in_code = False
+    for c in line.strip():
+        if c == "`":
+            in_code = not in_code
+            buf.append(c)
+        elif c == "|" and not in_code:
+            cells.append("".join(buf).strip())
+            buf = []
+        else:
+            buf.append(c)
+    cells.append("".join(buf).strip())
+    # A row is written `| a | b |`, so the first and last cells are empty.
+    if cells and cells[0] == "":
+        cells = cells[1:]
+    if cells and cells[-1] == "":
+        cells = cells[:-1]
+    return cells
+
+
+def _strip_code(cell: str) -> str:
+    cell = cell.strip()
+    if len(cell) >= 2 and cell[0] == "`" and cell[-1] == "`":
+        return cell[1:-1]
+    return cell
+
+
+def parse_rejected(term: str, rendering: str, cell: str) -> tuple[Rejection, ...]:
+    if cell.strip() in _NONE_MARKERS:
+        return ()
+    out: list[Rejection] = []
+    for piece in cell.split("、"):
+        spelled = _strip_code(piece)
+        if spelled in _NONE_MARKERS:
+            continue
+        if len(spelled) >= 2 and spelled[0] == "/" and spelled[-1] == "/":
+            pattern = re.compile(spelled[1:-1])
+        else:
+            pattern = re.compile(re.escape(spelled))
+        out.append(Rejection(term, rendering, spelled, pattern))
+    return tuple(out)
+
+
+def parse_glossary(text: str) -> list[Row]:
+    """Every row of the glossary table, located by its header row."""
+    lines = text.splitlines()
+    header_at = next(
+        (
+            i
+            for i, line in enumerate(lines)
+            if line.lstrip().startswith("|")
+            and tuple(split_cells(line)) == _HEADER_CELLS
+        ),
+        None,
+    )
+    if header_at is None:
+        raise SystemExit(
+            f"check-i18n-glossary: no table with the header row {list(_HEADER_CELLS)} in "
+            f"{GLOSSARY_PATH.relative_to(_REPO)} — the gate reads the glossary by that row"
+        )
+    rows: list[Row] = []
+    for line in lines[header_at + 2 :]:
+        if not line.lstrip().startswith("|"):
+            break
+        cells = split_cells(line)
+        if len(cells) != len(_HEADER_CELLS):
+            raise SystemExit(
+                f"check-i18n-glossary: glossary row has {len(cells)} cells, expected "
+                f"{len(_HEADER_CELLS)}: {line.strip()!r}"
+            )
+        _, term, rendering, _basis, rejected, _note = cells
+        if not term or not rendering:
+            raise SystemExit(
+                f"check-i18n-glossary: glossary row with an empty term or rendering: "
+                f"{line.strip()!r}"
+            )
+        rows.append(Row(term, rendering, parse_rejected(term, rendering, rejected)))
+    if not rows:
+        raise SystemExit("check-i18n-glossary: the glossary table has no rows")
+    return rows
+
+
+def check_consistency(rows: list[Row]) -> None:
+    """A rejected rendering may not appear inside ANY row's rendering."""
+    for row in rows:
+        for rejection in row.rejected:
+            for other in rows:
+                hit = rejection.find(_strip_code(other.rendering))
+                if hit:
+                    raise SystemExit(
+                        f"check-i18n-glossary: the glossary refuses itself — row "
+                        f"{row.term!r} rejects {rejection.spelled!r}, which matches "
+                        f"{hit!r} inside row {other.term!r}'s rendering "
+                        f"{other.rendering!r}. Spell the rejection as a /regex/ that "
+                        f"excludes the right rendering, or drop it"
+                    )
+
+
+def rejections(rows: list[Row]) -> list[Rejection]:
+    return [r for row in rows for r in row.rejected]
+
+
+def offences(label: str, text: str, rules: list[Rejection]) -> list[str]:
+    out: list[str] = []
+    for rule in rules:
+        hit = rule.find(text)
+        if hit is None:
+            continue
+        out.append(
+            f"{label}: {hit!r} is a rejected rendering of {rule.term!r} — the glossary "
+            f"says {rule.rendering!r} (docs/book/po/glossary-zh-Hans.md)"
+        )
+    return out
+
+
+def po_units(po_path: Path) -> list[tuple[str, str]]:
+    entries = po_catalog.messages(po_catalog.parse_po(po_path.read_text(encoding="utf-8")))
+    rel = po_path.relative_to(_REPO) if po_path.is_relative_to(_REPO) else po_path
+    return [
+        (f"{rel}:{e.line} (msgid {e.msgid[:48]!r})", e.msgstr)
+        for e in entries
+        if e.translated
+    ]
+
+
+def tracked_translated_files() -> list[Path]:
+    out = subprocess.run(
+        ["git", "-C", str(_REPO), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    paths = []
+    for rel in sorted(p for p in out.split("\0") if p):
+        if not (rel.endswith(".md") and TRANSLATED_PATH_MARK in rel):
+            continue
+        path = _REPO / rel
+        if path == GLOSSARY_PATH or not path.is_file():
+            continue
+        paths.append(path)
+    return paths
+
+
+def file_units(path: Path) -> list[tuple[str, str]]:
+    rel = path.relative_to(_REPO)
+    return [
+        (f"{rel}:{number}", line)
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
+    ]
+
+
+# ── This gate's own falsifiability ────────────────────────────────────────────
+
+
+def _po_with(msgstr: str, *, fuzzy: bool = False, obsolete: bool = False) -> str:
+    prefix = "#~ " if obsolete else ""
+    flag = "#, fuzzy\n" if fuzzy else ""
+    return (
+        'msgid ""\nmsgstr ""\n"Content-Type: text/plain; charset=UTF-8\\n"\n\n'
+        f"{flag}{prefix}msgid \"Entailment regimes\"\n"
+        f"{prefix}msgstr \"{po_catalog.escape(msgstr)}\"\n"
+    )
+
+
+def self_test(rows: list[Row], report: bool) -> list[str]:
+    """Every rejected rendering must be refused; every right one must pass."""
+    rules = rejections(rows)
+    problems: list[str] = []
+    if not rules:
+        return ["the glossary lists no rejected rendering, so this gate refuses nothing"]
+
+    def units_of(po_text: str) -> list[tuple[str, str]]:
+        entries = po_catalog.messages(po_catalog.parse_po(po_text))
+        return [("probe", e.msgstr) for e in entries if e.translated]
+
+    def verdict(what: str, po_text: str, must_refuse: bool) -> None:
+        found = [o for label, text in units_of(po_text) for o in offences(label, text, rules)]
+        ok = bool(found) is must_refuse
+        if report:
+            print(f"  {'ok' if ok else 'WRONG':5}  {'refused' if found else 'passes '}  {what}")
+        if not ok:
+            problems.append(
+                f"{'NOT REFUSED' if must_refuse else 'FALSELY REFUSED'}: {what}"
+                + (f" -> {found}" if found else "")
+            )
+
+    for row in rows:
+        for rule in row.rejected:
+            # A literal rejection is injected as itself; a /regex/ one needs a
+            # specimen, which is the rejection with its lookaround stripped.
+            specimen = re.sub(r"\(\?<?!.*?\)", "", rule.spelled.strip("/"))
+            verdict(
+                f"{rule.term}: the rejected rendering {specimen!r} in a msgstr",
+                _po_with(f"本页使用{specimen}一词。"),
+                True,
+            )
+        rendering = _strip_code(row.rendering)
+        verdict(
+            f"{row.term}: the glossary rendering {rendering!r} in a msgstr",
+            _po_with(f"本页使用 {rendering} 一词。"),
+            False,
+        )
+    first = rules[0]
+    specimen = re.sub(r"\(\?<?!.*?\)", "", first.spelled.strip("/"))
+    verdict("an untranslated entry (empty msgstr)", _po_with(""), False)
+    verdict("an English msgstr", _po_with("Entailment regimes"), False)
+    verdict(
+        f"a FUZZY entry carrying {specimen!r} (not rendered, so not refused)",
+        _po_with(f"本页使用{specimen}一词。", fuzzy=True),
+        False,
+    )
+    verdict(
+        f"an OBSOLETE entry carrying {specimen!r} (not rendered, so not refused)",
+        _po_with(f"本页使用{specimen}一词。", obsolete=True),
+        False,
+    )
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--self-test", action="store_true", help="prove the rule, then stop")
+    ap.add_argument("--po", type=Path, default=PO_PATH, help="the catalogue to check")
+    ap.add_argument("--glossary", type=Path, default=GLOSSARY_PATH)
+    args = ap.parse_args(argv)
+
+    rows = parse_glossary(args.glossary.read_text(encoding="utf-8"))
+    check_consistency(rows)
+    rules = rejections(rows)
+
+    if args.self_test:
+        print("check-i18n-glossary: proving every rejected rendering is refused —")
+    problems = self_test(rows, report=args.self_test)
+    if problems:
+        print(
+            "check-i18n-glossary: this gate answers its own cases wrongly:\n"
+            + "\n".join(f"  - {p}" for p in problems),
+            file=sys.stderr,
+        )
+        return 1
+    if args.self_test:
+        print(
+            f"OK: {len(rules)} rejected rendering(s) across {len(rows)} glossary row(s), "
+            "each refused, each row's own rendering spared."
+        )
+        return 0
+
+    units: list[tuple[str, str]] = []
+    if args.po.is_file():
+        units.extend(po_units(args.po))
+    else:
+        print(f"check-i18n-glossary: no catalogue at {args.po}", file=sys.stderr)
+        return 1
+    files = tracked_translated_files()
+    for path in files:
+        units.extend(file_units(path))
+
+    found = [o for label, text in units for o in offences(label, text, rules)]
+    if found:
+        print(
+            "check-i18n-glossary: translated text uses a rendering the glossary rejects:\n"
+            + "\n".join(f"  - {o}" for o in found),
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"OK: {len(rules)} rejected rendering(s) from {len(rows)} glossary row(s) absent "
+        f"from {len(units)} translated unit(s) ({args.po.relative_to(_REPO) if args.po.is_relative_to(_REPO) else args.po} "
+        f"plus {len(files)} tracked {TRANSLATED_PATH_MARK} Markdown file(s))."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check-i18n-glossary.py
+++ b/scripts/check-i18n-glossary.py
@@ -2,42 +2,60 @@
 # SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""Reject a translated unit that renders a glossary term the way the glossary says not to.
+"""Reject a translated unit that renders a glossary term the way the glossary says not to,
+and a translation that drops a keep-English term.
 
 The zh-Hans glossary (``docs/book/po/glossary-zh-Hans.md``) is a gate input, not a page.
 Roughly a third of the terms PurRDF's documentation turns on have no established mainland
 rendering, and for several of the rest two renderings circulate (蕴涵 and 蕴含 for
 *entailment*, 规范化 and 标准化 for *canonicalization*). A reader who meets both concludes
 they are two concepts. The glossary settles one rendering per term and lists, per term,
-the renderings that are WRONG wherever they appear; this gate refuses any translated unit
-that uses one.
+the renderings that are wrong FOR THAT TERM.
+
+A rejected rendering is wrong only when it renders the glossary's English term: 标准化
+is wrong for *canonicalization* and the only right word for *standardized* — which the
+English book says ("no standardized spelling exists"); 蕴含 is wrong for *entailment*
+and right as the ordinary verb *implies*. A substring test over a ``msgstr`` cannot tell
+those apart, and the first version of this gate refused all of them. So every rejection is
+ANCHORED: it is tested against a ``msgstr`` only when the ``msgid`` carries the row's
+English term (the **Anchor** column). The ``.po`` format gives that pairing for free. A
+row with no anchor is GLOBAL — its rejections apply wherever they appear — and only the
+zh-Hant-register words qualify; the row's note must say so.
+
+Two further rules, each the mirror of an over-refusal or a hole the first version had:
+
+* code spans and fenced blocks inside a ``msgstr`` are never matched (「不要写 `蕴含`」 is
+  prose about a spelling, not the spelling);
+* a **K** row (keep English) is enforced, not merely stated: when a ``msgid`` carries one
+  of its Anchor tokens (case-sensitively, at a word start), the ``msgstr`` must carry it
+  verbatim, so 研究物件 for *Research Object* or 吉猫协议 for *GMEOW* is refused although
+  no Rejected entry names it.
 
 Translated units are:
 
 * every ``msgstr`` in ``docs/book/po/zh-Hans.po`` that ``mdbook-gettext`` would render —
   non-empty, not fuzzy, not obsolete (a fuzzy or obsolete entry renders as English, so a
-  rejected rendering in it is not published and is not refused);
-* every line of every tracked Markdown file with ``zh-Hans`` in its path — a
-  ``README.zh-Hans.md`` sibling, a paragraph-aligned draft under
-  ``docs/book/po/zh-Hans/`` awaiting its pour into the catalogue — enumerated by
-  ``git ls-files`` like the other prose gates; the glossary itself excepted, since it
-  lists the rejected renderings by design.
-
-The glossary is read by its header row. A **Rejected** entry is a plain substring, or a
-``/…/`` regular expression where the wrong rendering is a substring of a right one (bare
-闭包 inside 推理闭包). The table is checked for self-consistency before it is applied: a
-rejected entry that appears inside any row's own rendering would make the glossary refuse
-itself, and is a hard error naming the two rows.
+  rejected rendering in it is not published and is not refused) — paired with its
+  ``msgid``;
+* every line of every tracked Markdown file with ``zh-Hans`` in its path (a
+  ``README.zh-Hans.md`` sibling, a paragraph-aligned draft under ``docs/book/po/zh-Hans/``
+  awaiting its pour into the catalogue), enumerated by ``git ls-files`` like the other
+  prose gates — the glossary itself excepted. A file has no ``msgid``, so it is checked
+  against the GLOBAL rows only; the pour is where the table is fully enforced.
 
     python3 scripts/check-i18n-glossary.py               # verify (exit 1 on a hit)
-    python3 scripts/check-i18n-glossary.py --self-test   # prove the rule bites both ways
+    python3 scripts/check-i18n-glossary.py --self-test   # prove every rule bites both ways
     python3 scripts/check-i18n-glossary.py --po PATH     # a different catalogue
 
-The self-test runs before every scan: each rejected rendering the glossary lists is
-injected into a ``msgstr`` and must be refused, and the glossary's own rendering for the
-same term, an untranslated entry, an English ``msgstr`` and a fuzzy entry carrying the
-rejected rendering must all pass. A glossary with no rejected entries at all is a
-self-test failure — the gate would then be proving nothing.
+The self-test runs before every scan. For every rejection it executes: the refused form
+under an anchored ``msgid`` (refused); the row's own rendering under the same ``msgid``
+(passes); the rejected word in its OTHER sense under an unrelated ``msgid`` — an ordinary
+Chinese sentence, kept in :data:`NEIGHBOURS` (passes); and the rejected word inside a code
+span under the anchored ``msgid`` (passes). For every K token: a translation that drops it
+(refused) and one that keeps it (passes). A rejection with no neighbour, a neighbour that
+does not actually contain the rejected form, a ``/regex/`` whose derived specimen it does
+not match, or a glossary that refuses one of its own renderings is a hard error — so the
+table cannot grow a refusal that is proven only one way.
 """
 
 from __future__ import annotations
@@ -49,22 +67,22 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import po_catalog  # noqa: E402 — the sibling module, found via the line above
+
 _REPO = Path(__file__).resolve().parent.parent
 PO_PATH = _REPO / "docs" / "book" / "po" / "zh-Hans.po"
 GLOSSARY_PATH = _REPO / "docs" / "book" / "po" / "glossary-zh-Hans.md"
 TRANSLATED_PATH_MARK = "zh-Hans"
 
-_HEADER_CELLS = ("#", "Term", "Rendering", "Basis", "Rejected", "Note")
+_HEADER_CELLS = ("#", "Term", "Anchor", "Rendering", "Basis", "Rejected", "Note")
 _NONE_MARKERS = {"", "—", "-", "–"}
-
-
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-import po_catalog  # noqa: E402 — the sibling module, found via the line above
+_SEPARATOR = "、"
 
 
 @dataclass(frozen=True)
 class Rejection:
-    """One rendering the glossary refuses, and the row that refuses it."""
+    """One rendering the glossary refuses for one term."""
 
     term: str
     rendering: str
@@ -79,21 +97,48 @@ class Rejection:
 @dataclass(frozen=True)
 class Row:
     term: str
+    anchors: tuple[str, ...]
     rendering: str
+    basis: str
     rejected: tuple[Rejection, ...]
+    note: str
+
+    @property
+    def is_global(self) -> bool:
+        return not self.anchors
+
+    @property
+    def keep_english(self) -> bool:
+        return self.basis.strip().startswith("K")
+
+    def anchored_in(self, msgid: str) -> bool:
+        """Whether one of the row's anchors appears in ``msgid`` (case-insensitive, at a
+        word start, as a prefix — ``entail`` covers ``entailment``)."""
+        return any(_anchor_re(a, case_sensitive=False).search(msgid) for a in self.anchors)
+
+
+def _anchor_re(anchor: str, *, case_sensitive: bool) -> re.Pattern[str]:
+    return re.compile(r"(?<![A-Za-z0-9])" + re.escape(anchor), 0 if case_sensitive else re.I)
 
 
 def split_cells(line: str) -> list[str]:
-    """The cells of a Markdown table row, honouring backtick spans.
+    """The cells of a Markdown table row, honouring backtick spans and ``\\|``.
 
-    ``|`` inside a code span is content (the annotation syntax ``{| |}`` sits in
-    one cell of the glossary), so the split tracks backtick state.
+    ``|`` inside a code span is content (the annotation syntax ``{| |}`` sits in one cell
+    of the glossary), and ``\\|`` is a literal pipe inside a cell (the regex alternation in
+    a Rejected entry), so the split tracks both.
     """
     cells: list[str] = []
     buf: list[str] = []
     in_code = False
+    escaped = False
     for c in line.strip():
-        if c == "`":
+        if escaped:
+            buf.append(c)
+            escaped = False
+        elif c == "\\":
+            escaped = True
+        elif c == "`":
             in_code = not in_code
             buf.append(c)
         elif c == "|" and not in_code:
@@ -102,7 +147,6 @@ def split_cells(line: str) -> list[str]:
         else:
             buf.append(c)
     cells.append("".join(buf).strip())
-    # A row is written `| a | b |`, so the first and last cells are empty.
     if cells and cells[0] == "":
         cells = cells[1:]
     if cells and cells[-1] == "":
@@ -117,14 +161,15 @@ def _strip_code(cell: str) -> str:
     return cell
 
 
-def parse_rejected(term: str, rendering: str, cell: str) -> tuple[Rejection, ...]:
+def _list_cell(cell: str) -> tuple[str, ...]:
     if cell.strip() in _NONE_MARKERS:
         return ()
+    return tuple(p for p in (_strip_code(x) for x in cell.split(_SEPARATOR)) if p not in _NONE_MARKERS)
+
+
+def parse_rejected(term: str, rendering: str, cell: str) -> tuple[Rejection, ...]:
     out: list[Rejection] = []
-    for piece in cell.split("、"):
-        spelled = _strip_code(piece)
-        if spelled in _NONE_MARKERS:
-            continue
+    for spelled in _list_cell(cell):
         if len(spelled) >= 2 and spelled[0] == "/" and spelled[-1] == "/":
             pattern = re.compile(spelled[1:-1])
         else:
@@ -140,8 +185,7 @@ def parse_glossary(text: str) -> list[Row]:
         (
             i
             for i, line in enumerate(lines)
-            if line.lstrip().startswith("|")
-            and tuple(split_cells(line)) == _HEADER_CELLS
+            if line.lstrip().startswith("|") and tuple(split_cells(line)) == _HEADER_CELLS
         ),
         None,
     )
@@ -160,23 +204,25 @@ def parse_glossary(text: str) -> list[Row]:
                 f"check-i18n-glossary: glossary row has {len(cells)} cells, expected "
                 f"{len(_HEADER_CELLS)}: {line.strip()!r}"
             )
-        _, term, rendering, _basis, rejected, _note = cells
+        _, term, anchor, rendering, basis, rejected, note = cells
         if not term or not rendering:
             raise SystemExit(
                 f"check-i18n-glossary: glossary row with an empty term or rendering: "
                 f"{line.strip()!r}"
             )
-        rows.append(Row(term, rendering, parse_rejected(term, rendering, rejected)))
+        rows.append(
+            Row(term, _list_cell(anchor), rendering, basis, parse_rejected(term, rendering, rejected), note)
+        )
     if not rows:
         raise SystemExit("check-i18n-glossary: the glossary table has no rows")
     return rows
 
 
-# How a self-test specimen is derived from a ``/regex/`` rejection: the
-# lookarounds are removed and the two quantified classes the glossary uses are
-# given a concrete value. ``check_consistency`` asserts the derived specimen
-# really matches its regex, so a regex this table cannot derive a specimen for
-# is a hard error rather than a rejection the self-test never exercises.
+# How a self-test specimen is derived from a ``/regex/`` rejection: the lookarounds are
+# removed and the quantified classes the glossary uses are given a concrete value.
+# ``check_consistency`` asserts the derived specimen really matches its regex, so a regex
+# this table cannot derive a specimen for is a hard error rather than a rejection the
+# self-test never exercises.
 _SPECIMEN_SUBSTITUTIONS = (
     (re.compile(r"\(\?<?[!=].*?\)"), ""),
     (re.compile(r"\\d\+"), "0"),
@@ -198,16 +244,25 @@ def specimen(rule: Rejection) -> str:
 
 
 def check_consistency(rows: list[Row]) -> None:
-    """A rejected rendering may not appear inside ANY row's rendering, and every
-    ``/regex/`` rejection must match the specimen derived for it."""
+    """The table's own invariants, each a hard error."""
     for row in rows:
+        if row.rejected and row.is_global and "global" not in row.note.lower():
+            raise SystemExit(
+                f"check-i18n-glossary: row {row.term!r} has rejections and no Anchor, which "
+                f"makes them GLOBAL, but its Note does not say so or why"
+            )
+        if row.keep_english and row.is_global:
+            raise SystemExit(
+                f"check-i18n-glossary: row {row.term!r} is K (keep English) but names no "
+                f"Anchor token to keep"
+            )
         for rejection in row.rejected:
             probe = specimen(rejection)
             if rejection.find(probe) is None:
                 raise SystemExit(
                     f"check-i18n-glossary: row {row.term!r} rejects {rejection.spelled!r}, "
-                    f"but the specimen derived for it ({probe!r}) does not match it, so "
-                    f"the self-test could never prove it bites. Spell the regex with the "
+                    f"but the specimen derived for it ({probe!r}) does not match it, so the "
+                    f"self-test could never prove it bites. Spell the regex with the "
                     f"constructs the specimen derivation knows (lookarounds, \\d, \\s)"
                 )
             for other in rows:
@@ -215,35 +270,101 @@ def check_consistency(rows: list[Row]) -> None:
                 if hit:
                     raise SystemExit(
                         f"check-i18n-glossary: the glossary refuses itself — row "
-                        f"{row.term!r} rejects {rejection.spelled!r}, which matches "
-                        f"{hit!r} inside row {other.term!r}'s rendering "
-                        f"{other.rendering!r}. Spell the rejection as a /regex/ that "
-                        f"excludes the right rendering, or drop it"
+                        f"{row.term!r} rejects {rejection.spelled!r}, which matches {hit!r} "
+                        f"inside row {other.term!r}'s rendering {other.rendering!r}. Spell "
+                        f"the rejection as a /regex/ that excludes the right rendering, or "
+                        f"drop it"
                     )
 
 
-def rejections(rows: list[Row]) -> list[Rejection]:
-    return [r for row in rows for r in row.rejected]
+# ── Markdown code, which is never prose ───────────────────────────────────────
 
 
-def offences(label: str, text: str, rules: list[Rejection]) -> list[str]:
-    out: list[str] = []
-    for rule in rules:
-        hit = rule.find(text)
-        if hit is None:
+def _inline_code_spans(line: str) -> list[tuple[int, int]]:
+    """``(start, end)`` of every inline code span: a backtick run of N opens a span,
+    closed by the next run of exactly N (the same rule the other prose gates apply)."""
+    spans: list[tuple[int, int]] = []
+    i = 0
+    n = len(line)
+    while i < n:
+        if line[i] != "`":
+            i += 1
             continue
-        out.append(
-            f"{label}: {hit!r} is a rejected rendering of {rule.term!r} — the glossary "
-            f"says {rule.rendering!r} (docs/book/po/glossary-zh-Hans.md)"
-        )
+        j = i
+        while j < n and line[j] == "`":
+            j += 1
+        run = j - i
+        k = j
+        while k < n:
+            if line[k] != "`":
+                k += 1
+                continue
+            m = k
+            while m < n and line[m] == "`":
+                m += 1
+            if m - k == run:
+                spans.append((i, m))
+                i = m
+                break
+            k = m
+        else:
+            i = j
+    return spans
+
+
+def strip_code(text: str) -> str:
+    """``text`` with fenced blocks and inline code spans removed."""
+    out: list[str] = []
+    fenced = False
+    for line in text.splitlines():
+        if re.match(r"\s*(?:```+|~~~+)", line):
+            fenced = not fenced
+            continue
+        if fenced:
+            continue
+        kept = []
+        last = 0
+        for start, end in _inline_code_spans(line):
+            kept.append(line[last:start])
+            last = end
+        kept.append(line[last:])
+        out.append("".join(kept))
+    return "\n".join(out)
+
+
+# ── The rule ──────────────────────────────────────────────────────────────────
+
+
+def offences(label: str, msgid: str | None, msgstr: str, rows: list[Row]) -> list[str]:
+    """Every way ``msgstr`` breaks the glossary for ``msgid`` (``None`` for a file line)."""
+    out: list[str] = []
+    prose = strip_code(msgstr)
+    for row in rows:
+        applies = row.is_global or (msgid is not None and row.anchored_in(msgid))
+        if applies:
+            for rule in row.rejected:
+                hit = rule.find(prose)
+                if hit is not None:
+                    out.append(
+                        f"{label}: {hit!r} is a rejected rendering of {rule.term!r} — the "
+                        f"glossary says {rule.rendering!r} (docs/book/po/glossary-zh-Hans.md)"
+                    )
+        if row.keep_english and msgid is not None:
+            for token in row.anchors:
+                if _anchor_re(token, case_sensitive=True).search(msgid) and token not in msgstr:
+                    out.append(
+                        f"{label}: the keep-English term {token!r} in the msgid does not "
+                        f"survive into the msgstr — glossary row {row.term!r} keeps it "
+                        f"verbatim (docs/book/po/glossary-zh-Hans.md)"
+                    )
     return out
 
 
-def po_units(po_path: Path) -> list[tuple[str, str]]:
+def po_units(po_path: Path) -> list[tuple[str, str | None, str]]:
     entries = po_catalog.messages(po_catalog.parse_po(po_path.read_text(encoding="utf-8")))
     rel = po_path.relative_to(_REPO) if po_path.is_relative_to(_REPO) else po_path
     return [
-        (f"{rel}:{e.line} (msgid {e.msgid[:48]!r})", e.msgstr)
+        (f"{rel}:{e.line} (msgid {e.msgid[:48]!r})", e.msgid, e.msgstr)
         for e in entries
         if e.translated
     ]
@@ -267,40 +388,80 @@ def tracked_translated_files() -> list[Path]:
     return paths
 
 
-def file_units(path: Path) -> list[tuple[str, str]]:
+def file_units(path: Path) -> list[tuple[str, str | None, str]]:
     rel = path.relative_to(_REPO)
     return [
-        (f"{rel}:{number}", line)
+        (f"{rel}:{number}", None, line)
         for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
     ]
 
 
 # ── This gate's own falsifiability ────────────────────────────────────────────
 
+# For every rejected rendering, an ordinary Chinese sentence that uses the rejected word
+# in its OTHER sense — the sentence a translator writes on a page about something else,
+# which the gate must not refuse. Keyed by the Rejected cell's spelling. A global row's
+# neighbour is a near miss instead (it must NOT contain the rejected form), because a
+# global rejection is wrong wherever it appears and has no other sense to spare.
+NEIGHBOURS: dict[str, str] = {
+    "具名图": "作者具名发表了这篇文章。",  # global near miss: 具名 alone
+    "资料集": "参考资料见附录。",  # global near miss: 资料 alone
+    "资料类型": "参考资料见附录。",  # global near miss
+    "空白节点": "网页模板中的空白节点会被忽略。",  # an empty DOM node
+    "字面值": "该常量的字面值为 42。",  # a constant's literal value
+    "语言标记": "编辑器根据语言标记进行语法高亮。",  # an editor's language marker
+    "本体论": "本体论是哲学的一个分支。",  # philosophy
+    "/知识图(?!谱)/": "这张知识图示意了课程结构。",  # a knowledge diagram
+    "蕴含": "这一设计蕴含着一个假设。",  # implies
+    "实体化": "该抽象概念被实体化为一个类。",  # reified into a class
+    "标准化": "RDF 1.2 已由 W3C 标准化。",  # standardized
+    "决定性": "这是决定性因素。",  # decisive
+    "出处": "引文出处见脚注。",  # a citation's source
+    "三元组术语": "本节解释三元组术语的由来。",  # the terminology of triples
+    "三元组词项": "三元组词项在逻辑学教材中另有含义。",
+    "基本方向": "设计的基本方向是确定性。",  # basic direction
+    "组合数据类型": "C 语言中的结构体是一种组合数据类型。",  # an aggregate type in C
+    "/(?<!台)账本/": "区块链是一种分布式账本。",  # a blockchain ledger
+    "核外": "核外电子决定了元素的化学性质。",  # extranuclear electrons
+    "/研究对象(?![（(]Research Object)/": "本研究的研究对象为大学生。",  # the object of study
+    "/表面(?!上|看来|来看)/": "水的表面张力很大。",  # surface tension
+    "铸造": "青铜器由铸造而成。",  # bronze casting
+    "抵达": "列车准时抵达车站。",  # a train arriving
+    "大声": "请勿大声喧哗。",  # loudly
+    "全文搜索": "本站提供全文搜索功能。",  # a website's search box
+    "校验报告": "文件校验报告显示哈希一致。",  # a checksum verification report
+}
 
-def _po_with(msgstr: str, *, fuzzy: bool = False, obsolete: bool = False) -> str:
+# A msgid no row anchors — asserted, not assumed, in ``self_test``.
+_UNRELATED_MSGID = "The weather was fine today."
+
+
+def _po_text(msgid: str, msgstr: str, *, fuzzy: bool = False, obsolete: bool = False) -> str:
     prefix = "#~ " if obsolete else ""
     flag = "#, fuzzy\n" if fuzzy else ""
     return (
         'msgid ""\nmsgstr ""\n"Content-Type: text/plain; charset=UTF-8\\n"\n\n'
-        f"{flag}{prefix}msgid \"Entailment regimes\"\n"
-        f"{prefix}msgstr \"{po_catalog.escape(msgstr)}\"\n"
+        f'{flag}{prefix}msgid "{po_catalog.escape(msgid)}"\n'
+        f'{prefix}msgstr "{po_catalog.escape(msgstr)}"\n'
     )
 
 
+def _units_of(po_text: str) -> list[tuple[str, str | None, str]]:
+    entries = po_catalog.messages(po_catalog.parse_po(po_text))
+    return [("probe", e.msgid, e.msgstr) for e in entries if e.translated]
+
+
 def self_test(rows: list[Row], report: bool) -> list[str]:
-    """Every rejected rendering must be refused; every right one must pass."""
-    rules = rejections(rows)
+    """Every rule, both ways, executed through :func:`offences`. Empty is the only pass."""
     problems: list[str] = []
+    rules = [r for row in rows for r in row.rejected]
     if not rules:
         return ["the glossary lists no rejected rendering, so this gate refuses nothing"]
-
-    def units_of(po_text: str) -> list[tuple[str, str]]:
-        entries = po_catalog.messages(po_catalog.parse_po(po_text))
-        return [("probe", e.msgstr) for e in entries if e.translated]
+    if any(row.anchored_in(_UNRELATED_MSGID) for row in rows):
+        return [f"the unrelated msgid {_UNRELATED_MSGID!r} is anchored by a row — pick another"]
 
     def verdict(what: str, po_text: str, must_refuse: bool) -> None:
-        found = [o for label, text in units_of(po_text) for o in offences(label, text, rules)]
+        found = [o for label, msgid, msgstr in _units_of(po_text) for o in offences(label, msgid, msgstr, rows)]
         ok = bool(found) is must_refuse
         if report:
             print(f"  {'ok' if ok else 'WRONG':5}  {'refused' if found else 'passes '}  {what}")
@@ -311,48 +472,140 @@ def self_test(rows: list[Row], report: bool) -> list[str]:
             )
 
     for row in rows:
+        anchored = _UNRELATED_MSGID if row.is_global else f"This paragraph is about {row.anchors[0]}."
         for rule in row.rejected:
             probe = specimen(rule)
+            neighbour = NEIGHBOURS.get(rule.spelled)
+            if neighbour is None:
+                problems.append(
+                    f"NO NEIGHBOUR: {row.term} rejects {rule.spelled!r} and NEIGHBOURS has no "
+                    f"ordinary sentence for it — a refusal proven only one way"
+                )
+                continue
+            if row.is_global:
+                if rule.find(neighbour) is not None:
+                    problems.append(
+                        f"BAD NEIGHBOUR: {row.term} is global, so its neighbour must be a near "
+                        f"miss, but {neighbour!r} contains {rule.spelled!r}"
+                    )
+                    continue
+                verdict(
+                    f"{row.term} (GLOBAL): {probe!r} under an unrelated msgid",
+                    _po_text(_UNRELATED_MSGID, f"本页使用{probe}一词。"),
+                    True,
+                )
+                verdict(
+                    f"{row.term} (GLOBAL): the near miss {neighbour!r}",
+                    _po_text(_UNRELATED_MSGID, neighbour),
+                    False,
+                )
+            else:
+                if rule.find(neighbour) is None:
+                    problems.append(
+                        f"BAD NEIGHBOUR: {neighbour!r} does not contain {rule.spelled!r}, so it "
+                        f"proves nothing about {row.term}'s rejection"
+                    )
+                    continue
+                verdict(
+                    f"{row.term}: {probe!r} under an anchored msgid ({row.anchors[0]!r})",
+                    _po_text(anchored, f"本页使用{probe}一词。"),
+                    True,
+                )
+                verdict(
+                    f"{row.term}: the other sense — {neighbour!r} under an unrelated msgid",
+                    _po_text(_UNRELATED_MSGID, neighbour),
+                    False,
+                )
+            # A K row's probe keeps the invariant token beside the code span, so the
+            # survival arm has nothing to say and only the code-span rule is tested.
+            keep = f"（{row.anchors[0]}）" if row.keep_english else ""
             verdict(
-                f"{rule.term}: the rejected rendering {probe!r} in a msgstr",
-                _po_with(f"本页使用{probe}一词。"),
-                True,
+                f"{row.term}: {probe!r} inside a code span under the anchored msgid",
+                _po_text(anchored, f"不要写 `{probe}`{keep}。"),
+                False,
             )
-        rendering = _strip_code(row.rendering)
-        verdict(
-            f"{row.term}: the glossary rendering {rendering!r} in a msgstr",
-            _po_with(f"本页使用 {rendering} 一词。"),
-            False,
-        )
+        if row.rejected:
+            rendering = _strip_code(row.rendering)
+            if rendering != "as written":
+                verdict(
+                    f"{row.term}: the glossary rendering {rendering!r} under the anchored msgid",
+                    _po_text(anchored, f"本页使用 {rendering} 一词。"),
+                    False,
+                )
+        if row.keep_english:
+            for token in row.anchors:
+                verdict(
+                    f"{row.term}: {token!r} in the msgid, DROPPED from the msgstr",
+                    _po_text(f"The {token} toolkit is here.", "该工具包在此。"),
+                    True,
+                )
+                verdict(
+                    f"{row.term}: {token!r} in the msgid, kept in the msgstr",
+                    _po_text(f"The {token} toolkit is here.", f"该 {token} 工具包在此。"),
+                    False,
+                )
+            verdict(
+                f"{row.term}: no token in the msgid, nothing to keep",
+                _po_text("The toolkit is here.", "该工具包在此。"),
+                False,
+            )
+
     probe = specimen(rules[0])
-    verdict("an untranslated entry (empty msgstr)", _po_with(""), False)
-    verdict("an English msgstr", _po_with("Entailment regimes"), False)
+    anchored = f"This paragraph is about {next(r for r in rows if r.rejected and not r.is_global).anchors[0]}."
+    verdict("an untranslated entry (empty msgstr)", _po_text(anchored, ""), False)
+    verdict("an English msgstr", _po_text(anchored, anchored), False)
     verdict(
         f"a FUZZY entry carrying {probe!r} (not rendered, so not refused)",
-        _po_with(f"本页使用{probe}一词。", fuzzy=True),
+        _po_text(anchored, f"本页使用{probe}一词。", fuzzy=True),
         False,
     )
     verdict(
         f"an OBSOLETE entry carrying {probe!r} (not rendered, so not refused)",
-        _po_with(f"本页使用{probe}一词。", obsolete=True),
+        _po_text(anchored, f"本页使用{probe}一词。", obsolete=True),
         False,
     )
+    # The sentences from the review that the first version refused, and the book's own.
+    for what, msgid, msgstr in (
+        (
+            "the book's own sentence: 'no standardized spelling exists'",
+            "Other engines already ship a form of it, but no standardized spelling exists.",
+            "其他引擎已经提供了某种形式，但不存在标准化的拼写。",
+        ),
+        (
+            "a faithful sentence keeping every invariant",
+            "PurRDF is an RDF 1.2 toolkit in Rust with Python and WebAssembly bindings.",
+            "PurRDF 是一个用 Rust 编写的 RDF 1.2 工具包，提供 Python 与 WebAssembly 绑定。",
+        ),
+        (
+            "the gloss form with the acronym",
+            "Research Object projections",
+            "研究对象（Research Object，RO）投影",
+        ),
+    ):
+        verdict(what, _po_text(msgid, msgstr), False)
+    for what, msgid, msgstr in (
+        ("Research Object rendered as 研究物件", "Research Object projections", "研究物件（RO）投影"),
+        ("GMEOW translated", "The GMEOW ontology.", "吉猫协议本体。"),
+        ("IRI translated in running text", "Every IRI is absolute.", "每个国际化资源标识符都是绝对的。"),
+    ):
+        verdict(what, _po_text(msgid, msgstr), True)
     return problems
 
 
 def main(argv: list[str]) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--self-test", action="store_true", help="prove the rule, then stop")
+    ap.add_argument("--self-test", action="store_true", help="prove the rules, then stop")
     ap.add_argument("--po", type=Path, default=PO_PATH, help="the catalogue to check")
     ap.add_argument("--glossary", type=Path, default=GLOSSARY_PATH)
     args = ap.parse_args(argv)
 
     rows = parse_glossary(args.glossary.read_text(encoding="utf-8"))
     check_consistency(rows)
-    rules = rejections(rows)
+    rules = [r for row in rows for r in row.rejected]
+    tokens = [t for row in rows if row.keep_english for t in row.anchors]
 
     if args.self_test:
-        print("check-i18n-glossary: proving every rejected rendering is refused —")
+        print("check-i18n-glossary: proving every rule bites, and only bites —")
     problems = self_test(rows, report=args.self_test)
     if problems:
         print(
@@ -363,33 +616,34 @@ def main(argv: list[str]) -> int:
         return 1
     if args.self_test:
         print(
-            f"OK: {len(rules)} rejected rendering(s) across {len(rows)} glossary row(s), "
-            "each refused, each row's own rendering spared."
+            f"OK: {len(rules)} rejected rendering(s) across {len(rows)} glossary row(s) "
+            f"({sum(1 for r in rows if r.rejected and r.is_global)} global), each refused "
+            f"under its anchor and spared in its other sense; {len(tokens)} keep-English "
+            f"token(s), each refused when dropped."
         )
         return 0
 
-    units: list[tuple[str, str]] = []
-    if args.po.is_file():
-        units.extend(po_units(args.po))
-    else:
+    if not args.po.is_file():
         print(f"check-i18n-glossary: no catalogue at {args.po}", file=sys.stderr)
         return 1
+    units = po_units(args.po)
     files = tracked_translated_files()
     for path in files:
         units.extend(file_units(path))
 
-    found = [o for label, text in units for o in offences(label, text, rules)]
+    found = [o for label, msgid, msgstr in units for o in offences(label, msgid, msgstr, rows)]
     if found:
         print(
-            "check-i18n-glossary: translated text uses a rendering the glossary rejects:\n"
+            "check-i18n-glossary: translated text breaks the glossary:\n"
             + "\n".join(f"  - {o}" for o in found),
             file=sys.stderr,
         )
         return 1
+    po_label = args.po.relative_to(_REPO) if args.po.is_relative_to(_REPO) else args.po
     print(
-        f"OK: {len(rules)} rejected rendering(s) from {len(rows)} glossary row(s) absent "
-        f"from {len(units)} translated unit(s) ({args.po.relative_to(_REPO) if args.po.is_relative_to(_REPO) else args.po} "
-        f"plus {len(files)} tracked {TRANSLATED_PATH_MARK} Markdown file(s))."
+        f"OK: {len(rules)} rejected rendering(s) and {len(tokens)} keep-English token(s) from "
+        f"{len(rows)} glossary row(s) respected by {len(units)} translated unit(s) ({po_label} "
+        f"plus {len(files)} tracked {TRANSLATED_PATH_MARK} Markdown file(s), global rows only)."
     )
     return 0
 

--- a/scripts/check-i18n-render.py
+++ b/scripts/check-i18n-render.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""Render the zh-Hans book to Markdown and run the prose gates and the SPARQL fence parser
+over the rendering.
+
+The book's translation is a gettext catalogue, ``docs/book/po/zh-Hans.po``, applied by the
+``mdbook-gettext`` preprocessor at build time. That is the right mechanism — an
+untranslated paragraph renders as its English source, so translation lag is visible to
+the reader by construction — and it has one consequence this gate exists for: a ``.po``
+file is read by NO other gate. ``check-brand-casing.py``, ``check-issue-refs.py``,
+``check-spec-attribution.py`` and ``check-doc-claims.py`` enumerate tracked ``.rs``/``.md``
+and never open a ``.po``; ``serializer_roundtrip_sweep.rs`` and
+``shipped_sparql_examples.rs`` extract fenced SPARQL from ``docs/**/*.md``, never from a
+``msgstr``. Without this step a bare ``purrdf`` in Chinese prose, a process token, an
+attribution of the quad template (a first-party extension) to SPARQL 1.2, an unscoped
+entailment claim, or a broken query inside a fence a translator added would all ship
+with every gate green.
+
+So this gate does what the reader's build does — ``mdbook build`` with
+``MDBOOK_BOOK__LANGUAGE=zh-Hans`` — with the ``markdown`` renderer added, into a temporary
+directory, and then runs over that tree:
+
+1. ``check-brand-casing.py --rendered-tree``
+2. ``check-issue-refs.py --rendered-tree``
+3. ``check-spec-attribution.py --rendered-tree``
+4. ``check-doc-claims.py --rendered-tree`` (the two rule bans; the numeric claims stay
+   English by policy — scoreboards are linked, not restated)
+5. ``cargo run -p purrdf-sparql-algebra --example sweep_sparql_fences`` — every fenced
+   ``sparql`` block must parse as a query or an update.
+6. Every translated message must have REACHED the rendering: the longest run of CJK
+   characters in each rendered ``msgstr`` must appear in the build output — the
+   Markdown tree, or the HTML tree for the messages that exist only in ``SUMMARY.md``
+   (part titles, chapter titles), which the ``markdown`` renderer does not emit and
+   which land in the HTML sidebar instead. The preprocessor never errors on a message
+   it cannot match — it renders the English — so a catalogue entry it silently ignores
+   is translation work that was done and is not shown. The everyday case is a STALE
+   entry: the English paragraph changed, the catalogue was not re-merged, and a
+   hand-edited ``msgid`` no longer exists in the source.
+
+It also asserts the pinned tool: ``mdbook-i18n-helpers`` is installed at exactly
+``MDBOOK_I18N_HELPERS_VERSION`` from the Makefile, read from ``cargo install --list``
+because the binaries themselves report no version. And it reports (report-only, by
+design) the catalogue's translated/fuzzy/untranslated counts and how far its msgids have
+drifted from a freshly extracted template — the per-release lag numbers the translation
+owner reads.
+
+    python3 scripts/check-i18n-render.py              # render and gate (exit 1 on a hit)
+    python3 scripts/check-i18n-render.py --self-test  # prove each arm can go red, then gate
+
+The self-test writes NOTHING under the repository. For each arm it builds a throwaway
+catalogue containing one poisoned ``msgstr`` — the arm's OWN self-test specimen, imported
+from the gate script (a bare ``purrdf`` glued to CJK, a hazard id glued to CJK, the
+Chinese attribution of the quad template, the overclaim ban's specimen after a full-width
+terminator) plus a fenced ``sparql`` block with a full-width brace written INSIDE a prose
+``msgstr``, plus a translation of a ``msgid`` the source does not carry — renders the book
+with THAT catalogue (``MDBOOK_PREPROCESSOR__GETTEXT__PO_DIR``), and asserts the arm goes
+red. The fence poison takes that shape because
+``mdbook-xgettext`` at the pinned version extracts no message for a ``sparql`` fence at
+all (only comments and string literals of the languages it lexes), so the English
+examples are byte-invariant under translation and the one way a query reaches the
+rendering through the catalogue is a translator writing a fence into a paragraph. A gate whose red state has never been observed is a gate
+whose green state means nothing.
+
+Run locally as ``make check-i18n``; CI runs it in the docs workflow before building
+the zh-Hans book into the Pages artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_SCRIPTS = _REPO / "scripts"
+_BOOK = _REPO / "docs" / "book"
+_PO_DIR = _BOOK / "po"
+_PO = _PO_DIR / "zh-Hans.po"
+_MAKEFILE = _REPO / "Makefile"
+LANGUAGE = "zh-Hans"
+
+# The four prose gates, each with a `--rendered-tree` mode, in the order the
+# report reads.
+PROSE_GATES = (
+    "check-brand-casing.py",
+    "check-issue-refs.py",
+    "check-spec-attribution.py",
+    "check-doc-claims.py",
+)
+FENCE_SWEEP = (
+    "cargo",
+    "run",
+    "-q",
+    "-p",
+    "purrdf-sparql-algebra",
+    "--example",
+    "sweep_sparql_fences",
+    "--locked",
+    "--",
+)
+
+
+sys.path.insert(0, str(_SCRIPTS))
+import po_catalog  # noqa: E402 — the sibling module, found via the line above
+
+
+def pinned_version() -> str:
+    match = re.search(r"^MDBOOK_I18N_HELPERS_VERSION := (\S+)$", _MAKEFILE.read_text(), re.M)
+    if not match:
+        raise SystemExit("check-i18n-render: MDBOOK_I18N_HELPERS_VERSION is not in the Makefile")
+    return match.group(1)
+
+
+def require_tools() -> str:
+    """mdbook and the pinned mdbook-i18n-helpers on PATH; returns the pin."""
+    pin = pinned_version()
+    install = f"cargo install mdbook-i18n-helpers --version {pin} --locked"
+    for binary in ("mdbook", "mdbook-gettext", "mdbook-xgettext", "cargo"):
+        if shutil.which(binary) is None:
+            raise SystemExit(
+                f"check-i18n-render: `{binary}` is not on PATH — install mdBook and the "
+                f"pinned helpers:\n  {install}"
+            )
+    listed = subprocess.run(
+        ["cargo", "install", "--list"], check=True, capture_output=True, text=True
+    ).stdout
+    found = re.search(r"^mdbook-i18n-helpers v(\S+):$", listed, re.M)
+    if found is None:
+        raise SystemExit(
+            f"check-i18n-render: `cargo install --list` does not report "
+            f"mdbook-i18n-helpers (the binaries carry no version of their own) — install "
+            f"the pin:\n  {install}"
+        )
+    if found.group(1) != pin:
+        raise SystemExit(
+            f"check-i18n-render: mdbook-i18n-helpers version mismatch — found "
+            f"{found.group(1)}, expected {pin}:\n  {install}"
+        )
+    return pin
+
+
+def render(out: Path, po_dir: Path | None = None) -> Path:
+    """Build the zh-Hans book into ``out`` (``html/`` and ``markdown/``); returns the
+    Markdown tree, ``out / "markdown"``."""
+    env = dict(os.environ)
+    env["MDBOOK_BOOK__LANGUAGE"] = LANGUAGE
+    env["MDBOOK_OUTPUT__MARKDOWN"] = "{}"
+    env["MDBOOK_OUTPUT__HTML__SEARCH__ENABLE"] = "false"
+    if po_dir is not None:
+        env["MDBOOK_PREPROCESSOR__GETTEXT__PO_DIR"] = str(po_dir)
+    run = subprocess.run(
+        ["mdbook", "build", "-d", str(out), str(_BOOK)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    tree = out / "markdown"
+    if run.returncode != 0 or not tree.is_dir():
+        raise SystemExit(
+            f"check-i18n-render: `mdbook build` of the {LANGUAGE} book failed "
+            f"(exit {run.returncode}):\n{run.stdout}{run.stderr}"
+        )
+    if not any(tree.rglob("*.md")):
+        raise SystemExit(f"check-i18n-render: the markdown renderer wrote nothing under {tree}")
+    return tree
+
+
+def extract_template(out: Path) -> list:
+    """A fresh ``.pot`` from the English source, parsed."""
+    env = dict(os.environ)
+    env["MDBOOK_OUTPUT"] = json.dumps({"xgettext": {"pot-file": "messages.pot"}})
+    run = subprocess.run(
+        ["mdbook", "build", "-d", str(out), str(_BOOK)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    pot = out / "messages.pot"
+    if run.returncode != 0 or not pot.is_file():
+        raise SystemExit(
+            f"check-i18n-render: mdbook-xgettext failed (exit {run.returncode}):\n"
+            f"{run.stdout}{run.stderr}"
+        )
+    return po_catalog.messages(po_catalog.parse_po(pot.read_text(encoding="utf-8")))
+
+
+def gate(name: str, tree: Path) -> int:
+    cmd = (
+        list(FENCE_SWEEP) + [str(tree)]
+        if name == "sweep_sparql_fences"
+        else [sys.executable, str(_SCRIPTS / name), "--rendered-tree", str(tree)]
+    )
+    run = subprocess.run(cmd, cwd=_REPO, capture_output=True, text=True)
+    for stream in (run.stdout, run.stderr):
+        if stream.strip():
+            print("    " + stream.strip().replace("\n", "\n    "))
+    return run.returncode
+
+
+def gate_all(tree: Path, catalogue: Path) -> list[str]:
+    """Run every arm over ``tree``; the names of the arms that went red."""
+    red: list[str] = []
+    for name in (*PROSE_GATES, "sweep_sparql_fences"):
+        print(f"  {name}:")
+        if gate(name, tree) != 0:
+            red.append(name)
+    if gate_reached(catalogue, tree) != 0:
+        red.append("reached-the-rendering")
+    return red
+
+
+def report_catalogue(template: list) -> None:
+    entries = po_catalog.messages(po_catalog.parse_po(_PO.read_text(encoding="utf-8")))
+    live = [e for e in entries if not e.obsolete]
+    translated = sum(e.translated for e in live)
+    fuzzy = sum(e.fuzzy for e in live)
+    obsolete = len(entries) - len(live)
+    source_ids = {(e.msgctxt, e.msgid) for e in template}
+    catalogue_ids = {(e.msgctxt, e.msgid) for e in live}
+    missing = len(source_ids - catalogue_ids)
+    stale = len(catalogue_ids - source_ids)
+    print(
+        f"  catalogue {_PO.relative_to(_REPO)}: {len(live)} message(s) — {translated} "
+        f"translated, {fuzzy} fuzzy, {len(live) - translated - fuzzy} untranslated, "
+        f"{obsolete} obsolete."
+    )
+    print(
+        f"  drift against a fresh template: {missing} source message(s) absent from the "
+        f"catalogue, {stale} catalogue message(s) no longer in the source"
+        + (" — `make book-po-update` refreshes it." if missing or stale else ".")
+    )
+
+
+# ── This gate's own falsifiability ────────────────────────────────────────────
+
+
+def _catalogue(pairs: list[tuple[str, str]]) -> str:
+    """A throwaway catalogue: the real scaffold's header, then ``pairs``.
+
+    The header is copied rather than written because ``mdbook-gettext``'s PO
+    reader requires the full metadata block (it panics on a header that
+    carries only ``Content-Type``), and the scaffold's is known to load.
+    """
+    text = _PO.read_text(encoding="utf-8")
+    head = text[: text.index("\n\n") + 1]
+    body = "".join(
+        f'\nmsgid "{po_catalog.escape(msgid)}"\nmsgstr "{po_catalog.escape(msgstr)}"\n'
+        for msgid, msgstr in pairs
+    )
+    return head + body
+
+
+# Runs of CJK ideographs, four or more: the part of a translated message that
+# survives Markdown re-serialization untouched, so its presence in the rendered
+# tree is the honest test of whether the message was applied.
+_CJK_RUN = re.compile(r"[\u4e00-\u9fff\u3400-\u4dbf]{4,}")
+
+
+def _prose_msgid(template: list) -> str:
+    """A plain body paragraph: one line, no code span, a full sentence — so it lives
+    in a page (not only in ``SUMMARY.md``) and its poison reaches the Markdown tree."""
+    for e in template:
+        if "\n" not in e.msgid and "`" not in e.msgid and len(e.msgid) > 60 and e.msgid.endswith("."):
+            return e.msgid
+    raise SystemExit("check-i18n-render: the template has no plain prose message to poison")
+
+
+# A msgid no English page carries: the stale entry arm 6 exists to refuse.
+_STALE_MSGID = "This sentence exists in the catalogue and nowhere in the English source."
+
+
+def unreached(catalogue: Path, tree: Path) -> list[str]:
+    """Translated messages whose CJK text is absent from the build output (arm 6).
+
+    ``tree`` is the Markdown tree; its sibling ``html/`` is read as well, because a
+    ``SUMMARY.md``-only message (a part or chapter title) is rendered into the sidebar
+    and the page ``<title>`` and into no Markdown file. CJK text is not entity-encoded
+    in mdBook's HTML, so the same probe works on both.
+    """
+    files = list(tree.rglob("*.md"))
+    html = tree.parent / "html"
+    files += list(html.rglob("*.html")) + list(html.glob("*.js"))
+    rendered = "".join(p.read_text(encoding="utf-8") for p in sorted(files))
+    entries = po_catalog.messages(po_catalog.parse_po(catalogue.read_text(encoding="utf-8")))
+    missing: list[str] = []
+    for e in entries:
+        if not e.translated:
+            continue
+        runs = _CJK_RUN.findall(e.msgstr)
+        if not runs:
+            continue
+        probe = max(runs, key=len)
+        if probe not in rendered:
+            missing.append(
+                f"{catalogue.name}:{e.line}: translated message never reached the rendering "
+                f"(msgid {e.msgid[:60]!r}; probe {probe!r}) — the preprocessor did not "
+                f"match its msgid; the English source no longer carries it "
+                f"(`make book-po-update` marks such entries fuzzy or obsolete)"
+            )
+    return missing
+
+
+def gate_reached(catalogue: Path, tree: Path) -> int:
+    print("  translated messages reached the rendering:")
+    missing = unreached(catalogue, tree)
+    for line in missing:
+        print(f"    {line}")
+    if missing:
+        return 1
+    print("    every rendered msgstr's CJK text is present in the tree.")
+    return 0
+
+
+def load_gate(name: str):  # noqa: ANN202 — a module object
+    """Import a sibling gate script as a module, for its own self-test specimens."""
+    path = _SCRIPTS / name
+    spec = importlib.util.spec_from_file_location(path.stem.replace("-", "_"), path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def poisons(template: list) -> tuple[tuple[str, str, str, str], ...]:
+    """``(arm, what, msgid, msgstr)`` — one poisoned message per arm.
+
+    Each poison is the arm's OWN self-test specimen, imported from the gate
+    script rather than restated here: the gates scan ``scripts/*.py`` too, and
+    a specimen restated in this file is a claim this file makes. Reusing the
+    gate's case also makes this the pipeline proof it is meant to be — the
+    same text the gate already refuses on a string must still be refused once
+    it has travelled through a ``.po`` file, ``mdbook-gettext`` and the
+    ``markdown`` renderer.
+    """
+    prose = _prose_msgid(template)
+    brand = load_gate("check-brand-casing.py")
+    refs = load_gate("check-issue-refs.py")
+    spec = load_gate("check-spec-attribution.py")
+    claims = load_gate("check-doc-claims.py")
+    glued_brand = next(text for what, _s, text, n in brand._CASES if n and "glued" in what)
+    glued_hazard = next(
+        src for what, _s, src, token in refs._DETECTION_CASES if token == "H12" and "glued" in what
+    )
+    zh_attribution = spec._MUST_CATCH_ZH[0][1]
+    overclaim = claims._OVERCLAIM_SPECIMENS[2][0]
+    return (
+        ("check-brand-casing.py", "a bare 'purrdf' glued to CJK", prose, glued_brand.strip()),
+        ("check-issue-refs.py", "a hazard id glued to CJK", prose, glued_hazard.strip()),
+        (
+            "check-spec-attribution.py",
+            "the quad template (a first-party extension, not defined by SPARQL 1.2) "
+            "attributed to it in Chinese",
+            prose,
+            zh_attribution,
+        ),
+        (
+            "check-doc-claims.py",
+            "the overclaim ban's own specimen after a full-width terminator, unscoped",
+            prose,
+            f"在此语料上的结果如下。{overclaim}",
+        ),
+        (
+            "sweep_sparql_fences",
+            "a fenced sparql block with a full-width brace, written inside a paragraph",
+            prose,
+            "示例：\n\n```sparql\nSELECT ?s WHERE ｛ ?s ?p ?o ｝\n```\n",
+        ),
+    )
+
+
+def self_test(template: list, scratch: Path) -> list[str]:
+    """Each arm must go red on a catalogue poisoned for it. Empty is the only pass.
+
+    Every poison is ALSO required to reach the rendering (arm 6), so a poison that
+    the preprocessor silently dropped would fail here as "not reached" rather than
+    pass as "not caught" — the two are different defects and the report must say
+    which. The last case is the mirror: a translation the preprocessor is known to
+    drop, which arm 6 must refuse.
+    """
+    failures: list[str] = []
+    cases = list(poisons(template))
+    if any(e.msgid == _STALE_MSGID for e in template):
+        raise SystemExit("check-i18n-render: the stale-msgid specimen exists in the source")
+    cases.append(
+        (
+            "reached-the-rendering",
+            "a translation of a msgid the English source does not carry (a stale entry)",
+            _STALE_MSGID,
+            "这段译文没有对应的英文段落。",
+        )
+    )
+    for index, (arm, what, msgid, msgstr) in enumerate(cases):
+        po_dir = scratch / f"poison-{index}"
+        po_dir.mkdir()
+        catalogue = po_dir / f"{LANGUAGE}.po"
+        catalogue.write_text(_catalogue([(msgid, msgstr)]), encoding="utf-8")
+        tree = render(scratch / f"render-{index}", po_dir=po_dir)
+        print(f"  {arm} on {what}:")
+        if arm == "reached-the-rendering":
+            code = gate_reached(catalogue, tree)
+        else:
+            if unreached(catalogue, tree):
+                failures.append(f"the poison for {arm} never reached the rendering — {msgstr!r}")
+                continue
+            code = gate(arm, tree)
+        if code == 0:
+            failures.append(f"{arm} stayed GREEN on {what} — {msgstr!r}")
+        else:
+            print(f"    -> red (exit {code}), as required")
+    return failures
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--self-test", action="store_true", help="prove each arm can go red first")
+    args = ap.parse_args(argv)
+
+    pin = require_tools()
+    print(f"check-i18n-render: mdbook-i18n-helpers {pin} (pinned), mdbook on PATH.")
+    if not _PO.is_file():
+        raise SystemExit(f"check-i18n-render: no catalogue at {_PO}")
+
+    with tempfile.TemporaryDirectory(prefix="check-i18n-render-") as tmp:
+        scratch = Path(tmp)
+        template = extract_template(scratch / "template")
+        if args.self_test:
+            print("check-i18n-render: proving each arm goes red on a poisoned catalogue —")
+            failures = self_test(template, scratch)
+            if failures:
+                print(
+                    "check-i18n-render: an arm cannot go red:\n"
+                    + "\n".join(f"  - {f}" for f in failures),
+                    file=sys.stderr,
+                )
+                return 1
+            print("check-i18n-render: every arm went red on its poison.")
+
+        print(f"check-i18n-render: rendering the {LANGUAGE} book with {_PO.relative_to(_REPO)} —")
+        tree = render(scratch / "render")
+        pages = sum(1 for _ in tree.rglob("*.md"))
+        print(f"  {pages} page(s) rendered to Markdown under a temporary directory.")
+        red = gate_all(tree, _PO)
+        report_catalogue(template)
+        if red:
+            print(
+                f"check-i18n-render: the {LANGUAGE} rendering fails {len(red)} gate(s): "
+                f"{', '.join(red)}",
+                file=sys.stderr,
+            )
+            return 1
+    print(f"OK: the {LANGUAGE} rendering passes all {len(PROSE_GATES) + 2} gates.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check-i18n-render.py
+++ b/scripts/check-i18n-render.py
@@ -39,9 +39,12 @@ directory, and then runs over that tree:
    entry: the English paragraph changed, the catalogue was not re-merged, and a
    hand-edited ``msgid`` no longer exists in the source.
 
-It also asserts the pinned tool: ``mdbook-i18n-helpers`` is installed at exactly
+It also asserts BOTH pinned tools: ``mdbook-i18n-helpers`` is installed at exactly
 ``MDBOOK_I18N_HELPERS_VERSION`` from the Makefile, read from ``cargo install --list``
-because the binaries themselves report no version. And it reports (report-only, by
+because the binaries themselves report no version; and ``mdbook`` on PATH reports exactly
+``MDBOOK_VERSION`` from ``.github/workflows/docs.yaml`` — the version CI builds with,
+whose Markdown re-serialization and search index are what the measurements in
+``book.toml`` were taken on. And it reports (report-only, by
 design) the catalogue's translated/fuzzy/untranslated counts and how far its msgids have
 drifted from a freshly extracted template — the per-release lag numbers the translation
 owner reads.
@@ -86,6 +89,7 @@ _BOOK = _REPO / "docs" / "book"
 _PO_DIR = _BOOK / "po"
 _PO = _PO_DIR / "zh-Hans.po"
 _MAKEFILE = _REPO / "Makefile"
+_DOCS_WORKFLOW = _REPO / ".github" / "workflows" / "docs.yaml"
 LANGUAGE = "zh-Hans"
 
 # The four prose gates, each with a `--rendered-tree` mode, in the order the
@@ -120,9 +124,17 @@ def pinned_version() -> str:
     return match.group(1)
 
 
+def pinned_mdbook_version() -> str:
+    match = re.search(r"^\s*MDBOOK_VERSION:\s*(\S+)\s*$", _DOCS_WORKFLOW.read_text(), re.M)
+    if not match:
+        raise SystemExit("check-i18n-render: MDBOOK_VERSION is not in .github/workflows/docs.yaml")
+    return match.group(1)
+
+
 def require_tools() -> str:
-    """mdbook and the pinned mdbook-i18n-helpers on PATH; returns the pin."""
+    """mdbook and mdbook-i18n-helpers on PATH, both at their pins; returns the helpers pin."""
     pin = pinned_version()
+    mdbook_pin = pinned_mdbook_version()
     install = f"cargo install mdbook-i18n-helpers --version {pin} --locked"
     for binary in ("mdbook", "mdbook-gettext", "mdbook-xgettext", "cargo"):
         if shutil.which(binary) is None:
@@ -130,6 +142,15 @@ def require_tools() -> str:
                 f"check-i18n-render: `{binary}` is not on PATH — install mdBook and the "
                 f"pinned helpers:\n  {install}"
             )
+    reported = subprocess.run(["mdbook", "--version"], check=True, capture_output=True, text=True).stdout
+    found_mdbook = re.search(r"v?(\d+\.\d+\.\d+)", reported)
+    if found_mdbook is None or found_mdbook.group(1) != mdbook_pin:
+        raise SystemExit(
+            f"check-i18n-render: mdbook version mismatch — `mdbook --version` says "
+            f"{reported.strip()!r}, docs.yaml pins {mdbook_pin}. Install the pin, e.g.\n  "
+            f"curl -sSfL https://github.com/rust-lang/mdBook/releases/download/v{mdbook_pin}/"
+            f"mdbook-v{mdbook_pin}-x86_64-unknown-linux-musl.tar.gz | tar -xz -C ~/.local/bin"
+        )
     listed = subprocess.run(
         ["cargo", "install", "--list"], check=True, capture_output=True, text=True
     ).stdout
@@ -426,7 +447,7 @@ def main(argv: list[str]) -> int:
     args = ap.parse_args(argv)
 
     pin = require_tools()
-    print(f"check-i18n-render: mdbook-i18n-helpers {pin} (pinned), mdbook on PATH.")
+    print(f"check-i18n-render: mdbook {pinned_mdbook_version()} and mdbook-i18n-helpers {pin}, both at their pins.")
     if not _PO.is_file():
         raise SystemExit(f"check-i18n-render: no catalogue at {_PO}")
 

--- a/scripts/check-issue-refs.py
+++ b/scripts/check-issue-refs.py
@@ -237,6 +237,19 @@ ISSUE_PATTERN = r"#\d{1,5}(?![\dA-Fa-f-])(?!\.\d)"
 # legitimately as provenance and are excluded by path, not by pattern.
 ISSUE_URL_PATTERN = r"github\.com/[\w.-]+/[\w.-]+/(?:issues|pull)/\d+"
 
+# The word boundary every process-token family anchors on — spelled as explicit
+# ASCII lookarounds rather than ``\b``. Python places ``\b`` only between a
+# ``\w`` and a ``\W`` character, and CJK characters are ``\w``, so ``\bH12\b``
+# matched ``风险 H12 点`` and did NOT match ``风险H12点``: every family below went
+# blind the moment a token was glued to Chinese prose, and the gate depended on
+# a typography rule (a half-width space between Latin and CJK runs) that it
+# does not check. A process token is an ASCII word; "not preceded or followed
+# by an ASCII word character" is the boundary that was meant, and it reads a
+# CJK neighbour as the prose it is. ``#NNN`` and the URL form were never
+# ``\b``-anchored and were not affected.
+_NOT_AFTER_WORD = r"(?<![A-Za-z0-9_])"
+_NOT_BEFORE_WORD = r"(?![A-Za-z0-9_])"
+
 # Every rejected token family in ONE pattern, so a file is lexed once no matter
 # how many families there are. ``match.lastgroup`` names the family, which is what
 # separates an issue reference from a process reference in the report and what
@@ -245,21 +258,25 @@ TOKEN_RE = re.compile(
     rf"(?P<issue_url>{ISSUE_URL_PATTERN})"
     rf"|(?P<issue>{ISSUE_PATTERN})"
     r"|(?P<issue_iri>example\.org/\d{2,4}-)"
-    r"|(?P<task>\b[Tt]ask\s+#?\d+\b)"
-    r"|(?P<epic>\bEPIC\b)"
-    r"|(?P<branch>(?i:\bthis\ branch\b))"
-    r"|(?P<history_ref>\bon\s+`?origin/main`?\b)"
-    r"|(?P<issue_normative>\bissue-normative\b)"
-    r"|(?P<hazard>\bH\d{1,3}\b)"
-    r"|(?P<hazard_label>\b[FN]\d{1,3}:|\([FHN]\d{1,3}\))"
-    r"|(?P<plan_ref>\bthe plan(?:[\'’]s\b|\s+§))"
-    r"|(?P<ac_label>\bAC\d\b)"
-    r"|(?P<gap_tag>(?i:gap)\s+R\d{1,2}\b"
-    r"|(?i:gap)\s+G\d{1,2}\b"
-    r"|\bG\d{1,2}\s+regression\b"
-    r"|\bG\d{1,2}:"
-    r"|\bR\d{1,2}:)"
+    rf"|(?P<task>{_NOT_AFTER_WORD}[Tt]ask\s+#?\d+{_NOT_BEFORE_WORD})"
+    rf"|(?P<epic>{_NOT_AFTER_WORD}EPIC{_NOT_BEFORE_WORD})"
+    rf"|(?P<branch>(?i:{_NOT_AFTER_WORD}this\ branch{_NOT_BEFORE_WORD}))"
+    rf"|(?P<history_ref>{_NOT_AFTER_WORD}on\s+`?origin/main`?{_NOT_BEFORE_WORD})"
+    rf"|(?P<issue_normative>{_NOT_AFTER_WORD}issue-normative{_NOT_BEFORE_WORD})"
+    rf"|(?P<hazard>{_NOT_AFTER_WORD}H\d{{1,3}}{_NOT_BEFORE_WORD})"
+    rf"|(?P<hazard_label>{_NOT_AFTER_WORD}[FN]\d{{1,3}}:|\([FHN]\d{{1,3}}\))"
+    rf"|(?P<plan_ref>{_NOT_AFTER_WORD}the plan(?:[\'’]s{_NOT_BEFORE_WORD}|\s+§))"
+    rf"|(?P<ac_label>{_NOT_AFTER_WORD}AC\d{_NOT_BEFORE_WORD})"
+    rf"|(?P<gap_tag>(?i:gap)\s+R\d{{1,2}}{_NOT_BEFORE_WORD}"
+    rf"|(?i:gap)\s+G\d{{1,2}}{_NOT_BEFORE_WORD}"
+    rf"|{_NOT_AFTER_WORD}G\d{{1,2}}\s+regression{_NOT_BEFORE_WORD}"
+    rf"|{_NOT_AFTER_WORD}G\d{{1,2}}:"
+    rf"|{_NOT_AFTER_WORD}R\d{{1,2}}:)"
 )
+
+# Where a rendered book tree's files live in the source tree, for register
+# lookups in ``--rendered-tree`` mode (see ``main``).
+RENDERED_SOURCE_PREFIX = "docs/book/src/"
 
 # The families that name a TRACKER ITEM — a bare number, a fixture host carrying
 # one, or the URL form of the same thing. They are banned outright with no
@@ -1373,6 +1390,32 @@ _DETECTION_CASES: tuple[tuple[str, str, str, str | None], ...] = (
         "ex:a <http://example.org/ns#123> ex:b .\n",
         None,
     ),
+    # The process-token families glued to CJK prose. Each is a token this gate
+    # already rejected in English and reported clean over when the neighbouring
+    # character was Chinese, because `\b` is not a boundary between a Latin
+    # letter and a CJK character. The English control beside each proves the
+    # ASCII lookaround is the same boundary `\b` was wherever `\b` worked, and
+    # the clean Chinese sentence at the end proves the widened match fires on
+    # tokens, not on Chinese.
+    ("a hazard id glued to CJK", ".md", "风险H12点已处理。\n", "H12"),
+    ("a hazard id spaced from CJK (house typography)", ".md", "风险 H12 点已处理。\n", "H12"),
+    ("a hazard id in English prose", ".md", "risk H12 handled.\n", "H12"),
+    ("EPIC glued to CJK", ".md", "此为EPIC的一部分。\n", "EPIC"),
+    ("a task reference glued to CJK", ".md", "见Task 28的描述。\n", "Task 28"),
+    ("an acceptance-criterion label glued to CJK", ".md", "满足AC1要求。\n", "AC1"),
+    ("a bare #NNN glued to CJK", ".md", "参见#31。\n", "#31"),
+    (
+        "a Chinese sentence with Latin acronyms and no process token",
+        ".md",
+        "本节描述三元组项（triple term）的处理方式，见 RDF 1.2 与 SHACL。\n",
+        None,
+    ),
+    (
+        "an ASCII word that merely ends in a token shape stays spared",
+        ".md",
+        "the MAC1 register and the SHA256 digest and ACID transactions\n",
+        None,
+    ),
     (
         "an ordinary N-Triples fixture with no reference at all",
         ".nt",
@@ -1471,12 +1514,75 @@ def self_test(report: bool) -> list[str]:
     return problems
 
 
+def scan_rendered_tree(tree: Path) -> int:
+    """Scan every ``.md`` under a rendered book tree. Returns the exit code.
+
+    A rendering of ``docs/book/src/`` — ``mdbook build`` with the ``markdown``
+    renderer and a translation applied (see ``scripts/check-i18n-render.py``)
+    — is outside the default enumeration twice over: it is build output, and
+    it is untracked. The same scanners run over it here; the registers are
+    consulted through the source mapping (``DIR/x.md`` is
+    ``docs/book/src/x.md``), and no stale-entry report is made, because the
+    tree carries only the book and the English scan is what keeps the
+    registers exact.
+    """
+    issues: list[str] = []
+    process: list[str] = []
+    scanned = 0
+    for path in sorted(p for p in tree.rglob("*.md") if p.is_file()):
+        scanned += 1
+        rel = path.relative_to(tree).as_posix()
+        source_rel = RENDERED_SOURCE_PREFIX + rel
+        for line, col, token, text, kind in scan_path(path):
+            if kind in ISSUE_FAMILIES:
+                issues.append(f"{path}:{line}:{col}: {token} {text}")
+                continue
+            if kind == "branch" and source_rel in AMBIGUOUS_BRANCH_PHRASES:
+                continue
+            if kind == "plan_ref" and source_rel in AMBIGUOUS_PLAN_PHRASES:
+                continue
+            if kind == "gap_tag" and source_rel in AMBIGUOUS_GAP_CLAUSE_FILES:
+                continue
+            if (source_rel, token) in PRE_EXISTING_PROCESS_REFERENCES:
+                continue
+            process.append(
+                f"{path}:{line}:{col}: process reference {token!r} — "
+                f"{PROCESS_REMEDY[kind]}\n    {text}"
+            )
+    if scanned == 0:
+        print(
+            f"check-issue-refs: no .md file under {tree} — a rendered tree with "
+            "nothing in it is a vacuous pass, not a clean one",
+            file=sys.stderr,
+        )
+        return 1
+    for entry in issues + process:
+        print(entry)
+    if issues or process:
+        return 1
+    print(
+        f"OK: no issue-reference tokens and no process references in the rendered "
+        f"tree ({scanned} page(s) scanned under {tree})."
+    )
+    return 0
+
+
 def main(argv: list[str]) -> int:
-    unknown = [argument for argument in argv[1:] if argument != "--self-test"]
-    if unknown:
-        print(f"usage: {Path(argv[0]).name} [--self-test]", file=sys.stderr)
-        return 2
-    alone = "--self-test" in argv[1:]
+    rendered: Path | None = None
+    alone = False
+    args = list(argv[1:])
+    while args:
+        argument = args.pop(0)
+        if argument == "--self-test":
+            alone = True
+        elif argument == "--rendered-tree" and args:
+            rendered = Path(args.pop(0))
+        else:
+            print(
+                f"usage: {Path(argv[0]).name} [--self-test] [--rendered-tree DIR]",
+                file=sys.stderr,
+            )
+            return 2
 
     if alone:
         print(
@@ -1505,6 +1611,12 @@ def main(argv: list[str]) -> int:
             "controls are excluded by path."
         )
         return 0
+
+    if rendered is not None:
+        if not rendered.is_dir():
+            print(f"check-issue-refs: {rendered} is not a directory", file=sys.stderr)
+            return 2
+        return scan_rendered_tree(rendered)
 
     root = repo_root()
 

--- a/scripts/check-spec-attribution.py
+++ b/scripts/check-spec-attribution.py
@@ -45,7 +45,7 @@ Scanned surface: every TRACKED ``.rs``, ``.py``, ``.pyi``, ``.md``, ``.mjs``,
 ``scripts/``, plus root ``*.md`` — enumerated by ``git ls-files``, exactly as
 ``check-brand-casing.py`` and ``check-issue-refs.py`` enumerate, so the four
 prose gates agree on what "the tree" is. This one used to walk the
-filesystem, and so scanned ``docs/book/book/searchindex.js`` after any local
+filesystem, and so scanned ``docs/book/book/searchindex-<hash>.js`` after any local
 ``mdbook build``: mdBook's search index flattens a page's text, putting the
 book's own CONSTRUCT-template sentence beside "SPARQL 1.1" with the
 disclaimer out of the window, and the gate failed on a clean commit. The
@@ -73,7 +73,7 @@ caught — so a future edit that guts the pattern fails here instead of passing
 silently and letting the seventh recurrence ship. It does the same for the
 Chinese pairs (a translated page with its disclaimer passes; the same page
 without it is caught), and it builds a throwaway git repository holding a
-tracked violation and an untracked ``book/searchindex.js`` carrying the same
+tracked violation and an untracked ``book/searchindex-<hash>.js`` carrying the same
 text, asserting the first is enumerated and caught and the second is not
 enumerated — the enumeration rule, proven rather than described.
 """
@@ -170,7 +170,17 @@ DISCLAIMERS: tuple[str, ...] = (
     "purrdf 的扩展",  # "an extension of PurRDF"
     "没有相应的语法",  # "has no syntax (for it)"
     "并无相应的语法",  # "has no syntax (for it)", formal register
+    "不属于 sparql",  # "does not belong to / is not part of SPARQL"
+    "没有四元组模板",  # "(SPARQL 1.2) has no quad template"
+    "非 sparql 1.2 标准",  # "not a SPARQL 1.2 standard (feature)"
+    "自有的扩展",  # "(PurRDF's) own extension"
 )
+# Every entry above, English or Chinese, is an EXACT substring, and a disclaimer is
+# recognized anywhere in the window whatever it is about: an unrelated 「并未定义」 (or
+# "does not define") near a real attribution masks it, and an honest paraphrase the list
+# does not carry is refused. Both are the English gate's own properties, kept on purpose —
+# the gate steers a new site onto an agreed wording rather than judging prose — so a
+# refused paraphrase is answered by adding the wording here, with a self-test line.
 
 # A non-ASCII character (in practice a CJK character or full-width punctuation)
 # with ASCII whitespace on one side of it. The house typography puts a
@@ -426,6 +436,19 @@ _MUST_PASS: tuple[tuple[str, str], ...] = (
         "a Chinese page: an unrelated SPARQL 1.2 mention with no extension phrasing",
         "SPARQL 1.2 新增了三元组项、具体化节点与注解语法。",
     ),
+    # Three paraphrases a reviewer wrote and the first list refused.
+    (
+        "a Chinese page: 'not part of SPARQL 1.2, PurRDF's own extension'",
+        "四元组模板（`CONSTRUCT { GRAPH ?g { ... } }`）不属于 SPARQL 1.2，是 PurRDF 自有的扩展。",
+    ),
+    (
+        "a Chinese page: 'SPARQL 1.2 has no quad template'",
+        "SPARQL 1.2 中没有四元组模板；这是 PurRDF 提供的能力。",
+    ),
+    (
+        "a Chinese page: 'not a SPARQL 1.2 standard feature'",
+        "四元组模板非 SPARQL 1.2 标准，属 PurRDF。",
+    ),
 )
 
 # The translated page WITHOUT its disclaimer: the same false claim the four
@@ -451,8 +474,9 @@ _MUST_CATCH_ZH: tuple[tuple[str, str], ...] = (
 )
 
 # A file name mdBook writes into the (untracked) build output, carrying the
-# flattened text that made the filesystem walk fail on a clean commit.
-_UNTRACKED_BUILD_OUTPUT = "docs/book/book/searchindex.js"
+# flattened text that made the filesystem walk fail on a clean commit (mdBook
+# 0.5 hashes the name; the hash here is only a shape).
+_UNTRACKED_BUILD_OUTPUT = "docs/book/book/searchindex-ef3e7a03.js"
 
 
 def enumeration_self_test(report: bool) -> list[str]:

--- a/scripts/check-spec-attribution.py
+++ b/scripts/check-spec-attribution.py
@@ -28,35 +28,63 @@ the specification defining the extension.
    claim about the extension.
 3. That claim passes ONLY when a **disclaimer** also appears within the same
    window — one of :data:`DISCLAIMERS`, the wordings already established in the
-   book, the playground worker, the ``.pyi`` stub and the rdflib shim.
+   book, the playground worker, the ``.pyi`` stub and the rdflib shim — or one
+   of their Simplified Chinese counterparts (the same tuple; see the note on
+   CJK spacing at :func:`normalize_cjk_spacing`). The extension phrasing and
+   the specification token are invariant across languages (the code example
+   is the anchor, and ``SPARQL 1.2`` stays English in Chinese prose), so a
+   translated page that names the extension beside the specification with a
+   Chinese disclaimer is exactly as honest as the English page and must pass
+   exactly as the English page does.
 
 Anything else is a hard failure naming the file, line, the anchor, and the
 specification token that made it an attribution.
 
-Scanned surface: ``.rs``, ``.py``, ``.pyi``, ``.md``, ``.mjs``, ``.ts`` and
-``.js`` under ``crates/``, ``bindings/``, ``docs/`` and ``scripts/``, plus root
-``*.md``. Whole file text is scanned rather than only comments: the four
-recurrences this gate exists for lived in a Rust module doc, a ``#[pyclass]``
-doc comment, a Python module docstring and a crate rustdoc — three different
-comment shapes and one that ships as runtime data — and a rule that only saw
-comments would have missed the day it moves into a string literal, a README
-table cell or a generated stub.
+Scanned surface: every TRACKED ``.rs``, ``.py``, ``.pyi``, ``.md``, ``.mjs``,
+``.ts`` and ``.js`` under ``crates/``, ``bindings/``, ``docs/`` and
+``scripts/``, plus root ``*.md`` — enumerated by ``git ls-files``, exactly as
+``check-brand-casing.py`` and ``check-issue-refs.py`` enumerate, so the four
+prose gates agree on what "the tree" is. This one used to walk the
+filesystem, and so scanned ``docs/book/book/searchindex.js`` after any local
+``mdbook build``: mdBook's search index flattens a page's text, putting the
+book's own CONSTRUCT-template sentence beside "SPARQL 1.1" with the
+disclaimer out of the window, and the gate failed on a clean commit. The
+price is the one its siblings already pay — an UNTRACKED file is not scanned,
+so ``git add`` before running the gates. Whole file text is scanned rather
+than only comments: the four recurrences this gate exists for lived in a Rust
+module doc, a ``#[pyclass]`` doc comment, a Python module docstring and a
+crate rustdoc — three different comment shapes and one that ships as runtime
+data — and a rule that only saw comments would have missed the day it moves
+into a string literal, a README table cell or a generated stub.
 
-    python3 scripts/check-spec-attribution.py              # verify (exit 1 on a hit)
-    python3 scripts/check-spec-attribution.py --self-test  # prove the rule bites
+    python3 scripts/check-spec-attribution.py                      # verify (exit 1 on a hit)
+    python3 scripts/check-spec-attribution.py --self-test          # prove the rule bites
+    python3 scripts/check-spec-attribution.py --rendered-tree DIR  # scan a rendered book tree
+
+``--rendered-tree DIR`` scans every ``.md`` under DIR — a rendering of
+``docs/book/src/`` with a translation applied (``scripts/check-i18n-render.py``)
+— which is build output and untracked, hence outside the default enumeration
+twice over, and the only way a gettext translation reaches this gate.
 
 The self-test is not decoration. It replays the exact four sentences that were
 removed from the tree, asserts each is caught, replays their corrected
 counterparts and the four pre-existing correct wordings, and asserts none is
 caught — so a future edit that guts the pattern fails here instead of passing
-silently and letting the seventh recurrence ship.
+silently and letting the seventh recurrence ship. It does the same for the
+Chinese pairs (a translated page with its disclaimer passes; the same page
+without it is caught), and it builds a throwaway git repository holding a
+tracked violation and an untracked ``book/searchindex.js`` carrying the same
+text, asserting the first is enumerated and caught and the second is not
+enumerated — the enumeration rule, proven rather than described.
 """
 
 from __future__ import annotations
 
 import argparse
 import re
+import subprocess
 import sys
+import tempfile
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -70,9 +98,15 @@ WINDOW = 220
 # spellings, plus the generic `CONSTRUCT template` — three of the four
 # recurrences never said "quad" at all, they said "a SPARQL 1.2 CONSTRUCT
 # template names a graph per statement", which is the same false claim.
+# The two Chinese spellings are the glossary's rendering of "quad template"
+# (四元组模板) and the bare "CONSTRUCT template" (CONSTRUCT 模板, with or
+# without the house half-width space): a translated page that names the
+# extension in prose rather than by its code example would otherwise carry no
+# anchor at all, and the attribution would be invisible.
 ANCHOR_ALTERNATION = (
     r"quad[\s-]?templates?|CONSTRUCT\s*\{\s*GRAPH"
     r"|CONSTRUCT\s+GRAPH\b|CONSTRUCT\s+templates?\b"
+    r"|四元组模板|CONSTRUCT\s*模板"
 )
 ANCHOR_RE = re.compile(ANCHOR_ALTERNATION, re.IGNORECASE)
 
@@ -89,10 +123,11 @@ SPEC_RE = re.compile(r"SPARQL\s*-?\s*1\.2", re.IGNORECASE)
 # The one shape in which naming SPARQL **1.1** is still an attribution: the
 # version token DIRECTLY modifying the extension phrase, with nothing but a
 # possessive or markup between them ("a SPARQL 1.1 quad template",
-# "SPARQL 1.1's `CONSTRUCT { GRAPH`"). One intervening word breaks it, so a
-# contrast sentence can never match and the rule needs no distance threshold.
+# "SPARQL 1.1's `CONSTRUCT { GRAPH`", 「SPARQL 1.1 的四元组模板」 — 的 is the
+# Chinese possessive). One intervening word breaks it, so a contrast sentence
+# can never match and the rule needs no distance threshold.
 ADJACENT_RE = re.compile(
-    r"SPARQL\s*-?\s*1\.[12](?:'s|’s)?[\s*`_“\"]{0,4}(?:"
+    r"SPARQL\s*-?\s*1\.[12](?:'s|’s)?[\s*`_“\"的]{0,4}(?:"
     + ANCHOR_ALTERNATION
     + r")",
     re.IGNORECASE,
@@ -116,23 +151,50 @@ DISCLAIMERS: tuple[str, ...] = (
     "nor sparql 1.2",
     "no syntax to ask for",
     "has no syntax",
+    # Simplified Chinese, in the house voice (a half-width space between Latin
+    # and CJK runs; the window is lower-cased before matching, which is why
+    # `PurRDF` reads `purrdf` here). Each is the counterpart of an English
+    # wording above, so a translated disclaimer is steered onto an agreed
+    # spelling rather than a seventh coinage:
+    "并非 sparql 1.2 特性",  # "not a SPARQL 1.2 feature"
+    "并非 sparql 1.2",  # "not SPARQL 1.2 ..." (the shorter cut of the same)
+    "不是 sparql 1.2 特性",  # "is not a SPARQL 1.2 feature"
+    "非 sparql 特性",  # "not a SPARQL feature"
+    "sparql 1.2 并未定义",  # "SPARQL 1.2 does not define"
+    "sparql 并未定义",  # "SPARQL does not define"
+    "并未定义",  # "does not define" — the verb phrase alone, as in English
+    "sparql 1.1 与 sparql 1.2 均未定义",  # "neither SPARQL 1.1 nor SPARQL 1.2 defines"
+    "均未定义",  # "neither ... defines"
+    "第一方扩展",  # "first-party extension"
+    "purrdf 扩展",  # "PurRDF extension"
+    "purrdf 的扩展",  # "an extension of PurRDF"
+    "没有相应的语法",  # "has no syntax (for it)"
+    "并无相应的语法",  # "has no syntax (for it)", formal register
 )
+
+# A non-ASCII character (in practice a CJK character or full-width punctuation)
+# with ASCII whitespace on one side of it. The house typography puts a
+# half-width space between a Latin run and a CJK run — 「并非 SPARQL 1.2 特性」
+# — and every Chinese disclaimer above is spelled that way; a translator who
+# drops the space writes 「并非SPARQL 1.2特性」, which is the same disclaimer.
+# The window is normalized by deleting that whitespace before the Chinese
+# wordings are looked for, so the gate recognizes the disclaimer rather than
+# the typography. Whitespace between two ASCII characters is never touched, so
+# the English wordings are matched exactly as before.
+_CJK_ADJACENT_SPACE = re.compile(r"(?<=[^\x00-\x7f])\s+|\s+(?=[^\x00-\x7f])")
 
 SCAN_DIRS = ("crates", "bindings", "docs", "scripts")
 SCAN_SUFFIXES = (".rs", ".py", ".pyi", ".md", ".mjs", ".ts", ".js")
 
-# Trees whose bytes are not ours to edit: a vendored suite is frozen upstream
-# text and a build output is a projection of a scanned source.
+# Tracked trees whose bytes are not ours to edit: a vendored suite is frozen
+# upstream text. (Build output is untracked and so never enumerated at all —
+# see ``iter_scan_paths``.)
 SKIP_PARTS = frozenset(
     {
-        ".git",
-        "target",
-        "node_modules",
         "vendor",
+        "node_modules",
         "__pycache__",
         "dist",
-        "build",
-        ".venv",
         "pkg",
     }
 )
@@ -144,23 +206,52 @@ def repo_root() -> Path:
     return SELF_PATH.parent.parent
 
 
+def normalize_cjk_spacing(text: str) -> str:
+    """``text`` with whitespace beside a non-ASCII character removed.
+
+    See :data:`_CJK_ADJACENT_SPACE`. ASCII-to-ASCII whitespace survives, so
+    the English disclaimers are matched exactly as they were.
+    """
+    return _CJK_ADJACENT_SPACE.sub("", text)
+
+
+def tracked_files(root: Path) -> list[str]:
+    """Every path ``git ls-files`` reports under ``root``, repository-relative."""
+    out = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return sorted(part for part in out.split("\0") if part)
+
+
 def iter_scan_paths(root: Path) -> Iterator[Path]:
-    """Every scanned file, in a deterministic order."""
-    for name in SCAN_DIRS:
-        base = root / name
-        if not base.is_dir():
+    """Every scanned file, in a deterministic order.
+
+    Enumeration is ``git ls-files`` — the convention ``check-brand-casing.py``
+    and ``check-issue-refs.py`` follow — so the scan covers exactly the
+    committed first-party source: never a build output (``docs/book/book/``),
+    never an untracked scratch file. ``root`` is a parameter rather than the
+    repository so the self-test can enumerate a throwaway repository and prove
+    the rule.
+    """
+    for rel in tracked_files(root):
+        path = Path(rel)
+        if path.suffix not in SCAN_SUFFIXES:
             continue
-        for path in sorted(base.rglob("*")):
-            if not path.is_file() or path.suffix not in SCAN_SUFFIXES:
-                continue
-            if SKIP_PARTS & set(path.relative_to(root).parts):
-                continue
-            if path.resolve() == SELF_PATH:
-                continue
-            yield path
-    for path in sorted(root.glob("*.md")):
-        if path.is_file():
-            yield path
+        segments = path.parts
+        in_scan_dir = segments[0] in SCAN_DIRS
+        root_markdown = len(segments) == 1 and path.suffix == ".md"
+        if not (in_scan_dir or root_markdown):
+            continue
+        if SKIP_PARTS & set(segments):
+            continue
+        full = root / path
+        if full.resolve() == SELF_PATH:
+            continue
+        if full.is_file():
+            yield full
 
 
 def pos_to_line(src: str, pos: int) -> int:
@@ -194,7 +285,10 @@ def scan_text(src: str) -> list[tuple[int, str, str]]:
 
     def disclaimed(start: int, end: int) -> bool:
         window = src[max(0, start - WINDOW) : min(len(src), end + WINDOW)].lower()
-        return any(d in window for d in DISCLAIMERS)
+        normalized = normalize_cjk_spacing(window)
+        return any(
+            d in window or normalize_cjk_spacing(d) in normalized for d in DISCLAIMERS
+        )
 
     for anchor in ANCHOR_RE.finditer(src):
         lo = max(0, anchor.start() - WINDOW)
@@ -303,7 +397,116 @@ _MUST_PASS: tuple[tuple[str, str], ...] = (
         "SPARQL 1.2 adds triple terms, reifiers and annotation syntax to the "
         "query language.",
     ),
+    # The translated page. The code example is the anchor and `SPARQL 1.2` is
+    # invariant, so only the DISCLAIMER is Chinese — and it must be enough.
+    (
+        "a Chinese page: the quad template disclaimed in the house voice",
+        "四元组模板（`CONSTRUCT { GRAPH ?g { ... } }`）并非 SPARQL 1.2 特性，"
+        "而是 PurRDF 的扩展：它让一个 CONSTRUCT 结果为每条语句命名一个图。",
+    ),
+    (
+        "a Chinese page: the same disclaimer with the Latin/CJK spaces dropped",
+        "四元组模板（`CONSTRUCT { GRAPH ?g { ... } }`）并非SPARQL 1.2特性，"
+        "而是PurRDF的扩展。",
+    ),
+    (
+        "a Chinese page: the negative statement, SPARQL 1.2 as the subject",
+        "**SPARQL 1.2 并未定义四元组模板。** SPARQL 1.1 与 SPARQL 1.2 的语法均无此项。",
+    ),
+    (
+        "a Chinese page: the introduction's feature-list wording",
+        "可 `CONSTRUCT` 到命名图中的四元组模板（第一方扩展，并非 SPARQL 1.2 特性）、"
+        "调用方注册的聚合函数",
+    ),
+    (
+        "a Chinese page: a plain SPARQL 1.1 CONSTRUCT description, no version claim",
+        "SPARQL 1.1 §16.2 的 CONSTRUCT 模板把每个解转换为默认图中的三元组。",
+    ),
+    (
+        "a Chinese page: an unrelated SPARQL 1.2 mention with no extension phrasing",
+        "SPARQL 1.2 新增了三元组项、具体化节点与注解语法。",
+    ),
 )
+
+# The translated page WITHOUT its disclaimer: the same false claim the four
+# English recurrences made, in Chinese, and exactly as much a hard failure.
+_MUST_CATCH_ZH: tuple[tuple[str, str], ...] = (
+    (
+        "a Chinese page attributing the quad template to SPARQL 1.2",
+        "SPARQL 1.2 的 `CONSTRUCT { GRAPH ?g { ... } }` 四元组模板为每条语句命名一个图，"
+        "因此一个结果可以跨越多个命名图。",
+    ),
+    (
+        "a Chinese page calling the quad template a SPARQL 1.2 feature",
+        "四元组模板是 SPARQL 1.2 的一项特性，可将 CONSTRUCT 结果写入命名图。",
+    ),
+    (
+        "a Chinese page: SPARQL 1.2's CONSTRUCT template names a graph per statement",
+        "SPARQL 1.2 的 CONSTRUCT 模板为每条语句命名一个图。",
+    ),
+    (
+        "a Chinese page: the quad template attributed to SPARQL 1.1 by the possessive",
+        "SPARQL 1.1 的四元组模板可写入命名图。",
+    ),
+)
+
+# A file name mdBook writes into the (untracked) build output, carrying the
+# flattened text that made the filesystem walk fail on a clean commit.
+_UNTRACKED_BUILD_OUTPUT = "docs/book/book/searchindex.js"
+
+
+def enumeration_self_test(report: bool) -> list[str]:
+    """The enumeration rule, proven on a throwaway repository.
+
+    Two files carry the same unqualified attribution: a TRACKED ``docs/x.md``
+    and an UNTRACKED ``docs/book/book/searchindex.js``. The first must be
+    enumerated and caught; the second must not be enumerated at all — the
+    build output that used to fail this gate after any local ``mdbook build``.
+    """
+    failures: list[str] = []
+    violation = _MUST_CATCH[3][1]
+    with tempfile.TemporaryDirectory(prefix="check-spec-attribution-") as tmp:
+        root = Path(tmp)
+        subprocess.run(
+            ["git", "init", "--quiet", str(root)], check=True, capture_output=True
+        )
+        tracked = root / "docs" / "x.md"
+        tracked.parent.mkdir(parents=True)
+        tracked.write_text(violation + "\n", encoding="utf-8")
+        untracked = root / _UNTRACKED_BUILD_OUTPUT
+        untracked.parent.mkdir(parents=True)
+        untracked.write_text(violation + "\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(root), "add", "docs/x.md"],
+            check=True,
+            capture_output=True,
+        )
+        enumerated = [p.relative_to(root).as_posix() for p in iter_scan_paths(root)]
+        if "docs/x.md" not in enumerated:
+            failures.append(
+                "NOT ENUMERATED: a tracked docs/x.md carrying a violation "
+                f"(enumerated: {enumerated})"
+            )
+        elif not scan_path(tracked):
+            failures.append("NOT CAUGHT: the violation in the tracked docs/x.md")
+        elif report:
+            print("  caught   a violation in a TRACKED file (throwaway repository)")
+        if _UNTRACKED_BUILD_OUTPUT in enumerated:
+            failures.append(
+                f"ENUMERATED: the untracked {_UNTRACKED_BUILD_OUTPUT} — build output "
+                "is outside the tree this gate scans"
+            )
+        elif not scan_path(untracked):
+            failures.append(
+                f"the untracked {_UNTRACKED_BUILD_OUTPUT} no longer carries a match, "
+                "so its exclusion proves nothing about the enumeration"
+            )
+        elif report:
+            print(
+                f"  spared   the untracked {_UNTRACKED_BUILD_OUTPUT} (it matches, and "
+                "is not enumerated)"
+            )
+    return failures
 
 
 def self_test(report: bool) -> list[str]:
@@ -332,7 +535,42 @@ def self_test(report: bool) -> list[str]:
     elif report:
         print("  caught   the quad template attributed to SPARQL 1.1")
 
+    for name, text in _MUST_CATCH_ZH:
+        if not scan_text(text):
+            failures.append(f"NOT CAUGHT: {name}")
+        elif report:
+            line, anchor, spec = scan_text(text)[0]
+            print(f"  caught   {name}: line {line}, `{anchor}` near `{spec}`")
+
+    failures.extend(enumeration_self_test(report))
     return failures
+
+
+def scan_rendered_tree(tree: Path) -> int:
+    """Scan every ``.md`` under a rendered book tree. Returns the exit code."""
+    findings: list[str] = []
+    scanned = 0
+    for path in sorted(p for p in tree.rglob("*.md") if p.is_file()):
+        scanned += 1
+        for line, anchor, spec in scan_path(path):
+            findings.append(f"{path}:{line}: `{anchor}` attributed to `{spec}`")
+    if scanned == 0:
+        print(
+            f"check-spec-attribution: no .md file under {tree} — a rendered tree "
+            "with nothing in it is a vacuous pass, not a clean one",
+            file=sys.stderr,
+        )
+        return 1
+    if findings:
+        for f in findings:
+            print(f"  {f}", file=sys.stderr)
+        print(f"\n{len(findings)} unqualified attribution(s).", file=sys.stderr)
+        return 1
+    print(
+        f"check-spec-attribution: no unqualified specification attributions in the "
+        f"rendered tree ({scanned} page(s) scanned under {tree})."
+    )
+    return 0
 
 
 def main(argv: list[str]) -> int:
@@ -341,6 +579,12 @@ def main(argv: list[str]) -> int:
         "--self-test",
         action="store_true",
         help="replay the removed sentences and their corrections, then scan",
+    )
+    ap.add_argument(
+        "--rendered-tree",
+        type=Path,
+        metavar="DIR",
+        help="scan every .md under DIR (a rendered, translated book) instead of the tree",
     )
     args = ap.parse_args(argv)
 
@@ -353,6 +597,15 @@ def main(argv: list[str]) -> int:
                 print(f"  {f}", file=sys.stderr)
             return 1
         print("  self-test OK")
+
+    if args.rendered_tree is not None:
+        if not args.rendered_tree.is_dir():
+            print(
+                f"check-spec-attribution: {args.rendered_tree} is not a directory",
+                file=sys.stderr,
+            )
+            return 2
+        return scan_rendered_tree(args.rendered_tree)
 
     root = repo_root()
     findings: list[str] = []

--- a/scripts/po_catalog.py
+++ b/scripts/po_catalog.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""A minimal reader for gettext ``.po``/``.pot`` catalogues.
+
+Shared by ``check-i18n-glossary.py`` and ``check-i18n-render.py``, which read
+the book's translation catalogue (``docs/book/po/zh-Hans.po``) and the
+template ``mdbook-xgettext`` extracts from the English source. Only the parts
+of the format those gates need are modelled: the ``msgctxt``/``msgid``/
+``msgstr`` triple with its continuation lines, the ``fuzzy`` flag, and the
+``#~`` obsolete marker. Plural forms are read but never produced by
+``mdbook-xgettext``, so they are folded into ``msgstr`` rather than modelled.
+
+No third-party dependency (``polib`` is not installed here and a gate should
+not need a package to read a text file), and the escapes are the four the
+tool emits: ``\\\\``, ``\\"``, ``\\n``, ``\\t``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Entry:
+    """One catalogue entry, at the 1-based line its first keyword sits on."""
+
+    line: int
+    msgctxt: str | None
+    msgid: str
+    msgstr: str
+    fuzzy: bool
+    obsolete: bool
+
+    @property
+    def translated(self) -> bool:
+        """Whether ``mdbook-gettext`` would render this entry's ``msgstr``.
+
+        A fuzzy entry is not rendered (the preprocessor keeps the source text
+        for it), and neither is an obsolete one, so both are "untranslated"
+        to a reader even when ``msgstr`` is non-empty.
+        """
+        return bool(self.msgstr) and not self.fuzzy and not self.obsolete
+
+
+_ESCAPES = {"\\": "\\", '"': '"', "n": "\n", "t": "\t"}
+
+
+def unescape(text: str) -> str:
+    """The value of a quoted PO string's body (between the quotes)."""
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c == "\\" and i + 1 < n and text[i + 1] in _ESCAPES:
+            out.append(_ESCAPES[text[i + 1]])
+            i += 2
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def escape(text: str) -> str:
+    """The body of a quoted PO string for ``text`` (inverse of :func:`unescape`)."""
+    return (
+        text.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\t", "\\t")
+    )
+
+
+def _quoted_body(line: str) -> str:
+    """The body of a ``"..."`` token, which is the whole of ``line``."""
+    line = line.strip()
+    if len(line) < 2 or line[0] != '"' or line[-1] != '"':
+        raise ValueError(f"not a quoted PO string: {line!r}")
+    return unescape(line[1:-1])
+
+
+def parse_po(text: str) -> list[Entry]:
+    """Every entry of a catalogue, including the header (``msgid ""``).
+
+    An entry ends at a blank line or at the next non-continuation keyword
+    after a ``msgstr``. Lines beginning ``#~`` are obsolete entries and are
+    read the same way with the marker stripped.
+    """
+    entries: list[Entry] = []
+    fields: dict[str, list[str]] = {}
+    current: str | None = None
+    fuzzy = False
+    obsolete = False
+    start = 0
+
+    def flush() -> None:
+        nonlocal fields, current, fuzzy, obsolete
+        if "msgid" in fields:
+            msgstr = "".join(fields.get("msgstr", []))
+            if "msgstr" not in fields:
+                # Plural forms: the first form stands for the entry.
+                plural = [k for k in fields if k.startswith("msgstr[")]
+                if plural:
+                    msgstr = "".join(fields[sorted(plural)[0]])
+            ctxt = fields.get("msgctxt")
+            entries.append(
+                Entry(
+                    line=start,
+                    msgctxt="".join(ctxt) if ctxt is not None else None,
+                    msgid="".join(fields["msgid"]),
+                    msgstr=msgstr,
+                    fuzzy=fuzzy,
+                    obsolete=obsolete,
+                )
+            )
+        fields = {}
+        current = None
+        fuzzy = False
+        obsolete = False
+
+    for number, raw in enumerate(text.splitlines(), start=1):
+        line = raw.strip()
+        if not line:
+            flush()
+            continue
+        entry_obsolete = False
+        if line.startswith("#~"):
+            entry_obsolete = True
+            line = line[2:].strip()
+            if not line:
+                continue
+        if line.startswith("#"):
+            if current is not None:
+                # A comment after a msgstr opens the next entry.
+                flush()
+            if line.startswith("#,") and "fuzzy" in [f.strip() for f in line[2:].split(",")]:
+                fuzzy = True
+            continue
+        if line.startswith('"'):
+            if current is None:
+                raise ValueError(f"line {number}: continuation string with no keyword")
+            fields[current].append(_quoted_body(line))
+            continue
+        keyword, _, rest = line.partition(" ")
+        if keyword in ("msgctxt", "msgid", "msgid_plural") or keyword.startswith(
+            "msgstr"
+        ):
+            if keyword in ("msgctxt", "msgid") and (
+                keyword in fields or "msgstr" in fields
+            ):
+                flush()
+            if not fields:
+                start = number
+                obsolete = entry_obsolete
+            current = keyword
+            fields[current] = [_quoted_body(rest)]
+            continue
+        raise ValueError(f"line {number}: unrecognized PO line {line!r}")
+    flush()
+    return entries
+
+
+def messages(entries: list[Entry]) -> list[Entry]:
+    """The entries that are messages: everything but the header."""
+    return [e for e in entries if e.msgid or e.msgctxt]


### PR DESCRIPTION
Phase 0 of the Chinese-translation plan (`docs/design/i18n-zh-assessment.md`, #241): the gate fixes and tooling that make a translation safe to land. **No Chinese prose is added** — the catalogue is an empty scaffold; the translator (#244) owns the text.

## A. Gate blind-spot fixes — each a tightening, each proven both ways, each pair permanent in `--self-test`

### 1. `check-brand-casing.py` — ASCII-only identifier neighbour
`'本'.isalnum()` is `True`, so a bare `purrdf` glued to CJK was "part of an identifier". Baseline on the old code (`scan_markdown` over one-line files):
```
  B glued    本工具包名为purrdf，用于处理RDF。 -> hits=0   (blind)
  B2 glued   本purrdf项目                      -> hits=0   (blind)
  english    the purrdf toolkit                -> hits=1
```
After (`python3 scripts/check-brand-casing.py --self-test`, the script had no self-test before):
```
  ok     flagged  .md: bare 'purrdf' glued to CJK on both sides
  ok     flagged  .md: bare 'purrdf' glued to CJK, full-width comma after
  ok     flagged  .md: bare 'purrdf' before full-width punctuation
  ok     flagged  .md: bare 'purrdf' in English prose
  ok     flagged  .rs: bare 'purrdf' glued to CJK in a Rust comment
  ok     flagged  .rs: bare 'purrdf' glued to CJK in a Rust doc comment
  ok     passes   .md: the brand, house typography (half-width spaces)      本 PurRDF 项目
  ok     passes   .md: the brand glued to CJK                               PurRDF工具包支持SPARQL。
  ok     passes   .md: the facade crate in a code span beside CJK           `purrdf` 门面 crate
  ok     passes   .md: a crate name beside CJK                              purrdf-core 是内核
  ok     passes   .md: a longer identifier and a plural                     libpurrdf and purrdfs
  ok     passes   .md: a Rust path and a module path
  ok     passes   .md: the crate name inside a fenced block
  ok     passes   .rs: a string literal in Rust is not a comment
OK: all 14 shapes are flagged or spared as written.
```
PR #242 (brand casing in CI) landed and is merged into this branch.

### 2. `check-issue-refs.py` — explicit ASCII lookarounds instead of `\b`
Baseline: `风险H12点已处理。 -> []`, `此为EPIC的一部分。 -> []`, `见Task 28的描述。 -> []`, `满足AC1要求。 -> []` (all blind); `风险 H12 点 -> ['H12']`, `参见#31。 -> ['#31']`. After (new `_DETECTION_CASES`):
```
  ok      .md: a hazard id glued to CJK                                   风险H12点已处理。      -> H12
  ok      .md: a hazard id spaced from CJK (house typography)             风险 H12 点已处理。    -> H12
  ok      .md: a hazard id in English prose                               risk H12 handled.     -> H12
  ok      .md: EPIC glued to CJK / a task reference glued to CJK / an acceptance-criterion label glued to CJK / a bare #NNN glued to CJK
  ok      .md: a Chinese sentence with Latin acronyms and no process token  本节描述三元组项（triple term）的处理方式，见 RDF 1.2 与 SHACL。 -> nothing
  ok      .md: an ASCII word that merely ends in a token shape stays spared  MAC1 / SHA256 / ACID -> nothing
OK: all 22 shapes are matched or spared as written ...
```
Whole-tree run unchanged: `31 pre-existing process reference(s) ... registered`, no new refusals.

### 3. `check-spec-attribution.py` — Chinese disclaimers, Chinese anchors, and (per the coordinator) `git ls-files` enumeration
Baseline: 「四元组模板（`CONSTRUCT { GRAPH ?g { ... } }`）并非 SPARQL 1.2 特性，而是 PurRDF 的扩展。」 → `[(1, 'CONSTRUCT { GRAPH', 'SPARQL 1.2')]` — a **false positive**. After:
```
  passes   a Chinese page: the quad template disclaimed in the house voice
  passes   a Chinese page: the same disclaimer with the Latin/CJK spaces dropped      并非SPARQL 1.2特性
  passes   a Chinese page: the negative statement, SPARQL 1.2 as the subject        SPARQL 1.2 并未定义四元组模板
  passes   a Chinese page: the introduction's feature-list wording                   第一方扩展
  passes   a Chinese page: a plain SPARQL 1.1 CONSTRUCT description, no version claim
  passes   a Chinese page: an unrelated SPARQL 1.2 mention with no extension phrasing
  caught   a Chinese page attributing the quad template to SPARQL 1.2: `CONSTRUCT { GRAPH` near `SPARQL 1.2`
  caught   a Chinese page calling the quad template a SPARQL 1.2 feature: `四元组模板` near `SPARQL 1.2`
  caught   a Chinese page: SPARQL 1.2's CONSTRUCT template names a graph per statement: `CONSTRUCT 模板` near `SPARQL 1.2`
  caught   a Chinese page: the quad template attributed to SPARQL 1.1 by the possessive: `四元组模板` near `SPARQL 1.1`
  caught   a violation in a TRACKED file (throwaway repository)
  spared   the untracked docs/book/book/searchindex.js (it matches, and is not enumerated)
```
The last two are the enumeration fix: the script used to walk the filesystem and failed a clean commit after any local `mdbook build` (`searchindex.js`). It now enumerates with `git ls-files` like its three siblings, so an untracked file is not scanned (`git add` before running the gates). Note: `check-doc-claims.py` also walks the filesystem, but its suffix set has no `.js`/`.html`, so it never saw the index; left as is. Every English case in the self-test is unchanged.

### 4. `check-doc-claims.py` — `。！？` in `_TERMINATOR`
Baseline: `_sentences("第一句。第二句！第三句？第四句。") -> [(1, '第一句。第二句！第三句？第四句。')]` (one unit). After: four units; the ban is evaluated per sentence:
```
  cjk leaked claim caught -> ['p:1: banned entailment overclaim `complete OWL 2 RL entailment` ...']   (scope phrase in sentence 1 no longer exempts sentence 2)
  cjk scoped claim exempt -> []                                                                          (scope in the same sentence, a Chinese sentence after it)
```
Permanent in `_check_cjk_terminators()`, run by `overclaim_self_test` (1087 injected sentences still answered correctly).

## B. Tooling
- **`mdbook-i18n-helpers 0.4.0`, pinned** as `MDBOOK_I18N_HELPERS_VERSION := 0.4.0` in the Makefile (beside `GIT_CLIFF_VERSION`/`BINARYEN_VERSION`), read by `docs.yaml` and asserted by the gate via `cargo install --list` (the binaries carry no `--version`; there are no release tarballs upstream, so CI does `cargo install --locked`, idempotent under the rust-cache-restored `~/.cargo/bin`).
- **`book.toml`**: `[preprocessor.gettext] after = ["links"]`; `[output.html.search] enable = true` for English, with the zh-Hans build rendered `MDBOOK_OUTPUT__HTML__SEARCH__ENABLE=false` and the zero-CJK-tokens measurement cited in the file. Verified: the zh build ships no `searchindex`, `<html lang="zh-Hans">`.
- **`docs/book/po/zh-Hans.po`**: the empty scaffold — 1908 msgids, every `msgstr` empty, SPDX-headed, `msgmerge`-stable (idempotent). **`mdbook-i18n-normalize` was run and its output is NOT committed**: besides re-wrapping it rewrites 83 msgids (strips the trailing newline of code-block comment messages, collapses whitespace inside string-literal messages), so those entries would no longer match `mdbook-xgettext`'s own extraction; verified by parsing both catalogues. `make book-pot` (template, gitignored) / `make book-po-update` (`msgmerge`).
- **`docs/book/po/glossary-zh-Hans.md`** — the §5.4 37-term table with its E/H/C/K markings preserved, plus 四元组模板 and PurRDF rows, and a **Rejected** column that **`scripts/check-i18n-glossary.py`** (in `make check` and the CI workspace job) enforces over every rendered `msgstr` and every tracked `zh-Hans` Markdown file. Proof: `蕴含机制` in a msgstr → `bad.po:7232 (msgid 'Entailment regimes'): '蕴含' is a rejected rendering of 'entailment' — the glossary says '蕴涵'`, exit 1; `蕴涵机制（entailment regime）` → exit 0; `--self-test` injects all 20 rejections and every row's own rendering, plus untranslated/English/fuzzy/obsolete entries.
- **New gate `scripts/check-i18n-render.py`** (`make check-i18n`; docs.yaml): renders the zh-Hans book with the `markdown` renderer into a temp dir and runs the four prose gates' new `--rendered-tree` modes, the new **`crates/sparql-algebra/examples/sweep_sparql_fences.rs`** (every fenced `sparql` block must parse as query or update; refuses an empty tree), and a *reached-the-rendering* arm (every translated message's CJK text must appear in the Markdown or HTML output — the preprocessor renders English for a msgid it cannot match without a word). `--self-test` poisons a throwaway catalogue with **each gate's own specimen** (imported from the gate script, not restated) and asserts red:
```
  check-brand-casing.py on a bare 'purrdf' glued to CJK:                      -> red (exit 1), as required
  check-issue-refs.py on a hazard id glued to CJK:                            -> red (exit 1), as required
  check-spec-attribution.py on the quad template ... attributed to it in Chinese: -> red (exit 1), as required
  check-doc-claims.py on the overclaim ban's own specimen after a full-width terminator, unscoped: -> red
  sweep_sparql_fences on a fenced sparql block with a full-width brace, written inside a paragraph: -> red
  reached-the-rendering on a translation of a msgid the English source does not carry (a stale entry): -> red
check-i18n-render: every arm went red on its poison.
  ... 31 page(s) rendered ... OK: the zh-Hans rendering passes all 6 gates.
  catalogue docs/book/po/zh-Hans.po: 1908 message(s) — 0 translated, 0 fuzzy, 1908 untranslated, 0 obsolete.
```
- **`docs.yaml`**: Rust + toolchain first, pinned helpers installed, English build, `make check-i18n`, `make book-zh` into the Pages artifact at **`/zh-Hans/`**, then the playground fold. An **empty `.po` is tolerated** — it renders the English book, which is what every run above exercised — so this can merge before the pour without breaking Pages.
- `README.zh-Hans.md`: nothing to build; it is a root `*.md` scanned by the four fixed gates, and the glossary gate scans any tracked Markdown with `zh-Hans` in its path (so the #244 drafts under `docs/book/po/zh-Hans/` are covered too).

## Findings the translator needs (from running the fixed gates over the #244 drafts, not pouring them)
- All 11 drafts pass all four prose gates and the fence sweep unchanged.
- The glossary gate over-refused twice, and the **glossary was corrected, not the drafts**: bare 闭包 is no longer gated (传递闭包, 宿主闭包 and 求闭包 are all correct), and 账本 became `/(?<!台)账本/` (台账本身 = "the ledger itself"). After that: 2191 lines, 0 offences.
- At the pinned versions `mdbook-xgettext` extracts **no message for a `sparql` fence** (only comments/string literals of languages it lexes, e.g. Rust); the English examples are byte-invariant under translation.
- `SUMMARY.md`-only messages (part/chapter titles) render into the HTML sidebar, not the Markdown tree; the reached arm reads both.
- Chinese-only paragraphs (mirror paragraph, tracking banner) have no `msgid`: attach each to the neighbouring paragraph's `msgstr` (a blank line inside a `msgstr` yields two paragraphs), rather than adding Chinese-only text to the English source.

Also pushed (one commit, not merged) to #241's branch: the diagnostic-code count corrected to **91** by construction-site trace (66 literals + 9 `iri-*` + 4 `native-sparql-*` + 12 via helper/`From`/constant), family list trimmed to the ten real prefixes with counts — verified independently before editing.


## Glossary correction from the native-reader review (after the first push)
Rows 30/32/40/41 corrected and rows 42–46 added per the review of #244's drafts: 台账 may not follow a bare numeral (`/\d+\s*台账/`; 「0 台账」 refused, 「5 例入台账」/「台账为空」 pass); **"out-of-core" is a pun on `purrdf-core`** — 核心之外, with 核外 (the CS sense) refused and the pun explained in the row; Research Object stays English (bare 研究对象 refused, 研究对象（Research Object） and Research Object（RO） pass); DL realization glossed (not gated: 实现 = implementation everywhere); surface → 接口 (`/表面(?!上)/`, 表面上 spared), seam → 扩展点, mint → 生成 (铸造 refused), reach → 到达 (抵达 refused), "dropped loudly" → 显式报错丢弃 (大声 refused). A first cut of row 42 listed 表面 in its own rendering cell and the gate's self-consistency check refused the glossary for it — the right answer; fixed in the last commit. `--self-test`: **27 rejected renderings across 46 rows, each refused, each row's own rendering spared.**

Re-scanning the #244 drafts against the corrected glossary (a report, not a pour): 2191 lines, **72 lines refused** — 表面 28 (all "surface" in the API sense), 研究对象 13 (all unglossed), 铸造 10, 抵达 8, 「N 台账」 7, 核外 4, 大声 2 — every one a draft finding under the review's rules, none an over-refusal (the 表面 and 研究对象 contexts were sampled by hand).

CI on the first head: Docs job step 8 "Gate the zh-Hans translation (render + prose gates + SPARQL fence parser)" `success`, step 9 "Build the zh-Hans book into the Pages artifact at /zh-Hans" `success` (with the empty catalogue). Local `make check`: exit 0.


## After the adversarial review: the glossary gate redesigned around the `msgid`
Both blockers were over-refusals. The root cause of the second: a rejected rendering is wrong only **when it renders the glossary's English term**, and a `msgstr` alone cannot say what it renders. So (design a): every rejection is now **anchored** — tested only when the `msgid` carries the row's English term (new **Anchor** column; case-insensitive word-start prefix: `entail` covers *entails/entailment*, `canonical` covers *canonicalize/canonicalization*). A row with no anchor is **global** and its note must say why (only the three zh-Hant-register words: 具名图, 资料集, 资料类型). Code spans and fenced blocks are never matched. **K rows are enforced**: a keep-English token in the `msgid` must survive verbatim into the `msgstr` (N1). Row 30's `\d+\s*台账` dropped (usage note); row 42 → 接口 with 表面看来/从表面来看 spared; row 40 accepts `研究对象（Research Object，RO）`.

Self-test (`python3 scripts/check-i18n-glossary.py --self-test`): **167 cases** — for every rejection, the refused form under an anchored `msgid`, the row's own rendering, the rejected word in its *other* sense under an unrelated `msgid` (an ordinary Chinese sentence per rejection in `NEIGHBOURS`; a missing or non-matching neighbour is a hard error), and the word inside a code span; for every K token, dropped (refused) and kept (passes). Summary line: `26 rejected rendering(s) across 49 glossary row(s) (3 global), each refused under its anchor and spared in its other sense; 24 keep-English token(s), each refused when dropped.`

The reviewer's probes, re-executed through `offences()` (msgid → msgstr):
```
  passes   'W3C standardized RDF 1.2.'          -> 'RDF 1.2 已由 W3C 标准化。'
  REFUSED  'Canonicalization of the dataset.'   -> '数据集的标准化。'
  passes   'A decisive factor.'                 -> '这是决定性因素。'
  REFUSED  'Deterministic output.'              -> '输出具有决定性。'
  passes   'Cited sources.'                     -> '引文出处见脚注。'
  passes   'This design implies an assumption.' -> '这一设计蕴含着一个假设。'
  REFUSED  'RDFS entailment.'                   -> 'RDFS 蕴含。'
  passes   'Entailment spelling note.'          -> '不要写 `蕴含`，要写 `蕴涵`。'     (code span)
  passes   'On the surface.'                    -> '表面看来没有区别。'
  REFUSED  'The API surface is stable.'         -> 'API 表面保持稳定。'
  passes   'Section 3'                          -> '## 3 台账与预期失败'
  passes   'Research Object projections'        -> '研究对象（Research Object，RO）投影'
  REFUSED  'Research Object projections'        -> '研究物件（RO）投影'                  (N1)
  REFUSED  'PostgreSQL support'                 -> '使用波斯特格雷数据库。'              (N1)
  REFUSED  'The GMEOW ontology'                 -> '吉猫协议'                            (N1)
```
A tracked `zh-Hans` Markdown file has no `msgid`, so it is checked against the global rows only (stated in the gate's summary line); the #244 drafts as files: 2191 lines, 0 offences. The pour into the catalogue is where the table is fully enforced.

Also from the review: **N3** `check-doc-claims.py` now enumerates `git ls-files` (one cached enumeration shared by the documented surface, the registry manifests and the coverage candidates) — proof: an untracked `docs/scratch-untracked-probe.md` carrying an overclaim, a bare `purrdf` and `#31`: all three of `check-doc-claims`/`check-brand-casing`/`check-issue-refs` exit 0 with 0 mentions; `git add` it and `check-doc-claims` exits 1 with 21 mentions. **N4** three paraphrases accepted (`不属于 SPARQL 1.2 … 自有的扩展`, `SPARQL 1.2 中没有四元组模板`, `非 SPARQL 1.2 标准`), with a comment stating the exact-substring/masking property is the English list's own. **N8** the glossary states it supersedes §5.4 row 32; a one-line follow-up PR corrects the merged assessment. **N9** the render gate asserts `mdbook --version` against `MDBOOK_VERSION` in `docs.yaml`: with 0.4.52 first on PATH → `mdbook version mismatch — 'mdbook v0.4.52', docs.yaml pins 0.5.3`, exit 1; with 0.5.3 → `mdbook 0.5.3 and mdbook-i18n-helpers 0.4.0, both at their pins`. The searchindex naming nit is fixed. `make check-i18n` on the final tree: every arm red on its poison, `OK: the zh-Hans rendering passes all 6 gates.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for building and publishing the documentation in Simplified Chinese (zh-Hans).
  - Added translation catalog generation and update workflows for maintaining localized documentation.
  - Enabled HTML search for the English documentation.

- **Documentation**
  - Added a zh-Hans terminology glossary covering key RDF, knowledge graph, product, and specification terms.
  - Improved documentation validation for translations, branding, issue references, attributions, claims, and embedded SPARQL examples.

- **Bug Fixes**
  - Improved detection of terminology and documentation issues in Chinese text and rendered documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->