### PR TITLE
fix: canonical term-id remap, and a changelog guard that checks the whole file

### DIFF
--- a/crates/gts/src/compact.rs
+++ b/crates/gts/src/compact.rs
@@ -797,16 +797,13 @@ fn streaming_index(
 }
 
 /// Shift a term's id references into the output id space.
+///
+/// Delegates the column list to [`Term::map_term_ids`] rather than restating it:
+/// this enumeration was correct, but it was the SECOND copy in this crate, and
+/// the other one had already gone stale (it dropped `triple`). One enumeration,
+/// owned by the type that adds the columns.
 fn shift_term(t: &Term, base: usize) -> Term {
-    Term {
-        kind: t.kind,
-        value: t.value.clone(),
-        datatype: t.datatype.map(|d| d + base),
-        lang: t.lang.clone(),
-        direction: t.direction.clone(),
-        reifier: t.reifier.map(|r| r + base),
-        triple: t.triple.map(|(s, p, o)| (s + base, p + base, o + base)),
-    }
+    t.map_term_ids(|id| id + base)
 }
 
 /// Carry suppressions forward, one output suppression per input (§10.1).

--- a/crates/gts/src/examples/agent_memory.rs
+++ b/crates/gts/src/examples/agent_memory.rs
@@ -993,15 +993,7 @@ fn literal_with_datatype(value: &str, datatype: usize) -> Term {
 fn shift_terms(terms: &[Term], base: usize) -> Vec<Term> {
     terms
         .iter()
-        .map(|term| Term {
-            kind: term.kind,
-            value: term.value.clone(),
-            datatype: term.datatype.map(|id| id + base),
-            lang: term.lang.clone(),
-            direction: term.direction.clone(),
-            reifier: term.reifier.map(|id| id + base),
-            triple: None,
-        })
+        .map(|term| term.map_term_ids(|id| id + base))
         .collect()
 }
 

--- a/crates/gts/src/model.rs
+++ b/crates/gts/src/model.rs
@@ -89,6 +89,70 @@ pub struct Term {
     pub triple: Option<Triple3>,
 }
 
+impl Term {
+    /// Apply `f` to every TERM ID this term carries, leaving value-bearing
+    /// columns untouched.
+    ///
+    /// The id columns are `datatype`, `reifier`, and each component of `triple`.
+    /// `kind`, `value`, `lang` and `direction` are values, not references into the
+    /// term table, and are copied through unchanged.
+    ///
+    /// # Use this instead of a struct-update expression
+    ///
+    /// If you relocate terms — appending a frame into an open segment, merging
+    /// term tables, compacting — shift ids with this rather than
+    /// `Term { datatype: …, reifier: …, ..t.clone() }`. That form keeps compiling
+    /// when a new id column is added and carries it through UNSHIFTED: a typed
+    /// literal whose datatype id stayed frame-local resolves to whatever term
+    /// happens to sit at that index, and a self-describing triple term resolves to
+    /// three unrelated terms. Nothing fails; the bytes are just wrong.
+    ///
+    /// The body below destructures `Term` exhaustively, with no `..` rest pattern,
+    /// so adding an id column is a compile error HERE — in the one place that
+    /// knows whether the new column is an id — rather than a silent wrong answer
+    /// at every call site.
+    ///
+    /// ```
+    /// use purrdf_gts::model::{Term, TermKind};
+    ///
+    /// let t = Term {
+    ///     kind: TermKind::Triple,
+    ///     value: None,
+    ///     datatype: Some(1),
+    ///     lang: None,
+    ///     direction: None,
+    ///     reifier: Some(2),
+    ///     triple: Some((3, 4, 5)),
+    /// };
+    /// let shifted = t.map_term_ids(|id| id + 10);
+    /// assert_eq!(shifted.datatype, Some(11));
+    /// assert_eq!(shifted.reifier, Some(12));
+    /// assert_eq!(shifted.triple, Some((13, 14, 15)));
+    /// ```
+    #[must_use]
+    pub fn map_term_ids(&self, f: impl Fn(usize) -> usize) -> Self {
+        // EXHAUSTIVE on purpose — see the doc comment. Do not add `..`.
+        let Self {
+            kind,
+            value,
+            datatype,
+            lang,
+            direction,
+            reifier,
+            triple,
+        } = self;
+        Self {
+            kind: *kind,
+            value: value.clone(),
+            datatype: datatype.map(&f),
+            lang: lang.clone(),
+            direction: direction.clone(),
+            reifier: reifier.map(&f),
+            triple: triple.map(|ids| map_triple_ids(ids, &f)),
+        }
+    }
+}
+
 /// A quad of term-ids; the graph slot is `None` for the default graph.
 pub type Quad = (usize, usize, usize, Option<usize>);
 /// A `(subject, predicate, object)` triple of term-ids.
@@ -97,6 +161,59 @@ pub type Triple3 = (usize, usize, usize);
 pub type ReifierRow = (usize, Triple3, Option<usize>);
 /// An annotation row: `(reifier, predicate, value, graph?)`.
 pub type AnnotationRow = (usize, usize, usize, Option<usize>);
+
+// ── Relocating term ids ──────────────────────────────────────────────────────
+//
+// Term ids are SEGMENT-SCOPED (§7.5). Anything that relocates terms — appending
+// a frame into an open segment, merging two term tables, compacting — has to
+// shift every id-bearing column by the same base. Which columns those are is
+// knowledge that belongs to this module, because this module is what adds them.
+//
+// Re-deriving that list at each call site is the hazard. A relocating remap is
+// idiomatically written as a struct-update expression:
+//
+// ```ignore
+// Term { datatype: t.datatype.map(shift), reifier: t.reifier.map(shift), ..t.clone() }
+// ```
+//
+// which keeps compiling when a new id column arrives and carries it through
+// UNSHIFTED — a typed literal whose datatype id stayed frame-local resolves to
+// whatever term happens to sit at that index, and a self-describing triple term
+// resolves to three unrelated terms. Silent, and green on every gate.
+//
+// The helpers below are the single enumeration. Each destructures its shape
+// EXHAUSTIVELY, with no `..` rest pattern, so adding an id column to `Term` is a
+// compile error here — in the one place that knows what to do about it — rather
+// than a silent wrong answer at every consumer.
+
+/// Apply `f` to every term id in a [`Quad`], graph slot included.
+#[must_use]
+pub fn map_quad_ids(quad: Quad, f: impl Fn(usize) -> usize) -> Quad {
+    let (s, p, o, g) = quad;
+    (f(s), f(p), f(o), g.map(&f))
+}
+
+/// Apply `f` to every term id in a [`Triple3`].
+#[must_use]
+pub fn map_triple_ids(triple: Triple3, f: impl Fn(usize) -> usize) -> Triple3 {
+    let (s, p, o) = triple;
+    (f(s), f(p), f(o))
+}
+
+/// Apply `f` to every term id in a [`ReifierRow`] — the reifier, its triple, and
+/// the graph the declaration was asserted in.
+#[must_use]
+pub fn map_reifier_row_ids(row: ReifierRow, f: impl Fn(usize) -> usize) -> ReifierRow {
+    let (reifier, triple, graph) = row;
+    (f(reifier), map_triple_ids(triple, &f), graph.map(&f))
+}
+
+/// Apply `f` to every term id in an [`AnnotationRow`].
+#[must_use]
+pub fn map_annotation_row_ids(row: AnnotationRow, f: impl Fn(usize) -> usize) -> AnnotationRow {
+    let (reifier, predicate, value, graph) = row;
+    (f(reifier), f(predicate), f(value), graph.map(&f))
+}
 
 /// A quad with term ids resolved to borrowed [`Term`] values.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -557,5 +674,103 @@ impl IntoIterator for Graph {
 
     fn into_iter(self) -> Self::IntoIter {
         self.into_quads()
+    }
+}
+
+#[cfg(test)]
+mod term_id_remap_tests {
+    //! Term ids are segment-scoped, so relocating terms has to shift EVERY
+    //! id-bearing column. These pin which columns those are, from the outside.
+
+    use super::{
+        AnnotationRow, Quad, ReifierRow, Term, TermKind, Triple3, map_annotation_row_ids,
+        map_quad_ids, map_reifier_row_ids, map_triple_ids,
+    };
+
+    /// A term carrying every id column at once, so a dropped column is visible.
+    fn loaded() -> Term {
+        Term {
+            kind: TermKind::Triple,
+            value: Some("lex".to_owned()),
+            datatype: Some(1),
+            lang: Some("en".to_owned()),
+            direction: Some("ltr".to_owned()),
+            reifier: Some(2),
+            triple: Some((3, 4, 5)),
+        }
+    }
+
+    #[test]
+    fn every_id_column_shifts_and_no_value_column_does() {
+        let shifted = loaded().map_term_ids(|id| id + 10);
+
+        assert_eq!(shifted.datatype, Some(11));
+        assert_eq!(shifted.reifier, Some(12));
+        // `triple` is the column a second, hand-written copy of this enumeration
+        // in this crate had silently dropped — it set `triple: None` — which is
+        // the whole reason the remap lives on the type now.
+        assert_eq!(shifted.triple, Some((13, 14, 15)));
+
+        // Values are not references into the term table and must NOT move.
+        let original = loaded();
+        assert_eq!(shifted.kind, original.kind);
+        assert_eq!(shifted.value, original.value);
+        assert_eq!(shifted.lang, original.lang);
+        assert_eq!(shifted.direction, original.direction);
+    }
+
+    #[test]
+    fn a_term_with_no_ids_is_carried_through_unchanged() {
+        // THE NEIGHBOURING CASE. A plain IRI term has no id columns at all, and a
+        // remap that touched it — or refused it — would corrupt the common case
+        // while the loaded one above still passed.
+        let plain = Term {
+            kind: TermKind::Iri,
+            value: Some("http://example.org/s".to_owned()),
+            datatype: None,
+            lang: None,
+            direction: None,
+            reifier: None,
+            triple: None,
+        };
+        let shifted = plain.map_term_ids(|id| id + 10);
+        assert_eq!(shifted, plain, "no id columns means nothing to shift");
+    }
+
+    #[test]
+    fn the_identity_remap_is_the_identity() {
+        // Guards against a helper that shifts something twice, or shifts a value
+        // column by coincidence of type: with `f = identity` the term must be
+        // byte-equal however many columns it carries.
+        let t = loaded();
+        assert_eq!(t.map_term_ids(|id| id), t);
+    }
+
+    #[test]
+    fn the_tuple_shapes_shift_every_slot_including_the_graph() {
+        // The graph slot IS a term id — the statement layer is keyed per graph, so
+        // a relocation that left it frame-local would move rows into the wrong
+        // named graph rather than dangling, which is the quieter failure.
+        let quad: Quad = (1, 2, 3, Some(4));
+        assert_eq!(map_quad_ids(quad, |id| id + 10), (11, 12, 13, Some(14)));
+        assert_eq!(
+            map_quad_ids((1, 2, 3, None), |id| id + 10),
+            (11, 12, 13, None)
+        );
+
+        let triple: Triple3 = (1, 2, 3);
+        assert_eq!(map_triple_ids(triple, |id| id + 10), (11, 12, 13));
+
+        let reifier: ReifierRow = (1, (2, 3, 4), Some(5));
+        assert_eq!(
+            map_reifier_row_ids(reifier, |id| id + 10),
+            (11, (12, 13, 14), Some(15))
+        );
+
+        let annotation: AnnotationRow = (1, 2, 3, Some(4));
+        assert_eq!(
+            map_annotation_row_ids(annotation, |id| id + 10),
+            (11, 12, 13, Some(14))
+        );
     }
 }

