### PR TITLE
fix(i18n): glossary gate — in-paragraph collision lookarounds, whole-token keep-English survival, regex anchors (review residuals of #245)

### DIFF
--- a/docs/book/po/glossary-zh-Hans.md
+++ b/docs/book/po/glossary-zh-Hans.md
@@ -44,8 +44,15 @@ How the gate reads the table:
 
 * **Anchor** — the English word(s) whose presence in a `msgid` makes the row
   apply, `、`-separated, matched case-insensitively at a word start and as a
-  prefix (`entail` covers *entails* and *entailment*; `canonical` covers
-  *canonicalize* and *canonicalization*). A rejection is tested against a
+  prefix (`canonical` covers *canonicalize* and *canonicalization*); an
+  anchor written `/…/` is a regular expression, used where the prefix would
+  reach an unrelated word (`/entail(?!s\b)/` covers *entailment* but not the
+  verb *entails a cost*; `/literal(?!ly)/` not *literally*). The refusal is
+  therefore on the term's PARAGRAPH, not on the word: a rejected form is
+  still refused when it appears in another sense inside a paragraph that
+  mentions the term (输出处理 in a paragraph about provenance), and the
+  escape hatch for such a collision is a lookaround on the Rejected entry
+  (`/(?<!输)出处/`, `/决定性(?!能)/`), added with its self-test neighbour. A rejection is tested against a
   `msgstr` only when its row is anchored in the `msgstr`'s `msgid`: 标准化
   is refused as a rendering of *canonicalization* and untouched as the
   rendering of *standardized* (the English book says "no standardized
@@ -62,7 +69,9 @@ How the gate reads the table:
   fenced blocks in a `msgstr` are never matched (a page may write
   「不要写 `蕴含`」).
 * **K rows** — every Anchor token is an invariant: if the `msgid` carries it
-  (case-sensitively, at a word start), the `msgstr` must contain it verbatim.
+  as a whole token (case-sensitively, not inside another word — `RDF` in
+  `RDFLib` does not count), the `msgstr` must carry the same whole token
+  (`RDF` inside `PurRDF` does not satisfy it).
   研究物件 for *Research Object* or 吉猫协议 for *GMEOW* is refused by this
   arm even though no Rejected entry names it.
 
@@ -80,16 +89,16 @@ way.
 | 1 | triple | triple | 三元组 | E, H | — | universal in 知识图谱 literature |
 | 2 | quad | quad | 四元组 | E | — | |
 | 3 | named graph | — | 命名图 | E | 具名图 | GLOBAL: 具名图 is the zh-Hant rendering, wrong anywhere in a zh-Hans book |
-| 4 | dataset | — | 数据集 | E, H | 资料集 | GLOBAL: 资料集 is the zh-Hant rendering, wrong anywhere in a zh-Hans book |
+| 4 | dataset | — | 数据集 | E, H | `/(?<!参考)资料集/` | GLOBAL: 资料集 is the zh-Hant rendering, wrong anywhere in a zh-Hans book; the lookbehind spares 参考资料集合 ("the collection of reference material") |
 | 5 | blank node | blank node | 空节点 | E | 空白节点 | 空白节点 is fine for an empty DOM node elsewhere |
-| 6 | literal | literal | 字面量 | E | 字面值 | 字面值 is fine for a constant's literal value elsewhere |
+| 6 | literal | `/literal(?!ly)/` | 字面量 | E | 字面值 | 字面值 is fine for a constant's literal value elsewhere; *literally* does not anchor the row |
 | 7 | datatype | — | 数据类型 | E | 资料类型 | GLOBAL: 资料类型 is the zh-Hant rendering, wrong anywhere in a zh-Hans book |
 | 8 | language tag | language tag | 语言标签 | E | 语言标记 | |
 | 9 | IRI | IRI | IRI | K | — | invariant; gloss 国际化资源标识符 once beside it, never instead of it |
 | 10 | ontology | ontology | 本体 | E, H | 本体论 | 本体论 is the philosophical sense |
 | 11 | knowledge graph | knowledge graph | 知识图谱 | E | `/知识图(?!谱)/` | the audience's own term for the field |
 | 12 | reasoning / inference | reasoning、inference | 推理 | E, H | — | house: 「以推理为核心」 |
-| 13 | entailment | entail | 蕴涵 | E (logic) | 蕴含 | 蕴含 also circulates for entailment; this book uses 蕴涵 only. As the ordinary verb "implies" it is untouched |
+| 13 | entailment | `/entail(?!s\b)/` | 蕴涵 | E (logic) | 蕴含 | 蕴含 also circulates for entailment; this book uses 蕴涵 only. As the ordinary verb "implies" it is untouched, and the verb *entails* ("streaming entails a cost") does not anchor the row |
 | 14 | entailment regime | entailment regime | 蕴涵机制 | C | — | keep "(entailment regime)" on first use; no W3C precedent |
 | 15 | materialization | materialization、materialize | 物化 | E | 实体化 | database/KG usage |
 | 16 | closure (inference) | closure | 推理闭包 | E, qualified | — | qualify on first use on a page; bare 闭包 is NOT gated, because 传递闭包 (transitive closure), 宿主闭包 (a host closure, the programming sense) and the verb phrase 求闭包 (compute the closure) are all correct and all contain it |
@@ -97,8 +106,8 @@ way.
 | 18 | canonicalization profile | profile | 规范化 profile | K + H | — | "profile" has no settled rendering (子集/概貌/配置 all circulate); keep English; `purrdf-rdfc12` is invariant |
 | 19 | codec / serialization | codec、serialization、serialize | 编解码器 / 序列化 | H, E | — | |
 | 20 | round-trip | round-trip | 往返（转换） | E | — | |
-| 21 | determinism | determinism、deterministic | 确定性 | E | 决定性 | 决定性 is "decisive" elsewhere |
-| 22 | provenance | provenance | 溯源 | H | 出处 | house: 声明溯源; not 出处/来源 (来源 is not gated: it is the ordinary word for a data source) |
+| 21 | determinism | determinism、deterministic | 确定性 | E | `/决定性(?!能)/` | 决定性 is "decisive" elsewhere; the lookahead spares 决定性能 ("determines performance") inside a paragraph about determinism |
+| 22 | provenance | provenance | 溯源 | H | `/(?<!输)出处/` | house: 声明溯源; not 出处/来源 (来源 is not gated: it is the ordinary word for a data source). The lookbehind spares 输出处理 ("output processing") inside a paragraph about provenance |
 | 23 | triple term (RDF 1.2) | triple term | 三元组项 | H | 三元组术语、三元组词项 | adopted by the house `/zh/purrdf/` page; W3C has none |
 | 24 | reifier / `rdf:reifies` | reifier、reifies | 具体化节点 / `rdf:reifies` | C | — | 具体化 (reification) is established; the noun for the subject is coined; the IRI never changes |
 | 25 | statement layer / annotation | statement layer、annotation | 陈述层 / 注解 | C / E | — | 陈述 (statement) is established; 注解 for the `{| |}` annotation syntax |
@@ -108,7 +117,7 @@ way.
 | 29 | governor / budget | governor | governor（执行调控器）/ 预算 | K / E | — | no settled rendering for "governor" in this sense; 预算 is established for resource budgets |
 | 30 | ledger (`xfail` ledger) | ledger | 台账（预期失败台账） | E, qualified | `/(?<!台)账本/` | 台账 is the engineering register word; 账本 reads as blockchain (the lookbehind spares 台账本身, "the ledger itself"). Usage, not gated: in a COUNT, 台账 may not follow a bare numeral — 「0 台账」 is "zero ledgers"; write 「0 例入账」, 「台账为空」, 「5 例入台账」. (A numeral before 台账 is also a section number or a table reference, so no regex can tell a count from those) |
 | 31 | walk vs. path | walk | 游走 vs. 路径 | E | — | the pair maps cleanly (随机游走 is standard); keep the distinction the code makes |
-| 32 | out-of-core (outside `purrdf-core`) | out-of-core | 核心之外 / 核心 crate 之外 | C | 核外 | The English is a PUN: "out-of-core" means outside the `purrdf-core` crate — capabilities that arrive as sibling crates through the extension seams — not the CS sense. 核外 / 核外计算 is exactly that CS sense (data larger than RAM, streamed from disk), so 「核外 SPARQL 扩展」 beside 「内存倒排索引」 two paragraphs later reads as a contradiction that the English does not have. Supersedes §5.4 row 32 of the assessment. 核外 elsewhere (核外电子) is untouched |
+| 32 | SPARQL extensions outside `purrdf-core` (formerly "out-of-core") | outside `purrdf-core`、out-of-core | 核心之外 / 核心 crate 之外 | C | 核外 | The English is a PUN: "out-of-core" means outside the `purrdf-core` crate — capabilities that arrive as sibling crates through the extension seams — not the CS sense. 核外 / 核外计算 is exactly that CS sense (data larger than RAM, streamed from disk), so 「核外 SPARQL 扩展」 beside 「内存倒排索引」 two paragraphs later reads as a contradiction that the English does not have. Supersedes §5.4 row 32 of the assessment. 核外 elsewhere (核外电子) is untouched |
 | 33 | interned / interner | intern | 驻留 / 驻留表 | E (Python community) | — | |
 | 34 | fixpoint, semi-naive | fixpoint、semi-naive | 不动点, 半朴素 | E | — | |
 | 35 | embedding, kNN | embedding、kNN | 嵌入（向量嵌入）, k 近邻 | E | — | the audience's core vocabulary |
@@ -116,7 +125,7 @@ way.
 | 37 | shape, focus node | shape、focus node | 形状, 焦点节点 | E | — | SHACL Chinese usage |
 | 38 | quad template | quad template | 四元组模板 | C | — | a first-party extension that SPARQL 1.2 does not define. `check-spec-attribution.py` treats 四元组模板 and `CONSTRUCT 模板` as anchors and accepts the Chinese disclaimers listed in its `DISCLAIMERS` tuple — 「并非 SPARQL 1.2 特性」, 「SPARQL 1.2 并未定义」, 「第一方扩展」, 「PurRDF 的扩展」, 「不属于 SPARQL 1.2」, 「没有四元组模板」 among them; an exact wording is required, as for the English list |
 | 39 | PurRDF | PurRDF | PurRDF | K | — | the brand is never translated or lower-cased in prose (`docs/BRAND.md`); `check-brand-casing.py` enforces the casing inside CJK text, this row enforces survival |
-| 40 | Research Object (RO-Crate) | Research Object | Research Object（RO） | K | `/研究对象(?![（(]Research Object)/` | a proper noun; 研究对象 means "the object of study". Keep English, or gloss it as 研究对象（Research Object） / 研究对象（Research Object，RO） — the bare word is refused where the msgid carries the term |
+| 40 | Research Object (RO-Crate) | Research Object | Research Object（RO） | K | `/研究对象(?!\s*[（(]\s*Research Object)/` | a proper noun; 研究对象 means "the object of study". Keep English, or gloss it as 研究对象（Research Object） / 研究对象（Research Object，RO） / 研究对象 (Research Object) — the bare word is refused where the msgid carries the term |
 | 41 | realization (DL, of an individual) | realization | 实现（realization） on first use / 实例归类 | C | — | bare 实现 collides with 实现 = "implementation", the far commoner sense in this book; gloss it or use 实例归类. Not gated: 实现 in the implementation sense is everywhere |
 | 42 | surface (API surface) | surface | 接口 | E | `/表面(?!上\|看来\|来看)/` | technical, not literary: the English "surface" is the API surface. 表面上 / 表面看来 / 从表面来看 ("ostensibly") are spared; 表面 in other senses (表面张力) is untouched by anchoring |
 | 43 | seam (extension seam) | seam | 扩展点 | E | — | 接缝 is acceptable but 扩展点 reads naturally to the audience |

--- a/docs/book/po/zh-Hans.po
+++ b/docs/book/po/zh-Hans.po
@@ -11,7 +11,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: The PurRDF Book\n"
-"POT-Creation-Date: 2026-09-02T16:37:33-06:00\n"
+"POT-Creation-Date: 2026-09-02T20:40:32-06:00\n"
 "PO-Revision-Date: 2026-09-02T15:58:27-06:00\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -406,8 +406,9 @@ msgstr ""
 msgid ""
 "Topological predicates, accessors and exactly computable measures over "
 "vector geometry, not a PostGIS: no CRS transform, no ellipsoidal geodesic, "
-"no buffers, hulls, overlay set operations or raster — each unimplemented "
-"function hard-errors by name."
+"no buffers, no concave hull, no overlay set operations, no raster — each "
+"unimplemented function hard-errors by name (`geof:convexHull` is "
+"implemented)."
 msgstr ""
 
 #: src/introduction.md:109
@@ -471,10 +472,24 @@ msgid ""
 msgstr ""
 
 #: src/introduction.md:136
-msgid "Why RDF 1.2?"
+msgid "What the version number commits to"
 msgstr ""
 
 #: src/introduction.md:138
+msgid ""
+"From 1.0.0 the suite follows semantic versioning in full: a breaking change "
+"bumps the major version, a minor bump is additive, a patch bump is bugfix-"
+"only, and the crates.io, PyPI and npm packages ship one workspace version in "
+"lockstep. The one exception is the C ABI (`purrdf.h`), which carries its own "
+"`0.x` ABI version, bumped on every exported-signature change, and is not "
+"frozen. See [Versioning & Releases](project/releases.md)."
+msgstr ""
+
+#: src/introduction.md:145
+msgid "Why RDF 1.2?"
+msgstr ""
+
+#: src/introduction.md:147
 msgid ""
 "RDF 1.2 (and SPARQL 1.2) add first-class statement-level metadata to the "
 "data model: **triple terms** that can appear in object position, "
@@ -485,11 +500,11 @@ msgid ""
 "transport. See [RDF 1.2 Features](concepts/rdf12.md)."
 msgstr ""
 
-#: src/introduction.md:146
+#: src/introduction.md:155
 msgid "Where PurRDF sits"
 msgstr ""
 
-#: src/introduction.md:148
+#: src/introduction.md:157
 msgid ""
 "PurRDF is the library layer of a small family of linked-data projects: it is "
 "the data backbone of the [GMEOW](https://github.com/Blackcat-Informatics/"
@@ -497,36 +512,36 @@ msgid ""
 "engine — but it assumes nothing about your ontology or application."
 msgstr ""
 
-#: src/introduction.md:154
+#: src/introduction.md:163
 msgid "How to read this book"
 msgstr ""
 
-#: src/introduction.md:156
+#: src/introduction.md:165
 msgid ""
 "New users: start with [Getting Started](getting-started/rust.md) in your "
 "language, then read the [Concepts](concepts/interned-dataset.md) chapters."
 msgstr ""
 
-#: src/introduction.md:158
+#: src/introduction.md:167
 msgid ""
 "Engine users: jump to [SPARQL](sparql/querying.md), [Validation](validation/"
 "shacl.md), or [Entailment](entailment.md)."
 msgstr ""
 
-#: src/introduction.md:160
+#: src/introduction.md:169
 msgid ""
 "Integrators: see [Interop](interop/rdflib.md) and [GTS Graph Transport]"
 "(gts.md)."
 msgstr ""
 
-#: src/introduction.md:162
+#: src/introduction.md:171
 msgid ""
 "Contributors: read the [Project](project/design-rules.md) chapters, then "
 "[AGENTS.md](https://github.com/Blackcat-Informatics/purrdf/blob/main/"
 "AGENTS.md) in the repository."
 msgstr ""
 
-#: src/introduction.md:166
+#: src/introduction.md:175
 msgid ""
 "API reference documentation lives on [docs.rs/purrdf](https://docs.rs/"
 "purrdf); the repository is [github.com/Blackcat-Informatics/purrdf](https://"
@@ -7842,12 +7857,12 @@ msgid ""
 "accessors, and exactly computable measures and constructors over vector "
 "geometry, not a PostGIS: `geof:transform` hard-errors by name (there is no "
 "CRS database), a `metric*` measure answers only in a CRS the caller declared "
-"in metres (there is no ellipsoidal geodesic), and buffers, hulls, the "
-"overlay set operations and the GML/KML/DGGS encodings are registered and "
-"hard-error by name. No raster."
+"in metres (there is no ellipsoidal geodesic), and the buffers, the concave "
+"hull (`geof:convexHull` is implemented), the overlay set operations and the "
+"GML/KML/DGGS encodings are registered and hard-error by name. No raster."
 msgstr ""
 
-#: src/sparql/geosparql.md:20
+#: src/sparql/geosparql.md:21
 msgid ""
 "`purrdf-geo` (`purrdf::geo` from the umbrella crate) implements GeoSPARQL "
 "1.1 (OGC 22-047r1) for PurRDF: exact, float-free geometry reached from "
@@ -7862,11 +7877,11 @@ msgid ""
 "unknown`."
 msgstr ""
 
-#: src/sparql/geosparql.md:31
+#: src/sparql/geosparql.md:32
 msgid "It mints no vocabulary"
 msgstr ""
 
-#: src/sparql/geosparql.md:33
+#: src/sparql/geosparql.md:34
 msgid ""
 "GeoSPARQL's IRIs are OGC's, not PurRDF's. Every IRI the crate reads or "
 "writes — the two literal datatypes, the `geof:` function names, the `geo:` "
@@ -7876,52 +7891,52 @@ msgid ""
 "makes the feature that needs it a hard error, never a fabricated fallback."
 msgstr ""
 
-#: src/sparql/geosparql.md:43
+#: src/sparql/geosparql.md:44
 msgid "\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\""
 msgstr ""
 
-#: src/sparql/geosparql.md:45
+#: src/sparql/geosparql.md:46
 msgid "\"http://www.opengis.net/ont/geosparql#\""
 msgstr ""
 
-#: src/sparql/geosparql.md:45
+#: src/sparql/geosparql.md:46
 msgid ""
 "// geo:\n"
 "    \"http://www.opengis.net/def/function/geosparql/\""
 msgstr ""
 
-#: src/sparql/geosparql.md:46
+#: src/sparql/geosparql.md:47
 msgid "// geof:\n"
 msgstr ""
 
-#: src/sparql/geosparql.md:47
+#: src/sparql/geosparql.md:48
 msgid "// the CRS a bare WKT literal means\n"
 msgstr ""
 
-#: src/sparql/geosparql.md:48
+#: src/sparql/geosparql.md:49
 msgid "// the CRS GeoJSON is in\n"
 msgstr ""
 
-#: src/sparql/geosparql.md:50 src/sparql/geosparql.md:51
+#: src/sparql/geosparql.md:51 src/sparql/geosparql.md:52
 msgid "\"http://www.opengis.net/def/uom/OGC/1.0/metre\""
 msgstr ""
 
-#: src/sparql/geosparql.md:52
+#: src/sparql/geosparql.md:53
 msgid "\"http://www.opengis.net/ont/sf#\""
 msgstr ""
 
-#: src/sparql/geosparql.md:56
+#: src/sparql/geosparql.md:57
 msgid "The `geof:` family on the scalar seam"
 msgstr ""
 
-#: src/sparql/geosparql.md:58
+#: src/sparql/geosparql.md:59
 msgid ""
 "`functions::register` installs every `geof:` function into a "
 "`UserFunctionRegistry` under the vocabulary's function namespace, and the "
 "registry is handed to the engine through `QueryOptions::functions`:"
 msgstr ""
 
-#: src/sparql/geosparql.md:73
+#: src/sparql/geosparql.md:74
 msgid ""
 "r#\"PREFIX geof: <http://www.opengis.net/def/function/geosparql/>\n"
 "                  PREFIX geo:  <http://www.opengis.net/ont/geosparql#>\n"
@@ -7932,7 +7947,7 @@ msgid ""
 "                  }\"#"
 msgstr ""
 
-#: src/sparql/geosparql.md:87
+#: src/sparql/geosparql.md:88
 msgid ""
 "A function's refusals travel exactly as far as SPARQL says they should. A "
 "malformed literal or a domain refusal — mixed CRSs, the measure of an empty "
@@ -7946,11 +7961,11 @@ msgid ""
 "`functions::compute`."
 msgstr ""
 
-#: src/sparql/geosparql.md:97
+#: src/sparql/geosparql.md:98
 msgid "Spatial relations on the property-function seam"
 msgstr ""
 
-#: src/sparql/geosparql.md:99
+#: src/sparql/geosparql.md:100
 msgid ""
 "GeoSPARQL's Query Rewrite rules let `?a geo:sfWithin ?b` hold between "
 "_features_ whose geometries satisfy the relation, not only where a triple "
@@ -7963,25 +7978,25 @@ msgid ""
 "matched nothing."
 msgstr ""
 
-#: src/sparql/geosparql.md:123
+#: src/sparql/geosparql.md:124
 msgid ""
 "// The parser must claim `geo:sfWithin` in predicate position; the "
 "registry's\n"
 "// own descriptors are exactly the IRIs it should claim.\n"
 msgstr ""
 
-#: src/sparql/geosparql.md:133
+#: src/sparql/geosparql.md:134
 msgid ""
 "An asserted `geo:sfWithin` triple matches whether or not the geometries "
 "satisfy it — the rewrite rules are entailments, not definitions — and a "
 "relation the index refutes contributes no row beyond what the data asserts."
 msgstr ""
 
-#: src/sparql/geosparql.md:137
+#: src/sparql/geosparql.md:138
 msgid "Every answer is exact, and identical on every target"
 msgstr ""
 
-#: src/sparql/geosparql.md:139
+#: src/sparql/geosparql.md:140
 msgid ""
 "Geometry is where floating point normally destroys reproducibility: `f64` "
 "addition is not associative, so a different traversal order gives a "
@@ -7990,14 +8005,14 @@ msgid ""
 "than mitigating it."
 msgstr ""
 
-#: src/sparql/geosparql.md:145
+#: src/sparql/geosparql.md:146
 msgid ""
 "**Coordinates are read as exact rationals.** A lexical decimal is parsed "
 "digit by digit into an exact numerator and denominator; nothing is rounded "
 "on the way in."
 msgstr ""
 
-#: src/sparql/geosparql.md:148
+#: src/sparql/geosparql.md:149
 msgid ""
 "**Every geometric decision is integer arithmetic.** Orientation, segment "
 "intersection, point-in-ring, ring winding and the DE-9IM matrix are "
@@ -8005,14 +8020,14 @@ msgid ""
 "specifies completely and identically on every target."
 msgstr ""
 
-#: src/sparql/geosparql.md:152
+#: src/sparql/geosparql.md:153
 msgid ""
 "**Irrational measures are integer square roots** at a fixed internal scale, "
 "summed as integers — one rounding, at the end, of a value that was exact "
 "until then."
 msgstr ""
 
-#: src/sparql/geosparql.md:155
+#: src/sparql/geosparql.md:156
 msgid ""
 "**The single float boundary is the result literal.** An `xsd:double` result "
 "is the correctly rounded nearest double, computed with integer arithmetic "
@@ -8020,17 +8035,17 @@ msgid ""
 "`clippy::float_arithmetic`, so there is no second float path to find."
 msgstr ""
 
-#: src/sparql/geosparql.md:160
+#: src/sparql/geosparql.md:161
 msgid ""
 "The cross-target claim is executed, not argued: `make geo-determinism` runs "
 "the same corpus natively and on wasm32 and compares bytes."
 msgstr ""
 
-#: src/sparql/geosparql.md:163
+#: src/sparql/geosparql.md:164
 msgid "What is here, and what is not"
 msgstr ""
 
-#: src/sparql/geosparql.md:165
+#: src/sparql/geosparql.md:166
 msgid ""
 "Implemented: the WKT and GeoJSON codecs (with CRS and coordinate-dimension "
 "support); every topological relation of the Simple Features, Egenhofer and "
@@ -8038,7 +8053,7 @@ msgid ""
 "constructors that are exactly computable."
 msgstr ""
 
-#: src/sparql/geosparql.md:170
+#: src/sparql/geosparql.md:171
 msgid ""
 "Registered but **hard-erroring by name**: the operations that would require "
 "facilities the crate deliberately does not have — a coordinate-reference-"
@@ -8050,7 +8065,7 @@ msgid ""
 "exists to keep out."
 msgstr ""
 
-#: src/sparql/geosparql.md:178
+#: src/sparql/geosparql.md:179
 msgid ""
 "Like the full-text index, this is a Rust-host seam: the registrations are "
 "host closures and do not cross the Python, WebAssembly or C boundary. The "
@@ -11828,43 +11843,63 @@ msgid ""
 msgstr ""
 
 #: src/project/releases.md:13
-msgid "Pre-1.0 semver policy"
+msgid "Semver policy from 1.0.0"
 msgstr ""
 
 #: src/project/releases.md:15
-msgid "While the version is `0.x`:"
+msgid "From 1.0.0 the suite follows semantic versioning in full:"
 msgstr ""
 
 #: src/project/releases.md:17
-msgid "a **minor** bump (`0.x` → `0.(x+1)`) may include breaking API changes;"
-msgstr ""
-
-#: src/project/releases.md:18
 msgid ""
-"a **patch** bump (`0.x.y` → `0.x.(y+1)`) is bugfix-only and API-compatible."
+"a **breaking** change bumps the **major** version. A commit carrying `!` or "
+"a `BREAKING CHANGE:` footer is a major-bump trigger, and the changelog marks "
+"each such entry **BREAKING**;"
 msgstr ""
 
 #: src/project/releases.md:20
-msgid ""
-"All three published surfaces share one workspace version and are released "
-"together. That coherence is enforced in CI: a version-coherence check fails "
-"the build if the three version sources disagree."
+msgid "a **minor** bump is additive and API-compatible;"
 msgstr ""
 
-#: src/project/releases.md:24
+#: src/project/releases.md:21
+msgid "a **patch** bump is bugfix-only."
+msgstr ""
+
+#: src/project/releases.md:23
+msgid ""
+"That is what the version number commits to; it is a policy statement, not a "
+"claim of stability beyond what semver means. All three published surfaces "
+"share one workspace version and are released together, and a version-"
+"coherence check in CI fails the build if the version sources (`Cargo.toml`, "
+"`pyproject.toml`, `package.json`, `CITATION.cff`) disagree."
+msgstr ""
+
+#: src/project/releases.md:29
+msgid ""
+"The one exception is the C ABI. `libpurrdf`'s [`purrdf.h`](https://"
+"github.com/Blackcat-Informatics/purrdf/blob/main/crates/rdf-capi/include/"
+"purrdf.h) carries its own `PURRDF_ABI_MAJOR.PURRDF_ABI_MINOR` (currently "
+"**0.7**), bumped on every exported-signature change, pinned by `crates/rdf-"
+"capi/tests/abi_signatures.rs`, and read back at runtime through "
+"`purrdf_abi_version`. It is versioned separately from the workspace and "
+"stays `0.x`: it is not frozen, and the workspace's 1.0.0 makes no promise "
+"about it."
+msgstr ""
+
+#: src/project/releases.md:31
 msgid "MSRV policy"
 msgstr ""
 
-#: src/project/releases.md:26
+#: src/project/releases.md:33
 msgid ""
 "The supported minimum Rust is `rust-version` in the root `Cargo.toml` — "
 "currently **1.96** — on the **stable** channel, enforced by a dedicated CI "
 "MSRV job that sets `RUSTUP_TOOLCHAIN` explicitly and asserts the compiler it "
 "measured really is 1.96. Raising the MSRV is a notable change recorded in "
-"the changelog and, pre-1.0, rides a minor bump."
+"the changelog; it rides a **minor** bump and never ships in a patch release."
 msgstr ""
 
-#: src/project/releases.md:32
+#: src/project/releases.md:39
 msgid ""
 "The MSRV is a promise to consumers; the development toolchain is a tool "
 "choice, and the two are orthogonal. `rust-toolchain.toml` pins a **dated "
@@ -11874,11 +11909,11 @@ msgid ""
 "change), and the release lanes build every published artifact on stable."
 msgstr ""
 
-#: src/project/releases.md:39
+#: src/project/releases.md:46
 msgid "Tag-driven trusted publishing"
 msgstr ""
 
-#: src/project/releases.md:41
+#: src/project/releases.md:48
 msgid ""
 "Releases are tag-driven: `rust-v<version>` publishes the crate suite to "
 "crates.io, `py-v<version>` publishes to PyPI, and `npm-v<version>` publishes "
@@ -11886,36 +11921,36 @@ msgid ""
 "cargo lane:"
 msgstr ""
 
-#: src/project/releases.md:46
+#: src/project/releases.md:53
 msgid ""
 "publication uses **Trusted Publishing** through GitHub Actions OIDC — no "
 "long-lived registry secret;"
 msgstr ""
 
-#: src/project/releases.md:48
+#: src/project/releases.md:55
 msgid "the privileged publish jobs use pinned actions and no dependency cache;"
 msgstr ""
 
-#: src/project/releases.md:49
+#: src/project/releases.md:56
 msgid ""
 "every `.crate` package receives a GitHub **build-provenance attestation**;"
 msgstr ""
 
-#: src/project/releases.md:50
+#: src/project/releases.md:57
 msgid "the package set receives an **SPDX SBOM** and SBOM attestation;"
 msgstr ""
 
-#: src/project/releases.md:51
+#: src/project/releases.md:58
 msgid ""
 "the release crate set is checked on `wasm32-unknown-unknown` before "
 "publishing;"
 msgstr ""
 
-#: src/project/releases.md:53
+#: src/project/releases.md:60
 msgid "every workspace crate version must match the tag version."
 msgstr ""
 
-#: src/project/releases.md:55
+#: src/project/releases.md:62
 msgid ""
 "Four workspace members are deliberately never published to crates.io: "
 "`purrdf-capi` (built via cargo-c, distributed as `libpurrdf`), `purrdf-"
@@ -11924,47 +11959,47 @@ msgid ""
 "instead)."
 msgstr ""
 
-#: src/project/releases.md:61
+#: src/project/releases.md:68
 msgid "Cutting a release"
 msgstr ""
 
-#: src/project/releases.md:63
+#: src/project/releases.md:70
 msgid ""
 "The coherent flow from `main` uses the `make` helpers so the three lanes can "
 "never drift:"
 msgstr ""
 
-#: src/project/releases.md:67
+#: src/project/releases.md:74
 msgid ""
 "# 1. Bump all three version sources in lockstep (fails unless they end up "
 "equal).\n"
 msgstr ""
 
-#: src/project/releases.md:69
+#: src/project/releases.md:76
 msgid ""
 "# 2. Regenerate the committed C-ABI header from the bumped crate version.\n"
 msgstr ""
 
-#: src/project/releases.md:72
+#: src/project/releases.md:79
 msgid "# 3. Regenerate the changelog from the conventional-commit history.\n"
 msgstr ""
 
-#: src/project/releases.md:75
+#: src/project/releases.md:82
 msgid ""
 "# 4. Review, then commit the release bump, generated header, and changelog.\n"
 msgstr ""
 
-#: src/project/releases.md:77
+#: src/project/releases.md:84
 msgid "\"chore(release): 0.2.2\""
 msgstr ""
 
-#: src/project/releases.md:78
+#: src/project/releases.md:85
 msgid ""
 "# 5. From an up-to-date main, run every release gate, then push all three "
 "tags.\n"
 msgstr ""
 
-#: src/project/releases.md:83
+#: src/project/releases.md:90
 msgid ""
 "`make release-tags` refuses to run unless the working tree is clean, the "
 "branch is `main` and synchronized with `origin/main`, the version check "
@@ -11979,11 +12014,11 @@ msgid ""
 "Release built from the committed `CHANGELOG.md`."
 msgstr ""
 
-#: src/project/releases.md:95
+#: src/project/releases.md:102
 msgid "Citing PurRDF"
 msgstr ""
 
-#: src/project/releases.md:97
+#: src/project/releases.md:104
 msgid ""
 "Releases carry a DOI; if you use PurRDF in research, please cite it — see "
 "[`CITATION.cff`](https://github.com/Blackcat-Informatics/purrdf/blob/main/"

--- a/scripts/check-i18n-glossary.py
+++ b/scripts/check-i18n-glossary.py
@@ -113,32 +113,49 @@ class Row:
 
     def anchored_in(self, msgid: str) -> bool:
         """Whether one of the row's anchors appears in ``msgid`` (case-insensitive, at a
-        word start, as a prefix — ``entail`` covers ``entailment``)."""
+        word start, as a prefix — ``canonical`` covers ``canonicalization``; a ``/…/``
+        anchor is a regular expression, so ``/entail(?!s\\b)/`` covers ``entailment``
+        and not the verb ``entails``)."""
         return any(_anchor_re(a, case_sensitive=False).search(msgid) for a in self.anchors)
 
 
 def _anchor_re(anchor: str, *, case_sensitive: bool) -> re.Pattern[str]:
-    return re.compile(r"(?<![A-Za-z0-9])" + re.escape(anchor), 0 if case_sensitive else re.I)
+    flags = 0 if case_sensitive else re.I
+    if len(anchor) >= 2 and anchor[0] == "/" and anchor[-1] == "/":
+        return re.compile(r"(?<![A-Za-z0-9])" + anchor[1:-1], flags)
+    return re.compile(r"(?<![A-Za-z0-9])" + re.escape(anchor), flags)
+
+
+def _token_re(token: str) -> re.Pattern[str]:
+    """A keep-English token as a WHOLE token: not inside another word on either side, so
+    ``RDF`` in ``RDFLib`` neither anchors the row in a msgid nor satisfies it in a msgstr
+    (``PurRDF`` used to). Case-sensitive: these are proper names."""
+    return re.compile(r"(?<![A-Za-z0-9])" + re.escape(token) + r"(?![A-Za-z0-9])")
 
 
 def split_cells(line: str) -> list[str]:
     """The cells of a Markdown table row, honouring backtick spans and ``\\|``.
 
     ``|`` inside a code span is content (the annotation syntax ``{| |}`` sits in one cell
-    of the glossary), and ``\\|`` is a literal pipe inside a cell (the regex alternation in
-    a Rejected entry), so the split tracks both.
+    of the glossary), ``\\|`` is a literal pipe inside a cell (the regex alternation in a
+    Rejected entry), and every other backslash is content too (``\\s``, ``\\b`` in a regex
+    cell) — the first version dropped those and silently read ``\\s*`` as ``s*``.
     """
     cells: list[str] = []
     buf: list[str] = []
     in_code = False
-    escaped = False
-    for c in line.strip():
-        if escaped:
-            buf.append(c)
-            escaped = False
-        elif c == "\\":
-            escaped = True
-        elif c == "`":
+    text = line.strip()
+    i = 0
+    while i < len(text):
+        c = text[i]
+        if c == "\\" and i + 1 < len(text) and text[i + 1] == "|":
+            # The one Markdown escape a cell needs: a literal pipe. Every other
+            # backslash is content — the regex classes in an Anchor or Rejected cell.
+            buf.append("|")
+            i += 2
+            continue
+        i += 1
+        if c == "`":
             in_code = not in_code
             buf.append(c)
         elif c == "|" and not in_code:
@@ -351,7 +368,8 @@ def offences(label: str, msgid: str | None, msgstr: str, rows: list[Row]) -> lis
                     )
         if row.keep_english and msgid is not None:
             for token in row.anchors:
-                if _anchor_re(token, case_sensitive=True).search(msgid) and token not in msgstr:
+                pattern = _token_re(token)
+                if pattern.search(msgid) and not pattern.search(msgstr):
                     out.append(
                         f"{label}: the keep-English term {token!r} in the msgid does not "
                         f"survive into the msgstr — glossary row {row.term!r} keeps it "
@@ -405,7 +423,7 @@ def file_units(path: Path) -> list[tuple[str, str | None, str]]:
 # global rejection is wrong wherever it appears and has no other sense to spare.
 NEIGHBOURS: dict[str, str] = {
     "具名图": "作者具名发表了这篇文章。",  # global near miss: 具名 alone
-    "资料集": "参考资料见附录。",  # global near miss: 资料 alone
+    "/(?<!参考)资料集/": "参考资料见附录。",  # global near miss: 资料 alone
     "资料类型": "参考资料见附录。",  # global near miss
     "空白节点": "网页模板中的空白节点会被忽略。",  # an empty DOM node
     "字面值": "该常量的字面值为 42。",  # a constant's literal value
@@ -415,15 +433,15 @@ NEIGHBOURS: dict[str, str] = {
     "蕴含": "这一设计蕴含着一个假设。",  # implies
     "实体化": "该抽象概念被实体化为一个类。",  # reified into a class
     "标准化": "RDF 1.2 已由 W3C 标准化。",  # standardized
-    "决定性": "这是决定性因素。",  # decisive
-    "出处": "引文出处见脚注。",  # a citation's source
+    "/决定性(?!能)/": "这是决定性因素。",  # decisive
+    "/(?<!输)出处/": "引文出处见脚注。",  # a citation's source
     "三元组术语": "本节解释三元组术语的由来。",  # the terminology of triples
     "三元组词项": "三元组词项在逻辑学教材中另有含义。",
     "基本方向": "设计的基本方向是确定性。",  # basic direction
     "组合数据类型": "C 语言中的结构体是一种组合数据类型。",  # an aggregate type in C
     "/(?<!台)账本/": "区块链是一种分布式账本。",  # a blockchain ledger
     "核外": "核外电子决定了元素的化学性质。",  # extranuclear electrons
-    "/研究对象(?![（(]Research Object)/": "本研究的研究对象为大学生。",  # the object of study
+    "/研究对象(?!\\s*[（(]\\s*Research Object)/": "本研究的研究对象为大学生。",  # the object of study
     "/表面(?!上|看来|来看)/": "水的表面张力很大。",  # surface tension
     "铸造": "青铜器由铸造而成。",  # bronze casting
     "抵达": "列车准时抵达车站。",  # a train arriving
@@ -564,13 +582,44 @@ def self_test(rows: list[Row], report: bool) -> list[str]:
         _po_text(anchored, f"本页使用{probe}一词。", obsolete=True),
         False,
     )
-    # The sentences from the review that the first version refused, and the book's own.
+    # The sentences from the review that the first version refused, and the book's own —
+    # the latter read from the REAL catalogue, so the proof is over the msgids the
+    # translator will actually meet, not a synthetic short one.
+    real = [
+        e.msgid
+        for e in po_catalog.messages(po_catalog.parse_po(PO_PATH.read_text(encoding="utf-8")))
+        if "standardized" in e.msgid
+    ] if PO_PATH.is_file() else []
+    if not real:
+        problems.append(
+            "NO REAL SPECIMEN: the catalogue no longer carries a msgid with 'standardized', so "
+            "the book's-own-sentence proof reads nothing; re-point it at a sentence the book "
+            "does say"
+        )
+    for index, msgid in enumerate(real, 1):
+        verdict(
+            f"the book's own msgid #{index} ('standardized', {len(msgid.split())} words) "
+            f"rendered with 标准化",
+            _po_text(msgid, "…但不存在标准化的拼写，因此这里描述的是 PurRDF 的写法。SPARQL 1.2 GRAPH CONSTRUCT"),
+            False,
+        )
     for what, msgid, msgstr in (
         (
             "the book's own sentence: 'no standardized spelling exists'",
             "Other engines already ship a form of it, but no standardized spelling exists.",
             "其他引擎已经提供了某种形式，但不存在标准化的拼写。",
         ),
+        # The residual collision class: the rejected form in its other sense INSIDE an
+        # anchored paragraph, spared by the row's lookaround.
+        ("输出处理 inside a paragraph about provenance", "Provenance of the output processing step.", "输出处理步骤的溯源。"),
+        ("决定性能 inside a paragraph about determinism", "Determinism determines performance.", "确定性决定性能。"),
+        ("the verb 'entails' does not anchor the entailment row", "Streaming entails a cost.", "流式处理蕴含着一定开销。"),
+        ("'literally' does not anchor the literal row", "The value is literally 42.", "该常量的字面值为 42。"),
+        ("参考资料集合 spared by the global row's lookbehind", "Reference materials.", "参考资料集合见附录。"),
+        # The half-width gloss with the house half-width space.
+        ("the gloss with half-width parentheses and a space", "Research Object projections", "研究对象 (Research Object) 投影"),
+        # A keep-English token inside another word neither anchors nor satisfies.
+        ("RDFLib in the msgid does not demand a standalone RDF", "RDFLib compatibility.", "RDFLib 兼容层。"),
         (
             "a faithful sentence keeping every invariant",
             "PurRDF is an RDF 1.2 toolkit in Rust with Python and WebAssembly bindings.",
@@ -585,6 +634,8 @@ def self_test(rows: list[Row], report: bool) -> list[str]:
         verdict(what, _po_text(msgid, msgstr), False)
     for what, msgid, msgstr in (
         ("Research Object rendered as 研究物件", "Research Object projections", "研究物件（RO）投影"),
+        ("RDF in the msgid, only PurRDF in the msgstr", "The RDF toolkit PurRDF.", "PurRDF 工具包。"),
+        ("the rejected form in the term's own paragraph, other sense but no lookaround", "Entailment of the statement.", "陈述所蕴含的东西。"),
         ("GMEOW translated", "The GMEOW ontology.", "吉猫协议本体。"),
         ("IRI translated in running text", "Every IRI is absolute.", "每个国际化资源标识符都是绝对的。"),
     ):

--- a/scripts/check-i18n-render.py
+++ b/scripts/check-i18n-render.py
@@ -57,13 +57,14 @@ catalogue containing one poisoned ``msgstr`` — the arm's OWN self-test specime
 from the gate script (a bare ``purrdf`` glued to CJK, a hazard id glued to CJK, the
 Chinese attribution of the quad template, the overclaim ban's specimen after a full-width
 terminator) plus a fenced ``sparql`` block with a full-width brace written INSIDE a prose
-``msgstr``, plus a translation of a ``msgid`` the source does not carry — renders the book
-with THAT catalogue (``MDBOOK_PREPROCESSOR__GETTEXT__PO_DIR``), and asserts the arm goes
-red. The fence poison takes that shape because
-``mdbook-xgettext`` at the pinned version extracts no message for a ``sparql`` fence at
-all (only comments and string literals of the languages it lexes), so the English
-examples are byte-invariant under translation and the one way a query reaches the
-rendering through the catalogue is a translator writing a fence into a paragraph. A gate whose red state has never been observed is a gate
+``msgstr`` AND a real ``sparql`` fence msgid with a full-width brace, plus a translation
+of a ``msgid`` the source does not carry — renders the book with THAT catalogue
+(``MDBOOK_PREPROCESSOR__GETTEXT__PO_DIR``), and asserts the arm goes red. Both fence
+shapes are real: ``mdbook-xgettext`` at the pinned version extracts a fence whose language
+it does not lex (``sparql``, ``console``, ``text``, no language) as ONE message — the whole
+block, marker lines included — while a Rust or shell fence contributes only its comments
+and string literals; so a translator can break a shipped query by editing its message, or
+add one inside a paragraph. A gate whose red state has never been observed is a gate
 whose green state means nothing.
 
 Run locally as ``make check-i18n``; CI runs it in the docs workflow before building
@@ -295,6 +296,16 @@ def _prose_msgid(template: list) -> str:
     raise SystemExit("check-i18n-render: the template has no plain prose message to poison")
 
 
+def _sparql_fence_msgid(template: list) -> str:
+    """A shipped ``sparql`` fence as the extractor emits it: the whole block, markers
+    included. Its presence is asserted — a book with no such message would leave the
+    fence arm proven only through the paragraph poison."""
+    for e in template:
+        if e.msgid.startswith("```sparql\n") and "{" in e.msgid:
+            return e.msgid
+    raise SystemExit("check-i18n-render: the template carries no sparql fence message to poison")
+
+
 # A msgid no English page carries: the stale entry arm 6 exists to refuse.
 _STALE_MSGID = "This sentence exists in the catalogue and nowhere in the English source."
 
@@ -364,6 +375,7 @@ def poisons(template: list) -> tuple[tuple[str, str, str, str], ...]:
     ``markdown`` renderer.
     """
     prose = _prose_msgid(template)
