### PR TITLE
feat: share native GTS payloads and parsed shape datasets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,6 +1475,7 @@ dependencies = [
  "fastrand",
  "filetime",
  "flate2",
+ "getrandom 0.3.4",
  "purrdf-events",
  "rayon",
  "serde",

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ test: ## Run the workspace test suite.
 	cargo test --workspace --locked
 
 lint-native-import-blobs: ## Lint the selected native-import production and test surfaces only.
-	cargo clippy -p purrdf-gts --lib --locked -- -D warnings
+	cargo clippy -p purrdf-gts --lib --test bounded_keyed_blobs --locked -- -D warnings
 	cargo clippy -p purrdf-rdf --lib --test gts_selected_blobs --locked -- -D warnings
 	cargo clippy -p purrdf-shapes --lib --locked -- -D warnings
 
@@ -166,6 +166,7 @@ doc-native-import-blobs: ## Check the native-import and shared shape-dataset pub
 
 test-native-import-blobs: ## Check bounded selected-blob import and native scope contracts only.
 	cargo test -p purrdf-gts --lib codec::tests:: --locked
+	cargo test -p purrdf-gts --test bounded_keyed_blobs --locked
 	cargo test -p purrdf-rdf --lib gts_import_sink::tests:: --locked
 	cargo test -p purrdf-rdf --test gts_selected_blobs --locked
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 CAPI_HEADER := crates/rdf-capi/include/purrdf.h
 
 .PHONY: help doctor metadata fmt check geo-determinism book book-samples book-pot book-po-update book-zh check-i18n check-issue-refs check-brand-casing check-spec-attribution changelog bump release-tags test doc bench bench-prepared-reuse bench-python columnar-oracle csvw-conformance csvw-oracle obographs-oracle projection-oracles pydantic-oracle linkml-oracle typescript-oracle graphql-oracle pytest conformance iri-resolver-hygiene rdf-core-hygiene wasm wasm-test wasm-pkg wasm-pkg-test wasm-pkg-bench playground playground-smoke \
-	capi-build capi-header capi-check capi-install
+	capi-build capi-header capi-check capi-install test-native-import-blobs lint-native-import-blobs doc-native-import-blobs
 
 # The changelog generator is pinned so the committed CHANGELOG.md and the notes
 # the release workflow slices out of it stay byte-reproducible across machines.
@@ -155,6 +155,19 @@ release-tags: ## Cut + push rust-v/py-v/npm-v tags for VERSION after coherence c
 
 test: ## Run the workspace test suite.
 	cargo test --workspace --locked
+
+lint-native-import-blobs: ## Lint the selected native-import production and test surfaces only.
+	cargo clippy -p purrdf-gts --lib --locked -- -D warnings
+	cargo clippy -p purrdf-rdf --lib --test gts_selected_blobs --locked -- -D warnings
+	cargo clippy -p purrdf-shapes --lib --locked -- -D warnings
+
+doc-native-import-blobs: ## Check the native-import and shared shape-dataset public API documentation.
+	RUSTDOCFLAGS="-D warnings" cargo doc -p purrdf-gts -p purrdf-rdf -p purrdf-shapes --no-deps --locked
+
+test-native-import-blobs: ## Check bounded selected-blob import and native scope contracts only.
+	cargo test -p purrdf-gts --lib codec::tests:: --locked
+	cargo test -p purrdf-rdf --lib gts_import_sink::tests:: --locked
+	cargo test -p purrdf-rdf --test gts_selected_blobs --locked
 
 doc: ## Build docs for the 21 publishable crates with rustdoc warnings denied.
 	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --exclude purrdf-capi --exclude purrdf-python --exclude purrdf-sparql-conformance --exclude purrdf-cli

--- a/crates/gts/Cargo.toml
+++ b/crates/gts/Cargo.toml
@@ -73,6 +73,10 @@ criterion = { workspace = true }
 # expectation states. Test-only: the library itself never parses JSON.
 serde_json = { workspace = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+# Fresh keys/nonces for native encryption tests; absent from every library target.
+getrandom = { workspace = true }
+
 [[bench]]
 # GTS writer/codec authoring hot paths: rsyncable zstd block compression and
 # deterministic graph snapshot emission. Report-only; excluded from check.

--- a/crates/gts/src/codec.rs
+++ b/crates/gts/src/codec.rs
@@ -397,16 +397,7 @@ pub fn decode_chain_bounded(
     data: &[u8],
     limit: usize,
 ) -> Result<Vec<u8>, CodecError> {
-    let mut current = Cow::Borrowed(data);
-    for codec in chain.iter().rev() {
-        if let Cow::Owned(decoded) = decode_one(codec, current.as_ref(), limit)? {
-            current = Cow::Owned(decoded);
-        }
-    }
-    if current.len() > limit {
-        return Err(decoded_limit(limit));
-    }
-    Ok(current.into_owned())
+    decode_chain_with_decrypt_bounded(chain, data, None, limit)
 }
 
 /// A caller-supplied encrypt-class transform resolver.
@@ -417,6 +408,19 @@ pub fn decode_chain_with_decrypt(
     chain: &[Codec],
     data: &[u8],
     decrypt: Option<&Decryptor<'_>>,
+) -> Result<Vec<u8>, CodecError> {
+    decode_chain_with_decrypt_bounded(chain, data, decrypt, usize::MAX)
+}
+
+/// Reverse a chain with a decryptor that enforces `limit` before allocating output.
+///
+/// This internal callback contract is stronger than the public unbounded
+/// decryptor API. Each decrypted output is checked again before the next transform.
+pub(crate) fn decode_chain_with_decrypt_bounded(
+    chain: &[Codec],
+    data: &[u8],
+    decrypt: Option<&Decryptor<'_>>,
+    limit: usize,
 ) -> Result<Vec<u8>, CodecError> {
     let mut current = Cow::Borrowed(data);
     for codec in chain.iter().rev() {
@@ -430,11 +434,17 @@ pub fn decode_chain_with_decrypt(
                     });
                 }
             });
-        } else if let Cow::Owned(decoded) = decode_one(codec, current.as_ref(), usize::MAX)? {
+        } else if let Cow::Owned(decoded) = decode_one(codec, current.as_ref(), limit)? {
             // `identity` returns a borrow of `current`; leave `current` untouched
             // instead of copying the payload once per identity step.
             current = Cow::Owned(decoded);
         }
+        if current.len() > limit {
+            return Err(decoded_limit(limit));
+        }
+    }
+    if current.len() > limit {
+        return Err(decoded_limit(limit));
     }
     Ok(current.into_owned())
 }

--- a/crates/gts/src/codec.rs
+++ b/crates/gts/src/codec.rs
@@ -106,7 +106,11 @@ fn zstd_level(level: Option<i32>) -> CompressionLevel {
 
 /// Decode one transform. `identity` borrows its input (no copy of the whole
 /// payload); every real codec produces an owned buffer.
-fn decode_one<'a>(codec: &Codec, data: &'a [u8]) -> Result<Cow<'a, [u8]>, CodecError> {
+fn decode_one<'a>(
+    codec: &Codec,
+    data: &'a [u8],
+    limit: usize,
+) -> Result<Cow<'a, [u8]>, CodecError> {
     if codec.cls == "encrypt" {
         return Err(CodecError::Unavailable {
             reason: "missing-key",
@@ -114,12 +118,30 @@ fn decode_one<'a>(codec: &Codec, data: &'a [u8]) -> Result<Cow<'a, [u8]>, CodecE
         });
     }
     match codec.name.as_str() {
-        "identity" => Ok(Cow::Borrowed(data)),
+        "identity" if data.len() <= limit => Ok(Cow::Borrowed(data)),
+        "identity" => Err(decoded_limit(limit)),
         "gzip" => {
+            let mut decoder = flate2::read::GzDecoder::new(data);
             let mut out = Vec::new();
-            flate2::read::GzDecoder::new(data)
-                .read_to_end(&mut out)
-                .map_err(|e| CodecError::Failed(format!("gzip decode failed: {e}")))?;
+            if limit == usize::MAX {
+                decoder
+                    .read_to_end(&mut out)
+                    .map_err(|e| CodecError::Failed(format!("gzip decode failed: {e}")))?;
+                return Ok(Cow::Owned(out));
+            }
+            let mut chunk = [0_u8; 8192];
+            loop {
+                let read = decoder
+                    .read(&mut chunk)
+                    .map_err(|e| CodecError::Failed(format!("gzip decode failed: {e}")))?;
+                if read == 0 {
+                    break;
+                }
+                if read > limit.saturating_sub(out.len()) {
+                    return Err(decoded_limit(limit));
+                }
+                out.extend_from_slice(&chunk[..read]);
+            }
             Ok(Cow::Owned(out))
         }
         "zstd" | "zstd-rsyncable" => {
@@ -130,21 +152,19 @@ fn decode_one<'a>(codec: &Codec, data: &'a [u8]) -> Result<Cow<'a, [u8]>, CodecE
                     .map_err(|e| CodecError::Failed(format!("zstd dictionary load failed: {e}")))?;
             }
             // Start with a generous expansion factor and grow until the frame fits.
-            let mut capacity = data.len().saturating_mul(4).max(4096);
+            let mut capacity = data.len().saturating_mul(4).max(4096).min(limit);
             loop {
                 let mut out = Vec::new();
-                out.try_reserve(capacity).map_err(|e| {
+                out.try_reserve_exact(capacity).map_err(|e| {
                     CodecError::Failed(format!("zstd decode failed: output allocation failed: {e}"))
                 })?;
                 match decoder.decode_all_to_vec(data, &mut out) {
                     Ok(()) => return Ok(Cow::Owned(out)),
                     Err(FrameDecoderError::TargetTooSmall) => {
-                        capacity = capacity.checked_mul(2).ok_or_else(|| {
-                            CodecError::Failed(
-                                "zstd decode failed: decoded output is too large for this platform"
-                                    .into(),
-                            )
-                        })?;
+                        if capacity == limit {
+                            return Err(decoded_limit(limit));
+                        }
+                        capacity = capacity.saturating_mul(2).max(1).min(limit);
                     }
                     Err(e) => return Err(CodecError::Failed(format!("zstd decode failed: {e}"))),
                 }
@@ -358,6 +378,37 @@ pub fn decode_chain(chain: &[Codec], data: &[u8]) -> Result<Vec<u8>, CodecError>
     decode_chain_with_decrypt(chain, data, None)
 }
 
+fn decoded_limit(limit: usize) -> CodecError {
+    CodecError::Failed(format!("decoded transform output exceeds {limit} bytes"))
+}
+
+/// Reverse a codec chain, bounding every decoded intermediate and final buffer.
+///
+/// `limit` caps decoded bytes per transform before output-buffer growth, including
+/// identity and empty chains. Encoded input and codec dictionary bytes belong to
+/// the caller and are not counted against this bound. Encryption requires the
+/// separate keyed reader API and is refused here, as by [`decode_chain`].
+///
+/// # Errors
+/// Returns a codec error for unavailable transforms, corrupt bytes or an output
+/// exceeding `limit`. No oversized decoded buffer is returned or retained.
+pub fn decode_chain_bounded(
+    chain: &[Codec],
+    data: &[u8],
+    limit: usize,
+) -> Result<Vec<u8>, CodecError> {
+    let mut current = Cow::Borrowed(data);
+    for codec in chain.iter().rev() {
+        if let Cow::Owned(decoded) = decode_one(codec, current.as_ref(), limit)? {
+            current = Cow::Owned(decoded);
+        }
+    }
+    if current.len() > limit {
+        return Err(decoded_limit(limit));
+    }
+    Ok(current.into_owned())
+}
+
 /// A caller-supplied encrypt-class transform resolver.
 pub type Decryptor<'a> = dyn Fn(&Codec, &[u8]) -> Result<Vec<u8>, CodecError> + 'a;
 
@@ -379,7 +430,7 @@ pub fn decode_chain_with_decrypt(
                     });
                 }
             });
