### PR TITLE
chore(release): 0.13.0 — consolidate the changelog and bump every lane in lockstep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ bump may carry breaking changes and a patch bump is bugfix-only.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-09-02
+
 This release re-founds the aggregate algebra on the SPARQL specification's own shape, adds a
 caller-extensible aggregate registry (with a first-party statistical set), retains and enforces
 the `VERSION` declaration, adds RDF 1.2's `ADJUST` and the underlying F&O temporal operation
@@ -16,7 +18,6 @@ and the Part 3 assignment restriction). It carries a large number of breaking su
 called out below with what a consumer must do.
 
 ### Bug Fixes
-
 - **BREAKING** **core:** `check_provenance` now measures the sidecar against the dataset in BOTH
   directions, and an empty quad set means "the dataset is empty", not "check nothing". Rule 3
   (every dataset quad has at least one occurrence) previously ran only when the handle slice was
@@ -450,7 +451,6 @@ called out below with what a consumer must do.
   query that depended on any of the three previous wrong answers now gets the correct one.
 
 ### Features
-
 - **shapes:** New `ValidationReport::to_dataset()` returns the report graph as a frozen
   `Arc<RdfDataset>` — the report's PRIMAL RDF form. Rendering a report in any syntax other
   than N-Triples previously forced a `to_ntriples()` → `parse_dataset()` round-trip; that
@@ -771,7 +771,6 @@ called out below with what a consumer must do.
   points, so its fuel is unchanged in value even though the schedule and its digest moved.
 
 ### Performance
-
 - **core:** The interner no longer mints a `String` for the datatype IRI of every untyped or
   language-tagged literal; `rdf:reifies` is interned once per builder rather than by string on
   every reifier push. RDFC-1.0 canonicalization renders blank labels and predicate IRIs by
@@ -815,50 +814,12 @@ called out below with what a consumer must do.
   set against a fresh walk at every consultation.
 
 ### Refactor
-
 - **sparql-eval:** Drive built-in aggregates through the same `AggregateAccumulator` fold trait
   as caller-registered ones — each built-in is now a concrete accumulator monomorphized through
   one generic driver, rather than a hand-rolled counter plus a per-function enum. No behavior
   change; governor charging and the frozen corpus are untouched.
 
-### Testing
-
-- **results:** Pin its:dir precedence over legacy spellings in SRX
-- **sparql,conformance:** Pin the newly-added SPARQL evaluation surface in the conformance
-  corpus: the `VERSION` declaration evaluated (not merely parsed), the `AGG` call form's
-  grammar, and `GROUP_CONCAT`'s row-order concatenation pinned to an exact string.
-- **sparql-algebra:** Pin the whole serializer with a corpus round-trip sweep: parse, serialize,
-  re-parse, and compare (modulo left-linearized join spines) over every vendored W3C, first-party,
-  and doc-example query text — the empty exception ledger is the point; every disagreement it
-  found is fixed above, not ledgered.
-- **rdf:** Reduce the golden-capture deferred-construct classifier to the engine's actual typed
-  residue — `LATERAL`, `SERVICE`, `DESCRIBE`, and property paths no longer misroute into expected
-  deferral now that they are implemented.
-- **sparql-conformance:** Add the `purrdf-extend` `LATERAL` manifest cases: the SEP-0006 worked
-  examples (including the scoping oracle, proving Project-boundary narrowing rather than mere
-  textual substitution), a shared-variable-injection case, and the SEP's own legal/illegal syntax
-  pair.
-- **sparql-conformance:** Add eight `purrdf-extend` SEP-0007 `EXISTS`/`NOT EXISTS` manifest cases
-  through the shipped stack — the correlated graph-variable body, the `OPTIONAL`-padding tautology
-  in both polarities, nested negation, a per-row `LIMIT 1` sub-select a one-shot probe would
-  truncate wrongly, the `MINUS` shape whose right-operand correlation a one-shot probe would flip,
-  and the Part 3 assignment restriction's own colliding-`BIND`/colliding-`VALUES` negative-syntax
-  pair — bringing the suite to fifty-five cases (forty-eight evaluation, five negative-syntax).
-  Each expected evaluation result was hand-derived from the `Replace`/`PrjMap` substitution
-  definition before being pinned against the release binary, so a still-wrong engine could not
-  have pinned itself correct.
-- **sparql-eval:** Pin the probe/definition strategy boundary from both sides with a test-only
-  forced-strategy seam: agreement tests run every admissible shape through both strategies and
-  assert row-for-row equality, and divergence witnesses force the probe onto each refused shape
-  and assert the specific wrong answer it would give. A bounded-exhaustive generator sweeps
-  hundreds of inner shapes at depth two, checking memo equivalence throughout and cross-strategy
-  agreement on every admitted one. Twenty-four `FILTER EXISTS`/`FILTER NOT EXISTS` shapes also run
-  as real query text through the public engine end to end, including the substitution document's
-  own worked examples, every solution modifier inside the body, the `HAVING`-position scope pin,
-  and quoted-triple/blank-node outer bindings.
-
 ### Documentation