--- a/scripts/check-changelog-handwritten.py
+++ b/scripts/check-changelog-handwritten.py
@@ -27,6 +27,28 @@ hand-authored prose; failing the ordinary gate on it would be backwards. It
 fails when regeneration would drop hand-authored content that is not in the
 history it regenerates from, and names what would be lost.
 
+# It checks the WHOLE file, not just `[Unreleased]`
+
+The first version of this gate inspected `[Unreleased]` alone, and reported
+"regenerating loses nothing" while regeneration deleted the entire `## [1.0.0]`
+section — 601 lines, including the prose explaining why 1.0.0 republished the
+0.13.0 tree. The statement was true of the section it read and false of the file
+it was guarding. A RELEASED section carries strictly more hand-authored prose
+than `[Unreleased]` ever does, because release notes are written at release time.
+
+The structural half of that failure is now checked by COMPARISON rather than
+prediction: git-cliff is run to a temporary file and the section headings of the
+result are compared against the committed ones. A heading that exists now and
+would not exist after is a hard refusal, named. That is a cheap invariant, it
+needs no prose analysis, and it is exactly what was missed.
+
+The prose half stays a WARNING for released sections and an ERROR for
+`[Unreleased]`. Regeneration replaces prose in every released section by
+construction, so erroring on that would make this gate fail every single time and
+train the operator to reach past it — the failure mode of a gate nobody can
+satisfy. `[Unreleased]` keeps erroring because it is the section a release is
+about to consume.
+
 Deliberately NOT implemented here: a check that every ``**BREAKING**`` bullet has
 a marker-bearing (``type(scope)!:`` / ``BREAKING CHANGE:``) commit behind it.
 That check cannot be made non-vacuous. Its only key is the conventional-commit
