### PR TITLE
fix(release): the token lane creates crates.io records only; a release carrying new crates interleaves it with Trusted Publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,10 @@ jobs:
       - name: Check the crates.io record preflight refuses every wrong registry state (offline)
         run: bash scripts/check-crates-io-records.sh --self-test
 
-      - name: Check the crates.io bootstrap refuses existing records and missing dependencies (offline)
+      - name: Check the release publish loop runs the bootstrap interleave to completion (offline)
+        run: bash scripts/publish-release-crates.sh --self-test
+
+      - name: Check the crates.io bootstrap refuses existing records and defers missing dependencies (offline)
         run: bash scripts/bootstrap-crates-io.sh --self-test
 
       - name: Check every wasm-bindgen free function is re-exported from the npm package root

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,6 +68,12 @@ jobs:
       - name: Check cross-registry release coherence
         run: python3 scripts/check-versions.py
 
+      - name: Check the crates.io record preflight refuses every wrong registry state (offline)
+        run: bash scripts/check-crates-io-records.sh --self-test
+
+      - name: Check the crates.io bootstrap refuses existing records and missing dependencies (offline)
+        run: bash scripts/bootstrap-crates-io.sh --self-test
+
       - name: Check every wasm-bindgen free function is re-exported from the npm package root
         run: python3 scripts/check-wasm-js-exports.py
 

--- a/.github/workflows/release-cargo.yaml
+++ b/.github/workflows/release-cargo.yaml
@@ -87,24 +87,28 @@ jobs:
 
       # THE POINT OF NO RETURN IS THE PUBLISH LOOP, AND IT IS NOT ATOMIC.
       # `cargo publish` runs once per crate, in dependency order, and cannot be
-      # undone. If any crate in the release set has no crates.io record, the loop
-      # irreversibly publishes every crate ahead of it and only then fails — and
-      # the OIDC token this lane uses cannot create the record, because crates.io
-      # requires a crate to exist before a Trusted Publisher can be configured for
-      # it. So the existence of the whole set is settled HERE, before anything
-      # leaves the runner: a missing record becomes a clean refusal naming the
-      # crate and the bootstrap command, not a half-published release.
+      # undone — and the OIDC token this lane uses cannot create a crate record
+      # ("Trusted Publishing tokens do not support creating new crates"). So the
+      # state of the whole set is settled HERE, before anything leaves the runner:
+      #
+      #   * a crate with no record that PURRDF_UNBOOTSTRAPPED_CRATES names is
+      #     "bootstrap pending": permitted, because the publish loop below skips
+      #     it and stops cleanly at its first dependent for the token step (the
+      #     interleave — docs/RELEASE.md, "Outstanding bootstrap");
+      #   * a crate with no record the ledger does NOT name is a clean refusal
+      #     naming the crate — an undocumented bootstrap requirement;
+      #   * a record NOT locked to Trusted Publishing (`trustpub_only` in the
+      #     public record JSON) is a refusal naming the setting: this lane is the
+      #     only one that publishes versions of these crates, an unlocked record
+      #     is one a leaked token could publish, and a record the token step just
+      #     created is unlocked until the maintainer enables it — that is the
+      #     step this check exists to catch between interleave runs.
       #
       # The preflight reads the same scripts/release-crates.sh the publish step
-      # below sources, so it cannot check a different list than the one published.
-      # It also refuses any record that is NOT locked to Trusted Publishing
-      # (`trustpub_only` in the public record JSON): this lane is the only one
-      # that publishes versions of these crates — an API token's sole remaining
-      # job is creating a record — and an unlocked record is one a leaked token
-      # could publish. What no preflight can see is whether a Trusted Publisher
-      # ENTRY exists for a crate; see the loop comment below for what that
-      # failure looks like.
-      - name: Preflight — every release crate has a crates.io record, locked to this lane
+      # sources, so it cannot check a different list than the one published. What
+      # no preflight can see is whether a Trusted Publisher ENTRY exists for a
+      # crate; see the publish step for what that failure looks like.
+      - name: Preflight — every release crate has a crates.io record or is ledgered for bootstrap; every record is locked to this lane
         env:
           PURRDF_RELEASE_VERSION: ${{ github.ref_name }}
         run: bash scripts/check-crates-io-records.sh
@@ -186,82 +190,68 @@ jobs:
         id: auth
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
 
+      # The loop lives in scripts/publish-release-crates.sh so the one piece of
+      # logic that decides what is published can be dry-run and self-tested
+      # locally against a mock registry (`--self-test` runs the whole interleave
+      # on every `make check`). Per crate, in publish order: already published
+      # -> skip (re-runs resume); in PURRDF_UNBOOTSTRAPPED_CRATES with no record
+      # -> SKIP, visibly; depends on a skipped ledger crate -> STOP CLEANLY
+      # (exit 0, `complete=false`) naming the crate, the ledger crate it waits
+      # on, and the token step as what comes next; otherwise `cargo publish
+      # --locked`, VERIFIED, then wait until crates.io serves the version.
+      #
+      # Verification resolves the packaged crate's whole graph, dev-dependencies
+      # included, which is resolvable because every dependency is either already
+      # served or a ledger crate the token step created — or the loop stopped.
+      # This loop used to pass `--no-verify`, load-bearing until `purrdf-geo`
+      # (dev-depending on two later crates) was reordered — see docs/RELEASE.md,
+      # "Verification is on, and why it was off".
+      #
+      # Failure mode, stated honestly: the OIDC token above is scoped to the
+      # crates whose Trusted Publisher entries matched this workflow. A crate
+      # with no entry — including a record the token step created whose entry
+      # was not added before this run was re-run — fails AT its own `cargo
+      # publish` ("The provided access token is not valid for crate `<name>`"),
+      # after every crate ahead of it has been published: a loud stop under
+      # `set -e`, with a partial publish that re-running this run resumes. The
+      # preflight cannot see entries (crates.io has no public API for them); its
+      # lock check is the closest thing, because the lock can only be enabled
+      # once an entry exists.
+      #
+      # Re-running: this workflow is tag-triggered only, so a stopped run is
+      # resumed with `gh run rerun <run-id>` (same tag, same SHA, same workflow
+      # file), not by re-pushing the tag.
       - name: Publish workspace crates to crates.io
+        id: publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
           VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          # One definition of the release set, sourced by the script:
+          # scripts/release-crates.sh (see also the wasm gate above).
+          bash scripts/publish-release-crates.sh "${VERSION#rust-v}"
 
-          version="${VERSION#rust-v}"
-          # One definition of the release set, shared with the preflight above
-          # and with scripts/bootstrap-crates-io.sh.
-          # shellcheck source=scripts/release-crates.sh
-          source scripts/release-crates.sh
-          crates=("${PURRDF_RELEASE_CRATES[@]}")
+      - name: Release incomplete — the interleave continues with the token step
+        if: steps.publish.outputs.complete != 'true'
+        env:
+          VERSION: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          cat <<EOF
+          This run stopped cleanly with crates still to publish (see the publish
+          step for the crate it stopped at and the ledger crate it waits on). The
+          GitHub Release for ${VERSION} is NOT created until the set is complete.
 
-          crate_version_exists() {
-            local crate="$1"
-            local status
-            status="$(curl -sS -H "User-Agent: purrdf-release/${version} (paudley@blackcatinformatics.ca)" \
-              -o /tmp/purrdf-crate-version.json -w "%{http_code}" \
-              "https://crates.io/api/v1/crates/${crate}/${version}")"
-            case "$status" in
-              200) return 0 ;;
-              404) return 1 ;;
-              *)
-                cat /tmp/purrdf-crate-version.json
-                echo "Unexpected crates.io status ${status} for ${crate} ${version}" >&2
-                exit 1
-                ;;
-            esac
-          }
-
-          wait_for_crate_version() {
-            local crate="$1"
-            for _ in $(seq 1 30); do
-              if crate_version_exists "$crate"; then
-                return 0
-              fi
-              sleep 10
-            done
-            echo "Timed out waiting for crates.io to expose ${crate} ${version}" >&2
-            exit 1
-          }
-
-          # Each publish VERIFIES: cargo builds the packaged crate against the
-          # registry before the upload that cannot be undone, so a broken or
-          # wrong-version artifact is refused rather than made permanent. That
-          # build resolves the crate's whole graph, dev-dependencies included,
-          # which is resolvable only because (1) `wait_for_crate_version` blocks
-          # until the previous crate is served, and (2) check-publish-order.py
-          # above proved every dev-edge points backward in this order. This loop
-          # used to pass `--no-verify`, and the flag was load-bearing until
-          # `purrdf-geo` (dev-depending on two later crates) was reordered — see
-          # docs/RELEASE.md, "Verification is on, and why it was off".
-          #
-          # Failure mode, stated honestly: the OIDC token above is scoped to the
-          # crates whose Trusted Publisher entries matched this workflow. A crate
-          # with no entry fails AT its own `cargo publish` ("The provided access
-          # token is not valid for crate `<name>`"), after every crate ahead of
-          # it has been published — a loud stop under `set -e`, with a partial
-          # publish that a re-run of this tag resumes (published versions are
-          # skipped). The preflight cannot see entries (crates.io has no public
-          # API for them); its lock check is the closest thing, because the lock
-          # can only be enabled once an entry exists.
-          for crate in "${crates[@]}"; do
-            if crate_version_exists "$crate"; then
-              echo "${crate} ${version} already exists on crates.io; skipping"
-              continue
-            fi
-            cargo publish -p "$crate" --locked
-            wait_for_crate_version "$crate"
-            # Give the registry index a short propagation window before publishing
-            # dependents that name the freshly-published version.
-            sleep 15
-          done
+          Next, from a clean checkout of ${VERSION}:
+            CARGO_REGISTRY_TOKEN="\${CARGO_TOKEN}" scripts/bootstrap-crates-io.sh ${VERSION#rust-v}
+          then on crates.io, for EACH record it created, add the Trusted Publisher
+          entry and enable "Require trusted publishing"; then resume this run:
+            gh run rerun ${RUN_ID}
+          EOF
 
       - name: Publish GitHub Release with changelog notes
+        if: steps.publish.outputs.complete == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ github.ref_name }}

--- a/.github/workflows/release-cargo.yaml
+++ b/.github/workflows/release-cargo.yaml
@@ -97,7 +97,14 @@ jobs:
       #
       # The preflight reads the same scripts/release-crates.sh the publish step
       # below sources, so it cannot check a different list than the one published.
-      - name: Preflight — every release crate has a crates.io record
+      # It also refuses any record that is NOT locked to Trusted Publishing
+      # (`trustpub_only` in the public record JSON): this lane is the only one
+      # that publishes versions of these crates — an API token's sole remaining
+      # job is creating a record — and an unlocked record is one a leaked token
+      # could publish. What no preflight can see is whether a Trusted Publisher
+      # ENTRY exists for a crate; see the loop comment below for what that
+      # failure looks like.
+      - name: Preflight — every release crate has a crates.io record, locked to this lane
         env:
           PURRDF_RELEASE_VERSION: ${{ github.ref_name }}
         run: bash scripts/check-crates-io-records.sh
@@ -232,6 +239,16 @@ jobs:
           # used to pass `--no-verify`, and the flag was load-bearing until
           # `purrdf-geo` (dev-depending on two later crates) was reordered — see
           # docs/RELEASE.md, "Verification is on, and why it was off".
+          #
+          # Failure mode, stated honestly: the OIDC token above is scoped to the
+          # crates whose Trusted Publisher entries matched this workflow. A crate
+          # with no entry fails AT its own `cargo publish` ("The provided access
+          # token is not valid for crate `<name>`"), after every crate ahead of
+          # it has been published — a loud stop under `set -e`, with a partial
+          # publish that a re-run of this tag resumes (published versions are
+          # skipped). The preflight cannot see entries (crates.io has no public
+          # API for them); its lock check is the closest thing, because the lock
+          # can only be enabled once an entry exists.
           for crate in "${crates[@]}"; do
             if crate_version_exists "$crate"; then
               echo "${crate} ${version} already exists on crates.io; skipping"

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ check: ## The full local gate: fmt, clippy, build, tests, hygiene.
 	python3 scripts/check-versions.py
 	python3 scripts/check-publish-order.py
 	bash scripts/check-crates-io-records.sh --self-test
+	bash scripts/publish-release-crates.sh --self-test
 	bash scripts/bootstrap-crates-io.sh --self-test
 	python3 scripts/check-wasm-js-exports.py
 	python3 scripts/check-entailment-surface.py

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ check: ## The full local gate: fmt, clippy, build, tests, hygiene.
 	python3 scripts/check-i18n-glossary.py
 	python3 scripts/check-versions.py
 	python3 scripts/check-publish-order.py
+	bash scripts/check-crates-io-records.sh --self-test
+	bash scripts/bootstrap-crates-io.sh --self-test
 	python3 scripts/check-wasm-js-exports.py
 	python3 scripts/check-entailment-surface.py
 	python3 scripts/conformance-matrix.py --self-test

--- a/docs/CUTOVER.md
+++ b/docs/CUTOVER.md
@@ -35,11 +35,14 @@ from its workspace. Integrated on the PurRDF side of the line:
 
 ## Prerequisites for the reasoning-substrate cutover
 
