### PR TITLE
chore(release): 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,71 @@ breaking change bumps the major version, a minor bump is additive, and a patch
 bump is bugfix-only. The C ABI (`purrdf.h`) is versioned separately and remains
 0.x.
 
-## [Unreleased]
+## [1.1.0] - 2026-09-04
+
+The first release after 1.0.0. Two reported bugs, the release fallout 1.0.0 left
+behind, and a data-conflation bug in the GTS carrier found while coordinating
+with the upstream wire-format freeze.
+
+Additive: no published API changes shape. A `TermRow` widening that would have
+forced a major bump was reworked into a parallel column before release — RDF 1.2
+base direction is now `purrdf_rdf::gts_view::term_directions()` and a
+`directions` key on the Python projection dict, so every 1.0.0 caller keeps
+working.
+
+### Bug Fixes
+
+- **shacl:** `sh:message` templates are substituted on the `sh:sparql` path.
+  `{$path}`/`{$value}` shipped as literal braces because the constraint's
+  message was resolved once and cloned into every result row; it is now rendered
+  per solution, from that solution's own bindings. Both `{?var}` and `{$var}`
+  spellings, and `{$this}` whether or not the SELECT projects it. An unbound
+  placeholder is still left verbatim rather than blanked.
+- **cli:** `purrdf validate` resolves a shapes graph's `owl:imports` from
+  `--import IRI=FILE`, transitively and cycle-safely. Previously they were
+  ignored in silence, so a shapes graph whose shapes lived in its imports
+  reported `conforms true` against no shapes at all. PurRDF fetches nothing: an
+  unresolved import with no `--import` given is reported on stderr, and with a
+  table given is refused by name.
+- **gts:** RDF 1.2 literal base direction is part of a term's identity in the
+  snapshot composer. It was absent from the intern key, so `"Cat"@en--ltr` and
+  `"Cat"@en--rtl` merged into ONE term and every quad was repointed at the
+  survivor — a different graph, not a missing column. Emitted bytes are
+  unchanged for any input without directional literals.
+- **release:** The crates.io bootstrap script packages and publishes its PLAN
+  rather than the whole ledger; a deferred crate no longer reaches `cargo
+  package`. Its self-test asserts the arguments handed to the irreversible step,
+  and the arm that had been failing since the ledger emptied is fixed — that arm
+  runs before `cargo test` in `make check`, so it had been failing the gate for
+  every contributor.
+
+### Features
+
+- **python:** `gts_to_sqlite`, `gts_to_duckdb` and `gts_to_parquet` are
+  implemented. They previously raised unconditionally. Five tables in the
+  projection's own row order, so the same container exports to the same content
+  twice. SQLite needs only the standard library; the other two take the
+  `[duckdb]` / `[parquet]` extras.
+- **rdf:** `gts_view::term_directions()` exposes RDF 1.2 base direction from the
+  relational projection, which previously dropped it.
+- **entail:** `entails::imports::imported_iris()` is public, so a consumer can
+  read a document's `owl:imports` without re-deriving which objects count.
+
+### Documentation
+
+- **pack:** The pack identity digest is no longer captioned "RDFC-1.0". It is
+  computed through the `purrdf-rdfc12` profile, which agrees with RDFC-1.0 byte
+  for byte only on the RDF 1.1 subset. Labelling only — no digest bytes change.
+
+### Build
+
+- **ci:** Benchmarks moved off the per-push path to a weekly schedule plus
+  `workflow_dispatch`, and its `uv` installer is pinned.
+- **make:** `make doctor` reports which build pins the local machine actually
+  enforces, and the wasm gate distinguishes "rustup absent" from "target not
+  installed" instead of printing the same line for both.
+- **python:** `bench = false` on the binding lib, so `cargo bench --workspace`
+  links.
 
 ## [1.0.0] - 2026-09-02
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,8 +31,8 @@ authors:
   - family-names: "Audley"
     given-names: "Patrick"
     orcid: "https://orcid.org/0000-0003-4382-7625"
-version: "1.0.0"
-date-released: "2026-09-02"
+version: "1.1.0"
+date-released: "2026-09-03"
 license:
   - Apache-2.0
   - MIT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "purrdf-columnar",
  "purrdf-datalog",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-capi"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-cdt"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "pretty_assertions",
  "proptest",
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-cli"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "criterion",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-columnar"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-core"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-datalog"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-entail"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ahash",
  "blake3",
