### PR TITLE
refactor(gts): carry base direction beside the term row, so 1.1.0 stays additive

### DIFF
--- a/bindings/python/python/src/purrdf/__init__.pyi
+++ b/bindings/python/python/src/purrdf/__init__.pyi
@@ -1074,19 +1074,14 @@ def feedback_bundle_native(
 
 # ── GTS fold view and relational exports (bindings/python/src/py_gts_view.rs) ───
 
-# (term_id, kind, value, datatype_id, lang, reifier_id, triple, direction).
-# `direction` is the RDF 1.2 literal base direction ("ltr"/"rtl") and is APPENDED
-# rather than placed beside `lang`: callers unpack this row positionally, so the
-# row grows only at the end.
+# (term_id, kind, value, datatype_id, lang, reifier_id, triple).
+#
+# RDF 1.2 base direction is NOT a field here — it is the parallel `directions`
+# column on `GtsRelationalRows`, index-aligned with `terms`. Callers unpack this
+# row positionally, so widening it would break them at runtime with no type
+# boundary to catch it.
 _TermRow = tuple[
-    int,
-    int,
-    str | None,
-    int | None,
-    str | None,
-    int | None,
-    tuple[int, int, int] | None,
-    str | None,
+    int, int, str | None, int | None, str | None, int | None, tuple[int, int, int] | None
 ]
 _QuadRow = tuple[int, int, int, int | None]
 _ReifierRow = tuple[int, int, int, int, int | None]
@@ -1099,6 +1094,8 @@ _InputTermRow = tuple[
 
 class GtsRelationalRows(TypedDict):
     terms: list[_TermRow]
+    # RDF 1.2 base direction ("ltr"/"rtl"), positionally parallel to `terms`.
+    directions: list[str | None]
     quads: list[_QuadRow]
     reifiers: list[_ReifierRow]
     annotations: list[_AnnotationRow]

--- a/bindings/python/python/src/purrdf/_gts_export.py
+++ b/bindings/python/python/src/purrdf/_gts_export.py
@@ -138,14 +138,22 @@ def _rows(data: bytes) -> dict[str, Any]:
     return _native.gts_relational_rows_from_bytes(data)
 
 
-def _flatten_terms(terms: Sequence[Any]) -> Iterator[tuple[Any, ...]]:
-    """Flatten each term row's optional ``(s, p, o)`` triple into three columns.
+def _flatten_terms(
+    terms: Sequence[Any], directions: Sequence[Any]
+) -> Iterator[tuple[Any, ...]]:
+    """Flatten each term row's ``(s, p, o)`` triple and zip in its base direction.
 
-    The unpack is deliberately strict about arity. The projection's row is public
-    API that grows only at the END, so a widened row should fail loudly here
-    rather than be silently accepted and written into the wrong columns.
+    ``directions`` is a column parallel to ``terms`` rather than a field inside the
+    row, because the row is public API that callers unpack positionally — see
+    ``purrdf_rdf::gts_view::term_directions``. The two are index-aligned by
+    construction; ``strict=True`` says so rather than trusting it.
+
+    The unpack is deliberately strict about arity: a row that changes shape should
+    fail loudly here rather than be accepted and written into the wrong columns.
     """
-    for term_id, kind, value, datatype_id, lang, reifier_id, triple, direction in terms:
+    for (term_id, kind, value, datatype_id, lang, reifier_id, triple), direction in zip(
+        terms, directions, strict=True
+    ):
         s, p, o = triple if triple is not None else (None, None, None)
         yield (term_id, kind, value, datatype_id, lang, direction, reifier_id, s, p, o)
 
@@ -153,7 +161,7 @@ def _flatten_terms(terms: Sequence[Any]) -> Iterator[tuple[Any, ...]]:
 def _table_rows(rows: dict[str, Any], table: str) -> list[tuple[Any, ...]]:
     """The row tuples for one table, in the projection's own order."""
     if table == "terms":
-        return list(_flatten_terms(rows["terms"]))
+        return list(_flatten_terms(rows["terms"], rows["directions"]))
     if table == "blobs":
         return [(digest, payload) for digest, payload in rows["blobs"]]
     return [tuple(row) for row in rows[table]]

--- a/bindings/python/src/py_gts_view.rs
+++ b/bindings/python/src/py_gts_view.rs
@@ -259,10 +259,13 @@ impl PyGtsFoldView {
 
     fn relational_rows<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let view = &self.inner;
-        let rows = py
-            .detach(|| view.relational_rows())
+        let (rows, directions) = py
+            .detach(|| {
+                view.relational_rows()
+                    .map(|rows| (rows, crate::gts_view::term_directions(view.graph())))
+            })
             .map_err(PyValueError::new_err)?;
-        relational_rows_dict(py, rows)
+        relational_rows_dict(py, rows, directions)
     }
 }
 
@@ -285,13 +288,14 @@ fn gts_relational_rows_from_bytes<'py>(
     py: Python<'py>,
     data: &[u8],
 ) -> PyResult<Bound<'py, PyDict>> {