-
 - **sparql:** Document the aggregate seam and the SPARQL 1.2 remainder: the book's query chapter
   gains `ADJUST`, the `VERSION` declaration, the custom-aggregate seam with a worked registration
   example, and the ten statistical aggregates; the results chapter documents the `its:dir`
@@ -940,6 +901,40 @@ called out below with what a consumer must do.
   three-record run. The environment override is kept.
 
 ### Testing
+- **results:** Pin its:dir precedence over legacy spellings in SRX
+- **sparql,conformance:** Pin the newly-added SPARQL evaluation surface in the conformance
+  corpus: the `VERSION` declaration evaluated (not merely parsed), the `AGG` call form's
+  grammar, and `GROUP_CONCAT`'s row-order concatenation pinned to an exact string.
+- **sparql-algebra:** Pin the whole serializer with a corpus round-trip sweep: parse, serialize,
+  re-parse, and compare (modulo left-linearized join spines) over every vendored W3C, first-party,
+  and doc-example query text — the empty exception ledger is the point; every disagreement it
+  found is fixed above, not ledgered.
+- **rdf:** Reduce the golden-capture deferred-construct classifier to the engine's actual typed
+  residue — `LATERAL`, `SERVICE`, `DESCRIBE`, and property paths no longer misroute into expected
+  deferral now that they are implemented.
+- **sparql-conformance:** Add the `purrdf-extend` `LATERAL` manifest cases: the SEP-0006 worked
+  examples (including the scoping oracle, proving Project-boundary narrowing rather than mere
+  textual substitution), a shared-variable-injection case, and the SEP's own legal/illegal syntax
+  pair.
+- **sparql-conformance:** Add eight `purrdf-extend` SEP-0007 `EXISTS`/`NOT EXISTS` manifest cases
+  through the shipped stack — the correlated graph-variable body, the `OPTIONAL`-padding tautology
+  in both polarities, nested negation, a per-row `LIMIT 1` sub-select a one-shot probe would
+  truncate wrongly, the `MINUS` shape whose right-operand correlation a one-shot probe would flip,
+  and the Part 3 assignment restriction's own colliding-`BIND`/colliding-`VALUES` negative-syntax
+  pair — bringing the suite to fifty-five cases (forty-eight evaluation, five negative-syntax).
+  Each expected evaluation result was hand-derived from the `Replace`/`PrjMap` substitution
+  definition before being pinned against the release binary, so a still-wrong engine could not
+  have pinned itself correct.
+- **sparql-eval:** Pin the probe/definition strategy boundary from both sides with a test-only
+  forced-strategy seam: agreement tests run every admissible shape through both strategies and
+  assert row-for-row equality, and divergence witnesses force the probe onto each refused shape
+  and assert the specific wrong answer it would give. A bounded-exhaustive generator sweeps
+  hundreds of inner shapes at depth two, checking memo equivalence throughout and cross-strategy
+  agreement on every admitted one. Twenty-four `FILTER EXISTS`/`FILTER NOT EXISTS` shapes also run
+  as real query text through the public engine end to end, including the substitution document's
+  own worked examples, every solution modifier inside the body, the `HAVING`-position scope pin,
+  and quoted-triple/blank-node outer bindings.
+
 
 - **conformance:** Bring `scripts/conformance-baseline.json`'s free-text `note:` prose under the
   same gate as its `ledgered` integer. Only the integer was ever machine-checked, and the OWL 2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,8 +31,8 @@ authors:
   - family-names: "Audley"
     given-names: "Patrick"
     orcid: "https://orcid.org/0000-0003-4382-7625"
-version: "0.12.0"
-date-released: "2026-08-02"
+version: "0.13.0"
+date-released: "2026-09-02"
 license:
   - Apache-2.0
   - MIT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "purrdf-columnar",
  "purrdf-datalog",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-cdt"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "pretty_assertions",
  "proptest",
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "clap",
  "criterion",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-columnar"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-datalog"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -1445,11 +1445,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "purrdf-geo"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "purrdf-core",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-gts"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "boon",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "boon",
  "criterion",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "hex",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-text"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blake3",
  "caseless",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -54,26 +54,26 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "0.12.0" }