@@ -1445,11 +1445,11 @@ dependencies = [
 
 [[package]]
 name = "purrdf-events"
-version = "1.0.0"
+version = "1.1.0"
 
 [[package]]
 name = "purrdf-geo"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "purrdf-core",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-gts"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "ahash",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-iri"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-python"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "purrdf",
  "purrdf-core",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-rdf"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ahash",
  "boon",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shapes"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "boon",
  "criterion",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-shex"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-slice"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "hex",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-algebra"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-conformance"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "camino",
  "datatest-stable",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-eval"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ahash",
  "criterion",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-sparql-results"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "insta",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-text"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "blake3",
  "caseless",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-validate"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "pretty_assertions",
  "purrdf-core",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-wasm"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "pretty_assertions",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "purrdf-xsd"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -54,26 +54,26 @@ homepage = "https://blackcatinformatics.ca/purrdf/"
 # re-enabled per crate with `default-features = true` where required.
 [workspace.dependencies]
 # --- internal crates (paths are relative to the WORKSPACE ROOT) ---
-purrdf = { path = "crates/purrdf", version = "1.0.0" }
-purrdf-cdt = { path = "crates/cdt", version = "1.0.0" }
-purrdf-columnar = { path = "crates/columnar", version = "1.0.0" }
-purrdf-core = { path = "crates/rdf-core", version = "1.0.0" }
-purrdf-datalog = { path = "crates/datalog", version = "1.0.0" }
-purrdf-entail = { path = "crates/entail", version = "1.0.0" }
-purrdf-events = { path = "crates/rdf-events", version = "1.0.0" }
-purrdf-geo = { path = "crates/geo", version = "1.0.0" }
-purrdf-gts = { path = "crates/gts", version = "1.0.0" }
-purrdf-iri = { path = "crates/iri", version = "1.0.0" }
-purrdf-rdf = { path = "crates/rdf", version = "1.0.0" }
-purrdf-shapes = { path = "crates/shapes", version = "1.0.0" }
-purrdf-shex = { path = "crates/shex", version = "1.0.0" }
-purrdf-slice = { path = "crates/slice", version = "1.0.0" }
-purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "1.0.0" }
-purrdf-sparql-eval = { path = "crates/sparql-eval", version = "1.0.0" }
-purrdf-sparql-results = { path = "crates/sparql-results", version = "1.0.0" }
-purrdf-text = { path = "crates/text", version = "1.0.0" }
-purrdf-validate = { path = "crates/validate", version = "1.0.0" }
-purrdf-xsd = { path = "crates/xsd", version = "1.0.0" }
+purrdf = { path = "crates/purrdf", version = "1.1.0" }
+purrdf-cdt = { path = "crates/cdt", version = "1.1.0" }
+purrdf-columnar = { path = "crates/columnar", version = "1.1.0" }
+purrdf-core = { path = "crates/rdf-core", version = "1.1.0" }
+purrdf-datalog = { path = "crates/datalog", version = "1.1.0" }
+purrdf-entail = { path = "crates/entail", version = "1.1.0" }
+purrdf-events = { path = "crates/rdf-events", version = "1.1.0" }
+purrdf-geo = { path = "crates/geo", version = "1.1.0" }
+purrdf-gts = { path = "crates/gts", version = "1.1.0" }
+purrdf-iri = { path = "crates/iri", version = "1.1.0" }
+purrdf-rdf = { path = "crates/rdf", version = "1.1.0" }
+purrdf-shapes = { path = "crates/shapes", version = "1.1.0" }
+purrdf-shex = { path = "crates/shex", version = "1.1.0" }
+purrdf-slice = { path = "crates/slice", version = "1.1.0" }
+purrdf-sparql-algebra = { path = "crates/sparql-algebra", version = "1.1.0" }
+purrdf-sparql-eval = { path = "crates/sparql-eval", version = "1.1.0" }
+purrdf-sparql-results = { path = "crates/sparql-results", version = "1.1.0" }
+purrdf-text = { path = "crates/text", version = "1.1.0" }
+purrdf-validate = { path = "crates/validate", version = "1.1.0" }
+purrdf-xsd = { path = "crates/xsd", version = "1.1.0" }
 
 # --- external crates ---
 aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 
 [project]
 name = "purrdf"