-    let rows = py
+    let (rows, directions) = py
         .detach(|| {
             let graph = purrdf_gts::reader::read(data, true, None);
             crate::gts_view::relational_rows(&graph)
+                .map(|rows| (rows, crate::gts_view::term_directions(&graph)))
         })
         .map_err(PyValueError::new_err)?;
-    relational_rows_dict(py, rows)
+    relational_rows_dict(py, rows, directions)
 }
 
 // `gts_to_sqlite` / `gts_to_duckdb` / `gts_to_parquet` are NOT here.
@@ -457,9 +461,20 @@ fn term_kind_int(kind: TermKind) -> u8 {
     }
 }
 
-fn relational_rows_dict(py: Python<'_>, rows: RelationalRows) -> PyResult<Bound<'_, PyDict>> {
+/// Build the projection dict.
+///
+/// `directions` is a SEPARATE key positionally parallel to `terms`, not an eighth
+/// column inside each term row. Python callers unpack those rows positionally, so
+/// widening them breaks at runtime with no type boundary to catch it; a new key
+/// breaks nothing that does not already ask for it.
+fn relational_rows_dict(
+    py: Python<'_>,
+    rows: RelationalRows,
+    directions: Vec<Option<String>>,
+) -> PyResult<Bound<'_, PyDict>> {
     let out = PyDict::new(py);
     out.set_item("terms", rows.terms)?;
+    out.set_item("directions", directions)?;
     out.set_item("quads", rows.quads)?;
     out.set_item("reifiers", rows.reifiers)?;
     out.set_item("annotations", rows.annotations)?;

--- a/bindings/python/tests/test_gts_fold_view.py
+++ b/bindings/python/tests/test_gts_fold_view.py
@@ -113,12 +113,12 @@ def test_a_quoted_triple_terms_own_components_survive_the_fold_view() -> None:
     assert view.term_tuple(10) == (3, None, None, None, None, None, (0, 1, 5))
     assert view.reifier_count() == 2, "both bindings of the one reifier id are kept"
 
-    # The projection row is `(term_id, kind, value, datatype_id, lang, reifier_id,
-    # triple, direction)`. The trailing `direction` is `None` here because a quoted
-    # triple term is not a literal and has no base direction.
     rows = view.relational_rows()
-    assert rows["terms"][9] == (9, 3, None, None, None, None, (0, 1, 2), None)
-    assert rows["terms"][10] == (10, 3, None, None, None, None, (0, 1, 5), None)
+    assert rows["terms"][9] == (9, 3, None, None, None, None, (0, 1, 2))
+    assert rows["terms"][10] == (10, 3, None, None, None, None, (0, 1, 5))
+    # Base direction is a parallel column, and a quoted triple term has none.
+    assert rows["directions"][9] is None
+    assert rows["directions"][10] is None
 
 
 def test_an_out_of_range_triple_component_is_refused() -> None:

--- a/bindings/python/tests/test_gts_relational_export.py
+++ b/bindings/python/tests/test_gts_relational_export.py
@@ -92,7 +92,9 @@ def test_sqlite_export_round_trips_every_table(
         ).fetchall()
         expected = [
             (tid, kind, value, dt, lang, direction, rid, *(triple or (None, None, None)))
-            for tid, kind, value, dt, lang, rid, triple, direction in rows["terms"]
+            for (tid, kind, value, dt, lang, rid, triple), direction in zip(
+                rows["terms"], rows["directions"], strict=True
+            )
         ]
         assert terms == expected
     finally:
@@ -259,7 +261,10 @@ def test_base_direction_survives_the_export(tmp_path: Path) -> None:
     # property that was actually lost.
     assert len({(v, lang, d) for v, lang, d in stored}) == 3, stored
     # The export agrees with the projection it is derived from.
-    assert sorted(t[7] or "" for t in rows["terms"] if t[1] == 1) == ["", "ltr", "rtl"]
+    literal_dirs = [
+        d for t, d in zip(rows["terms"], rows["directions"], strict=True) if t[1] == 1
+    ]
+    assert sorted(d or "" for d in literal_dirs) == ["", "ltr", "rtl"]
 
 
 def test_one_reifier_binding_two_triples_exports_both(tmp_path: Path) -> None:

--- a/crates/rdf/src/gts_view.rs
+++ b/crates/rdf/src/gts_view.rs
@@ -104,28 +104,22 @@ pub enum PublicValue {
 }
 
 /// One dictionary term row: `(term_id, kind, value, datatype_id, lang,
-/// reifier_id, triple, direction)` where `kind` is `0` IRI / `1` literal / `2`
-/// blank node / `3` triple term.
+/// reifier_id, triple)` where `kind` is `0` IRI / `1` literal / `2` blank node /
+/// `3` triple term.
 ///
 /// `triple` carries a quoted-triple term's OWN `(s, p, o)` component ids when
 /// the term is self-describing. It is not derivable from `reifier_id`: one
 /// reifier id may bind several different triples, so a projection that offered
 /// only the reifier column could not say which triple THIS term is.
 ///
-/// `direction` is the RDF 1.2 literal BASE DIRECTION (`"ltr"` / `"rtl"`), and it
-/// is a column of its own rather than a suffix on `lang`. The term model stores
-/// the two separately — `lang` is bare (`en`), and the public-text renderer
-/// recombines them into `@en--ltr` for display only — so a projection that
-/// emitted `lang` alone dropped the direction entirely. Two literals differing
-/// only in direction are DIFFERENT terms under the canonicalization profile
-/// (`@en--ltr` ≠ `@en--rtl`), so collapsing them is a silent conflation, not a
-/// cosmetic loss.
+/// # RDF 1.2 base direction is NOT in this row
 ///
-/// It is APPENDED rather than placed beside `lang` where it reads best. Every
-/// index in this tuple is public API that callers unpack positionally, so a
-/// reordering would keep compiling and silently move `reifier_id` into a
-/// caller's `direction` slot. Growing only at the end is what makes widening
-/// this row safe.
+/// It is a parallel column instead — [`term_directions`] — because this alias is
+/// published API and callers unpack it POSITIONALLY. Widening the tuple is a
+/// breaking change to every such caller, and it fails at runtime rather than at
+/// the type boundary for the Python and JS surfaces that see the same row. A
+/// parallel column is a worse shape to read than an eighth field and a better one
+/// to add, which is the whole trade: this is an additive release.
 pub type TermRow = (
     usize,
     u8,
@@ -134,7 +128,6 @@ pub type TermRow = (
     Option<String>,
     Option<usize>,
     Option<(usize, usize, usize)>,
-    Option<String>,
 );
 /// One quad row of dictionary term ids: `(subject, predicate, object, graph?)`.
 pub type QuadRow = (usize, usize, usize, Option<usize>);
@@ -148,6 +141,34 @@ pub type ReifierRow = (usize, usize, usize, usize, Option<usize>);
 pub type AnnotationRow = (usize, usize, usize, Option<usize>);
 /// One decoded blob row: `(digest, payload bytes)`.
 pub type BlobRow = (String, Vec<u8>);
+
+/// The RDF 1.2 base direction of every term, positionally parallel to
+/// [`RelationalRows::terms`].
+///
+/// `Some("ltr")` / `Some("rtl")` for a directional language-tagged literal, `None`
+/// for everything else. Index `i` describes the term whose id is `i`, which is the
+/// same index [`relational_rows`] assigns, so the two zip.
+///
+/// # Why this is not an eighth column on `TermRow`
+///
+/// Direction genuinely belongs beside `lang`, and putting it there is a breaking
+/// change: [`TermRow`] is a published tuple alias that callers unpack positionally,
+/// and the Python and JS surfaces expose the same row shape where the failure is at
+/// runtime rather than at a type boundary. So it is added ALONGSIDE rather than
+/// inside — a worse shape to read, a safe one to ship.
+///
+/// The term model has always carried direction; only the projection omitted it, and
+/// `lang` is stored bare (`en`) with `@en--ltr` recombined for display, so a caller
+/// reading `lang` alone silently loses it. Two literals differing only in direction
+/// are DIFFERENT terms under the canonicalization profile, so that loss conflates.
+#[must_use]
+pub fn term_directions(graph: &Graph) -> Vec<Option<String>> {
+    graph
+        .terms
+        .iter()
+        .map(|term| term.direction.clone())
+        .collect()
+}
 
 /// The compact dictionary-encoded relational projection of a folded GTS graph:
 /// term dictionary, quads, statement-layer rows, and decoded blobs, all keyed by
@@ -810,7 +831,6 @@ pub fn relational_rows(graph: &Graph) -> Result<RelationalRows, String> {
                     term.lang.clone(),
                     term.reifier,
                     term.triple,
-                    term.direction.clone(),
                 )
             })
             .collect(),


### PR DESCRIPTION
Makes `main` releasable as **1.1.0** instead of 2.0.0. No functional change — the data-conflation fix is untouched; only how its result is surfaced moved.

## The problem

#266 widened `purrdf_rdf::gts_view::TermRow` from a 7-tuple to an 8-tuple to carry RDF 1.2 base direction. That alias is `pub` in a `pub mod` of a **published crate**, and callers unpack it positionally — so it is a breaking change under the semver policy adopted at 1.0.0 (`README.md:749`).

The Python surface is the worse half: `gts_relational_rows_from_bytes()` returns the same row shape with no type boundary, so a caller unpacking seven values fails at **runtime**. Not hypothetical — a test in this repo did exactly that and broke when the row grew.

Shipping it would have forced **2.0.0 one day after 1.0.0**, for what is otherwise two bug fixes plus additive surface.

## The fix

`TermRow` goes back to its 1.0.0 shape. Direction becomes a parallel column:

- Rust: `purrdf_rdf::gts_view::term_directions(&Graph) -> Vec<Option<String>>`, indexed identically to `RelationalRows::terms`
- Python: a `directions` key on the projection dict, positionally parallel to `terms`

A new function and a new dict key break nothing that does not already ask for them. A parallel column is a worse shape to *read* than an eighth field and a better one to *add* — that trade is the whole PR.

`RelationalRows` gains no field either: it is not `#[non_exhaustive]`, so adding one would break exhaustive construction and matching for the same reason.

## What is deliberately unchanged

The **composer fix stays**. Base direction still participates in the intern key and the content-sort key, so `"Cat"@en--ltr` and `"Cat"@en--rtl` remain two terms rather than merging into one. That was the actual data-corruption bug; this PR only moves how the result is exposed.

## Verified, not asserted

- `TermRow` diffs **byte-identical** against the `rust-v1.0.0` tag
- A 1.0.0-era seven-value unpack still succeeds on the Python surface
- Both directional literals still survive as distinct terms with their directions intact
- `make check` green · `make conformance` GREEN · 778 Python tests · clippy clean

## Note on the commit marker

The commit is **not** marked `!` on purpose. There is no break here — it reverses an *unreleased* API change — and `!` is what git-cliff reads as a major-bump trigger, which is the exact outcome this PR exists to avoid. Breaking-trigger count on this branch: 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **API Changes**
  - Relational term rows no longer include literal base direction as an embedded tuple element.
  - Literal directions are now provided separately in a position-aligned `directions` list.
  - Added access to term direction metadata through the RDF view interface.
  - Updated Python projections and relational exports to use the separate direction data while preserving existing term-row structure.
  - Direction values continue to support `None`, `ltr`, and `rtl`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->