-        } else if let Cow::Owned(decoded) = decode_one(codec, current.as_ref())? {
+        } else if let Cow::Owned(decoded) = decode_one(codec, current.as_ref(), usize::MAX)? {
             // `identity` returns a borrow of `current`; leave `current` untouched
             // instead of copying the payload once per identity step.
             current = Cow::Owned(decoded);
@@ -392,6 +443,39 @@ pub fn decode_chain_with_decrypt(
 mod tests {
     use super::*;
     use crate::dict::DictSeed;
+
+    #[test]
+    fn bounded_decode_checks_empty_identity_and_every_chain_intermediate() {
+        assert_eq!(decode_chain_bounded(&[], b"", 0).unwrap(), b"");
+        assert!(decode_chain_bounded(&[], b"x", 0).is_err());
+        assert!(decode_chain_bounded(&[Codec::new("identity", "encode")], b"x", 0).is_err());
+        let raw = b"x";
+        let encoded = encode_chain(&["gzip".into(), "gzip".into()], raw).unwrap();
+        // Final output fits; the larger inner gzip stream exceeds this bound.
+        assert!(
+            decode_chain_bounded(
+                &[
+                    Codec::new("gzip", "compress"),
+                    Codec::new("gzip", "compress")
+                ],
+                &encoded,
+                raw.len()
+            )
+            .is_err()
+        );
+        assert_eq!(
+            decode_chain_bounded(
+                &[
+                    Codec::new("gzip", "compress"),
+                    Codec::new("gzip", "compress")
+                ],
+                &encoded,
+                1024
+            )
+            .unwrap(),
+            raw
+        );
+    }
 
     #[test]
     fn encoded_core_codecs_round_trip() {
@@ -431,9 +515,13 @@ mod tests {
         let mut encoded = compress_to_vec(&block1[..], CompressionLevel::Uncompressed);
         encoded.extend(compress_to_vec(&block2[..], CompressionLevel::Uncompressed));
 
-        let decoded = decode_one(&Codec::new("zstd-rsyncable", "compress"), &encoded)
-            .expect("multi-frame zstd must decode")
-            .into_owned();
+        let decoded = decode_one(
+            &Codec::new("zstd-rsyncable", "compress"),
+            &encoded,
+            usize::MAX,
+        )
+        .expect("multi-frame zstd must decode")
+        .into_owned();
 
         let mut expected = block1.to_vec();
         expected.extend_from_slice(block2);

--- a/crates/gts/src/cose.rs
+++ b/crates/gts/src/cose.rs
@@ -7,8 +7,8 @@
 //! carries the `kid` (label 4). Ed25519 is deterministic (RFC 8032), so the same
 //! key + id always yields the same signature — gated by `vectors/cose/*.json`.
 
-use aes_gcm::aead::{Aead, KeyInit, Payload};
-use aes_gcm::{Aes256Gcm, Nonce};
+use aes_gcm::aead::{Aead, AeadInPlace, KeyInit, Payload};
+use aes_gcm::{Aes256Gcm, Nonce, Tag};
 use ciborium::value::{Integer, Value};
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 
@@ -238,13 +238,17 @@ fn parse_encrypt0(blob: &[u8]) -> Option<Encrypt0Parts> {
         Value::Tag(_, inner) => *inner,
         other => other,
     };
-    let array = body.as_array()?;
-    if array.len() != 3 {
+    let Value::Array(array) = body else {
         return None;
-    }
-    let protected = array[0].as_bytes()?.clone();
-    let unprotected = array[1].as_map()?;
-    let ciphertext = array[2].as_bytes()?.clone();
+    };
+    let [
+        Value::Bytes(protected),
+        Value::Map(unprotected),
+        Value::Bytes(ciphertext),
+    ]: [Value; 3] = array.try_into().ok()?
+    else {
+        return None;
+    };
     let kid_target = Integer::from(KID);
     let iv_target = Integer::from(IV);
     let kid = unprotected.iter().find_map(|(k, v)| match (k, v) {
@@ -291,4 +295,50 @@ pub fn decrypt0(
             },
         )
         .map_err(|_| Encrypt0Error::AuthFailed)
+}
+
+/// Internal bounded decryption failures, without extending the public error enum.
+#[derive(Debug)]
+pub(crate) enum BoundedDecrypt0Error {
+    Crypto(Encrypt0Error),
+    Limit,
+}
+
+/// Decrypt in the parsed ciphertext buffer after checking the exact plaintext size.
+///
+/// COSE parsing consumes encoded input storage. The AES-GCM tag is excluded from
+/// the decoded limit, and no separate plaintext buffer is allocated.
+pub(crate) fn decrypt0_bounded(
+    blob: &[u8],
+    resolve: impl Fn(&str) -> Option<[u8; 32]>,
+    limit: usize,
+) -> Result<Vec<u8>, BoundedDecrypt0Error> {
+    use BoundedDecrypt0Error::{Crypto, Limit};
+
+    let mut parts = parse_encrypt0(blob).ok_or(Crypto(Encrypt0Error::Malformed))?;
+    let key = resolve(&parts.kid).ok_or(Crypto(Encrypt0Error::MissingKey))?;
+    if parts.iv.len() != 12 {
+        return Err(Crypto(Encrypt0Error::Malformed));
+    }
+    let plaintext_len = parts
+        .ciphertext
+        .len()
+        .checked_sub(16)
+        .ok_or(Crypto(Encrypt0Error::AuthFailed))?;
+    if plaintext_len > limit {
+        return Err(Limit);
+    }
+    let tag = Tag::clone_from_slice(&parts.ciphertext[plaintext_len..]);
+    parts.ciphertext.truncate(plaintext_len);
+    let aad = enc_structure(&parts.protected);
+    let cipher = Aes256Gcm::new((&key).into());
+    cipher
+        .decrypt_in_place_detached(
+            Nonce::from_slice(&parts.iv),
+            &aad,
+            &mut parts.ciphertext,
+            &tag,
+        )
+        .map_err(|_| Crypto(Encrypt0Error::AuthFailed))?;
+    Ok(parts.ciphertext)
 }

--- a/crates/gts/src/reader.rs
+++ b/crates/gts/src/reader.rs
@@ -17,7 +17,7 @@ use std::io::Read;
 use ciborium::value::Value;
 
 use crate::codec::{
-    Codec, CodecError, decode_chain, decode_chain_bounded, decode_chain_with_decrypt,
+    Codec, CodecError, decode_chain, decode_chain_bounded, decode_chain_with_decrypt_bounded,
 };
 use crate::model::{
     AnnotationRow, ByteRange, Diagnostic, Graph, OpaqueNode, Quad, ReifierRow, Signature,
@@ -183,6 +183,7 @@ fn decrypt_codec(
     codec: &Codec,
     data: &[u8],
     content_key: &ContentKeyResolver<'_>,
+    limit: usize,
 ) -> Result<Vec<u8>, CodecError> {
     if codec.name != "cose-encrypt0" {
         return Err(CodecError::Unavailable {
@@ -190,9 +191,14 @@ fn decrypt_codec(
             detail: format!("no decryptor for encrypt codec '{}'", codec.name),
         });
     }
-    crate::cose::decrypt0(data, |kid| content_key(kid)).map_err(|err| CodecError::Unavailable {
-        reason: "missing-key",
-        detail: format!("{} decrypt failed: {err}", codec.name),
+    crate::cose::decrypt0_bounded(data, content_key, limit).map_err(|err| match err {
+        crate::cose::BoundedDecrypt0Error::Crypto(err) => CodecError::Unavailable {
+            reason: "missing-key",
+            detail: format!("{} decrypt failed: {err}", codec.name),
+        },
+        crate::cose::BoundedDecrypt0Error::Limit => {
+            CodecError::Failed(format!("decoded transform output exceeds {limit} bytes"))
+        }
     })
 }
 
@@ -319,18 +325,19 @@ pub trait StreamingSink {
     /// Called after the legacy metadata-only [`Self::blob`] event. The metadata
     /// is repeated here so consumers need not pair callbacks by arrival order.
     fn blob_payload(&mut self, _payload: BlobPayload<'_>) {}
-    /// Optional encoded-byte bound before eager decoding without a public digest.
+    /// Optional encoded-byte bound before eager blob decoding, including decryption.
     ///
     /// Existing sinks leave the reader behavior unchanged. This does not bound
     /// ordinary RDF frame decoding or reader frame buffers.
     fn blob_encoded_limit(&self) -> Option<usize> {
         None
     }
-    /// Optional bound for eager blob decoding when no public digest is present.
+    /// Optional bound for each intermediate and final eager blob decode output.
     ///
     /// Existing sinks leave the reader behavior unchanged. Bounded collectors
-    /// apply their per-blob limit before this otherwise unavoidable decode.
-    /// This does not bound ordinary RDF frame decoding or keyed decryption.
+    /// apply their per-blob limit before decoding without a public digest or
+    /// decrypting with a content key. This does not bound ordinary RDF frame
+    /// decoding, encoded COSE parsing buffers, or codec dictionary storage.
     fn blob_decode_limit(&self) -> Option<usize> {
         None
     }
@@ -587,17 +594,19 @@ impl Folder<'_, '_, '_> {
                 ));
             };
             let chain = self.resolve_codecs(ids)?;
-            let decoded = if let Some(content_key) = self.content_key {
-                let decrypt = |codec: &Codec, data: &[u8]| decrypt_codec(codec, data, content_key);
-                decode_chain_with_decrypt(&chain, db, Some(&decrypt))?
-            } else if let Some(limit) = blob
+            let limit = blob
                 .then(|| {
                     self.sink
                         .as_deref()
                         .and_then(StreamingSink::blob_decode_limit)
                 })
-                .flatten()
-            {
+                .flatten();
+            let decoded = if let Some(content_key) = self.content_key {
+                let limit = limit.unwrap_or(usize::MAX);
+                let decrypt =
+                    |codec: &Codec, data: &[u8]| decrypt_codec(codec, data, content_key, limit);
+                decode_chain_with_decrypt_bounded(&chain, db, Some(&decrypt), limit)?
+            } else if let Some(limit) = limit {
                 decode_chain_bounded(&chain, db, limit)?
             } else {
                 decode_chain(&chain, db)?

--- a/crates/gts/src/reader.rs
+++ b/crates/gts/src/reader.rs
@@ -16,7 +16,9 @@ use std::io::Read;
 
 use ciborium::value::Value;
 
-use crate::codec::{Codec, CodecError, decode_chain, decode_chain_with_decrypt};
+use crate::codec::{
+    Codec, CodecError, decode_chain, decode_chain_bounded, decode_chain_with_decrypt,
+};
 use crate::model::{
     AnnotationRow, ByteRange, Diagnostic, Graph, OpaqueNode, Quad, ReifierRow, Signature,
     StreamableInfo, Suppression, Term, TermKind, Triple3,
@@ -63,7 +65,14 @@ fn diag_code_for(reason: &str) -> &'static str {
     }
 }
 
-fn pub_digest(value: &Value) -> Option<String> {
+/// Resolve public blob metadata's digest using the reader's identity convention.
+///
+/// Accepts text with or without the `blake3:` prefix, or a 32-byte digest value.
+/// The original metadata is borrowed and unchanged. This only resolves the
+/// declaration; callers authenticating payloads must compare the result with the
+/// decoded content digest and reject ambiguous metadata keys separately.
+#[must_use]
+pub fn public_blob_digest(value: &Value) -> Option<String> {
     let Value::Map(entries) = value else {
         return None;
     };
@@ -251,6 +260,38 @@ impl FrameContext<'_> {
     }
 }
 
+/// Borrowed payload and public metadata for one accepted inline blob occurrence.
+///
+/// This event carries no RDF term ids. Its segment index and the preceding
+/// [`StreamingSink::frame`] event identify its exact physical source. A later
+/// occurrence may replace a digest's public metadata; absent metadata preserves
+/// earlier metadata under the ordinary cross-segment union contract.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug)]
+pub struct BlobPayload<'a> {
+    /// Zero-based segment containing this occurrence.
+    pub segment_index: usize,
+    /// Declared content digest, or the computed digest when not declared.
+    pub digest: &'a str,
+    /// Public metadata available at this occurrence, independent of RDF rows.
+    pub metadata: Option<&'a Value>,
+    /// True only when this occurrence explicitly declares public metadata.
+    /// False distinguishes inherited segment metadata from a new declaration.
+    pub metadata_declared: bool,
+    /// Decoded bytes for an empty codec chain, otherwise transformed wire bytes.
+    /// `None` exposes a metadata-only occurrence without inventing a payload.
+    pub bytes: Option<&'a [u8]>,
+    /// Whether the occurrence contains a payload field at all. A present field
+    /// with `bytes == None` is malformed, distinct from a metadata-only update.
+    pub payload_present: bool,
+    /// Original blob byte-string length before any eager decoding. For a snapshot
+    /// entry this is the embedded blob length, excluding its enclosing RDF frame.
+    /// Metadata-only occurrences have length zero.
+    pub encoded_len: usize,
+    /// Resolved transform chain for `bytes`; apply in reverse to decode.
+    pub codecs: &'a [Codec],
+}
+
 /// Sink for [`read_to_sink`] events.
 ///
 /// Term ids in events are segment-local ids. A sink that needs a file-level
@@ -272,6 +313,27 @@ pub trait StreamingSink {
     fn suppression(&mut self, _segment_index: usize, _suppression: &Suppression) {}
     /// Accepted inline blob digest and declared metadata.
     fn blob(&mut self, _segment_index: usize, _digest: &str, _meta: Option<&Value>) {}
+    /// Borrowed blob bytes with their public metadata and codec chain.
+    ///
+    /// The default is inert: existing sinks neither copy nor decode payloads.
+    /// Called after the legacy metadata-only [`Self::blob`] event. The metadata
+    /// is repeated here so consumers need not pair callbacks by arrival order.
+    fn blob_payload(&mut self, _payload: BlobPayload<'_>) {}
+    /// Optional encoded-byte bound before eager decoding without a public digest.
+    ///
+    /// Existing sinks leave the reader behavior unchanged. This does not bound
+    /// ordinary RDF frame decoding or reader frame buffers.
+    fn blob_encoded_limit(&self) -> Option<usize> {
+        None
+    }
+    /// Optional bound for eager blob decoding when no public digest is present.
+    ///
+    /// Existing sinks leave the reader behavior unchanged. Bounded collectors
+    /// apply their per-blob limit before this otherwise unavoidable decode.
+    /// This does not bound ordinary RDF frame decoding or keyed decryption.
+    fn blob_decode_limit(&self) -> Option<usize> {
+        None
+    }
     /// Opaque frame produced by unknown, encrypted, or damaged payloads.
     fn opaque(&mut self, _segment_index: usize, _opaque: &OpaqueNode) {}
     /// Signature status observed on a frame.
@@ -436,7 +498,15 @@ impl Folder<'_, '_, '_> {
         );
     }
 
-    fn emit_blob(&mut self, digest: &str) {
+    fn emit_blob(
+        &mut self,
+        digest: &str,
+        bytes: Option<&[u8]>,
+        codecs: &[Codec],
+        declared_metadata: Option<&Value>,
+        payload_present: bool,
+        encoded_len: usize,
+    ) {
         // Only a sink can observe the meta, so look it up only when one is
         // present — and borrow it (`self.g` shared, `self.sink` mut are
         // disjoint fields) instead of deep-cloning the CBOR map per blob.
@@ -450,6 +520,16 @@ impl Folder<'_, '_, '_> {
             .find(|(stored, _)| stored == digest)
             .map(|(_, meta)| meta);
         sink.blob(self.segment_index, digest, meta);
+        sink.blob_payload(BlobPayload {
+            segment_index: self.segment_index,
+            digest,
+            metadata: declared_metadata.or(meta),
+            metadata_declared: declared_metadata.is_some(),
+            bytes,
+            payload_present,
+            encoded_len,
+            codecs,
+        });
     }
 
     fn push_opaque(&mut self, opaque: OpaqueNode) {
@@ -486,6 +566,18 @@ impl Folder<'_, '_, '_> {
     /// Resolve a frame's logical payload (§6.1); error on missing capability.
     fn payload(&self, frame: &[(Value, Value)], blob: bool) -> Result<Value, PayloadError> {
         let d = map_get(frame, "d");
+        if blob
+            && let Some(Value::Bytes(bytes)) = d
+            && let Some(limit) = self
+                .sink
+                .as_deref()
+                .and_then(StreamingSink::blob_encoded_limit)
+            && bytes.len() > limit
+        {
+            return Err(PayloadError::Damaged(format!(
+                "encoded blob exceeds {limit} bytes"
+            )));
+        }
         if let Some(Value::Array(ids)) = map_get(frame, "x")
             && !ids.is_empty()
         {
@@ -498,6 +590,15 @@ impl Folder<'_, '_, '_> {
             let decoded = if let Some(content_key) = self.content_key {
                 let decrypt = |codec: &Codec, data: &[u8]| decrypt_codec(codec, data, content_key);
                 decode_chain_with_decrypt(&chain, db, Some(&decrypt))?
+            } else if let Some(limit) = blob
+                .then(|| {
+                    self.sink
+                        .as_deref()
+                        .and_then(StreamingSink::blob_decode_limit)
+                })
+                .flatten()
+            {
+                decode_chain_bounded(&chain, db, limit)?
             } else {
                 decode_chain(&chain, db)?
             };
@@ -506,6 +607,18 @@ impl Folder<'_, '_, '_> {
             }
             return ciborium::de::from_reader(&decoded[..])
                 .map_err(|e| PayloadError::Damaged(e.to_string()));
+        }
+        if blob
+            && let Some(Value::Bytes(bytes)) = d
+            && let Some(limit) = self
+                .sink
+                .as_deref()
+                .and_then(StreamingSink::blob_decode_limit)
+            && bytes.len() > limit
+        {
+            return Err(PayloadError::Damaged(format!(
+                "decoded blob exceeds {limit} bytes"
+            )));
         }
         Ok(d.cloned().unwrap_or(Value::Null))
     }
@@ -749,10 +862,11 @@ impl Folder<'_, '_, '_> {
 
     fn h_blob_frame(&mut self, frame: &[(Value, Value)], index: usize) {
         let d = map_get(frame, "d");
-        let pub_meta = map_get(frame, "pub")
+        let declared_metadata = map_get(frame, "pub");
+        let pub_meta = declared_metadata
             .filter(|value| matches!(value, Value::Map(_)))
             .cloned();
-
+        let encoded_len = d.and_then(Value::as_bytes).map_or(0, Vec::len);
         let chain = match map_get(frame, "x") {
             Some(Value::Array(ids)) if !ids.is_empty() => match self.resolve_codecs(ids) {
                 Ok(chain) => chain,
@@ -786,10 +900,17 @@ impl Folder<'_, '_, '_> {
                         digest.clone(),
                         self.described.contains(&digest),
                     ));
+                    self.emit_blob(
+                        &digest,
+                        Some(&bytes),
+                        &[],
+                        declared_metadata,
+                        true,
+                        encoded_len,
+                    );
                     if self.materialize {
                         self.g.set_blob(digest.clone(), bytes);
                     }
-                    self.emit_blob(&digest);
                 }
                 Ok(_) => {}
                 Err(PayloadError::Unavailable { reason, detail }) => {
@@ -808,10 +929,18 @@ impl Folder<'_, '_, '_> {
             return;
         }
 
-        if let Some(digest) = pub_meta.as_ref().and_then(pub_digest) {
+        if let Some(digest) = pub_meta.as_ref().and_then(public_blob_digest) {
             if let Some(meta) = pub_meta {
                 self.g.set_blob_meta(digest.clone(), meta);
             }
+            self.emit_blob(
+                &digest,
+                d.and_then(Value::as_bytes).map(Vec::as_slice),
+                &chain,
+                declared_metadata,
+                d.is_some(),
+                encoded_len,
+            );
             if let Some(Value::Bytes(raw)) = d
                 && self.materialize
             {
@@ -823,7 +952,6 @@ impl Folder<'_, '_, '_> {
             }
             self.blob_events
                 .push((index, digest.clone(), self.described.contains(&digest)));
-            self.emit_blob(&digest);
             return;
         }
 
@@ -838,10 +966,17 @@ impl Folder<'_, '_, '_> {
                 }
                 self.blob_events
                     .push((index, digest.clone(), self.described.contains(&digest)));
+                self.emit_blob(
+                    &digest,
+                    Some(&bytes),
+                    &[],
+                    declared_metadata,
+                    true,
+                    encoded_len,
+                );
                 if self.materialize {
                     self.g.set_blob(digest.clone(), bytes);
                 }
-                self.emit_blob(&digest);
             }
             Ok(_) => {}
             Err(PayloadError::Unavailable { reason, detail }) => {
@@ -959,7 +1094,7 @@ impl Folder<'_, '_, '_> {
                     if self.materialize {
                         self.g.set_blob(digest.clone(), bytes.clone());
                     }
-                    self.emit_blob(&digest);
+                    self.emit_blob(&digest, Some(bytes), &[], None, true, bytes.len());
                 }
             }
         }

--- a/crates/gts/src/segment_decode.rs
+++ b/crates/gts/src/segment_decode.rs
@@ -60,7 +60,7 @@ use ciborium::value::Value;
 use crate::model::{
     Diagnostic, OpaqueNode, Quad, Signature, StreamableInfo, Suppression, Term, TermKind, Triple3,
 };
-use crate::reader::{FrameContext, StreamingSink};
+use crate::reader::{BlobPayload, FrameContext, StreamingSink};
 
 /// A [`std::collections::HashMap`] keyed by the workspace's fixed-key `ahash`
 /// policy (`crates/rdf-core/src/hash.rs`'s `FastHasher`) — no runtime RNG
@@ -198,6 +198,21 @@ pub trait ResolvedSink {
         _digest: &str,
         _meta: Option<&Value>,
     ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Original encoded blob bound passthrough (default unbounded).
+    fn blob_encoded_limit(&self) -> Option<usize> {
+        None
+    }
+
+    /// Eager blob decoding bound passthrough (default unbounded).
+    fn blob_decode_limit(&self) -> Option<usize> {
+        None
+    }
+
+    /// Borrowed blob payload passthrough (default no-op).
+    fn blob_payload(&mut self, _payload: BlobPayload<'_>) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -664,6 +679,23 @@ impl<S: ResolvedSink> StreamingSink for SegmentResolver<S> {
             return;
         }
         if let Err(error) = self.sink.blob(segment_index, digest, meta) {
+            self.fail(error);
+        }
+    }
+
+    fn blob_encoded_limit(&self) -> Option<usize> {
+        self.sink.blob_encoded_limit()
+    }
+
+    fn blob_decode_limit(&self) -> Option<usize> {
+        self.sink.blob_decode_limit()
+    }
+
+    fn blob_payload(&mut self, payload: BlobPayload<'_>) {
+        if self.error.is_some() {
+            return;
+        }
+        if let Err(error) = self.sink.blob_payload(payload) {
             self.fail(error);
         }
     }

--- a/crates/gts/tests/bounded_keyed_blobs.rs
+++ b/crates/gts/tests/bounded_keyed_blobs.rs
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Streaming blob limits remain effective when a content key is supplied.
+
+use purrdf_gts::reader::{
+    BlobPayload, ReadOptions, StreamingReadResult, StreamingSink, read_to_sink_with_options,
+};
+use purrdf_gts::writer::{Encrypt0Options, FrameOptions, Writer};
+
+const KEY: [u8; 32] = [7; 32];
+
+#[derive(Default)]
+struct Sink {
+    decoded_limit: Option<usize>,
+    encoded_limit: Option<usize>,
+    payloads: Vec<Vec<u8>>,
+}
+
+impl StreamingSink for Sink {
+    fn blob_decode_limit(&self) -> Option<usize> {
+        self.decoded_limit
+    }
+
+    fn blob_encoded_limit(&self) -> Option<usize> {
+        self.encoded_limit
+    }
+
+    fn blob_payload(&mut self, payload: BlobPayload<'_>) {
+        assert!(
+            payload.codecs.is_empty(),
+            "eager decoding must complete first"
+        );
+        self.payloads
+            .push(payload.bytes.expect("decoded payload").to_vec());
+    }
+}
+
+fn blob(data: &[u8], transforms: &[&str], encrypted: bool) -> Vec<u8> {
+    let mut writer = Writer::new("generic");
+    writer
+        .add_frame_with_options(
+            "blob",
+            FrameOptions {
+                raw: Some(data.to_vec()),
+                transform: transforms.iter().map(|name| (*name).into()).collect(),
+                encrypt: encrypted.then(|| Encrypt0Options {
+                    kid: "recipient".into(),
+                    key: KEY,
+                    iv: [3; 12],
+                }),
+                ..FrameOptions::default()
+            },
+        )
+        .expect("tiny authored frame");
+    writer.into_bytes()
+}
+
+fn read(bytes: &[u8], sink: &mut Sink, key: Option<[u8; 32]>) -> StreamingReadResult {
+    let resolve = |kid: &str| if kid == "recipient" { key } else { None };
+    read_to_sink_with_options(
+        bytes,
+        ReadOptions::new(true, None).with_content_key(&resolve),
+        sink,
+    )
+}
+
+fn assert_limit(result: &StreamingReadResult, sink: &Sink, detail: &str) {
+    assert!(
+        sink.payloads.is_empty(),
+        "oversized output cannot reach the sink"
+    );
+    assert!(
+        result.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "DamagedFrame" && diagnostic.detail.contains(detail)
+        }),
+        "expected {detail}: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn encrypted_plaintext_accepts_exact_and_empty_limits() {
+    for data in [b"".as_slice(), b"bounded".as_slice()] {
+        let mut sink = Sink {
+            decoded_limit: Some(data.len()),
+            ..Sink::default()
+        };
+        let result = read(&blob(data, &[], true), &mut sink, Some(KEY));
+        assert!(
+            !result.diagnostics.iter().any(|diagnostic| {
+                matches!(diagnostic.code.as_str(), "DamagedFrame" | "MissingKey")
+            }),
+            "{:?}",
+            result.diagnostics
+        );
+        assert_eq!(sink.payloads, vec![data.to_vec()]);
+    }
+}
+
+#[test]
+fn encrypted_plaintext_limit_is_checked_before_authentication_or_emission() {
+    let bytes = blob(b"bounded", &[], true);
+    for key in [KEY, [8; 32]] {
+        let mut sink = Sink {
+            decoded_limit: Some(6),
+            ..Sink::default()
+        };
+        let result = read(&bytes, &mut sink, Some(key));
+        // The wrong key would fail authentication if decryption ran first.
+        assert_limit(&result, &sink, "decoded transform output exceeds 6 bytes");
+    }
+}
+
+#[test]
+fn supplied_key_does_not_unbound_compression_with_or_without_encryption() {
+    let data = [b'x'; 4096];
+    for codec in ["gzip", "zstd"] {
+        for encrypted in [false, true] {
+            let bytes = blob(&data, &[codec], encrypted);
+            let mut sink = Sink {
+                decoded_limit: Some(4095),
+                ..Sink::default()
+            };
+            let result = read(&bytes, &mut sink, Some(KEY));
+            assert_limit(
+                &result,
+                &sink,
+                "decoded transform output exceeds 4095 bytes",
+            );
+            let mut exact = Sink {
+                decoded_limit: Some(4096),
+                ..Sink::default()
+            };
+            read(&bytes, &mut exact, Some(KEY));
+            assert_eq!(exact.payloads, vec![data.to_vec()]);
+        }
+    }
+}
+
+#[test]
+fn encrypted_intermediate_limit_applies_even_when_final_plaintext_fits() {
+    let bytes = blob(b"x", &["gzip"], true);
+    let mut sink = Sink {
+        decoded_limit: Some(1),
+        ..Sink::default()
+    };
+    let result = read(&bytes, &mut sink, Some(KEY));
+    assert_limit(&result, &sink, "decoded transform output exceeds 1 bytes");
+    let mut unbounded = Sink::default();
+    read(&bytes, &mut unbounded, Some(KEY));
+    assert_eq!(unbounded.payloads, vec![b"x".to_vec()]);
+}
+
+#[test]
+fn keyed_blob_still_enforces_original_encoded_limit() {
+    let bytes = blob(b"bounded", &[], true);
+    let mut sink = Sink {
+        decoded_limit: Some(7),
+        encoded_limit: Some(7),
+        ..Sink::default()
+    };
+    let result = read(&bytes, &mut sink, Some(KEY));
+    assert_limit(&result, &sink, "encoded blob exceeds 7 bytes");
+}
+
+#[test]
+fn bounded_decryption_preserves_missing_and_wrong_key_failures() {
+    let bytes = blob(b"bounded", &[], true);
+    for key in [None, Some([8; 32])] {
+        let mut sink = Sink {
+            decoded_limit: Some(7),
+            ..Sink::default()
+        };
+        let result = read(&bytes, &mut sink, key);
+        assert_eq!(sink.payloads, Vec::<Vec<u8>>::new());
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diagnostic| { diagnostic.code == "MissingKey" }),
+            "{:?}",
+            result.diagnostics
+        );
+    }
+}

--- a/crates/gts/tests/bounded_keyed_blobs.rs
+++ b/crates/gts/tests/bounded_keyed_blobs.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![cfg(not(target_arch = "wasm32"))]
+
 //! Streaming blob limits remain effective when a content key is supplied.
 
 use purrdf_gts::reader::{
@@ -8,7 +10,16 @@ use purrdf_gts::reader::{
 };
 use purrdf_gts::writer::{Encrypt0Options, FrameOptions, Writer};
 
-const KEY: [u8; 32] = [7; 32];
+fn fresh_bytes<const N: usize>() -> [u8; N] {
+    let mut bytes = [0; N];
+    getrandom::fill(&mut bytes).expect("test encryption randomness");
+    bytes
+}
+
+fn wrong_key(mut key: [u8; 32]) -> [u8; 32] {
+    key[0] ^= 1;
+    key
+}
 
 #[derive(Default)]
 struct Sink {
@@ -36,7 +47,7 @@ impl StreamingSink for Sink {
     }
 }
 
-fn blob(data: &[u8], transforms: &[&str], encrypted: bool) -> Vec<u8> {
+fn blob(data: &[u8], transforms: &[&str], key: Option<[u8; 32]>) -> Vec<u8> {
     let mut writer = Writer::new("generic");
     writer
         .add_frame_with_options(
@@ -44,10 +55,10 @@ fn blob(data: &[u8], transforms: &[&str], encrypted: bool) -> Vec<u8> {
             FrameOptions {
                 raw: Some(data.to_vec()),
                 transform: transforms.iter().map(|name| (*name).into()).collect(),
-                encrypt: encrypted.then(|| Encrypt0Options {
+                encrypt: key.map(|key| Encrypt0Options {
                     kid: "recipient".into(),
-                    key: KEY,
-                    iv: [3; 12],
+                    key,
+                    iv: fresh_bytes(),
                 }),
                 ..FrameOptions::default()
             },
@@ -86,7 +97,8 @@ fn encrypted_plaintext_accepts_exact_and_empty_limits() {
             decoded_limit: Some(data.len()),
             ..Sink::default()
         };
-        let result = read(&blob(data, &[], true), &mut sink, Some(KEY));
+        let key = fresh_bytes();
+        let result = read(&blob(data, &[], Some(key)), &mut sink, Some(key));
         assert!(
             !result.diagnostics.iter().any(|diagnostic| {
                 matches!(diagnostic.code.as_str(), "DamagedFrame" | "MissingKey")
@@ -100,8 +112,9 @@ fn encrypted_plaintext_accepts_exact_and_empty_limits() {
 
 #[test]
 fn encrypted_plaintext_limit_is_checked_before_authentication_or_emission() {
-    let bytes = blob(b"bounded", &[], true);
-    for key in [KEY, [8; 32]] {
+    let key = fresh_bytes();
+    let bytes = blob(b"bounded", &[], Some(key));
+    for key in [key, wrong_key(key)] {
         let mut sink = Sink {
             decoded_limit: Some(6),
             ..Sink::default()
@@ -117,12 +130,13 @@ fn supplied_key_does_not_unbound_compression_with_or_without_encryption() {
     let data = [b'x'; 4096];
     for codec in ["gzip", "zstd"] {
         for encrypted in [false, true] {
-            let bytes = blob(&data, &[codec], encrypted);
+            let key = fresh_bytes();
+            let bytes = blob(&data, &[codec], encrypted.then_some(key));
             let mut sink = Sink {
                 decoded_limit: Some(4095),
                 ..Sink::default()
             };
-            let result = read(&bytes, &mut sink, Some(KEY));
+            let result = read(&bytes, &mut sink, Some(key));
             assert_limit(
                 &result,
                 &sink,
@@ -132,7 +146,7 @@ fn supplied_key_does_not_unbound_compression_with_or_without_encryption() {
                 decoded_limit: Some(4096),
                 ..Sink::default()
             };
-            read(&bytes, &mut exact, Some(KEY));
+            read(&bytes, &mut exact, Some(key));
             assert_eq!(exact.payloads, vec![data.to_vec()]);
         }
     }
@@ -140,34 +154,37 @@ fn supplied_key_does_not_unbound_compression_with_or_without_encryption() {
 
 #[test]
 fn encrypted_intermediate_limit_applies_even_when_final_plaintext_fits() {
-    let bytes = blob(b"x", &["gzip"], true);
+    let key = fresh_bytes();
+    let bytes = blob(b"x", &["gzip"], Some(key));
     let mut sink = Sink {
         decoded_limit: Some(1),
         ..Sink::default()
     };
-    let result = read(&bytes, &mut sink, Some(KEY));
+    let result = read(&bytes, &mut sink, Some(key));
     assert_limit(&result, &sink, "decoded transform output exceeds 1 bytes");
     let mut unbounded = Sink::default();
-    read(&bytes, &mut unbounded, Some(KEY));
+    read(&bytes, &mut unbounded, Some(key));
     assert_eq!(unbounded.payloads, vec![b"x".to_vec()]);
 }
 
 #[test]
 fn keyed_blob_still_enforces_original_encoded_limit() {
-    let bytes = blob(b"bounded", &[], true);
+    let key = fresh_bytes();
+    let bytes = blob(b"bounded", &[], Some(key));
     let mut sink = Sink {
         decoded_limit: Some(7),
         encoded_limit: Some(7),
         ..Sink::default()
     };
-    let result = read(&bytes, &mut sink, Some(KEY));
+    let result = read(&bytes, &mut sink, Some(key));
     assert_limit(&result, &sink, "encoded blob exceeds 7 bytes");
 }
 
 #[test]
 fn bounded_decryption_preserves_missing_and_wrong_key_failures() {
-    let bytes = blob(b"bounded", &[], true);
-    for key in [None, Some([8; 32])] {
+    let key = fresh_bytes();
+    let bytes = blob(b"bounded", &[], Some(key));
+    for key in [None, Some(wrong_key(key))] {
         let mut sink = Sink {
             decoded_limit: Some(7),
             ..Sink::default()

--- a/crates/rdf/src/gts_import_blobs.rs
+++ b/crates/rdf/src/gts_import_blobs.rs
@@ -1,0 +1,480 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Explicit, bounded blob selection alongside the authoritative native import.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use ciborium::Value;
+use purrdf_gts::model::ByteRange;
+use purrdf_gts::reader::{BlobPayload, FrameContext};
+
+use crate::{GtsBundle, RdfDiagnostic};
+
+/// A required inline blob, selected independently of RDF statement order.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GtsBlobSelector<'a> {
+    /// Match the exact content digest.
+    Digest(&'a str),
+    /// Match the final public metadata's `rep` text value.
+    Representation(&'a str),
+}
+
+/// Explicit retention and decode budgets for selected inline blobs.
+///
+/// These bounds cover selected payloads and their metadata, not the native RDF
+/// dataset, input file, reader frame buffers or codec working memory. Every
+/// decoded intermediate is bounded, including compression-chain intermediates.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug)]
+pub struct GtsBlobLimits {
+    /// Maximum selected encoded payload bytes in one occurrence.
+    pub max_encoded_bytes: usize,
+    /// Maximum decoded bytes in one blob or intermediate transform buffer.
+    pub max_decoded_bytes: usize,
+    /// Maximum sum of decoded bytes retained across selected unique digests.
+    pub max_total_decoded_bytes: usize,
+    /// Maximum CBOR-encoded public metadata bytes retained for one blob.
+    pub max_metadata_bytes: usize,
+}
+
+impl GtsBlobLimits {
+    /// Set payload budgets; metadata defaults to a bounded 64 KiB per blob.
+    ///
+    /// The encoded limit initially equals `max_decoded_bytes`; callers may set
+    /// it separately when incompressible or chained encodings need more room.
+    #[must_use]
+    pub const fn new(max_decoded_bytes: usize, max_total_decoded_bytes: usize) -> Self {
+        Self {
+            max_encoded_bytes: max_decoded_bytes,
+            max_decoded_bytes,
+            max_total_decoded_bytes,
+            max_metadata_bytes: 64 * 1024,
+        }
+    }
+}
+
+/// Physical source of the effective public metadata for a selected blob.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct GtsBlobMetadataSource {
+    /// Segment containing the last explicit public metadata declaration.
+    pub segment_index: usize,
+    /// Frame containing that declaration.
+    pub frame_index: usize,
+    /// Verified frame content id.
+    pub frame_id: Vec<u8>,
+    /// Original source range of that frame.
+    pub frame_range: ByteRange,
+    /// Verified completed head of the metadata's segment.
+    pub segment_head: Vec<u8>,
+}
+
+/// Authenticated selected bytes and exact public metadata from one GTS import.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct GtsImportedBlob {
+    /// Content digest, checked against the decoded bytes.
+    pub digest: String,
+    /// Final effective public metadata, preserved without a lossy projection.
+    pub metadata: Option<Value>,
+    /// Exact source of effective metadata, including metadata-only updates.
+    pub metadata_source: Option<GtsBlobMetadataSource>,
+    /// Decoded payload, shared without copying by retained consumer views.
+    pub bytes: Arc<[u8]>,
+    /// Zero-based segment containing the selected payload occurrence.
+    pub segment_index: usize,
+    /// Zero-based frame within that segment.
+    pub frame_index: usize,
+    /// Exact frame content id verified by the reader.
+    pub frame_id: Vec<u8>,
+    /// Frame's original byte range in the imported source.
+    pub frame_range: ByteRange,
+    /// Verified completed head of the payload's segment.
+    pub segment_head: Vec<u8>,
+}
+
+/// Native RDF 1.2 bundle and its explicitly requested inline blobs.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct GtsImportWithBlobs {
+    /// The same scoped native dataset and envelope as [`crate::import_gts_events`].
+    pub bundle: GtsBundle,
+    /// Selected unique digests in deterministic digest order.
+    pub blobs: Vec<GtsImportedBlob>,
+}
+
+/// Import the native dataset and retain required blobs during the same GTS read.
+///
+/// `selectors` names exact digests or public `rep` values, never RDF predicates.
+/// Each selector must resolve to exactly one final blob; multiple selectors may
+/// name the same blob, which is decoded and retained once per occurrence. At most
+/// 1024 nonempty, distinct selectors of at most 4096 bytes each are accepted.
+/// Unselected payloads are neither copied nor decoded by this collector. Blobs
+/// without a public digest require the reader to decode before selection and
+/// obey both the encoded and decoded per-blob limits before eager decoding,
+/// including when ultimately unselected. Snapshot-entry bounds cover their
+/// embedded blob bytes; enclosing RDF frame decoding remains the reader's scope.
+///
+/// Later public metadata replaces earlier metadata for that digest; absent
+/// metadata preserves it, including across segment boundaries. A newly selected
+/// metadata-only occurrence is explicitly refused: this bounded one-pass API
+/// does not retain unrelated earlier payloads to recover that ordering. A selected
+/// metadata-only update can reuse bytes already retained for the same digest.
+/// All legacy reader diagnostics, term resolution and per-segment blank scopes
+/// retain [`crate::import_gts_events`]'s behavior. Existing importers do not opt
+/// into this retention or its additional payload-integrity checks.
+///
+/// # Errors
+/// Returns a diagnostic for invalid selection, missing or ambiguous final blobs,
+/// selected malformed metadata, absent payloads, corrupt decoded digests, reader
+/// or codec failures, or a retention/decode bound violation.
+pub fn import_gts_events_with_blobs(
+    bytes: &[u8],
+    selectors: &[GtsBlobSelector<'_>],
+    limits: GtsBlobLimits,
+) -> Result<GtsImportWithBlobs, RdfDiagnostic> {
+    let collector = BlobCollector::new(selectors, limits)?;
+    let (bundle, collector) =
+        crate::gts_import_sink::import_with_collector(bytes, Some(collector))?;
+    let blobs = collector
+        .expect("selected importer retains its collector")
+        .finish()?;
+    Ok(GtsImportWithBlobs { bundle, blobs })
+}
+
+#[derive(Clone, Debug)]
+struct BlobFrame {
+    segment_index: usize,
+    frame_index: usize,
+    frame_id: Vec<u8>,
+    range: ByteRange,
+}
+
+pub(crate) struct BlobCollector<'a> {
+    selectors: Vec<GtsBlobSelector<'a>>,
+    limits: GtsBlobLimits,
+    selected: BTreeMap<String, GtsImportedBlob>,
+    frame: Option<BlobFrame>,
+    total: usize,
+}
+
+fn fail(code: &str, message: impl Into<String>) -> RdfDiagnostic {
+    RdfDiagnostic::error(code, message)
+}
+
+fn metadata_field<'a>(
+    meta: Option<&'a Value>,
+    key: &str,
+) -> Result<Option<&'a Value>, RdfDiagnostic> {
+    let Some(Value::Map(fields)) = meta else {
+        return Ok(None);
+    };
+    let mut values = fields
+        .iter()
+        .filter(|(name, _)| name.as_text() == Some(key))
+        .map(|(_, value)| value);
+    let value = values.next();
+    if values.next().is_some() {
+        return Err(fail(
+            "rdf-ir-gts-blob-metadata",
+            format!("selected blob repeats metadata key {key}"),
+        ));
+    }
+    Ok(value)
+}
+
+fn matches(selector: GtsBlobSelector<'_>, digest: &str, meta: Option<&Value>) -> bool {
+    match selector {
+        GtsBlobSelector::Digest(expected) => expected == digest,
+        GtsBlobSelector::Representation(expected) => {
+            let Some(Value::Map(fields)) = meta else {
+                return false;
+            };
+            fields.iter().any(|(key, value)| {
+                key.as_text() == Some("rep") && value.as_text() == Some(expected)
+            })
+        }
+    }
+}
+
+impl<'a> BlobCollector<'a> {
+    fn new(
+        selectors: &[GtsBlobSelector<'a>],
+        limits: GtsBlobLimits,
+    ) -> Result<Self, RdfDiagnostic> {
+        if selectors.len() > 1024
+            || selectors.iter().enumerate().any(|(index, selector)| {
+                let (GtsBlobSelector::Digest(value) | GtsBlobSelector::Representation(value)) =
+                    selector;
+                value.is_empty() || value.len() > 4096 || selectors[..index].contains(selector)
+            })
+        {
+            return Err(fail(
+                "rdf-ir-gts-blob-selection",
+                "selectors must be distinct, nonempty, bounded exact identities",
+            ));
+        }
+        Ok(Self {
+            selectors: selectors.to_vec(),
+            limits,
+            selected: BTreeMap::new(),
+            frame: None,
+            total: 0,
+        })
+    }
+
+    pub(crate) const fn encoded_limit(&self) -> usize {
+        self.limits.max_encoded_bytes
+    }
+
+    pub(crate) fn check_metadata_before_retention(
+        &self,
+        digest: &str,
+        metadata: Option<&Value>,
+    ) -> Result<(), RdfDiagnostic> {
+        let metadata = metadata.or_else(|| {
+            self.selected
+                .get(digest)
+                .and_then(|blob| blob.metadata.as_ref())
+        });
+        if self
+            .selectors
+            .iter()
+            .any(|selector| matches(*selector, digest, metadata))
+        {
+            check_metadata_bound(metadata, self.limits.max_metadata_bytes)?;
+            validate_metadata(metadata, digest)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) const fn decode_limit(&self) -> usize {
+        self.limits.max_decoded_bytes
+    }
+
+    pub(crate) fn frame(&mut self, ctx: FrameContext<'_>) {
+        self.frame = Some(BlobFrame {
+            segment_index: ctx.segment_index,
+            frame_index: ctx.frame_index,
+            frame_id: ctx.content_id.to_vec(),
+            range: ctx.range,
+        });
+    }
+
+    pub(crate) fn payload(&mut self, payload: BlobPayload<'_>) -> Result<(), RdfDiagnostic> {
+        let previous = self.selected.get(payload.digest);
+        let metadata = payload
+            .metadata
+            .or_else(|| previous.and_then(|blob| blob.metadata.as_ref()));
+        if !self
+            .selectors
+            .iter()
+            .any(|selector| matches(*selector, payload.digest, metadata))
+        {
+            if let Some(old) = self.selected.remove(payload.digest) {
+                self.total -= old.bytes.len();
+            }
+            return Ok(());
+        }
+        if payload.payload_present && payload.bytes.is_none() {
+            return Err(fail(
+                "rdf-ir-gts-blob-payload",
+                "selected blob payload field is not a byte string",
+            ));
+        }
+        let metadata = bounded_metadata(metadata, self.limits.max_metadata_bytes)?;
+        validate_metadata(metadata.as_ref(), payload.digest)?;
+        let frame = self
+            .frame
+            .as_ref()
+            .filter(|frame| frame.segment_index == payload.segment_index)
+            .ok_or_else(|| {
+                fail(
+                    "rdf-ir-gts-blob-provenance",
+                    "selected blob has no matching source frame",
+                )
+            })?;
+        let metadata_source = if payload.metadata_declared {
+            Some(GtsBlobMetadataSource {
+                segment_index: frame.segment_index,
+                frame_index: frame.frame_index,
+                frame_id: frame.frame_id.clone(),
+                frame_range: frame.range.clone(),
+                segment_head: Vec::new(),
+            })
+        } else {
+            previous.and_then(|blob| blob.metadata_source.clone())
+        };
+        let Some(wire_bytes) = payload.bytes else {
+            let Some(previous) = self.selected.get_mut(payload.digest) else {
+                return Err(fail(
+                    "rdf-ir-gts-blob-selection-order",
+                    format!(
+                        "blob {} became selected without a payload; earlier unselected bytes are not retained",
+                        payload.digest
+                    ),
+                ));
+            };
+            validate_length(metadata.as_ref(), previous.bytes.len())?;
+            previous.metadata = metadata;
+            previous.metadata_source = metadata_source;
+            return Ok(());
+        };
+        if payload.encoded_len > self.limits.max_encoded_bytes {
+            return Err(fail(
+                "rdf-ir-gts-blob-limit",
+                "selected encoded blob exceeds its byte budget",
+            ));
+        }
+        // A representation can temporarily match many different digests before
+        // later metadata updates. Bound that transient retention as well.
+        if previous.is_none() && self.selected.len() >= 1024 {
+            return Err(fail(
+                "rdf-ir-gts-blob-limit",
+                "more than 1024 selected unique blob digests",
+            ));
+        }
+        let old_len = previous.map_or(0, |blob| blob.bytes.len());
+        let other_bytes = self.total - old_len;
+        let remaining = self
+            .limits
+            .max_total_decoded_bytes
+            .saturating_sub(other_bytes);
+        let limit = self.limits.max_decoded_bytes.min(remaining);
+        let bytes = purrdf_gts::codec::decode_chain_bounded(payload.codecs, wire_bytes, limit)
+            .map_err(|error| fail("rdf-ir-gts-blob-decode", error.to_string()))?;
+        let digest = purrdf_gts::wire::digest_str(&bytes);
+        if digest != payload.digest {
+            return Err(fail(
+                "rdf-ir-gts-blob-digest",
+                format!(
+                    "selected blob digest {digest} differs from declared {}",
+                    payload.digest
+                ),
+            ));
+        }
+        validate_length(metadata.as_ref(), bytes.len())?;
+        self.total = other_bytes + bytes.len();
+        self.selected.insert(
+            digest.clone(),
+            GtsImportedBlob {
+                digest,
+                metadata,
+                metadata_source,
+                bytes: bytes.into(),
+                segment_index: payload.segment_index,
+                frame_index: frame.frame_index,
+                frame_id: frame.frame_id.clone(),
+                frame_range: frame.range.clone(),
+                segment_head: Vec::new(),
+            },
+        );
+        Ok(())
+    }
+
+    pub(crate) fn segment_head(&mut self, segment_index: usize, head: &[u8]) {
+        for blob in self.selected.values_mut() {
+            if blob.segment_index == segment_index {
+                blob.segment_head = head.to_vec();
+            }
+            if let Some(source) = &mut blob.metadata_source
+                && source.segment_index == segment_index
+            {
+                source.segment_head = head.to_vec();
+            }
+        }
+    }
+
+    fn finish(self) -> Result<Vec<GtsImportedBlob>, RdfDiagnostic> {
+        for selector in self.selectors {
+            let count = self
+                .selected
+                .values()
+                .filter(|blob| matches(selector, &blob.digest, blob.metadata.as_ref()))
+                .count();
+            if count != 1 {
+                return Err(fail(
+                    "rdf-ir-gts-blob-selection",
+                    format!(
+                        "required selector {selector:?} resolves to {count} blobs; expected exactly one"
+                    ),
+                ));
+            }
+        }
+        Ok(self.selected.into_values().collect())
+    }
+}
+
+fn validate_metadata(meta: Option<&Value>, digest: &str) -> Result<(), RdfDiagnostic> {
+    if let Some(meta) = meta {
+        if !matches!(meta, Value::Map(_)) {
+            return Err(fail(
+                "rdf-ir-gts-blob-metadata",
+                "selected blob public metadata must be a map",
+            ));
+        }
+        if metadata_field(Some(meta), "digest")?.is_some()
+            && purrdf_gts::reader::public_blob_digest(meta).as_deref() != Some(digest)
+        {
+            return Err(fail(
+                "rdf-ir-gts-blob-digest",
+                "selected blob metadata digest differs from its identity",
+            ));
+        }
+    }
+    for key in ["rep", "mt"] {
+        if let Some(value) = metadata_field(meta, key)? {
+            value.as_text().ok_or_else(|| {
+                fail(
+                    "rdf-ir-gts-blob-metadata",
+                    format!("selected blob metadata {key} must be text"),
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_length(meta: Option<&Value>, length: usize) -> Result<(), RdfDiagnostic> {
+    if let Some(value) = metadata_field(meta, "len")? {
+        let declared = value
+            .as_integer()
+            .and_then(|value| usize::try_from(value).ok());
+        if declared != Some(length) {
+            return Err(fail(
+                "rdf-ir-gts-blob-length",
+                "selected blob declared length differs from decoded length",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn bounded_metadata(meta: Option<&Value>, limit: usize) -> Result<Option<Value>, RdfDiagnostic> {
+    check_metadata_bound(meta, limit)?;
+    Ok(meta.cloned())
+}
+
+fn check_metadata_bound(meta: Option<&Value>, limit: usize) -> Result<(), RdfDiagnostic> {
+    struct Counter {
+        remaining: usize,
+    }
+    impl std::io::Write for Counter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.remaining = self.remaining.checked_sub(bytes.len()).ok_or_else(|| {
+                std::io::Error::other("selected blob metadata exceeds its byte budget")
+            })?;
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    if let Some(meta) = meta {
+        ciborium::ser::into_writer(meta, Counter { remaining: limit })
+            .map_err(|error| fail("rdf-ir-gts-blob-limit", error.to_string()))?;
+    }
+    Ok(())
+}

--- a/crates/rdf/src/gts_import_sink.rs
+++ b/crates/rdf/src/gts_import_sink.rs
@@ -34,9 +34,11 @@
 //! seen — is an `Err`, never a silent skip. Only the merely out-of-order case
 //! resolves.
 
+use crate::gts_import_blobs::BlobCollector;
 use ciborium::value::Value;
 use purrdf_core::cdt_blank::BlankBinding;
 use purrdf_gts::model::{Diagnostic, OpaqueNode, Signature, StreamableInfo, Suppression};
+use purrdf_gts::reader::{BlobPayload, FrameContext};
 use purrdf_gts::segment_decode::{ResolvedSink, SegmentResolver};
 
 use crate::{
@@ -50,7 +52,8 @@ use crate::{
 /// GTS-frame decode and two-phase resolution that drive it live once in
 /// [`purrdf_gts::segment_decode`]; this type only interns resolved terms, pushes
 /// resolved rows, and maps decode failures onto [`RdfDiagnostic`] locations.
-struct SinkImporter {
+struct SinkImporter<'a> {
+    blobs: Option<BlobCollector<'a>>,
     /// The fallible IR builder we intern terms and push structure into.
     builder: RdfDatasetBuilder,
     /// Out-of-band material accumulated from blob / signature / suppression /
@@ -58,16 +61,17 @@ struct SinkImporter {
     lookaside: RdfLookaside,
 }
 
-impl SinkImporter {
+impl SinkImporter<'_> {
     fn new() -> Self {
         Self {
+            blobs: None,
             builder: RdfDatasetBuilder::new(),
             lookaside: RdfLookaside::default(),
         }
     }
 }
 
-impl ResolvedSink for SinkImporter {
+impl ResolvedSink for SinkImporter<'_> {
     type Id = TermId;
     type Error = RdfDiagnostic;
 
@@ -281,6 +285,9 @@ impl ResolvedSink for SinkImporter {
         digest: &str,
         meta: Option<&Value>,
     ) -> Result<(), RdfDiagnostic> {
+        if let Some(blobs) = &self.blobs {
+            blobs.check_metadata_before_retention(digest, meta)?;
+        }
         let metadata = match meta.map(metadata_value_from_cbor) {
             Some(RdfMetadataValue::Map(map)) => map,
             Some(value) => {
@@ -313,6 +320,28 @@ impl ResolvedSink for SinkImporter {
         Ok(())
     }
 
+    fn frame(&mut self, ctx: FrameContext<'_>) -> Result<(), RdfDiagnostic> {
+        if let Some(blobs) = &mut self.blobs {
+            blobs.frame(ctx);
+        }
+        Ok(())
+    }
+
+    fn blob_encoded_limit(&self) -> Option<usize> {
+        self.blobs.as_ref().map(BlobCollector::encoded_limit)
+    }
+
+    fn blob_decode_limit(&self) -> Option<usize> {
+        self.blobs.as_ref().map(BlobCollector::decode_limit)
+    }
+
+    fn blob_payload(&mut self, payload: BlobPayload<'_>) -> Result<(), RdfDiagnostic> {
+        if let Some(blobs) = &mut self.blobs {
+            blobs.payload(payload)?;
+        }
+        Ok(())
+    }
+
     fn opaque(&mut self, _segment_index: usize, opaque: &OpaqueNode) -> Result<(), RdfDiagnostic> {
         self.lookaside.opaque_nodes.push(RdfOpaqueNodeRecord {
             id: hex_bytes(&opaque.id),
@@ -339,6 +368,9 @@ impl ResolvedSink for SinkImporter {
     }
 
     fn segment_head(&mut self, segment_index: usize, head: &[u8]) -> Result<(), RdfDiagnostic> {
+        if let Some(blobs) = &mut self.blobs {
+            blobs.segment_head(segment_index, head);
+        }
         // Grow/patch the per-segment record with its head id.
         self.ensure_segment_record(segment_index).head = Some(hex_bytes(head));
         Ok(())
@@ -418,7 +450,7 @@ fn metadata_value_from_cbor(value: &Value) -> RdfMetadataValue {
     }
 }
 
-impl SinkImporter {
+impl SinkImporter<'_> {
     /// Ensure a [`RdfSegmentRecord`] exists for `segment_index`, returning it.
     fn ensure_segment_record(&mut self, segment_index: usize) -> &mut RdfSegmentRecord {
         if let Some(position) = self
@@ -458,7 +490,16 @@ impl SinkImporter {
 /// the interned terms are frozen via [`RdfDatasetBuilder::freeze`] and paired with
 /// the envelope.
 pub fn import_gts_events(bytes: &[u8]) -> Result<GtsBundle, RdfDiagnostic> {
-    let mut resolver = SegmentResolver::new(SinkImporter::new());
+    import_with_collector(bytes, None).map(|(bundle, _)| bundle)
+}
+
+pub(crate) fn import_with_collector<'a>(
+    bytes: &[u8],
+    blobs: Option<BlobCollector<'a>>,
+) -> Result<(GtsBundle, Option<BlobCollector<'a>>), RdfDiagnostic> {
+    let mut importer = SinkImporter::new();
+    importer.blobs = blobs;
+    let mut resolver = SegmentResolver::new(importer);
     let _ = purrdf_gts::reader::read_to_sink(bytes, true, None, &mut resolver);
 
     // A latched streaming error (e.g. a reader diagnostic) precedes phase-2.
@@ -472,7 +513,10 @@ pub fn import_gts_events(bytes: &[u8]) -> Result<GtsBundle, RdfDiagnostic> {
     let importer = resolver.into_sink();
     let lookaside = importer.lookaside;
     let dataset = importer.builder.freeze()?;
-    Ok(GtsBundle::new(dataset, RdfEnvelope::new(lookaside)))
+    Ok((
+        GtsBundle::new(dataset, RdfEnvelope::new(lookaside)),
+        importer.blobs,
+    ))
 }
 
 #[cfg(test)]
@@ -543,7 +587,7 @@ mod tests {
     /// the same blank label resolves to different ids"). Holding that map here,
     /// in the test harness, is fine — it is not the hot streaming path.
     struct RecordingSink {
-        inner: SinkImporter,
+        inner: SinkImporter<'static>,
         ids: std::collections::HashMap<(usize, usize), TermId>,
     }
 

--- a/crates/rdf/src/lib.rs
+++ b/crates/rdf/src/lib.rs
@@ -46,6 +46,7 @@ pub mod gts;
 // the certifying authoring wrapper `compact_and_certify`.
 pub mod gts_certify;
 mod gts_core;
+mod gts_import_blobs;
 mod gts_import_graph;
 mod gts_import_sink;
 mod gts_resolve;
@@ -102,6 +103,10 @@ mod nesting;
 // `purrdf::RdfDiagnostic`, … keep resolving exactly as before. The two
 // IR import helpers are re-exported here.
 pub use dataset_io::dataset_from_bytes;
+pub use gts_import_blobs::{
+    GtsBlobLimits, GtsBlobMetadataSource, GtsBlobSelector, GtsImportWithBlobs, GtsImportedBlob,
+    import_gts_events_with_blobs,
+};
 pub use gts_import_graph::import_gts_graph;
 pub use gts_import_sink::import_gts_events;
 pub use native_codecs::jsonld::{

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -1,0 +1,591 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Native import with bounded selected payloads: product-independent carrier contracts.
+
+use ciborium::Value;
+use purrdf_gts::model::{Term, TermKind};
+use purrdf_gts::reader::FrameContext;
+use purrdf_gts::wire::digest_str;
+use purrdf_gts::writer::Writer;
+use purrdf_rdf::{GtsBlobLimits, GtsBlobSelector, import_gts_events, import_gts_events_with_blobs};
+
+fn limits() -> GtsBlobLimits {
+    GtsBlobLimits::new(1024 * 1024, 2 * 1024 * 1024)
+}
+fn meta(digest: &str, rep: &str) -> Value {
+    Value::Map(vec![
+        ("digest".into(), digest.into()),
+        ("rep".into(), rep.into()),
+    ])
+}
+fn term(kind: TermKind, value: &str) -> Term {
+    Term {
+        kind,
+        value: Some(value.into()),
+        datatype: None,
+        lang: None,
+        direction: None,
+        reifier: None,
+        triple: None,
+    }
+}
+
+#[test]
+fn selected_import_preserves_native_scope_and_late_rdf_with_exact_provenance() {
+    let mut bytes = Vec::new();
+    for segment in 0..2 {
+        let mut writer = Writer::new("generic");
+        writer.add_blob(
+            b"native laws",
+            Some("application/octet-stream"),
+            Some("laws"),
+        );
+        // RDF descriptions may follow the blob; they cannot affect pub.rep selection.
+        writer.add_terms(&[
+            term(TermKind::Iri, "http://example.org/s"),
+            term(TermKind::Iri, "http://example.org/p"),
+            term(TermKind::Bnode, "b1"),
+        ]);
+        writer.add_quads(&[(0, 1, 2, None)]);
+        if segment == 1 {
+            writer.add_blob(b"unused", None, Some("other"));
+        }
+        bytes.extend(writer.into_bytes());
+    }
+    let old = import_gts_events(&bytes).expect("legacy native import");
+    let imported =
+        import_gts_events_with_blobs(&bytes, &[GtsBlobSelector::Representation("laws")], limits())
+            .expect("selected import");
+    assert_eq!(imported.bundle.envelope, old.envelope);
+    assert_eq!(
+        imported.bundle.dataset.owned_quads().collect::<Vec<_>>(),
+        old.dataset.owned_quads().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        imported.bundle.dataset.quad_count(),
+        2,
+        "segment blank scopes must stay distinct"
+    );
+    let [blob] = imported.blobs.as_slice() else {
+        panic!("one selected digest");
+    };
+    assert_eq!(&*blob.bytes, b"native laws");
+    assert_eq!(blob.digest, digest_str(b"native laws"));
+    assert_eq!(blob.segment_index, 1);
+    assert_eq!(blob.frame_index, 0);
+    assert_eq!(blob.segment_head.len(), 32);
+    let ctx = FrameContext {
+        segment_index: blob.segment_index,
+        frame_index: blob.frame_index,
+        content_id: &blob.frame_id,
+        range: blob.frame_range.clone(),
+        frame_type: "blob",
+        valid: true,
+    };
+    assert!(ctx.verify(&bytes));
+    let source = blob
+        .metadata_source
+        .as_ref()
+        .expect("explicit public metadata");
+    assert_eq!(source.frame_id, blob.frame_id);
+    assert_eq!(source.segment_head, blob.segment_head);
+}
+
+#[test]
+fn selected_import_decodes_each_supported_transform_with_bounded_growth() {
+    let data = vec![b'x'; 100_000];
+    for codec in ["identity", "gzip", "zstd", "zstd-rsyncable"] {
+        let mut writer = Writer::new("generic");
+        writer
+            .add_blob_transformed(data.clone(), None, Some("wanted"), &[codec.into()], None)
+            .unwrap();
+        let bytes = writer.into_bytes();
+        let exact = GtsBlobLimits::new(data.len(), data.len());
+        let result = import_gts_events_with_blobs(
+            &bytes,
+            &[GtsBlobSelector::Representation("wanted")],
+            exact,
+        )
+        .expect("exact decoded bound");
+        assert_eq!(&*result.blobs[0].bytes, data);
+        let too_small = GtsBlobLimits::new(data.len() - 1, data.len());
+        let error = import_gts_events_with_blobs(
+            &bytes,
+            &[GtsBlobSelector::Representation("wanted")],
+            too_small,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(
+                error.code.as_str(),
+                "rdf-ir-gts-blob-decode" | "rdf-ir-gts-blob-limit"
+            ),
+            "{error:?}"
+        );
+    }
+}
+
+#[test]
+fn unselected_payload_integrity_remains_lazy_while_selected_integrity_is_mandatory() {
+    let mut writer = Writer::new("generic");
+    writer.add_blob(b"wanted", None, Some("wanted"));
+    writer.add_frame(
+        "blob",
+        None,
+        Some(b"wrong digest".to_vec()),
+        None,
+        Some(meta(&digest_str(b"something else"), "unused")),
+    );
+    let bytes = writer.into_bytes();
+    assert!(import_gts_events(&bytes).is_ok());
+    let selected = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .unwrap();
+    assert_eq!(selected.blobs.len(), 1);
+    assert_eq!(&*selected.blobs[0].bytes, b"wanted");
+    let error = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Representation("unused")],
+        limits(),
+    )
+    .unwrap_err();
+    assert_eq!(error.code, "rdf-ir-gts-blob-digest");
+}
+
+#[test]
+fn final_replacement_evicts_old_representation_and_reuses_one_digest() {
+    let mut writer = Writer::new("generic");
+    writer.add_blob(b"first", None, Some("wanted"));
+    writer.add_blob(b"first", None, Some("other"));
+    writer.add_blob(b"second", None, Some("wanted"));
+    writer.add_blob(b"second", None, Some("wanted"));
+    let result = import_gts_events_with_blobs(
+        &writer.into_bytes(),
+        &[
+            GtsBlobSelector::Representation("wanted"),
+            GtsBlobSelector::Digest(&digest_str(b"second")),
+        ],
+        limits(),
+    )
+    .unwrap();
+    assert_eq!(result.blobs.len(), 1);
+    assert_eq!(&*result.blobs[0].bytes, b"second");
+    assert_eq!(result.blobs[0].frame_index, 3);
+}
+
+#[test]
+fn missing_and_ambiguous_and_duplicate_selectors_fail_closed() {
+    let mut writer = Writer::new("generic");
+    writer.add_blob(b"first", None, Some("wanted"));
+    writer.add_blob(b"second", None, Some("wanted"));
+    let bytes = writer.into_bytes();
+    for selectors in [
+        vec![GtsBlobSelector::Representation("absent")],
+        vec![GtsBlobSelector::Representation("wanted")],
+        vec![GtsBlobSelector::Digest("x"), GtsBlobSelector::Digest("x")],
+    ] {
+        assert_eq!(
+            import_gts_events_with_blobs(&bytes, &selectors, limits())
+                .unwrap_err()
+                .code,
+            "rdf-ir-gts-blob-selection"
+        );
+    }
+    assert!(
+        import_gts_events_with_blobs(&bytes, &[], limits())
+            .unwrap()
+            .blobs
+            .is_empty()
+    );
+}
+
+#[test]
+fn metadata_only_updates_preserve_payload_provenance_and_reject_unretained_ordering() {
+    let data = b"native";
+    let digest = digest_str(data);
+    for initially_selected in [false, true] {
+        let mut first = Writer::new("generic");
+        first.add_blob(
+            data,
+            None,
+            Some(if initially_selected {
+                "wanted"
+            } else {
+                "other"
+            }),
+        );
+        let first_head = first.head().to_vec();
+        let mut bytes = first.into_bytes();
+        let mut next = Writer::new("generic");
+        let updated = Value::Map(vec![
+            ("digest".into(), digest.clone().into()),
+            ("rep".into(), "wanted".into()),
+            (
+                "custom".into(),
+                Value::Array(vec![Value::Bytes(vec![1, 2, 3])]),
+            ),
+        ]);
+        let metadata_frame = next.add_frame("blob", None, None, None, Some(updated.clone()));
+        let metadata_head = next.head().to_vec();
+        bytes.extend(next.into_bytes());
+        assert!(
+            import_gts_events(&bytes).is_ok(),
+            "legacy metadata-only behavior is preserved"
+        );
+        let result = import_gts_events_with_blobs(
+            &bytes,
+            &[GtsBlobSelector::Representation("wanted")],
+            limits(),
+        );
+        if initially_selected {
+            let result = result.unwrap();
+            let blob = &result.blobs[0];
+            assert_eq!(&*blob.bytes, data);
+            assert_eq!(
+                purrdf_gts::wire::canonical(blob.metadata.as_ref().unwrap()),
+                purrdf_gts::wire::canonical(&updated)
+            );
+            assert_eq!(blob.segment_index, 0);
+            assert_eq!(blob.segment_head, first_head);
+            let source = blob.metadata_source.as_ref().unwrap();
+            assert_eq!(source.segment_index, 1);
+            assert_eq!(source.frame_id, metadata_frame);
+            assert_eq!(source.segment_head, metadata_head);
+        } else {
+            assert_eq!(result.unwrap_err().code, "rdf-ir-gts-blob-selection-order");
+        }
+    }
+}
+
+#[test]
+fn absent_public_metadata_preserves_previous_segment_metadata() {
+    let data = b"native";
+    let mut first = Writer::new("generic");
+    first.add_blob(data, None, Some("wanted"));
+    let first_head = first.head().to_vec();
+    let mut bytes = first.into_bytes();
+    let mut next = Writer::new("generic");
+    next.add_frame("blob", None, Some(data.to_vec()), None, None);
+    bytes.extend(next.into_bytes());
+    let result = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .unwrap();
+    let blob = &result.blobs[0];
+    assert_eq!(blob.segment_index, 1);
+    assert_eq!(&*blob.bytes, data);
+    let source = blob.metadata_source.as_ref().unwrap();
+    assert_eq!(source.segment_index, 0);
+    assert_eq!(source.segment_head, first_head);
+}
+
+#[test]
+fn retained_total_wire_and_metadata_budgets_are_independent() {
+    let mut writer = Writer::new("generic");
+    writer.add_blob(b"first", None, Some("a"));
+    writer.add_blob(b"second", None, Some("b"));
+    let bytes = writer.into_bytes();
+    let selectors = [
+        GtsBlobSelector::Representation("a"),
+        GtsBlobSelector::Representation("b"),
+    ];
+    let mut total = limits();
+    total.max_total_decoded_bytes = 10;
+    assert_eq!(
+        import_gts_events_with_blobs(&bytes, &selectors, total)
+            .unwrap_err()
+            .code,
+        "rdf-ir-gts-blob-decode"
+    );
+    let mut wire = limits();
+    wire.max_encoded_bytes = 4;
+    assert_eq!(
+        import_gts_events_with_blobs(&bytes, &selectors, wire)
+            .unwrap_err()
+            .code,
+        "rdf-ir-gts-blob-limit"
+    );
+    let mut metadata = limits();
+    metadata.max_metadata_bytes = 2;
+    assert_eq!(
+        import_gts_events_with_blobs(&bytes, &selectors, metadata)
+            .unwrap_err()
+            .code,
+        "rdf-ir-gts-blob-limit"
+    );
+}
+
+#[test]
+fn malformed_selected_metadata_and_declared_lengths_fail() {
+    let data = b"native";
+    for (key, value, expected) in [
+        ("len", Value::from(99), "rdf-ir-gts-blob-length"),
+        ("rep", Value::from("wanted"), "rdf-ir-gts-blob-metadata"),
+        ("mt", Value::from(99), "rdf-ir-gts-blob-metadata"),
+    ] {
+        let mut fields = vec![
+            ("digest".into(), digest_str(data).into()),
+            ("rep".into(), "wanted".into()),
+        ];
+        fields.push((key.into(), value));
+        let mut writer = Writer::new("generic");
+        writer.add_frame(
+            "blob",
+            None,
+            Some(data.to_vec()),
+            None,
+            Some(Value::Map(fields)),
+        );
+        assert_eq!(
+            import_gts_events_with_blobs(
+                &writer.into_bytes(),
+                &[GtsBlobSelector::Representation("wanted")],
+                limits()
+            )
+            .unwrap_err()
+            .code,
+            expected
+        );
+    }
+}
+
+#[test]
+fn snapshot_payload_selection_and_reader_diagnostics_remain_native() {
+    let data = b"snapshot";
+    let mut writer = Writer::new("generic");
+    writer.add_frame(
+        "snapshot",
+        Some(Value::Map(vec![(
+            "blobs".into(),
+            Value::Map(vec![("ignored-key".into(), Value::Bytes(data.to_vec()))]),
+        )])),
+        None,
+        None,
+        None,
+    );
+    let result = import_gts_events_with_blobs(
+        &writer.into_bytes(),
+        &[GtsBlobSelector::Digest(&digest_str(data))],
+        limits(),
+    )
+    .unwrap();
+    assert_eq!(&*result.blobs[0].bytes, data);
+    assert!(result.blobs[0].metadata.is_none());
+    for malformed in [b"not gts".as_slice(), b"".as_slice()] {
+        assert_eq!(
+            import_gts_events_with_blobs(malformed, &[], limits())
+                .unwrap_err()
+                .code,
+            import_gts_events(malformed).unwrap_err().code
+        );
+    }
+}
+
+#[test]
+fn inherited_same_segment_metadata_keeps_its_original_frame_identity() {
+    let mut writer = Writer::new("generic");
+    let first_frame = writer.add_blob(b"native", None, Some("wanted"));
+    writer.add_frame("blob", None, Some(b"native".to_vec()), None, None);
+    let head = writer.head().to_vec();
+    let imported = import_gts_events_with_blobs(
+        &writer.into_bytes(),
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .unwrap();
+    let blob = &imported.blobs[0];
+    assert_eq!(blob.frame_index, 1);
+    let source = blob.metadata_source.as_ref().unwrap();
+    assert_eq!(source.frame_index, 0);
+    assert_eq!(source.frame_id, first_frame);
+    assert_eq!(source.segment_head, head);
+}
+
+#[test]
+fn selection_count_and_unadvertised_blob_expansion_are_bounded() {
+    let selectors: Vec<_> = (0..1025).map(|index| format!("rep-{index}")).collect();
+    let selectors: Vec<_> = selectors
+        .iter()
+        .map(|rep| GtsBlobSelector::Representation(rep))
+        .collect();
+    let bytes = Writer::new("generic").into_bytes();
+    assert_eq!(
+        import_gts_events_with_blobs(&bytes, &selectors, limits())
+            .unwrap_err()
+            .code,
+        "rdf-ir-gts-blob-selection"
+    );
+    let mut writer = Writer::new("generic");
+    for index in 0_u32..1025 {
+        writer.add_blob(&index.to_be_bytes(), None, Some("wanted"));
+    }
+    assert_eq!(
+        import_gts_events_with_blobs(
+            &writer.into_bytes(),
+            &[GtsBlobSelector::Representation("wanted")],
+            limits()
+        )
+        .unwrap_err()
+        .code,
+        "rdf-ir-gts-blob-limit"
+    );
+    let mut writer = Writer::new("generic");
+    writer.add_frame(
+        "blob",
+        None,
+        Some(vec![b'x'; 100_000]),
+        Some(&["zstd".into()]),
+        None,
+    );
+    let bytes = writer.into_bytes();
+    assert!(import_gts_events(&bytes).is_ok());
+    assert_eq!(
+        import_gts_events_with_blobs(&bytes, &[], GtsBlobLimits::new(100, 100))
+            .unwrap_err()
+            .code,
+        "rdf-ir-gts-fold-diagnostic"
+    );
+}
+
+#[test]
+fn malformed_payload_cannot_masquerade_as_a_metadata_only_update() {
+    let data = b"native";
+    let mut writer = Writer::new("generic");
+    writer.add_blob(data, None, Some("wanted"));
+    writer.add_frame(
+        "blob",
+        Some(Value::from("not bytes")),
+        None,
+        None,
+        Some(meta(&digest_str(data), "wanted")),
+    );
+    let bytes = writer.into_bytes();
+    assert!(
+        import_gts_events(&bytes).is_ok(),
+        "legacy metadata observation remains compatible"
+    );
+    assert_eq!(
+        import_gts_events_with_blobs(
+            &bytes,
+            &[GtsBlobSelector::Representation("wanted")],
+            limits()
+        )
+        .unwrap_err()
+        .code,
+        "rdf-ir-gts-blob-payload"
+    );
+}
+
+#[test]
+fn legal_public_digest_encodings_preserve_raw_metadata_and_native_identity() {
+    let data = b"native digest encodings";
+    let digest = digest_str(data);
+    let hex = digest.strip_prefix("blake3:").unwrap();
+    for declaration in [
+        Value::Text(digest.clone()),
+        Value::Text(hex.to_owned()),
+        Value::Bytes(purrdf_gts::wire::blake3_256(data)),
+    ] {
+        let metadata = Value::Map(vec![
+            ("digest".into(), declaration),
+            ("rep".into(), "wanted".into()),
+        ]);
+        let mut writer = Writer::new("generic");
+        writer.add_frame(
+            "blob",
+            None,
+            Some(data.to_vec()),
+            None,
+            Some(metadata.clone()),
+        );
+        let bytes = writer.into_bytes();
+        let legacy = import_gts_events(&bytes).unwrap();
+        let selected = import_gts_events_with_blobs(
+            &bytes,
+            &[
+                GtsBlobSelector::Digest(&digest),
+                GtsBlobSelector::Representation("wanted"),
+            ],
+            limits(),
+        )
+        .unwrap();
+        assert_eq!(selected.bundle.envelope, legacy.envelope);
+        assert_eq!(selected.blobs.len(), 1);
+        assert_eq!(selected.blobs[0].digest, digest);
+        assert_eq!(&*selected.blobs[0].bytes, data);
+        assert_eq!(
+            purrdf_gts::wire::canonical(selected.blobs[0].metadata.as_ref().unwrap()),
+            purrdf_gts::wire::canonical(&metadata),
+            "metadata keeps its original digest representation"
+        );
+    }
+}
+
+#[test]
+fn eager_digest_resolution_enforces_the_original_encoded_length() {
+    for data in [vec![b'x'], vec![b'x'; 10_000]] {
+        for codec in ["gzip", "zstd", "zstd-rsyncable"] {
+            let chain = [codec.to_owned()];
+            let encoded_len = purrdf_gts::codec::encode_chain(&chain, &data)
+                .unwrap()
+                .len();
+            assert_ne!(
+                encoded_len,
+                data.len(),
+                "fixture distinguishes wire and decoded lengths"
+            );
+            let mut writer = Writer::new("generic");
+            writer.add_frame("blob", None, Some(data.clone()), Some(&chain), None);
+            let bytes = writer.into_bytes();
+            assert!(import_gts_events(&bytes).is_ok());
+            let digest = digest_str(&data);
+            let mut exact = GtsBlobLimits::new(data.len(), data.len());
+            exact.max_encoded_bytes = encoded_len;
+            let selected =
+                import_gts_events_with_blobs(&bytes, &[GtsBlobSelector::Digest(&digest)], exact)
+                    .expect("independent exact wire and decoded bounds");
+            assert_eq!(&*selected.blobs[0].bytes, data);
+            let mut too_small = exact;
+            too_small.max_encoded_bytes -= 1;
+            let error = import_gts_events_with_blobs(
+                &bytes,
+                &[GtsBlobSelector::Digest(&digest)],
+                too_small,
+            )
+            .unwrap_err();
+            assert_eq!(error.code, "rdf-ir-gts-fold-diagnostic");
+            assert!(error.message.contains("encoded blob exceeds"), "{error:?}");
+        }
+    }
+}
+
+#[test]
+fn malformed_public_metadata_is_not_silently_treated_as_absent() {
+    let data = b"native";
+    let mut writer = Writer::new("generic");
+    writer.add_frame(
+        "blob",
+        None,
+        Some(data.to_vec()),
+        None,
+        Some(Value::from("not a map")),
+    );
+    let bytes = writer.into_bytes();
+    assert!(
+        import_gts_events(&bytes).is_ok(),
+        "legacy importer behavior remains unchanged"
+    );
+    let error = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Digest(&digest_str(data))],
+        limits(),
+    )
+    .unwrap_err();
+    assert_eq!(error.code, "rdf-ir-gts-blob-metadata");
+}

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -326,6 +326,7 @@ fn malformed_selected_metadata_and_declared_lengths_fail() {
     let data = b"native";
     for (key, value, expected) in [
         ("len", Value::from(99), "rdf-ir-gts-blob-length"),
+        // A second "rep" entry makes the metadata map ambiguous.
         ("rep", Value::from("wanted"), "rdf-ir-gts-blob-metadata"),
         ("mt", Value::from(99), "rdf-ir-gts-blob-metadata"),
     ] {

--- a/crates/shapes/src/constraints.rs
+++ b/crates/shapes/src/constraints.rs
@@ -379,7 +379,7 @@ fn eval_closed(
         let path_roles = path_box_roles(store, &Path::Predicate(predicate.clone()), box_role_vocab);
         let mut result = ValidationResult {
             focus_node: focus.clone(),
-            result_path: Some(Term::NamedNode(predicate.clone())),
+            result_path: Some(Term::NamedNode(predicate)),
             path_structure: None,
             value: Some(object),
             source_constraint_component: NamedNode::from(sh::CLOSED_CONSTRAINT_COMPONENT),
@@ -619,7 +619,7 @@ fn eval_reifier_shapes(ctx: ReifierEvalContext<'_>) -> Result<Vec<ValidationResu
                 focus_node: focus.clone(),
                 result_path: Some(path_term.clone()),
                 path_structure: None,
-                value: Some(triple_term.clone()),
+                value: Some(triple_term),
                 source_constraint_component: NamedNode::from(
                     sh::REIFIER_SHAPE_CONSTRAINT_COMPONENT,
                 ),

--- a/crates/shapes/src/report.rs
+++ b/crates/shapes/src/report.rs
@@ -325,7 +325,7 @@ impl ValidationReport {
             if let Some(msg) = &r.message {
                 push_triple(
                     &mut builder,
-                    result_subj.clone(),
+                    result_subj,
                     sh::RESULT_MESSAGE,
                     RdfTerm::Literal(::purrdf::RdfLiteral::simple(msg.as_str())),
                 );

--- a/crates/shapes/src/shapes.rs
+++ b/crates/shapes/src/shapes.rs
@@ -426,6 +426,21 @@ pub struct Shapes {
     pub(crate) shapes_dataset: Arc<RdfDataset>,
 }
 
+impl Shapes {
+    /// Borrow the original frozen dataset retained when these shapes were parsed.
+    ///
+    /// This returns the existing shared owner without reparsing, copying the
+    /// dataset, or incrementing its reference count. Use `Arc::clone(shapes.dataset())`
+    /// to retain the same immutable dataset independently of the `Shapes` value.
+    ///
+    /// Document-prefix handling remains part of [`crate::engine::parse_shapes`]:
+    /// the dataset contains RDF statements, not the source document's prefix map.
+    #[must_use]
+    pub const fn dataset(&self) -> &Arc<RdfDataset> {
+        &self.shapes_dataset
+    }
+}
+
 impl Default for Shapes {
     fn default() -> Self {
         Self {
@@ -807,9 +822,9 @@ impl<'s> Parser<'s> {
         crate::term::sort_terms_canonical(&mut ids);
         for term in ids {
             let shape = if self.first_object_of(&term, sh::PATH).is_some() {
-                self.parse_standalone_property_shape(term.clone())?
+                self.parse_standalone_property_shape(term)?
             } else {
-                self.parse_node_shape(term.clone())?
+                self.parse_node_shape(term)?
             };
             node_shapes.push(shape);
         }

--- a/crates/shapes/src/shapes/parser/custom_fn.rs
+++ b/crates/shapes/src/shapes/parser/custom_fn.rs
@@ -332,7 +332,7 @@ impl Parser<'_> {
             // happened to reach it first, and sharing the caller's stack would make
             // a legitimate shared sub-expression look like a cycle.
             let saved = std::mem::take(&mut self.in_flight);
-            self.in_flight.insert(InFlight::NodeExpr(id.clone()));
+            self.in_flight.insert(InFlight::NodeExpr(id));
             let parsed = self.parse_node_expr(body_node);
             self.in_flight = saved;
             let body = parsed.map_err(|e| {

--- a/crates/slice/src/ownership.rs
+++ b/crates/slice/src/ownership.rs
@@ -397,7 +397,7 @@ impl<'a> OwnershipAnalyzer<'a> {
                         term: term.clone(),
                         claimants: owners_vec.clone(),
                     });
-                    OwnershipStatus::Conflict(owners_vec.clone())
+                    OwnershipStatus::Conflict(owners_vec)
                 } else {
                     match &physical_origin {
                         Some(origin) if origin.slice == declared_owner => {

--- a/crates/slice/src/rdf_query.rs
+++ b/crates/slice/src/rdf_query.rs
@@ -491,18 +491,14 @@ impl Dataset {
     fn flat_quads(&self) -> Vec<RdfQuad> {
         let mut quads: Vec<RdfQuad> = self.ds.owned_quads().collect();
         for reifier in self.ds.owned_reifiers() {
-            let statement = RdfTerm::triple(reifier.statement.clone());
-            quads.push(RdfQuad::new(
-                reifier.reifier.clone(),
-                RDF_REIFIES,
-                statement,
-            ));
+            let statement = RdfTerm::triple(reifier.statement);
+            quads.push(RdfQuad::new(reifier.reifier, RDF_REIFIES, statement));
         }
         for annotation in self.ds.owned_annotations() {
             quads.push(RdfQuad::new(
-                annotation.reifier.clone(),
-                annotation.predicate.clone(),
-                annotation.object.clone(),
+                annotation.reifier,
+                annotation.predicate,
+                annotation.object,
             ));
         }
         quads


### PR DESCRIPTION
Native GTS consumers currently need a second container read to retrieve archive payloads, and SHACL consumers reparse shape text to recover its RDF dataset. This adds required, bounded blob selection to the existing native importer and exposes the immutable dataset already retained by `Shapes`.

`import_gts_events_with_blobs` uses the existing segment resolver and returns the native bundle plus shared selected bytes, exact metadata and separate payload/metadata frame and segment provenance. Selectors resolve by exact digest or final representation; missing, ambiguous, corrupt and unsupported ordering cases fail explicitly. Encoded, decoded/intermediate, retained-total and metadata bounds are enforced. The existing importer and default sink behavior remain compatible; no production dependency, feature, version or wire format changes.

The sink's encoded and decoded limits also remain effective with a content-key resolver. Keyed decoding shares the bounded transform loop; COSE plaintext size is checked before decryption, which reuses the parsed ciphertext allocation. Original encoded bytes, every decoded intermediate and retained selected payloads have distinct enforced bounds.

Native encrypted fixtures generate fresh keys and nonces through a native-only `getrandom` dev dependency; invalid-key controls differ from the actual key by a guaranteed bit flip. This addresses CodeQL without suppressing checks or adding randomness to library output.

`Shapes::dataset()` borrows the original `Arc<RdfDataset>`, preserving blank identity and document-prefix behavior without copying or parsing. Consumed-value clones reported by the affected dependency's warning-denied check are replaced with moves.

Validation on the pinned nightly toolchain: 45 focused tests passed (11 codec, 6 keyed-bound, 12 native-import, 16 selected-payload contracts); Clippy passed for GTS, RDF and shapes with warnings denied; focused rustdoc and issue-reference, brand and spec-attribution checks passed; formatting passed. The local checks are scoped per the requested test-ownership boundary. The full local gate/conformance suite was not run; every existing upstream CI lane remains required before merge. GMEOW adoption, optimized producer measurements and its two independent cold generations remain downstream requirements.

Closes #281.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native GTS blob importing with selection by digest or public representation.
  - Added encoded, decoded, aggregate, and metadata size limits for safer blob processing.
  - Imported blobs now include authenticated decoded data, metadata, provenance, and integrity validation.
  - Added access to retained RDF datasets from shape collections.
  - Added blob payload events for streaming and segment-processing integrations.
  - Added bounded processing for encrypted and compressed blob content.

- **Tests**
  - Added comprehensive coverage for blob selection, limits, metadata, integrity, compression, snapshots, and malformed inputs.

- **Chores**
  - Added focused commands for linting, documenting, and testing native blob imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