-1. **A crates.io record for `purrdf-datalog`.** The crate is new; a Trusted
-   Publisher entry can only be configured after a first token-authenticated
-   bootstrap publish (`scripts/bootstrap-crates-io.sh`). Until that exists, a
-   `rust-v*` tag fails mid-publish. This is a maintainer-token action no
-   automation may take.
+1. **A crates.io record for `purrdf-datalog`.** **Satisfied**: the record has
+   existed since 2026-07-31 and `0.12.0` was published through the Trusted
+   Publishing lane on 2026-08-02. It was a prerequisite because a Trusted
+   Publisher entry can only be configured for a crate that exists, and creating
+   a record is the one thing an API token still does for this workspace
+   (`scripts/bootstrap-crates-io.sh`; every later version of every crate goes
+   through the `rust-v*` lane — see `docs/RELEASE.md`). A maintainer-token
+   action no automation may take.
 2. **gmeow re-pins.** The measured pin predates `crates/datalog` existing; every
    row below requires a purrdf version that carries `purrdf-datalog`,
    `purrdf-entail`'s reasoning surface, and `purrdf-xsd::{range,rational}`.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -103,10 +103,12 @@ on every `make check` that it is a topological order of normal **and**
 dev-dependencies, which is what lets `cargo publish` verify every crate — see
 [Verification](#verification-is-on-and-why-it-was-off).
 
-crates.io currently requires the crate to exist before a Trusted Publisher can
-be configured. Bootstrap publishes for new crate records therefore use an
-explicit token. After those crate records exist, enable the Trusted Publisher
-entries above and use the GitHub release workflow for future releases.
+crates.io requires a crate to exist before a Trusted Publisher can be
+configured for it, and refuses to create one from a Trusted Publishing token —
+its publish handler answers `Trusted Publishing tokens do not support creating
+new crates. Publish the crate manually, first`. Creating a record is therefore
+the **only** thing an API token does in this release process, and the next
+section is exact about how little that is.
 
 ### Outstanding bootstrap: `purrdf-cdt`, `purrdf-text`, `purrdf-geo`
 
@@ -123,6 +125,107 @@ that the ledger does not name fails the preflight, and a ledger entry crates.io
 now *has* a record for also fails it, so the ledger cannot go on naming a crate
 someone has since bootstrapped. This section restates the ledger, and
 `scripts/check-doc-claims.py` fails `make check` if it restates it wrongly.
+
+#### What a token can do, and what it cannot
+
+**The token lane creates records. It publishes nothing else.** Every existing
+PurRDF crate on crates.io is locked with crates.io's per-crate *Require trusted
+publishing* setting — `"trustpub_only": true` in the public record JSON of all
+eighteen — and crates.io answers a token publish of a locked crate with a 403.
+That was established by an actual publish attempt, not by reading about it:
+`scripts/bootstrap-crates-io.sh 0.13.0`, run with a valid `CARGO_TOKEN` from a
+clean tree, packaged all 21 crates, verified `purrdf-events`, and on its
+**first** upload received
+
+```text
+error: failed to publish purrdf-events v0.13.0 to registry at https://crates.io
+
+Caused by:
+  the remote server responded with an error (status 403 Forbidden): New versions of this crate can only be published using Trusted Publishing (see https://crates.io/docs/trusted-publishing).
+```
+
+Nothing landed (`purrdf-events/0.13.0` answered 404 afterwards). Until then
+this document and that script both assumed the token lane could publish the
+whole 21-crate set; that has been false since the records were locked. The
+real division of labour:
+
+| Lane | Publishes |
+| --- | --- |
+| API token (`scripts/bootstrap-crates-io.sh`) | the first-ever version of a crate with **no record** — nothing else |
+| Trusted Publishing (`rust-v*` tag, `release-cargo.yaml`) | **every** subsequent version of **every** crate, all 21, the three new ones included |
+
+The bootstrap script therefore walks `PURRDF_UNBOOTSTRAPPED_CRATES` and only
+that: a ledger crate that already has a record is refused by name (a token
+walking into eighteen 403s in a row fails safe, but it is wrong, not strict),
+and `scripts/check-crates-io-records.sh` refuses any record that is not locked,
+naming the setting to enable. Both refusals, and their valid neighbours, are
+exercised offline by each script's `--self-test` on every `make check`.
+
+#### The deadlock, and the two shapes that break it
+
+Creating a record is a real `cargo publish`, and `cargo publish` — with **or
+without** `--no-verify` — resolves the packaged crate's dependency graph against
+the registry to write its lockfile. The three ledger crates depend on
+`purrdf-iri`, `purrdf-xsd`, `purrdf-core` and `purrdf-sparql-eval`, and as
+dev-dependencies on `purrdf-sparql-results`, `purrdf-rdf`, `purrdf-shapes` and
+`purrdf-sparql-algebra`, all at the workspace version — and those versions can
+only reach crates.io through the trusted lane, which refuses while any record is
+missing. At 0.13.0, verbatim:
+
+```text
+$ cargo publish -p purrdf-cdt --no-verify --dry-run --locked
+error: failed to prepare local package for uploading
+
+Caused by:
+  failed to select a version for the requirement `purrdf-iri = "^0.13.0"`
+  candidate versions found which didn't match: 0.12.0, 0.11.0, 0.10.0, ...
+  location searched: crates.io index
+  required by package `purrdf-cdt v0.13.0 (…/crates/cdt)`
+```
+
+`--no-verify` skips the build, not the resolve. The bootstrap script's preflight
+checks every path-dependency of every ledger crate at the target version and
+refuses naming the missing ones — that is the failure above, caught before the
+token is even read. `--plan` runs only that preflight and needs no token:
+
+```sh
+scripts/bootstrap-crates-io.sh --plan
+```
+
+Two shapes break the deadlock. **Choosing between them is a maintainer
+decision; this document states their costs and makes neither.**
+
+1. **A placeholder record.** Publish, with the token, a dependency-free stub
+   under each of the three names — an empty `lib.rs` at a version below any
+   real release, such as `0.0.0` — from a throwaway crate, *not* from this
+   workspace, whose version is single-sourced and whose crates carry the real
+   dependencies. That creates the records. Add the Trusted Publisher entry and
+   the *Require trusted publishing* lock to each, remove them from the ledger,
+   and push the tag: one `rust-v*` run publishes all 21 crates through the
+   trusted lane, each verified against its published dependencies, with no
+   partial state in between; yank the stubs once the real version is up.
+   Cost: a stub is a version in each crate's history forever — a yanked version
+   stays listed and is never deleted — and the first real artifact is not the
+   first version.
+2. **The real crates at the release version, after their dependencies.** Let
+   the trusted lane publish the eighteen existing crates at the release
+   version, create the three records at that same version with the token, then
+   re-run the tag (the loop skips versions already published). Cost: the
+   preflight exists precisely to refuse a tag while a record is missing, so
+   this shape needs it relaxed for that one release — a deliberate partial
+   publish, the suite split across two versions between runs — and because the
+   ledger crates sit fourth, thirteenth and seventeenth in the order, the
+   stop-create-resume cycle happens three times, not once. Once the
+   dependencies are on the registry the token publish *can* verify, so
+   `--no-verify` buys nothing here; used anyway, it ships the first real
+   artifact of three crates unverified against its published dependencies.
+
+Neither shape is implemented as a flag. The scripts refuse the current state
+and say why; whichever shape is chosen, the token step is
+`scripts/bootstrap-crates-io.sh` (or a hand-run `cargo publish` of a stub) and
+everything after it is the tag lane.
+
+#### The preflight
 
 **What that would cost without the preflight, and why the preflight exists.**
 `cargo publish` cannot be undone, and this lane publishes one crate at a time in
@@ -151,9 +254,11 @@ read in place of running the preflight.
 
 The mechanism that makes it a refusal rather than a partial publish: the release job runs
 [`scripts/check-crates-io-records.sh`](../scripts/check-crates-io-records.sh)
-**before any packaging or publishing**; it queries `/api/v1/crates/<name>` for
-every crate in the release set and fails the job naming the missing crate and
-the bootstrap command below. Run it locally at any time:
+**before any packaging or publishing**. For every crate in the release set it
+queries `/api/v1/crates/<name>` and fails the job naming any missing crate and
+the bootstrap command; it holds the ledger to the registry both ways; and it
+reads `trustpub_only` out of every record it finds and fails naming any crate
+that is **not** locked to Trusted Publishing. Run it locally at any time:
 
 ```sh
 bash scripts/check-crates-io-records.sh
@@ -164,24 +269,45 @@ Only a literal 404 counts as missing: crates.io answers 403 to a default
 publish loop uses, retries transient statuses, and treats any other answer as a
 hard stop rather than as "missing".
 
+What the preflight **cannot** see, so that a green run is not read as more than
+it is: whether a Trusted Publisher entry exists for a crate and points at this
+repository and workflow. crates.io has no public API for those entries. The OIDC
+token the lane exchanges is scoped to the crates whose entries matched, and a
+crate with no entry fails at its **own** `cargo publish` (`The provided access
+token is not valid for crate `<name>``) — after every crate ahead of it has been
+published. Read the loop in
+[`release-cargo.yaml`](../.github/workflows/release-cargo.yaml): it is
+sequential under `set -euo pipefail`, so that failure is a loud stop with a
+partial, re-runnable publish, not a pre-publish refusal. The lock check is the
+closest a preflight gets, because on crates.io the lock can only be enabled from
+a crate's settings page once an entry exists.
+
 **The record itself can only be created by a maintainer**, because creating it
 is a token-authenticated, irreversible outward publish that a Trusted Publisher
 is not permitted to perform. Do it once, from a clean local checkout, before the
-next `rust-v*` tag:
+next `rust-v*` tag — once the deadlock above has been broken one way or the other:
 
 ```sh
-CARGO_REGISTRY_TOKEN="${CARGO_TOKEN}" scripts/bootstrap-crates-io.sh
+scripts/bootstrap-crates-io.sh --plan                                 # preflight only
+CARGO_REGISTRY_TOKEN="${CARGO_TOKEN}" scripts/bootstrap-crates-io.sh  # create the records
 ```
 
 The version argument is optional and deliberately omitted here: with none given
 the script reads the workspace version out of `cargo metadata`, so this command
 cannot go stale the way a pinned literal in a document does.
 
-The bootstrap script prints its full plan — which crates it will skip, publish,
-and **create a record for** — before it runs any gate, so the irreversible part
-is visible while it is still stoppable. After it completes, add a Trusted
-Publisher entry for each newly created record using the table above; the
-preflight then passes and the tag lane works unchanged.
+The script prints its full plan — which ledger crates it will skip, which it
+refuses, and which records it will **create** — and every refusal, before it
+runs any gate, so the irreversible part is visible while it is still stoppable.
+It then runs the local release gates on the ledger crates, refuses a dirty
+tree by default, skips a ledger crate whose version an earlier run already
+created (so a run stopped by a rate limit resumes), publishes the ledger crates
+in dependency order, and verifies each `cargo publish` against the registry.
+After it completes, on crates.io for each new crate: add the Trusted Publisher
+entry using the table above, enable *Require trusted publishing* so the record
+is locked like its siblings, then remove the crate from
+`PURRDF_UNBOOTSTRAPPED_CRATES` and from this section; the preflight then passes
+and the tag lane works unchanged.
 
 `purrdf-python`, `purrdf-sparql-conformance`, `purrdf-cli`, and `purrdf-capi`
 remain workspace crates, but they are not in this crates.io release lane.
@@ -190,20 +316,6 @@ conformance harness is an internal W3C fixture runner, `purrdf-cli` is the
 native command-line package, and
 the C ABI is a native artifact that should get a separate release lane if/when it
 is shipped.
-
-For the bootstrap publish from a clean local checkout:
-
-```sh
-CARGO_REGISTRY_TOKEN="${CARGO_TOKEN}" scripts/bootstrap-crates-io.sh
-```
-
-The script states its crates.io plan first (skip / publish / **create record**,
-per crate), then runs the local release gates, refuses dirty source by default,
-skips crate versions that already exist, and publishes crates in dependency
-order.
-It also verifies the published crate set with `cargo check --target
-wasm32-unknown-unknown --lib`; if the target is not installed and `rustup` is
-available, the script installs it before checking.
 
 #### Verification is on, and why it was off
 
@@ -229,9 +341,11 @@ point of no return — that the release order is a topological order of normal
 workspace members, and that the bootstrap ledger is in-set and in order. Its
 `--self-test` perturbs each of those and requires the refusal.
 
-Two `--no-verify` remain, both deliberate. The pre-loop `cargo package
---workspace` (in both lanes) packages every crate before *any* is published, so
-verification there is impossible by construction; it exists to find a packaging failure
+Two `--no-verify` remain, both deliberate. The pre-loop `cargo package` (the
+whole workspace in the workflow, the ledger crates in the bootstrap) packages
+every crate before *any* is published, so verification there is impossible by
+construction in the workflow and pointless in the bootstrap, whose preflight
+already proved every dependency resolves; it exists to find a packaging failure
 before the first irreversible upload rather than midway through the set. And
 `PUBLISH_NO_VERIFY=true` restores the old loop behaviour for one run, for a
 verification failure that is demonstrably not a broken artifact (a registry
@@ -293,7 +407,8 @@ git push origin rust-v0.1.5
 ```
 
 The workflow first refuses outright if any crate in the release set has no
-crates.io record (see [Outstanding
+crates.io record, or has one that is not locked to Trusted Publishing (see
+[Outstanding
 bootstrap](#outstanding-bootstrap-purrdf-cdt-purrdf-text-purrdf-geo)); that check runs before
 packaging, so a missing record costs a red job rather than a half-published
 release. It then publishes crates in dependency order and skips any

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -161,16 +161,15 @@ and `scripts/check-crates-io-records.sh` refuses any record that is not locked,
 naming the setting to enable. Both refusals, and their valid neighbours, are
 exercised offline by each script's `--self-test` on every `make check`.
 
-#### The deadlock, and the two shapes that break it
+#### The deadlock
 
 Creating a record is a real `cargo publish`, and `cargo publish` — with **or
 without** `--no-verify` — resolves the packaged crate's dependency graph against
 the registry to write its lockfile. The three ledger crates depend on
 `purrdf-iri`, `purrdf-xsd`, `purrdf-core` and `purrdf-sparql-eval`, and as
 dev-dependencies on `purrdf-sparql-results`, `purrdf-rdf`, `purrdf-shapes` and
-`purrdf-sparql-algebra`, all at the workspace version — and those versions can
-only reach crates.io through the trusted lane, which refuses while any record is
-missing. At 0.13.0, verbatim:
+`purrdf-sparql-algebra`, all at the workspace version. At 0.13.0, verbatim, on
+the stable cargo the lane uses and on the pinned nightly alike:
 
 ```text
 $ cargo publish -p purrdf-cdt --no-verify --dry-run --locked
@@ -183,131 +182,165 @@ Caused by:
   required by package `purrdf-cdt v0.13.0 (…/crates/cdt)`
 ```
 
-`--no-verify` skips the build, not the resolve. The bootstrap script's preflight
-checks every path-dependency of every ledger crate at the target version and
-refuses naming the missing ones — that is the failure above, caught before the
-token is even read. `--plan` runs only that preflight and needs no token:
+And the trusted lane cannot simply go first: `purrdf-cdt` is a *normal*
+dependency of `purrdf-core`, `purrdf-sparql-algebra` and `purrdf-sparql-eval`,
+and `purrdf` depends on `purrdf-text` and `purrdf-geo`, so `purrdf-core 0.13.0`
+cannot be published before `purrdf-cdt 0.13.0` exists any more than
+`purrdf-cdt` can before `purrdf-iri`. The two lanes block each other in both
+directions, and the release is published by **interleaving** them.
+
+#### The procedure: the interleave
+
+The trusted lane publishes everything it can, skips each ledger crate, and
+**stops cleanly at the first crate that depends on a skipped one**; the token
+creates that ledger crate's record — its dependencies now exist, so the publish
+is *verified* — the maintainer enables Trusted Publishing on the new record, and
+the same workflow run is re-run and resumes where it stopped. The loop is
+[`scripts/publish-release-crates.sh`](../scripts/publish-release-crates.sh); its
+stop condition is computed from `cargo metadata` over every dependency kind
+(verification resolves dev-dependencies too, and a dev-edge onto a *skipped*
+crate fails exactly like a normal one), never hand-listed, and its `--self-test`
+runs the whole interleave against a mock registry on every `make check`,
+checking each stop against an independently computed first dependent. For the
+current graph that is **three tag runs and two token steps**, because
+`purrdf-text` and `purrdf-geo` share their first dependent (`purrdf`) and are
+created in one token pass.
+
+The workflow is tag-triggered only, so a stopped run is resumed with
+`gh run rerun <run-id>` — same tag, same SHA, same workflow file — never by
+re-pushing the tag. The GitHub Release is created only by the run that reports
+the set complete. The sequence, with the exact commands and the messages to
+expect (`gh run list --workflow release-cargo.yaml` gives the run id):
 
 ```sh
+# 1. Tag. The lane publishes purrdf-events, purrdf-iri, purrdf-xsd, purrdf-gts;
+#    skips purrdf-cdt ("skipping purrdf-cdt: bootstrap pending"); stops with
+#      STOP: purrdf-core 0.13.0 depends on purrdf-cdt 0.13.0 (normal), which is in
+#      PURRDF_UNBOOTSTRAPPED_CRATES and not on crates.io yet.
+#    The job is green; the "Release incomplete" step names what comes next.
+make release-tags VERSION=0.13.0
+
+# 2. Token step 1, from a clean checkout of rust-v0.13.0. The plan says
+#      CREATE RECORD  purrdf-cdt (no crates.io record; dependencies on crates.io: …)
+#      DEFER          purrdf-text (… its dependencies are not on crates.io yet …)
+#      DEFER          purrdf-geo  (…)
+#    and it creates purrdf-cdt, verified.
+git checkout rust-v0.13.0
 scripts/bootstrap-crates-io.sh --plan
+CARGO_REGISTRY_TOKEN="${CARGO_TOKEN}" scripts/bootstrap-crates-io.sh
+
+# 3. On crates.io, for purrdf-cdt: add the Trusted Publisher entry (table above)
+#    AND enable "Require trusted publishing". This release never touches
+#    purrdf-cdt again (it is published), so a missed entry bites at the NEXT
+#    release — a 403 at purrdf-cdt after the crates ahead of it — while a missed
+#    lock makes step 4 refuse in the preflight, by design; and the lock can only
+#    be enabled once the entry exists. Then resume the run:
+gh run rerun <run-id>
+
+# 4. The lane resumes at purrdf-core, publishes through purrdf-validate, skips
+#    purrdf-text and purrdf-geo, and stops with
+#      STOP: purrdf 0.13.0 depends on purrdf-text 0.13.0 (normal),purrdf-geo 0.13.0 (normal), …
+
+# 5. Token step 2 (the plan shows purrdf-cdt as "skip … created by an earlier
+#    run" and CREATE RECORD for purrdf-text and purrdf-geo):
+CARGO_REGISTRY_TOKEN="${CARGO_TOKEN}" scripts/bootstrap-crates-io.sh
+
+# 6. On crates.io, for purrdf-text AND purrdf-geo: Trusted Publisher entry AND
+#    "Require trusted publishing". Then resume once more:
+gh run rerun <run-id>
+#    The lane publishes purrdf and purrdf-wasm, reports
+#      COMPLETE: all 21 release crates are on crates.io at 0.13.0
+#    and creates the GitHub Release.
 ```
 
-Two shapes break the deadlock. **Choosing between them is a maintainer
-decision; this document states their costs and makes neither.**
+After the release: remove the three crates from `PURRDF_UNBOOTSTRAPPED_CRATES`
+and from this section (the offline gate holds the two together), on `main`. Not
+before — the tag's tree is frozen while its release is in flight, which is why
+the preflight tolerates a ledgered crate whose record exists *at the version
+being released* (it reports it as `created … by this release's token step`)
+and still refuses one whose record exists at any other version as stale.
 
-1. **A placeholder record.** Publish, with the token, a dependency-free stub
-   under each of the three names — an empty `lib.rs` at a version below any
-   real release, such as `0.0.0` — from a throwaway crate, *not* from this
-   workspace, whose version is single-sourced and whose crates carry the real
-   dependencies. That creates the records. Add the Trusted Publisher entry and
-   the *Require trusted publishing* lock to each, remove them from the ledger,
-   and push the tag: one `rust-v*` run publishes all 21 crates through the
-   trusted lane, each verified against its published dependencies, with no
-   partial state in between; yank the stubs once the real version is up.
-   Cost: a stub is a version in each crate's history forever — a yanked version
-   stays listed and is never deleted — and the first real artifact is not the
-   first version.
-2. **The real crates at the release version, after their dependencies.** Let
-   the trusted lane publish the eighteen existing crates at the release
-   version, create the three records at that same version with the token, then
-   re-run the tag (the loop skips versions already published). Cost: the
-   preflight exists precisely to refuse a tag while a record is missing, so
-   this shape needs it relaxed for that one release — a deliberate partial
-   publish, the suite split across two versions between runs — and because the
-   ledger crates sit fourth, thirteenth and seventeenth in the order, the
-   stop-create-resume cycle happens three times, not once. Once the
-   dependencies are on the registry the token publish *can* verify, so
-   `--no-verify` buys nothing here; used anyway, it ships the first real
-   artifact of three crates unverified against its published dependencies.
+The bootstrap script is the token step, and only that: it walks the ledger,
+creates in one pass every ledger crate whose dependencies are on crates.io at
+the target version, **defers** the rest by name — with the trusted-lane run
+that will publish their dependencies as the next step — and refuses outright
+when it can create nothing (`REFUSING: nothing can be created yet`), when a
+ledger crate already has a record at another version, or when the ledger is
+empty. `--plan` runs only that preflight and needs no token. It refuses a dirty
+tree by default and skips a ledger crate whose version an earlier pass created.
 
-Neither shape is implemented as a flag. The scripts refuse the current state
-and say why; whichever shape is chosen, the token step is
-`scripts/bootstrap-crates-io.sh` (or a hand-run `cargo publish` of a stub) and
-everything after it is the tag lane.
+#### The shapes that were rejected, and why
+
+**`--no-verify` at the release version, token first.** Proposed on the
+assumption that skipping verification skips dependency resolution. It does
+not: the error above is `cargo publish --no-verify --dry-run`, and it is
+cargo's lockfile resolve, which runs before any upload with or without the
+flag. There is nothing for `--no-verify` to buy at the point the token step
+becomes possible either — the dependencies exist, so the publish verifies.
+
+**A temporary unlock.** Disable *Require trusted publishing* on the eighteen
+existing crates, token-publish all 21 in order with the old whole-set loop,
+re-lock. One run, no workflow change — and 0.13.0 of every crate becomes a
+token publish with no Trusted Publishing provenance, no build-provenance
+attestation and no SBOM attestation (both are made by the workflow), plus
+thirty-six hand flips of a setting whose every change emails every owner.
+That discards the posture the lane exists for.
+
+**A placeholder record.** Token-publish a dependency-free stub (an empty
+`lib.rs` at `0.0.0`) under each name from a throwaway crate, lock it, yank it
+once the real version is up. One tag run, fully verified, no interleave — but a
+yanked version stays in a crate's history forever, and the first real artifact
+of three crates would not be their first version.
 
 #### The preflight
 
-**What that would cost without the preflight, and why the preflight exists.**
-`cargo publish` cannot be undone, and this lane publishes one crate at a time in
-dependency order — so a `rust-v*` tag would irreversibly publish the three crates
-ahead of `purrdf-cdt` and only then fail. `purrdf-cdt` moved that failure point
-EARLIER than any previous new crate did: it is a leaf over `purrdf-iri` +
-`purrdf-xsd`, so it sorts near the front of the dependency order, and the damage
-would stop after three crates rather than after six. **That is the counterfactual,
-not current behaviour**: the preflight described below runs before any packaging
-or publishing, so today a tag pushed in this state costs a red job and publishes
-nothing at all.
-
-This section previously also named `purrdf-datalog`, which has had a crates.io
-record since 2026-07-31 and answers `0.12.0`. That was a stale entry, not a
-missing record, and nothing could see it: the list lived only in this prose. It
-is why the list is now a ledger with two gates on it. Offline,
-`outstanding_bootstrap_claim` in
-[`scripts/check-doc-claims.py`](../scripts/check-doc-claims.py) holds this
-section — heading, crate names, publish-order ordinals and the anchor that links
-here — to `PURRDF_UNBOOTSTRAPPED_CRATES` and `PURRDF_RELEASE_CRATES` on every
-`make check`, so a crate that moves in the release set cannot leave a wrong
-ordinal behind. Online, the preflight below holds the ledger itself to crates.io.
-*Membership* is only ever decided by that second gate: whether a record exists is
-a fact about the registry, not about this tree, and this section must never be
-read in place of running the preflight.
-
-The mechanism that makes it a refusal rather than a partial publish: the release job runs
+The release job runs
 [`scripts/check-crates-io-records.sh`](../scripts/check-crates-io-records.sh)
 **before any packaging or publishing**. For every crate in the release set it
-queries `/api/v1/crates/<name>` and fails the job naming any missing crate and
-the bootstrap command; it holds the ledger to the registry both ways; and it
-reads `trustpub_only` out of every record it finds and fails naming any crate
-that is **not** locked to Trusted Publishing. Run it locally at any time:
+queries `/api/v1/crates/<name>` and:
+
+- **permits** a crate with no record that the ledger names, reporting it as
+  `PENDING … bootstrap pending` — the loop above handles it;
+- **refuses** a crate with no record that the ledger does *not* name — an
+  undocumented bootstrap requirement, which the loop would only skip if the
+  ledger named it;
+- **refuses** a ledgered crate that has a record at any version other than the
+  one being released — a stale ledger entry (this section previously named
+  `purrdf-datalog`, which has had a record since 2026-07-31, for a full cycle,
+  because the list lived only in prose);
+- **refuses** any record that is not locked to Trusted Publishing
+  (`trustpub_only`), naming the setting — the step most easily forgotten
+  between interleave runs.
+
+Run it locally at any time; give it the version so the in-flight tolerance
+applies:
 
 ```sh
-bash scripts/check-crates-io-records.sh
+PURRDF_RELEASE_VERSION=0.13.0 bash scripts/check-crates-io-records.sh
 ```
 
 Only a literal 404 counts as missing: crates.io answers 403 to a default
 `User-Agent`, so the script sends the same `purrdf-release/<version>` agent the
 publish loop uses, retries transient statuses, and treats any other answer as a
-hard stop rather than as "missing".
+hard stop rather than as "missing". Offline, `outstanding_bootstrap_claim` in
+[`scripts/check-doc-claims.py`](../scripts/check-doc-claims.py) holds this
+section — heading, crate names, publish-order ordinals and the anchor that links
+here — to `PURRDF_UNBOOTSTRAPPED_CRATES` and `PURRDF_RELEASE_CRATES` on every
+`make check`. *Membership* is only ever decided by the online gate: whether a
+record exists is a fact about the registry, not about this tree.
 
 What the preflight **cannot** see, so that a green run is not read as more than
 it is: whether a Trusted Publisher entry exists for a crate and points at this
 repository and workflow. crates.io has no public API for those entries. The OIDC
 token the lane exchanges is scoped to the crates whose entries matched, and a
-crate with no entry fails at its **own** `cargo publish` (`The provided access
-token is not valid for crate `<name>``) — after every crate ahead of it has been
-published. Read the loop in
-[`release-cargo.yaml`](../.github/workflows/release-cargo.yaml): it is
-sequential under `set -euo pipefail`, so that failure is a loud stop with a
-partial, re-runnable publish, not a pre-publish refusal. The lock check is the
-closest a preflight gets, because on crates.io the lock can only be enabled from
-a crate's settings page once an entry exists.
-
-**The record itself can only be created by a maintainer**, because creating it
-is a token-authenticated, irreversible outward publish that a Trusted Publisher
-is not permitted to perform. Do it once, from a clean local checkout, before the
-next `rust-v*` tag — once the deadlock above has been broken one way or the other:
-
-```sh
-scripts/bootstrap-crates-io.sh --plan                                 # preflight only
-CARGO_REGISTRY_TOKEN="${CARGO_TOKEN}" scripts/bootstrap-crates-io.sh  # create the records
-```
-
-The version argument is optional and deliberately omitted here: with none given
-the script reads the workspace version out of `cargo metadata`, so this command
-cannot go stale the way a pinned literal in a document does.
-
-The script prints its full plan — which ledger crates it will skip, which it
-refuses, and which records it will **create** — and every refusal, before it
-runs any gate, so the irreversible part is visible while it is still stoppable.
-It then runs the local release gates on the ledger crates, refuses a dirty
-tree by default, skips a ledger crate whose version an earlier run already
-created (so a run stopped by a rate limit resumes), publishes the ledger crates
-in dependency order, and verifies each `cargo publish` against the registry.
-After it completes, on crates.io for each new crate: add the Trusted Publisher
-entry using the table above, enable *Require trusted publishing* so the record
-is locked like its siblings, then remove the crate from
-`PURRDF_UNBOOTSTRAPPED_CRATES` and from this section; the preflight then passes
-and the tag lane works unchanged.
+crate with no entry — including a record the token step just created whose
+entry was not added before the run was re-run — fails at its **own**
+`cargo publish` (`The provided access token is not valid for crate `<name>``),
+after every crate ahead of it has been published: a loud stop under
+`set -euo pipefail` with a partial publish that re-running the run resumes,
+not a pre-publish refusal. The lock check is the closest a preflight gets,
+because on crates.io the lock can only be enabled from a crate's settings page
+once an entry exists.
 
 `purrdf-python`, `purrdf-sparql-conformance`, `purrdf-cli`, and `purrdf-capi`
 remain workspace crates, but they are not in this crates.io release lane.
@@ -319,9 +352,10 @@ is shipped.
 
 #### Verification is on, and why it was off
 
-Each `cargo publish` — in this bootstrap script **and** in the tag-driven
-[`release-cargo.yaml`](../.github/workflows/release-cargo.yaml) loop, which is
-the same loop under an OIDC token — **verifies**: cargo unpacks the `.crate` it
+Each `cargo publish` — in the bootstrap script **and** in the tag lane's loop
+([`scripts/publish-release-crates.sh`](../scripts/publish-release-crates.sh),
+run by [`release-cargo.yaml`](../.github/workflows/release-cargo.yaml) under an
+OIDC token) — **verifies**: cargo unpacks the `.crate` it
 is about to upload and builds it against the registry, so a wrong-version or
 broken artifact is refused *before* the one step that cannot be undone. Both
 loops used to pass `--no-verify`, and that flag was **load-bearing**, not
@@ -407,13 +441,14 @@ git push origin rust-v0.1.5
 ```
 
 The workflow first refuses outright if any crate in the release set has no
-crates.io record, or has one that is not locked to Trusted Publishing (see
-[Outstanding
-bootstrap](#outstanding-bootstrap-purrdf-cdt-purrdf-text-purrdf-geo)); that check runs before
-packaging, so a missing record costs a red job rather than a half-published
-release. It then publishes crates in dependency order and skips any
-crate/version that already exists on crates.io, which keeps reruns safe after a
-partial publish.
+crates.io record and is not in the bootstrap ledger, or has a record that is
+not locked to Trusted Publishing (see [Outstanding
+bootstrap](#outstanding-bootstrap-purrdf-cdt-purrdf-text-purrdf-geo)); that
+check runs before packaging. It then publishes crates in dependency order,
+skips any crate/version that already exists on crates.io (which keeps re-runs
+safe after a partial publish), skips ledgered crates, and stops cleanly at the
+first crate that depends on one — the interleave described there — resuming
+with `gh run rerun <run-id>`.
 
 ## PyPI Release
 

--- a/docs/book/src/project/releases.md
+++ b/docs/book/src/project/releases.md
@@ -52,6 +52,17 @@ cargo lane:
   publishing;
 - every workspace crate version must match the tag version.
 
+Every version of every crate — all 21 — is published by that lane and nothing
+else. Each existing crate record is locked on crates.io with *Require trusted
+publishing* (`trustpub_only`), so an API token cannot publish a new version of
+any of them: crates.io answers with `403 Forbidden: New versions of this crate
+can only be published using Trusted Publishing`. A token has exactly one role
+left, creating the record of a brand-new crate — the one thing a Trusted
+Publishing token is refused (`Trusted Publishing tokens do not support creating
+new crates`) — and the release process document above is exact about how that
+bootstrap works, what it cannot do while the new crate's dependencies are not
+on the registry yet, and the two shapes that break that deadlock.
+
 Four workspace members are deliberately never published to crates.io:
 `purrdf-capi` (built via cargo-c, distributed as `libpurrdf`),
 `purrdf-sparql-conformance` (the test harness), `purrdf-cli` (the `purrdf`

--- a/docs/book/src/project/releases.md
+++ b/docs/book/src/project/releases.md
@@ -60,8 +60,9 @@ can only be published using Trusted Publishing`. A token has exactly one role
 left, creating the record of a brand-new crate — the one thing a Trusted
 Publishing token is refused (`Trusted Publishing tokens do not support creating
 new crates`) — and the release process document above is exact about how that
-bootstrap works, what it cannot do while the new crate's dependencies are not
-on the registry yet, and the two shapes that break that deadlock.
+bootstrap works: the lane publishes up to the first crate that depends on a
+new one and stops cleanly, the token creates the new crate's record, Trusted
+Publishing is enabled on it, and the same run is resumed.
 
 Four workspace members are deliberately never published to crates.io:
 `purrdf-capi` (built via cargo-c, distributed as `libpurrdf`),

--- a/scripts/bootstrap-crates-io.sh
+++ b/scripts/bootstrap-crates-io.sh
@@ -42,12 +42,16 @@
 #         candidate versions found which didn't match: 0.12.0, 0.11.0, 0.10.0, ...
 #
 # (`cargo publish -p purrdf-cdt --no-verify --dry-run` at 0.13.0, verbatim.)
-# `--no-verify` skips the BUILD, not the resolve. Those dependencies can only
-# reach crates.io through the trusted lane, which refuses while any record is
-# missing — the deadlock docs/RELEASE.md's bootstrap section lays out, with the
-# two shapes that break it. This script checks every dependency BEFORE any
-# gate, names the missing ones, and stops; it never discovers them one upload
-# in.
+# `--no-verify` skips the BUILD, not the resolve. Those dependencies reach
+# crates.io through the trusted lane, which publishes up to the first crate
+# that depends on a ledger crate and STOPS (scripts/publish-release-crates.sh)
+# — that is the token step's cue. So this script creates, in one pass, every
+# ledger crate whose dependencies are on crates.io at the target version,
+# VERIFIED (the dependencies exist, so nothing needs `--no-verify`), DEFERS
+# every ledger crate whose dependencies are not up yet — naming them and the
+# trusted-lane run that will publish them — and refuses outright only when it
+# can create nothing. That is the interleave in docs/RELEASE.md, "Outstanding
+# bootstrap".
 #
 # Usage:
 #   scripts/bootstrap-crates-io.sh [VERSION]          create the ledger records
@@ -205,7 +209,7 @@ EOF
     return 1
   fi
 
-  local -a to_create=() to_skip=() has_record=() missing_deps=() not_in_set=()
+  local -a to_create=() to_skip=() has_record=() deferred=() not_in_set=()
   local crate idx dep_line kind dep dep_state state
 
   echo "crates.io bootstrap plan for ${VERSION} (ledger: ${crates[*]}):"
@@ -237,11 +241,12 @@ EOF
       [[ -z "$dep_line" ]] && continue
       kind="${dep_line%% *}"
       dep="${dep_line#* }"
-      # A dependency that is itself an EARLIER ledger entry is created by this
-      # same run before this crate is reached; a later one is an ordering bug
-      # check-publish-order.py refuses, and is reported as missing here too.
-      if in_list "$dep" "${crates[@]:0:$idx}"; then
-        deps_ok+=("${dep} (${kind}; created earlier in this run)")
+      # A dependency that is itself an EARLIER ledger entry and is being
+      # created (or already exists) in this pass is satisfied; one that is
+      # deferred is not — and a LATER one is an ordering bug
+      # check-publish-order.py refuses, reported as missing here too.
+      if in_list "$dep" "${crates[@]:0:$idx}" && in_list "$dep" "${to_create[@]}" "${to_skip[@]}"; then
+        deps_ok+=("${dep} (${kind}; created earlier in this pass)")
         continue
       fi
       dep_state="$(version_state "$dep")"
@@ -250,11 +255,11 @@ EOF
         deps_ok+=("${dep} ${VERSION} (${kind})")
       else
         deps_missing+=("${dep} ${VERSION} (${kind})")
-        missing_deps+=("${crate} needs ${dep} ${VERSION} (${kind} dependency) — not on crates.io")
       fi
     done < <(workspace_path_deps "$crate")
     if [[ "${#deps_missing[@]}" -gt 0 ]]; then
-      printf '  BLOCKED        %s (no record; cannot be uploaded: %s)\n' "$crate" "$(IFS=,; echo "${deps_missing[*]}")"
+      printf '  DEFER          %s (no record; its dependencies are not on crates.io yet: %s — the next trusted-lane run publishes them)\n' "$crate" "$(IFS=,; echo "${deps_missing[*]}")"
+      deferred+=("${crate} waits on $(IFS=,; echo "${deps_missing[*]}")")
     else
       printf '  CREATE RECORD  %s (no crates.io record; dependencies on crates.io: %s)\n' "$crate" "$(IFS=,; echo "${deps_ok[*]:-none}")"
       to_create+=("$crate")
@@ -291,23 +296,22 @@ registry in both directions. Fix the ledger, never the registry.
 EOF
     } >&2
   fi
-  if [[ "${#missing_deps[@]}" -gt 0 ]]; then
+  if [[ "${#deferred[@]}" -gt 0 && "${#to_create[@]}" -eq 0 && "${#to_skip[@]}" -eq 0 && "$failed" == "false" ]]; then
     failed=true
     {
       echo
-      echo "REFUSING: these ledger crates depend on versions crates.io does not have:"
-      for dep in "${missing_deps[@]}"; do echo "  - ${dep}"; done
+      echo "REFUSING: nothing can be created yet — every ledger crate depends on versions crates.io does not have:"
+      for dep in "${deferred[@]}"; do echo "  - ${dep}"; done
       cat <<EOF
 
 \`cargo publish\` resolves the packaged crate's dependency graph against the
 registry to write its lockfile — with or without --no-verify — so each crate
 above would fail with "failed to select a version for the requirement" before
-anything is uploaded. Those dependencies are existing crates, which only the
-Trusted Publishing lane can publish, and that lane refuses while any release
-crate lacks a record. docs/RELEASE.md, "Outstanding bootstrap", lays out the
-two shapes that break this deadlock: a dependency-free placeholder record,
-or publishing the rest of the set at ${VERSION} ahead of the ledger crates.
-Neither is this script's decision to make.
+anything is uploaded. Those dependencies are published by the trusted lane:
+push (or re-run) the rust-v${VERSION} tag first. Its publish loop
+(scripts/publish-release-crates.sh) publishes everything up to the first crate
+that depends on a ledger crate, then STOPS and names this script as the next
+step; run it again then. docs/RELEASE.md, "Outstanding bootstrap".
 EOF
     } >&2
   fi
@@ -317,17 +321,20 @@ EOF
 
   echo
   if [[ "${#to_create[@]}" -eq 0 ]]; then
-    echo "Nothing left to create at ${VERSION}: ${to_skip[*]} already exist. Remove them from the ledger and push the rust-v* tag."
+    echo "Nothing to create at ${VERSION} in this pass: ${to_skip[*]} already exist${deferred[0]:+; deferred: ${#deferred[@]} (see above)}."
+    echo "Next: re-run the rust-v${VERSION} workflow run (gh run rerun <run-id>); it resumes where it stopped."
     return 0
   fi
   cat <<EOF
-${#to_create[@]} crate record(s) will be CREATED by this token: ${to_create[*]}
-Creating a record is permanent. Afterwards, for each new crate on crates.io:
+${#to_create[@]} crate record(s) will be CREATED by this token in this pass: ${to_create[*]}
+${deferred[0]:+deferred to a later pass (dependencies not up yet): ${#deferred[@]} — see DEFER above
+}Creating a record is permanent. Afterwards, on crates.io, for EACH new crate:
 add the Trusted Publisher entry (GitHub Actions / Blackcat-Informatics /
-purrdf / release-cargo.yaml / no environment), enable "Require trusted
-publishing" so the record is locked like its siblings, and remove the crate
-from PURRDF_UNBOOTSTRAPPED_CRATES. The rust-v* lane refuses until then, by
-design (scripts/check-crates-io-records.sh).
+purrdf / release-cargo.yaml / no environment) and enable "Require trusted
+publishing" so the record is locked like its siblings — this release does not
+touch the crate again, but the next release's run would 403 at it without the
+entry, and the preflight refuses it without the lock. Then re-run the rust-v${VERSION}
+workflow run (gh run rerun <run-id>): it resumes at the crate it stopped on.
 EOF
 }
 
@@ -427,14 +434,43 @@ self_test() {
     while IFS= read -r dep_line; do
       [[ -z "$dep_line" ]] && continue
       dep="${dep_line#* }"
-      in_list "$dep" "${fixture[@]}" || expect_missing+=("${crate} needs ${dep} ${VERSION}")
+      in_list "$dep" "${fixture[@]}" || expect_missing+=("${crate} waits on")
+      in_list "$dep" "${fixture[@]}" || expect_missing+=("${dep} ${VERSION} (${dep_line%% *})")
     done < <(workspace_path_deps "$crate")
   done
-  arm "ledger crates' dependencies absent at ${VERSION}" refuse \
+  arm "every ledger crate's dependencies absent at ${VERSION}: nothing creatable" refuse \
     "$mock" "$(ledger_file absent "${fixture[@]}")" \
-    "REFUSING: these ledger crates depend on versions crates.io does not have" \
+    "REFUSING: nothing can be created yet" \
     "failed to select a version for the requirement" \
+    "scripts/publish-release-crates.sh" \
     "${expect_missing[@]}"
+
+  # 2b. Token step 1 of the interleave: the FIRST ledger crate's dependencies
+  #     are up (the trusted lane stopped at its first dependent), the others'
+  #     are not — create the first, DEFER the rest, proceed.
+  mock="${tmp}/step1"; mkdir -p "$mock"
+  while IFS= read -r dep_line; do
+    [[ -n "$dep_line" ]] && version "$mock" "${dep_line#* }"
+  done < <(workspace_path_deps "${fixture[0]}")
+  local -a expect_step1=("CREATE RECORD  ${fixture[0]} (no crates.io record")
+  local -a others=("${fixture[@]:1}")
+  for crate in "${others[@]}"; do
+    # A later ledger crate whose dependencies happen to be a subset of the
+    # first's would be creatable too; only assert DEFER for those that are not.
+    local deferred_here=false
+    while IFS= read -r dep_line; do
+      [[ -z "$dep_line" ]] && continue
+      dep="${dep_line#* }"
+      in_list "$dep" "${fixture[@]}" && continue
+      [[ -f "${mock}/${dep}@${VERSION}" ]] || deferred_here=true
+    done < <(workspace_path_deps "$crate")
+    [[ "$deferred_here" == "true" ]] && expect_step1+=("DEFER          ${crate} (no record; its dependencies are not on crates.io yet")
+  done
+  arm "token step 1: ${fixture[0]}'s dependencies present, the rest deferred" pass \
+    "$mock" "$(ledger_file step1 "${fixture[@]}")" \
+    "1 crate record(s) will be CREATED by this token in this pass: ${fixture[0]}" \
+    "gh run rerun" \
+    "${expect_step1[@]}"
 
   # 3. The valid path: no records, every dependency present — the plan proceeds
   #    and names every ledger crate as a record to CREATE.
@@ -444,7 +480,7 @@ self_test() {
   for crate in "${fixture[@]}"; do expect_create+=("CREATE RECORD  ${crate} (no crates.io record"); done
   arm "valid: no records, dependencies present" pass \
     "$mock" "$(ledger_file valid "${fixture[@]}")" \
-    "${#fixture[@]} crate record(s) will be CREATED by this token" \
+    "${#fixture[@]} crate record(s) will be CREATED by this token in this pass" \
     "${expect_create[@]}"
 
   # 4. Resumability: the first ledger crate was created at VERSION by an
@@ -606,12 +642,16 @@ cat <<EOF
 
 Created crates.io record(s): ${created[*]:-none}
 
-This token's job is done; it cannot publish another version of these crates
-once they are locked. Now, on crates.io, for each of them:
+This token's job for them is done; it cannot publish another version once
+they are locked. Now, on crates.io, for EACH of them:
   1. add the Trusted Publisher entry (GitHub Actions / Blackcat-Informatics /
      purrdf / release-cargo.yaml / no environment);
-  2. enable "Require trusted publishing" (trustpub_only), as on every sibling;
-then remove them from PURRDF_UNBOOTSTRAPPED_CRATES in scripts/release-crates.sh,
-update the "Outstanding bootstrap" section of docs/RELEASE.md that
-scripts/check-doc-claims.py derives from it, and push the rust-v* tag.
+  2. enable "Require trusted publishing" (trustpub_only), as on every sibling
+     — the next release's run would 403 at the crate without the entry, and
+     the preflight refuses it without the lock;
+then re-run the rust-v${VERSION} workflow run (gh run rerun <run-id>): it
+resumes at the crate it stopped on. If it stops again, run this script again
+for the ledger crates it deferred. After the release is complete, remove the
+new crates from PURRDF_UNBOOTSTRAPPED_CRATES in scripts/release-crates.sh and
+from the "Outstanding bootstrap" section of docs/RELEASE.md.
 EOF

--- a/scripts/bootstrap-crates-io.sh
+++ b/scripts/bootstrap-crates-io.sh
@@ -1,43 +1,521 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 # SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# Create the crates.io RECORDS the release lane cannot create — and nothing else.
+#
+# What a crates.io API token can do for this workspace, and what it cannot:
+#
+#   * It CAN create a crate record: the first-ever publish of a brand-new crate
+#     name. crates.io's own publish handler refuses that from the OIDC lane —
+#     "Trusted Publishing tokens do not support creating new crates. Publish
+#     the crate manually, first" — so a new crate always needs one token
+#     publish before a `rust-v*` tag can carry it.
+#   * It CANNOT publish a new version of any existing PurRDF crate. Every
+#     existing record is locked to Trusted Publishing (`trustpub_only`, visible
+#     in the public record JSON), and crates.io answers a token publish with:
+#
+#       error: failed to publish purrdf-events v0.13.0 to registry at https://crates.io
+#       Caused by:
+#         the remote server responded with an error (status 403 Forbidden):
+#         New versions of this crate can only be published using Trusted
+#         Publishing (see https://crates.io/docs/trusted-publishing).
+#
+#     That is the verbatim answer the previous version of this script met on
+#     its FIRST upload, at the front of a 21-crate loop. It failed safe (nothing
+#     landed), but a token lane that walks into eighteen 403s is wrong, not
+#     strict.
+#
+# So this script iterates PURRDF_UNBOOTSTRAPPED_CRATES — the committed ledger
+# of release crates with no record — and REFUSES to touch any crate that has
+# one. Every later version of every crate, the three new ones included, goes
+# through the tag-driven Trusted Publishing lane (.github/workflows/release-cargo.yaml).
+#
+# The second refusal, and why it is here. `cargo publish` — with OR without
+# `--no-verify` — resolves the packaged crate's dependency graph against the
+# registry to write its lockfile, so a ledger crate whose path-dependencies are
+# not on crates.io at the target version cannot be uploaded at all:
+#
+#       error: failed to prepare local package for uploading
+#       Caused by:
+#         failed to select a version for the requirement `purrdf-iri = "^0.13.0"`
+#         candidate versions found which didn't match: 0.12.0, 0.11.0, 0.10.0, ...
+#
+# (`cargo publish -p purrdf-cdt --no-verify --dry-run` at 0.13.0, verbatim.)
+# `--no-verify` skips the BUILD, not the resolve. Those dependencies can only
+# reach crates.io through the trusted lane, which refuses while any record is
+# missing — the deadlock docs/RELEASE.md's bootstrap section lays out, with the
+# two shapes that break it. This script checks every dependency BEFORE any
+# gate, names the missing ones, and stops; it never discovers them one upload
+# in.
+#
+# Usage:
+#   scripts/bootstrap-crates-io.sh [VERSION]          create the ledger records
+#   scripts/bootstrap-crates-io.sh [VERSION] --plan   the preflight and plan only:
+#                                                     no token, no gates, no publish
+#   scripts/bootstrap-crates-io.sh --self-test        every refusal, and the
+#                                                     valid path, against a mock
+#                                                     registry (offline)
+#
+# VERSION defaults to the workspace version. Environment:
+#   CARGO_REGISTRY_TOKEN / CARGO_TOKEN   required for a publish run
+#   ALLOW_DIRTY=true                     publish from a dirty tree (default: refuse)
+#   PUBLISH_NO_VERIFY=true               skip `cargo publish`'s verification build
+#   PUBLISH_COOLDOWN_SECONDS=N           pause after each created record (default 0)
+#   PURRDF_RELEASE_CRATES_FILE           an alternative release-set/ledger file
+#                                        (self-test only; default scripts/release-crates.sh)
+#   PURRDF_CRATES_IO_MOCK                a mock registry directory (scripts/crates-io-api.sh)
 
 set -euo pipefail
 
-VERSION="${1:-}"
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+mode="publish"
+VERSION=""
+for arg in "$@"; do
+  case "$arg" in
+    --plan) mode="plan" ;;
+    --self-test) mode="self-test" ;;
+    -h | --help)
+      sed -n '/^# Usage:/,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    -*)
+      echo "unknown option: ${arg}" >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n "${VERSION}" ]]; then
+        echo "more than one version given: ${VERSION} and ${arg}" >&2
+        exit 2
+      fi
+      VERSION="$arg"
+      ;;
+  esac
+done
+
+# `cargo metadata --no-deps`, read once. The workspace version comes from it,
+# and so does every ledger crate's path-dependency list (below).
+metadata_json="$(mktemp)"
+trap 'rm -f "${metadata_json}" "${CRATES_IO_BODY:-}"' EXIT
+(cd "${repo}" && cargo metadata --no-deps --format-version 1) > "${metadata_json}"
 if [[ -z "${VERSION}" ]]; then
-  VERSION="$(cargo metadata --no-deps --format-version 1 \
-    | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')"
+  VERSION="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["packages"][0]["version"])' "${metadata_json}")"
 fi
+
+# One definition of the release set AND of the ledger, shared with the release
+# workflow and with scripts/check-crates-io-records.sh. The release set is read
+# only to place ledger crates in publish order; this script walks the LEDGER.
+release_list="${PURRDF_RELEASE_CRATES_FILE:-${repo}/scripts/release-crates.sh}"
+# shellcheck source=scripts/release-crates.sh
+source "${release_list}"
+# shellcheck source=scripts/crates-io-api.sh
+source "${repo}/scripts/crates-io-api.sh"
+crates=("${PURRDF_UNBOOTSTRAPPED_CRATES[@]}")
+release_set=("${PURRDF_RELEASE_CRATES[@]}")
+user_agent="$(crates_io_user_agent "${VERSION}")"
+
 # Pause after publishing a crate that CREATED a new crates.io record, before
-# the next publish. Default 0, for two reasons. First, crates.io's new-crate
-# rate limit is enforced AT the publish: a limited `cargo publish` exits
-# non-zero on the registry's 429, `set -e` stops this script before the next
-# crate, nothing is half-uploaded, and a re-run resumes because every version
-# already published is skipped above — so a hit limit is a visible, resumable
-# refusal, not a corrupted release. Second, the limit is a burst allowance
-# refilled at one new crate per ten minutes, and the old default of 620 s was
-# that refill interval plus slack: it modelled the WORST case (burst already
-# spent) unconditionally, adding ~31 minutes of dead time to a three-record
-# run whose every other step is observable. Set PUBLISH_COOLDOWN_SECONDS=620
-# only if a run actually meets a 429 with several records still to create.
+# the next publish. Default 0: crates.io's new-crate rate limit is enforced AT
+# the publish — a limited `cargo publish` exits non-zero on the registry's 429,
+# `set -e` stops this script before the next crate, nothing is half-uploaded,
+# and a re-run resumes because every record already created is skipped. The
+# old default of 620 s modelled the limit's ten-minute refill unconditionally
+# and added ~31 minutes of dead time to a three-record run. Set it only if a
+# run actually meets a 429 with records still to create.
 PUBLISH_COOLDOWN_SECONDS="${PUBLISH_COOLDOWN_SECONDS:-0}"
 # Set PUBLISH_NO_VERIFY=true to skip `cargo publish`'s verification build. See
-# the comment above the publish loop for why the default is to verify.
+# the comment above the publish loop for why the default is to verify — and
+# the header for why the flag does NOT get a crate past missing dependencies.
 PUBLISH_NO_VERIFY="${PUBLISH_NO_VERIFY:-false}"
+
+# ---------------------------------------------------------------------------
+# Registry questions. Any answer other than present/missing is a hard stop —
+# never read as "missing", because "missing" is what licenses a record CREATE.
+# ---------------------------------------------------------------------------
+
+# registry_or_die <state>: present/missing pass through; anything else stops.
+# Called in the PARENT shell after every capture, never inside the captured
+# function: an `exit` inside `$(...)` only ends the subshell, and the parent
+# would read the empty answer as "not present" — the one misreading that
+# licenses a record CREATE.
+registry_or_die() {
+  local state="$1"
+  case "$state" in
+    present | missing) ;;
+    *)
+      echo "crates.io preflight could not reach a verdict — ${state#error: }" >&2
+      echo "Refusing to continue: an unknown registry answer is a stop, never \"probably fine\"." >&2
+      exit 1
+      ;;
+  esac
+}
+
+record_state() {
+  crates_io_record_state "$1" "${user_agent}"
+}
+
+version_state() {
+  crates_io_version_state "$1" "${VERSION}" "${user_agent}"
+}
+
+# workspace_path_deps <crate>: one "<kind> <name>" line per PATH dependency of
+# the crate, every kind — `cargo publish` resolves the packaged crate's whole
+# graph, dev-dependencies included, to write its lockfile, so every kind must
+# exist on the registry at the target version.
+workspace_path_deps() {
+  python3 - "${metadata_json}" "$1" <<'PY'
+import json
+import sys
+
+metadata = json.load(open(sys.argv[1], encoding="utf-8"))
+for package in metadata["packages"]:
+    if package["name"] != sys.argv[2]:
+        continue
+    for dep in package["dependencies"]:
+        if dep.get("path"):
+            print(dep["kind"] or "normal", dep["name"])
+PY
+}
+
+in_list() {
+  local needle="$1"
+  shift
+  local item
+  for item in "$@"; do
+    [[ "$item" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Preflight + plan. Runs before the token check, before the gates, before
+# anything irreversible — and is the whole of `--plan`.
+# ---------------------------------------------------------------------------
+
+preflight() {
+  if [[ "${#crates[@]}" -eq 0 ]]; then
+    cat >&2 <<EOF
+PURRDF_UNBOOTSTRAPPED_CRATES in ${release_list} is empty: nothing to bootstrap.
+
+Every crate in the release set has a crates.io record, and a token cannot
+publish a new version of an existing record (crates.io: "New versions of this
+crate can only be published using Trusted Publishing"). Push a rust-v* tag.
+EOF
+    return 1
+  fi
+
+  local -a to_create=() to_skip=() has_record=() missing_deps=() not_in_set=()
+  local crate idx dep_line kind dep dep_state state
+
+  echo "crates.io bootstrap plan for ${VERSION} (ledger: ${crates[*]}):"
+  for idx in "${!crates[@]}"; do
+    crate="${crates[$idx]}"
+    if ! in_list "$crate" "${release_set[@]}"; then
+      printf '  REFUSE         %s (in the ledger but not in the release set)\n' "$crate"
+      not_in_set+=("$crate")
+      continue
+    fi
+    state="$(record_state "$crate")"
+    registry_or_die "$state"
+    if [[ "$state" == "present" ]]; then
+      local locked
+      locked="$(crates_io_trustpub_only)"
+      state="$(version_state "$crate")"
+      registry_or_die "$state"
+      if [[ "$state" == "present" ]]; then
+        printf '  skip           %s (%s already on crates.io: created by an earlier run — remove it from PURRDF_UNBOOTSTRAPPED_CRATES)\n' "$crate" "${VERSION}"
+        to_skip+=("$crate")
+      else
+        printf '  REFUSE         %s (crate record exists, trustpub_only=%s)\n' "$crate" "$locked"
+        has_record+=("${crate} (trustpub_only=${locked})")
+      fi
+      continue
+    fi
+    local -a deps_ok=() deps_missing=()
+    while IFS= read -r dep_line; do
+      [[ -z "$dep_line" ]] && continue
+      kind="${dep_line%% *}"
+      dep="${dep_line#* }"
+      # A dependency that is itself an EARLIER ledger entry is created by this
+      # same run before this crate is reached; a later one is an ordering bug
+      # check-publish-order.py refuses, and is reported as missing here too.
+      if in_list "$dep" "${crates[@]:0:$idx}"; then
+        deps_ok+=("${dep} (${kind}; created earlier in this run)")
+        continue
+      fi
+      dep_state="$(version_state "$dep")"
+      registry_or_die "$dep_state"
+      if [[ "$dep_state" == "present" ]]; then
+        deps_ok+=("${dep} ${VERSION} (${kind})")
+      else
+        deps_missing+=("${dep} ${VERSION} (${kind})")
+        missing_deps+=("${crate} needs ${dep} ${VERSION} (${kind} dependency) — not on crates.io")
+      fi
+    done < <(workspace_path_deps "$crate")
+    if [[ "${#deps_missing[@]}" -gt 0 ]]; then
+      printf '  BLOCKED        %s (no record; cannot be uploaded: %s)\n' "$crate" "$(IFS=,; echo "${deps_missing[*]}")"
+    else
+      printf '  CREATE RECORD  %s (no crates.io record; dependencies on crates.io: %s)\n' "$crate" "$(IFS=,; echo "${deps_ok[*]:-none}")"
+      to_create+=("$crate")
+    fi
+  done
+
+  local failed=false
+  if [[ "${#not_in_set[@]}" -gt 0 ]]; then
+    failed=true
+    {
+      echo
+      echo "REFUSING: these ledger entries are not release crates: ${not_in_set[*]}"
+      echo "PURRDF_UNBOOTSTRAPPED_CRATES must name crates in PURRDF_RELEASE_CRATES (scripts/check-publish-order.py gates this offline)."
+    } >&2
+  fi
+  if [[ "${#has_record[@]}" -gt 0 ]]; then
+    failed=true
+    {
+      echo
+      echo "REFUSING: these ledger crates already have a crates.io record:"
+      for crate in "${has_record[@]}"; do echo "  - ${crate}"; done
+      cat <<'EOF'
+
+A token cannot publish a new version of an existing PurRDF crate. Every
+existing record is locked to Trusted Publishing, and crates.io answers a token
+publish with (status 403 Forbidden):
+  New versions of this crate can only be published using Trusted Publishing
+— the answer the 21-crate version of this script met on its first upload.
+New versions go through the rust-v* tag lane.
+
+PURRDF_UNBOOTSTRAPPED_CRATES in scripts/release-crates.sh is a ledger of
+crates WITHOUT a record; scripts/check-crates-io-records.sh holds it to the
+registry in both directions. Fix the ledger, never the registry.
+EOF
+    } >&2
+  fi
+  if [[ "${#missing_deps[@]}" -gt 0 ]]; then
+    failed=true
+    {
+      echo
+      echo "REFUSING: these ledger crates depend on versions crates.io does not have:"
+      for dep in "${missing_deps[@]}"; do echo "  - ${dep}"; done
+      cat <<EOF
+
+\`cargo publish\` resolves the packaged crate's dependency graph against the
+registry to write its lockfile — with or without --no-verify — so each crate
+above would fail with "failed to select a version for the requirement" before
+anything is uploaded. Those dependencies are existing crates, which only the
+Trusted Publishing lane can publish, and that lane refuses while any release
+crate lacks a record. docs/RELEASE.md, "Outstanding bootstrap", lays out the
+two shapes that break this deadlock: a dependency-free placeholder record,
+or publishing the rest of the set at ${VERSION} ahead of the ledger crates.
+Neither is this script's decision to make.
+EOF
+    } >&2
+  fi
+  if [[ "$failed" == "true" ]]; then
+    return 1
+  fi
+
+  echo
+  if [[ "${#to_create[@]}" -eq 0 ]]; then
+    echo "Nothing left to create at ${VERSION}: ${to_skip[*]} already exist. Remove them from the ledger and push the rust-v* tag."
+    return 0
+  fi
+  cat <<EOF
+${#to_create[@]} crate record(s) will be CREATED by this token: ${to_create[*]}
+Creating a record is permanent. Afterwards, for each new crate on crates.io:
+add the Trusted Publisher entry (GitHub Actions / Blackcat-Informatics /
+purrdf / release-cargo.yaml / no environment), enable "Require trusted
+publishing" so the record is locked like its siblings, and remove the crate
+from PURRDF_UNBOOTSTRAPPED_CRATES. The rust-v* lane refuses until then, by
+design (scripts/check-crates-io-records.sh).
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Self-test: every refusal above, and the valid path, against a mock registry.
+# ---------------------------------------------------------------------------
+
+self_test() {
+  local tmp
+  tmp="$(mktemp -d)"
+  # shellcheck disable=SC2064  # expand now: tmp is what to remove.
+  trap "rm -rf '${tmp}'; rm -f '${metadata_json}'" EXIT
+  local failures=0
+
+  # The fixture ledger: the real one when it is non-empty, else the last two
+  # release crates, so the arms below still exercise dependency handling after
+  # the real ledger has been drained.
+  local -a fixture
+  if [[ "${#crates[@]}" -gt 0 ]]; then
+    fixture=("${crates[@]}")
+  else
+    fixture=("${release_set[@]: -2}")
+  fi
+
+  # ledger_file <name> <crate>... : the real release set with the ledger replaced.
+  ledger_file() {
+    local name="$1"
+    shift
+    {
+      cat "${repo}/scripts/release-crates.sh"
+      printf '\nPURRDF_UNBOOTSTRAPPED_CRATES=(%s)\n' "$*"
+    } > "${tmp}/${name}.sh"
+    echo "${tmp}/${name}.sh"
+  }
+
+  # record <dir> <crate> <trustpub_only>; version <dir> <crate>
+  record() {
+    printf '200\n{"crate":{"name":"%s","trustpub_only":%s}}\n' "$2" "$3" > "$1/$2"
+  }
+  version() {
+    printf '200\n{"version":{"crate":"%s","num":"%s"}}\n' "$2" "${VERSION}" > "$1/$2@${VERSION}"
+  }
+  # deps_present <dir>: every path-dependency of every fixture crate, at VERSION.
+  deps_present() {
+    local crate dep_line
+    for crate in "${fixture[@]}"; do
+      while IFS= read -r dep_line; do
+        [[ -n "$dep_line" ]] && version "$1" "${dep_line#* }"
+      done < <(workspace_path_deps "$crate")
+    done
+  }
+
+  # arm <label> <expect: pass|refuse> <mock-dir> <ledger-file> <must-mention>...
+  arm() {
+    local label="$1" expect="$2" mock="$3" ledger="$4"
+    shift 4
+    local out status=0
+    out="$(PURRDF_CRATES_IO_MOCK="${mock}" PURRDF_RELEASE_CRATES_FILE="${ledger}" \
+      bash "${BASH_SOURCE[0]}" "${VERSION}" --plan 2>&1)" || status=$?
+    local ok=true
+    if [[ "$expect" == "pass" && "$status" -ne 0 ]]; then ok=false; fi
+    if [[ "$expect" == "refuse" && "$status" -eq 0 ]]; then ok=false; fi
+    local needle
+    for needle in "$@"; do
+      if ! grep -qF -- "$needle" <<<"$out"; then
+        ok=false
+        echo "    output does not mention: ${needle}"
+      fi
+    done
+    if [[ "$ok" == "true" ]]; then
+      printf '  ok      %s (exit %s)\n' "$label" "$status"
+    else
+      printf '  FAILED  %s (exit %s, expected %s)\n' "$label" "$status" "$expect"
+      while IFS= read -r line; do printf '    | %s\n' "$line"; done <<<"$out"
+      failures=$((failures + 1))
+    fi
+  }
+
+  echo "bootstrap-crates-io.sh self-test (fixture ledger: ${fixture[*]}; version ${VERSION})"
+  local existing="${release_set[0]}"
+  local mock
+
+  # 1. A ledger naming a crate that HAS a record: refuse, naming it.
+  mock="${tmp}/existing"; mkdir -p "$mock"
+  record "$mock" "$existing" true
+  arm "ledger names an existing crate (${existing}, trustpub_only=true)" refuse \
+    "$mock" "$(ledger_file existing "$existing")" \
+    "REFUSE         ${existing} (crate record exists, trustpub_only=true)" \
+    "New versions of this crate can only be published using Trusted Publishing"
+
+  # 2. The ledger with every dependency absent at VERSION: refuse, naming
+  #    every missing dependency of every ledger crate.
+  mock="${tmp}/deps-absent"; mkdir -p "$mock"
+  local -a expect_missing=()
+  local crate dep_line dep
+  for crate in "${fixture[@]}"; do
+    while IFS= read -r dep_line; do
+      [[ -z "$dep_line" ]] && continue
+      dep="${dep_line#* }"
+      in_list "$dep" "${fixture[@]}" || expect_missing+=("${crate} needs ${dep} ${VERSION}")
+    done < <(workspace_path_deps "$crate")
+  done
+  arm "ledger crates' dependencies absent at ${VERSION}" refuse \
+    "$mock" "$(ledger_file absent "${fixture[@]}")" \
+    "REFUSING: these ledger crates depend on versions crates.io does not have" \
+    "failed to select a version for the requirement" \
+    "${expect_missing[@]}"
+
+  # 3. The valid path: no records, every dependency present — the plan proceeds
+  #    and names every ledger crate as a record to CREATE.
+  mock="${tmp}/valid"; mkdir -p "$mock"
+  deps_present "$mock"
+  local -a expect_create=()
+  for crate in "${fixture[@]}"; do expect_create+=("CREATE RECORD  ${crate} (no crates.io record"); done
+  arm "valid: no records, dependencies present" pass \
+    "$mock" "$(ledger_file valid "${fixture[@]}")" \
+    "${#fixture[@]} crate record(s) will be CREATED by this token" \
+    "${expect_create[@]}"
+
+  # 4. Resumability: the first ledger crate was created at VERSION by an
+  #    earlier run — skipped with a notice, the rest still proceed.
+  mock="${tmp}/resume"; mkdir -p "$mock"
+  deps_present "$mock"
+  record "$mock" "${fixture[0]}" false
+  version "$mock" "${fixture[0]}"
+  arm "resumable: ${fixture[0]} already created at ${VERSION}" pass \
+    "$mock" "$(ledger_file resume "${fixture[@]}")" \
+    "skip           ${fixture[0]} (${VERSION} already on crates.io: created by an earlier run"
+
+  # 5. A ledger crate whose record exists at some OTHER version is an existing
+  #    crate, whatever the ledger says: refuse.
+  mock="${tmp}/other-version"; mkdir -p "$mock"
+  deps_present "$mock"
+  record "$mock" "${fixture[0]}" true
+  arm "ledger crate has a record at another version" refuse \
+    "$mock" "$(ledger_file other "${fixture[@]}")" \
+    "REFUSE         ${fixture[0]} (crate record exists, trustpub_only=true)"
+
+  # 6. An empty ledger: nothing for a token to do.
+  mock="${tmp}/empty"; mkdir -p "$mock"
+  arm "empty ledger" refuse "$mock" "$(ledger_file empty)" \
+    "is empty: nothing to bootstrap"
+
+  # 7. A registry fault is a stop, never "missing" — with every dependency
+  #    present, so the ONLY thing standing between this arm and a green plan
+  #    is the fault itself.
+  mock="${tmp}/fault"; mkdir -p "$mock"
+  deps_present "$mock"
+  printf '500\n' > "${mock}/${fixture[0]}"
+  arm "registry answers 500" refuse "$mock" "$(ledger_file fault "${fixture[@]}")" \
+    "could not reach a verdict" "returned 500"
+
+  if [[ "$failures" -gt 0 ]]; then
+    echo "bootstrap-crates-io.sh self-test: ${failures} arm(s) FAILED" >&2
+    return 1
+  fi
+  echo "bootstrap-crates-io.sh self-test: every refusal fires and the valid path proceeds"
+}
+
+case "$mode" in
+  self-test)
+    self_test
+    exit
+    ;;
+  plan)
+    preflight
+    echo
+    echo "--plan: stopping before the token check, the gates and any publish."
+    exit
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# A publish run.
+# ---------------------------------------------------------------------------
 
 if [[ -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
   if [[ -n "${CARGO_TOKEN:-}" ]]; then
     export CARGO_REGISTRY_TOKEN="${CARGO_TOKEN}"
   else
-    echo "Set CARGO_TOKEN or CARGO_REGISTRY_TOKEN before bootstrapping crates.io" >&2
+    echo "Set CARGO_TOKEN or CARGO_REGISTRY_TOKEN before bootstrapping crates.io (or run with --plan)" >&2
     exit 1
   fi
 fi
 
 if [[ "${ALLOW_DIRTY:-false}" != "true" ]]; then
-  if ! git diff --quiet || ! git diff --cached --quiet \
-    || [[ -n "$(git ls-files --others --exclude-standard)" ]]; then
+  if ! git -C "${repo}" diff --quiet || ! git -C "${repo}" diff --cached --quiet \
+    || [[ -n "$(git -C "${repo}" ls-files --others --exclude-standard)" ]]; then
     cat >&2 <<'EOF'
 Refusing to publish from a dirty tree.
 
@@ -48,90 +526,16 @@ EOF
   fi
 fi
 
-# One definition of the release set, shared with the release workflow and with
-# scripts/check-crates-io-records.sh.
-# shellcheck source=scripts/release-crates.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/release-crates.sh"
-crates=("${PURRDF_RELEASE_CRATES[@]}")
-
-crate_version_exists() {
-  local crate="$1"
-  local status
-  status="$(curl -sS -H "User-Agent: purrdf-release/${VERSION} (paudley@blackcatinformatics.ca)" \
-    -o /tmp/purrdf-crate-version.json -w "%{http_code}" \
-    "https://crates.io/api/v1/crates/${crate}/${VERSION}")"
-  case "$status" in
-    200) return 0 ;;
-    404) return 1 ;;
-    *)
-      cat /tmp/purrdf-crate-version.json
-      echo "Unexpected crates.io status ${status} for ${crate} ${VERSION}" >&2
-      exit 1
-      ;;
-  esac
-}
-
-crate_record_exists() {
-  local crate="$1"
-  local status
-  status="$(curl -sS -H "User-Agent: purrdf-release/${VERSION} (paudley@blackcatinformatics.ca)" \
-    -o /tmp/purrdf-crate-record.json -w "%{http_code}" \
-    "https://crates.io/api/v1/crates/${crate}")"
-  case "$status" in
-    200) return 0 ;;
-    404) return 1 ;;
-    *)
-      cat /tmp/purrdf-crate-record.json
-      echo "Unexpected crates.io status ${status} for ${crate}" >&2
-      exit 1
-      ;;
-  esac
-}
-
-wait_for_crate_version() {
-  local crate="$1"
-  for _ in $(seq 1 30); do
-    if crate_version_exists "$crate"; then
-      return 0
-    fi
-    sleep 10
-  done
-  echo "Timed out waiting for crates.io to expose ${crate} ${VERSION}" >&2
-  exit 1
-}
-
-# State the irreversible plan BEFORE the long gates run, not one crate at a
-# time while publishing. This script is the token lane, so unlike the release
-# workflow it is ALLOWED to create crate records — but creating one is a
-# permanent, outward-facing act, so which records it will create is stated up
-# front where the operator can still stop. Any crates.io status other than
-# 200/404 aborts inside the helpers above rather than being read as "missing".
-echo "crates.io plan for ${VERSION}:"
-new_records=0
-for crate in "${crates[@]}"; do
-  if crate_version_exists "$crate"; then
-    printf '  skip           %s (version already published)\n' "$crate"
-  elif crate_record_exists "$crate"; then
-    printf '  publish        %s (crate record exists)\n' "$crate"
-  else
-    printf '  CREATE RECORD  %s (new crate — needs this token; a Trusted Publisher cannot create it)\n' "$crate"
-    new_records=$((new_records + 1))
-  fi
-done
-if [[ "$new_records" -gt 0 ]]; then
-  cat <<EOF
-
-${new_records} crate record(s) above do not exist yet. This run will create them.
-After it finishes, add a crates.io Trusted Publisher entry for each new crate
-(GitHub Actions / Blackcat-Informatics / purrdf / release-cargo.yaml / no
-environment) — until then the rust-v* release workflow refuses to publish, by
-design (scripts/check-crates-io-records.sh).
-EOF
-fi
+# The irreversible plan, stated BEFORE the long gates run and while the
+# operator can still stop. Any refusal above exits here.
+preflight
 echo
 
+cd "${repo}"
 cargo fmt --all --check
 cargo check --workspace --lib --tests --locked
+python3 scripts/check-versions.py
+python3 scripts/check-publish-order.py
 if command -v rustup >/dev/null; then
   if ! rustup target list --installed | grep -qx 'wasm32-unknown-unknown'; then
     rustup target add wasm32-unknown-unknown
@@ -142,64 +546,72 @@ for crate in "${crates[@]}"; do
   cargo_args+=("-p" "$crate")
 done
 cargo check --locked --target wasm32-unknown-unknown --lib "${cargo_args[@]}"
-cargo test -p purrdf-gts --test transport --locked
-cargo test -p purrdf-slice --locked
+cargo test --locked "${cargo_args[@]}"
 rm -rf target/package
-# `--no-verify` is LOAD-BEARING here and only here. This packages every crate
-# BEFORE any of them is published, so a verification build of crate N would
-# have to resolve crate N-1 at ${VERSION} from crates.io, where it does not
-# exist yet. Verification is impossible at this point by construction; the
-# `.crate` files are produced so that a packaging failure (a missing file, a
-# path dependency with no version) is found before the first irreversible
-# upload rather than midway through the set.
-cargo package --workspace \
-  --exclude purrdf-python \
-  --exclude purrdf-capi \
-  --exclude purrdf-sparql-conformance \
-  --locked \
-  --no-verify
+# Package every ledger crate before any is published, so a packaging failure
+# (a missing file, a path dependency with no version) is found before the
+# first irreversible upload rather than midway through the set. `--no-verify`
+# here only skips the build: the preflight already proved every dependency
+# resolves, and the loop below verifies each crate for real.
+cargo package --locked --no-verify "${cargo_args[@]}"
 
-# The publish loop VERIFIES by default. `cargo publish` unpacks the `.crate` it
-# is about to upload and builds it against the registry, so a wrong-version or
-# broken artifact is refused BEFORE it is uploaded — and an upload is the one
-# step here that cannot be undone. Two things make that build resolvable, and
-# both are gated rather than assumed:
-#
-#   1. `wait_for_crate_version` below blocks until crate N-1 is actually served
-#      by crates.io before crate N is published, so N's normal dependencies
-#      resolve; and
-#   2. scripts/check-publish-order.py (`make check`) proves the release order is
-#      a topological order of DEV-dependencies too, because verification
-#      resolves the full graph. `purrdf-geo` dev-depends on `purrdf-rdf` and
-#      `purrdf-shapes`; while it was ordered before them, verification could
-#      not work for this set at all, which is why this loop used to pass
-#      `--no-verify` and why the flag is not simply "safe to drop".
-#
-# PUBLISH_NO_VERIFY=true restores the old behaviour for one run. Use it only if
-# a verification build fails for a reason that is demonstrably not a broken
-# artifact (a registry outage mid-run, say) — and note that it is then YOUR
-# build of the artifact that is the last check before permanence.
+# The publish loop VERIFIES by default: `cargo publish` unpacks the `.crate` it
+# is about to upload and builds it against the registry, so a broken artifact
+# is refused BEFORE the one step that cannot be undone. The preflight is what
+# makes that build resolvable — every dependency of every ledger crate is on
+# crates.io at ${VERSION}, or this script never got here — and
+# scripts/check-publish-order.py proves the ledger is in dependency order,
+# dev-edges included. PUBLISH_NO_VERIFY=true is for a verification failure
+# that is demonstrably not a broken artifact (a registry outage mid-run); it
+# leaves your own build as the last check before permanence.
 publish_args=(--locked)
 if [[ "${PUBLISH_NO_VERIFY}" == "true" ]]; then
   publish_args+=(--no-verify)
   echo "PUBLISH_NO_VERIFY=true: cargo publish will NOT build the packaged crates before uploading them" >&2
 fi
 
+wait_for_crate_version() {
+  local crate="$1"
+  local state
+  for _ in $(seq 1 30); do
+    state="$(version_state "$crate")"
+    registry_or_die "$state"
+    if [[ "$state" == "present" ]]; then
+      return 0
+    fi
+    sleep 10
+  done
+  echo "Timed out waiting for crates.io to expose ${crate} ${VERSION}" >&2
+  exit 1
+}
+
+created=()
 for idx in "${!crates[@]}"; do
   crate="${crates[$idx]}"
-  if crate_version_exists "$crate"; then
+  state="$(version_state "$crate")"
+  registry_or_die "$state"
+  if [[ "$state" == "present" ]]; then
     echo "${crate} ${VERSION} already exists on crates.io; skipping"
     continue
   fi
-  record_exists_before=false
-  if crate_record_exists "$crate"; then
-    record_exists_before=true
-  fi
   cargo publish -p "$crate" "${publish_args[@]}"
   wait_for_crate_version "$crate"
-  if [[ "$record_exists_before" == "false" ]] \
-    && ((idx + 1 < ${#crates[@]})) \
-    && [[ "${PUBLISH_COOLDOWN_SECONDS}" != "0" ]]; then
+  created+=("$crate")
+  if ((idx + 1 < ${#crates[@]})) && [[ "${PUBLISH_COOLDOWN_SECONDS}" != "0" ]]; then
     sleep "${PUBLISH_COOLDOWN_SECONDS}"
   fi
 done
+
+cat <<EOF
+
+Created crates.io record(s): ${created[*]:-none}
+
+This token's job is done; it cannot publish another version of these crates
+once they are locked. Now, on crates.io, for each of them:
+  1. add the Trusted Publisher entry (GitHub Actions / Blackcat-Informatics /
+     purrdf / release-cargo.yaml / no environment);
+  2. enable "Require trusted publishing" (trustpub_only), as on every sibling;
+then remove them from PURRDF_UNBOOTSTRAPPED_CRATES in scripts/release-crates.sh,
+update the "Outstanding bootstrap" section of docs/RELEASE.md that
+scripts/check-doc-claims.py derives from it, and push the rust-v* tag.
+EOF

--- a/scripts/check-crates-io-records.sh
+++ b/scripts/check-crates-io-records.sh
@@ -2,109 +2,256 @@
 # SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
 # SPDX-License-Identifier: MIT OR Apache-2.0
 #
-# Preflight: every crate in the release set already has a crates.io RECORD.
+# Preflight: every crate in the release set already has a crates.io RECORD,
+# and every record is locked to the lane about to publish it.
 #
 # Why this exists. `cargo publish` cannot be undone. The release lane publishes
 # the crates in dependency order, one at a time; without this check a release
 # tag whose Nth crate has no crates.io record irreversibly publishes the N-1
-# crates before it and only then fails. crates.io additionally requires a crate
-# to exist before a Trusted Publisher can be configured for it, so a brand-new
-# crate can never be created by the OIDC lane at all — it needs a one-time token
-# bootstrap (docs/RELEASE.md). This script converts that from a mid-publish
-# blowup into a refusal taken before anything leaves the runner.
+# crates before it and only then fails. A brand-new crate can never be created
+# by the OIDC lane at all — crates.io's publish handler answers a Trusted
+# Publishing token with "Trusted Publishing tokens do not support creating new
+# crates. Publish the crate manually, first" — so it needs a one-time token
+# bootstrap (scripts/bootstrap-crates-io.sh, docs/RELEASE.md). This script
+# converts that from a mid-publish blowup into a refusal taken before anything
+# leaves the runner.
 #
 # It checks the RECORD (`/api/v1/crates/<name>`), not a version. The publish
-# loop's own `crate_version_exists` asks whether THIS version is already up, so
-# it answers 404 for every crate on a normal release and can never notice that
+# loop's own version check asks whether THIS version is already up, so it
+# answers 404 for every crate on a normal release and can never notice that
 # the crate itself does not exist.
 #
-# It ALSO holds `PURRDF_UNBOOTSTRAPPED_CRATES` (the committed ledger of crates
-# known to lack a record) to the registry in both directions when run over the
-# whole release set: a missing crate the ledger does not name is a new,
-# undocumented bootstrap requirement, and a ledgered crate that now HAS a
-# record is a stale entry — the ledger named `purrdf-datalog` for a full cycle
-# after that crate was published, because nothing checked that direction.
-# Either disagreement is a failure on its own, independent of the publish
-# verdict, so the ledger docs/RELEASE.md derives its prose from cannot rot.
+# Three checks, each a failure on its own:
+#
+#   1. RECORDS. Every release crate has one. A missing record names the crate
+#      and the bootstrap command.
+#   2. LEDGER. `PURRDF_UNBOOTSTRAPPED_CRATES` (the committed ledger of crates
+#      known to lack a record) agrees with the registry in BOTH directions when
+#      run over the whole release set: a missing crate the ledger does not name
+#      is a new, undocumented bootstrap requirement, and a ledgered crate that
+#      now HAS a record is a stale entry — the ledger named `purrdf-datalog`
+#      for a full cycle after that crate was published, because nothing
+#      checked that direction.
+#   3. LOCK. Every record carries `trustpub_only = true`: crates.io's per-crate
+#      "Require trusted publishing" setting, the registry-side statement that
+#      an API token cannot publish a new version (crates.io answers one with
+#      "403 Forbidden: New versions of this crate can only be published using
+#      Trusted Publishing"). It is the only registry-visible evidence of which
+#      lane owns a crate; the Trusted Publisher configurations themselves have
+#      no public API. A record that is NOT locked is a crate a leaked token
+#      could publish — the posture docs/RELEASE.md promises is gone for it —
+#      and it is also the step most easily forgotten after a bootstrap, so a
+#      fresh record without the lock refuses here, naming the setting to flip.
+#
+# What this preflight CANNOT see, stated so nobody reads a green run as more
+# than it is: whether a Trusted Publisher entry exists for a crate and points
+# at this repository and workflow. The OIDC token the lane exchanges is scoped
+# to the crates whose entries matched, and a crate with no entry fails AT its
+# own `cargo publish` ("The provided access token is not valid for crate
+# `<name>`") — after every crate ahead of it has been published. That is a
+# loud stop with a partial, re-runnable publish, not a refusal; the lock
+# check above is the closest a preflight can get, because the setting can only
+# be enabled from the crate's settings page once an entry exists.
 #
 # Usage:
 #   scripts/check-crates-io-records.sh                # the whole release set
 #   scripts/check-crates-io-records.sh purrdf-core …  # an explicit list
 #                                                     # (no ledger check)
+#   scripts/check-crates-io-records.sh --self-test    # every refusal and the
+#                                                     # green path, offline
 #
 # Environment:
-#   PURRDF_RELEASE_VERSION  version string put in the User-Agent (cosmetic).
+#   PURRDF_RELEASE_VERSION      version string put in the User-Agent (cosmetic).
+#   PURRDF_RELEASE_CRATES_FILE  an alternative release-set/ledger file
+#                               (self-test only; default scripts/release-crates.sh)
+#   PURRDF_CRATES_IO_MOCK       a mock registry directory (scripts/crates-io-api.sh)
 
 set -euo pipefail
 
 repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# shellcheck source=scripts/crates-io-api.sh
+source "${repo}/scripts/crates-io-api.sh"
+
 version="${PURRDF_RELEASE_VERSION:-preflight}"
-user_agent="purrdf-release/${version} (paudley@blackcatinformatics.ca)"
+user_agent="$(crates_io_user_agent "${version}")"
+release_list="${PURRDF_RELEASE_CRATES_FILE:-${repo}/scripts/release-crates.sh}"
+
+self_test() {
+  local tmp
+  tmp="$(mktemp -d)"
+  # shellcheck disable=SC2064  # expand now: tmp is what to remove.
+  trap "rm -rf '${tmp}'" EXIT
+  local failures=0
+
+  # shellcheck source=scripts/release-crates.sh
+  source "${repo}/scripts/release-crates.sh"
+  local -a set=("${PURRDF_RELEASE_CRATES[@]}")
+
+  # ledger_file <name> <crate>... : the real release set with the ledger replaced.
+  ledger_file() {
+    local name="$1"
+    shift
+    {
+      cat "${repo}/scripts/release-crates.sh"
+      printf '\nPURRDF_UNBOOTSTRAPPED_CRATES=(%s)\n' "$*"
+    } > "${tmp}/${name}.sh"
+    echo "${tmp}/${name}.sh"
+  }
+  # locked <dir> <crate> <trustpub_only>
+  locked() {
+    printf '200\n{"crate":{"name":"%s","trustpub_only":%s}}\n' "$2" "$3" > "$1/$2"
+  }
+  # all_locked <dir> [except...]: every release crate present and locked.
+  all_locked() {
+    local dir="$1"
+    shift
+    local crate skip
+    for crate in "${set[@]}"; do
+      skip=false
+      for except in "$@"; do [[ "$except" == "$crate" ]] && skip=true; done
+      [[ "$skip" == "false" ]] && locked "$dir" "$crate" true
+    done
+    return 0
+  }
+
+  # arm <label> <expect: pass|refuse> <mock-dir> <ledger-file> <must-mention>...
+  arm() {
+    local label="$1" expect="$2" mock="$3" ledger="$4"
+    shift 4
+    local out status=0
+    out="$(PURRDF_CRATES_IO_MOCK="${mock}" PURRDF_RELEASE_CRATES_FILE="${ledger}" \
+      bash "${BASH_SOURCE[0]}" 2>&1)" || status=$?
+    local ok=true
+    if [[ "$expect" == "pass" && "$status" -ne 0 ]]; then ok=false; fi
+    if [[ "$expect" == "refuse" && "$status" -eq 0 ]]; then ok=false; fi
+    local needle
+    for needle in "$@"; do
+      if ! grep -qF -- "$needle" <<<"$out"; then
+        ok=false
+        echo "    output does not mention: ${needle}"
+      fi
+    done
+    if [[ "$ok" == "true" ]]; then
+      printf '  ok      %s (exit %s)\n' "$label" "$status"
+    else
+      printf '  FAILED  %s (exit %s, expected %s)\n' "$label" "$status" "$expect"
+      while IFS= read -r line; do printf '    | %s\n' "$line"; done <<<"$out"
+      failures=$((failures + 1))
+    fi
+  }
+
+  echo "check-crates-io-records.sh self-test (release set: ${#set[@]} crates)"
+  local first="${set[0]}" last="${set[-1]}"
+  local mock
+
+  # 1. Green: every record present and locked, ledger empty.
+  mock="${tmp}/green"; mkdir -p "$mock"; all_locked "$mock"
+  arm "every record present and locked, empty ledger" pass \
+    "$mock" "$(ledger_file green)" \
+    "ledger   PURRDF_UNBOOTSTRAPPED_CRATES agrees with crates.io (0 unbootstrapped)" \
+    "lock     every record is trustpub_only=true" \
+    "All ${#set[@]} release crates have a crates.io record."
+
+  # 2. A ledgered crate really is missing: refuse, naming it and the bootstrap.
+  mock="${tmp}/missing"; mkdir -p "$mock"; all_locked "$mock" "$last"
+  arm "ledgered crate missing (${last})" refuse \
+    "$mock" "$(ledger_file missing "$last")" \
+    "MISSING  ${last}" \
+    "ledger   PURRDF_UNBOOTSTRAPPED_CRATES agrees with crates.io (1 unbootstrapped)" \
+    "crates.io has no crate record for: ${last}" \
+    "scripts/bootstrap-crates-io.sh"
+
+  # 3. A missing crate the ledger does not name: refuse on the ledger too.
+  mock="${tmp}/unledgered"; mkdir -p "$mock"; all_locked "$mock" "$last"
+  arm "missing crate absent from the ledger (${last})" refuse \
+    "$mock" "$(ledger_file unledgered)" \
+    "${last} has no crates.io record but is NOT in PURRDF_UNBOOTSTRAPPED_CRATES"
+
+  # 4. A stale ledger entry: present crate still ledgered.
+  mock="${tmp}/stale"; mkdir -p "$mock"; all_locked "$mock"
+  arm "stale ledger entry (${first} has a record)" refuse \
+    "$mock" "$(ledger_file stale "$first")" \
+    "${first} is in PURRDF_UNBOOTSTRAPPED_CRATES but crates.io HAS a record for it (stale ledger entry)"
+
+  # 5. A record that is NOT locked to Trusted Publishing: refuse, naming the
+  #    crate and the setting — the green neighbour is arm 1.
+  mock="${tmp}/unlocked"; mkdir -p "$mock"; all_locked "$mock" "$first"
+  locked "$mock" "$first" false
+  arm "record not locked (${first} trustpub_only=false)" refuse \
+    "$mock" "$(ledger_file unlocked)" \
+    "OPEN     ${first} (trustpub_only=false)" \
+    "not locked to Trusted Publishing: ${first}" \
+    "Require trusted publishing"
+
+  # 6. A record whose lock state the API did not report: refuse the same way,
+  #    never folded into a verdict.
+  mock="${tmp}/unknown"; mkdir -p "$mock"; all_locked "$mock" "$first"
+  printf '200\n{"crate":{"name":"%s"}}\n' "$first" > "${mock}/${first}"
+  arm "record with no trustpub_only field (${first})" refuse \
+    "$mock" "$(ledger_file unknown)" \
+    "OPEN     ${first} (trustpub_only=unknown)"
+
+  # 7. An explicit crate list: records and locks are checked, the ledger is not.
+  mock="${tmp}/explicit"; mkdir -p "$mock"; all_locked "$mock"
+  local out status=0
+  out="$(PURRDF_CRATES_IO_MOCK="${mock}" bash "${BASH_SOURCE[0]}" "$first" "$last" 2>&1)" || status=$?
+  if [[ "$status" -eq 0 ]] && grep -qF "All 2 release crates have a crates.io record." <<<"$out" \
+    && ! grep -qF "ledger " <<<"$out"; then
+    printf '  ok      explicit list of 2 crates (exit 0, no ledger check)\n'
+  else
+    printf '  FAILED  explicit list of 2 crates (exit %s)\n' "$status"
+    while IFS= read -r line; do printf '    | %s\n' "$line"; done <<<"$out"
+    failures=$((failures + 1))
+  fi
+
+  # 8. A registry fault is a stop, never a verdict.
+  mock="${tmp}/fault"; mkdir -p "$mock"; all_locked "$mock" "$first"
+  printf '503\n' > "${mock}/${first}"
+  arm "registry answers 503 for ${first}" refuse \
+    "$mock" "$(ledger_file fault)" \
+    "ERROR    ${first}" "could not reach a verdict for: ${first}"
+
+  if [[ "$failures" -gt 0 ]]; then
+    echo "check-crates-io-records.sh self-test: ${failures} arm(s) FAILED" >&2
+    return 1
+  fi
+  echo "check-crates-io-records.sh self-test: every refusal fires and the green path passes"
+}
 
 ledger=()
 check_ledger=false
-if [[ "$#" -gt 0 ]]; then
+if [[ "$#" -gt 0 && "$1" == "--self-test" ]]; then
+  self_test
+  exit
+elif [[ "$#" -gt 0 ]]; then
   crates=("$@")
 else
   # shellcheck source=scripts/release-crates.sh
-  source "${repo}/scripts/release-crates.sh"
+  source "${release_list}"
   crates=("${PURRDF_RELEASE_CRATES[@]}")
   ledger=("${PURRDF_UNBOOTSTRAPPED_CRATES[@]}")
   check_ledger=true
 fi
 
-body="$(mktemp)"
-trap 'rm -f "$body"' EXIT
-
-# Query one crate record. Echoes "present", "missing", or "error: <detail>".
-#
-# crates.io answers 403 to a default curl User-Agent, so the UA above is load
-# bearing: without it EVERY crate would answer non-200 and, read carelessly,
-# would look missing. Only a literal 404 is missing here; anything else is an
-# error that stops the run rather than a verdict.
-crate_record_state() {
-  local crate="$1"
-  local status attempt
-  for attempt in 1 2 3; do
-    status="$(curl -sS --max-time 30 -H "User-Agent: ${user_agent}" \
-      -o "$body" -w "%{http_code}" \
-      "https://crates.io/api/v1/crates/${crate}" 2>/dev/null || echo "000")"
-    case "$status" in
-      200)
-        echo "present"
-        return 0
-        ;;
-      404)
-        echo "missing"
-        return 0
-        ;;
-      000 | 429 | 5??)
-        # Transient: no response, rate limited, or a registry-side fault.
-        if [[ "$attempt" -lt 3 ]]; then
-          sleep $((attempt * 5))
-          continue
-        fi
-        echo "error: crates.io returned ${status} for ${crate} after 3 attempts"
-        return 0
-        ;;
-      *)
-        echo "error: unexpected crates.io status ${status} for ${crate} ($(head -c 200 "$body"))"
-        return 0
-        ;;
-    esac
-  done
-}
+trap 'rm -f "${CRATES_IO_BODY:-}"' EXIT
 
 missing=()
 present=()
 errors=()
+unlocked=()
 
 for crate in "${crates[@]}"; do
-  state="$(crate_record_state "$crate")"
+  state="$(crates_io_record_state "$crate" "${user_agent}")"
   case "$state" in
     present)
-      printf 'ok       %s\n' "$crate"
+      lock="$(crates_io_trustpub_only)"
+      if [[ "$lock" == "true" ]]; then
+        printf 'ok       %s (trustpub_only=true)\n' "$crate"
+      else
+        printf 'OPEN     %s (trustpub_only=%s)\n' "$crate" "$lock"
+        unlocked+=("$crate")
+      fi
       present+=("$crate")
       ;;
     missing)
@@ -117,7 +264,7 @@ for crate in "${crates[@]}"; do
       ;;
   esac
   # crates.io asks API clients for roughly one request per second.
-  sleep 1
+  [[ -n "${PURRDF_CRATES_IO_MOCK:-}" ]] || sleep 1
 done
 
 if [[ "${#errors[@]}" -gt 0 ]]; then
@@ -169,6 +316,29 @@ EOF
   printf 'ledger   PURRDF_UNBOOTSTRAPPED_CRATES agrees with crates.io (%d unbootstrapped)\n' "${#ledger[@]}"
 fi
 
+# The lock check, also before the verdict, for the same reason: a record that
+# is open to token publishes is wrong whether or not this run publishes.
+if [[ "${#unlocked[@]}" -gt 0 ]]; then
+  cat >&2 <<EOF
+
+crates.io records not locked to Trusted Publishing: ${unlocked[*]}
+
+Every PurRDF crate record is published by the rust-v* lane through Trusted
+Publishing and nothing else; crates.io enforces that with the per-crate
+"Require trusted publishing" setting (trustpub_only), which makes a token
+publish a 403. A record without it is one a leaked token could publish, and
+this preflight cannot tell a deliberate relaxation from a bootstrap that
+stopped one step early. On crates.io, open each crate's Settings page, add
+the Trusted Publisher entry if it is not there yet (GitHub Actions /
+Blackcat-Informatics / purrdf / release-cargo.yaml / no environment), enable
+"Require trusted publishing", and re-run this tag.
+EOF
+  exit 1
+fi
+if [[ "${#present[@]}" -gt 0 ]]; then
+  printf 'lock     every record is trustpub_only=true (%d)\n' "${#present[@]}"
+fi
+
 if [[ "${#missing[@]}" -gt 0 ]]; then
   cat >&2 <<EOF
 
@@ -178,16 +348,20 @@ Refusing to publish. This lane publishes ${#crates[@]} crates one at a time in
 dependency order and cargo publish CANNOT be undone, so continuing would
 irreversibly publish every crate ahead of the missing one and then fail.
 
-crates.io also requires a crate to exist before a Trusted Publisher can be
-configured for it, so this workflow's OIDC token cannot create these records.
-The bootstrap is a one-time token publish from a clean local checkout
-(docs/RELEASE.md, "Trusted Publisher Setup"):
+crates.io refuses to create a crate from a Trusted Publishing token ("Trusted
+Publishing tokens do not support creating new crates"), so this workflow cannot
+create these records. Creating a record is the ONE thing an API token still
+does for this workspace — it cannot publish a new version of any existing
+crate, they are all locked — and it is a one-time publish from a clean local
+checkout (docs/RELEASE.md, "Outstanding bootstrap"):
 
-    CARGO_REGISTRY_TOKEN="\${CARGO_TOKEN}" scripts/bootstrap-crates-io.sh <version>
+    scripts/bootstrap-crates-io.sh --plan          # the preflight and plan, no token
+    CARGO_REGISTRY_TOKEN="\${CARGO_TOKEN}" scripts/bootstrap-crates-io.sh
 
 Then add the Trusted Publisher entry for each newly created crate
 (GitHub Actions / Blackcat-Informatics / purrdf / release-cargo.yaml / no
-environment) and re-run this tag.
+environment), enable "Require trusted publishing" on it, remove it from
+PURRDF_UNBOOTSTRAPPED_CRATES, and re-run this tag.
 EOF
   exit 1
 fi

--- a/scripts/check-crates-io-records.sh
+++ b/scripts/check-crates-io-records.sh
@@ -23,15 +23,24 @@
 #
 # Three checks, each a failure on its own:
 #
-#   1. RECORDS. Every release crate has one. A missing record names the crate
-#      and the bootstrap command.
+#   1. RECORDS. Every release crate has one, EXCEPT a crate the ledger names:
+#      a ledgered crate with no record is "bootstrap pending" — permitted, and
+#      reported as such — because the release lane handles it by the
+#      interleave (scripts/publish-release-crates.sh skips it and stops cleanly
+#      at its first dependent for the token step). A missing record the ledger
+#      does NOT name refuses the run, naming the crate: it is a new,
+#      undocumented bootstrap requirement.
 #   2. LEDGER. `PURRDF_UNBOOTSTRAPPED_CRATES` (the committed ledger of crates
 #      known to lack a record) agrees with the registry in BOTH directions when
-#      run over the whole release set: a missing crate the ledger does not name
-#      is a new, undocumented bootstrap requirement, and a ledgered crate that
-#      now HAS a record is a stale entry — the ledger named `purrdf-datalog`
-#      for a full cycle after that crate was published, because nothing
-#      checked that direction.
+#      run over the whole release set: the missing-but-unledgered case above,
+#      and a ledgered crate that HAS a record — a stale entry; the ledger named
+#      `purrdf-datalog` for a full cycle after that crate was published,
+#      because nothing checked that direction. One tolerance, needed by the
+#      interleave: a tag's tree is frozen while its release is in flight, so a
+#      ledgered crate whose record exists AT THE RELEASE VERSION being
+#      published (PURRDF_RELEASE_VERSION) was created by this release's own
+#      token step and is reported, not refused. A record at any other version
+#      is stale, as before.
 #   3. LOCK. Every record carries `trustpub_only = true`: crates.io's per-crate
 #      "Require trusted publishing" setting, the registry-side statement that
 #      an API token cannot publish a new version (crates.io answers one with
@@ -61,7 +70,10 @@
 #                                                     # green path, offline
 #
 # Environment:
-#   PURRDF_RELEASE_VERSION      version string put in the User-Agent (cosmetic).
+#   PURRDF_RELEASE_VERSION      the version being released (`rust-v` prefix
+#                               accepted); decides the stale-ledger tolerance
+#                               above and goes in the User-Agent. Unset, no
+#                               tolerance applies.
 #   PURRDF_RELEASE_CRATES_FILE  an alternative release-set/ledger file
 #                               (self-test only; default scripts/release-crates.sh)
 #   PURRDF_CRATES_IO_MOCK       a mock registry directory (scripts/crates-io-api.sh)
@@ -73,8 +85,9 @@ repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=scripts/crates-io-api.sh
 source "${repo}/scripts/crates-io-api.sh"
 
-version="${PURRDF_RELEASE_VERSION:-preflight}"
-user_agent="$(crates_io_user_agent "${version}")"
+version="${PURRDF_RELEASE_VERSION:-}"
+version="${version#rust-v}"
+user_agent="$(crates_io_user_agent "${version:-preflight}")"
 release_list="${PURRDF_RELEASE_CRATES_FILE:-${repo}/scripts/release-crates.sh}"
 
 self_test() {
@@ -141,7 +154,10 @@ self_test() {
     fi
   }
 
-  echo "check-crates-io-records.sh self-test (release set: ${#set[@]} crates)"
+  local VERSION
+  VERSION="$(cd "${repo}" && cargo metadata --no-deps --format-version 1 \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')"
+  echo "check-crates-io-records.sh self-test (release set: ${#set[@]} crates; version ${VERSION})"
   local first="${set[0]}" last="${set[-1]}"
   local mock
 
@@ -153,14 +169,34 @@ self_test() {
     "lock     every record is trustpub_only=true" \
     "All ${#set[@]} release crates have a crates.io record."
 
-  # 2. A ledgered crate really is missing: refuse, naming it and the bootstrap.
+  # 2. A ledgered crate really is missing: permitted — "bootstrap pending" —
+  #    and said so, with the interleave named.
   mock="${tmp}/missing"; mkdir -p "$mock"; all_locked "$mock" "$last"
-  arm "ledgered crate missing (${last})" refuse \
+  arm "ledgered crate missing (${last}): bootstrap pending, permitted" pass \
     "$mock" "$(ledger_file missing "$last")" \
-    "MISSING  ${last}" \
+    "PENDING  ${last} (no crates.io record; in PURRDF_UNBOOTSTRAPPED_CRATES — bootstrap pending)" \
     "ledger   PURRDF_UNBOOTSTRAPPED_CRATES agrees with crates.io (1 unbootstrapped)" \
-    "crates.io has no crate record for: ${last}" \
+    "bootstrap pending for: ${last}" \
     "scripts/bootstrap-crates-io.sh"
+
+  # 2b. A ledgered crate whose record exists AT the release version: created
+  #     by this release's token step — tolerated when the version is known...
+  mock="${tmp}/created"; mkdir -p "$mock"; all_locked "$mock"
+  printf '200\n{"version":{"crate":"%s","num":"%s"}}\n' "$last" "${VERSION}" > "${mock}/${last}@${VERSION}"
+  local out status=0
+  out="$(PURRDF_CRATES_IO_MOCK="${mock}" PURRDF_RELEASE_CRATES_FILE="$(ledger_file created "$last")" \
+    PURRDF_RELEASE_VERSION="rust-v${VERSION}" bash "${BASH_SOURCE[0]}" 2>&1)" || status=$?
+  if [[ "$status" -eq 0 ]] && grep -qF "created  ${last} (ledgered, but its ${VERSION} record exists: created by this release's token step" <<<"$out"; then
+    printf '  ok      ledgered crate created at %s by this release: tolerated (exit 0)\n' "$VERSION"
+  else
+    printf '  FAILED  ledgered crate created at %s by this release (exit %s)\n' "$VERSION" "$status"
+    while IFS= read -r line; do printf '    | %s\n' "$line"; done <<<"$out"
+    failures=$((failures + 1))
+  fi
+  #     ...and stale without it (no version given: no tolerance).
+  arm "ledgered crate with a record, no release version given: stale" refuse \
+    "$mock" "$(ledger_file created2 "$last")" \
+    "${last} is in PURRDF_UNBOOTSTRAPPED_CRATES but crates.io HAS a record for it (stale ledger entry)"
 
   # 3. A missing crate the ledger does not name: refuse on the ledger too.
   mock="${tmp}/unledgered"; mkdir -p "$mock"; all_locked "$mock" "$last"
@@ -194,7 +230,7 @@ self_test() {
 
   # 7. An explicit crate list: records and locks are checked, the ledger is not.
   mock="${tmp}/explicit"; mkdir -p "$mock"; all_locked "$mock"
-  local out status=0
+  status=0
   out="$(PURRDF_CRATES_IO_MOCK="${mock}" bash "${BASH_SOURCE[0]}" "$first" "$last" 2>&1)" || status=$?
   if [[ "$status" -eq 0 ]] && grep -qF "All 2 release crates have a crates.io record." <<<"$out" \
     && ! grep -qF "ledger " <<<"$out"; then
@@ -236,6 +272,12 @@ fi
 
 trap 'rm -f "${CRATES_IO_BODY:-}"' EXIT
 
+in_ledger() {
+  local entry
+  for entry in "${ledger[@]}"; do [[ "$entry" == "$1" ]] && return 0; done
+  return 1
+}
+
 missing=()
 present=()
 errors=()
@@ -255,7 +297,11 @@ for crate in "${crates[@]}"; do
       present+=("$crate")
       ;;
     missing)
-      printf 'MISSING  %s\n' "$crate"
+      if [[ "$check_ledger" == "true" ]] && in_ledger "$crate"; then
+        printf 'PENDING  %s (no crates.io record; in PURRDF_UNBOOTSTRAPPED_CRATES — bootstrap pending)\n' "$crate"
+      else
+        printf 'MISSING  %s\n' "$crate"
+      fi
       missing+=("$crate")
       ;;
     *)
@@ -293,9 +339,22 @@ if [[ "$check_ledger" == "true" ]]; then
   done
   for entry in "${ledger[@]}"; do
     for crate in "${present[@]}"; do
-      if [[ "$entry" == "$crate" ]]; then
-        ledger_problems+=("${entry} is in PURRDF_UNBOOTSTRAPPED_CRATES but crates.io HAS a record for it (stale ledger entry)")
+      [[ "$entry" == "$crate" ]] || continue
+      if [[ -n "$version" ]]; then
+        state="$(crates_io_version_state "$crate" "$version" "${user_agent}")"
+        case "$state" in
+          present)
+            printf 'created  %s (ledgered, but its %s record exists: created by this release'"'"'s token step; drop it from the ledger after the release)\n' "$crate" "$version"
+            continue 2
+            ;;
+          missing) ;;
+          *)
+            echo "ERROR    ${crate} — ${state#error: }" >&2
+            exit 1
+            ;;
+        esac
       fi
+      ledger_problems+=("${entry} is in PURRDF_UNBOOTSTRAPPED_CRATES but crates.io HAS a record for it (stale ledger entry)")
     done
   done
   if [[ "${#ledger_problems[@]}" -gt 0 ]]; then
@@ -339,31 +398,57 @@ if [[ "${#present[@]}" -gt 0 ]]; then
   printf 'lock     every record is trustpub_only=true (%d)\n' "${#present[@]}"
 fi
 
-if [[ "${#missing[@]}" -gt 0 ]]; then
+pending=()
+unledgered=()
+for crate in "${missing[@]}"; do
+  if [[ "$check_ledger" == "true" ]] && in_ledger "$crate"; then
+    pending+=("$crate")
+  else
+    unledgered+=("$crate")
+  fi
+done
+
+if [[ "${#unledgered[@]}" -gt 0 ]]; then
   cat >&2 <<EOF
 
-crates.io has no crate record for: ${missing[*]}
+crates.io has no crate record for: ${unledgered[*]}
 
 Refusing to publish. This lane publishes ${#crates[@]} crates one at a time in
-dependency order and cargo publish CANNOT be undone, so continuing would
-irreversibly publish every crate ahead of the missing one and then fail.
+dependency order and cargo publish CANNOT be undone; a crate with no record
+that the ledger does not name is an undocumented bootstrap requirement, and
+the publish loop would only skip it if PURRDF_UNBOOTSTRAPPED_CRATES named it.
 
 crates.io refuses to create a crate from a Trusted Publishing token ("Trusted
 Publishing tokens do not support creating new crates"), so this workflow cannot
-create these records. Creating a record is the ONE thing an API token still
-does for this workspace — it cannot publish a new version of any existing
-crate, they are all locked — and it is a one-time publish from a clean local
-checkout (docs/RELEASE.md, "Outstanding bootstrap"):
+create the record; creating one is the ONE thing an API token still does for
+this workspace (it cannot publish a new version of any existing crate — they
+are all locked). Add the crate to PURRDF_UNBOOTSTRAPPED_CRATES in
+scripts/release-crates.sh and to the "Outstanding bootstrap" section of
+docs/RELEASE.md, re-tag, and follow the interleave that section describes:
+the lane publishes up to the crate's first dependent and stops, then
 
     scripts/bootstrap-crates-io.sh --plan          # the preflight and plan, no token
     CARGO_REGISTRY_TOKEN="\${CARGO_TOKEN}" scripts/bootstrap-crates-io.sh
 
-Then add the Trusted Publisher entry for each newly created crate
-(GitHub Actions / Blackcat-Informatics / purrdf / release-cargo.yaml / no
-environment), enable "Require trusted publishing" on it, remove it from
-PURRDF_UNBOOTSTRAPPED_CRATES, and re-run this tag.
+creates the record, you add its Trusted Publisher entry and enable "Require
+trusted publishing", and the workflow run is re-run.
 EOF
   exit 1
+fi
+
+if [[ "${#pending[@]}" -gt 0 ]]; then
+  cat <<EOF
+
+bootstrap pending for: ${pending[*]}
+
+Each is in PURRDF_UNBOOTSTRAPPED_CRATES and has no crates.io record. The publish
+loop (scripts/publish-release-crates.sh) skips each of them, publishes every
+crate that does not depend on one, and STOPS cleanly at the first crate that
+does — naming the token step, scripts/bootstrap-crates-io.sh, as what comes
+next. The set is not complete until every one has been created and this
+workflow run has been re-run (docs/RELEASE.md, "Outstanding bootstrap").
+EOF
+  exit 0
 fi
 
 printf '\nAll %d release crates have a crates.io record.\n' "${#crates[@]}"

--- a/scripts/check-versions.py
+++ b/scripts/check-versions.py
@@ -26,7 +26,7 @@ lint closes both gaps as a hard, no-optionality gate:
    publishable crate missing from the lane is a latent release break — e.g. a
    listed crate depending on an unlisted one makes ``cargo publish`` fail on a
    missing dependency. Its consumers (``.github/workflows/release-cargo.yaml``,
-   ``scripts/bootstrap-crates-io.sh`` and
+   ``scripts/publish-release-crates.sh``, ``scripts/bootstrap-crates-io.sh`` and
    ``scripts/check-crates-io-records.sh``) must *source* that file rather than
    restate the list, so the crates.io record preflight can never be checking a
    different set than the one the publisher walks.
@@ -179,6 +179,7 @@ _CRATE_TOKEN_RE = re.compile(r"^purrdf(?:-[a-z]+)*$")
 _RELEASE_LIST = "scripts/release-crates.sh"
 _RELEASE_LIST_CONSUMERS = (
     ".github/workflows/release-cargo.yaml",
+    "scripts/publish-release-crates.sh",
     "scripts/bootstrap-crates-io.sh",
     "scripts/check-crates-io-records.sh",
 )

--- a/scripts/crates-io-api.sh
+++ b/scripts/crates-io-api.sh
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# shellcheck shell=bash
+#
+# The one crates.io read path the release scripts share.
+#
+# This file is SOURCED, never executed. `scripts/bootstrap-crates-io.sh` and
+# `scripts/check-crates-io-records.sh` both ask crates.io the same three
+# questions — does a crate RECORD exist, does a crate VERSION exist, and is the
+# record locked to Trusted Publishing — and both used to carry their own curl
+# loop with slightly different retry and error rules. There is now one.
+#
+# Every question is answered from the public, unauthenticated API:
+#
+#   GET /api/v1/crates/<name>            200 = record exists, 404 = no record
+#   GET /api/v1/crates/<name>/<version>  200 = version exists, 404 = no version
+#
+# and the record body carries `crate.trustpub_only`, the per-crate setting
+# crates.io added in 2025-11 ("When true, this crate can only be published via
+# Trusted Publishing, not with API tokens" — the column comment in the crates.io
+# schema). That flag is the only registry-visible evidence of which lane can
+# publish a crate; there is no public API for the Trusted Publisher
+# configurations themselves.
+#
+# Rules every caller inherits:
+#
+#   * The User-Agent is load bearing. crates.io answers 403 to a default curl
+#     agent, and a 403 read carelessly looks like "missing". Only a literal 404
+#     is ever "missing"; every other non-200 status is an error that stops the
+#     caller rather than a verdict.
+#   * 000 (no response), 429 (rate limited) and 5xx are retried three times
+#     with a growing pause; anything else is reported at once.
+#   * crates.io asks API clients for about one request per second; callers
+#     sleep between crates, not this file, so a mocked run stays instant.
+#
+# Mocking, for the scripts' `--self-test` arms and for proving a refusal
+# without a registry: set PURRDF_CRATES_IO_MOCK to a directory. A record query
+# for `<name>` reads `<dir>/<name>`, a version query for `<name>/<version>`
+# reads `<dir>/<name>@<version>`; the file's first line is the HTTP status and
+# the rest is the body. A file that does not exist answers 404, so a fixture
+# that forgets a dependency makes the script REFUSE (the safe direction) rather
+# than proceed.
+
+# Set by crates_io_get: the HTTP status and the path of a file holding the body.
+# The body file is created HERE, at source time, not lazily inside crates_io_get:
+# callers run the state helpers in command substitutions (subshells), so a path
+# chosen there would never reach the parent, and crates_io_trustpub_only would
+# read nothing. Callers remove it on exit.
+CRATES_IO_STATUS=""
+CRATES_IO_BODY="$(mktemp)"
+
+# crates_io_user_agent <version-or-label>
+crates_io_user_agent() {
+  echo "purrdf-release/$1 (paudley@blackcatinformatics.ca)"
+}
+
+# crates_io_get <api-path-under-/api/v1/crates/> <user-agent>
+#
+# Populates CRATES_IO_STATUS and CRATES_IO_BODY. Never exits; the caller decides
+# what a status means. Transient statuses are retried here.
+crates_io_get() {
+  local path="$1"
+  local user_agent="$2"
+  if [[ -n "${PURRDF_CRATES_IO_MOCK:-}" ]]; then
+    local fixture="${PURRDF_CRATES_IO_MOCK}/${path/\//@}"
+    if [[ -f "$fixture" ]]; then
+      CRATES_IO_STATUS="$(head -n 1 "$fixture")"
+      tail -n +2 "$fixture" > "${CRATES_IO_BODY}"
+    else
+      CRATES_IO_STATUS="404"
+      : > "${CRATES_IO_BODY}"
+    fi
+    return 0
+  fi
+  local attempt
+  for attempt in 1 2 3; do
+    CRATES_IO_STATUS="$(curl -sS --max-time 30 -H "User-Agent: ${user_agent}" \
+      -o "${CRATES_IO_BODY}" -w "%{http_code}" \
+      "https://crates.io/api/v1/crates/${path}" 2>/dev/null || echo "000")"
+    case "${CRATES_IO_STATUS}" in
+      000 | 429 | 5??)
+        if [[ "$attempt" -lt 3 ]]; then
+          sleep $((attempt * 5))
+          continue
+        fi
+        ;;
+    esac
+    break
+  done
+}
+
+# crates_io_record_state <crate> <user-agent>
+#
+# Echoes "present", "missing", or "error: <detail>". After "present",
+# CRATES_IO_BODY holds the record JSON (see crates_io_trustpub_only).
+crates_io_record_state() {
+  local crate="$1"
+  crates_io_get "${crate}" "$2"
+  case "${CRATES_IO_STATUS}" in
+    200) echo "present" ;;
+    404) echo "missing" ;;
+    000 | 429 | 5??)
+      echo "error: crates.io returned ${CRATES_IO_STATUS} for ${crate} after 3 attempts"
+      ;;
+    *)
+      echo "error: unexpected crates.io status ${CRATES_IO_STATUS} for ${crate} ($(head -c 200 "${CRATES_IO_BODY}"))"
+      ;;
+  esac
+}
+
+# crates_io_version_state <crate> <version> <user-agent>
+#
+# Echoes "present", "missing", or "error: <detail>".
+crates_io_version_state() {
+  local crate="$1"
+  local version="$2"
+  crates_io_get "${crate}/${version}" "$3"
+  case "${CRATES_IO_STATUS}" in
+    200) echo "present" ;;
+    404) echo "missing" ;;
+    000 | 429 | 5??)
+      echo "error: crates.io returned ${CRATES_IO_STATUS} for ${crate} ${version} after 3 attempts"
+      ;;
+    *)
+      echo "error: unexpected crates.io status ${CRATES_IO_STATUS} for ${crate} ${version} ($(head -c 200 "${CRATES_IO_BODY}"))"
+      ;;
+  esac
+}
+
+# crates_io_trustpub_only
+#
+# Reads `crate.trustpub_only` out of the record body the last
+# crates_io_record_state left in CRATES_IO_BODY. Echoes "true", "false", or
+# "unknown" (field absent or body unparseable — an older API shape, or a mock
+# fixture that gave a status and no body). Never guesses: "unknown" is reported
+# as such by the callers, not folded into either verdict.
+crates_io_trustpub_only() {
+  python3 - "${CRATES_IO_BODY}" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        record = json.load(handle)
+    value = record["crate"]["trustpub_only"]
+except (OSError, ValueError, KeyError, TypeError):
+    print("unknown")
+else:
+    print("true" if value is True else "false" if value is False else "unknown")
+PY
+}

--- a/scripts/publish-release-crates.sh
+++ b/scripts/publish-release-crates.sh
@@ -1,0 +1,424 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+# SPDX-License-Identifier: MIT OR Apache-2.0
+#
+# The crates.io publish loop of the rust-v* release lane — the point of no
+# return of .github/workflows/release-cargo.yaml, kept in a script so the one
+# piece of logic that decides what is published can be run, dry-run and
+# self-tested locally against a mock registry instead of only on a tag.
+#
+# What it does, per crate of PURRDF_RELEASE_CRATES, in publish order:
+#
+#   * VERSION already on crates.io           -> skip (re-runs resume);
+#   * in PURRDF_UNBOOTSTRAPPED_CRATES, absent -> SKIP, visibly: only an API
+#     token can create a record ("Trusted Publishing tokens do not support
+#     creating new crates"), so the ledger crate is left for the token step
+#     (scripts/bootstrap-crates-io.sh) and the loop goes on;
+#   * depends on a skipped ledger crate      -> STOP CLEANLY (exit 0): naming
+#     the crate, the ledger crate it waits on, everything published so far and
+#     the next step. `cargo publish` resolves the packaged crate's whole graph
+#     against the registry before uploading, so this crate cannot be published
+#     until the token step has run; re-running the same tag resumes here;
+#   * otherwise                              -> `cargo publish --locked`,
+#     VERIFIED, then wait until crates.io serves the version.
+#
+# This is the three-way interleave that lets a release carry brand-new crates:
+# the trusted lane publishes up to the first dependent of a ledger crate and
+# stops; the token creates the ledger crate's record (its dependencies now
+# exist); the maintainer enables Trusted Publishing on the new record; the tag
+# run is re-run and resumes. docs/RELEASE.md, "Outstanding bootstrap", is the
+# step-by-step procedure with the expected stop messages.
+#
+# The stop condition is computed from `cargo metadata`, never hand-listed, and
+# over EVERY dependency kind, dev-dependencies included: the publish verifies,
+# and verification resolves dev-dependencies too, so a dev-edge onto a skipped
+# ledger crate would fail exactly like a normal one — after the upload of the
+# crates ahead of it. Ordering alone does not save a dev-edge here: the
+# ledger crate it points at is not "earlier and published", it is skipped.
+#
+# Usage:
+#   scripts/publish-release-crates.sh VERSION             publish (needs CARGO_REGISTRY_TOKEN)
+#   scripts/publish-release-crates.sh VERSION --dry-run   the same decisions, no publish
+#   scripts/publish-release-crates.sh --self-test         the interleave end to end,
+#                                                         offline, against a mock registry
+#
+# Environment:
+#   GITHUB_OUTPUT               if set, `complete=true|false` is appended, so the
+#                               workflow can hold the GitHub Release until the
+#                               whole set is up
+#   PURRDF_RELEASE_CRATES_FILE  an alternative release-set/ledger file (self-test)
+#   PURRDF_CRATES_IO_MOCK       a mock registry directory (scripts/crates-io-api.sh)
+
+set -euo pipefail
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+mode="publish"
+VERSION=""
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) mode="dry-run" ;;
+    --self-test) mode="self-test" ;;
+    -h | --help)
+      sed -n '/^# Usage:/,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    -*)
+      echo "unknown option: ${arg}" >&2
+      exit 2
+      ;;
+    *)
+      VERSION="${arg#rust-v}"
+      ;;
+  esac
+done
+
+metadata_json="$(mktemp)"
+trap 'rm -f "${metadata_json}" "${CRATES_IO_BODY:-}"' EXIT
+(cd "${repo}" && cargo metadata --no-deps --format-version 1) > "${metadata_json}"
+if [[ -z "${VERSION}" ]]; then
+  if [[ "$mode" == "self-test" ]]; then
+    VERSION="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["packages"][0]["version"])' "${metadata_json}")"
+  else
+    echo "usage: $0 VERSION [--dry-run] | --self-test" >&2
+    exit 2
+  fi
+fi
+
+# One definition of the release set and of the ledger, shared with the
+# preflight (scripts/check-crates-io-records.sh) and the token bootstrap
+# (scripts/bootstrap-crates-io.sh).
+release_list="${PURRDF_RELEASE_CRATES_FILE:-${repo}/scripts/release-crates.sh}"
+# shellcheck source=scripts/release-crates.sh
+source "${release_list}"
+# shellcheck source=scripts/crates-io-api.sh
+source "${repo}/scripts/crates-io-api.sh"
+crates=("${PURRDF_RELEASE_CRATES[@]}")
+ledger=("${PURRDF_UNBOOTSTRAPPED_CRATES[@]}")
+user_agent="$(crates_io_user_agent "${VERSION}")"
+
+in_list() {
+  local needle="$1"
+  shift
+  local item
+  for item in "$@"; do
+    [[ "$item" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+# registry_or_die <state>: present/missing pass; anything else is a hard stop.
+# Called in the parent shell after every capture — an `exit` inside `$(...)`
+# only ends the subshell, and an empty answer must never read as "missing".
+registry_or_die() {
+  case "$1" in
+    present | missing) ;;
+    *)
+      echo "crates.io could not give a verdict — ${1#error: }" >&2
+      echo "Stopping: an unknown registry answer is a stop, never \"probably fine\"." >&2
+      exit 1
+      ;;
+  esac
+}
+
+version_state() {
+  crates_io_version_state "$1" "${VERSION}" "${user_agent}"
+}
+
+# workspace_path_deps <crate>: "<kind> <name>" per PATH dependency, every kind.
+workspace_path_deps() {
+  python3 - "${metadata_json}" "$1" <<'PY'
+import json
+import sys
+
+metadata = json.load(open(sys.argv[1], encoding="utf-8"))
+for package in metadata["packages"]:
+    if package["name"] != sys.argv[2]:
+        continue
+    for dep in package["dependencies"]:
+        if dep.get("path"):
+            print(dep["kind"] or "normal", dep["name"])
+PY
+}
+
+wait_for_crate_version() {
+  local crate="$1" state
+  for _ in $(seq 1 30); do
+    state="$(version_state "$crate")"
+    registry_or_die "$state"
+    if [[ "$state" == "present" ]]; then
+      return 0
+    fi
+    sleep 10
+  done
+  echo "Timed out waiting for crates.io to expose ${crate} ${VERSION}" >&2
+  exit 1
+}
+
+emit_output() {
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "$1" >> "${GITHUB_OUTPUT}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# The loop.
+# ---------------------------------------------------------------------------
+
+run_loop() {
+  local crate state dep_line kind dep dep_state idx
+  local -a published=() skipped=() waiting=() not_attempted=()
+  local verb="published"
+  [[ "$mode" == "dry-run" ]] && verb="would publish"
+
+  for idx in "${!crates[@]}"; do
+    crate="${crates[$idx]}"
+    state="$(version_state "$crate")"
+    registry_or_die "$state"
+    if [[ "$state" == "present" ]]; then
+      echo "${crate} ${VERSION} already exists on crates.io; skipping"
+      continue
+    fi
+    if in_list "$crate" "${ledger[@]}"; then
+      echo "skipping ${crate}: bootstrap pending — no crates.io record; it is in PURRDF_UNBOOTSTRAPPED_CRATES and only the token step (scripts/bootstrap-crates-io.sh) can create it"
+      skipped+=("$crate")
+      continue
+    fi
+    waiting=()
+    while IFS= read -r dep_line; do
+      [[ -z "$dep_line" ]] && continue
+      kind="${dep_line%% *}"
+      dep="${dep_line#* }"
+      in_list "$dep" "${ledger[@]}" || continue
+      in_list "$dep" "${published[@]}" && continue
+      dep_state="$(version_state "$dep")"
+      registry_or_die "$dep_state"
+      [[ "$dep_state" == "present" ]] || waiting+=("${dep} ${VERSION} (${kind})")
+    done < <(workspace_path_deps "$crate")
+    if [[ "${#waiting[@]}" -gt 0 ]]; then
+      not_attempted=("${crates[@]:$idx}")
+      cat <<EOF
+
+STOP: ${crate} ${VERSION} depends on $(IFS=,; echo "${waiting[*]}"), which is in PURRDF_UNBOOTSTRAPPED_CRATES and not on crates.io yet.
+cargo publish resolves ${crate}'s dependency graph against the registry before uploading, so it cannot be published until the token step has created that record. This run stops here, cleanly; nothing after ${crate} was attempted.
+
+  ${verb} in this run: ${published[*]:-nothing}
+  skipped (bootstrap pending): ${skipped[*]:-none}
+  not attempted: ${not_attempted[*]}
+
+Next — the interleave (docs/RELEASE.md, "Outstanding bootstrap"):
+  1. from a clean checkout of this tag, create the ledger records whose dependencies are now on crates.io:
+       CARGO_REGISTRY_TOKEN="\${CARGO_TOKEN}" scripts/bootstrap-crates-io.sh ${VERSION}
+  2. on crates.io, for EACH record it created: add the Trusted Publisher entry
+     (GitHub Actions / Blackcat-Informatics / purrdf / release-cargo.yaml / no environment)
+     and enable "Require trusted publishing" — this release no longer touches that crate, but the NEXT release's run would 403 at it without the entry, and the preflight refuses it without the lock;
+  3. re-run this workflow run (gh run rerun <run-id>): published versions are skipped, so it resumes at ${crate}.
+EOF
+      emit_output "complete=false"
+      return 0
+    fi
+    if [[ "$mode" == "dry-run" ]]; then
+      echo "would publish ${crate} ${VERSION} (cargo publish -p ${crate} --locked)"
+    else
+      # VERIFIED: cargo unpacks the .crate and builds it against the registry
+      # before the upload that cannot be undone. Resolvable because every
+      # dependency is either already served (wait_for_crate_version) or is a
+      # ledger crate the token step created — or this loop stopped above.
+      cargo publish -p "$crate" --locked
+      wait_for_crate_version "$crate"
+      # Give the registry index a short propagation window before publishing
+      # dependents that name the freshly-published version.
+      sleep 15
+    fi
+    published+=("$crate")
+  done
+
+  echo
+  if [[ "${#skipped[@]}" -gt 0 ]]; then
+    # Every remaining crate published; only ledger crates with no dependent in
+    # the set are still absent. The set is not complete until they exist.
+    cat <<EOF
+INCOMPLETE: every crate that could be published is on crates.io, but these ledger crates still have no record: ${skipped[*]}
+Create them with the token step, enable Trusted Publishing on each, then re-run this workflow run to confirm the set (it will publish nothing and report complete).
+EOF
+    emit_output "complete=false"
+    return 0
+  fi
+  echo "COMPLETE: all ${#crates[@]} release crates are on crates.io at ${VERSION} (${verb}: ${published[*]:-none})."
+  emit_output "complete=true"
+}
+
+# ---------------------------------------------------------------------------
+# Self-test: the interleave, end to end, against a mock registry. Each round
+# is a dry-run; between rounds the mock is advanced exactly as the real
+# procedure would advance the registry — the crates the loop "would publish"
+# appear, then the token step creates every ledger crate whose dependencies
+# now exist. The rounds must terminate, every STOP must name the first crate
+# in publish order that depends on the ledger crate it waits on (computed
+# independently here, from the metadata), and the final round must say
+# COMPLETE.
+# ---------------------------------------------------------------------------
+
+self_test() {
+  local tmp
+  tmp="$(mktemp -d)"
+  # shellcheck disable=SC2064  # expand now: tmp is what to remove.
+  trap "rm -rf '${tmp}'; rm -f '${metadata_json}'" EXIT
+  local failures=0
+
+  # The fixture ledger: the real one when non-empty, else one crate with
+  # dependents, so the STOP arm is always exercised.
+  local -a fixture
+  if [[ "${#ledger[@]}" -gt 0 ]]; then
+    fixture=("${ledger[@]}")
+  else
+    fixture=("${crates[1]}")
+  fi
+  local ledger_file="${tmp}/ledger.sh"
+  {
+    cat "${repo}/scripts/release-crates.sh"
+    printf '\nPURRDF_UNBOOTSTRAPPED_CRATES=(%s)\n' "${fixture[*]}"
+  } > "${ledger_file}"
+
+  local mock="${tmp}/registry"
+  mkdir -p "$mock"
+  present() { printf '200\n{"version":{"crate":"%s","num":"%s"}}\n' "$1" "${VERSION}" > "${mock}/$1@${VERSION}"; }
+  is_present() { [[ -f "${mock}/$1@${VERSION}" ]]; }
+
+  # first_dependent <ledger-crate>: the first release crate, in publish order,
+  # with a path dependency (any kind) on it — the crate the loop must stop at.
+  first_dependent() {
+    python3 - "${metadata_json}" "$1" "${crates[@]}" <<'PY'
+import json
+import sys
+
+metadata = json.load(open(sys.argv[1], encoding="utf-8"))
+target = sys.argv[2]
+order = sys.argv[3:]
+deps = {
+    p["name"]: {d["name"] for d in p["dependencies"] if d.get("path")}
+    for p in metadata["packages"]
+}
+for crate in order:
+    if target in deps.get(crate, set()):
+        print(crate)
+        break
+PY
+  }
+
+  # token_step: create every fixture crate whose path deps are all present.
+  token_step() {
+    local crate dep_line ok created=()
+    for crate in "${fixture[@]}"; do
+      is_present "$crate" && continue
+      ok=true
+      while IFS= read -r dep_line; do
+        [[ -z "$dep_line" ]] && continue
+        is_present "${dep_line#* }" || ok=false
+      done < <(workspace_path_deps "$crate")
+      if [[ "$ok" == "true" ]]; then
+        present "$crate"
+        created+=("$crate")
+      fi
+    done
+    echo "${created[*]:-}"
+  }
+
+  echo "publish-release-crates.sh self-test (fixture ledger: ${fixture[*]}; version ${VERSION})"
+  local round=0 out status crate stop_crate expect created
+  while :; do
+    round=$((round + 1))
+    if [[ "$round" -gt 10 ]]; then
+      echo "  FAILED  the interleave did not terminate in 10 rounds"
+      failures=$((failures + 1))
+      break
+    fi
+    status=0
+    out="$(PURRDF_CRATES_IO_MOCK="${mock}" PURRDF_RELEASE_CRATES_FILE="${ledger_file}" \
+      bash "${BASH_SOURCE[0]}" "${VERSION}" --dry-run 2>&1)" || status=$?
+    if [[ "$status" -ne 0 ]]; then
+      echo "  FAILED  round ${round}: dry-run exited ${status}"
+      while IFS= read -r line; do printf '    | %s\n' "$line"; done <<<"$out"
+      failures=$((failures + 1))
+      break
+    fi
+    # Advance the mock by what the loop would have published.
+    while IFS= read -r crate; do
+      [[ -n "$crate" ]] && present "$crate"
+    done < <(sed -n 's/^would publish \([a-z0-9-]*\) .*/\1/p' <<<"$out")
+
+    if grep -q '^COMPLETE:' <<<"$out"; then
+      printf '  ok      round %s: COMPLETE — every release crate on crates.io\n' "$round"
+      break
+    fi
+    stop_crate="$(sed -n 's/^STOP: \([a-z0-9-]*\) .*/\1/p' <<<"$out")"
+    if [[ -n "$stop_crate" ]]; then
+      # The STOP must be at the first dependent of a still-absent ledger crate,
+      # every earlier non-ledger crate must have been published, and the crate
+      # itself must not have been.
+      expect=""
+      for crate in "${fixture[@]}"; do
+        if ! is_present "$crate"; then
+          expect="$(first_dependent "$crate")"
+          [[ -n "$expect" ]] && break
+        fi
+      done
+      if [[ "$stop_crate" == "$expect" ]] && ! grep -q "^would publish ${stop_crate} " <<<"$out" \
+        && grep -q "^skipping ${crate}: bootstrap pending" <<<"$out" \
+        && grep -q "gh run rerun" <<<"$out" && grep -q 'enable "Require trusted publishing"' <<<"$out"; then
+        printf '  ok      round %s: STOP at %s, waiting on %s (first dependent in publish order, computed independently)\n' "$round" "$stop_crate" "$crate"
+      else
+        printf '  FAILED  round %s: STOP at %s, expected %s (waiting on %s)\n' "$round" "$stop_crate" "$expect" "$crate"
+        while IFS= read -r line; do printf '    | %s\n' "$line"; done <<<"$out"
+        failures=$((failures + 1))
+        break
+      fi
+    elif grep -q '^INCOMPLETE:' <<<"$out"; then
+      printf '  ok      round %s: INCOMPLETE — only dependent-free ledger crates remain\n' "$round"
+    else
+      echo "  FAILED  round ${round}: neither STOP, INCOMPLETE nor COMPLETE"
+      while IFS= read -r line; do printf '    | %s\n' "$line"; done <<<"$out"
+      failures=$((failures + 1))
+      break
+    fi
+    created="$(token_step)"
+    printf '          token step creates: %s\n' "${created:-nothing (its dependencies are not up yet)}"
+    if [[ -z "$created" ]]; then
+      echo "  FAILED  round ${round}: the token step could create nothing, so the interleave is stuck"
+      failures=$((failures + 1))
+      break
+    fi
+  done
+
+  # A registry fault is a stop with a non-zero exit, never a verdict.
+  local fault="${tmp}/fault"
+  mkdir -p "$fault"
+  printf '502\n' > "${fault}/${crates[0]}@${VERSION}"
+  status=0
+  out="$(PURRDF_CRATES_IO_MOCK="${fault}" PURRDF_RELEASE_CRATES_FILE="${ledger_file}" \
+    bash "${BASH_SOURCE[0]}" "${VERSION}" --dry-run 2>&1)" || status=$?
+  if [[ "$status" -ne 0 ]] && grep -q "returned 502" <<<"$out"; then
+    printf '  ok      registry answers 502: exit %s, no decision taken\n' "$status"
+  else
+    printf '  FAILED  registry answers 502: exit %s\n' "$status"
+    failures=$((failures + 1))
+  fi
+
+  if [[ "$failures" -gt 0 ]]; then
+    echo "publish-release-crates.sh self-test: ${failures} arm(s) FAILED" >&2
+    return 1
+  fi
+  echo "publish-release-crates.sh self-test: the interleave terminates, every STOP is at the right crate, faults stop the loop"
+}
+
+case "$mode" in
+  self-test) self_test ;;
+  *)
+    if [[ "$mode" == "publish" && -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
+      echo "CARGO_REGISTRY_TOKEN is not set (use --dry-run to see the decisions without publishing)" >&2
+      exit 1
+    fi
+    cd "${repo}"
+    run_loop
+    ;;
+esac

--- a/scripts/release-crates.sh
+++ b/scripts/release-crates.sh
@@ -72,6 +72,12 @@ PURRDF_RELEASE_CRATES=(
 # the in-page anchor all derive from it — and scripts/check-publish-order.py
 # holds it to the release set. Membership itself is a fact about crates.io and
 # is only ever decided by the preflight, never by prose.
+#
+# This array is ALSO the whole of what scripts/bootstrap-crates-io.sh will
+# publish. An API token can create a record; it cannot publish a new version of
+# any crate that has one (every existing record is locked to Trusted Publishing
+# and answers a token publish with 403), so the bootstrap walks this ledger and
+# refuses any entry that has a record, by name.
 
 # shellcheck disable=SC2034  # consumed by the sourcing script.
 PURRDF_UNBOOTSTRAPPED_CRATES=(


### PR DESCRIPTION
## The false premise

`docs/RELEASE.md` and `scripts/bootstrap-crates-io.sh` assumed the token lane could publish the whole 21-crate set. An actual attempt — `scripts/bootstrap-crates-io.sh 0.13.0`, valid `CARGO_TOKEN`, clean tree at `fa10b23b` — packaged all 21 crates, verified `purrdf-events`, and on the **first** upload got:

```
error: failed to publish purrdf-events v0.13.0 to registry at https://crates.io
Caused by:
  the remote server responded with an error (status 403 Forbidden): New versions of this crate can only be published using Trusted Publishing (see https://crates.io/docs/trusted-publishing).
```

Nothing landed. Verified against primary sources:

- **All 18 existing crates carry `trustpub_only: true`** in the public `/api/v1/crates/<name>` record; crates.io's publish handler answers a token publish of such a crate with exactly that 403 (`src/controllers/krate/publish.rs`).
- **A Trusted Publishing token cannot create a crate** (`Trusted Publishing tokens do not support creating new crates. Publish the crate manually, first`). Creating the three missing records is the token's *only* remaining job.
- **`--no-verify` does not skip dependency resolution.** `cargo publish -p purrdf-cdt --no-verify --dry-run --locked` at 0.13.0, on stable 1.98 and the nightly pin alike: `failed to select a version for the requirement purrdf-iri = "^0.13.0"`.
- **Neither lane can go first.** `purrdf-cdt` is a normal dependency of `purrdf-core`, `purrdf-sparql-algebra`, `purrdf-sparql-eval`; `purrdf` depends on `purrdf-text` and `purrdf-geo`.

## The decided shape: the interleave

The lane publishes everything it can, skips each ledger crate, and **stops cleanly** at the first crate that depends on a skipped one; the token creates that crate's record (deps now exist — the publish is *verified*); Trusted Publishing is enabled on the new record; the same run is resumed with `gh run rerun <run-id>` (the workflow is tag-triggered only). For the current graph: **three tag runs, two token steps** — `purrdf-text` and `purrdf-geo` share their first dependent (`purrdf`).

- **`scripts/publish-release-crates.sh`** (new) — the lane's loop, extracted from the workflow. Stop condition from `cargo metadata`, every dependency kind (verification resolves dev-deps; a dev-edge onto a *skipped* crate fails like a normal one). `--dry-run`; `--self-test` runs the whole interleave against a mock registry, checking each STOP against an independently computed first dependent. Writes `complete=` to `GITHUB_OUTPUT`; the workflow creates the GitHub Release only when complete, otherwise prints the next step.
- **`scripts/check-crates-io-records.sh`** — permits a missing record the ledger names (`PENDING`), refuses one it does not; tolerates a ledgered record that exists *at the version being released* (the tag's tree is frozen in flight), refuses one at any other version as stale; refuses any record not locked to Trusted Publishing — the check that catches a missed enable between runs. `--self-test`, 10 arms.
- **`scripts/bootstrap-crates-io.sh`** — walks the ledger only; creates every ledger crate whose deps are up (verified), `DEFER`s the rest by name, refuses when nothing is creatable, refuses any ledger crate with a record, keeps dirty-tree refusal and resumability. `--plan`; `--self-test`, 8 arms.
- **`scripts/crates-io-api.sh`** — one shared read path (record / version / lock), mockable.
- **`docs/RELEASE.md`** — the six-step procedure with exact commands and expected STOP messages, the enable at each token point, `gh run rerun` as the resume, and the three rejected shapes with evidence (`--no-verify` token-first, temporary unlock, placeholder). Book page, `CUTOVER.md`, workflow comments updated. `CHANGELOG.md` / `cliff.toml` untouched.

## Proofs against the **real** registry at 0.13.0

- `publish-release-crates.sh 0.13.0 --dry-run`: would publish events, iri, xsd, gts; `skipping purrdf-cdt: bootstrap pending`; `STOP: purrdf-core 0.13.0 depends on purrdf-cdt 0.13.0 (normal)`; exit 0.
- `bootstrap-crates-io.sh --plan`: `DEFER` ×3, `REFUSING: nothing can be created yet`, exit 1. Self-test: token step 1 (cdt's deps present) creates cdt and defers text/geo; fake ledger naming `purrdf-events` refuses by name.
- `check-crates-io-records.sh` with `PURRDF_RELEASE_VERSION=rust-v0.13.0`: 18 `ok (trustpub_only=true)`, `PENDING` ×3, exit 0; with a fake ledger omitting `purrdf-geo`: `MISSING purrdf-geo … NOT in PURRDF_UNBOOTSTRAPPED_CRATES`, exit 1.
- Self-test of the loop: round 1 STOP at `purrdf-core` (cdt) → token creates cdt → round 2 STOP at `purrdf` (text) → token creates text, geo → round 3 COMPLETE; 502 → exit 1.

Gates: `shellcheck -x` clean on all five scripts; the three self-tests are in `make check` and the CI hygiene job; `check-doc-claims`, `check-versions`, `check-publish-order`, `check-toolchain-pin` pass; `mdbook build` exit 0; `make check-i18n` passes all 6 gates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer crates.io bootstrapping with dependency-aware planning, staged execution, resumable workflows, and publication verification.
  * Added release publishing that pauses cleanly when prerequisite crate records are unavailable and resumes after bootstrapping.
  * Added validation for missing, stale, untracked, and Trusted Publishing-locked crates.
  * Added offline self-tests for crates.io checks, bootstrapping, and release publishing.

* **Documentation**
  * Updated release guidance with bootstrap procedures, recovery steps, Trusted Publishing requirements, and verification details.
  * Documented the completed prerequisite cutover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->