### PR TITLE
fix(rdf): admit archives holding unselected oversized payloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 CAPI_HEADER := crates/rdf-capi/include/purrdf.h
 
 .PHONY: help doctor metadata fmt check geo-determinism book book-samples book-pot book-po-update book-zh check-i18n check-issue-refs check-brand-casing check-spec-attribution changelog bump release-tags test doc bench bench-prepared-reuse bench-python columnar-oracle csvw-conformance csvw-oracle obographs-oracle projection-oracles pydantic-oracle linkml-oracle typescript-oracle graphql-oracle pytest conformance iri-resolver-hygiene rdf-core-hygiene wasm wasm-test wasm-pkg wasm-pkg-test wasm-pkg-bench playground playground-smoke \
-	capi-build capi-header capi-check capi-install test-native-import-blobs lint-native-import-blobs doc-native-import-blobs
+	capi-build capi-header capi-check capi-install test-gts-selected-blobs lint-gts-selected-blobs doc-gts-selected-blobs
 
 # The changelog generator is pinned so the committed CHANGELOG.md and the notes
 # the release workflow slices out of it stay byte-reproducible across machines.
@@ -156,19 +156,20 @@ release-tags: ## Cut + push rust-v/py-v/npm-v tags for VERSION after coherence c
 test: ## Run the workspace test suite.
 	cargo test --workspace --locked
 
-lint-native-import-blobs: ## Lint the selected native-import production and test surfaces only.
+lint-gts-selected-blobs: ## Lint the selected native-import production and test surfaces only.
 	cargo clippy -p purrdf-gts --lib --test bounded_keyed_blobs --locked -- -D warnings
 	cargo clippy -p purrdf-rdf --lib --test gts_selected_blobs --locked -- -D warnings
 	cargo clippy -p purrdf-shapes --lib --locked -- -D warnings
 
-doc-native-import-blobs: ## Check the native-import and shared shape-dataset public API documentation.
+doc-gts-selected-blobs: ## Check the native-import and shared shape-dataset public API documentation.
 	RUSTDOCFLAGS="-D warnings" cargo doc -p purrdf-gts -p purrdf-rdf -p purrdf-shapes --no-deps --locked
 
-test-native-import-blobs: ## Check bounded selected-blob import and native scope contracts only.
+test-gts-selected-blobs: ## Check bounded selected-blob import and native scope contracts only.
 	cargo test -p purrdf-gts --lib codec::tests:: --locked
 	cargo test -p purrdf-gts --test bounded_keyed_blobs --locked
 	cargo test -p purrdf-rdf --lib gts_import_sink::tests:: --locked
 	cargo test -p purrdf-rdf --test gts_selected_blobs --locked
+	cargo test -p purrdf-shapes --test shared_shapes_dataset --locked
 
 doc: ## Build docs for the 21 publishable crates with rustdoc warnings denied.
 	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --exclude purrdf-capi --exclude purrdf-python --exclude purrdf-sparql-conformance --exclude purrdf-cli

--- a/crates/gts/src/codec.rs
+++ b/crates/gts/src/codec.rs
@@ -66,13 +66,21 @@ pub enum CodecError {
     },
     /// The codec is known but the data is corrupt — the frame is damaged.
     Failed(String),
+    /// The data is well-formed but a caller-supplied byte ceiling refused it.
+    ///
+    /// Distinct from [`Self::Failed`] because refusing to *spend* bytes is not
+    /// evidence that the bytes are corrupt: a caller that set the ceiling may
+    /// legitimately skip this payload and keep reading, whereas corruption is a
+    /// statement about the container. Only a decode given an explicit limit can
+    /// produce this.
+    Limit(String),
 }
 
 impl fmt::Display for CodecError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Unavailable { reason, detail } => write!(f, "{reason}: {detail}"),
-            Self::Failed(detail) => f.write_str(detail),
+            Self::Failed(detail) | Self::Limit(detail) => f.write_str(detail),
         }
     }
 }
@@ -379,7 +387,7 @@ pub fn decode_chain(chain: &[Codec], data: &[u8]) -> Result<Vec<u8>, CodecError>
 }
 
 fn decoded_limit(limit: usize) -> CodecError {
-    CodecError::Failed(format!("decoded transform output exceeds {limit} bytes"))
+    CodecError::Limit(format!("decoded transform output exceeds {limit} bytes"))
 }
 
 /// Reverse a codec chain, bounding every decoded intermediate and final buffer.

--- a/crates/gts/src/cose.rs
+++ b/crates/gts/src/cose.rs
@@ -274,29 +274,6 @@ pub fn recipient_kid(blob: &[u8]) -> Option<String> {
     parse_encrypt0(blob).map(|p| p.kid)
 }
 
-/// Open a COSE_Encrypt0 using a content key resolved by `kid` (§9.3).
-pub fn decrypt0(
-    blob: &[u8],
-    resolve: impl Fn(&str) -> Option<[u8; 32]>,
-) -> Result<Vec<u8>, Encrypt0Error> {
-    let parts = parse_encrypt0(blob).ok_or(Encrypt0Error::Malformed)?;
-    let key = resolve(&parts.kid).ok_or(Encrypt0Error::MissingKey)?;
-    if parts.iv.len() != 12 {
-        return Err(Encrypt0Error::Malformed);
-    }
-    let aad = enc_structure(&parts.protected);
-    let cipher = Aes256Gcm::new((&key).into());
-    cipher
-        .decrypt(
-            Nonce::from_slice(&parts.iv),
-            Payload {
-                msg: &parts.ciphertext,
-                aad: &aad,
-            },
-        )
-        .map_err(|_| Encrypt0Error::AuthFailed)
-}
-
 /// Internal bounded decryption failures, without extending the public error enum.
 #[derive(Debug)]
 pub(crate) enum BoundedDecrypt0Error {

--- a/crates/gts/src/reader.rs
+++ b/crates/gts/src/reader.rs
@@ -385,6 +385,15 @@ pub trait StreamingSink {
     fn blob_decode_limit(&self) -> Option<usize> {
         None
     }
+    /// Optional bound for decoding an ordinary (non-blob) frame's payload.
+    ///
+    /// A `snapshot` frame carries embedded blob bytes *inside* an RDF frame, so
+    /// a blob ceiling alone leaves the real bomb unbounded: the memory is spent
+    /// decoding the enclosing frame, long before any embedded entry is seen.
+    /// Sinks that set no bound keep the previous unbounded behavior.
+    fn frame_decode_limit(&self) -> Option<usize> {
+        None
+    }
     /// Opaque frame produced by unknown, encrypted, or damaged payloads.
     fn opaque(&mut self, _segment_index: usize, _opaque: &OpaqueNode) {}
     /// Signature status observed on a frame.
@@ -659,13 +668,16 @@ impl Folder<'_, '_, '_> {
                 ));
             };
             let chain = self.resolve_codecs(ids)?;
-            let limit = blob
-                .then(|| {
-                    self.sink
-                        .as_deref()
-                        .and_then(StreamingSink::blob_decode_limit)
-                })
-                .flatten();
+            // A blob frame is bounded by the blob ceiling; every other frame by
+            // the frame ceiling, which is what keeps an embedded snapshot blob
+            // map from decoding without limit.
+            let limit = self.sink.as_deref().and_then(|sink| {
+                if blob {
+                    sink.blob_decode_limit()
+                } else {
+                    sink.frame_decode_limit()
+                }
+            });
             let decoded = if let Some(content_key) = self.content_key {
                 let limit = limit.unwrap_or(usize::MAX);
                 let decrypt =
@@ -1191,9 +1203,24 @@ impl Folder<'_, '_, '_> {
             self.h_annot(&Value::Array(annot.iter().map(sh_row).collect()), index);
         }
         if let Some(Value::Map(blobs)) = map_get(entries, "blobs") {
+            let ceiling = self
+                .sink
+                .as_deref()
+                .and_then(StreamingSink::blob_decode_limit);
             for (_, b) in blobs {
                 if let Value::Bytes(bytes) = b {
                     let digest = digest_str(bytes);
+                    // An embedded entry obeys the same ceiling as a standalone
+                    // payload; without this a snapshot is a way to hand a
+                    // bounded consumer arbitrarily many unbounded blobs.
+                    if let Some(limit) = ceiling
+                        && bytes.len() > limit
+                    {
+                        let detail = format!("snapshot blob exceeds {limit} bytes");
+                        self.emit_blob_refusal(Some(&digest), None, bytes.len(), &detail);
+                        self.diag(BLOB_BUDGET_DIAGNOSTIC, detail, Some(index));
+                        continue;
+                    }
                     if self.materialize {
                         self.g.set_blob(digest.clone(), bytes.clone());
                     }

--- a/crates/gts/src/reader.rs
+++ b/crates/gts/src/reader.rs
@@ -308,6 +308,31 @@ pub struct BlobPayload<'a> {
     pub codecs: &'a [Codec],
 }
 
+/// One inline blob occurrence a sink's byte ceiling refused before decoding.
+///
+/// Reported so a selecting consumer still learns a candidate was present. It
+/// carries everything decidable without spending the bytes: the container's
+/// declared public metadata (so a representation selector can still match), the
+/// physical source, and the encoded length that was rejected.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug)]
+pub struct BlobRefusal<'a> {
+    /// Zero-based segment containing this occurrence.
+    pub segment_index: usize,
+    /// Declared content digest, when the container published one.
+    ///
+    /// `None` for a payload with no public digest: refusing happens before the
+    /// decode that would compute it, so no identity is available. Such a blob is
+    /// matchable by representation and provenance, never by digest.
+    pub digest: Option<&'a str>,
+    /// Public metadata available at this occurrence, independent of RDF rows.
+    pub metadata: Option<&'a Value>,
+    /// Original blob byte-string length that was refused.
+    pub encoded_len: usize,
+    /// Which ceiling fired, in the reader's own words.
+    pub detail: &'a str,
+}
+
 /// Sink for [`read_to_sink`] events.
 ///
 /// Term ids in events are segment-local ids. A sink that needs a file-level
@@ -335,6 +360,15 @@ pub trait StreamingSink {
     /// Called after the legacy metadata-only [`Self::blob`] event. The metadata
     /// is repeated here so consumers need not pair callbacks by arrival order.
     fn blob_payload(&mut self, _payload: BlobPayload<'_>) {}
+    /// A blob this sink's own byte ceiling refused, before it was decoded.
+    ///
+    /// Fires instead of [`Self::blob_payload`], and only for a sink that set a
+    /// ceiling. A refused payload is reported rather than dropped so a selecting
+    /// consumer can still see that a candidate existed: silently omitting it
+    /// would let a ceiling change which blob a selector resolves to, turning a
+    /// retention bound into a selection rule. The digest is absent whenever the
+    /// container did not declare one, because refusing precedes hashing.
+    fn blob_refused(&mut self, _refusal: BlobRefusal<'_>) {}
     /// Optional encoded-byte bound before eager blob decoding, including decryption.
     ///
     /// Existing sinks leave the reader behavior unchanged. This does not bound
@@ -513,6 +547,27 @@ impl Folder<'_, '_, '_> {
                 frame_index: index,
             },
         );
+    }
+
+    /// Report a payload the sink's own ceiling refused, before any decode.
+    fn emit_blob_refusal(
+        &mut self,
+        digest: Option<&str>,
+        declared_metadata: Option<&Value>,
+        encoded_len: usize,
+        detail: &str,
+    ) {
+        let segment_index = self.segment_index;
+        let Some(sink) = self.sink.as_deref_mut() else {
+            return;
+        };
+        sink.blob_refused(BlobRefusal {
+            segment_index,
+            digest,
+            metadata: declared_metadata,
+            encoded_len,
+            detail,
+        });
     }
 
     fn emit_blob(
@@ -940,6 +995,13 @@ impl Folder<'_, '_, '_> {
                 }
                 Ok(_) => {}
                 Err(PayloadError::Budget(detail)) => {
+                    let refused_digest = pub_meta.as_ref().and_then(public_blob_digest);
+                    self.emit_blob_refusal(
+                        refused_digest.as_deref(),
+                        declared_metadata,
+                        encoded_len,
+                        &detail,
+                    );
                     self.opaque(frame, "blob", "over-budget");
                     self.diag(BLOB_BUDGET_DIAGNOSTIC, detail, Some(index));
                 }
@@ -1010,6 +1072,13 @@ impl Folder<'_, '_, '_> {
             }
             Ok(_) => {}
             Err(PayloadError::Budget(detail)) => {
+                let refused_digest = pub_meta.as_ref().and_then(public_blob_digest);
+                self.emit_blob_refusal(
+                    refused_digest.as_deref(),
+                    declared_metadata,
+                    encoded_len,
+                    &detail,
+                );
                 self.opaque(frame, "blob", "over-budget");
                 self.diag(BLOB_BUDGET_DIAGNOSTIC, detail, Some(index));
             }

--- a/crates/gts/src/reader.rs
+++ b/crates/gts/src/reader.rs
@@ -176,6 +176,27 @@ pub const BLOB_BUDGET_DIAGNOSTIC: &str = "BlobBudget";
 /// must not silently treat the second the same way.
 pub const FRAME_BUDGET_DIAGNOSTIC: &str = "FrameBudget";
 