+    fence = _sparql_fence_msgid(template)
     brand = load_gate("check-brand-casing.py")
     refs = load_gate("check-issue-refs.py")
     spec = load_gate("check-spec-attribution.py")
@@ -395,6 +407,12 @@ def poisons(template: list) -> tuple[tuple[str, str, str, str], ...]:
             "a fenced sparql block with a full-width brace, written inside a paragraph",
             prose,
             "示例：\n\n```sparql\nSELECT ?s WHERE ｛ ?s ?p ?o ｝\n```\n",
+        ),
+        (
+            "sweep_sparql_fences",
+            "a shipped sparql fence's own message, its first brace made full-width",
+            fence,
+            fence.replace("{", "｛", 1),
         ),
     )
 


### PR DESCRIPTION
The residual findings R1–R4 of the second adversarial review of #245, each with a permanent self-test case, plus the row-32 term rename requested by the coordinator. One file of Rust-free Python and one Markdown table; no other surface.

- **R1** — in-paragraph substring collisions: `/(?<!输)出处/` (输出处理 under *provenance*), `/决定性(?!能)/` (决定性能 under *determinism*), `/(?<!参考)资料集/` (参考资料集合, global row); anchors may be `/regex/`: `/entail(?!s\b)/` and `/literal(?!ly)/` stop the prefix anchor reaching *entails a cost* / *literally*. Preamble states the refusal is on the term's paragraph, not the word, and names the escape hatch.
- **R2** — the "no standardized spelling exists" proof reads the two real catalogue msgids (94 and 76 words): `the book's own msgid #1 … rendered with 标准化 → passes`, `#2 → passes`; a catalogue without such a msgid is a self-test failure.
- **R3** — `研究对象 (Research Object)` (half-width parens, house space) accepted: `/研究对象(?!\s*[（(]\s*Research Object)/`.
- **R4** — keep-English survival is whole-token on both sides: `'RDFLib compatibility.' → 'RDFLib 兼容层。'` passes (no standalone `RDF` demanded); `'The RDF toolkit PurRDF.' → 'PurRDF 工具包。'` refused (`PurRDF` no longer satisfies `RDF`).
- **Row 32** — term is now the heading text **"SPARQL extensions outside `purrdf-core`"** (formerly "out-of-core"), anchored on `outside `purrdf-core`` and `out-of-core`; rendering 核心之外 unchanged, 核外 still rejected.
- Found while doing this: the table parser dropped every backslash except before `|`, so `\s*` in a regex cell was silently read as `s*` — fixed, with `\|` the only escape; and #245's docstring claim that `mdbook-xgettext` extracts no message for a `sparql` fence was **wrong** — a fence in a language it does not lex is one message, marker lines included (24 in the catalogue). The render gate's docstring is corrected and a second fence poison edits a shipped fence's own message: `sweep_sparql_fences on a shipped sparql fence's own message, its first brace made full-width: -> red (exit 1), as required`.

Proofs: `python3 scripts/check-i18n-glossary.py --self-test` → `OK: 26 rejected rendering(s) across 49 glossary row(s) (3 global) … 24 keep-English token(s), each refused when dropped.` (179 cases); `make check-i18n` on mdbook 0.5.3 + helpers 0.4.0 → all seven poisons red, `OK: the zh-Hans rendering passes all 6 gates.`; brand-casing / issue-refs / spec-attribution / doc-claims all green on the tree (issue-refs first refused my own `# R4:` comments — correctly — and they were reworded).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Simplified Chinese glossary with clearer, more consistent terminology for dataset, literal, entailment, determinism, provenance, and related concepts.
  - Refined contextual translation guidance to distinguish technical terms and prevent misleading renderings.
  - Clarified SPARQL terminology, including extensions outside the core feature set and supported Research Object notation.
  - Added updated guidance on semantic versioning, MSRV and release practices, tag-driven publishing, and GeoSPARQL support, including `geof:convexHull`.
  - Improved consistency for code-like terms and standardized wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->