-version = "1.0.0"
+version = "1.1.0"
 description = "Python bindings for the PurRDF RDF 1.2 kernel, GTS carrier, SHACL, and slice tooling"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -976,7 +976,7 @@ wheels = [
 
 [[package]]
 name = "purrdf"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/crates/rdf-capi/Cargo.toml
+++ b/crates/rdf-capi/Cargo.toml
@@ -33,7 +33,7 @@ path = "src/lib.rs"
 # The `python` feature stays OFF: this is a C-ABI, not a PyO3 extension.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf-rs = { package = "purrdf", path = "../purrdf", version = "1.0.0" }
+purrdf-rs = { package = "purrdf", path = "../purrdf", version = "1.1.0" }
 # purrdf re-exports the core types, but the capi depends on the kernel
 # directly too so it can name MutableDataset/QuadValues/GraphMatchValue/DatasetMut
 # without leaning on re-export aliasing. Harmless to crate-check (acyclic).
@@ -84,4 +84,4 @@ description = "PurRDF purrdf semantic RDF-1.2 C-ABI"
 
 [package.metadata.capi.library]
 name = "purrdf"
-version = "1.0.0"
+version = "1.1.0"

--- a/crates/rdf-capi/include/purrdf.h
+++ b/crates/rdf-capi/include/purrdf.h
@@ -9,7 +9,7 @@
 
 /* WARNING: generated file — edit crates/rdf-capi instead. */
 #define PURRDF_MAJOR 1
-#define PURRDF_MINOR 0
+#define PURRDF_MINOR 1
 #define PURRDF_PATCH 0
 
 

--- a/crates/rdf-wasm/js/package.json
+++ b/crates/rdf-wasm/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackcatinformatics/purrdf",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A wasm32, in-memory RDF 1.2 engine with an idiomatic RDF/JS (DataFactory/Dataset/Stream) API. Quoted-triple terms and directional literals included.",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/crates/shapes/Cargo.toml
+++ b/crates/shapes/Cargo.toml
@@ -58,7 +58,7 @@ purrdf-iri = { workspace = true }
 # Shared PyO3-free RDF 1.2 kernel and native GTS/text-codec boundary.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "1.0.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "1.1.0" }
 # Inline small-vector primitive for hot, short-lived id rows (default features
 # only — no `union`/`serde`; wasm-clean, `unsafe`-free). Version is pinned once
 # in the root `[workspace.dependencies]`.

--- a/crates/slice/Cargo.toml
+++ b/crates/slice/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 # `gts` text codecs (`parse_dataset`) into the `RdfDataset` IR and query it directly.
 # NOT workspace-inherited: renamed deps (`package = ...`) cannot be expressed
 # at an inheriting use site, and the workspace key `purrdf` is the umbrella.
-purrdf = { package = "purrdf-rdf", path = "../rdf", version = "1.0.0" }
+purrdf = { package = "purrdf-rdf", path = "../rdf", version = "1.1.0" }
 # Native SPARQL parser — competency/verify queries are PARSED
 # (RFC §10), never text-searched, to extract referenced term IRIs. Replaces the
 # oxigraph-family SPARQL parser; RDF-1.2 quoted triple terms are first-class.


### PR DESCRIPTION
Version bump, regenerated C-ABI header, and the 1.1.0 changelog section.

## Why 1.1.0 and not 1.0.1

The two reported bug fixes do not travel alone. `main` also carries additive surface — `purrdf validate --import`, `imported_iris()` made public, and three Python export functions that previously raised unconditionally. Additive means **minor**, not patch, under the policy adopted at 1.0.0.

It was nearly 2.0.0: #266 widened the published `TermRow` tuple, which is a break. #267 reworked that into a parallel column before release, so nothing published changes shape and 1.1.0 is honest.

## Version coherence

- Cargo / PyPI / npm / `CITATION.cff` all at `1.1.0` — `check-versions.py` green
- **C ABI pair unchanged at `0.7`** (`PURRDF_ABI_MAJOR`/`PURRDF_ABI_MINOR`), per the policy that the C surface stays 0.x. Only `PURRDF_MINOR`, the crate-version macro cbindgen derives, moves 0 → 1.

## The changelog needed hand-splicing — worth knowing why

`make changelog` regenerated the file and **deleted the entire `## [1.0.0]` release-notes section**, dropping 601 lines. `git-cliff` rebuilds the whole file from commit subjects with no keep-region, which the Makefile comment does warn about — but the guard (`check-changelog-handwritten.py`) only inspects `[Unreleased]`, so it reported "regenerating loses nothing" and passed.

Handled by keeping git-cliff's generated `[1.1.0]` entries, restoring the committed file, and splicing the section in by hand with prose. All historical sections verified present afterwards (1.1.0 / 1.0.0 / 0.13.0 / 0.12.0); the file is 2279 → 2343 lines, purely additive.

That guard gap is worth its own issue — it will silently eat the 1.1.0 notes at the next release too.

## No breaking markers

Zero commits in the range carry `!` or `BREAKING CHANGE:`, which is correct: nothing in this release breaks. The `refactor(gts)` commit is deliberately unmarked — it *reverses* an unreleased change, and `!` is exactly what git-cliff reads as a major-bump trigger.

## Verification

`make check` green · `make conformance` GREEN · `check-versions` green · `check-doc-claims` green.

After merge: `make release-tags VERSION=1.1.0` from `main`, which runs the full release gate set before pushing `rust-v1.1.0` / `py-v1.1.0` / `npm-v1.1.0`.