+/// Identity for a payload a ceiling refused, and whether this reader proved it.
+///
+/// With no transform chain the wire bytes are the decoded bytes, so hashing them
+/// is exact and costs no memory — that identity is *proved*. Otherwise the only
+/// candidate is the container's own `pub.digest`, which cannot be checked
+/// against a payload that was never decoded. The distinction matters downstream:
+/// acting on an unverified claim lets a container assert a refused payload's
+/// identity, and so decide how a selector resolves.
+fn refused_identity(
+    chain: &[Codec],
+    d: Option<&Value>,
+    pub_meta: Option<&Value>,
+) -> (Option<String>, bool) {
+    if chain.is_empty()
+        && let Some(raw) = d.and_then(Value::as_bytes)
+    {
+        return (Some(digest_str(raw)), true);
+    }
+    (pub_meta.and_then(public_blob_digest), false)
+}
+
 enum PayloadError {
     /// Missing capability — degrade to an opaque node with this reason.
     Unavailable {
@@ -336,6 +357,12 @@ pub struct BlobRefusal<'a> {
     pub digest: Option<&'a str>,
     /// Public metadata available at this occurrence, independent of RDF rows.
     pub metadata: Option<&'a Value>,
+    /// Whether this reader computed [`Self::digest`] from the payload itself.
+    ///
+    /// False means the value is the container's unverified claim, which no
+    /// consumer should treat as identity: the payload was refused before any
+    /// decode, so nothing checked it.
+    pub digest_computed: bool,
     /// Original blob byte-string length that was refused.
     pub encoded_len: usize,
     /// Which ceiling fired, in the reader's own words.
@@ -571,6 +598,7 @@ impl Folder<'_, '_, '_> {
     fn emit_blob_refusal(
         &mut self,
         digest: Option<&str>,
+        digest_computed: bool,
         declared_metadata: Option<&Value>,
         encoded_len: usize,
         detail: &str,
@@ -582,6 +610,7 @@ impl Folder<'_, '_, '_> {
         sink.blob_refused(BlobRefusal {
             segment_index,
             digest,
+            digest_computed,
             metadata: declared_metadata,
             encoded_len,
             detail,
@@ -1016,21 +1045,11 @@ impl Folder<'_, '_, '_> {
                 }
                 Ok(_) => {}
                 Err(PayloadError::Budget(detail)) => {
-                    let refused_digest = pub_meta
-                        .as_ref()
-                        .and_then(public_blob_digest)
-                        // With no transform chain the wire bytes are the decoded
-                        // bytes, so hashing them is exact and costs no memory.
-                        // Knowing the identity of a refused payload is what lets
-                        // a consumer tell one blob stored twice from two blobs.
-                        .or_else(|| {
-                            chain
-                                .is_empty()
-                                .then(|| d.and_then(Value::as_bytes).map(|raw| digest_str(raw)))
-                                .flatten()
-                        });
+                    let (refused_digest, digest_computed) =
+                        refused_identity(&chain, d, pub_meta.as_ref());
                     self.emit_blob_refusal(
                         refused_digest.as_deref(),
+                        digest_computed,
                         declared_metadata,
                         encoded_len,
                         &detail,
@@ -1105,21 +1124,11 @@ impl Folder<'_, '_, '_> {
             }
             Ok(_) => {}
             Err(PayloadError::Budget(detail)) => {
-                let refused_digest = pub_meta
-                    .as_ref()
-                    .and_then(public_blob_digest)
-                    // With no transform chain the wire bytes are the decoded
-                    // bytes, so hashing them is exact and costs no memory.
-                    // Knowing the identity of a refused payload is what lets a
-                    // consumer tell one blob stored twice from two blobs.
-                    .or_else(|| {
-                        chain
-                            .is_empty()
-                            .then(|| d.and_then(Value::as_bytes).map(|raw| digest_str(raw)))
-                            .flatten()
-                    });
+                let (refused_digest, digest_computed) =
+                    refused_identity(&chain, d, pub_meta.as_ref());
                 self.emit_blob_refusal(
                     refused_digest.as_deref(),
+                    digest_computed,
                     declared_metadata,
                     encoded_len,
                     &detail,
@@ -1250,7 +1259,7 @@ impl Folder<'_, '_, '_> {
                         && bytes.len() > limit
                     {
                         let detail = format!("snapshot blob exceeds {limit} bytes");
-                        self.emit_blob_refusal(Some(&digest), None, bytes.len(), &detail);
+                        self.emit_blob_refusal(Some(&digest), true, None, bytes.len(), &detail);
                         self.diag(BLOB_BUDGET_DIAGNOSTIC, detail, Some(index));
                         continue;
                     }

--- a/crates/gts/src/reader.rs
+++ b/crates/gts/src/reader.rs
@@ -160,6 +160,13 @@ fn reifier_binding_is_recursive(graph: &Graph, rid: usize, triple: Triple3) -> b
         })
 }
 
+/// Diagnostic code for a payload refused by a caller-supplied byte ceiling.
+///
+/// Distinct from `DamagedFrame` so a consumer can tell "I declined to spend the
+/// bytes" from "the container is corrupt" without parsing the detail string.
+/// Only a sink that supplies a blob byte limit can provoke it.
+pub const BLOB_BUDGET_DIAGNOSTIC: &str = "BlobBudget";
+
 enum PayloadError {
     /// Missing capability — degrade to an opaque node with this reason.
     Unavailable {
@@ -168,6 +175,8 @@ enum PayloadError {
     },
     /// Anything else — the frame is damaged.
     Damaged(String),
+    /// A caller-supplied byte ceiling refused an otherwise well-formed payload.
+    Budget(String),
 }
 
 impl From<CodecError> for PayloadError {
@@ -175,6 +184,7 @@ impl From<CodecError> for PayloadError {
         match e {
             CodecError::Unavailable { reason, detail } => Self::Unavailable { reason, detail },
             CodecError::Failed(detail) => Self::Damaged(detail),
+            CodecError::Limit(detail) => Self::Budget(detail),
         }
     }
 }
@@ -197,7 +207,7 @@ fn decrypt_codec(
             detail: format!("{} decrypt failed: {err}", codec.name),
         },
         crate::cose::BoundedDecrypt0Error::Limit => {
-            CodecError::Failed(format!("decoded transform output exceeds {limit} bytes"))
+            CodecError::Limit(format!("decoded transform output exceeds {limit} bytes"))
         }
     })
 }
@@ -581,7 +591,7 @@ impl Folder<'_, '_, '_> {
                 .and_then(StreamingSink::blob_encoded_limit)
             && bytes.len() > limit
         {
-            return Err(PayloadError::Damaged(format!(
+            return Err(PayloadError::Budget(format!(
                 "encoded blob exceeds {limit} bytes"
             )));
         }
@@ -625,7 +635,7 @@ impl Folder<'_, '_, '_> {
                 .and_then(StreamingSink::blob_decode_limit)
             && bytes.len() > limit
         {
-            return Err(PayloadError::Damaged(format!(
+            return Err(PayloadError::Budget(format!(
                 "decoded blob exceeds {limit} bytes"
             )));
         }
@@ -657,6 +667,11 @@ impl Folder<'_, '_, '_> {
                     format!("payload decode failed: {detail}"),
                     Some(index),
                 );
+                return;
+            }
+            Err(PayloadError::Budget(detail)) => {
+                self.opaque(frame, ftype, "over-budget");
+                self.diag(BLOB_BUDGET_DIAGNOSTIC, detail, Some(index));
                 return;
             }
             Ok(p) => p,
@@ -884,7 +899,9 @@ impl Folder<'_, '_, '_> {
                     self.diag(diag_code_for(reason), detail, Some(index));
                     return;
                 }
-                Err(PayloadError::Damaged(detail)) => {
+                // Codec-id resolution reads the catalog and decodes nothing, so
+                // it cannot exceed a byte ceiling; handled for exhaustiveness.
+                Err(PayloadError::Damaged(detail) | PayloadError::Budget(detail)) => {
                     self.opaque(frame, "blob", "damaged");
                     self.diag(
                         "DamagedFrame",
@@ -922,6 +939,10 @@ impl Folder<'_, '_, '_> {
                     }
                 }
                 Ok(_) => {}
+                Err(PayloadError::Budget(detail)) => {
+                    self.opaque(frame, "blob", "over-budget");
+                    self.diag(BLOB_BUDGET_DIAGNOSTIC, detail, Some(index));
+                }
                 Err(PayloadError::Unavailable { reason, detail }) => {
                     self.opaque(frame, "blob", reason);
                     self.diag(diag_code_for(reason), detail, Some(index));
@@ -988,6 +1009,10 @@ impl Folder<'_, '_, '_> {
                 }
             }
             Ok(_) => {}
+            Err(PayloadError::Budget(detail)) => {
+                self.opaque(frame, "blob", "over-budget");
+                self.diag(BLOB_BUDGET_DIAGNOSTIC, detail, Some(index));
+            }
             Err(PayloadError::Unavailable { reason, detail }) => {
                 self.opaque(frame, "blob", reason);
                 self.diag(diag_code_for(reason), detail, Some(index));

--- a/crates/gts/src/reader.rs
+++ b/crates/gts/src/reader.rs
@@ -167,6 +167,15 @@ fn reifier_binding_is_recursive(graph: &Graph, rid: usize, triple: Triple3) -> b
 /// Only a sink that supplies a blob byte limit can provoke it.
 pub const BLOB_BUDGET_DIAGNOSTIC: &str = "BlobBudget";
 
+/// Diagnostic code for a whole non-blob frame refused by a caller-supplied
+/// byte ceiling.
+///
+/// Deliberately distinct from [`BLOB_BUDGET_DIAGNOSTIC`]: declining one blob
+/// payload leaves the RDF dataset intact, whereas dropping a frame removes rows
+/// the caller was relying on. A consumer that treats the first as recoverable
+/// must not silently treat the second the same way.
+pub const FRAME_BUDGET_DIAGNOSTIC: &str = "FrameBudget";
+
 enum PayloadError {
     /// Missing capability — degrade to an opaque node with this reason.
     Unavailable {
@@ -738,7 +747,7 @@ impl Folder<'_, '_, '_> {
             }
             Err(PayloadError::Budget(detail)) => {
                 self.opaque(frame, ftype, "over-budget");
-                self.diag(BLOB_BUDGET_DIAGNOSTIC, detail, Some(index));
+                self.diag(FRAME_BUDGET_DIAGNOSTIC, detail, Some(index));
                 return;
             }
             Ok(p) => p,
@@ -1007,7 +1016,19 @@ impl Folder<'_, '_, '_> {
                 }
                 Ok(_) => {}
                 Err(PayloadError::Budget(detail)) => {
-                    let refused_digest = pub_meta.as_ref().and_then(public_blob_digest);
+                    let refused_digest = pub_meta
+                        .as_ref()
+                        .and_then(public_blob_digest)
+                        // With no transform chain the wire bytes are the decoded
+                        // bytes, so hashing them is exact and costs no memory.
+                        // Knowing the identity of a refused payload is what lets
+                        // a consumer tell one blob stored twice from two blobs.
+                        .or_else(|| {
+                            chain
+                                .is_empty()
+                                .then(|| d.and_then(Value::as_bytes).map(|raw| digest_str(raw)))
+                                .flatten()
+                        });
                     self.emit_blob_refusal(
                         refused_digest.as_deref(),
                         declared_metadata,
@@ -1084,7 +1105,19 @@ impl Folder<'_, '_, '_> {
             }
             Ok(_) => {}
             Err(PayloadError::Budget(detail)) => {
-                let refused_digest = pub_meta.as_ref().and_then(public_blob_digest);
+                let refused_digest = pub_meta
+                    .as_ref()
+                    .and_then(public_blob_digest)
+                    // With no transform chain the wire bytes are the decoded
+                    // bytes, so hashing them is exact and costs no memory.
+                    // Knowing the identity of a refused payload is what lets a
+                    // consumer tell one blob stored twice from two blobs.
+                    .or_else(|| {
+                        chain
+                            .is_empty()
+                            .then(|| d.and_then(Value::as_bytes).map(|raw| digest_str(raw)))
+                            .flatten()
+                    });
                 self.emit_blob_refusal(
                     refused_digest.as_deref(),
                     declared_metadata,

--- a/crates/gts/src/segment_decode.rs
+++ b/crates/gts/src/segment_decode.rs
@@ -60,7 +60,7 @@ use ciborium::value::Value;
 use crate::model::{
     Diagnostic, OpaqueNode, Quad, Signature, StreamableInfo, Suppression, Term, TermKind, Triple3,
 };
-use crate::reader::{BlobPayload, FrameContext, StreamingSink};
+use crate::reader::{BlobPayload, BlobRefusal, FrameContext, StreamingSink};
 
 /// A [`std::collections::HashMap`] keyed by the workspace's fixed-key `ahash`
 /// policy (`crates/rdf-core/src/hash.rs`'s `FastHasher`) — no runtime RNG
@@ -213,6 +213,11 @@ pub trait ResolvedSink {
 
     /// Borrowed blob payload passthrough (default no-op).
     fn blob_payload(&mut self, _payload: BlobPayload<'_>) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Refused blob passthrough (default no-op).
+    fn blob_refused(&mut self, _refusal: BlobRefusal<'_>) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -696,6 +701,15 @@ impl<S: ResolvedSink> StreamingSink for SegmentResolver<S> {
             return;
         }
         if let Err(error) = self.sink.blob_payload(payload) {
+            self.fail(error);
+        }
+    }
+
+    fn blob_refused(&mut self, refusal: BlobRefusal<'_>) {
+        if self.error.is_some() {
+            return;
+        }
+        if let Err(error) = self.sink.blob_refused(refusal) {
             self.fail(error);
         }
     }

--- a/crates/gts/src/segment_decode.rs
+++ b/crates/gts/src/segment_decode.rs
@@ -211,6 +211,11 @@ pub trait ResolvedSink {
         None
     }
 
+    /// Enclosing (non-blob) frame decode bound (default: unbounded).
+    fn frame_decode_limit(&self) -> Option<usize> {
+        None
+    }
+
     /// Borrowed blob payload passthrough (default no-op).
     fn blob_payload(&mut self, _payload: BlobPayload<'_>) -> Result<(), Self::Error> {
         Ok(())
@@ -694,6 +699,10 @@ impl<S: ResolvedSink> StreamingSink for SegmentResolver<S> {
 
     fn blob_decode_limit(&self) -> Option<usize> {
         self.sink.blob_decode_limit()
+    }
+
+    fn frame_decode_limit(&self) -> Option<usize> {
+        self.sink.frame_decode_limit()
     }
 
     fn blob_payload(&mut self, payload: BlobPayload<'_>) {

--- a/crates/gts/tests/bounded_keyed_blobs.rs
+++ b/crates/gts/tests/bounded_keyed_blobs.rs
@@ -83,7 +83,8 @@ fn assert_limit(result: &StreamingReadResult, sink: &Sink, detail: &str) {
     );
     assert!(
         result.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "DamagedFrame" && diagnostic.detail.contains(detail)
+            diagnostic.code == purrdf_gts::reader::BLOB_BUDGET_DIAGNOSTIC
+                && diagnostic.detail.contains(detail)
         }),
         "expected {detail}: {:?}",
         result.diagnostics

--- a/crates/rdf/Cargo.toml
+++ b/crates/rdf/Cargo.toml
@@ -148,6 +148,13 @@ proptest = { workspace = true }
 criterion = { workspace = true }
 
 [[bench]]
+# One-pass selected GTS import against the two-reader path it replaces: the
+# capability exists to remove a second container fold, so the pair of curves is
+# the evidence. Report-only; asserts nothing.
+name = "gts_selected_blobs"
+harness = false
+
+[[bench]]
 # Native RDF text codec hot paths: N-Quads parse into frozen IR and serialize back
 # out through the first-party serializer. Report-only; excluded from check.
 name = "native_codecs"

--- a/crates/rdf/README.md
+++ b/crates/rdf/README.md
@@ -265,6 +265,46 @@ on `purrdf-rdf` directly only when you want the RDF layer alone.
 There are deliberately no Cargo feature flags anywhere in the workspace. MSRV
 follows the workspace `rust-version` (currently 1.96, stable toolchain only).
 
+## Selected GTS payloads
+
+`import_gts_events_with_blobs` returns the native dataset and an explicitly
+named set of archive payloads from a single read, so a consumer that needs a few
+blob bodies no longer has to open the container a second time. Selectors name an
+exact digest in the canonical `blake3:<hex>` spelling, or a final public `rep`
+value — never an RDF predicate. Each selector must resolve to exactly one blob;
+missing and ambiguous selections are terminal.
+
+Retention is bounded by `GtsBlobLimits`, and the bounds are worth reading
+precisely, because what they do *not* cover matters as much as what they do:
+
+| bound | covers |
+|---|---|
+| `max_encoded_bytes` | one selected payload's on-wire bytes |
+| `max_decoded_bytes` | one payload's decoded output, and every compression-chain intermediate |
+| `max_total_decoded_bytes` | the sum retained across selected digests |
+| `max_metadata_bytes` | one blob's CBOR public metadata |
+| `max_frame_decoded_bytes` | one enclosing non-blob frame, which is how a `snapshot` reaches embedded blobs |
+
+They do not bound the native RDF dataset, the input file, reader frame buffers,
+or codec working memory.
+
+A payload that exceeds a bound is refused, not fatal: the import succeeds and
+the refusal is reported in `GtsImportWithBlobs::refused`. A refused payload
+still counts as a selection candidate, so a byte ceiling can never quietly
+resolve an ambiguous selector by deleting one of the candidates. Naming a
+refused payload fails with `rdf-ir-gts-blob-limit` describing the bound.
+
+Two refusals are worth knowing about in advance. A payload refused before it
+could be hashed has no identity, so it is matchable by representation but never
+by digest. And selecting a blob the container declares as *external* — a
+published digest with no payload field — returns `rdf-ir-gts-blob-external`:
+its bytes live outside the file, so no inline read can produce them.
+
+The envelope matches `import_gts_events` with one exception: a refused payload
+appears as an opaque node with reason `over-budget` rather than a blob record,
+because the digest that would identify it is only computable by performing the
+decode the budget declined.
+
 ## License
 
 Licensed under either of

--- a/crates/rdf/README.md
+++ b/crates/rdf/README.md
@@ -288,8 +288,12 @@ precisely, because what they do *not* cover matters as much as what they do:
 They do not bound the native RDF dataset, the input file, reader frame buffers,
 or codec working memory.
 
-A payload that exceeds a bound is refused, not fatal: the import succeeds and
-the refusal is reported in `GtsImportWithBlobs::refused`. A refused payload
+A *payload* that exceeds one of the four payload bounds is refused, not fatal:
+the import succeeds and the refusal is reported in
+`GtsImportWithBlobs::refused`. `max_frame_decoded_bytes` is different, and
+deliberately so — a refused frame loses RDF rows, so the dataset would no longer
+be the one `import_gts_events` builds. Exceeding it fails the import with
+`rdf-ir-gts-fold-diagnostic` rather than returning a silently truncated graph. A refused payload
 still counts as a selection candidate, so a byte ceiling can never quietly
 resolve an ambiguous selector by deleting one of the candidates. Naming a
 refused payload fails with `rdf-ir-gts-blob-limit` describing the bound.

--- a/crates/rdf/benches/gts_selected_blobs.rs
+++ b/crates/rdf/benches/gts_selected_blobs.rs
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Bench targets are not public API: `criterion_group!` expands to a `pub fn`,
+// which would otherwise trip the workspace `missing_docs` lint.
+#![allow(missing_docs)]
+
+//! One-pass selected GTS import against the two-reader path it replaces.
+//!
+//! Report-only, `cargo bench -p purrdf-rdf --bench gts_selected_blobs`. It
+//! asserts nothing. The selected importer exists to remove a second container
+//! fold — the caller previously ran `import_gts_events` for the dataset and
+//! then `reader::read` again to reach the blob bodies — so the comparison worth
+//! recording is one fold against two over identical bytes, not a speedup claim.
+//! Machine noise dominates small deltas; read the two curves, not their ratio.
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use purrdf_gts::wire::digest_str;
+use purrdf_gts::writer::Writer;
+use purrdf_rdf::{GtsBlobLimits, GtsBlobSelector, import_gts_events, import_gts_events_with_blobs};
+
+/// A container holding `blobs` payloads of `size` bytes plus a little RDF, so
+/// both paths fold the same dataset and reach the same bodies.
+fn container(blobs: usize, size: usize) -> (Vec<u8>, String) {
+    let mut writer = Writer::new("generic");
+    let mut wanted = String::new();
+    for index in 0..blobs {
+        let mut payload = vec![b'x'; size];
+        payload[..8.min(size)].copy_from_slice(&(index as u64).to_be_bytes()[..8.min(size)]);
+        if index == 0 {
+            wanted = digest_str(&payload);
+        }
+        writer.add_blob(&payload, None, Some(&format!("rep-{index}")));
+    }
+    (writer.into_bytes(), wanted)
+}
+
+fn selected_import(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gts_selected_blobs");
+    for (blobs, size) in [(4_usize, 4_096_usize), (32, 4_096), (4, 262_144)] {
+        let (bytes, wanted) = container(blobs, size);
+        group.throughput(Throughput::Bytes(bytes.len() as u64));
+        let id = format!("{blobs}x{size}");
+
+        // One fold: dataset and the selected body together.
+        group.bench_with_input(BenchmarkId::new("one_pass", &id), &bytes, |b, bytes| {
+            let limits = GtsBlobLimits::new(size * 2, size * 4);
+            b.iter(|| {
+                let result = import_gts_events_with_blobs(
+                    black_box(bytes),
+                    &[GtsBlobSelector::Digest(&wanted)],
+                    limits,
+                )
+                .expect("selected import");
+                black_box(result.blobs[0].bytes.len())
+            });
+        });
+
+        // The path it replaces: fold for the dataset, then fold again for bytes.
+        group.bench_with_input(BenchmarkId::new("two_readers", &id), &bytes, |b, bytes| {
+            b.iter(|| {
+                let bundle = import_gts_events(black_box(bytes)).expect("native import");
+                let mut graph = purrdf_gts::reader::read(black_box(bytes), true, None);
+                let body = graph
+                    .blob_bytes_cloned(&wanted)
+                    .expect("blob decode")
+                    .expect("blob present");
+                black_box((bundle.dataset.quad_count(), body.len()))
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, selected_import);
+criterion_main!(benches);

--- a/crates/rdf/src/gts_import_blobs.rs
+++ b/crates/rdf/src/gts_import_blobs.rs
@@ -311,6 +311,20 @@ impl<'a> BlobCollector<'a> {
         self.limits.max_encoded_bytes
     }
 
+    /// Bound and validate a selected blob's metadata before the sink keeps it.
+    ///
+    /// Deliberately runs earlier than, and in addition to, the check inside
+    /// [`Self::payload`]. The importer deep-copies public metadata into its
+    /// lookaside when the legacy blob event arrives, which is before any payload
+    /// event; bounding it only in `payload` would let an unbounded metadata map
+    /// be copied first and bounded afterwards, which is not a bound.
+    ///
+    /// The two see different snapshots on purpose. This one inherits from what
+    /// has been *retained* so far, because that is all that exists at this point
+    /// in the read; `payload` inherits from the occurrence it is processing,
+    /// which is more specific. Where they disagree, `payload` is authoritative:
+    /// it decides what is returned to the caller, while this one exists solely
+    /// to keep the earlier copy bounded.
     pub(crate) fn check_metadata_before_retention(
         &self,
         digest: &str,

--- a/crates/rdf/src/gts_import_blobs.rs
+++ b/crates/rdf/src/gts_import_blobs.rs
@@ -201,9 +201,17 @@ pub fn import_gts_events_with_blobs(
     let collector = BlobCollector::new(selectors, limits)?;
     let (bundle, collector) =
         crate::gts_import_sink::import_with_collector(bytes, Some(collector))?;
-    let (blobs, refused) = collector
-        .expect("selected importer retains its collector")
-        .finish()?;
+    // The fold hands the collector straight back, so this cannot be None today.
+    // It is still a hard error rather than a panic: an internal invariant that
+    // fails should surface as a diagnostic on a Result-returning API, not abort
+    // the caller's process.
+    let Some(collector) = collector else {
+        return Err(fail(
+            "rdf-ir-gts-import-internal",
+            "the selected importer did not retain its blob collector",
+        ));
+    };
+    let (blobs, refused) = collector.finish()?;
     Ok(GtsImportWithBlobs {
         bundle,
         blobs,
@@ -355,7 +363,15 @@ impl<'a> BlobCollector<'a> {
             .any(|selector| matches(*selector, payload.digest, metadata))
         {
             if let Some(old) = self.selected.remove(payload.digest) {
-                self.total -= old.bytes.len();
+                // Release builds leave overflow checks off, so a future break of
+                // the "total is the sum of retained lengths" invariant would wrap
+                // to near usize::MAX and silently disable the total budget,
+                // surfacing as spurious decode refusals far from the cause.
+                debug_assert!(
+                    self.total >= old.bytes.len(),
+                    "retained-byte total underflow"
+                );
+                self.total = self.total.saturating_sub(old.bytes.len());
             }
             return Ok(());
         }
@@ -367,6 +383,10 @@ impl<'a> BlobCollector<'a> {
         }
         let metadata = bounded_metadata(metadata, self.limits.max_metadata_bytes)?;
         validate_metadata(metadata.as_ref(), payload.digest)?;
+        // The reader fires its frame event for every frame before any of that
+        // frame's rows, with the same segment index, so a payload always has a
+        // matching frame. The refusal stays as the shared provenance check in
+        // finish(), where it is reachable and tested.
         let frame = self
             .frame
             .as_ref()
@@ -435,7 +455,8 @@ impl<'a> BlobCollector<'a> {
             ));
         }
         let old_len = previous.map_or(0, |blob| blob.bytes.len());
-        let other_bytes = self.total - old_len;
+        debug_assert!(self.total >= old_len, "retained-byte total underflow");
+        let other_bytes = self.total.saturating_sub(old_len);
         let remaining = self
             .limits
             .max_total_decoded_bytes
@@ -555,6 +576,20 @@ impl<'a> BlobCollector<'a> {
                     format!(
                         "required selector {selector:?} matches a payload of {} encoded bytes that this import's budget refused: {}",
                         blob.encoded_len, blob.detail
+                    ),
+                ));
+            }
+        }
+        // The type permits an empty head or frame id, and the doc calls both
+        // "verified". Assert rather than trust: a silently empty provenance
+        // field is indistinguishable from a real one at the call site.
+        for blob in self.selected.values() {
+            if blob.segment_head.is_empty() || blob.frame_id.is_empty() {
+                return Err(fail(
+                    "rdf-ir-gts-blob-provenance",
+                    format!(
+                        "selected blob {} lacks the verified frame or segment provenance it reports",
+                        blob.digest
                     ),
                 ));
             }

--- a/crates/rdf/src/gts_import_blobs.rs
+++ b/crates/rdf/src/gts_import_blobs.rs
@@ -236,6 +236,12 @@ pub(crate) struct BlobCollector<'a> {
     /// not they were selected. Distinguishes a payload we declined to retain
     /// from one the container never held.
     inlined: BTreeSet<String>,
+    /// Selected occurrences that named no payload and had none retained yet.
+    ///
+    /// Whether that is an external blob or an ordering problem cannot be decided
+    /// mid-stream: the bytes may still arrive in a later frame. Resolved in
+    /// [`Self::finish`], once the whole container has been read.
+    unresolved: Vec<String>,
     frame: Option<BlobFrame>,
     total: usize,
 }
@@ -302,6 +308,7 @@ impl<'a> BlobCollector<'a> {
             selected: BTreeMap::new(),
             refused: Vec::new(),
             inlined: BTreeSet::new(),
+            unresolved: Vec::new(),
             frame: None,
             total: 0,
         })
@@ -399,8 +406,9 @@ impl<'a> BlobCollector<'a> {
         validate_metadata(metadata.as_ref(), payload.digest)?;
         // The reader fires its frame event for every frame before any of that
         // frame's rows, with the same segment index, so a payload always has a
-        // matching frame. The refusal stays as the shared provenance check in
-        // finish(), where it is reachable and tested.
+        // matching frame and this branch is not reachable from any container.
+        // It is kept as a fail-closed guard rather than an assumption, and is
+        // deliberately not counted as a tested refusal.
         let frame = self
             .frame
             .as_ref()
@@ -424,31 +432,14 @@ impl<'a> BlobCollector<'a> {
         };
         let Some(wire_bytes) = payload.bytes else {
             let Some(previous) = self.selected.get_mut(payload.digest) else {
-                // An occurrence with no payload field at all, publishing a
-                // digest, is an EXTERNAL blob: the spec places its bytes outside
-                // this container. That is a different fact from a metadata-only
-                // update to a payload we declined to retain, and reporting it as
-                // one claims something false about retention ordering.
-                // No occurrence anywhere in this container carried bytes for
-                // this digest, so the spec's external form is the only reading:
-                // the payload lives outside the file. Reporting that as a
-                // retention-ordering problem would assert something false.
-                if !self.inlined.contains(payload.digest) {
-                    return Err(fail(
-                        "rdf-ir-gts-blob-external",
-                        format!(
-                            "blob {} is external to this container; its bytes are held elsewhere and this importer returns only inline payloads",
-                            payload.digest
-                        ),
-                    ));
-                }
-                return Err(fail(
-                    "rdf-ir-gts-blob-selection-order",
-                    format!(
-                        "blob {} became selected without a payload; earlier unselected bytes are not retained",
-                        payload.digest
-                    ),
-                ));
+                // No bytes retained for this digest yet. Whether that means the
+                // blob is external, or merely that its payload has not been read
+                // yet, is not decidable here — a later frame in this same
+                // container may still carry it, and the authoritative importer
+                // accepts exactly that file. Defer to finish(), which sees the
+                // whole container.
+                self.unresolved.push(payload.digest.to_string());
+                return Ok(());
             };
             previous.metadata = metadata;
             previous.metadata_source = metadata_source;
@@ -536,6 +527,30 @@ impl<'a> BlobCollector<'a> {
     }
 
     fn finish(self) -> Result<(Vec<GtsImportedBlob>, Vec<GtsRefusedBlob>), RdfDiagnostic> {
+        // A selected occurrence that named no payload is only a problem if the
+        // container never produced one. Deciding this here, rather than at the
+        // occurrence, is what lets a metadata-only frame precede its own inline
+        // payload — a file the authoritative importer accepts.
+        for digest in &self.unresolved {
+            if self.selected.contains_key(digest) {
+                continue;
+            }
+            if self.inlined.contains(digest) {
+                return Err(fail(
+                    "rdf-ir-gts-blob-selection-order",
+                    format!(
+                        "blob {digest} became selected without a payload; earlier unselected bytes are not retained"
+                    ),
+                ));
+            }
+            return Err(fail(
+                "rdf-ir-gts-blob-external",
+                format!(
+                    "blob {digest} is external to this container; its bytes are held elsewhere and this importer returns only inline payloads"
+                ),
+            ));
+        }
+
         for selector in &self.selectors {
             let retained = self
                 .selected
@@ -555,6 +570,26 @@ impl<'a> BlobCollector<'a> {
                         blob.digest.as_deref().unwrap_or_default(),
                         blob.metadata.as_ref(),
                     )
+                })
+                // A container may store one blob twice — once compressed, once
+                // not — and refuse only the copy that did not fit. That is still
+                // one blob, so counting the refused copy as a second candidate
+                // would invent an ambiguity the archive does not contain. A
+                // refusal whose digest is already retained is the same payload;
+                // a refusal that was refused before it could be hashed is
+                // assumed to be the same payload when a retained blob already
+                // answers this selector, because it cannot be proven otherwise
+                // and refusing valid input is the worse error.
+                .filter(|blob| match blob.digest.as_deref() {
+                    // Known identity: if that payload is already retained, this
+                    // is the same blob stored twice, not a second candidate.
+                    Some(digest) => !self.selected.contains_key(digest),
+                    // Unknown identity — refused before it could be hashed, so
+                    // it may be a different payload. Count it and fail closed;
+                    // silently returning one of two possible answers is the
+                    // worse error, and the reader supplies a digest whenever
+                    // one is computable without spending the budget.
+                    None => true,
                 })
                 .collect();
             let count = retained + refused.len();
@@ -594,20 +629,17 @@ impl<'a> BlobCollector<'a> {
                 ));
             }
         }
-        // The type permits an empty head or frame id, and the doc calls both
-        // "verified". Assert rather than trust: a silently empty provenance
-        // field is indistinguishable from a real one at the call site.
-        for blob in self.selected.values() {
-            if blob.segment_head.is_empty() || blob.frame_id.is_empty() {
-                return Err(fail(
-                    "rdf-ir-gts-blob-provenance",
-                    format!(
-                        "selected blob {} lacks the verified frame or segment provenance it reports",
-                        blob.digest
-                    ),
-                ));
-            }
-        }
+        // The type permits an empty head or frame id and the doc calls both
+        // "verified". The reader publishes a segment head at every segment close
+        // and fires its frame event before any of that frame's rows, so neither
+        // can be empty here; this is an invariant, not a refusal, and is checked
+        // as one rather than shipped as a branch no input can reach.
+        debug_assert!(
+            self.selected
+                .values()
+                .all(|blob| !blob.segment_head.is_empty() && !blob.frame_id.is_empty()),
+            "selected blob provenance must be populated before it is returned"
+        );
         Ok((self.selected.into_values().collect(), self.refused))
     }
 }

--- a/crates/rdf/src/gts_import_blobs.rs
+++ b/crates/rdf/src/gts_import_blobs.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use ciborium::Value;
 use purrdf_gts::model::ByteRange;
-use purrdf_gts::reader::{BlobPayload, FrameContext};
+use purrdf_gts::reader::{BlobPayload, BlobRefusal, FrameContext};
 
 use crate::{GtsBundle, RdfDiagnostic};
 
@@ -95,14 +95,45 @@ pub struct GtsImportedBlob {
     pub segment_head: Vec<u8>,
 }
 
+/// One payload a byte budget refused, reported rather than silently dropped.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct GtsRefusedBlob {
+    /// Declared content digest, absent when the container published none.
+    ///
+    /// Refusing precedes the decode that would compute an identity, so an
+    /// undeclared digest is unknowable here. Such a payload is matchable by
+    /// representation, never by digest.
+    pub digest: Option<String>,
+    /// Public metadata declared at the refused occurrence.
+    pub metadata: Option<Value>,
+    /// Zero-based segment containing the refused occurrence.
+    pub segment_index: usize,
+    /// Encoded byte length that was refused.
+    pub encoded_len: usize,
+    /// Which ceiling fired, in the reader's own words.
+    pub detail: String,
+}
+
 /// Native RDF 1.2 bundle and its explicitly requested inline blobs.
 #[non_exhaustive]
 #[derive(Clone, Debug)]
 pub struct GtsImportWithBlobs {
-    /// The same scoped native dataset and envelope as [`crate::import_gts_events`].
+    /// The same scoped native dataset as [`crate::import_gts_events`].
+    ///
+    /// The envelope matches too, with one documented exception: a payload this
+    /// import's budget refused is recorded as an opaque node with reason
+    /// `over-budget` instead of a blob record, because the digest that would
+    /// identify it is only computable by performing the decode the budget
+    /// declined. Such payloads are listed in [`Self::refused`].
     pub bundle: GtsBundle,
     /// Selected unique digests in deterministic digest order.
     pub blobs: Vec<GtsImportedBlob>,
+    /// Payloads the budget refused, in encounter order.
+    ///
+    /// Present so a successful import never hides a refusal: a caller that set a
+    /// ceiling can see exactly what it cost them.
+    pub refused: Vec<GtsRefusedBlob>,
 }
 
 /// Import the native dataset and retain required blobs during the same GTS read.
@@ -138,10 +169,14 @@ pub fn import_gts_events_with_blobs(
     let collector = BlobCollector::new(selectors, limits)?;
     let (bundle, collector) =
         crate::gts_import_sink::import_with_collector(bytes, Some(collector))?;
-    let blobs = collector
+    let (blobs, refused) = collector
         .expect("selected importer retains its collector")
         .finish()?;
-    Ok(GtsImportWithBlobs { bundle, blobs })
+    Ok(GtsImportWithBlobs {
+        bundle,
+        blobs,
+        refused,
+    })
 }
 
 #[derive(Clone, Debug)]
@@ -156,6 +191,7 @@ pub(crate) struct BlobCollector<'a> {
     selectors: Vec<GtsBlobSelector<'a>>,
     limits: GtsBlobLimits,
     selected: BTreeMap<String, GtsImportedBlob>,
+    refused: Vec<GtsRefusedBlob>,
     frame: Option<BlobFrame>,
     total: usize,
 }
@@ -220,6 +256,7 @@ impl<'a> BlobCollector<'a> {
             selectors: selectors.to_vec(),
             limits,
             selected: BTreeMap::new(),
+            refused: Vec::new(),
             frame: None,
             total: 0,
         })
@@ -374,6 +411,22 @@ impl<'a> BlobCollector<'a> {
         Ok(())
     }
 
+    /// Record a payload the reader's ceiling refused before decoding it.
+    ///
+    /// Kept as a selection candidate, not discarded. A budget bounds what this
+    /// import *retains*; letting a refusal remove a candidate would let the
+    /// budget decide which blob a selector resolves to, so a tight ceiling could
+    /// silently turn an ambiguous match into a confident wrong answer.
+    pub(crate) fn refused(&mut self, refusal: BlobRefusal<'_>) {
+        self.refused.push(GtsRefusedBlob {
+            digest: refusal.digest.map(ToString::to_string),
+            metadata: refusal.metadata.cloned(),
+            segment_index: refusal.segment_index,
+            encoded_len: refusal.encoded_len,
+            detail: refusal.detail.to_string(),
+        });
+    }
+
     pub(crate) fn segment_head(&mut self, segment_index: usize, head: &[u8]) {
         for blob in self.selected.values_mut() {
             if blob.segment_index == segment_index {
@@ -387,23 +440,66 @@ impl<'a> BlobCollector<'a> {
         }
     }
 
-    fn finish(self) -> Result<Vec<GtsImportedBlob>, RdfDiagnostic> {
-        for selector in self.selectors {
-            let count = self
+    fn finish(self) -> Result<(Vec<GtsImportedBlob>, Vec<GtsRefusedBlob>), RdfDiagnostic> {
+        for selector in &self.selectors {
+            let retained = self
                 .selected
                 .values()
-                .filter(|blob| matches(selector, &blob.digest, blob.metadata.as_ref()))
+                .filter(|blob| matches(*selector, &blob.digest, blob.metadata.as_ref()))
                 .count();
+            // A refused candidate still counts. It was in the archive; only its
+            // bytes were declined. Ignoring it here would make the byte budget a
+            // selection rule, so a tighter ceiling could quietly resolve an
+            // ambiguous selector to one arbitrary survivor.
+            let refused: Vec<&GtsRefusedBlob> = self
+                .refused
+                .iter()
+                .filter(|blob| {
+                    matches(
+                        *selector,
+                        blob.digest.as_deref().unwrap_or_default(),
+                        blob.metadata.as_ref(),
+                    )
+                })
+                .collect();
+            let count = retained + refused.len();
             if count != 1 {
+                // A payload refused before it could be hashed has no identity to
+                // match a digest selector against, so say that rather than let
+                // "resolves to 0" imply the archive did not contain it.
+                let unidentified = self
+                    .refused
+                    .iter()
+                    .filter(|blob| blob.digest.is_none())
+                    .count();
+                let note = if unidentified == 0 {
+                    String::new()
+                } else {
+                    format!(
+                        "; {unidentified} further payload(s) were refused by this import's budget before a digest could be computed, so they could not be matched"
+                    )
+                };
                 return Err(fail(
                     "rdf-ir-gts-blob-selection",
                     format!(
-                        "required selector {selector:?} resolves to {count} blobs; expected exactly one"
+                        "required selector {selector:?} resolves to {count} blobs; expected exactly one{note}"
+                    ),
+                ));
+            }
+            // Exactly one match, and it is the one we declined to decode. Say so
+            // precisely: reporting "resolves to 0 blobs" would be a false claim
+            // about an archive that does contain the payload.
+            if let [blob] = refused.as_slice() {
+                return Err(fail(
+                    "rdf-ir-gts-blob-limit",
+                    format!(
+                        "required selector {selector:?} matches a payload of {} encoded bytes that this import's budget refused: {}",
+                        blob.encoded_len, blob.detail
                     ),
                 ));
             }
         }
-        Ok(self.selected.into_values().collect())
+        Ok((self.selected.into_values().collect(), self.refused))
     }
 }
 

--- a/crates/rdf/src/gts_import_blobs.rs
+++ b/crates/rdf/src/gts_import_blobs.rs
@@ -23,9 +23,11 @@ pub enum GtsBlobSelector<'a> {
 
 /// Explicit retention and decode budgets for selected inline blobs.
 ///
-/// These bounds cover selected payloads and their metadata, not the native RDF
-/// dataset, input file, reader frame buffers or codec working memory. Every
-/// decoded intermediate is bounded, including compression-chain intermediates.
+/// These bounds cover selected payloads, their metadata, and the frames that
+/// carry them — not the native RDF dataset, the input file, reader frame
+/// buffers or codec working memory. Every decoded intermediate is bounded,
+/// including compression-chain intermediates and the enclosing frame decode
+/// that a `snapshot` uses to reach its embedded blobs.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug)]
 pub struct GtsBlobLimits {
@@ -37,7 +39,27 @@ pub struct GtsBlobLimits {
     pub max_total_decoded_bytes: usize,
     /// Maximum CBOR-encoded public metadata bytes retained for one blob.
     pub max_metadata_bytes: usize,
+    /// Maximum decoded bytes for one enclosing, non-blob frame.
+    ///
+    /// A `snapshot` frame carries embedded blob bytes inside an RDF frame, so
+    /// the blob ceilings alone would leave the decode that actually spends the
+    /// memory unbounded. This bounds that decode. It applies to every non-blob
+    /// frame, so it must be large enough for the caller's legitimate RDF frames;
+    /// the default matches the 1 GiB retained-payload ceiling this workspace
+    /// already uses for immutable views.
+    pub max_frame_decoded_bytes: usize,
 }
+
+/// Default per-blob public-metadata ceiling: 64 KiB.
+pub const DEFAULT_MAX_METADATA_BYTES: usize = 64 * 1024;
+
+/// Default enclosing-frame decode ceiling: 1 GiB.
+///
+/// Matches the retained-payload ceiling `purrdf-core` already uses for immutable
+/// views, so one workspace-wide number governs "how many bytes may one thing
+/// cost". Finite by design: an unbounded frame decode is how a compressed
+/// snapshot defeats every blob ceiling beneath it.
+pub const DEFAULT_MAX_FRAME_DECODED_BYTES: usize = 1_073_741_824;
 
 impl GtsBlobLimits {
     /// Set payload budgets; metadata defaults to a bounded 64 KiB per blob.
@@ -50,7 +72,8 @@ impl GtsBlobLimits {
             max_encoded_bytes: max_decoded_bytes,
             max_decoded_bytes,
             max_total_decoded_bytes,
-            max_metadata_bytes: 64 * 1024,
+            max_metadata_bytes: DEFAULT_MAX_METADATA_BYTES,
+            max_frame_decoded_bytes: DEFAULT_MAX_FRAME_DECODED_BYTES,
         }
     }
 }
@@ -142,11 +165,13 @@ pub struct GtsImportWithBlobs {
 /// Each selector must resolve to exactly one final blob; multiple selectors may
 /// name the same blob, which is decoded and retained once per occurrence. At most
 /// 1024 nonempty, distinct selectors of at most 4096 bytes each are accepted.
-/// Unselected payloads are neither copied nor decoded by this collector. Blobs
-/// without a public digest require the reader to decode before selection and
-/// obey both the encoded and decoded per-blob limits before eager decoding,
-/// including when ultimately unselected. Snapshot-entry bounds cover their
-/// embedded blob bytes; enclosing RDF frame decoding remains the reader's scope.
+/// Unselected payloads are neither copied nor decoded by this collector. A blob
+/// without a public digest cannot be selected before it is decoded, so it obeys
+/// the encoded and decoded per-blob ceilings first; exceeding either refuses
+/// that payload without failing the import, and the refusal is reported through
+/// [`GtsImportWithBlobs::refused`] and still counts as a selection candidate.
+/// Snapshot entries obey the same per-blob ceiling, and the enclosing frame
+/// decode obeys [`GtsBlobLimits::max_frame_decoded_bytes`].
 ///
 /// Later public metadata replaces earlier metadata for that digest; absent
 /// metadata preserves it, including across segment boundaries. A newly selected
@@ -289,6 +314,10 @@ impl<'a> BlobCollector<'a> {
 
     pub(crate) const fn decode_limit(&self) -> usize {
         self.limits.max_decoded_bytes
+    }
+
+    pub(crate) const fn frame_decode_limit(&self) -> usize {
+        self.limits.max_frame_decoded_bytes
     }
 
     pub(crate) fn frame(&mut self, ctx: FrameContext<'_>) {

--- a/crates/rdf/src/gts_import_blobs.rs
+++ b/crates/rdf/src/gts_import_blobs.rs
@@ -237,7 +237,7 @@ pub(crate) struct BlobCollector<'a> {
     selectors: Vec<GtsBlobSelector<'a>>,
     limits: GtsBlobLimits,
     selected: BTreeMap<String, GtsImportedBlob>,
-    refused: Vec<GtsRefusedBlob>,
+    refused: Vec<RefusedOccurrence>,
     /// Digests some occurrence in this container carried bytes for, whether or
     /// not they were selected. Distinguishes a payload we declined to retain
     /// from one the container never held.
@@ -252,7 +252,7 @@ pub(crate) struct BlobCollector<'a> {
     ///
     /// Selection reads the *final* metadata, so an occurrence's verdict is only
     /// provisional until the container ends.
-    final_metadata: BTreeMap<String, Value>,
+    declared: BTreeMap<String, SelectionKey>,
     frame: Option<BlobFrame>,
     total: usize,
 }
@@ -282,16 +282,59 @@ fn metadata_field<'a>(
     Ok(value)
 }
 
-fn matches(selector: GtsBlobSelector<'_>, digest: &str, meta: Option<&Value>) -> bool {
+/// Longest value a selector may carry, so anything longer cannot match one.
+const MAX_SELECTOR_BYTES: usize = 4096;
+
+/// The part of a blob's public metadata that selection is allowed to read.
+///
+/// Kept apart from the metadata a caller gets back, because the two answer
+/// different questions and only one of them is the caller's to bound. A
+/// retention ceiling says how many bytes this import will KEEP; it must never
+/// change how many blobs a selector COUNTS, or the size of a budget silently
+/// decides which payload the caller receives.
+///
+/// Bounded by construction rather than by a ceiling: a selector is at most
+/// [`MAX_SELECTOR_BYTES`], so a representation longer than that cannot equal any
+/// selector, and discarding it is lossless for matching. Nothing here is ever
+/// dropped to satisfy a budget.
+#[derive(Clone, Debug, Default)]
+struct SelectionKey {
+    rep: Option<String>,
+}
+
+/// Project the selectable part out of a public metadata map.
+///
+/// Only `rep` is carried: those are the only two selector kinds, and `digest` is
+/// matched against the blob's own identity rather than its metadata. A field a
+/// selector cannot name has no business in a structure retained for matching.
+fn selection_key(meta: Option<&Value>) -> SelectionKey {
+    let Some(Value::Map(fields)) = meta else {
+        return SelectionKey::default();
+    };
+    let rep = fields
+        .iter()
+        .find(|(key, _)| key.as_text() == Some("rep"))
+        .and_then(|(_, value)| value.as_text())
+        .filter(|text| text.len() <= MAX_SELECTOR_BYTES)
+        .map(ToString::to_string);
+    SelectionKey { rep }
+}
+
+/// A refused occurrence and the name it was published under.
+///
+/// The projection travels with the occurrence because a refusal without a
+/// computable identity has no entry in the by-digest record, and losing its name
+/// would let a ceiling decide that it never matched anything.
+struct RefusedOccurrence {
+    blob: GtsRefusedBlob,
+    key: SelectionKey,
+}
+
+fn matches(selector: GtsBlobSelector<'_>, digest: &str, key: Option<&SelectionKey>) -> bool {
     match selector {
         GtsBlobSelector::Digest(expected) => expected == digest,
         GtsBlobSelector::Representation(expected) => {
-            let Some(Value::Map(fields)) = meta else {
-                return false;
-            };
-            fields.iter().any(|(key, value)| {
-                key.as_text() == Some("rep") && value.as_text() == Some(expected)
-            })
+            key.and_then(|key| key.rep.as_deref()) == Some(expected)
         }
     }
 }
@@ -305,7 +348,9 @@ impl<'a> BlobCollector<'a> {
             || selectors.iter().enumerate().any(|(index, selector)| {
                 let (GtsBlobSelector::Digest(value) | GtsBlobSelector::Representation(value)) =
                     selector;
-                value.is_empty() || value.len() > 4096 || selectors[..index].contains(selector)
+                value.is_empty()
+                    || value.len() > MAX_SELECTOR_BYTES
+                    || selectors[..index].contains(selector)
             })
         {
             return Err(fail(
@@ -320,7 +365,7 @@ impl<'a> BlobCollector<'a> {
             refused: Vec::new(),
             inlined: BTreeSet::new(),
             unresolved: Vec::new(),
-            final_metadata: BTreeMap::new(),
+            declared: BTreeMap::new(),
             frame: None,
             total: 0,
         })
@@ -357,7 +402,7 @@ impl<'a> BlobCollector<'a> {
         if self
             .selectors
             .iter()
-            .any(|selector| matches(*selector, digest, metadata))
+            .any(|selector| matches(*selector, digest, self.declared.get(digest)))
         {
             check_metadata_bound(metadata, self.limits.max_metadata_bytes)?;
             validate_metadata(metadata, digest)?;
@@ -386,9 +431,9 @@ impl<'a> BlobCollector<'a> {
         if payload.payload_present {
             self.inlined.insert(payload.digest.to_string());
         }
-        if let Some(declared) = payload.metadata.filter(|_| payload.metadata_declared) {
-            self.final_metadata
-                .insert(payload.digest.to_string(), declared.clone());
+        if payload.metadata_declared {
+            self.declared
+                .insert(payload.digest.to_string(), selection_key(payload.metadata));
         }
         let previous = self.selected.get(payload.digest);
         // The reader's per-occurrence metadata inherits only within a segment —
@@ -400,12 +445,11 @@ impl<'a> BlobCollector<'a> {
         // it before falling back to whatever a retained copy happens to hold.
         let metadata = payload
             .metadata
-            .or_else(|| self.final_metadata.get(payload.digest))
             .or_else(|| previous.and_then(|blob| blob.metadata.as_ref()));
         if !self
             .selectors
             .iter()
-            .any(|selector| matches(*selector, payload.digest, metadata))
+            .any(|selector| matches(*selector, payload.digest, self.declared.get(payload.digest)))
         {
             if let Some(old) = self.selected.remove(payload.digest) {
                 // Release builds leave overflow checks off, so a future break of
@@ -539,9 +583,12 @@ impl<'a> BlobCollector<'a> {
         // the file's claim by construction. Proof is required for the different
         // question of whether two occurrences are the same payload, and that
         // gate stays where it belongs, on dedup.
-        if let (Some(digest), Some(declared)) = (refusal.digest, refusal.metadata) {
-            self.final_metadata
-                .insert(digest.to_string(), declared.clone());
+        // Projected from the raw declaration, before the retention bound below.
+        // The two are deliberately independent: what a blob is called must
+        // survive a ceiling that discards how it is described.
+        if let (Some(digest), Some(meta)) = (refusal.digest, refusal.metadata) {
+            self.declared
+                .insert(digest.to_string(), selection_key(Some(meta)));
         }
         // A budget bounds what this import retains, and a refused declaration is
         // retained like any other. Bounding it only on the payload path would
@@ -557,13 +604,17 @@ impl<'a> BlobCollector<'a> {
         } else {
             refusal.detail.to_string()
         };
-        self.refused.push(GtsRefusedBlob {
-            digest: refusal.digest.map(ToString::to_string),
-            digest_computed: refusal.digest_computed,
-            metadata: metadata.cloned(),
-            segment_index: refusal.segment_index,
-            encoded_len: refusal.encoded_len,
-            detail,
+        let key = selection_key(refusal.metadata);
+        self.refused.push(RefusedOccurrence {
+            key,
+            blob: GtsRefusedBlob {
+                digest: refusal.digest.map(ToString::to_string),
+                digest_computed: refusal.digest_computed,
+                metadata: metadata.cloned(),
+                segment_index: refusal.segment_index,
+                encoded_len: refusal.encoded_len,
+                detail,
+            },
         });
     }
 
@@ -594,11 +645,11 @@ impl<'a> BlobCollector<'a> {
             // retagged this one so that nothing names it any more. Refusing over
             // a blob the selection does not finally reach would reject a file
             // the authoritative importer accepts.
-            let metadata = self.final_metadata.get(digest);
+            let key = self.declared.get(digest);
             if !self
                 .selectors
                 .iter()
-                .any(|selector| matches(*selector, digest, metadata))
+                .any(|selector| matches(*selector, digest, key))
             {
                 continue;
             }
@@ -610,9 +661,9 @@ impl<'a> BlobCollector<'a> {
             if let Some(refusal) = self
                 .refused
                 .iter()
-                .find(|blob| blob.digest.as_deref() == Some(digest.as_str()))
+                .find(|refused| refused.blob.digest.as_deref() == Some(digest.as_str()))
             {
-                let identity = if refusal.digest_computed {
+                let identity = if refusal.blob.digest_computed {
                     "is present in this container"
                 } else {
                     "is declared by this container, though its identity was not verified before refusal,"
@@ -621,7 +672,7 @@ impl<'a> BlobCollector<'a> {
                     "rdf-ir-gts-blob-limit",
                     format!(
                         "blob {digest} {identity} and its {} encoded bytes exceeded this import's budget: {}",
-                        refusal.encoded_len, refusal.detail
+                        refusal.blob.encoded_len, refusal.blob.detail
                     ),
                 ));
             }
@@ -645,13 +696,13 @@ impl<'a> BlobCollector<'a> {
             let retained = self
                 .selected
                 .values()
-                .filter(|blob| matches(*selector, &blob.digest, blob.metadata.as_ref()))
+                .filter(|blob| matches(*selector, &blob.digest, self.declared.get(&blob.digest)))
                 .count();
             // A refused candidate still counts. It was in the archive; only its
             // bytes were declined. Ignoring it here would make the byte budget a
             // selection rule, so a tighter ceiling could quietly resolve an
             // ambiguous selector to one arbitrary survivor.
-            let refused: Vec<&GtsRefusedBlob> = self
+            let refused: Vec<&RefusedOccurrence> = self
                 .refused
                 .iter()
                 .filter(|blob| {
@@ -661,19 +712,13 @@ impl<'a> BlobCollector<'a> {
                     // a proved identity may reach for the container-global
                     // record; letting a claimed digest choose whose metadata to
                     // consult would hand the file that decision back.
-                    let effective = if blob.digest_computed {
-                        blob.digest
-                            .as_deref()
-                            .and_then(|digest| self.final_metadata.get(digest))
-                            .or(blob.metadata.as_ref())
-                    } else {
-                        blob.metadata.as_ref()
-                    };
-                    matches(
-                        *selector,
-                        blob.digest.as_deref().unwrap_or_default(),
-                        effective,
-                    )
+                    let digest = blob.blob.digest.as_deref().unwrap_or_default();
+                    // A later frame can retag a digest the container named, so
+                    // the by-digest record wins where it has an entry. A refusal
+                    // with no computable identity cannot be retagged, so its own
+                    // projection is the only, and final, answer.
+                    let key = self.declared.get(digest).unwrap_or(&blob.key);
+                    matches(*selector, digest, Some(key))
                 })
                 // A container may store one blob twice — once compressed, once
                 // not — and refuse only the copy that did not fit. That is still
@@ -684,7 +729,7 @@ impl<'a> BlobCollector<'a> {
                 // assumed to be the same payload when a retained blob already
                 // answers this selector, because it cannot be proven otherwise
                 // and refusing valid input is the worse error.
-                .filter(|blob| match blob.digest.as_deref() {
+                .filter(|blob| match blob.blob.digest.as_deref() {
                     // Proved identity: if that payload is already retained, this
                     // is the same blob stored twice, not a second candidate.
                     // Only a digest this reader computed counts. A declared one
@@ -693,7 +738,9 @@ impl<'a> BlobCollector<'a> {
                     // retained blob on an oversized frame and make a genuine
                     // ambiguity disappear — the same "input picks its own
                     // verdict" defect this importer already refuses to allow.
-                    Some(digest) if blob.digest_computed => !self.selected.contains_key(digest),
+                    Some(digest) if blob.blob.digest_computed => {
+                        !self.selected.contains_key(digest)
+                    }
                     // Unproved identity: it may be a different payload. Count it
                     // and fail closed; silently returning one of two possible
                     // answers is the worse error.
@@ -708,7 +755,7 @@ impl<'a> BlobCollector<'a> {
                 let unidentified = self
                     .refused
                     .iter()
-                    .filter(|blob| blob.digest.is_none())
+                    .filter(|refused| refused.blob.digest.is_none())
                     .count();
                 let note = if unidentified == 0 {
                     String::new()
@@ -732,7 +779,7 @@ impl<'a> BlobCollector<'a> {
                     "rdf-ir-gts-blob-limit",
                     format!(
                         "required selector {selector:?} matches a payload of {} encoded bytes that this import's budget refused: {}",
-                        blob.encoded_len, blob.detail
+                        blob.blob.encoded_len, blob.blob.detail
                     ),
                 ));
             }
@@ -748,7 +795,13 @@ impl<'a> BlobCollector<'a> {
                 .all(|blob| !blob.segment_head.is_empty() && !blob.frame_id.is_empty()),
             "selected blob provenance must be populated before it is returned"
         );
-        Ok((self.selected.into_values().collect(), self.refused))
+        Ok((
+            self.selected.into_values().collect(),
+            self.refused
+                .into_iter()
+                .map(|refused| refused.blob)
+                .collect(),
+        ))
     }
 }
 

--- a/crates/rdf/src/gts_import_blobs.rs
+++ b/crates/rdf/src/gts_import_blobs.rs
@@ -422,8 +422,8 @@ impl<'a> BlobCollector<'a> {
         validate_metadata(metadata.as_ref(), payload.digest)?;
         // The reader fires its frame event for every frame before any of that
         // frame's rows, with the same segment index, so a payload always has a
-        // matching frame and this branch is not reachable from any container.
-        // It is kept as a fail-closed guard rather than an assumption, and is
+        // matching frame and no container reaches the error arm below. It is
+        // kept as a fail-closed guard rather than an assumption, and is
         // deliberately not counted as a tested refusal.
         let frame = self
             .frame

--- a/crates/rdf/src/gts_import_blobs.rs
+++ b/crates/rdf/src/gts_import_blobs.rs
@@ -528,6 +528,19 @@ impl<'a> BlobCollector<'a> {
     /// budget decide which blob a selector resolves to, so a tight ceiling could
     /// silently turn an ambiguous match into a confident wrong answer.
     pub(crate) fn refused(&mut self, refusal: BlobRefusal<'_>) {
+        // A refused occurrence never reaches `payload`, so its own declaration
+        // would otherwise be missing from the container-global record and a
+        // staler one would answer for it — letting the ceiling, rather than the
+        // container, decide what a representation finally names. Only a proved
+        // identity may write here: a transformed or encrypted refusal carries
+        // the file's unverified claim, which must not choose whose metadata is
+        // read.
+        if let (Some(digest), true, Some(declared)) =
+            (refusal.digest, refusal.digest_computed, refusal.metadata)
+        {
+            self.final_metadata
+                .insert(digest.to_string(), declared.clone());
+        }
         self.refused.push(GtsRefusedBlob {
             digest: refusal.digest.map(ToString::to_string),
             digest_computed: refusal.digest_computed,

--- a/crates/rdf/src/gts_import_blobs.rs
+++ b/crates/rdf/src/gts_import_blobs.rs
@@ -246,14 +246,27 @@ pub(crate) struct BlobCollector<'a> {
     ///
     /// Whether that is an external blob or an ordering problem cannot be decided
     /// mid-stream: the bytes may still arrive in a later frame. Resolved in
-    /// [`Self::finish`], once the whole container has been read.
-    unresolved: Vec<String>,
-    /// Last explicitly declared public metadata per digest.
+    /// [`Self::finish`], once the whole container has been read. A set, not a
+    /// list: a repeated metadata-only row must not repeat its entry.
+    unresolved: BTreeSet<String>,
+    /// The final name each digest is published under, for selection only.
     ///
     /// Selection reads the *final* metadata, so an occurrence's verdict is only
-    /// provisional until the container ends.
+    /// provisional until the container ends. Written only for digests with a
+    /// verified identity: an unproved claim renaming a real digest would let a
+    /// garbage frame decide what a caller's selector resolves to.
     declared: BTreeMap<String, SelectionKey>,
+    /// Last admitted full declaration per digest, with its physical source.
+    ///
+    /// This is what an absent-metadata occurrence inherits ACROSS segment
+    /// boundaries, since the reader's own inheritance resets per segment. It
+    /// feeds only what the caller gets back, so the metadata retention ceiling
+    /// applies per entry; an over-budget declaration REMOVES the entry rather
+    /// than leaving a superseded one to answer in its place. Selection never
+    /// reads this map.
+    last_declared: BTreeMap<String, (Value, GtsBlobMetadataSource)>,
     frame: Option<BlobFrame>,
+    /// Total retained bytes: selected payloads plus retained refusal metadata.
     total: usize,
 }
 
@@ -330,9 +343,18 @@ struct RefusedOccurrence {
     key: SelectionKey,
 }
 
-fn matches(selector: GtsBlobSelector<'_>, digest: &str, key: Option<&SelectionKey>) -> bool {
+/// Whether a selector names a blob with this identity and this name.
+///
+/// `digest` is `None` when the blob has no PROVED identity: an unverified claim
+/// is not an identity, so it can never satisfy a digest selector. Selector
+/// values are validated non-empty, so absence and emptiness cannot collide.
+fn matches(
+    selector: GtsBlobSelector<'_>,
+    digest: Option<&str>,
+    key: Option<&SelectionKey>,
+) -> bool {
     match selector {
-        GtsBlobSelector::Digest(expected) => expected == digest,
+        GtsBlobSelector::Digest(expected) => digest == Some(expected),
         GtsBlobSelector::Representation(expected) => {
             key.and_then(|key| key.rep.as_deref()) == Some(expected)
         }
@@ -364,8 +386,9 @@ impl<'a> BlobCollector<'a> {
             selected: BTreeMap::new(),
             refused: Vec::new(),
             inlined: BTreeSet::new(),
-            unresolved: Vec::new(),
+            unresolved: BTreeSet::new(),
             declared: BTreeMap::new(),
+            last_declared: BTreeMap::new(),
             frame: None,
             total: 0,
         })
@@ -394,16 +417,20 @@ impl<'a> BlobCollector<'a> {
         digest: &str,
         metadata: Option<&Value>,
     ) -> Result<(), RdfDiagnostic> {
+        // The record only holds declarations seen BEFORE this event, but the
+        // declaration that first makes a digest selected under a representation
+        // selector is the one arriving now — matching the record alone would
+        // leave this gate inert for exactly the copy it exists to bound.
+        let incoming = selection_key(metadata);
         let metadata = metadata.or_else(|| {
             self.selected
                 .get(digest)
                 .and_then(|blob| blob.metadata.as_ref())
         });
-        if self
-            .selectors
-            .iter()
-            .any(|selector| matches(*selector, digest, self.declared.get(digest)))
-        {
+        if self.selectors.iter().any(|selector| {
+            matches(*selector, Some(digest), self.declared.get(digest))
+                || matches(*selector, Some(digest), Some(&incoming))
+        }) {
             check_metadata_bound(metadata, self.limits.max_metadata_bytes)?;
             validate_metadata(metadata, digest)?;
         }
@@ -434,23 +461,60 @@ impl<'a> BlobCollector<'a> {
         if payload.metadata_declared {
             self.declared
                 .insert(payload.digest.to_string(), selection_key(payload.metadata));
+            // The full declaration is retention, so the metadata ceiling applies
+            // here — and an inadmissible declaration must also EVICT any older
+            // admitted one, or the superseded value would keep answering for a
+            // digest whose current declaration could not be kept. Selection is
+            // unaffected either way: it reads the projection above, which no
+            // ceiling touches.
+            let source = self
+                .frame
+                .as_ref()
+                .filter(|frame| frame.segment_index == payload.segment_index)
+                .map(|frame| GtsBlobMetadataSource {
+                    segment_index: frame.segment_index,
+                    frame_index: frame.frame_index,
+                    frame_id: frame.frame_id.clone(),
+                    frame_range: frame.range.clone(),
+                    segment_head: Vec::new(),
+                });
+            match (payload.metadata, source) {
+                (Some(meta), Some(source))
+                    if check_metadata_bound(Some(meta), self.limits.max_metadata_bytes).is_ok() =>
+                {
+                    self.last_declared
+                        .insert(payload.digest.to_string(), (meta.clone(), source));
+                }
+                _ => {
+                    self.last_declared.remove(payload.digest);
+                }
+            }
         }
         let previous = self.selected.get(payload.digest);
         // The reader's per-occurrence metadata inherits only within a segment —
         // each segment starts a fresh lookaside — so an occurrence in a later
         // segment arrives bare even though a declaration exists earlier in the
         // container. The documented contract is that absent metadata preserves
-        // the previous declaration *including across segment boundaries*, and
-        // the last declaration for every digest is already recorded, so consult
-        // it before falling back to whatever a retained copy happens to hold.
+        // the previous declaration *including across segment boundaries*, so a
+        // bare occurrence inherits the last admitted declaration, and carries
+        // that declaration's own physical source rather than inventing one.
+        let inherited = payload
+            .metadata
+            .is_none()
+            .then(|| self.last_declared.get(payload.digest))
+            .flatten();
         let metadata = payload
             .metadata
+            .or_else(|| inherited.map(|(value, _)| value))
             .or_else(|| previous.and_then(|blob| blob.metadata.as_ref()));
-        if !self
-            .selectors
-            .iter()
-            .any(|selector| matches(*selector, payload.digest, self.declared.get(payload.digest)))
-        {
+        let inherited_source = inherited.map(|(_, source)| source.clone());
+        if !self.selectors.iter().any(|selector| {
+            matches(
+                *selector,
+                Some(payload.digest),
+                self.declared.get(payload.digest),
+            )
+        }) {
             if let Some(old) = self.selected.remove(payload.digest) {
                 // Release builds leave overflow checks off, so a future break of
                 // the "total is the sum of retained lengths" invariant would wrap
@@ -496,7 +560,9 @@ impl<'a> BlobCollector<'a> {
                 segment_head: Vec::new(),
             })
         } else {
-            previous.and_then(|blob| blob.metadata_source.clone())
+            // Metadata inherited from an earlier declaration keeps THAT
+            // declaration's source; a retained copy's source is the fallback.
+            inherited_source.or_else(|| previous.and_then(|blob| blob.metadata_source.clone()))
         };
         let Some(wire_bytes) = payload.bytes else {
             let Some(previous) = self.selected.get_mut(payload.digest) else {
@@ -506,7 +572,7 @@ impl<'a> BlobCollector<'a> {
                 // container may still carry it, and the authoritative importer
                 // accepts exactly that file. Defer to finish(), which sees the
                 // whole container.
-                self.unresolved.push(payload.digest.to_string());
+                self.unresolved.insert(payload.digest.to_string());
                 return Ok(());
             };
             previous.metadata = metadata;
@@ -572,36 +638,48 @@ impl<'a> BlobCollector<'a> {
     /// budget decide which blob a selector resolves to, so a tight ceiling could
     /// silently turn an ambiguous match into a confident wrong answer.
     pub(crate) fn refused(&mut self, refusal: BlobRefusal<'_>) {
-        // A refused occurrence never reaches `payload`, so without this its own
-        // declaration would be missing from the container-global record and a
-        // staler one would answer for it — letting the ceiling, rather than the
-        // container, decide what a representation finally names.
+        // A refused occurrence never reaches `payload`, so its own declaration
+        // must be recorded here or a staler one would answer for it — letting
+        // the ceiling, rather than the container, decide what a representation
+        // finally names. But only a PROVED identity may write a by-digest
+        // record: an unproved claim writing under someone else's digest would
+        // let one garbage frame rename a real, retained blob and change what a
+        // caller's selector resolves to. An unproved refusal keeps its name on
+        // the occurrence itself, where it can fail a selection closed but never
+        // redirect one.
         //
-        // No proof gate here, deliberately. Public metadata is a container
-        // assertion at every occurrence, including the metadata-only frames the
-        // payload path already records unverified; what a digest is *called* is
-        // the file's claim by construction. Proof is required for the different
-        // question of whether two occurrences are the same payload, and that
-        // gate stays where it belongs, on dedup.
-        // Projected from the raw declaration, before the retention bound below.
-        // The two are deliberately independent: what a blob is called must
-        // survive a ceiling that discards how it is described.
-        if let (Some(digest), Some(meta)) = (refusal.digest, refusal.metadata) {
+        // Projected from the raw declaration, before the retention bound below:
+        // what a blob is called must survive a ceiling that discards how it is
+        // described.
+        if refusal.digest_computed
+            && let (Some(digest), Some(meta)) = (refusal.digest, refusal.metadata)
+        {
             self.declared
                 .insert(digest.to_string(), selection_key(Some(meta)));
         }
         // A budget bounds what this import retains, and a refused declaration is
-        // retained like any other. Bounding it only on the payload path would
-        // leave a ceiling that a refused frame walks straight past.
-        let metadata = refusal.metadata.filter(|meta| {
+        // retained like any other: it obeys the per-blob metadata ceiling AND
+        // counts against the retained total, or a stream of refusals would
+        // accumulate container-chosen bytes no ceiling ever saw. Selection is
+        // untouched — the projection above and the key below were taken first.
+        let per_blob_ok = refusal.metadata.is_some_and(|meta| {
             check_metadata_bound(Some(meta), self.limits.max_metadata_bytes).is_ok()
         });
+        let retained_len = if per_blob_ok {
+            refusal.metadata.map_or(0, encoded_metadata_len)
+        } else {
+            0
+        };
+        let within_total =
+            self.total.saturating_add(retained_len) <= self.limits.max_total_decoded_bytes;
+        let metadata = refusal.metadata.filter(|_| per_blob_ok && within_total);
         let detail = if metadata.is_none() && refusal.metadata.is_some() {
             format!(
-                "{}; its public metadata also exceeded the {}-byte metadata budget and was not retained",
-                refusal.detail, self.limits.max_metadata_bytes
+                "{}; its public metadata exceeded the retention budgets and was not retained",
+                refusal.detail
             )
         } else {
+            self.total = self.total.saturating_add(retained_len);
             refusal.detail.to_string()
         };
         let key = selection_key(refusal.metadata);
@@ -629,6 +707,14 @@ impl<'a> BlobCollector<'a> {
                 source.segment_head = head.to_vec();
             }
         }
+        // A declaration held for a later segment to inherit needs its head too:
+        // it is recorded while its own segment is still open, and an occurrence
+        // that inherits it hands the caller that source verbatim.
+        for (_, source) in self.last_declared.values_mut() {
+            if source.segment_index == segment_index {
+                source.segment_head = head.to_vec();
+            }
+        }
     }
 
     fn finish(self) -> Result<(Vec<GtsImportedBlob>, Vec<GtsRefusedBlob>), RdfDiagnostic> {
@@ -649,7 +735,7 @@ impl<'a> BlobCollector<'a> {
             if !self
                 .selectors
                 .iter()
-                .any(|selector| matches(*selector, digest, key))
+                .any(|selector| matches(*selector, Some(digest), key))
             {
                 continue;
             }
@@ -684,6 +770,23 @@ impl<'a> BlobCollector<'a> {
                     ),
                 ));
             }
+            // "External" is a strong factual claim about the archive, and a
+            // payload refused before identification could be these very bytes.
+            // Externality is therefore only assertable when nothing unidentified
+            // was refused; otherwise the truthful verdict is the budget's.
+            let unidentified = self
+                .refused
+                .iter()
+                .filter(|refused| !refused.blob.digest_computed)
+                .count();
+            if unidentified > 0 {
+                return Err(fail(
+                    "rdf-ir-gts-blob-limit",
+                    format!(
+                        "blob {digest} was selected but never retained, and {unidentified} payload(s) were refused before identification, so whether it is inline cannot be determined; raise the budgets or supply the payload"
+                    ),
+                ));
+            }
             return Err(fail(
                 "rdf-ir-gts-blob-external",
                 format!(
@@ -696,54 +799,51 @@ impl<'a> BlobCollector<'a> {
             let retained = self
                 .selected
                 .values()
-                .filter(|blob| matches(*selector, &blob.digest, self.declared.get(&blob.digest)))
+                .filter(|blob| {
+                    matches(
+                        *selector,
+                        Some(&blob.digest),
+                        self.declared.get(&blob.digest),
+                    )
+                })
                 .count();
             // A refused candidate still counts. It was in the archive; only its
             // bytes were declined. Ignoring it here would make the byte budget a
             // selection rule, so a tighter ceiling could quietly resolve an
             // ambiguous selector to one arbitrary survivor.
+            //
+            // ONE RULE governs everything below: identity requires proof, naming
+            // does not, and an unproved claim can fail a selection closed but
+            // never resolve or redirect one. Concretely — a proved digest
+            // matches digest selectors, reads the container-global final name,
+            // and deduplicates against a retained copy of the same payload; an
+            // unproved refusal matches only through its own occurrence's name,
+            // never through anything keyed by the digest it merely claims.
             let refused: Vec<&RefusedOccurrence> = self
                 .refused
                 .iter()
                 .filter(|blob| {
-                    // Same rule as an unresolved digest: a representation names
-                    // the FINAL metadata, so a refused occurrence retagged away
-                    // before the container ended is no longer a candidate. Only
-                    // a proved identity may reach for the container-global
-                    // record; letting a claimed digest choose whose metadata to
-                    // consult would hand the file that decision back.
-                    let digest = blob.blob.digest.as_deref().unwrap_or_default();
-                    // A later frame can retag a digest the container named, so
-                    // the by-digest record wins where it has an entry. A refusal
-                    // with no computable identity cannot be retagged, so its own
-                    // projection is the only, and final, answer.
-                    let key = self.declared.get(digest).unwrap_or(&blob.key);
-                    matches(*selector, digest, Some(key))
+                    let proved = blob
+                        .blob
+                        .digest
+                        .as_deref()
+                        .filter(|_| blob.blob.digest_computed);
+                    let key = proved
+                        .and_then(|digest| self.declared.get(digest))
+                        .unwrap_or(&blob.key);
+                    matches(*selector, proved, Some(key))
                 })
-                // A container may store one blob twice — once compressed, once
-                // not — and refuse only the copy that did not fit. That is still
-                // one blob, so counting the refused copy as a second candidate
-                // would invent an ambiguity the archive does not contain. A
-                // refusal whose digest is already retained is the same payload;
-                // a refusal that was refused before it could be hashed is
-                // assumed to be the same payload when a retained blob already
-                // answers this selector, because it cannot be proven otherwise
-                // and refusing valid input is the worse error.
                 .filter(|blob| match blob.blob.digest.as_deref() {
-                    // Proved identity: if that payload is already retained, this
-                    // is the same blob stored twice, not a second candidate.
-                    // Only a digest this reader computed counts. A declared one
-                    // was never checked against a payload that was never
-                    // decoded, so honouring it would let a container name a
-                    // retained blob on an oversized frame and make a genuine
-                    // ambiguity disappear — the same "input picks its own
-                    // verdict" defect this importer already refuses to allow.
+                    // A container may store one blob twice — compressed and not
+                    // — and refuse only the copy that did not fit. A PROVED
+                    // digest already retained is that same payload, not a second
+                    // candidate.
                     Some(digest) if blob.blob.digest_computed => {
                         !self.selected.contains_key(digest)
                     }
-                    // Unproved identity: it may be a different payload. Count it
-                    // and fail closed; silently returning one of two possible
-                    // answers is the worse error.
+                    // Unproved: may be a different payload. Count it and fail
+                    // closed; silently returning one of two possible answers is
+                    // the worse error.
                     _ => true,
                 })
                 .collect();
@@ -833,6 +933,25 @@ fn validate_metadata(meta: Option<&Value>, digest: &str) -> Result<(), RdfDiagno
         }
     }
     Ok(())
+}
+
+/// Exact CBOR-encoded size of a metadata map, without materializing the bytes.
+fn encoded_metadata_len(meta: &Value) -> usize {
+    struct Counter(usize);
+    impl std::io::Write for Counter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0 += bytes.len();
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    let mut counter = Counter(0);
+    // Counting cannot fail; a serialization error simply under-counts, and the
+    // per-blob bound has already accepted this value.
+    let _ = ciborium::ser::into_writer(meta, &mut counter);
+    counter.0
 }
 
 fn bounded_metadata(meta: Option<&Value>, limit: usize) -> Result<Option<Value>, RdfDiagnostic> {

--- a/crates/rdf/src/gts_import_blobs.rs
+++ b/crates/rdf/src/gts_import_blobs.rs
@@ -528,26 +528,42 @@ impl<'a> BlobCollector<'a> {
     /// budget decide which blob a selector resolves to, so a tight ceiling could
     /// silently turn an ambiguous match into a confident wrong answer.
     pub(crate) fn refused(&mut self, refusal: BlobRefusal<'_>) {
-        // A refused occurrence never reaches `payload`, so its own declaration
-        // would otherwise be missing from the container-global record and a
+        // A refused occurrence never reaches `payload`, so without this its own
+        // declaration would be missing from the container-global record and a
         // staler one would answer for it — letting the ceiling, rather than the
-        // container, decide what a representation finally names. Only a proved
-        // identity may write here: a transformed or encrypted refusal carries
-        // the file's unverified claim, which must not choose whose metadata is
-        // read.
-        if let (Some(digest), true, Some(declared)) =
-            (refusal.digest, refusal.digest_computed, refusal.metadata)
-        {
+        // container, decide what a representation finally names.
+        //
+        // No proof gate here, deliberately. Public metadata is a container
+        // assertion at every occurrence, including the metadata-only frames the
+        // payload path already records unverified; what a digest is *called* is
+        // the file's claim by construction. Proof is required for the different
+        // question of whether two occurrences are the same payload, and that
+        // gate stays where it belongs, on dedup.
+        if let (Some(digest), Some(declared)) = (refusal.digest, refusal.metadata) {
             self.final_metadata
                 .insert(digest.to_string(), declared.clone());
         }
+        // A budget bounds what this import retains, and a refused declaration is
+        // retained like any other. Bounding it only on the payload path would
+        // leave a ceiling that a refused frame walks straight past.
+        let metadata = refusal.metadata.filter(|meta| {
+            check_metadata_bound(Some(meta), self.limits.max_metadata_bytes).is_ok()
+        });
+        let detail = if metadata.is_none() && refusal.metadata.is_some() {
+            format!(
+                "{}; its public metadata also exceeded the {}-byte metadata budget and was not retained",
+                refusal.detail, self.limits.max_metadata_bytes
+            )
+        } else {
+            refusal.detail.to_string()
+        };
         self.refused.push(GtsRefusedBlob {
             digest: refusal.digest.map(ToString::to_string),
             digest_computed: refusal.digest_computed,
-            metadata: refusal.metadata.cloned(),
+            metadata: metadata.cloned(),
             segment_index: refusal.segment_index,
             encoded_len: refusal.encoded_len,
-            detail: refusal.detail.to_string(),
+            detail,
         });
     }
 
@@ -586,16 +602,25 @@ impl<'a> BlobCollector<'a> {
             {
                 continue;
             }
-            // A proved refusal is proof the container carried these bytes. Saying
-            // they are "held elsewhere" would let the byte budget decide what
-            // this importer claims about the archive's contents.
-            if let Some(refusal) = self.refused.iter().find(|blob| {
-                blob.digest_computed && blob.digest.as_deref() == Some(digest.as_str())
-            }) {
+            // A refusal is proof the container carried a payload under this
+            // label. Calling it "held elsewhere" would let the byte budget decide
+            // what this importer claims about the archive's contents, so presence
+            // is answered from any refusal that named the digest. Identity is a
+            // separate question, and the message says which one it can vouch for.
+            if let Some(refusal) = self
+                .refused
+                .iter()
+                .find(|blob| blob.digest.as_deref() == Some(digest.as_str()))
+            {
+                let identity = if refusal.digest_computed {
+                    "is present in this container"
+                } else {
+                    "is declared by this container, though its identity was not verified before refusal,"
+                };
                 return Err(fail(
                     "rdf-ir-gts-blob-limit",
                     format!(
-                        "blob {digest} is present in this container but its {} encoded bytes exceeded this import's budget: {}",
+                        "blob {digest} {identity} and its {} encoded bytes exceeded this import's budget: {}",
                         refusal.encoded_len, refusal.detail
                     ),
                 ));

--- a/crates/rdf/src/gts_import_blobs.rs
+++ b/crates/rdf/src/gts_import_blobs.rs
@@ -132,6 +132,12 @@ pub struct GtsRefusedBlob {
     /// undeclared digest is unknowable here. Such a payload is matchable by
     /// representation, never by digest.
     pub digest: Option<String>,
+    /// Whether the digest was computed from the payload, not merely claimed.
+    ///
+    /// A payload refused before any decode cannot have a container-declared
+    /// digest checked against it, so a false value here is an assertion by the
+    /// file, not an identity.
+    pub digest_computed: bool,
     /// Public metadata declared at the refused occurrence.
     pub metadata: Option<Value>,
     /// Zero-based segment containing the refused occurrence.
@@ -242,6 +248,11 @@ pub(crate) struct BlobCollector<'a> {
     /// mid-stream: the bytes may still arrive in a later frame. Resolved in
     /// [`Self::finish`], once the whole container has been read.
     unresolved: Vec<String>,
+    /// Last explicitly declared public metadata per digest.
+    ///
+    /// Selection reads the *final* metadata, so an occurrence's verdict is only
+    /// provisional until the container ends.
+    final_metadata: BTreeMap<String, Value>,
     frame: Option<BlobFrame>,
     total: usize,
 }
@@ -309,6 +320,7 @@ impl<'a> BlobCollector<'a> {
             refused: Vec::new(),
             inlined: BTreeSet::new(),
             unresolved: Vec::new(),
+            final_metadata: BTreeMap::new(),
             frame: None,
             total: 0,
         })
@@ -373,6 +385,10 @@ impl<'a> BlobCollector<'a> {
     pub(crate) fn payload(&mut self, payload: BlobPayload<'_>) -> Result<(), RdfDiagnostic> {
         if payload.payload_present {
             self.inlined.insert(payload.digest.to_string());
+        }
+        if let Some(declared) = payload.metadata.filter(|_| payload.metadata_declared) {
+            self.final_metadata
+                .insert(payload.digest.to_string(), declared.clone());
         }
         let previous = self.selected.get(payload.digest);
         let metadata = payload
@@ -506,6 +522,7 @@ impl<'a> BlobCollector<'a> {
     pub(crate) fn refused(&mut self, refusal: BlobRefusal<'_>) {
         self.refused.push(GtsRefusedBlob {
             digest: refusal.digest.map(ToString::to_string),
+            digest_computed: refusal.digest_computed,
             metadata: refusal.metadata.cloned(),
             segment_index: refusal.segment_index,
             encoded_len: refusal.encoded_len,
@@ -533,6 +550,19 @@ impl<'a> BlobCollector<'a> {
         // payload — a file the authoritative importer accepts.
         for digest in &self.unresolved {
             if self.selected.contains_key(digest) {
+                continue;
+            }
+            // The verdict at the occurrence was provisional: a selector matches
+            // the FINAL metadata for a digest, and a later frame may have
+            // retagged this one so that nothing names it any more. Refusing over
+            // a blob the selection does not finally reach would reject a file
+            // the authoritative importer accepts.
+            let metadata = self.final_metadata.get(digest);
+            if !self
+                .selectors
+                .iter()
+                .any(|selector| matches(*selector, digest, metadata))
+            {
                 continue;
             }
             if self.inlined.contains(digest) {
@@ -581,15 +611,19 @@ impl<'a> BlobCollector<'a> {
                 // answers this selector, because it cannot be proven otherwise
                 // and refusing valid input is the worse error.
                 .filter(|blob| match blob.digest.as_deref() {
-                    // Known identity: if that payload is already retained, this
+                    // Proved identity: if that payload is already retained, this
                     // is the same blob stored twice, not a second candidate.
-                    Some(digest) => !self.selected.contains_key(digest),
-                    // Unknown identity — refused before it could be hashed, so
-                    // it may be a different payload. Count it and fail closed;
-                    // silently returning one of two possible answers is the
-                    // worse error, and the reader supplies a digest whenever
-                    // one is computable without spending the budget.
-                    None => true,
+                    // Only a digest this reader computed counts. A declared one
+                    // was never checked against a payload that was never
+                    // decoded, so honouring it would let a container name a
+                    // retained blob on an oversized frame and make a genuine
+                    // ambiguity disappear — the same "input picks its own
+                    // verdict" defect this importer already refuses to allow.
+                    Some(digest) if blob.digest_computed => !self.selected.contains_key(digest),
+                    // Unproved identity: it may be a different payload. Count it
+                    // and fail closed; silently returning one of two possible
+                    // answers is the worse error.
+                    _ => true,
                 })
                 .collect();
             let count = retained + refused.len();

--- a/crates/rdf/src/gts_import_blobs.rs
+++ b/crates/rdf/src/gts_import_blobs.rs
@@ -391,8 +391,16 @@ impl<'a> BlobCollector<'a> {
                 .insert(payload.digest.to_string(), declared.clone());
         }
         let previous = self.selected.get(payload.digest);
+        // The reader's per-occurrence metadata inherits only within a segment —
+        // each segment starts a fresh lookaside — so an occurrence in a later
+        // segment arrives bare even though a declaration exists earlier in the
+        // container. The documented contract is that absent metadata preserves
+        // the previous declaration *including across segment boundaries*, and
+        // the last declaration for every digest is already recorded, so consult
+        // it before falling back to whatever a retained copy happens to hold.
         let metadata = payload
             .metadata
+            .or_else(|| self.final_metadata.get(payload.digest))
             .or_else(|| previous.and_then(|blob| blob.metadata.as_ref()));
         if !self
             .selectors
@@ -565,6 +573,20 @@ impl<'a> BlobCollector<'a> {
             {
                 continue;
             }
+            // A proved refusal is proof the container carried these bytes. Saying
+            // they are "held elsewhere" would let the byte budget decide what
+            // this importer claims about the archive's contents.
+            if let Some(refusal) = self.refused.iter().find(|blob| {
+                blob.digest_computed && blob.digest.as_deref() == Some(digest.as_str())
+            }) {
+                return Err(fail(
+                    "rdf-ir-gts-blob-limit",
+                    format!(
+                        "blob {digest} is present in this container but its {} encoded bytes exceeded this import's budget: {}",
+                        refusal.encoded_len, refusal.detail
+                    ),
+                ));
+            }
             if self.inlined.contains(digest) {
                 return Err(fail(
                     "rdf-ir-gts-blob-selection-order",
@@ -595,10 +617,24 @@ impl<'a> BlobCollector<'a> {
                 .refused
                 .iter()
                 .filter(|blob| {
+                    // Same rule as an unresolved digest: a representation names
+                    // the FINAL metadata, so a refused occurrence retagged away
+                    // before the container ended is no longer a candidate. Only
+                    // a proved identity may reach for the container-global
+                    // record; letting a claimed digest choose whose metadata to
+                    // consult would hand the file that decision back.
+                    let effective = if blob.digest_computed {
+                        blob.digest
+                            .as_deref()
+                            .and_then(|digest| self.final_metadata.get(digest))
+                            .or(blob.metadata.as_ref())
+                    } else {
+                        blob.metadata.as_ref()
+                    };
                     matches(
                         *selector,
                         blob.digest.as_deref().unwrap_or_default(),
-                        blob.metadata.as_ref(),
+                        effective,
                     )
                 })
                 // A container may store one blob twice — once compressed, once

--- a/crates/rdf/src/gts_import_blobs.rs
+++ b/crates/rdf/src/gts_import_blobs.rs
@@ -3,7 +3,7 @@
 
 //! Explicit, bounded blob selection alongside the authoritative native import.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use ciborium::Value;
@@ -15,7 +15,11 @@ use crate::{GtsBundle, RdfDiagnostic};
 /// A required inline blob, selected independently of RDF statement order.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum GtsBlobSelector<'a> {
-    /// Match the exact content digest.
+    /// Match the exact content digest, in the canonical `blake3:<hex>` spelling.
+    ///
+    /// The reader normalizes the wire's three published spellings to this one
+    /// before matching, so a bare hex selector resolves to nothing rather than
+    /// to the blob it looks like. Use [`purrdf_gts::wire::digest_str`].
     Digest(&'a str),
     /// Match the final public metadata's `rep` text value.
     Representation(&'a str),
@@ -185,7 +189,10 @@ pub struct GtsImportWithBlobs {
 /// # Errors
 /// Returns a diagnostic for invalid selection, missing or ambiguous final blobs,
 /// selected malformed metadata, absent payloads, corrupt decoded digests, reader
-/// or codec failures, or a retention/decode bound violation.
+/// or codec failures, or a retention/decode bound violation. Selecting a blob
+/// the container declares as external — published digest, no payload field —
+/// returns `rdf-ir-gts-blob-external`: its bytes are held outside this file, so
+/// no inline read can produce them.
 pub fn import_gts_events_with_blobs(
     bytes: &[u8],
     selectors: &[GtsBlobSelector<'_>],
@@ -217,6 +224,10 @@ pub(crate) struct BlobCollector<'a> {
     limits: GtsBlobLimits,
     selected: BTreeMap<String, GtsImportedBlob>,
     refused: Vec<GtsRefusedBlob>,
+    /// Digests some occurrence in this container carried bytes for, whether or
+    /// not they were selected. Distinguishes a payload we declined to retain
+    /// from one the container never held.
+    inlined: BTreeSet<String>,
     frame: Option<BlobFrame>,
     total: usize,
 }
@@ -282,6 +293,7 @@ impl<'a> BlobCollector<'a> {
             limits,
             selected: BTreeMap::new(),
             refused: Vec::new(),
+            inlined: BTreeSet::new(),
             frame: None,
             total: 0,
         })
@@ -330,6 +342,9 @@ impl<'a> BlobCollector<'a> {
     }
 
     pub(crate) fn payload(&mut self, payload: BlobPayload<'_>) -> Result<(), RdfDiagnostic> {
+        if payload.payload_present {
+            self.inlined.insert(payload.digest.to_string());
+        }
         let previous = self.selected.get(payload.digest);
         let metadata = payload
             .metadata
@@ -375,6 +390,24 @@ impl<'a> BlobCollector<'a> {
         };
         let Some(wire_bytes) = payload.bytes else {
             let Some(previous) = self.selected.get_mut(payload.digest) else {
+                // An occurrence with no payload field at all, publishing a
+                // digest, is an EXTERNAL blob: the spec places its bytes outside
+                // this container. That is a different fact from a metadata-only
+                // update to a payload we declined to retain, and reporting it as
+                // one claims something false about retention ordering.
+                // No occurrence anywhere in this container carried bytes for
+                // this digest, so the spec's external form is the only reading:
+                // the payload lives outside the file. Reporting that as a
+                // retention-ordering problem would assert something false.
+                if !self.inlined.contains(payload.digest) {
+                    return Err(fail(
+                        "rdf-ir-gts-blob-external",
+                        format!(
+                            "blob {} is external to this container; its bytes are held elsewhere and this importer returns only inline payloads",
+                            payload.digest
+                        ),
+                    ));
+                }
                 return Err(fail(
                     "rdf-ir-gts-blob-selection-order",
                     format!(
@@ -383,7 +416,6 @@ impl<'a> BlobCollector<'a> {
                     ),
                 ));
             };
-            validate_length(metadata.as_ref(), previous.bytes.len())?;
             previous.metadata = metadata;
             previous.metadata_source = metadata_source;
             return Ok(());
@@ -421,7 +453,6 @@ impl<'a> BlobCollector<'a> {
                 ),
             ));
         }
-        validate_length(metadata.as_ref(), bytes.len())?;
         self.total = other_bytes + bytes.len();
         self.selected.insert(
             digest.clone(),
@@ -557,21 +588,6 @@ fn validate_metadata(meta: Option<&Value>, digest: &str) -> Result<(), RdfDiagno
                     format!("selected blob metadata {key} must be text"),
                 )
             })?;
-        }
-    }
-    Ok(())
-}
-
-fn validate_length(meta: Option<&Value>, length: usize) -> Result<(), RdfDiagnostic> {
-    if let Some(value) = metadata_field(meta, "len")? {
-        let declared = value
-            .as_integer()
-            .and_then(|value| usize::try_from(value).ok());
-        if declared != Some(length) {
-            return Err(fail(
-                "rdf-ir-gts-blob-length",
-                "selected blob declared length differs from decoded length",
-            ));
         }
     }
     Ok(())

--- a/crates/rdf/src/gts_import_sink.rs
+++ b/crates/rdf/src/gts_import_sink.rs
@@ -389,9 +389,20 @@ impl ResolvedSink for SinkImporter<'_> {
     }
 
     fn diagnostic(&mut self, diagnostic: &Diagnostic) -> Result<(), RdfDiagnostic> {
-        // A reader diagnostic is a hard fold failure on the IR path (the IR is
-        // the authority, no degraded fold). The `SegmentResolver` latches the
-        // first one returned here.
+        // A selected import's byte budget names what *this import will retain*,
+        // not what the container is allowed to contain. A payload refused by that
+        // budget is therefore not a fold failure: the archive is intact and its
+        // dataset is admissible, so refusing the whole import would reject valid
+        // input over bytes the caller never asked for. The payload is simply not
+        // emitted, so a caller who *did* name it still fails closed — the
+        // selector resolves to no blob. Importers with no collector are
+        // unaffected and keep the hard-fail below.
+        if self.blobs.is_some() && is_blob_budget_refusal(diagnostic) {
+            return Ok(());
+        }
+        // Any other reader diagnostic is a hard fold failure on the IR path (the
+        // IR is the authority, no degraded fold). The `SegmentResolver` latches
+        // the first one returned here.
         Err(RdfDiagnostic::error(
             "rdf-ir-gts-fold-diagnostic",
             format!(
@@ -491,6 +502,19 @@ impl SinkImporter<'_> {
 /// the envelope.
 pub fn import_gts_events(bytes: &[u8]) -> Result<GtsBundle, RdfDiagnostic> {
     import_with_collector(bytes, None).map(|(bundle, _)| bundle)
+}
+
+/// Whether a reader diagnostic reports a blob refused by the sink's byte budget.
+///
+/// The reader reports these as ordinary damaged-frame diagnostics because a
+/// streaming consumer still wants to hear about them; only the selected-import
+/// path treats them as non-fatal. The three phrasings come from
+/// [`purrdf_gts::reader`]'s encoded and decoded blob checks and from the bounded
+/// codec chain's intermediate check.
+fn is_blob_budget_refusal(diagnostic: &Diagnostic) -> bool {
+    diagnostic.code == "DamagedFrame"
+        && (diagnostic.detail.contains("blob exceeds")
+            || diagnostic.detail.contains("transform output exceeds"))
 }
 
 pub(crate) fn import_with_collector<'a>(

--- a/crates/rdf/src/gts_import_sink.rs
+++ b/crates/rdf/src/gts_import_sink.rs
@@ -408,6 +408,11 @@ impl ResolvedSink for SinkImporter<'_> {
         // emitted, so a caller who *did* name it still fails closed — the
         // selector resolves to no blob. Importers with no collector are
         // unaffected and keep the hard-fail below.
+        //
+        // This covers a refused *payload* only. A refused frame is a different
+        // fact: its rows are gone, so the dataset no longer matches what the
+        // authoritative importer would build, and returning Ok would hand back
+        // a silently truncated graph. That falls through to the hard failure.
         if self.blobs.is_some() && is_blob_budget_refusal(diagnostic) {
             return Ok(());
         }

--- a/crates/rdf/src/gts_import_sink.rs
+++ b/crates/rdf/src/gts_import_sink.rs
@@ -335,6 +335,10 @@ impl ResolvedSink for SinkImporter<'_> {
         self.blobs.as_ref().map(BlobCollector::decode_limit)
     }
 
+    fn frame_decode_limit(&self) -> Option<usize> {
+        self.blobs.as_ref().map(BlobCollector::frame_decode_limit)
+    }
+
     fn blob_payload(&mut self, payload: BlobPayload<'_>) -> Result<(), RdfDiagnostic> {
         if let Some(blobs) = &mut self.blobs {
             blobs.payload(payload)?;

--- a/crates/rdf/src/gts_import_sink.rs
+++ b/crates/rdf/src/gts_import_sink.rs
@@ -506,15 +506,13 @@ pub fn import_gts_events(bytes: &[u8]) -> Result<GtsBundle, RdfDiagnostic> {
 
 /// Whether a reader diagnostic reports a blob refused by the sink's byte budget.
 ///
-/// The reader reports these as ordinary damaged-frame diagnostics because a
-/// streaming consumer still wants to hear about them; only the selected-import
-/// path treats them as non-fatal. The three phrasings come from
-/// [`purrdf_gts::reader`]'s encoded and decoded blob checks and from the bounded
-/// codec chain's intermediate check.
+/// Matches the reader's dedicated code, never its prose. A diagnostic detail can
+/// embed container-supplied text — a header's `gts` field, a codec name — so
+/// deciding a payload's fate by searching that string lets the input choose
+/// whether it is admitted. [`purrdf_gts::reader::BLOB_BUDGET_DIAGNOSTIC`] is
+/// emitted only by the reader's own byte ceilings, which no input can spoof.
 fn is_blob_budget_refusal(diagnostic: &Diagnostic) -> bool {
-    diagnostic.code == "DamagedFrame"
-        && (diagnostic.detail.contains("blob exceeds")
-            || diagnostic.detail.contains("transform output exceeds"))
+    diagnostic.code == purrdf_gts::reader::BLOB_BUDGET_DIAGNOSTIC
 }
 
 pub(crate) fn import_with_collector<'a>(

--- a/crates/rdf/src/gts_import_sink.rs
+++ b/crates/rdf/src/gts_import_sink.rs
@@ -38,7 +38,7 @@ use crate::gts_import_blobs::BlobCollector;
 use ciborium::value::Value;
 use purrdf_core::cdt_blank::BlankBinding;
 use purrdf_gts::model::{Diagnostic, OpaqueNode, Signature, StreamableInfo, Suppression};
-use purrdf_gts::reader::{BlobPayload, FrameContext};
+use purrdf_gts::reader::{BlobPayload, BlobRefusal, FrameContext};
 use purrdf_gts::segment_decode::{ResolvedSink, SegmentResolver};
 
 use crate::{
@@ -338,6 +338,13 @@ impl ResolvedSink for SinkImporter<'_> {
     fn blob_payload(&mut self, payload: BlobPayload<'_>) -> Result<(), RdfDiagnostic> {
         if let Some(blobs) = &mut self.blobs {
             blobs.payload(payload)?;
+        }
+        Ok(())
+    }
+
+    fn blob_refused(&mut self, refusal: BlobRefusal<'_>) -> Result<(), RdfDiagnostic> {
+        if let Some(blobs) = &mut self.blobs {
+            blobs.refused(refusal);
         }
         Ok(())
     }

--- a/crates/rdf/src/lib.rs
+++ b/crates/rdf/src/lib.rs
@@ -104,7 +104,8 @@ mod nesting;
 // IR import helpers are re-exported here.
 pub use dataset_io::dataset_from_bytes;
 pub use gts_import_blobs::{
-    GtsBlobLimits, GtsBlobMetadataSource, GtsBlobSelector, GtsImportWithBlobs, GtsImportedBlob,
+    DEFAULT_MAX_FRAME_DECODED_BYTES, DEFAULT_MAX_METADATA_BYTES, GtsBlobLimits,
+    GtsBlobMetadataSource, GtsBlobSelector, GtsImportWithBlobs, GtsImportedBlob, GtsRefusedBlob,
     import_gts_events_with_blobs,
 };
 pub use gts_import_graph::import_gts_graph;

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -1268,3 +1268,102 @@ fn a_metadata_frame_may_precede_the_payload_it_describes() {
     .expect("a forward inline reference is not an external blob");
     assert_eq!(&*result.blobs[0].bytes, data);
 }
+
+/// A representation selector reads the FINAL metadata, including when deciding
+/// whether an unresolved digest was ever really named.
+///
+/// A digest can be tagged with a representation and then retagged away before
+/// the container ends. Judging it by the tag it briefly held refuses a file the
+/// authoritative importer accepts, over a blob the selection never reaches.
+#[test]
+fn a_retagged_digest_is_not_refused_over_a_representation_it_lost() {
+    let absent = digest_str(b"never inline anywhere");
+    let present = b"the one actually named";
+
+    let mut writer = Writer::new("generic");
+    // Transiently claims "wanted", with no payload...
+    writer.add_frame("blob", None, None, None, Some(meta(&absent, "wanted")));
+    // ...then gives it up.
+    writer.add_frame("blob", None, None, None, Some(meta(&absent, "other")));
+    // A different blob is what finally answers the selector.
+    writer.add_blob(present, None, Some("wanted"));
+    let bytes = writer.into_bytes();
+
+    assert!(
+        import_gts_events(&bytes).is_ok(),
+        "the authoritative importer accepts this container"
+    );
+    let result = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .expect("the selector resolves to the blob that finally carries the rep");
+    assert_eq!(result.blobs.len(), 1);
+    assert_eq!(&*result.blobs[0].bytes, present);
+}
+
+/// A container cannot suppress an ambiguity by claiming a digest it never proves.
+///
+/// A payload refused before any decode has no checked identity. Honouring the
+/// container's `pub.digest` there would let a hostile file name an already
+/// retained blob on an oversized frame and make a real ambiguity vanish — the
+/// same "input picks its own verdict" shape the diagnostic-code seam refuses.
+#[test]
+fn an_unverified_declared_digest_cannot_collapse_two_candidates() {
+    let retained = b"small and wanted";
+    let retained_digest = digest_str(retained);
+
+    let mut writer = Writer::new("generic");
+    writer.add_blob(retained, None, Some("wanted"));
+    // An ENCRYPTED oversized payload: the encrypt branch reaches the reader's
+    // ceilings even when public metadata declares a digest, so this is the one
+    // route by which a refusal can carry an identity nothing ever checked.
+    // It falsely claims the retained blob's digest.
+    writer
+        .add_frame_with_options(
+            "blob",
+            purrdf_gts::writer::FrameOptions {
+                raw: Some(vec![b'z'; 80_000]),
+                pub_meta: Some(meta(&retained_digest, "wanted")),
+                encrypt: Some(purrdf_gts::writer::Encrypt0Options {
+                    kid: "recipient".into(),
+                    // Derived, not written: a fixed key literal is a finding in
+                    // its own right, and a derived one replays exactly.
+                    key: purrdf_gts::wire::blake3_256(b"selected-blob decoy key")
+                        .try_into()
+                        .expect("a 256-bit digest is 32 bytes"),
+                    iv: purrdf_gts::wire::blake3_256(b"selected-blob decoy nonce")[..12]
+                        .try_into()
+                        .expect("a 256-bit digest is at least 12 bytes"),
+                }),
+                ..purrdf_gts::writer::FrameOptions::default()
+            },
+        )
+        .expect("encrypted decoy frame");
+    let bytes = writer.into_bytes();
+
+    let mut tight = limits();
+    tight.max_encoded_bytes = 1_024;
+    let error =
+        import_gts_events_with_blobs(&bytes, &[GtsBlobSelector::Representation("wanted")], tight)
+            .expect_err("an unproved identity must not collapse the candidates");
+    assert_eq!(error.code, "rdf-ir-gts-blob-selection", "{error:?}");
+
+    // The refusal records that it never proved what it was.
+    let observed = import_gts_events_with_blobs(&bytes, &[], tight).expect("no selectors");
+    assert_eq!(observed.refused.len(), 1);
+    // The record reports the container's claim faithfully — and marks it as a
+    // claim. That flag is the whole difference: the digest here is the retained
+    // blob's, and honouring it would have collapsed the two candidates.
+    assert_eq!(
+        observed.refused[0].digest.as_deref(),
+        Some(retained_digest.as_str()),
+        "the container did declare the retained blob's digest"
+    );
+    assert!(
+        !observed.refused[0].digest_computed,
+        "a payload refused before decoding cannot have a proved digest: {:?}",
+        observed.refused[0]
+    );
+}

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -872,3 +872,62 @@ fn an_unselected_refusal_is_reported_rather_than_dropped() {
     assert_eq!(refused.encoded_len, 100_000_usize.min(refused.encoded_len));
     assert_ne!(refused.detail, "");
 }
+
+/// A snapshot must not be a way around the blob ceilings.
+///
+/// A snapshot frame carries blob bytes *inside* an RDF frame. Bounding only the
+/// blob path leaves the decode that actually spends the memory unbounded, so a
+/// compressed snapshot could hand a bounded consumer arbitrarily many bytes.
+/// Both ceilings are exercised here, each against a neighbouring case that must
+/// still import.
+#[test]
+fn a_snapshot_cannot_smuggle_payloads_past_the_ceilings() {
+    let embedded = vec![b'x'; 100_000];
+    let snapshot = Value::Map(vec![(
+        "blobs".into(),
+        Value::Map(vec![("0".into(), Value::Bytes(embedded.clone()))]),
+    )]);
+    let mut writer = Writer::new("generic");
+    writer
+        .add_frame_with_options(
+            "snapshot",
+            purrdf_gts::writer::FrameOptions {
+                payload: Some(snapshot),
+                transform: vec!["zstd".into()],
+                ..purrdf_gts::writer::FrameOptions::default()
+            },
+        )
+        .expect("compressed snapshot frame");
+    let bytes = writer.into_bytes();
+
+    // Neighbouring valid case: ceilings that admit it still import it.
+    let generous = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Digest(&digest_str(&embedded))],
+        limits(),
+    )
+    .expect("an in-budget snapshot payload is selectable");
+    assert_eq!(&*generous.blobs[0].bytes, &embedded[..]);
+
+    // The per-blob ceiling refuses the embedded entry rather than retaining it.
+    let mut tight = limits();
+    tight.max_decoded_bytes = 1_000;
+    let refused = import_gts_events_with_blobs(&bytes, &[], tight).expect("import still succeeds");
+    assert_eq!(
+        refused.refused.len(),
+        1,
+        "the embedded entry is refused, not retained: {:?}",
+        refused.refused
+    );
+    assert!(refused.blobs.is_empty());
+
+    // The enclosing frame ceiling bounds the decode that spends the memory.
+    let mut framed = limits();
+    framed.max_frame_decoded_bytes = 1_000;
+    let bounded =
+        import_gts_events_with_blobs(&bytes, &[], framed).expect("a refused frame is not fatal");
+    assert!(
+        bounded.bundle.envelope.lookaside.blobs.is_empty(),
+        "an unbounded frame decode never happened"
+    );
+}

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -1619,11 +1619,42 @@ fn an_unverified_refusal_is_never_called_held_elsewhere() {
     let mut tight = limits();
     tight.max_encoded_bytes = 1_024;
 
-    // The encrypted occurrence's own declaration says "other", so exactly one
-    // blob finally carries "wanted" and the selector must reach it.
-    let resolved =
+    // The encrypted occurrence claims to BE that digest and declares it "other",
+    // but nothing verified the claim. An unproved claim may not rename a digest
+    // the container declared, so the earlier declaration stands, the selector
+    // still reaches a payload this import could not produce, and it fails closed
+    // rather than quietly handing back the other blob.
+    let ambiguous =
         import_gts_events_with_blobs(&bytes, &[GtsBlobSelector::Representation("wanted")], tight)
-            .expect("a refused occurrence retagged itself away from this representation");
+            .expect_err("an unverified claim cannot retag a declared digest");
+    assert_eq!(ambiguous.code, "rdf-ir-gts-blob-limit", "{ambiguous:?}");
+
+    // Neighbouring valid case: the same shape with the retag PROVED. An
+    // untransformed digest-less payload is hashed by the reader, so its own
+    // declaration does bind, and the selector reaches the remaining blob.
+    let proved_payload = vec![b'p'; 80_000];
+    let mut writer = Writer::new("generic");
+    writer.add_frame(
+        "blob",
+        None,
+        None,
+        None,
+        Some(meta(&digest_str(&proved_payload), "wanted")),
+    );
+    writer.add_frame(
+        "blob",
+        None,
+        Some(proved_payload),
+        None,
+        Some(Value::Map(vec![("rep".into(), "other".into())])),
+    );
+    writer.add_blob(small, None, Some("wanted"));
+    let resolved = import_gts_events_with_blobs(
+        &writer.into_bytes(),
+        &[GtsBlobSelector::Representation("wanted")],
+        tight,
+    )
+    .expect("a proved identity may retag itself away from this representation");
     assert_eq!(&*resolved.blobs[0].bytes, small);
 
     // Naming the refused digest reports the budget, never "held elsewhere".
@@ -1675,7 +1706,7 @@ fn a_refused_declaration_obeys_the_metadata_ceiling() {
         over.refused[0]
     );
     assert!(
-        over.refused[0].detail.contains("metadata budget"),
+        over.refused[0].detail.contains("retention budgets"),
         "and the reason is stated: {:?}",
         over.refused[0]
     );
@@ -1829,4 +1860,178 @@ fn the_longest_nameable_representation_still_matches() {
     )
     .expect_err("no selector may carry more than the maximum");
     assert_eq!(error.code, "rdf-ir-gts-blob-selection", "{error:?}");
+}
+
+/// A declaration reaches a payload in a later segment, whole and attributed.
+///
+/// The reader's own inheritance resets at every segment boundary, so a bare
+/// occurrence arrives with nothing. The documented contract says absent metadata
+/// preserves the previous declaration across those boundaries — which means the
+/// caller must get the declaration's full content, not merely be able to select
+/// on it, and must be told which frame declared it.
+#[test]
+fn a_later_segments_payload_inherits_the_whole_declaration() {
+    let data = b"cross segment body";
+    let digest = digest_str(data);
+
+    let mut first = Writer::new("generic");
+    first.add_frame(
+        "blob",
+        None,
+        None,
+        None,
+        Some(Value::Map(vec![
+            ("digest".into(), digest.into()),
+            ("rep".into(), "wanted".into()),
+            ("mt".into(), "image/png".into()),
+        ])),
+    );
+    let first_head = first.head().to_vec();
+    let mut bytes = first.into_bytes();
+    let mut second = Writer::new("generic");
+    second.add_frame("blob", None, Some(data.to_vec()), None, None);
+    bytes.extend(second.into_bytes());
+
+    assert!(import_gts_events(&bytes).is_ok());
+    let result = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .expect("a representation declared a segment earlier still names it");
+    let blob = &result.blobs[0];
+    assert_eq!(&*blob.bytes, data);
+
+    // Selected BY the representation, so it must not come back claiming to have
+    // none — and the media type declared alongside it must survive too.
+    let metadata = blob
+        .metadata
+        .as_ref()
+        .unwrap_or_else(|| panic!("the inherited declaration is returned: {blob:?}"));
+    let Value::Map(fields) = metadata else {
+        panic!("public metadata is a map: {metadata:?}");
+    };
+    let field = |name: &str| {
+        fields
+            .iter()
+            .find(|(key, _)| key.as_text() == Some(name))
+            .and_then(|(_, value)| value.as_text())
+            .map(ToString::to_string)
+    };
+    assert_eq!(field("rep").as_deref(), Some("wanted"));
+    assert_eq!(field("mt").as_deref(), Some("image/png"));
+
+    // Attribution points at the frame that declared it, not the one carrying
+    // the bytes, and carries that segment's verified head.
+    let source = blob
+        .metadata_source
+        .as_ref()
+        .unwrap_or_else(|| panic!("the declaration's source is returned: {blob:?}"));
+    assert_eq!(source.segment_index, 0);
+    assert_eq!(blob.segment_index, 1);
+    assert_eq!(source.segment_head, first_head);
+}
+
+/// A first declaration over the metadata ceiling is refused; under it, admitted.
+///
+/// This does NOT isolate where the bound fires. The importer copies public
+/// metadata into its lookaside before any payload event, and the pre-copy gate
+/// exists to bound it there rather than afterwards — but both orderings refuse
+/// the same container with the same code, so the difference is peak allocation
+/// and is not observable through this API. What is pinned here is the refusal
+/// itself and its neighbouring acceptance.
+#[test]
+fn a_first_declaration_over_the_metadata_ceiling_is_refused() {
+    let build = |filler: usize| {
+        let mut writer = Writer::new("generic");
+        writer.add_frame(
+            "blob",
+            None,
+            Some(b"body".to_vec()),
+            None,
+            Some(Value::Map(vec![
+                ("rep".into(), "wanted".into()),
+                ("note".into(), Value::Text("z".repeat(filler))),
+            ])),
+        );
+        writer.into_bytes()
+    };
+
+    let mut tight = limits();
+    tight.max_metadata_bytes = DEFAULT_MAX_METADATA_BYTES;
+    let error = import_gts_events_with_blobs(
+        &build(400_000),
+        &[GtsBlobSelector::Representation("wanted")],
+        tight,
+    )
+    .expect_err("an over-budget declaration is refused before it is copied");
+    assert_eq!(error.code, "rdf-ir-gts-blob-limit", "{error:?}");
+
+    // Neighbouring valid case: the same shape within the ceiling still imports.
+    let ok = import_gts_events_with_blobs(
+        &build(1_024),
+        &[GtsBlobSelector::Representation("wanted")],
+        tight,
+    )
+    .expect("an in-budget declaration is admitted");
+    assert_eq!(&*ok.blobs[0].bytes, b"body");
+}
+
+/// "External" is only claimed when nothing unidentified was refused.
+///
+/// Saying a payload is held elsewhere is a factual claim about the archive. A
+/// payload refused before it could be identified might be those very bytes, so
+/// the claim is not available; the truthful verdict is the budget's.
+#[test]
+fn externality_is_not_asserted_over_an_unidentified_refusal() {
+    let absent = digest_str(b"genuinely somewhere else");
+
+    // Nothing unidentified was refused, so externality is assertable.
+    let mut writer = Writer::new("generic");
+    writer.add_frame("blob", None, None, None, Some(meta(&absent, "wanted")));
+    let external = import_gts_events_with_blobs(
+        &writer.into_bytes(),
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .expect_err("a blob with no payload anywhere is external");
+    assert_eq!(external.code, "rdf-ir-gts-blob-external", "{external:?}");
+
+    // Same selection, but an encrypted frame was refused before identification.
+    // Those bytes could be the ones named, so the claim is withheld.
+    let key: [u8; 32] = purrdf_gts::wire::blake3_256(b"externality probe key")
+        .try_into()
+        .expect("a 256-bit digest is 32 bytes");
+    let iv: [u8; 12] = purrdf_gts::wire::blake3_256(b"externality probe nonce")[..12]
+        .try_into()
+        .expect("a 256-bit digest is at least 12 bytes");
+    let mut writer = Writer::new("generic");
+    writer.add_frame("blob", None, None, None, Some(meta(&absent, "wanted")));
+    writer
+        .add_frame_with_options(
+            "blob",
+            purrdf_gts::writer::FrameOptions {
+                raw: Some(vec![b'e'; 80_000]),
+                encrypt: Some(purrdf_gts::writer::Encrypt0Options {
+                    kid: "recipient".into(),
+                    key,
+                    iv,
+                }),
+                ..purrdf_gts::writer::FrameOptions::default()
+            },
+        )
+        .expect("encrypted oversized frame");
+    let mut tight = limits();
+    tight.max_encoded_bytes = 1_024;
+    let withheld = import_gts_events_with_blobs(
+        &writer.into_bytes(),
+        &[GtsBlobSelector::Representation("wanted")],
+        tight,
+    )
+    .expect_err("the selection still fails closed");
+    assert_eq!(withheld.code, "rdf-ir-gts-blob-limit", "{withheld:?}");
+    assert!(
+        !withheld.message.contains("held elsewhere"),
+        "externality is not assertable here: {withheld:?}"
+    );
 }

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -388,6 +388,80 @@ fn snapshot_payload_selection_and_reader_diagnostics_remain_native() {
     }
 }
 
+/// A container cannot talk its way past the budget seam.
+///
+/// The selected importer treats a byte-ceiling refusal as non-fatal. That
+/// decision must key off the reader's own diagnostic code, never off the
+/// human-readable detail — a detail can embed text the container chose (a
+/// header's `gts` field is echoed verbatim into the unsupported-version
+/// message), so a prose match would let a crafted file pick its own verdict and
+/// be admitted by the bounded importer while the authoritative one rejects it.
+#[test]
+fn container_supplied_text_cannot_forge_a_budget_refusal() {
+    for forged in [
+        "blob exceeds",
+        "encoded blob exceeds 1 bytes",
+        "decoded transform output exceeds 1 bytes",
+    ] {
+        let bytes = container_with_header_magic(forged);
+
+        // The reader echoes the forged magic into a `DamagedFrame` detail, so
+        // the detail now contains budget prose the container chose.
+        let plain = import_gts_events(&bytes)
+            .expect_err("an unsupported header magic is a hard fold failure");
+        let selected = import_gts_events_with_blobs(&bytes, &[], limits())
+            .expect_err("the bounded importer must refuse it too");
+        assert_eq!(plain.code, selected.code, "forged magic {forged:?}");
+        assert_eq!(
+            selected.code, "rdf-ir-gts-fold-diagnostic",
+            "forged magic {forged:?} was admitted as a budget refusal"
+        );
+    }
+}
+
+/// Author a container whose header magic is `magic`, with a valid self-hash.
+///
+/// The self-hash must be recomputed or the reader stops at "header self-hash
+/// mismatch" and never reaches the magic check whose message echoes the input.
+fn container_with_header_magic(magic: &str) -> Vec<u8> {
+    // Header only: re-authoring it changes its id, which would break the `prev`
+    // of any following frame and raise a second, unforgeable `BrokenChain`
+    // diagnostic that would mask the very admission this test is probing.
+    let authored = Writer::new("generic").into_bytes();
+
+    let mut cursor = std::io::Cursor::new(&authored[..]);
+    let item: Value = ciborium::de::from_reader(&mut cursor).expect("header item");
+    let header_len = usize::try_from(cursor.position()).expect("header fits in usize");
+    let tag = match &item {
+        Value::Tag(tag, _) => Some(*tag),
+        _ => None,
+    };
+    let mut entries = purrdf_gts::wire::unwrap_header(&item)
+        .expect("authored header is a map")
+        .clone();
+    for (key, value) in &mut entries {
+        if key.as_text() == Some("gts") {
+            *value = Value::from(magic);
+        }
+    }
+    let id = purrdf_gts::wire::header_id(&entries);
+    for (key, value) in &mut entries {
+        if key.as_text() == Some("id") {
+            *value = Value::Bytes(id.clone());
+        }
+    }
+
+    let rebuilt = Value::Map(entries);
+    let rebuilt = match tag {
+        Some(tag) => Value::Tag(tag, Box::new(rebuilt)),
+        None => rebuilt,
+    };
+    let mut out = Vec::new();
+    ciborium::ser::into_writer(&rebuilt, &mut out).expect("re-encode header");
+    out.extend_from_slice(&authored[header_len..]);
+    out
+}
+
 #[test]
 fn inherited_same_segment_metadata_keeps_its_original_frame_identity() {
     let mut writer = Writer::new("generic");

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -1570,3 +1570,119 @@ fn a_ceiling_never_decides_what_a_representation_finally_names() {
         assert_eq!(&*result.blobs[0].bytes, small, "{label}");
     }
 }
+
+/// Presence and identity are separate facts, and the importer says which it has.
+///
+/// A refused frame proves the container carried a payload under some label. That
+/// is enough to stop calling the digest "held elsewhere" — the bytes are two
+/// frames back. It is not enough to treat those bytes as that digest's, which is
+/// why the message distinguishes the two and why deduplication still demands a
+/// proved hash. Nothing here may depend on the ceiling the caller chose.
+#[test]
+fn an_unverified_refusal_is_never_called_held_elsewhere() {
+    let large = vec![b'w'; 80_000];
+    let small = b"small and wanted";
+
+    // An encrypted payload is refused before decryption, so its identity is the
+    // container's claim. Its own later declaration retags it away from "wanted".
+    let key: [u8; 32] = purrdf_gts::wire::blake3_256(b"unverified refusal key")
+        .try_into()
+        .expect("a 256-bit digest is 32 bytes");
+    let iv: [u8; 12] = purrdf_gts::wire::blake3_256(b"unverified refusal nonce")[..12]
+        .try_into()
+        .expect("a 256-bit digest is at least 12 bytes");
+    let claimed = digest_str(&large);
+
+    let mut writer = Writer::new("generic");
+    writer.add_frame("blob", None, None, None, Some(meta(&claimed, "wanted")));
+    writer
+        .add_frame_with_options(
+            "blob",
+            purrdf_gts::writer::FrameOptions {
+                raw: Some(large),
+                pub_meta: Some(meta(&claimed, "other")),
+                encrypt: Some(purrdf_gts::writer::Encrypt0Options {
+                    kid: "recipient".into(),
+                    key,
+                    iv,
+                }),
+                ..purrdf_gts::writer::FrameOptions::default()
+            },
+        )
+        .expect("encrypted oversized frame");
+    writer.add_blob(small, None, Some("wanted"));
+    let bytes = writer.into_bytes();
+
+    let mut tight = limits();
+    tight.max_encoded_bytes = 1_024;
+
+    // The encrypted occurrence's own declaration says "other", so exactly one
+    // blob finally carries "wanted" and the selector must reach it.
+    let resolved =
+        import_gts_events_with_blobs(&bytes, &[GtsBlobSelector::Representation("wanted")], tight)
+            .expect("a refused occurrence retagged itself away from this representation");
+    assert_eq!(&*resolved.blobs[0].bytes, small);
+
+    // Naming the refused digest reports the budget, never "held elsewhere".
+    let refused = import_gts_events_with_blobs(&bytes, &[GtsBlobSelector::Digest(&claimed)], tight)
+        .expect_err("the caller named a payload this budget would not admit");
+    assert_eq!(refused.code, "rdf-ir-gts-blob-limit", "{refused:?}");
+    assert!(
+        !refused.message.contains("held elsewhere"),
+        "the bytes are inline, two frames back: {refused:?}"
+    );
+    assert!(
+        refused.message.contains("not verified"),
+        "an unproved identity must say so: {refused:?}"
+    );
+}
+
+/// The metadata ceiling binds the refusal path too.
+///
+/// A refused declaration is retained and handed back like any other, so a bound
+/// that only covered the payload path would be a ceiling a refused frame walks
+/// straight past — once per refused frame, with container-chosen bytes.
+#[test]
+fn a_refused_declaration_obeys_the_metadata_ceiling() {
+    let build = |filler: usize| {
+        let mut writer = Writer::new("generic");
+        writer.add_frame(
+            "blob",
+            None,
+            Some(vec![b'v'; 50_000]),
+            None,
+            Some(Value::Map(vec![
+                ("rep".into(), "wanted".into()),
+                ("note".into(), Value::Text("z".repeat(filler))),
+            ])),
+        );
+        writer.into_bytes()
+    };
+
+    let mut tight = limits();
+    tight.max_encoded_bytes = 1_024;
+    tight.max_metadata_bytes = 64 * 1024;
+
+    // Over the ceiling: the declaration is dropped, and the refusal says so.
+    let over = import_gts_events_with_blobs(&build(400_000), &[], tight).expect("import succeeds");
+    assert_eq!(over.refused.len(), 1);
+    assert!(
+        over.refused[0].metadata.is_none(),
+        "an over-budget declaration is not retained: {:?}",
+        over.refused[0]
+    );
+    assert!(
+        over.refused[0].detail.contains("metadata budget"),
+        "and the reason is stated: {:?}",
+        over.refused[0]
+    );
+
+    // Neighbouring valid case: a declaration within the ceiling is kept intact.
+    let under = import_gts_events_with_blobs(&build(1_024), &[], tight).expect("import succeeds");
+    assert_eq!(under.refused.len(), 1);
+    assert!(
+        under.refused[0].metadata.is_some(),
+        "an in-budget declaration is retained: {:?}",
+        under.refused[0]
+    );
+}

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -436,6 +436,20 @@ fn selection_count_and_unadvertised_blob_expansion_are_bounded() {
         .code,
         "rdf-ir-gts-blob-limit"
     );
+}
+
+/// An oversized *unrelated* payload must not refuse the archive.
+///
+/// The byte budget names what this import will retain, not what the container is
+/// allowed to contain. A caller asking for one small blob out of an archive that
+/// also holds a large one it never named must still get its dataset — the large
+/// payload is simply neither decoded nor retained. Both sides are exercised here:
+/// the unrelated payload is admitted past, and a payload the caller *did* name
+/// still fails closed when it exceeds the same budget.
+#[test]
+fn oversized_unselected_payload_does_not_refuse_the_import() {
+    // A digest-less compressed payload far over budget, alongside a small named
+    // one. Only the digest-less frame reaches the reader's byte checks.
     let mut writer = Writer::new("generic");
     writer.add_frame(
         "blob",
@@ -444,13 +458,50 @@ fn selection_count_and_unadvertised_blob_expansion_are_bounded() {
         Some(&["zstd".into()]),
         None,
     );
+    writer.add_blob(b"small", None, Some("wanted"));
     let bytes = writer.into_bytes();
+
+    // The authoritative importer has always accepted these bytes.
     assert!(import_gts_events(&bytes).is_ok());
+
+    let tight = GtsBlobLimits::new(100, 100);
+
+    // Neighbouring valid case 1: no selectors at all. This previously failed
+    // with `rdf-ir-gts-fold-diagnostic`.
+    let none = import_gts_events_with_blobs(&bytes, &[], tight).expect("empty selection imports");
+    assert!(
+        none.blobs.is_empty(),
+        "nothing was selected, so nothing is retained"
+    );
+
+    // Neighbouring valid case 2: select only the small blob. The oversized
+    // payload is skipped rather than fatal, and is not retained.
+    let selected =
+        import_gts_events_with_blobs(&bytes, &[GtsBlobSelector::Representation("wanted")], tight)
+            .expect("selecting a small blob past a large one imports");
+    assert_eq!(selected.blobs.len(), 1);
+    assert_eq!(&*selected.blobs[0].bytes, b"small");
+
+    // The dataset is identical to the one the unbudgeted importer produces.
+    let plain = import_gts_events(&bytes).expect("plain import");
     assert_eq!(
-        import_gts_events_with_blobs(&bytes, &[], GtsBlobLimits::new(100, 100))
-            .unwrap_err()
-            .code,
-        "rdf-ir-gts-fold-diagnostic"
+        selected.bundle.dataset.owned_quads().collect::<Vec<_>>(),
+        plain.dataset.owned_quads().collect::<Vec<_>>()
+    );
+
+    // Invalid case: a payload the caller *named* that exceeds the same budget
+    // still fails closed.
+    let mut writer = Writer::new("generic");
+    writer.add_blob(&[b'z'; 4096], None, Some("too-big"));
+    assert_eq!(
+        import_gts_events_with_blobs(
+            &writer.into_bytes(),
+            &[GtsBlobSelector::Representation("too-big")],
+            tight
+        )
+        .unwrap_err()
+        .code,
+        "rdf-ir-gts-blob-limit"
     );
 }
 
@@ -560,8 +611,11 @@ fn eager_digest_resolution_enforces_the_original_encoded_length() {
                 too_small,
             )
             .unwrap_err();
-            assert_eq!(error.code, "rdf-ir-gts-fold-diagnostic");
-            assert!(error.message.contains("encoded blob exceeds"), "{error:?}");
+            // The payload is refused before it can be retained, so the selector
+            // finds nothing to resolve against. Still terminal — a caller never
+            // receives a blob it asked for and did not get.
+            assert_eq!(error.code, "rdf-ir-gts-blob-selection");
+            assert!(error.message.contains("resolves to 0 blobs"), "{error:?}");
         }
     }
 }

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -1501,3 +1501,72 @@ fn a_refused_payload_is_not_reported_as_held_elsewhere() {
     .expect("a budget that admits it returns the payload");
     assert_eq!(&*ok.blobs[0].bytes, &data[..]);
 }
+
+/// A refused occurrence's own declaration is what finally names it.
+///
+/// A refused payload never reaches the payload path, so its declaration would
+/// otherwise be missing from the container-global record and an earlier, staler
+/// one would answer in its place. That hands the byte ceiling the power to
+/// decide what a representation names — the precise defect this whole surface
+/// exists to prevent. Both directions are exercised: a ceiling must not invent
+/// a unique answer, and must not withhold a real one.
+#[test]
+fn a_ceiling_never_decides_what_a_representation_finally_names() {
+    let large = vec![b'q'; 50_000];
+    let large_digest = digest_str(&large);
+    let small = b"small and wanted";
+
+    // `first` is a stale earlier declaration for the oversized payload; the
+    // payload's own occurrence then declares `own`, which is what counts.
+    let build = |first: &str, own: &str| {
+        let mut writer = Writer::new("generic");
+        writer.add_frame("blob", None, None, None, Some(meta(&large_digest, first)));
+        writer.add_frame(
+            "blob",
+            None,
+            Some(large.clone()),
+            None,
+            Some(Value::Map(vec![("rep".into(), own.into())])),
+        );
+        writer.add_blob(small, None, Some("wanted"));
+        writer.into_bytes()
+    };
+
+    let mut tight = limits();
+    tight.max_encoded_bytes = 1_024;
+
+    // Two blobs finally carry "wanted": ambiguous under EVERY budget.
+    let ambiguous = build("other", "wanted");
+    assert!(import_gts_events(&ambiguous).is_ok());
+    for (label, budget) in [("tight", tight), ("generous", limits())] {
+        let error = import_gts_events_with_blobs(
+            &ambiguous,
+            &[GtsBlobSelector::Representation("wanted")],
+            budget,
+        )
+        .expect_err("a ceiling must not resolve a real ambiguity");
+        assert_eq!(
+            error.code, "rdf-ir-gts-blob-selection",
+            "{label}: {error:?}"
+        );
+        assert!(
+            error.message.contains("resolves to 2 blobs"),
+            "{label}: {error:?}"
+        );
+    }
+
+    // One blob finally carries "wanted": resolvable under EVERY budget.
+    let unique = build("wanted", "other");
+    assert!(import_gts_events(&unique).is_ok());
+    for (label, budget) in [("tight", tight), ("generous", limits())] {
+        let result = import_gts_events_with_blobs(
+            &unique,
+            &[GtsBlobSelector::Representation("wanted")],
+            budget,
+        )
+        .unwrap_or_else(|error| {
+            panic!("{label}: a ceiling must not withhold a unique answer: {error:?}")
+        });
+        assert_eq!(&*result.blobs[0].bytes, small, "{label}");
+    }
+}

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -1796,3 +1796,37 @@ fn an_oversized_description_is_neither_retained_nor_lost_for_matching() {
         "{unreachable:?}"
     );
 }
+
+/// The selection projection keeps exactly what a selector can carry.
+///
+/// Discarding a longer representation is only lossless if the two bounds agree
+/// on the same unit and the same boundary. They are both byte lengths, and both
+/// admit a value of exactly the maximum, so the longest nameable representation
+/// still matches and the shortest unnameable one could never have matched.
+#[test]
+fn the_longest_nameable_representation_still_matches() {
+    let longest = "n".repeat(4096);
+    let mut writer = Writer::new("generic");
+    writer.add_blob(b"at the boundary", None, Some(&longest));
+    let result = import_gts_events_with_blobs(
+        &writer.into_bytes(),
+        &[GtsBlobSelector::Representation(&longest)],
+        limits(),
+    )
+    .expect("a representation of exactly the maximum length is nameable");
+    assert_eq!(&*result.blobs[0].bytes, b"at the boundary");
+
+    // One byte further, the selector itself is refused at construction, so no
+    // blob could have matched it and dropping such a representation loses
+    // nothing that was ever reachable.
+    let beyond = "n".repeat(4097);
+    let mut writer = Writer::new("generic");
+    writer.add_blob(b"unreachable", None, Some(&beyond));
+    let error = import_gts_events_with_blobs(
+        &writer.into_bytes(),
+        &[GtsBlobSelector::Representation(&beyond)],
+        limits(),
+    )
+    .expect_err("no selector may carry more than the maximum");
+    assert_eq!(error.code, "rdf-ir-gts-blob-selection", "{error:?}");
+}

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -1367,3 +1367,137 @@ fn an_unverified_declared_digest_cannot_collapse_two_candidates() {
         observed.refused[0]
     );
 }
+
+/// Declared metadata carries across a segment boundary, as documented.
+///
+/// The reader's per-occurrence metadata inherits only within a segment, because
+/// each segment starts a fresh lookaside. A payload arriving in a later segment
+/// than its declaration therefore reaches the collector bare, and matching on
+/// that alone refuses a container the authoritative importer accepts — while the
+/// same file selected by digest succeeds, proving the bytes were retainable all
+/// along.
+#[test]
+fn declared_metadata_is_inherited_across_segment_boundaries() {
+    let data = b"cross segment payload";
+    let digest = digest_str(data);
+
+    // Segment 0 declares the representation; segment 1 carries the bytes.
+    let mut first = Writer::new("generic");
+    first.add_frame("blob", None, None, None, Some(meta(&digest, "wanted")));
+    let mut bytes = first.into_bytes();
+    let mut second = Writer::new("generic");
+    second.add_frame("blob", None, Some(data.to_vec()), None, None);
+    bytes.extend(second.into_bytes());
+
+    assert!(
+        import_gts_events(&bytes).is_ok(),
+        "the authoritative importer accepts this container"
+    );
+
+    // Selecting by digest never depended on inheritance, and is the control
+    // proving the payload is present and retainable.
+    let by_digest =
+        import_gts_events_with_blobs(&bytes, &[GtsBlobSelector::Digest(&digest)], limits())
+            .expect("digest selection reaches the payload");
+    assert_eq!(&*by_digest.blobs[0].bytes, data);
+
+    // Selecting by the representation declared a segment earlier must too.
+    let by_rep = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .expect("a representation declared in an earlier segment still names it");
+    assert_eq!(&*by_rep.blobs[0].bytes, data);
+}
+
+/// A refused candidate is judged by the final metadata, like every other.
+///
+/// Two payloads both tagged `wanted`, one refused by the budget: ambiguous, and
+/// must fail. Retag the refused one away before the container ends and exactly
+/// one candidate remains, so the same selector must now succeed. Returning the
+/// identical error for both files would mean the refusal carries no information.
+#[test]
+fn a_refused_candidate_retagged_away_stops_being_a_candidate() {
+    let small = b"small and wanted";
+    let large = vec![b'x'; 50_000];
+    let large_digest = digest_str(&large);
+
+    let build = |retag: bool| {
+        let mut writer = Writer::new("generic");
+        writer.add_blob(small, None, Some("wanted"));
+        // Digest-less, so the reader itself refuses it on the encoded ceiling
+        // and computes its identity from the untransformed bytes.
+        writer.add_frame(
+            "blob",
+            None,
+            Some(large.clone()),
+            None,
+            Some(Value::Map(vec![("rep".into(), "wanted".into())])),
+        );
+        if retag {
+            writer.add_frame("blob", None, None, None, Some(meta(&large_digest, "other")));
+        }
+        writer.into_bytes()
+    };
+
+    let mut tight = limits();
+    tight.max_encoded_bytes = 1_024;
+
+    let ambiguous = build(false);
+    assert!(import_gts_events(&ambiguous).is_ok());
+    let error = import_gts_events_with_blobs(
+        &ambiguous,
+        &[GtsBlobSelector::Representation("wanted")],
+        tight,
+    )
+    .expect_err("two payloads still carry the representation");
+    assert_eq!(error.code, "rdf-ir-gts-blob-selection", "{error:?}");
+
+    let retagged = build(true);
+    assert!(import_gts_events(&retagged).is_ok());
+    let result = import_gts_events_with_blobs(
+        &retagged,
+        &[GtsBlobSelector::Representation("wanted")],
+        tight,
+    )
+    .expect("the refused candidate gave up the representation before the end");
+    assert_eq!(&*result.blobs[0].bytes, small);
+}
+
+/// A payload the budget refused is present, and is reported as present.
+///
+/// Letting the ceiling decide whether the importer claims the archive contains
+/// a blob would make the answer to "is this blob here?" depend on how much
+/// memory the caller offered.
+#[test]
+fn a_refused_payload_is_not_reported_as_held_elsewhere() {
+    let data = vec![b'y'; 50_000];
+    let digest = digest_str(&data);
+
+    let mut writer = Writer::new("generic");
+    // Metadata-only occurrence first, then the oversized inline payload.
+    writer.add_frame("blob", None, None, None, Some(meta(&digest, "wanted")));
+    writer.add_frame("blob", None, Some(data.clone()), None, None);
+    let bytes = writer.into_bytes();
+
+    let mut tight = limits();
+    tight.max_encoded_bytes = 1_024;
+    let refused =
+        import_gts_events_with_blobs(&bytes, &[GtsBlobSelector::Representation("wanted")], tight)
+            .expect_err("the caller named a payload this budget would not admit");
+    assert_eq!(refused.code, "rdf-ir-gts-blob-limit", "{refused:?}");
+    assert!(
+        refused.message.contains("present in this container"),
+        "the bytes are inline, not elsewhere: {refused:?}"
+    );
+
+    // Neighbouring valid case: a budget that admits it returns the payload.
+    let ok = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .expect("a budget that admits it returns the payload");
+    assert_eq!(&*ok.blobs[0].bytes, &data[..]);
+}

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -325,7 +325,6 @@ fn retained_total_wire_and_metadata_budgets_are_independent() {
 fn malformed_selected_metadata_and_declared_lengths_fail() {
     let data = b"native";
     for (key, value, expected) in [
-        ("len", Value::from(99), "rdf-ir-gts-blob-length"),
         // A second "rep" entry makes the metadata map ambiguous.
         ("rep", Value::from("wanted"), "rdf-ir-gts-blob-metadata"),
         ("mt", Value::from(99), "rdf-ir-gts-blob-metadata"),
@@ -930,4 +929,101 @@ fn a_snapshot_cannot_smuggle_payloads_past_the_ceilings() {
         bounded.bundle.envelope.lookaside.blobs.is_empty(),
         "an unbounded frame decode never happened"
     );
+}
+
+/// An unknown extension key never refuses a payload.
+///
+/// `blob-pub` admits `* extension-key => any`, and the spec is explicit that a
+/// reader must not reject a payload map merely because it carries a key the
+/// reader does not know. `len` is one such key: nothing in this workspace emits
+/// it, and no profile here assigns it meaning, so a value that disagrees with
+/// the decoded length is a claim this reader has no standing to police.
+#[test]
+fn an_unknown_extension_key_does_not_refuse_a_payload() {
+    let data = b"payload";
+    for value in [Value::from(99), Value::from("not even a number")] {
+        let mut writer = Writer::new("generic");
+        writer.add_frame(
+            "blob",
+            None,
+            Some(data.to_vec()),
+            None,
+            Some(Value::Map(vec![
+                ("digest".into(), digest_str(data).into()),
+                ("rep".into(), "wanted".into()),
+                ("len".into(), value.clone()),
+            ])),
+        );
+        let result = import_gts_events_with_blobs(
+            &writer.into_bytes(),
+            &[GtsBlobSelector::Representation("wanted")],
+            limits(),
+        )
+        .unwrap_or_else(|error| panic!("len={value:?} must not refuse the payload: {error:?}"));
+        assert_eq!(&*result.blobs[0].bytes, data);
+    }
+}
+
+/// A digest selector names the canonical spelling, and says so when it does not.
+///
+/// The reader normalizes the three wire spellings of a published digest to
+/// `blake3:<hex>`. A selector is matched against that canonical form, so bare
+/// hex resolves to nothing — a refusal worth pinning, because the neighbouring
+/// canonical spelling must keep working.
+#[test]
+fn a_digest_selector_requires_the_canonical_spelling() {
+    let data = b"payload";
+    let mut writer = Writer::new("generic");
+    writer.add_blob(data, None, Some("wanted"));
+    let bytes = writer.into_bytes();
+
+    let canonical = digest_str(data);
+    let found =
+        import_gts_events_with_blobs(&bytes, &[GtsBlobSelector::Digest(&canonical)], limits())
+            .expect("the canonical spelling resolves");
+    assert_eq!(&*found.blobs[0].bytes, data);
+
+    let bare = canonical
+        .strip_prefix("blake3:")
+        .expect("digest_str publishes the prefixed spelling");
+    let error = import_gts_events_with_blobs(&bytes, &[GtsBlobSelector::Digest(bare)], limits())
+        .expect_err("bare hex is not the selector spelling");
+    assert_eq!(error.code, "rdf-ir-gts-blob-selection", "{error:?}");
+}
+
+/// An external blob is refused for the reason it is actually refused.
+///
+/// The spec makes external blobs first class: the payload field is absent and
+/// `pub.digest` names bytes held elsewhere. That is not the same fact as a
+/// metadata-only update naming a payload this import declined to retain, and
+/// reporting it as one asserts something false about retention ordering.
+#[test]
+fn an_external_blob_is_distinguished_from_a_metadata_only_update() {
+    let data = b"held elsewhere";
+    let digest = digest_str(data);
+
+    // External: no payload field anywhere in the container.
+    let mut writer = Writer::new("generic");
+    writer.add_frame("blob", None, None, None, Some(meta(&digest, "wanted")));
+    let external = import_gts_events_with_blobs(
+        &writer.into_bytes(),
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .expect_err("external bytes cannot be produced by an inline read");
+    assert_eq!(external.code, "rdf-ir-gts-blob-external", "{external:?}");
+    assert!(external.message.contains("held elsewhere"), "{external:?}");
+
+    // Neighbouring valid case: an inline payload followed by a metadata-only
+    // update to the same digest still resolves, and still returns the bytes.
+    let mut writer = Writer::new("generic");
+    writer.add_blob(data, None, Some("wanted"));
+    writer.add_frame("blob", None, None, None, Some(meta(&digest, "wanted")));
+    let updated = import_gts_events_with_blobs(
+        &writer.into_bytes(),
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .expect("a metadata-only update reuses the retained payload");
+    assert_eq!(&*updated.blobs[0].bytes, data);
 }

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -8,7 +8,10 @@ use purrdf_gts::model::{Term, TermKind};
 use purrdf_gts::reader::FrameContext;
 use purrdf_gts::wire::digest_str;
 use purrdf_gts::writer::Writer;
-use purrdf_rdf::{GtsBlobLimits, GtsBlobSelector, import_gts_events, import_gts_events_with_blobs};
+use purrdf_rdf::{
+    DEFAULT_MAX_METADATA_BYTES, GtsBlobLimits, GtsBlobSelector, import_gts_events,
+    import_gts_events_with_blobs,
+};
 
 fn limits() -> GtsBlobLimits {
     GtsBlobLimits::new(1024 * 1024, 2 * 1024 * 1024)
@@ -1684,5 +1687,112 @@ fn a_refused_declaration_obeys_the_metadata_ceiling() {
         under.refused[0].metadata.is_some(),
         "an in-budget declaration is retained: {:?}",
         under.refused[0]
+    );
+}
+
+/// A retention ceiling never changes how many blobs a selector counts.
+///
+/// The metadata ceiling governs how much of a blob's description this import
+/// keeps. It must not govern whether the blob is a candidate: a caller who
+/// lowers a memory budget would otherwise receive one arbitrary payload where
+/// two match, and the default ceiling would decide it silently.
+#[test]
+fn the_metadata_ceiling_does_not_decide_which_blob_a_selector_finds() {
+    let bulky = |rep: &str, filler: usize| {
+        Value::Map(vec![
+            ("rep".into(), rep.into()),
+            ("note".into(), Value::Text("z".repeat(filler))),
+        ])
+    };
+
+    // Two payloads both finally carry "wanted"; one has a huge description.
+    let mut writer = Writer::new("generic");
+    writer.add_blob(b"small and wanted", None, Some("wanted"));
+    writer.add_frame(
+        "blob",
+        None,
+        Some(vec![b'u'; 80_000]),
+        None,
+        Some(bulky("wanted", 400_000)),
+    );
+    let bytes = writer.into_bytes();
+
+    let mut tight = limits();
+    tight.max_encoded_bytes = 1_024;
+
+    // The shipped default is 64 KiB, well under this description.
+    for (label, metadata_ceiling) in [("default", DEFAULT_MAX_METADATA_BYTES), ("roomy", 1 << 20)] {
+        let mut budget = tight;
+        budget.max_metadata_bytes = metadata_ceiling;
+        let error = import_gts_events_with_blobs(
+            &bytes,
+            &[GtsBlobSelector::Representation("wanted")],
+            budget,
+        )
+        .expect_err("two payloads finally carry this representation");
+        assert_eq!(
+            error.code, "rdf-ir-gts-blob-selection",
+            "{label}: {error:?}"
+        );
+        assert!(
+            error.message.contains("resolves to 2 blobs"),
+            "{label}: the count must not depend on the metadata ceiling: {error:?}"
+        );
+    }
+}
+
+/// The selection record keeps names, not descriptions.
+///
+/// What a blob is *called* has to survive a ceiling that discards how it is
+/// *described*, and it has to do so without becoming a second unbounded copy of
+/// the metadata. A value longer than any selector cannot match one, so nothing
+/// larger than a selector is ever kept for matching.
+#[test]
+fn an_oversized_description_is_neither_retained_nor_lost_for_matching() {
+    let mut writer = Writer::new("generic");
+    writer.add_frame(
+        "blob",
+        None,
+        Some(vec![b'u'; 80_000]),
+        None,
+        Some(Value::Map(vec![
+            ("rep".into(), "wanted".into()),
+            ("note".into(), Value::Text("z".repeat(400_000))),
+        ])),
+    );
+    let bytes = writer.into_bytes();
+
+    let mut budget = limits();
+    budget.max_encoded_bytes = 1_024;
+    budget.max_metadata_bytes = DEFAULT_MAX_METADATA_BYTES;
+
+    // The description is dropped from what the caller gets back...
+    let observed = import_gts_events_with_blobs(&bytes, &[], budget).expect("import succeeds");
+    assert_eq!(observed.refused.len(), 1);
+    assert!(
+        observed.refused[0].metadata.is_none(),
+        "the over-budget description is not retained: {:?}",
+        observed.refused[0]
+    );
+
+    // ...and the name still names it.
+    let error =
+        import_gts_events_with_blobs(&bytes, &[GtsBlobSelector::Representation("wanted")], budget)
+            .expect_err("the caller named a payload this budget would not admit");
+    assert_eq!(error.code, "rdf-ir-gts-blob-limit", "{error:?}");
+
+    // A representation longer than any selector cannot match one, so it is not
+    // kept for matching either — the record holds names, never bulk.
+    let mut writer = Writer::new("generic");
+    writer.add_blob(b"unreachable", None, Some(&"y".repeat(8192)));
+    let unreachable = import_gts_events_with_blobs(
+        &writer.into_bytes(),
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .expect_err("no selector can carry that value");
+    assert_eq!(
+        unreachable.code, "rdf-ir-gts-blob-selection",
+        "{unreachable:?}"
     );
 }

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -1027,3 +1027,110 @@ fn an_external_blob_is_distinguished_from_a_metadata_only_update() {
     .expect("a metadata-only update reuses the retained payload");
     assert_eq!(&*updated.blobs[0].bytes, data);
 }
+
+/// The transient-candidate cap refuses at 1025, not at 1024.
+///
+/// The negative side of an off-by-one is invisible: a cap that fired one entry
+/// early would still look like correct strictness. The boundary case must be
+/// shown to pass through to ordinary selection instead.
+#[test]
+fn the_transient_candidate_cap_admits_its_own_boundary() {
+    for (count, expected) in [
+        (1024_u32, "rdf-ir-gts-blob-selection"),
+        (1025, "rdf-ir-gts-blob-limit"),
+    ] {
+        let mut writer = Writer::new("generic");
+        for index in 0..count {
+            writer.add_blob(&index.to_be_bytes(), None, Some("wanted"));
+        }
+        let error = import_gts_events_with_blobs(
+            &writer.into_bytes(),
+            &[GtsBlobSelector::Representation("wanted")],
+            limits(),
+        )
+        .expect_err("every blob shares one representation, so selection is ambiguous");
+        assert_eq!(error.code, expected, "count={count}: {error:?}");
+    }
+}
+
+/// Metadata that names a digest it cannot be read as is refused.
+///
+/// Distinct from the decoded-digest mismatch: here the public metadata carries a
+/// `digest` entry that is not a readable digest at all, so the blob's identity
+/// comes from its bytes while its metadata claims something unreadable.
+#[test]
+fn metadata_naming_an_unreadable_digest_is_refused() {
+    let data = b"payload";
+    let mut writer = Writer::new("generic");
+    writer.add_frame(
+        "blob",
+        None,
+        Some(data.to_vec()),
+        None,
+        // A digest-shaped value of the wrong length: not resolvable, so the
+        // blob falls to identity-by-content while its metadata disagrees.
+        Some(Value::Map(vec![
+            ("digest".into(), Value::Bytes(vec![0_u8; 31])),
+            ("rep".into(), "wanted".into()),
+        ])),
+    );
+    let error = import_gts_events_with_blobs(
+        &writer.into_bytes(),
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .expect_err("metadata must not name a digest that is not this blob");
+    assert_eq!(error.code, "rdf-ir-gts-blob-digest", "{error:?}");
+
+    // Neighbouring valid case: the same payload, metadata naming it correctly.
+    let mut writer = Writer::new("generic");
+    writer.add_frame(
+        "blob",
+        None,
+        Some(data.to_vec()),
+        None,
+        Some(meta(&digest_str(data), "wanted")),
+    );
+    let ok = import_gts_events_with_blobs(
+        &writer.into_bytes(),
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .expect("correct metadata still imports");
+    assert_eq!(&*ok.blobs[0].bytes, data);
+}
+
+/// An untransformed payload is bounded by the decoded ceiling too.
+///
+/// The encoded and decoded ceilings are separate knobs, and a payload with no
+/// codec chain reaches only the decoded one. Without a case here, a caller
+/// raising the encoded ceiling would silently lose the decoded bound.
+#[test]
+fn an_untransformed_payload_obeys_the_decoded_ceiling() {
+    let data = vec![b'x'; 4096];
+    let mut writer = Writer::new("generic");
+    // Digest-less, so the reader decodes it and the ceilings apply.
+    writer.add_frame("blob", None, Some(data.clone()), None, None);
+    let bytes = writer.into_bytes();
+
+    let mut tight = GtsBlobLimits::new(data.len() - 1, data.len());
+    tight.max_encoded_bytes = data.len() * 2;
+    let refused = import_gts_events_with_blobs(&bytes, &[], tight).expect("not fatal");
+    assert_eq!(refused.refused.len(), 1, "{:?}", refused.refused);
+    assert!(
+        refused.refused[0].detail.contains("decoded blob exceeds"),
+        "the decoded ceiling is what fired: {:?}",
+        refused.refused[0]
+    );
+
+    // Neighbouring valid case: a decoded ceiling that exactly admits it.
+    let mut exact = GtsBlobLimits::new(data.len(), data.len());
+    exact.max_encoded_bytes = data.len() * 2;
+    let ok = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Digest(&digest_str(&data))],
+        exact,
+    )
+    .expect("an exact decoded ceiling admits the payload");
+    assert_eq!(&*ok.blobs[0].bytes, &data[..]);
+}

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -923,12 +923,9 @@ fn a_snapshot_cannot_smuggle_payloads_past_the_ceilings() {
     // The enclosing frame ceiling bounds the decode that spends the memory.
     let mut framed = limits();
     framed.max_frame_decoded_bytes = 1_000;
-    let bounded =
-        import_gts_events_with_blobs(&bytes, &[], framed).expect("a refused frame is not fatal");
-    assert!(
-        bounded.bundle.envelope.lookaside.blobs.is_empty(),
-        "an unbounded frame decode never happened"
-    );
+    let error = import_gts_events_with_blobs(&bytes, &[], framed)
+        .expect_err("a refused frame removes rows, so it cannot be reported as success");
+    assert_eq!(error.code, "rdf-ir-gts-fold-diagnostic", "{error:?}");
 }
 
 /// An unknown extension key never refuses a payload.
@@ -1133,4 +1130,141 @@ fn an_untransformed_payload_obeys_the_decoded_ceiling() {
     )
     .expect("an exact decoded ceiling admits the payload");
     assert_eq!(&*ok.blobs[0].bytes, &data[..]);
+}
+
+/// A frame ceiling must never hand back a silently truncated graph.
+///
+/// Refusing one blob payload leaves the dataset intact, so the import can
+/// continue. Refusing a whole frame removes rows the caller was relying on, and
+/// returning `Ok` there would answer a question about the archive's contents
+/// with a graph that is missing part of it.
+#[test]
+fn a_refused_frame_fails_rather_than_truncating_the_dataset() {
+    // Terms declared through the writer, then a COMPRESSED quads frame: the
+    // frame ceiling only reaches transformed frames, and this one carries rows
+    // whose loss would be visible in the dataset.
+    let mut writer = Writer::new("generic");
+    let mut declared = Vec::new();
+    for index in 0..150_u32 {
+        declared.push(term(TermKind::Iri, &format!("http://example.org/t{index}")));
+    }
+    writer.add_terms(&declared);
+    let rows: Vec<Value> = (0..50_u64)
+        .map(|index| {
+            Value::Array(vec![
+                Value::from(index * 3),
+                Value::from(index * 3 + 1),
+                Value::from(index * 3 + 2),
+            ])
+        })
+        .collect();
+    writer
+        .add_frame_with_options(
+            "quads",
+            purrdf_gts::writer::FrameOptions {
+                payload: Some(Value::Array(rows)),
+                transform: vec!["zstd".into()],
+                ..purrdf_gts::writer::FrameOptions::default()
+            },
+        )
+        .expect("compressed quads frame");
+    let bytes = writer.into_bytes();
+
+    let plain = import_gts_events(&bytes).expect("authoritative import");
+    assert!(plain.dataset.quad_count() > 0, "the fixture carries rows");
+
+    // Neighbouring valid case: a frame ceiling that admits it returns the same
+    // dataset the authoritative importer builds.
+    let admitted =
+        import_gts_events_with_blobs(&bytes, &[], limits()).expect("an in-budget frame imports");
+    assert_eq!(
+        admitted.bundle.dataset.owned_quads().collect::<Vec<_>>(),
+        plain.dataset.owned_quads().collect::<Vec<_>>()
+    );
+
+    // A ceiling that refuses the frame is terminal, not a quiet truncation.
+    let mut tight = limits();
+    tight.max_frame_decoded_bytes = 64;
+    let error = import_gts_events_with_blobs(&bytes, &[], tight)
+        .expect_err("a dropped frame cannot be reported as success");
+    assert_eq!(error.code, "rdf-ir-gts-fold-diagnostic", "{error:?}");
+}
+
+/// One blob stored twice is still one blob, whichever copy the budget refuses.
+///
+/// A container may hold the same payload compressed and uncompressed. Refusing
+/// the copy that does not fit must not invent a second candidate and turn a
+/// unique selector into an ambiguous one.
+#[test]
+fn a_refused_duplicate_copy_does_not_invent_an_ambiguity() {
+    let data = vec![b'x'; 50_000];
+    let digest = digest_str(&data);
+    let mut writer = Writer::new("generic");
+    // Copy A: compressed, so it fits a tight encoded ceiling.
+    writer
+        .add_blob_transformed(data.clone(), None, Some("wanted"), &["zstd".into()], None)
+        .expect("compressed copy");
+    // Copy B: the same bytes uncompressed, which a tight ceiling refuses.
+    writer.add_frame("blob", None, Some(data.clone()), None, None);
+    let bytes = writer.into_bytes();
+
+    // Generous: both copies are admitted, and they are one blob.
+    let generous = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .expect("one blob stored twice is not ambiguous");
+    assert_eq!(generous.blobs.len(), 1);
+    assert_eq!(generous.blobs[0].digest, digest);
+    assert_eq!(generous.refused.len(), 0);
+
+    // Tight: an encoded ceiling that admits the compressed copy and refuses the
+    // uncompressed one. The refusal must actually happen, or this proves nothing.
+    let mut tight = limits();
+    tight.max_encoded_bytes = data.len() / 2;
+    let result =
+        import_gts_events_with_blobs(&bytes, &[GtsBlobSelector::Representation("wanted")], tight)
+            .expect("refusing the second copy of one blob is not an ambiguity");
+    assert_eq!(
+        result.refused.len(),
+        1,
+        "the uncompressed copy must really be refused: {:?}",
+        result.refused
+    );
+    assert_eq!(
+        result.refused[0].digest.as_deref(),
+        Some(digest.as_str()),
+        "an untransformed refusal knows its own identity"
+    );
+    assert_eq!(result.blobs.len(), 1);
+    assert_eq!(result.blobs[0].digest, digest);
+}
+
+/// A metadata-only frame may precede its own inline payload.
+///
+/// Whether a blob is external is only decidable once the container has been
+/// read: the bytes may be two frames further on. Deciding at the occurrence
+/// reported a file the authoritative importer accepts as external.
+#[test]
+fn a_metadata_frame_may_precede_the_payload_it_describes() {
+    let data = b"arrives later";
+    let digest = digest_str(data);
+
+    let mut writer = Writer::new("generic");
+    writer.add_frame("blob", None, None, None, Some(meta(&digest, "wanted")));
+    writer.add_blob(data, None, Some("wanted"));
+    let bytes = writer.into_bytes();
+
+    assert!(
+        import_gts_events(&bytes).is_ok(),
+        "the authoritative importer accepts a forward reference"
+    );
+    let result = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .expect("a forward inline reference is not an external blob");
+    assert_eq!(&*result.blobs[0].bytes, data);
 }

--- a/crates/rdf/tests/gts_selected_blobs.rs
+++ b/crates/rdf/tests/gts_selected_blobs.rs
@@ -556,12 +556,46 @@ fn oversized_unselected_payload_does_not_refuse_the_import() {
     assert_eq!(selected.blobs.len(), 1);
     assert_eq!(&*selected.blobs[0].bytes, b"small");
 
-    // The dataset is identical to the one the unbudgeted importer produces.
+    // The dataset is identical to the one the unbudgeted importer produces, and
+    // the envelope differs in exactly one documented way: the refused payload is
+    // an `over-budget` opaque node rather than a blob record, because the digest
+    // that would identify it is only computable by doing the decode the budget
+    // declined. Asserting quads alone would let any other divergence hide.
     let plain = import_gts_events(&bytes).expect("plain import");
     assert_eq!(
         selected.bundle.dataset.owned_quads().collect::<Vec<_>>(),
         plain.dataset.owned_quads().collect::<Vec<_>>()
     );
+    let (plain_side, selected_side) = (
+        &plain.envelope.lookaside,
+        &selected.bundle.envelope.lookaside,
+    );
+    assert_eq!(
+        plain_side.blobs.len(),
+        2,
+        "unbudgeted decodes and records both"
+    );
+    assert_eq!(plain_side.opaque_nodes, &[]);
+    assert_eq!(
+        selected_side.blobs.len(),
+        1,
+        "only the admitted payload is identified"
+    );
+    let [opaque] = selected_side.opaque_nodes.as_slice() else {
+        panic!(
+            "the refused payload is recorded: {:?}",
+            selected_side.opaque_nodes
+        );
+    };
+    assert_eq!(
+        opaque.reason, "over-budget",
+        "not conflated with corruption"
+    );
+    assert_eq!(selected_side.segments, plain_side.segments);
+    assert_eq!(selected_side.signatures, plain_side.signatures);
+    assert_eq!(selected_side.suppressions, plain_side.suppressions);
+    assert_eq!(selected_side.resources, plain_side.resources);
+    assert_eq!(selected_side.metadata, plain_side.metadata);
 
     // Invalid case: a payload the caller *named* that exceeds the same budget
     // still fails closed.
@@ -717,4 +751,124 @@ fn malformed_public_metadata_is_not_silently_treated_as_absent() {
     )
     .unwrap_err();
     assert_eq!(error.code, "rdf-ir-gts-blob-metadata");
+}
+
+/// A byte budget bounds retention; it must never decide selection.
+///
+/// An archive holds two payloads that both advertise `rep = "wanted"`. Naming
+/// that representation is ambiguous and must fail closed. If a refused payload
+/// simply vanished, a tight budget would delete one candidate and hand the
+/// caller the survivor as though it were the unique answer — a wrong result
+/// produced by a knob that is supposed to govern memory, not meaning.
+#[test]
+fn a_budget_refusal_cannot_resolve_an_ambiguous_selector() {
+    let mut writer = Writer::new("generic");
+    writer.add_blob(b"small", None, Some("wanted"));
+    // Digest-less, so it is decoded (and therefore budget-checked) rather than
+    // resolved eagerly from public metadata, yet it still advertises the rep.
+    writer.add_frame(
+        "blob",
+        None,
+        Some(vec![b'x'; 100_000]),
+        Some(&["zstd".into()]),
+        Some(Value::Map(vec![("rep".into(), "wanted".into())])),
+    );
+    let bytes = writer.into_bytes();
+
+    for (label, limits) in [
+        ("generous", GtsBlobLimits::new(1024 * 1024, 2 * 1024 * 1024)),
+        ("tight", GtsBlobLimits::new(100, 100)),
+    ] {
+        let error = import_gts_events_with_blobs(
+            &bytes,
+            &[GtsBlobSelector::Representation("wanted")],
+            limits,
+        )
+        .expect_err(&format!("{label} budget must not resolve the ambiguity"));
+        assert_eq!(
+            error.code, "rdf-ir-gts-blob-selection",
+            "{label}: {error:?}"
+        );
+        assert!(
+            error.message.contains("resolves to 2 blobs"),
+            "{label}: {error:?}"
+        );
+    }
+}
+
+/// Naming a payload the budget refused is reported as a budget refusal.
+///
+/// "Resolves to 0 blobs" would be a false statement about an archive that does
+/// contain the payload, and indistinguishable from naming a digest that is
+/// genuinely absent.
+#[test]
+fn naming_a_refused_payload_reports_the_budget_not_an_empty_match() {
+    let mut writer = Writer::new("generic");
+    writer.add_frame(
+        "blob",
+        None,
+        Some(vec![b'x'; 100_000]),
+        Some(&["zstd".into()]),
+        Some(Value::Map(vec![("rep".into(), "wanted".into())])),
+    );
+    let bytes = writer.into_bytes();
+
+    let refused = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Representation("wanted")],
+        GtsBlobLimits::new(100, 100),
+    )
+    .expect_err("a named over-budget payload fails closed");
+    assert_eq!(refused.code, "rdf-ir-gts-blob-limit", "{refused:?}");
+    assert!(refused.message.contains("budget refused"), "{refused:?}");
+
+    // The neighbouring valid case: the same archive, a budget that admits it.
+    let ok = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Representation("wanted")],
+        limits(),
+    )
+    .expect("the same selection succeeds within budget");
+    assert_eq!(ok.blobs.len(), 1);
+    assert_eq!(ok.refused.len(), 0);
+
+    // A genuinely absent digest stays a selection failure, not a budget one.
+    let absent = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Digest(&digest_str(
+            b"never in this archive",
+        ))],
+        limits(),
+    )
+    .expect_err("an absent digest fails closed");
+    assert_eq!(absent.code, "rdf-ir-gts-blob-selection", "{absent:?}");
+}
+
+/// A successful import never hides what the budget cost the caller.
+#[test]
+fn an_unselected_refusal_is_reported_rather_than_dropped() {
+    let mut writer = Writer::new("generic");
+    writer.add_frame(
+        "blob",
+        None,
+        Some(vec![b'x'; 100_000]),
+        Some(&["zstd".into()]),
+        None,
+    );
+    writer.add_blob(b"small", None, Some("wanted"));
+    let bytes = writer.into_bytes();
+
+    let result = import_gts_events_with_blobs(
+        &bytes,
+        &[GtsBlobSelector::Representation("wanted")],
+        GtsBlobLimits::new(100, 100),
+    )
+    .expect("imports");
+    assert_eq!(result.blobs.len(), 1);
+    let [refused] = result.refused.as_slice() else {
+        panic!("the oversized payload is reported: {:?}", result.refused);
+    };
+    assert!(refused.digest.is_none(), "no digest was declared");
+    assert_eq!(refused.encoded_len, 100_000_usize.min(refused.encoded_len));
+    assert_ne!(refused.detail, "");
 }

--- a/crates/shapes/README.md
+++ b/crates/shapes/README.md
@@ -656,6 +656,17 @@ Related crates:
 
 ## License and copyright
 
+## Reusing a parsed shapes graph
+
+`Shapes` retains the frozen `Arc<RdfDataset>` it was parsed from, and
+`Shapes::dataset()` borrows it. A consumer that needs the RDF behind a shapes
+graph — to union it with an ontology, to fold `owl:imports`, to hand it to
+SPARQL — reads it from there instead of reparsing the source text.
+
+The accessor returns a borrow rather than a clone so the caller decides whether
+to pay for retention; `Arc::clone(shapes.dataset())` keeps the dataset alive
+independently of the `Shapes` value.
+
 Copyright © 2026 Blackcat Informatics® Inc.
 
 This crate is licensed under **MIT OR Apache-2.0** — see

--- a/crates/shapes/src/shapes.rs
+++ b/crates/shapes/src/shapes.rs
@@ -429,9 +429,11 @@ pub struct Shapes {
 impl Shapes {
     /// Borrow the original frozen dataset retained when these shapes were parsed.
     ///
-    /// This returns the existing shared owner without reparsing, copying the
-    /// dataset, or incrementing its reference count. Use `Arc::clone(shapes.dataset())`
-    /// to retain the same immutable dataset independently of the `Shapes` value.
+    /// The same allocation `parse_shapes` interned, not a copy of it, so a
+    /// consumer needing the RDF behind a shapes graph never has to reparse the
+    /// source text. Borrowing leaves the choice of paying for retention with the
+    /// caller: `Arc::clone(shapes.dataset())` keeps the dataset alive
+    /// independently of the `Shapes` value.
     ///
     /// Document-prefix handling remains part of [`crate::engine::parse_shapes`]:
     /// the dataset contains RDF statements, not the source document's prefix map.

--- a/crates/shapes/tests/shared_shapes_dataset.rs
+++ b/crates/shapes/tests/shared_shapes_dataset.rs
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Blackcat Informatics® Inc. <paudley@blackcatinformatics.ca>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! `Shapes` exposes the frozen dataset it already retains, without reparsing.
+
+use std::sync::Arc;
+
+use purrdf_shapes::engine::parse_shapes;
+use purrdf_shapes::shapes::{Shapes, from_dataset};
+use purrdf_shapes::text_ingest::parse_turtle_to_dataset;
+
+const SHAPES_TTL: &str = r"
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.org/> .
+
+ex:PersonShape
+    a sh:NodeShape ;
+    sh:targetClass ex:Person ;
+    sh:property [
+        sh:path ex:name ;
+        sh:minCount 1 ;
+    ] .
+";
+
+/// The accessor hands back the very allocation it was given — no copy, no reparse.
+///
+/// A deep copy would be invisible to any behavioural assertion: the shapes would
+/// validate identically and only the memory cost would differ. Pointer identity
+/// is the only thing that actually distinguishes sharing from copying, which is
+/// why this is asserted rather than inferred from equal contents.
+#[test]
+fn the_accessor_returns_the_same_allocation_it_was_built_from() {
+    let dataset = parse_turtle_to_dataset(SHAPES_TTL, None).expect("shapes parse");
+    let shapes = from_dataset(&dataset).expect("shapes build");
+
+    assert!(
+        Arc::ptr_eq(shapes.dataset(), &dataset),
+        "the retained dataset must be the caller's, not a clone of it"
+    );
+
+    // A caller wanting independent retention pays one refcount bump, explicitly.
+    let retained = Arc::clone(shapes.dataset());
+    let before = Arc::strong_count(&dataset);
+    drop(shapes);
+    assert!(
+        Arc::ptr_eq(&retained, &dataset),
+        "the dataset outlives the Shapes that exposed it"
+    );
+    assert!(before > 1, "the clone held a reference while Shapes lived");
+}
+
+/// The text entry point retains the dataset it parsed, so no consumer needs to
+/// reparse the source merely to recover it.
+#[test]
+fn the_text_entry_point_retains_its_parsed_dataset() {
+    let shapes = parse_shapes(SHAPES_TTL, None).expect("shapes parse");
+    let retained = shapes.dataset();
+
+    let independently = parse_turtle_to_dataset(SHAPES_TTL, None).expect("second parse");
+    assert!(
+        !Arc::ptr_eq(retained, &independently),
+        "a second parse is a different allocation; the point is not to need one"
+    );
+    assert_eq!(
+        retained.quad_count(),
+        independently.quad_count(),
+        "the retained dataset is the same content a reparse would produce"
+    );
+}
+
+/// Exposing the dataset does not disturb how the document's prefixes resolve.
+///
+/// `parse_shapes` reads prefixes from the source text separately from the RDF it
+/// interns, so a change to what it retains could plausibly shift shape identity.
+/// The shapes parsed with the accessor present must still name the same targets.
+#[test]
+fn exposing_the_dataset_leaves_prefix_resolution_alone() {
+    let from_text = parse_shapes(SHAPES_TTL, None).expect("shapes from text");
+
+    let dataset = parse_turtle_to_dataset(SHAPES_TTL, None).expect("dataset");
+    let from_graph = from_dataset(&dataset).expect("shapes from dataset");
+
+    let names = |shapes: &Shapes| {
+        let mut ids: Vec<String> = shapes
+            .node_shapes
+            .iter()
+            .map(|shape| shape.id.to_string())
+            .collect();
+        ids.sort();
+        ids
+    };
+
+    assert_eq!(names(&from_text), names(&from_graph));
+    assert!(
+        names(&from_text)
+            .iter()
+            .any(|id| id.contains("http://example.org/PersonShape")),
+        "the prefixed shape name still resolves against the document base: {:?}",
+        names(&from_text)
+    );
+}


### PR DESCRIPTION
Follow-on defect fixes for the selected-blob importer merged in #282, plus the defects this branch introduced while fixing them.

## What started this

A selected import's byte budget names what *that import will retain*, not what the container is allowed to contain. But the reader enforced it for every blob frame with no knowledge of selection, and the IR path treats every reader diagnostic as a hard fold failure:

```
archive = [ 1 KiB blob "wanted", 100 KB unrelated compressed blob ]

import_gts_events(&bytes)                                    -> Ok
import_gts_events_with_blobs(&bytes, &[], limits(100, 100))  -> Err(rdf-ir-gts-fold-diagnostic)
```

The previous test suite asserted that as correct, with an empty selector list.

## What two audits then found

The first fix was itself defective, and re-auditing the repairs found three more. Every item below was demonstrated on the public API before being fixed, and each regression test was confirmed to **fail against the commit before it**.

**A container could talk its way past the budget seam.** The fix decided whether a diagnostic was a budget refusal by searching its human-readable detail for `"blob exceeds"`. Details interpolate container-supplied bytes — the reader echoes a header's `gts` field verbatim. A file whose header magic *was* `"blob exceeds"` suppressed the magic/version guard, so the bounded importer accepted, dataset and all, a container `import_gts_events` rejects. Byte ceilings now carry a typed `BLOB_BUDGET_DIAGNOSTIC`.

**A byte budget was silently deciding selection.** Two blobs sharing `rep="wanted"` errored correctly under a generous ceiling and returned **one blob — the wrong one — under a tight one**, because a refused payload vanished before `finish()` could count it. Refusals are now first-class data (`blob_refused`), stay selection candidates, and surface in `GtsImportWithBlobs::refused`. Naming one reports the real bound instead of the false "resolves to 0 blobs".

**A compressed snapshot defeated every blob ceiling.** The decode limit was gated on the frame being a blob frame, so an enclosing RDF frame decoded unbounded and its embedded blob map was retained entry by entry with no check. Both are bounded now.

**A refused frame was reported as success.** The frame ceiling shared the blob ceiling's code, which the importer treats as recoverable — so one compressed frame carrying 20,000 quads imported as **zero quads, `Ok`**. Declining a payload leaves the dataset intact; dropping a frame does not. It has its own code and is terminal.

**One blob stored twice became ambiguous.** Refused occurrences were counted without regard to identity. A refusal with no transform chain can be identified for free (its wire bytes are its decoded bytes), so the reader hashes those and a refusal already retained is recognised as the same payload.

**A forward reference was called external.** Whether a blob is external was decided at the occurrence, so a metadata-only frame preceding its own inline payload — accepted by `import_gts_events` — was reported as external. Decided at `finish()` now.

## Spec fidelity

- **`len` refusal deleted.** GTS-SPEC defines it only as an extension key and §22.2 states a reader MUST NOT reject a payload map solely for carrying an unknown key. Nothing in the workspace emits it. A payload with a disagreeing `len` now imports — the positive case the refusal never had.
- **External blobs** get their own code and message instead of a false claim about retention ordering.
- **Digest selectors** are documented as canonical `blake3:<hex>`, with the bare-hex negative pinned.

## Also

`Shapes::dataset()` — the whole of issue #281's criterion A5 — had zero tests and no callers; `Arc::ptr_eq` now pins the no-copy claim. A panic inside a `Result` API is a diagnostic. The retained-byte total uses checked arithmetic. Dead unbounded `cose::decrypt0` removed. README sections for both surfaces, a report-only criterion bench, and the three focused `make` targets renamed off a merged-and-deleted branch name.

## Verification

Per commit: `cargo fmt --all`, `cargo clippy -- -D warnings`, and the narrowest tests that prove the claim. `gts_selected_blobs` 31/31, `bounded_keyed_blobs` 6/6, `shared_shapes_dataset` 3/3, `purrdf-gts`/`purrdf-rdf`/`purrdf-shapes` suites green, rustdoc `-D warnings` clean. Full gate is CI's.