-purrdf-cdt = { path = "crates/cdt", version = "0.12.0" }
-purrdf-columnar = { path = "crates/columnar", version = "0.12.0" }
-purrdf-core = { path = "crates/rdf-core", version = "0.12.0" }
-purrdf-datalog = { path = "crates/datalog", version = "0.12.0" }
-purrdf-entail = { path = "crates/entail", version = "0.12.0" }
-purrdf-events = { path = "crates/rdf-events", version = "0.12.0" }
-purrdf-geo = { path = "crates/geo", version = "0.12.0" }
-purrdf-gts = { path = "crates/gts", version = "0.12.0" }
-purrdf-iri = { path = "crates/iri", version = "0.12.0" }
-purrdf-rdf = { path = "crates/rdf", version = "0.12.0" }
-purrdf-shapes = { path = "crates/shapes", version = "0.12.0" }
-purrdf-shex = { path = "crates/shex", version = "0.12.0" }
-purrdf-slice = { path = "crates/slice", version = "0.12.0" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.12.0" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.12.0" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "0.12.0" }
-purrdf-text = { path = "crates/text", version = "0.12.0" }
-purrdf-validate = { path = "crates/validate", version = "0.12.0" }
-purrdf-xsd = { path = "crates/xsd", version = "0.12.0" }
+purrdf = { path = "crates/purrdf", version = "0.13.0" }
+purrdf-cdt = { path = "crates/cdt", version = "0.13.0" }
+purrdf-columnar = { path = "crates/columnar", version = "0.13.0" }
+purrdf-core = { path = "crates/rdf-core", version = "0.13.0" }
+purrdf-datalog = { path = "crates/datalog", version = "0.13.0" }
+purrdf-entail = { path = "crates/entail", version = "0.13.0" }
+purrdf-events = { path = "crates/rdf-events", version = "0.13.0" }
+purrdf-geo = { path = "crates/geo", version = "0.13.0" }
+purrdf-gts = { path = "crates/gts", version = "0.13.0" }
+purrdf-iri = { path = "crates/iri", version = "0.13.0" }
+purrdf-rdf = { path = "crates/rdf", version = "0.13.0" }
+purrdf-shapes = { path = "crates/shapes", version = "0.13.0" }
+purrdf-shex = { path = "crates/shex", version = "0.13.0" }
+purrdf-slice = { path = "crates/slice", version = "0.13.0" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "0.13.0" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "0.13.0" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "0.13.0" }
+purrdf-text = { path = "crates/text", version = "0.13.0" }
+purrdf-validate = { path = "crates/validate", version = "0.13.0" }
+purrdf-xsd = { path = "crates/xsd", version = "0.13.0" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "0.12.0"
+version = "0.13.0"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.12.0" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "0.13.0" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -84,4 +84,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "0.12.0"
+version = "0.13.0"

--- a/crates/rdf-capi/include/purrdf.h
+++ b/crates/rdf-capi/include/purrdf.h
@@ -9,7 +9,7 @@
 
 /* WARNING: generated file — edit crates/rdf-capi instead. */
 #define PURRDF_MAJOR 0
-#define PURRDF_MINOR 12
+#define PURRDF_MINOR 13
 #define PURRDF_PATCH 0
 
 

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -58,7 +58,7 @@ purrdf-iri = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.12.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.13.0" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.12.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "0.13.0" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.


### PR DESCRIPTION
First half of the two-step release. 0.13.0's only purpose is to create the crates.io records for `purrdf-cdt`, `purrdf-geo` and `purrdf-text` via token-authenticated publish (Trusted Publishing cannot create a crate that does not exist). 0.14.0 follows immediately through the `rust-v*` tag lane and is the release users see.

## Changelog
- 109 hand-written `[Unreleased]` entries (48 BREAKING) moved under `## [0.13.0] - 2026-09-02` **verbatim** — entry set diffed identical before/after.
- Duplicated `### Testing` heading (merge artifact) merged into git-cliff group order.
- `[Unreleased]` left empty for 0.14.0. `make changelog` was NOT run.

## Version
- `make bump VERSION=0.13.0` + `cargo update --workspace --offline` (the bump script does not rewrite `Cargo.lock`).
- `check-versions.py`, `check-publish-order.py` (21 crates, all 8 dev-edges backward, 3-entry bootstrap ledger in order), `check-toolchain-pin.py`: all OK.
- No stale `0.12.0` in README / book / CITATION / Python README.

## After merge
1. CI green on `main` at the merge SHA.
2. `scripts/bootstrap-crates-io.sh 0.13.0` with `CARGO_TOKEN` — all 21 crates, verification ON, cooldown 0. Maintainer-approved.
3. Maintainer flips every crate to Trusted Publishing.
4. Bump 0.14.0 → `rust-v0.14.0` tag lane.