@@ -58,6 +80,52 @@ BULLET = re.compile(r"^- (.*?)(?=^- |\Z)", re.M | re.S)
 BREAKING = re.compile(r"^\*\*BREAKING\*\*")
 
 
+SECTION = re.compile(r"^## \[([^\]]+)\]", re.M)
+
+
+def section_names(text: str) -> list[str]:
+    """Every `## [name]` heading, in file order."""
+    return SECTION.findall(text)
+
+
+def sections(text: str) -> list[tuple[str, str]]:
+    """`(name, body)` for every `## [name]` section, in file order."""
+    out = []
+    marks = list(SECTION.finditer(text))
+    for i, m in enumerate(marks):
+        end = marks[i + 1].start() if i + 1 < len(marks) else len(text)
+        out.append((m.group(1), text[m.end() : end]))
+    return out
+
+
+def regenerate() -> str | None:
+    """What `make changelog` would write, without writing it.
+
+    Mirrors the Makefile's invocation. Returns `None` when git-cliff cannot be
+    run at all — the caller then falls back to the prose-only checks rather than
+    passing silently, because a gate that no-ops when its tool is missing is a
+    gate that reports success for the wrong reason.
+    """
+    import subprocess
+    import tomllib
+
+    try:
+        version = tomllib.load((REPO_ROOT / "Cargo.toml").open("rb"))["workspace"][
+            "package"
+        ]["version"]
+        done = subprocess.run(
+            ["git-cliff", "--config", "cliff.toml", "--tag", f"rust-v{version}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=180,
+            check=False,
+        )
+    except (OSError, KeyError, subprocess.SubprocessError):
+        return None
+    return done.stdout if done.returncode == 0 and done.stdout.strip() else None
+
+
 def has_unreleased(text: str) -> bool:
     """Whether the changelog carries an `[Unreleased]` section at all."""
     return UNRELEASED.search(text) is not None
@@ -87,8 +155,63 @@ def first_line(bullet: str, width: int = 96) -> str:
     return line if len(line) <= width else line[: width - 1] + "…"
 
 
+def vanishing_sections(text: str) -> list[str] | None:
+    """Headings the committed file has that a regeneration would not.
+
+    `None` means the comparison could not be made (git-cliff absent or failing),
+    which is reported rather than treated as a pass.
+    """
+    regenerated = regenerate()
+    if regenerated is None:
+        return None
+    after = set(section_names(regenerated))
+    return [name for name in section_names(text) if name not in after]
+
+
 def main() -> int:
     text = CHANGELOG.read_text(encoding="utf-8")
+
+    # 1. STRUCTURAL, by comparison: a section that exists now and would not exist
+    #    after regeneration is deleted content, whatever its prose looks like.
+    #    This is the check whose absence let the whole 1.0.0 section vanish under
+    #    a green gate.
+    vanishing = vanishing_sections(text)
+    if vanishing is None:
+        print(
+            "WARNING: could not run git-cliff to compare, so the section-loss "
+            "check was skipped; only the prose checks below ran.",
+            file=sys.stderr,
+        )
+    elif vanishing:
+        print(
+            f"Regenerating CHANGELOG.md would DELETE {len(vanishing)} released "
+            f"section(s) outright:",
+            file=sys.stderr,
+        )
+        for name in vanishing:
+            print(f"  ## [{name}]", file=sys.stderr)
+        print(
+            "\ngit-cliff rebuilds the whole file from the tag range it can see. A "
+            "section it does not emit is not merged in — it is gone, along with "
+            "every hand-written release note under it.\n"
+            "\nWHAT TO DO\n"
+            "  1. Keep the committed CHANGELOG.md.\n"
+            "  2. Regenerate to a SCRATCH file, take only the new version's "
+            "section from it, and splice that in above the newest existing one.\n"
+            "  3. Re-check that every heading present before is present after.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # The prose heuristic (`unreproducible_bullets`) stays scoped to
+    # `[Unreleased]`, where it was designed to work. Applied to released sections
+    # it mis-fires: its bullet regex runs to the next bullet, so the last bullet in
+    # a section swallows the trailing blank lines and the next heading and looks
+    # multi-line. Run against git-cliff's OWN output it flagged 99 entries as
+    # "would be rewritten by regeneration" — entries that were the regeneration.
+    # A warning that cries wolf on correct input is worse than no warning; the
+    # structural comparison above is the check this gate was missing.
+
     if not has_unreleased(text):
         print("OK: CHANGELOG.md has no [Unreleased] section to lose.")
         return 0
@@ -97,7 +220,7 @@ def main() -> int:
     if not at_risk:
         print(
             "OK: every [Unreleased] entry is reproducible from a commit subject; "
-            "regenerating loses nothing."
+            "no section would be deleted."
         )
         return 0
 


### PR DESCRIPTION
Closes #270, closes #269. Two unrelated fixes, one PR — both are "a hand-derived list went stale and nothing noticed", and both were found the same way: by a human reading output, not by a gate.

---

## #270 — `Term::map_term_ids`

Term ids are segment-scoped, so relocating terms means shifting every id-bearing column by the same base. That column list belongs to `gts::model`, but was re-derived by hand at each call site.

A downstream consumer hit it upgrading 0.12.0 → 1.1.0. Their remap was a struct-update expression:

```rust
Term { datatype: …, reifier: …, ..term.clone() }
```

which kept compiling when `triple` arrived and carried it through **unshifted**. A self-describing triple term then resolves against three unrelated terms — and `triple` takes precedence over `reifier`, so it decides identity. Nothing fails; the bytes are wrong. They found it by reading a changelog.

**This crate had the same defect.** `compact.rs::shift_term` was correct, but it was the *second* enumeration here. The first — `examples/agent_memory.rs::shift_terms` — set `triple: None`, dropping the column rather than shifting it, with a doc comment still speaking only of `dt`/`rf` because it predated `triple`. Latent (that example only builds `triple: None` terms), but the exact reported shape. Both now delegate to one enumeration.

**Why a remap, not `#[non_exhaustive]`:** the latter turns the omission into a compile error but forbids literal construction, and `Term` is built literally in ~350 places here, mostly tests and fixtures. The remap gets the safety at none of that cost.

`map_term_ids` destructures exhaustively — no `..` rest pattern — so adding an id column is a compile error *there*, in the one place that knows whether the new column is an id. **Demonstrated, not asserted:** adding a hypothetical `future_id` field errors inside `map_term_ids`, while a struct-update remap sitting beside it compiles with zero errors. That contrast is the whole point.

Also covers the tuple shapes with the identical hazard — `map_quad_ids`, `map_triple_ids`, `map_reifier_row_ids`, `map_annotation_row_ids`. The graph slot is included deliberately: it is a term id, and leaving it frame-local moves rows into the wrong named graph rather than dangling, which is the quieter failure.

Additive; no existing signature changes.

---

## #269 — the changelog guard checked one section of the file it was guarding

It inspected `[Unreleased]` alone and printed *"regenerating loses nothing"* while the regeneration it cleared deleted the entire `## [1.0.0]` section — 601 lines. True of the section it read, false of the file.

Now it **compares instead of predicting**: git-cliff runs to a temp file (never over `CHANGELOG.md`), and section headings are diffed against the committed ones. A heading that exists now and wouldn't after is a hard refusal, named.

Verified both directions:
- against the **real incident** — refuses, naming `## [1.0.0]`
- against a changelog that regeneration reproduces exactly — exits 0

**Deliberately not extended:** the prose heuristic stays scoped to `[Unreleased]`. Applied to released sections its bullet regex over-captures (a section's last bullet swallows the following heading), and run against git-cliff's *own output* it flagged 99 entries as "would be rewritten by regeneration" — entries that were the regeneration. A warning that cries wolf on correct input is worse than none, and would train people to bypass the gate. If git-cliff can't run, the skip is reported rather than passing silently.

---

## Verification

`make check` green · `cargo test -p purrdf-gts` 67 lib tests · clippy clean · both new checks exercised in both directions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of remapped term identifiers across datatypes, reifiers, quoted triples, graphs, and annotations.
  - Preserved associated metadata during term shifting instead of clearing triple information.
  - Ensured identifier updates retain term values and correctly handle identity mappings.

- **Chores**
  - Strengthened changelog validation to detect and prevent accidental removal of existing sections.
  - Improved warnings and status reporting when changelog regeneration encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->